### PR TITLE
Add service/provider disambiguation step to SKILL.md

### DIFF
--- a/plugins/uipath/skills/uipath-rpa-workflows/SKILL.md
+++ b/plugins/uipath/skills/uipath-rpa-workflows/SKILL.md
@@ -343,6 +343,8 @@ When results contain multiple competing packages for the same capability (e.g., 
 3. Include a one-line difference for each (e.g., "requires Integration Service connection" vs "protocol-based, works on-premise")
 4. Continue with **only** the chosen package
 
+**Save the preference:** After resolving disambiguation (whether auto-selected or user-chosen), suggest saving the preference to `CLAUDE.md` and `AGENTS.md` in the project folder so future sessions auto-select without re-prompting. For example: _"Want me to save this preference (e.g., 'Always use O365 for email activities') to CLAUDE.md and AGENTS.md so it's remembered for future workflows?"_
+
 ### Step 1.6: Resolve Activity Properties
 
 When you need to insert or edit a specific activity, use `uipcli rpa get-default-activity-xaml` to retrieve the activity's default XAML template, its properties, and the default values. Use it as a starting point for configuring new activities. This default representation is a crucial starting point as it ensures that Studio can properly render and parse the activity.


### PR DESCRIPTION
## Summary
- Adds **Step 1.5: Disambiguate Service / Provider** to the Discovery phase — when `find-activities` returns multiple competing packages/connectors for the same capability (e.g., O365 vs Gmail vs SMTP for email), the model now asks the user to choose instead of picking arbitrarily
- Renumbers subsequent steps (1.5→1.6, 1.6→1.7, 1.7→1.8) to maintain sequential numbering
- Adds a matching anti-pattern ("Never ask the user to choose based on general knowledge") and quality checklist item

## Test plan
- [ ] Verify step numbering is sequential (1.1 through 1.8) in Phase 1
- [ ] Verify the new Step 1.5 skip conditions cover the common cases (user specified provider, single match, package already installed)
- [ ] Verify the anti-pattern bullet reads naturally under the "Never:" prefix
- [ ] Verify the checklist item matches the existing `- [ ]` format
- [ ] End-to-end: prompt the skill with a vague request like "send the pdf over email" and confirm it triggers disambiguation

🤖 Generated with [Claude Code](https://claude.com/claude-code)