### PR TITLE
Add Node.js prerequisite to Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,37 @@ UiPath Agent Skills give AI coding agents the domain knowledge to build, run, te
 
 ## Quick Start
 
+> **Prerequisite:** [Node.js](https://nodejs.org/) (LTS) is required — it includes `npx`.
+
 ```bash
 npx skills add uipath/skills
 ```
 
 Select the skills you need from the wizard. Skills are installed into your coding agent's directory and ready to use.
+
+<details>
+<summary>Don't have Node.js installed?</summary>
+
+**macOS**
+```bash
+brew install node
+```
+
+**Windows**
+```bash
+winget install OpenJS.NodeJS.LTS
+```
+
+**Linux**
+```bash
+curl -fsSL https://fnm.vercel.app/install | bash
+fnm install --lts
+```
+See [Installing Node.js via package manager](https://nodejs.org/en/download/package-manager) for other methods.
+
+After installing, verify with `node -v` and then run the quick start command above.
+
+</details>
 
 ## Skill Catalog
 


### PR DESCRIPTION
## Summary
- Adds a note that Node.js (LTS) is required as a prerequisite for `npx skills add`
- Adds a collapsible `<details>` block with OS-specific install instructions for macOS, Windows, and Linux
- Keeps the happy path (one command) front and center

Stacked on top of #42.

## Test plan
- [ ] Verify the `<details>` block renders correctly on GitHub
- [ ] Confirm install commands are accurate for each OS

🤖 Generated with [Claude Code](https://claude.com/claude-code)