### PR TITLE
feat: rename Integration Service → Integration Platform & Experiences, CLI prefix is → ipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The repository contains skills for building and managing UiPath automation proje
 | **uipath-coded-workflows** | Create, edit, build, and run UiPath coded automations (.cs) with activity references for 20+ packages |
 | **uipath-rpa-workflows** | Generate and edit RPA workflows (XAML) in UiPath Studio Desktop with discovery-first approach |
 | **uipath-flow** | Create, validate, and debug UiPath Flow projects using the `.flow` JSON format and `uip` CLI |
-| **uipath-platform** | Authentication, Orchestrator management, solution lifecycle, Integration Service, and CLI tools |
+| **uipath-platform** | Authentication, Orchestrator management, solution lifecycle, Integration Platform & Experiences, and CLI tools |
 | **uipath-coded-agents** | End-to-end toolkit for UiPath coded agents: scaffold, build, run, evaluate, deploy (LangGraph, LlamaIndex, OpenAI Agents, Simple Function) |
 | **uipath-servo** | Desktop and browser UI automation and testing — click, type, read, verify, screenshot, and extract UI elements |
 

--- a/references/activity-docs/UiPath.AzureWVD.Activities/1.5/coded/azure-wvd.md
+++ b/references/activity-docs/UiPath.AzureWVD.Activities/1.5/coded/azure-wvd.md
@@ -33,7 +33,7 @@ SessionHostList sessionHosts = await sessionHostService.ListSessionHosts(hostPoo
 
 ### Client Provider
 
-The `IClientProvider` parameter is obtained from an Azure WVD Scope activity. It provides authenticated access to Azure WVD REST APIs and the Azure Management SDK using either service principal credentials or Integration Service tokens.
+The `IClientProvider` parameter is obtained from an Azure WVD Scope activity. It provides authenticated access to Azure WVD REST APIs and the Azure Management SDK using either service principal credentials or Integration Platform & Experiences tokens.
 
 ### API Categories
 

--- a/references/activity-docs/UiPath.GSuite.Activities/3.8/activities/overview.md
+++ b/references/activity-docs/UiPath.GSuite.Activities/3.8/activities/overview.md
@@ -11,7 +11,7 @@ All GSuite activities authenticate via two attributes:
 ConnectionId="<guid>" UseConnectionService="True"
 ```
 
-Use `uip is connections list --format json` to obtain the connection GUID. If no GSuite connection exists, create one: `uip is connections create <gsuite-connector-key>`. Verify it's active: `uip is connections ping <connection-id>`. All activity names end in `Connections` (e.g., `GetNewestEmailConnections`, `ReadRangeConnections`).
+Use `uip ipe connections list --format json` to obtain the connection GUID. If no GSuite connection exists, create one: `uip ipe connections create <gsuite-connector-key>`. Verify it's active: `uip ipe connections ping <connection-id>`. All activity names end in `Connections` (e.g., `GetNewestEmailConnections`, `ReadRangeConnections`).
 
 ## Model Types
 

--- a/references/activity-docs/UiPath.GSuite.Activities/3.8/coded/examples.md
+++ b/references/activity-docs/UiPath.GSuite.Activities/3.8/coded/examples.md
@@ -4,7 +4,7 @@ Examples using the `google` service from `UiPath.GSuite.Activities` package.
 
 **Required package:** `"UiPath.GSuite.Activities": "[3.6.10]"`
 
-> **Prerequisites:** All examples require Integration Service connections configured in UiPath Automation Cloud (Google OAuth). The `connections` property provides typed access to configured connections. Studio auto-generates `ConnectionsManager.cs` and `ConnectionsFactory.cs` in `.codedworkflows/` with the available connection names.
+> **Prerequisites:** All examples require Integration Platform & Experiences connections configured in UiPath Automation Cloud (Google OAuth). The `connections` property provides typed access to configured connections. Studio auto-generates `ConnectionsManager.cs` and `ConnectionsFactory.cs` in `.codedworkflows/` with the available connection names.
 
 ---
 

--- a/references/activity-docs/UiPath.GSuite.Activities/3.8/coded/gsuite.md
+++ b/references/activity-docs/UiPath.GSuite.Activities/3.8/coded/gsuite.md
@@ -10,7 +10,7 @@ Reference for the `google` service from `UiPath.GSuite.Activities` package.
 
 ## Overview
 
-The Google Workspace API provides coded workflow access to **Gmail, Google Calendar, Google Drive, Google Sheets, and Google Docs** via Google Workspace APIs. Uses **OAuth tokens managed by Integration Service** — no local installation needed.
+The Google Workspace API provides coded workflow access to **Gmail, Google Calendar, Google Drive, Google Sheets, and Google Docs** via Google Workspace APIs. Uses **OAuth tokens managed by Integration Platform & Experiences** — no local installation needed.
 
 ### Architecture
 
@@ -25,7 +25,7 @@ google (IGoogleConnectionsService)
 
 ### Prerequisites
 
-1. **Integration Service connections** must be configured in UiPath Automation Cloud (Google OAuth)
+1. **Integration Platform & Experiences connections** must be configured in UiPath Automation Cloud (Google OAuth)
 2. Studio auto-generates `ConnectionsManager.cs` and `ConnectionsFactory.cs` in `.codedworkflows/` with typed connection accessors
 3. Access connections via the `connections` property on `CodedWorkflow`
 

--- a/references/activity-docs/UiPath.Mail.Activities/2.8/activities/overview.md
+++ b/references/activity-docs/UiPath.Mail.Activities/2.8/activities/overview.md
@@ -36,7 +36,7 @@ Classic Outlook mail activity patterns for `UiPath.Mail.Activities`. Always get 
 
 ## IS Connection Pattern (Classic activities)
 
-When using Integration Service connection, add `UseISConnection="True"` and the `ConnectionDetailsBackupSlot` child to `GetOutlookMailMessages` and `SendOutlookMail`. Use `uip is connections list --format json` to discover available connection GUIDs. If no Outlook connection exists, create one: `uip is connections create <outlook-connector-key>`.
+When using Integration Platform & Experiences connection, add `UseISConnection="True"` and the `ConnectionDetailsBackupSlot` child to `GetOutlookMailMessages` and `SendOutlookMail`. Use `uip ipe connections list --format json` to discover available connection GUIDs. If no Outlook connection exists, create one: `uip ipe connections create <outlook-connector-key>`.
 
 ```xml
 <ui:GetOutlookMailMessages ... UseISConnection="True">

--- a/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/overview.md
+++ b/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/overview.md
@@ -21,7 +21,7 @@ All activities authenticate via:
 ConnectionId="<guid>" UseConnectionService="True" AuthScopesInvalid="False"
 ```
 
-Use `uip is connections list --format json` to obtain the connection GUID. If no O365 connection exists, create one: `uip is connections create <o365-connector-key>`. Verify it's active: `uip is connections ping <connection-id>`.
+Use `uip ipe connections list --format json` to obtain the connection GUID. If no O365 connection exists, create one: `uip ipe connections create <o365-connector-key>`. Verify it's active: `uip ipe connections ping <connection-id>`.
 
 ## Key Patterns
 

--- a/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/coded/examples.md
+++ b/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/coded/examples.md
@@ -4,7 +4,7 @@ Examples using the `office365` service from `UiPath.MicrosoftOffice365.Activitie
 
 **Required package:** `"UiPath.MicrosoftOffice365.Activities": "[3.6.10]"`
 
-> **Prerequisites:** All examples require Integration Service connections configured in UiPath Automation Cloud. The `connections` property provides typed access to configured connections. Studio auto-generates `ConnectionsManager.cs` and `ConnectionsFactory.cs` in `.codedworkflows/` with the available connection names.
+> **Prerequisites:** All examples require Integration Platform & Experiences connections configured in UiPath Automation Cloud. The `connections` property provides typed access to configured connections. Studio auto-generates `ConnectionsManager.cs` and `ConnectionsFactory.cs` in `.codedworkflows/` with the available connection names.
 
 ---
 

--- a/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/coded/office365.md
+++ b/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/coded/office365.md
@@ -10,7 +10,7 @@ Reference for the `office365` service from `UiPath.MicrosoftOffice365.Activities
 
 ## Overview
 
-The Microsoft 365 API provides coded workflow access to **Mail, Calendar, Excel (cloud), OneDrive, and SharePoint** via the Microsoft Graph API. Unlike the `mail` service (COM-based Outlook/IMAP/SMTP), `office365` uses **OAuth tokens managed by Integration Service** — no local Outlook installation needed.
+The Microsoft 365 API provides coded workflow access to **Mail, Calendar, Excel (cloud), OneDrive, and SharePoint** via the Microsoft Graph API. Unlike the `mail` service (COM-based Outlook/IMAP/SMTP), `office365` uses **OAuth tokens managed by Integration Platform & Experiences** — no local Outlook installation needed.
 
 ### Architecture
 
@@ -25,7 +25,7 @@ office365 (IOffice365ConnectionsService)
 
 ### Prerequisites
 
-1. **Integration Service connections** must be configured in UiPath Automation Cloud
+1. **Integration Platform & Experiences connections** must be configured in UiPath Automation Cloud
 2. Studio auto-generates `ConnectionsManager.cs` and `ConnectionsFactory.cs` in `.codedworkflows/` with typed connection accessors
 3. Access connections via the `connections` property on `CodedWorkflow`
 

--- a/skills/uipath-coded-agents/references/bindings-reference.md
+++ b/skills/uipath-coded-agents/references/bindings-reference.md
@@ -296,7 +296,7 @@ results = sdk.context_grounding.search(name="index_name", query="...", folder_pa
 
 ---
 
-### Connection (Integration Service)
+### Connection (Integration Platform & Experiences)
 
 **SDK call:**
 ```python

--- a/skills/uipath-coded-agents/references/sdk-services.md
+++ b/skills/uipath-coded-agents/references/sdk-services.md
@@ -28,7 +28,7 @@ sdk = UiPath(client_id="id", client_secret="secret", scope="scope", base_url="ur
 | Context Grounding | `sdk.context_grounding` | RAG index management and search |
 | Documents | `sdk.documents` | Document extraction and validation |
 | Entities | `sdk.entities` | Data Service entity and record management |
-| Connections | `sdk.connections` | Integration Service connections |
+| Connections | `sdk.connections` | Integration Platform & Experiences connections |
 | LLM | `sdk.llm` | Chat completions via normalized LLM Gateway |
 | LLM OpenAI | `sdk.llm_openai` | OpenAI-compatible chat and embeddings |
 | Guardrails | `sdk.guardrails` | Evaluate guardrails on data |

--- a/skills/uipath-coded-workflows/SKILL.md
+++ b/skills/uipath-coded-workflows/SKILL.md
@@ -111,7 +111,7 @@ Choose your task to find the right reference files:
 | **Add a test case** | [operations-guide.md § Add Test Case](references/operations-guide.md) |
 | **Write UI automation** | [ui-automation.md](../../references/activity-docs/UiPath.UIAutomation.Activities/26.2/coded/ui-automation.md) → [operations-guide.md § Indicate](references/operations-guide.md) |
 | **Use Excel/Word/Mail/etc.** | Service table below → activity reference in `../../references/activity-docs/{PackageId}/{Version}/coded/` (e.g. [excel](../../references/activity-docs/UiPath.Excel.Activities/3.5/coded/excel.md), [word](../../references/activity-docs/UiPath.Word.Activities/2.5/coded/word.md), [mail](../../references/activity-docs/UiPath.Mail.Activities/2.8/coded/mail.md), [powerpoint](../../references/activity-docs/UiPath.Presentations.Activities/2.5/coded/powerpoint.md)) |
-| **Use Office 365 / Google** | Service table below → [codedworkflow-reference.md § Integration Service](references/codedworkflow-reference.md) |
+| **Use Office 365 / Google** | Service table below → [codedworkflow-reference.md § Integration Platform & Experiences](references/codedworkflow-reference.md) |
 | **Use Azure services** | Service table below → [azure](../../references/activity-docs/UiPath.Azure.Activities/1.7/coded/azure.md) |
 | **Use Google Cloud (GCP)** | Service table below → [google-cloud](../../references/activity-docs/UiPath.GoogleCloud.Activities/2.5/coded/google-cloud.md) |
 | **Use Exchange Server** | Service table below → [exchange-server](../../references/activity-docs/UiPath.ExchangeServer.Activities/1.4/coded/exchange-server.md) |
@@ -180,7 +180,7 @@ These packages provide services for cloud platforms, virtualization, directory s
 | `hyperv` | `UiPath.HyperV.Activities` | [hyperv](../../references/activity-docs/UiPath.HyperV.Activities/1.4/coded/hyperv.md) |
 | `netiq` | `UiPath.NetIQeDirectory.Activities` | [netiq-edirectory](../../references/activity-docs/UiPath.NetIQeDirectory.Activities/1.6/coded/netiq-edirectory.md) |
 
-> **Note:** The `office365` and `google` services require **Integration Service connections** configured in UiPath Automation Cloud. They inject both a service property (`office365` / `google`) and a `connections` property for accessing configured connection instances. `office365` provides Mail, Calendar, Excel (cloud), OneDrive, and SharePoint via Microsoft Graph API. `google` provides Gmail, Google Calendar, Google Drive, Google Sheets, and Google Docs via Google Workspace APIs. Both use OAuth tokens managed by Integration Service — see [references/codedworkflow-reference.md § Integration Service Connections](references/codedworkflow-reference.md).
+> **Note:** The `office365` and `google` services require **Integration Platform & Experiences connections** configured in UiPath Automation Cloud. They inject both a service property (`office365` / `google`) and a `connections` property for accessing configured connection instances. `office365` provides Mail, Calendar, Excel (cloud), OneDrive, and SharePoint via Microsoft Graph API. `google` provides Gmail, Google Calendar, Google Drive, Google Sheets, and Google Docs via Google Workspace APIs. Both use OAuth tokens managed by Integration Platform & Experiences — see [references/codedworkflow-reference.md § Integration Platform & Experiences Connections](references/codedworkflow-reference.md).
 
 ### Determining Package Version for Activity Docs
 
@@ -273,4 +273,4 @@ When you finish a task, report to the user:
 1. **What was done** — files created, edited, or deleted (list file paths)
 2. **Validation status** — whether all files passed validation (or remaining errors if max retries hit)
 3. **How to run** — the `uip rpa run-file` command to execute the workflow (if applicable)
-4. **Next steps** — any follow-up actions the user should take (e.g. configure Integration Service connections, add Object Repository elements)
+4. **Next steps** — any follow-up actions the user should take (e.g. configure Integration Platform & Experiences connections, add Object Repository elements)

--- a/skills/uipath-coded-workflows/references/codedworkflow-reference.md
+++ b/skills/uipath-coded-workflows/references/codedworkflow-reference.md
@@ -54,9 +54,9 @@ var result = RunWorkflow(workflowPath, new Dictionary<string, object>
 
 Services are accessed as properties on `this`: `system.GetAsset(...)`, `excel.ReadRange(...)`, `testing.VerifyExpression(...)`, etc. See the Service-to-Package mapping in SKILL.md.
 
-## Integration Service Connections
+## Integration Platform & Experiences Connections
 
-When packages that use Integration Service connections are installed (e.g. `UiPath.MicrosoftOffice365.Activities`, `UiPath.GSuite.Activities`), Studio auto-generates two files in `.codedworkflows/`:
+When packages that use Integration Platform & Experiences connections are installed (e.g. `UiPath.MicrosoftOffice365.Activities`, `UiPath.GSuite.Activities`), Studio auto-generates two files in `.codedworkflows/`:
 
 - **`ConnectionsManager.cs`** — Exposes a typed property for each connection category (e.g. `O365Mail`, `Excel`, `OneDrive`, `Gmail`, etc.)
 - **`ConnectionsFactory.cs`** — Contains factory classes with typed properties for each configured connection instance
@@ -65,7 +65,7 @@ These are injected via the `connections` property on `CodedWorkflow`.
 
 ### How It Works
 
-1. **Configure connections** in UiPath Automation Cloud → Integration Service
+1. **Configure connections** in UiPath Automation Cloud → Integration Platform & Experiences
 2. **Studio detects them** and generates typed accessors in `.codedworkflows/`
 3. **Access in code** via `connections.<FactoryName>.<ConnectionName>`
 
@@ -92,7 +92,7 @@ public class ConnectionsManager
 ```csharp
 public class O365MailFactory
 {
-    // Connection name derived from Integration Service display name
+    // Connection name derived from Integration Platform & Experiences display name
     public MailConnection My_Workspace_user_company_com { get; set; }
 
     public O365MailFactory(ICodedWorkflowsServiceContainer resolver)
@@ -139,9 +139,9 @@ mailService.SendEmail("recipient@example.com", "Subject", "Body");
 
 ### Important Notes
 
-- Connection names in the factory are sanitized versions of the Integration Service display name (spaces/special chars replaced with `_`)
-- The connection ID (GUID) is embedded in the factory — it references the specific Integration Service connection
-- If a connection is **not authorized** or the token is expired, you get `ConnectionHttpException: Connection [...] failed to authorize` at runtime — re-authorize in Automation Cloud → Integration Service
+- Connection names in the factory are sanitized versions of the Integration Platform & Experiences display name (spaces/special chars replaced with `_`)
+- The connection ID (GUID) is embedded in the factory — it references the specific Integration Platform & Experiences connection
+- If a connection is **not authorized** or the token is expired, you get `ConnectionHttpException: Connection [...] failed to authorize` at runtime — re-authorize in Automation Cloud → Integration Platform & Experiences
 - The `connections` property is always available on `CodedWorkflow` regardless of installed packages, but the factory properties (`.O365Mail`, `.OneDrive`, etc.) only exist when the corresponding package is installed and connections are configured
 
 ## The `workflows` Property (Strongly-Typed Workflow Invocation)

--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-platform
-description: "UiPath development environment assistant — authentication, Orchestrator management (folders, assets, queues, storage buckets), solution lifecycle (pack, publish, deploy), Integration Service, resources management, Test Manager, CLI tools, and general UiPath platform knowledge. TRIGGER when: User asks about UiPath platform operations (authentication, Orchestrator, folders, assets, robots, queues, packages, processes, storage buckets); User asks about solution lifecycle (pack, publish, deploy, activate); User references Integration Service (connectors, connections, activities, resources); User wants to manage resources (assets, queues, queue items, storage buckets, bucket files); User wants to use Test Manager (projects, test sets, test cases, executions, results, reports); User wants to use uip CLI commands; User asks about environment setup, credentials, or tenant configuration; User asks general UiPath platform questions (folders, robots, queues, triggers, machine policies). DO NOT TRIGGER when: User is writing or editing workflow code (use uipath-coded-workflows or uipath-rpa-workflows instead), or asking how to automate a specific task within a workflow."
+description: "UiPath development environment assistant — authentication, Orchestrator management (folders, assets, queues, storage buckets), solution lifecycle (pack, publish, deploy), Integration Platform & Experiences, resources management, Test Manager, CLI tools, and general UiPath platform knowledge. TRIGGER when: User asks about UiPath platform operations (authentication, Orchestrator, folders, assets, robots, queues, packages, processes, storage buckets); User asks about solution lifecycle (pack, publish, deploy, activate); User references Integration Platform & Experiences (connectors, connections, activities, resources); User wants to manage resources (assets, queues, queue items, storage buckets, bucket files); User wants to use Test Manager (projects, test sets, test cases, executions, results, reports); User wants to use uip CLI commands; User asks about environment setup, credentials, or tenant configuration; User asks general UiPath platform questions (folders, robots, queues, triggers, machine policies). DO NOT TRIGGER when: User is writing or editing workflow code (use uipath-coded-workflows or uipath-rpa-workflows instead), or asking how to automate a specific task within a workflow."
 metadata: 
    allowed-tools: Bash, Read, Write, Glob, Grep
 ---
@@ -40,7 +40,7 @@ This token can be reused for direct Orchestrator REST API calls when CLI command
 
 ### Step 1 — Authenticate
 
-Before interacting with Orchestrator, solutions, or Integration Service, the user must be logged in.
+Before interacting with Orchestrator, solutions, or Integration Platform & Experiences, the user must be logged in.
 
 **Interactive login (browser OAuth2):**
 ```bash
@@ -96,7 +96,7 @@ Choose the appropriate operation from the Task Navigation table below.
 | **Use Test Manager** (projects, test sets, test cases, executions, reports) | [references/test-manager/test-manager-guide.md](references/test-manager/test-manager-guide.md) |
 | **Install / manage CLI tools** | [references/uip-commands.md - Tools](references/uip-commands.md) |
 | **Set up CI/CD pipeline** | [references/solution-guide.md - CI/CD](references/solution-guide.md) |
-| **Use Integration Service** (connectors, connections, activities, resources) | [references/integration-service/integration-service.md](references/integration-service/integration-service.md) |
+| **Use Integration Platform & Experiences** (connectors, connections, activities, resources) | [references/integration-platform-experiences/integration-platform-experiences.md](references/integration-platform-experiences/integration-platform-experiences.md) |
 | **Full CLI command reference** | [references/uip-commands.md](references/uip-commands.md) |
 | **Build/run/validate coded workflows** | [/uipath-coded-workflows:uipath-coded-workflows](/uipath-coded-workflows:uipath-coded-workflows) |
 
@@ -185,7 +185,7 @@ The UiPath CLI (`uip`) is a unified command-line tool for interacting with the U
 | **Orchestrator** | `or` | Folders, jobs, processes, releases | Available |
 | **Resources** | `resources` | Assets, queues, queue items, storage buckets, bucket files | Available |
 | **Solutions** | `solution` | Create, pack, publish, deploy solutions | Available |
-| **Integration Service** | `is` | Connectors, connections, activities, resources | Available |
+| **Integration Platform & Experiences** | `ipe` | Connectors, connections, activities, resources | Available |
 | **Test Manager** | `tm` | Test projects, test sets, test cases, executions, reports | Available |
 | **Tools** | `tools` | CLI tool extension management | Available |
 | **MCP** | `mcp` | Model Context Protocol server | Available |
@@ -260,5 +260,5 @@ The `X-UIPATH-OrganizationUnitId` header is the **folder ID** (get it from `uip 
 - **[Resources Guide](references/resources/resources-guide.md)** — Assets, queues, queue items, storage buckets, bucket files
 - **[Solution Guide](references/solution-guide.md)** — Solution lifecycle: create, pack, publish, deploy
 - **[Test Manager Guide](references/test-manager/test-manager-guide.md)** — Test projects, test sets, test cases, executions, reports, attachments
-- **[Integration Service](references/integration-service/integration-service.md)** — Connectors, connections, activities, resources for third-party services
+- **[Integration Platform & Experiences](references/integration-platform-experiences/integration-platform-experiences.md)** — Connectors, connections, activities, resources for third-party services
 - **[Coded Workflows](/uipath-coded-workflows:uipath-coded-workflows)** — Building coded automation projects

--- a/skills/uipath-platform/references/integration-platform-experiences/activities.md
+++ b/skills/uipath-platform/references/integration-platform-experiences/activities.md
@@ -2,14 +2,14 @@
 
 Activities are pre-built actions available for each connector (e.g., "Send Message", "Create Issue"). They represent specific operations the connector supports. Activities include both **actions** (non-trigger) and **triggers** (event listeners).
 
-> Full command syntax and options: [uip-commands.md — Integration Service](../uip-commands.md#integration-service-is). Domain-specific usage patterns are shown inline below.
+> Full command syntax and options: [uip-commands.md — Integration Platform & Experiences](../uip-commands.md#integration-platform--experiences-ipe). Domain-specific usage patterns are shown inline below.
 
 ---
 
 ## List Activities (Non-Trigger)
 
 ```bash
-uip is activities list "<connector-key>" --format json
+uip ipe activities list "<connector-key>" --format json
 ```
 
 This lists **non-trigger activities only** (actions, not event listeners).
@@ -17,7 +17,7 @@ This lists **non-trigger activities only** (actions, not event listeners).
 ## List Trigger Activities
 
 ```bash
-uip is activities list "<connector-key>" --triggers --format json
+uip ipe activities list "<connector-key>" --triggers --format json
 ```
 
 The `--triggers` flag filters to **trigger activities only** (`isTrigger=true`). These represent events the connector can fire (e.g., "Record Created", "Record Updated").
@@ -44,8 +44,8 @@ The **Operation** field on trigger activities indicates the trigger type:
 
 ## When to Use Activities vs Resources vs Triggers
 
-- **Activities** = named actions (e.g., "Send Email"). Discovered via `is activities list`.
-- **Triggers** = event listeners (e.g., "Record Created"). Discovered via `is activities list --triggers`. Metadata via `is triggers objects` / `is triggers describe`. See [triggers.md](triggers.md).
-- **Resources** = data objects with CRUD (e.g., "Account"). Discovered via `is resources list`. Executed via `is resources execute <verb>`.
+- **Activities** = named actions (e.g., "Send Email"). Discovered via `ipe activities list`.
+- **Triggers** = event listeners (e.g., "Record Created"). Discovered via `ipe activities list --triggers`. Metadata via `ipe triggers objects` / `ipe triggers describe`. See [triggers.md](triggers.md).
+- **Resources** = data objects with CRUD (e.g., "Account"). Discovered via `ipe resources list`. Executed via `ipe resources execute <verb>`.
 
 > After listing activities, present the available actions to the user. Activities provide context for what a connector can do — use this to guide which resource operations, triggers, or workflow actions to pursue.

--- a/skills/uipath-platform/references/integration-platform-experiences/agent-workflow.md
+++ b/skills/uipath-platform/references/integration-platform-experiences/agent-workflow.md
@@ -31,7 +31,7 @@ Copy and track progress:
 ## Step 1: Find the Connector
 
 ```bash
-uip is connectors list --filter "<vendor>" --format json
+uip ipe connectors list --filter "<vendor>" --format json
 ```
 
 | Outcome | Action |
@@ -42,33 +42,33 @@ uip is connectors list --filter "<vendor>" --format json
 ## Step 2: Find a Connection
 
 ```bash
-uip is connections list "<connector-key>" --format json
+uip ipe connections list "<connector-key>" --format json
 ```
 
 - **Native**: Pick default enabled connection (`IsDefault: Yes`, `State: Enabled`).
 - **HTTP fallback**: Match connection by vendor **Name** (case-insensitive substring).
 - **Multiple**: Present options to the user.
-- **None**: Ask user to create via `is connections create "<connector-key>"`.
+- **None**: Ask user to create via `ipe connections create "<connector-key>"`.
 
 See [connections.md — Selecting a Connection](connections.md#selecting-a-connection) for full selection logic.
 
 ## Step 3: Ping the Connection
 
 ```bash
-uip is connections ping "<connection-id>" --format json
+uip ipe connections ping "<connection-id>" --format json
 ```
 
 | Result | Action |
 |---|---|
 | `Enabled` | Healthy. Proceed to Step 4. |
-| Fails | Run `is connections edit <id>` to re-authenticate, then ping again. If still fails, ask user to choose another or create new. |
+| Fails | Run `ipe connections edit <id>` to re-authenticate, then ping again. If still fails, ask user to choose another or create new. |
 
 ## Step 4: Discover Capabilities
 
 **4a. Check activities first** — activities are pre-built actions (e.g., "Send Email", "Create Invoice") that may directly accomplish the task:
 
 ```bash
-uip is activities list "<connector-key>" --format json
+uip ipe activities list "<connector-key>" --format json
 ```
 
 | Outcome | Action |
@@ -79,14 +79,14 @@ uip is activities list "<connector-key>" --format json
 **4b. List resources** — if no activity matches, discover CRUD-capable objects. **Always pass `--connection-id`** to include custom objects, and **`--operation`** to filter to the intended action:
 
 ```bash
-uip is resources list "<connector-key>" \
+uip ipe resources list "<connector-key>" \
   --connection-id "<id>" --operation <Create|List|Retrieve|Update|Delete|Replace> --format json
 ```
 
 **4c. Describe the target resource** — get field metadata for the matched object:
 
 ```bash
-uip is resources describe "<connector-key>" "<object>" \
+uip ipe resources describe "<connector-key>" "<object>" \
   --connection-id "<id>" --operation <operation> --format json
 ```
 
@@ -104,7 +104,7 @@ If the user's task involves **event triggers** (e.g., "when a record is created"
 **4T-a. List trigger activities** to see what events the connector supports:
 
 ```bash
-uip is activities list "<connector-key>" --triggers --format json
+uip ipe activities list "<connector-key>" --triggers --format json
 ```
 
 Present trigger activities to the user. Note the **Operation** field (e.g., CREATED, UPDATED, DELETED).
@@ -112,7 +112,7 @@ Present trigger activities to the user. Note the **Operation** field (e.g., CREA
 **4T-b. For CREATED/UPDATED/DELETED operations** — get available trigger objects:
 
 ```bash
-uip is triggers objects "<connector-key>" "<OPERATION>" \
+uip ipe triggers objects "<connector-key>" "<OPERATION>" \
   --connection-id "<id>" --format json
 ```
 
@@ -121,7 +121,7 @@ Present objects to the user and let them choose.
 **4T-c. Get trigger field metadata** for the selected object:
 
 ```bash
-uip is triggers describe "<connector-key>" "<OPERATION>" "<object-name>" \
+uip ipe triggers describe "<connector-key>" "<OPERATION>" "<object-name>" \
   --connection-id "<id>" --format json
 ```
 
@@ -146,7 +146,7 @@ See [resources.md — Reference Fields](resources.md#reference-fields-critical) 
 ## Step 6: Execute
 
 ```bash
-uip is resources execute <verb> "<connector-key>" "<object>" \
+uip ipe resources execute <verb> "<connector-key>" "<object>" \
   --connection-id "<id>" --body '{"field": "value"}' --format json
 ```
 
@@ -158,35 +158,35 @@ See [resources.md — Execute Operations](resources.md#execute-operations) for t
 
 ```bash
 # 1. Find connector
-uip is connectors list --filter "salesforce" --format json
+uip ipe connectors list --filter "salesforce" --format json
 # → Key: "uipath-salesforce-sfdc"
 
 # 2. Find connection
-uip is connections list "uipath-salesforce-sfdc" --format json
+uip ipe connections list "uipath-salesforce-sfdc" --format json
 # → Id: "abc-123", IsDefault: Yes, State: Enabled
 
 # 3. Ping
-uip is connections ping "abc-123" --format json
+uip ipe connections ping "abc-123" --format json
 # → Status: Enabled
 
 # 4a. Check activities first
-uip is activities list "uipath-salesforce-sfdc" --format json
+uip ipe activities list "uipath-salesforce-sfdc" --format json
 # → No matching activity for "create contact" → fall back to resources
 
 # 4b. List resources with operation
-uip is resources list "uipath-salesforce-sfdc" \
+uip ipe resources list "uipath-salesforce-sfdc" \
   --connection-id "abc-123" --operation Create --format json
 # → includes "Contact"
 
 # 4c. Describe the target resource
-uip is resources describe "uipath-salesforce-sfdc" "Contact" \
+uip ipe resources describe "uipath-salesforce-sfdc" "Contact" \
   --connection-id "abc-123" --operation Create --format json
 # → requiredFields: [LastName], optionalFields: [FirstName, Email, ...], referenceFields: []
 
 # 5. No referenceFields → skip resolution, go straight to execute
 
 # 6. Execute
-uip is resources execute create "uipath-salesforce-sfdc" "Contact" \
+uip ipe resources execute create "uipath-salesforce-sfdc" "Contact" \
   --connection-id "abc-123" --body '{"LastName": "Doe", "FirstName": "Jane"}' --format json
 ```
 
@@ -196,29 +196,29 @@ uip is resources execute create "uipath-salesforce-sfdc" "Contact" \
 
 ```bash
 # 1. Find connector
-uip is connectors list --filter "salesforce" --format json
+uip ipe connectors list --filter "salesforce" --format json
 # → Key: "uipath-salesforce-sfdc"
 
 # 2. Find connection
-uip is connections list "uipath-salesforce-sfdc" --format json
+uip ipe connections list "uipath-salesforce-sfdc" --format json
 # → Id: "228624", IsDefault: Yes, State: Enabled
 
 # 3. Ping
-uip is connections ping "228624" --format json
+uip ipe connections ping "228624" --format json
 # → Status: Enabled
 
 # 4T-a. List trigger activities
-uip is activities list "uipath-salesforce-sfdc" --triggers --format json
+uip ipe activities list "uipath-salesforce-sfdc" --triggers --format json
 # → Trigger activities with Operation: CREATED, UPDATED, DELETED
 
 # 4T-b. Get objects for CREATED operation
-uip is triggers objects "uipath-salesforce-sfdc" CREATED \
+uip ipe triggers objects "uipath-salesforce-sfdc" CREATED \
   --connection-id "228624" --format json
 # → [AccountHistory, Contact, Lead, ...]
 # → User picks "AccountHistory"
 
 # 4T-c. Get trigger metadata (fields) for AccountHistory
-uip is triggers describe "uipath-salesforce-sfdc" CREATED "AccountHistory" \
+uip ipe triggers describe "uipath-salesforce-sfdc" CREATED "AccountHistory" \
   --connection-id "228624" --format json
 # → Returns field definitions (names, types, descriptions)
 ```

--- a/skills/uipath-platform/references/integration-platform-experiences/connections.md
+++ b/skills/uipath-platform/references/integration-platform-experiences/connections.md
@@ -2,7 +2,7 @@
 
 Connections are authenticated sessions for a specific connector. They store credentials and tokens, and can be shared across automations within a folder.
 
-> Full command syntax and options: [uip-commands.md — Integration Service](../uip-commands.md#integration-service-is). Domain-specific usage patterns are shown inline below.
+> Full command syntax and options: [uip-commands.md — Integration Platform & Experiences](../uip-commands.md#integration-platform--experiences-ipe). Domain-specific usage patterns are shown inline below.
 
 ---
 

--- a/skills/uipath-platform/references/integration-platform-experiences/connectors.md
+++ b/skills/uipath-platform/references/integration-platform-experiences/connectors.md
@@ -2,7 +2,7 @@
 
 Connectors are pre-built integrations to external applications. Each connector has a unique key (e.g., `uipath-salesforce-sfdc`, `uipath-servicenow-servicenow`). A connector contains **connections** (authenticated sessions), **activities** (pre-built actions), and **resources** (object types with CRUD operations).
 
-> Full command syntax and options: [uip-commands.md — Integration Service](../uip-commands.md#integration-service-is). Domain-specific usage patterns are shown inline below.
+> Full command syntax and options: [uip-commands.md — Integration Platform & Experiences](../uip-commands.md#integration-platform--experiences-ipe). Domain-specific usage patterns are shown inline below.
 
 ---
 
@@ -24,11 +24,11 @@ When no native connector exists for a vendor, use the HTTP connector (`uipath-ui
 
 ```bash
 # Search for vendor → not found → fall back to HTTP connector
-uip is connectors list --filter "apify" --format json
+uip ipe connectors list --filter "apify" --format json
 # → No connectors found
 
 # List HTTP connections and look for one named after the vendor
-uip is connections list "uipath-uipath-http" --format json
+uip ipe connections list "uipath-uipath-http" --format json
 ```
 
 The HTTP connector supports generic HTTP requests (GET, POST, PUT, PATCH, DELETE) to any REST API. The connection stores the authentication configuration (API keys, OAuth tokens, base URL).
@@ -44,7 +44,7 @@ The HTTP connector supports generic HTTP requests (GET, POST, PUT, PATCH, DELETE
 The HTTP connector has a single resource: `http-request`.
 
 ```bash
-uip is resources execute create "uipath-uipath-http" "http-request" \
+uip ipe resources execute create "uipath-uipath-http" "http-request" \
   --connection-id "<id>" \
   --body '{"method": "GET", "url": "https://api.example.com/v2/resource"}' \
   --format json

--- a/skills/uipath-platform/references/integration-platform-experiences/integration-platform-experiences.md
+++ b/skills/uipath-platform/references/integration-platform-experiences/integration-platform-experiences.md
@@ -1,8 +1,8 @@
-# Integration Service
+# Integration Platform & Experiences
 
-Interact with external services through UiPath Integration Service — discover connectors, manage connections, and execute operations via the `uip` CLI.
+Interact with external services through UiPath Integration Platform & Experiences — discover connectors, manage connections, and execute operations via the `uip` CLI.
 
-> Full command syntax and options: [uip-commands.md — Integration Service](../uip-commands.md#integration-service-is). Domain-specific usage patterns are shown inline in each reference file.
+> Full command syntax and options: [uip-commands.md — Integration Platform & Experiences](../uip-commands.md#integration-platform--experiences-ipe). Domain-specific usage patterns are shown inline in each reference file.
 
 ## Prerequisites
 
@@ -45,7 +45,7 @@ When multiple options exist, present them clearly:
 
 | Problem | Recovery |
 |---|---|
-| Ping returns non-enabled | Run `is connections edit <id>` to re-authenticate, then ping again. If still fails, ask user to choose another connection or create new. |
+| Ping returns non-enabled | Run `ipe connections edit <id>` to re-authenticate, then ping again. If still fails, ask user to choose another connection or create new. |
 | List returns empty after `--refresh` | Inform user the data does not exist. Do not retry. Suggest checking permissions or folder context. |
 | Reference field lookup returns empty | Inform user — the referenced object has no records. Ask if they want to create one or use a different value. |
 | Execute fails with validation error | Re-check describe output for required fields. Verify field types and reference IDs are correct. |

--- a/skills/uipath-platform/references/integration-platform-experiences/resources.md
+++ b/skills/uipath-platform/references/integration-platform-experiences/resources.md
@@ -2,7 +2,7 @@
 
 Resources represent the data objects available through a connector (e.g., Salesforce Account, Contact, Opportunity). Each resource supports a set of CRUD operations.
 
-> Full command syntax and options: [uip-commands.md — Integration Service](../uip-commands.md#integration-service-is). Domain-specific usage patterns are shown inline below.
+> Full command syntax and options: [uip-commands.md — Integration Platform & Experiences](../uip-commands.md#integration-platform--experiences-ipe). Domain-specific usage patterns are shown inline below.
 
 ## Contents
 - Listing and Describing Resources
@@ -74,7 +74,7 @@ A reference field in the describe output:
   "field": "departmentId",
   "referencedObject": "departments",
   "lookupValue": "id",
-  "hint": "Resolve by executing: is resources execute list ... \"departments\" ..."
+  "hint": "Resolve by executing: ipe resources execute list ... \"departments\" ..."
 }
 ```
 
@@ -82,17 +82,17 @@ A reference field in the describe output:
 
 ```bash
 # 1. Describe → discover referenceFields: departmentId → "departments", contactId → "contacts"
-uip is resources describe "uipath-zoho-desk" "tickets" \
+uip ipe resources describe "uipath-zoho-desk" "tickets" \
   --connection-id "<id>" --operation Create --format json
 
 # 2. Resolve references
-uip is resources execute list "uipath-zoho-desk" "departments" --connection-id "<id>" --format json
+uip ipe resources execute list "uipath-zoho-desk" "departments" --connection-id "<id>" --format json
 # → { "id": "1892000000006907", "name": "Engineering" }
-uip is resources execute list "uipath-zoho-desk" "contacts" --connection-id "<id>" --format json
+uip ipe resources execute list "uipath-zoho-desk" "contacts" --connection-id "<id>" --format json
 # → { "id": "1892000000048009", "name": "John Doe" }
 
 # 3. Execute with resolved IDs
-uip is resources execute create "uipath-zoho-desk" "tickets" \
+uip ipe resources execute create "uipath-zoho-desk" "tickets" \
   --connection-id "<id>" \
   --body '{"departmentId": "1892000000006907", "subject": "Bug report", "contactId": "1892000000048009"}' \
   --format json
@@ -105,7 +105,7 @@ uip is resources execute create "uipath-zoho-desk" "tickets" \
 When describe metadata is unavailable (see [Describe Failures](#describe-failures)), infer reference fields from naming conventions:
 
 - Fields ending in **`Id`** (e.g., `PromotionId`, `AccountId`) typically reference the object with the matching base name (`Promotion`, `Account`).
-- List the inferred object to resolve the ID: `is resources execute list "<connector-key>" "<base-name>" --connection-id "<id>" --format json`
+- List the inferred object to resolve the ID: `ipe resources execute list "<connector-key>" "<base-name>" --connection-id "<id>" --format json`
 - Match the user's value by `Name` or `DisplayName` in the results.
 
 ### Example: Coupon → Promotion (no describe available)
@@ -113,12 +113,12 @@ When describe metadata is unavailable (see [Describe Failures](#describe-failure
 ```bash
 # User wants: create coupon "XYZ" for promotion "Chandu Test"
 # Infer: PromotionId → list Promotion objects
-uip is resources execute list "uipath-salesforce-sfdc" "Promotion" \
+uip ipe resources execute list "uipath-salesforce-sfdc" "Promotion" \
   --connection-id "<id>" --format json
 # → { "Id": "<promotion-id>", "Name": "Summer Sale" }
 
 # Use resolved Id in create
-uip is resources execute create "uipath-salesforce-sfdc" "Coupon" \
+uip ipe resources execute create "uipath-salesforce-sfdc" "Coupon" \
   --connection-id "<id>" \
   --body '{"CouponCode": "SAVE20", "PromotionId": "<promotion-id>"}' --format json
 ```
@@ -160,7 +160,7 @@ Some objects have auto-generated fields that cannot be set on create (e.g., Sale
 List operations may return paginated results. Use `--query "limit=50&offset=0"` and increment `offset` by `limit` to page through. Stop when the result set is empty or smaller than the limit.
 
 ```bash
-uip is resources execute list "<connector-key>" "<object>" \
+uip ipe resources execute list "<connector-key>" "<object>" \
   --connection-id "<id>" --query "limit=50&offset=0" --format json
 # → next page: --query "limit=50&offset=50"
 ```

--- a/skills/uipath-platform/references/integration-platform-experiences/triggers.md
+++ b/skills/uipath-platform/references/integration-platform-experiences/triggers.md
@@ -2,7 +2,7 @@
 
 Triggers are event-based activities that fire when something happens in an external system (e.g., a Salesforce record is created, updated, or deleted). Use trigger metadata to discover which objects and fields are available for each event type.
 
-> Full command syntax and options: [uip-commands.md — Integration Service](../uip-commands.md#integration-service-is). Domain-specific usage patterns are shown inline below.
+> Full command syntax and options: [uip-commands.md — Integration Platform & Experiences](../uip-commands.md#integration-platform--experiences-ipe). Domain-specific usage patterns are shown inline below.
 
 ---
 
@@ -32,7 +32,7 @@ Triggers are event-based activities that fire when something happens in an exter
 ## List Trigger Activities
 
 ```bash
-uip is activities list "<connector-key>" --triggers --format json
+uip ipe activities list "<connector-key>" --triggers --format json
 ```
 
 Returns activities where `isTrigger=true`. The **Operation** field indicates the event type.
@@ -44,10 +44,10 @@ Returns activities where `isTrigger=true`. The **Operation** field indicates the
 List objects available for a specific trigger operation:
 
 ```bash
-uip is triggers objects "<connector-key>" "<OPERATION>" --format json
+uip ipe triggers objects "<connector-key>" "<OPERATION>" --format json
 
 # With connection (includes custom objects):
-uip is triggers objects "<connector-key>" "<OPERATION>" \
+uip ipe triggers objects "<connector-key>" "<OPERATION>" \
   --connection-id "<id>" --format json
 ```
 
@@ -62,10 +62,10 @@ uip is triggers objects "<connector-key>" "<OPERATION>" \
 Get field metadata for a trigger object:
 
 ```bash
-uip is triggers describe "<connector-key>" "<OPERATION>" "<object-name>" --format json
+uip ipe triggers describe "<connector-key>" "<OPERATION>" "<object-name>" --format json
 
 # With connection (includes custom fields):
-uip is triggers describe "<connector-key>" "<OPERATION>" "<object-name>" \
+uip ipe triggers describe "<connector-key>" "<OPERATION>" "<object-name>" \
   --connection-id "<id>" --format json
 ```
 
@@ -108,18 +108,18 @@ Object with field definitions. Structure varies by connector but typically inclu
 
 ```bash
 # 1. List trigger activities for Salesforce
-uip is activities list "uipath-salesforce-sfdc" --triggers --format json
+uip ipe activities list "uipath-salesforce-sfdc" --triggers --format json
 # → Operations: CREATED, UPDATED, DELETED
 # → User selects CREATED
 
 # 2. Get objects for CREATED operation
-uip is triggers objects "uipath-salesforce-sfdc" CREATED \
+uip ipe triggers objects "uipath-salesforce-sfdc" CREATED \
   --connection-id "228624" --format json
 # → [AccountHistory, Contact, Lead, Opportunity, ...]
 # → User picks "AccountHistory"
 
 # 3. Get field metadata for AccountHistory
-uip is triggers describe "uipath-salesforce-sfdc" CREATED "AccountHistory" \
+uip ipe triggers describe "uipath-salesforce-sfdc" CREATED "AccountHistory" \
   --connection-id "228624" --format json
 # → Returns field definitions with types and descriptions
 ```
@@ -128,11 +128,11 @@ uip is triggers describe "uipath-salesforce-sfdc" CREATED "AccountHistory" \
 
 ```bash
 # 1. List trigger activities
-uip is activities list "uipath-some-connector" --triggers --format json
+uip ipe activities list "uipath-some-connector" --triggers --format json
 # → Name: "custom_event_trigger", Operation: "WEBHOOK", ObjectName: "WebhookPayload"
 
 # 2. Skip objects step — go directly to describe using ObjectName
-uip is triggers describe "uipath-some-connector" "WEBHOOK" "WebhookPayload" \
+uip ipe triggers describe "uipath-some-connector" "WEBHOOK" "WebhookPayload" \
   --connection-id "<id>" --format json
 # → Returns field definitions
 ```

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -58,16 +58,16 @@ Create, pack, publish, and deploy solutions. See [solution-guide.md](solution-gu
 
 ---
 
-## Integration Service (`is`)
+## Integration Platform & Experiences (`ipe`)
 
-Manage connectors, connections, and resources. See [integration-service/](integration-service/). Use `uip is --help` for all subcommands.
+Manage connectors, connections, and resources. See [integration-platform-experiences/](integration-platform-experiences/). Use `uip ipe --help` for all subcommands.
 
 | Command | Description |
 |---|---|
-| `uip is connectors list` | List all connectors |
-| `uip is connections list [connector-key]` | List connections |
-| `uip is connections create <connector-key>` | Create a connection |
-| `uip is connections ping <connection-id>` | Test connection health |
+| `uip ipe connectors list` | List all connectors |
+| `uip ipe connections list [connector-key]` | List connections |
+| `uip ipe connections create <connector-key>` | Create a connection |
+| `uip ipe connections ping <connection-id>` | Test connection health |
 
 ---
 

--- a/skills/uipath-rpa-workflows/SKILL.md
+++ b/skills/uipath-rpa-workflows/SKILL.md
@@ -24,7 +24,7 @@ This skill uses `uip` CLI commands (via `Bash`) and Claude Code's built-in tools
 
 All `uip` commands support `--format <format>` (table, json, yaml, plain).
 
-**Always use `--format json`** for commands whose output you need to parse or act on (e.g., `get-errors`, `find-activities`, `list-workflow-examples`, `is connections list`). JSON output is structured, unambiguous, and avoids table-formatting surprises.
+**Always use `--format json`** for commands whose output you need to parse or act on (e.g., `get-errors`, `find-activities`, `list-workflow-examples`, `ipe connections list`). JSON output is structured, unambiguous, and avoids table-formatting surprises.
 
 Use the default (table) only when displaying results directly to the user for readability.
 
@@ -34,9 +34,9 @@ Use the default (table) only when displaying results directly to the user for re
 
 For the full CLI command reference (all tools, parameters, and error recovery), see **[references/cli-reference.md](./references/cli-reference.md)**.
 
-Key commands at a glance: `find-activities`, `get-default-activity-xaml`, `get-errors`, `install-or-update-packages`, `run-file`, `list-workflow-examples`, `get-workflow-example`. For IS connectors: `is connectors list/get`, `is connections list/create/ping`, `is activities list`, `is resources list/describe/execute`.
+Key commands at a glance: `find-activities`, `get-default-activity-xaml`, `get-errors`, `install-or-update-packages`, `run-file`, `list-workflow-examples`, `get-workflow-example`. For IS connectors: `ipe connectors list/get`, `ipe connections list/create/ping`, `ipe activities list`, `ipe resources list/describe/execute`.
 
-**The CLI is fully self-documenting.** Append `--help` or `-h` at any level to discover commands, subcommands, and parameters: `uip --help`, `uip rpa --help`, `uip rpa get-default-activity-xaml --help`, `uip is --help`, `uip is connections --help`, etc.
+**The CLI is fully self-documenting.** Append `--help` or `-h` at any level to discover commands, subcommands, and parameters: `uip --help`, `uip rpa --help`, `uip rpa get-default-activity-xaml --help`, `uip ipe --help`, `uip ipe connections --help`, etc.
 
 ---
 
@@ -265,7 +265,7 @@ When results contain multiple competing packages for the same capability (e.g., 
 **Prompt only as a last resort** — when multiple viable options exist and none of the above signals apply:
 1. Present the top 2–4 choices from the search results
 2. Mark the recommended option with **(Recommended)** — prefer the most modern/full-featured option
-3. Include a one-line difference for each (e.g., "requires Integration Service connection" vs "protocol-based, works on-premise")
+3. Include a one-line difference for each (e.g., "requires Integration Platform & Experiences connection" vs "protocol-based, works on-premise")
 4. Continue with **only** the chosen package
 
 **Save the preference:** After resolving disambiguation (whether auto-selected or user-chosen), suggest saving the preference to `CLAUDE.md` and `AGENTS.md` in the project folder so future sessions auto-select without re-prompting. For example: _"Want me to save this preference (e.g., 'Always use O365 for email activities') to CLAUDE.md and AGENTS.md so it's remembered for future workflows?"_
@@ -285,7 +285,7 @@ uip rpa get-default-activity-xaml --activity-class-name "UiPath.Core.Activities.
 #### For Dynamic Activities
 
 ```bash
-uip is connections list # Find relevant connection ID, if any
+uip ipe connections list # Find relevant connection ID, if any
 uip rpa get-default-activity-xaml --activity-type-id "178a864d-90fd-43d3-a305-249b07ac0127" --connection-id "{connectionId}"
 
 # Or, if no relevant connection, pass an empty string
@@ -301,7 +301,7 @@ uip rpa get-default-activity-xaml --activity-type-id "178a864d-90fd-43d3-a305-24
 **Key parameters:**
 - `--activity-class-name`: For non-dynamic activities. Must be fully qualified (e.g., `UiPath.Core.Activities.WriteLine`)
 - `--activity-type-id`: For dynamic activities. Use `uip rpa find-activities` to find the exact type ID
-- `--connection-id`: Optional, only used for dynamic activities. Discover available connections using `uip is connections list [connector-key]`
+- `--connection-id`: Optional, only used for dynamic activities. Discover available connections using `uip ipe connections list [connector-key]`
 
 **For JIT custom types**, read the schema file:
 
@@ -357,15 +357,15 @@ Glob: pattern="**/*" path="{projectRoot}/.objects/"         → explore object r
 Read: file_path="{projectRoot}/.objects/.metadata"          → object repository metadata
 Read: file_path="{projectRoot}/Main.xaml"                   → existing workflow (variables, arguments, imports)
 Glob: pattern="**/*" path="{projectRoot}/.settings/"        → settings profiles
-Bash: uip is connections list --format json              → available Integration Service connections
-Bash: uip is connectors list --format json               → available connectors
+Bash: uip ipe connections list --format json              → available Integration Platform & Experiences connections
+Bash: uip ipe connectors list --format json               → available connectors
 ```
 
 This surfaces variables, arguments, imports, expression language, available connections, and reusable project-level resources.
 
 ### Step 1.9: Discover Connector Capabilities (For IS/Connector Workflows)
 
-When the workflow involves Integration Service connectors (dynamic activities), explore capabilities and manage connections before writing XAML. See **[references/connector-capabilities.md](./references/connector-capabilities.md)** for the full procedure (activity/resource discovery, connection management, schema inspection).
+When the workflow involves Integration Platform & Experiences connectors (dynamic activities), explore capabilities and manage connections before writing XAML. See **[references/connector-capabilities.md](./references/connector-capabilities.md)** for the full procedure (activity/resource discovery, connection management, schema inspection).
 
 ---
 
@@ -449,7 +449,7 @@ uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --skip-validation --f
 
 **3. Type Errors** — Wrong property type, invalid cast, type mismatch
 - Check the activity doc at `.local/docs/packages/{PackageId}/activities/{ActivityName}.md` for correct types and enum values
-- For dynamic activities, Integration Service connectors, JIT types: see [jit-custom-types-schema.md](./references/jit-custom-types-schema.md)
+- For dynamic activities, Integration Platform & Experiences connectors, JIT types: see [jit-custom-types-schema.md](./references/jit-custom-types-schema.md)
 - If docs are unavailable, use `uip rpa get-default-activity-xaml` to see the expected default property types
 - Push for package updates if docs are missing, inaccurate, or if `get-default-activity-xaml` cannot resolve
 - If default activity activity XAML is unavailable, check for examples in the examples repository (`list-workflow-examples` and `get-workflow-example`)
@@ -458,7 +458,7 @@ uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --skip-validation --f
 - **Primary:** Read the activity doc — it documents all properties, conditional groups (`Visible When`), valid configurations, and enum values
 - **Fallback:** `uip rpa get-default-activity-xaml` for the activity's default XAML template
 - Pay attention to mutually exclusive property groups (OverloadGroups) — setting properties from multiple groups causes errors
-- For IS/dynamic activities, check connection status: `uip is connections list <connector-key> --format json`
+- For IS/dynamic activities, check connection status: `uip ipe connections list <connector-key> --format json`
 
 **5. Logic Errors** — Wrong behavior, incorrect expressions, business logic issues
 - `Read` the XAML to understand current flow → `Edit` to correct
@@ -507,7 +507,7 @@ For CLI error diagnosis and recovery patterns (IPC failures, auth errors, packag
 - Ask the user to choose a service provider without first checking project signals — auto-select when possible (Step 1.5)
 - Retry failing CLI commands in a loop without diagnosing the root cause
 - Skip Phase 0 (Studio readiness) — all subsequent phases depend on Studio IPC
-- Use connector/dynamic activities without checking whether a connection exists (`uip is connections list`)
+- Use connector/dynamic activities without checking whether a connection exists (`uip ipe connections list`)
 
 ---
 
@@ -524,7 +524,7 @@ Before handover, verify:
 - [ ] Activity properties sourced from activity docs, `find-activities`, `get-default-activity-xaml`, `get-workflow-example` (priority ladder followed)
 - [ ] Local project explored for existing patterns and conventions
 - [ ] Service/provider disambiguation resolved — auto-selected or prompted only when ambiguous (Step 1.5)
-- [ ] For connector workflows: connections verified with `uip is connections list`
+- [ ] For connector workflows: connections verified with `uip ipe connections list`
 
 **XAML Content Quality:**
 - [ ] VB.NET or C# syntax matches project language (checked existing workflows)

--- a/skills/uipath-rpa-workflows/references/cli-reference.md
+++ b/skills/uipath-rpa-workflows/references/cli-reference.md
@@ -7,9 +7,9 @@ Complete reference for all `uip` CLI commands and error recovery patterns.
 uip --help                                  # top-level command groups
 uip rpa --help                              # all rpa subcommands
 uip rpa get-default-activity-xaml --help     # parameters for a specific command
-uip is --help                               # Integration Service command groups
-uip is connections --help                   # IS connections subcommands
-uip is connections list --help              # parameters for a specific IS command
+uip ipe --help                               # Integration Platform & Experiences command groups
+uip ipe connections --help                   # IS connections subcommands
+uip ipe connections list --help              # parameters for a specific IS command
 ```
 
 ## Installed Package Activity Documentation (Primary Discovery)
@@ -85,20 +85,20 @@ Use these when building UI Automation workflows to capture selectors into the Ob
 | **Get manual test cases** | `Bash`: `uip rpa get-manual-test-cases --format json` | (none) |
 | **Get manual test steps** | `Bash`: `uip rpa get-manual-test-steps --format json` | (none) |
 
-## Integration Service (IS) Tools
+## Integration Platform & Experiences (`ipe`) Tools
 
 | Action | How | Key Parameters |
 |--------|-----|----------------|
-| **List connectors** | `Bash`: `uip is connectors list [--filter "..."] --format json` | `--filter` (by name/key) |
-| **Get connector details** | `Bash`: `uip is connectors get <connector-key> --format json` | `connector-key` (required) |
-| **List connections** | `Bash`: `uip is connections list [connector-key] [--connection-id "..."] [--folder-key "..."] --format json` | `connector-key` (optional filter), `--connection-id`, `--folder-key` |
-| **Create connection (OAuth)** | `Bash`: `uip is connections create <connector-key> [--no-browser]` | `connector-key` (required), opens OAuth flow |
-| **Ping/verify connection** | `Bash`: `uip is connections ping <connection-id>` | `connection-id` (required) |
-| **Edit/re-auth connection** | `Bash`: `uip is connections edit <connection-id>` | `connection-id` (required), opens OAuth flow |
-| **List connector activities** | `Bash`: `uip is activities list <connector-key> --format json` | `connector-key` (required) |
-| **List connector resources** | `Bash`: `uip is resources list <connector-key> [--operation ...] --format json` | `connector-key`, `--operation` (List/Retrieve/Create/Update/Delete/Replace) |
-| **Describe resource schema** | `Bash`: `uip is resources describe <connector-key> <object-name> [--operation ...] --format json` | `connector-key`, `object-name`, `--operation` |
-| **Execute resource CRUD** | `Bash`: `uip is resources execute <op> <connector-key> <object-name>` | Operations: `create`, `list`, `get`, `update`, `replace`, `delete` |
+| **List connectors** | `Bash`: `uip ipe connectors list [--filter "..."] --format json` | `--filter` (by name/key) |
+| **Get connector details** | `Bash`: `uip ipe connectors get <connector-key> --format json` | `connector-key` (required) |
+| **List connections** | `Bash`: `uip ipe connections list [connector-key] [--connection-id "..."] [--folder-key "..."] --format json` | `connector-key` (optional filter), `--connection-id`, `--folder-key` |
+| **Create connection (OAuth)** | `Bash`: `uip ipe connections create <connector-key> [--no-browser]` | `connector-key` (required), opens OAuth flow |
+| **Ping/verify connection** | `Bash`: `uip ipe connections ping <connection-id>` | `connection-id` (required) |
+| **Edit/re-auth connection** | `Bash`: `uip ipe connections edit <connection-id>` | `connection-id` (required), opens OAuth flow |
+| **List connector activities** | `Bash`: `uip ipe activities list <connector-key> --format json` | `connector-key` (required) |
+| **List connector resources** | `Bash`: `uip ipe resources list <connector-key> [--operation ...] --format json` | `connector-key`, `--operation` (List/Retrieve/Create/Update/Delete/Replace) |
+| **Describe resource schema** | `Bash`: `uip ipe resources describe <connector-key> <object-name> [--operation ...] --format json` | `connector-key`, `object-name`, `--operation` |
+| **Execute resource CRUD** | `Bash`: `uip ipe resources execute <op> <connector-key> <object-name>` | Operations: `create`, `list`, `get`, `update`, `replace`, `delete` |
 
 ## CLI Error Recovery
 

--- a/skills/uipath-rpa-workflows/references/common-pitfalls.md
+++ b/skills/uipath-rpa-workflows/references/common-pitfalls.md
@@ -162,10 +162,10 @@ The HTTP Request activity (`NetHttpRequest`) has extensive configuration:
 - Child activities expect their parent scope to have initialized OAuth extensions (`IGraphServiceClient`, `OAuthDataOptions`, etc.) — using them without a parent scope causes `NullReferenceException` at runtime
 
 **Connection lifecycle with CLI:**
-- **Discover connections**: `uip is connections list [connector-key] --format json` — find existing connection GUIDs
-- **Verify connection health**: `uip is connections ping <connection-id>` — check if a connection is still active
-- **Create new connection**: `uip is connections create <connector-key>` — opens OAuth flow for user to authenticate
-- **Re-authenticate**: `uip is connections edit <connection-id>` — re-runs OAuth flow for expired/revoked connections
+- **Discover connections**: `uip ipe connections list [connector-key] --format json` — find existing connection GUIDs
+- **Verify connection health**: `uip ipe connections ping <connection-id>` — check if a connection is still active
+- **Create new connection**: `uip ipe connections create <connector-key>` — opens OAuth flow for user to authenticate
+- **Re-authenticate**: `uip ipe connections edit <connection-id>` — re-runs OAuth flow for expired/revoked connections
 - If no connection exists and you cannot create one interactively, use a placeholder GUID (`00000000-0000-0000-0000-000000000000`) and inform the user they must configure the connection in Studio
 
 ## Deprecated Activities (Do Not Use)

--- a/skills/uipath-rpa-workflows/references/connector-capabilities.md
+++ b/skills/uipath-rpa-workflows/references/connector-capabilities.md
@@ -1,32 +1,32 @@
 # Discover Connector Capabilities (For IS/Connector Workflows)
 
-When the workflow involves Integration Service connectors (e.g., Salesforce, Jira, ServiceNow), explore the connector's capabilities before writing XAML:
+When the workflow involves Integration Platform & Experiences connectors (e.g., Salesforce, Jira, ServiceNow), explore the connector's capabilities before writing XAML:
 
 ```bash
 # What activities does this connector offer?
-uip is activities list <connector-key> --format json
+uip ipe activities list <connector-key> --format json
 
 # What data objects/resources does it expose?
-uip is resources list <connector-key> --format json
+uip ipe resources list <connector-key> --format json
 
 # What fields does a specific resource have? (essential for configuring dynamic activity properties)
-uip is resources describe <connector-key> <object-name> --format json
+uip ipe resources describe <connector-key> <object-name> --format json
 ```
 
 ## Connection Management
 
 **Check if a connection exists:**
 ```bash
-uip is connections list <connector-key> --format json
+uip ipe connections list <connector-key> --format json
 ```
 
 **If no connection exists**, you have two options:
-1. **Create one** (requires user interaction for OAuth): `uip is connections create <connector-key>`
+1. **Create one** (requires user interaction for OAuth): `uip ipe connections create <connector-key>`
 2. **Use a placeholder** — insert the dynamic activity with an empty `connectionId` and inform the user they need to configure the connection in Studio
 
 **Verify a connection is active:**
 ```bash
-uip is connections ping <connection-id>
+uip ipe connections ping <connection-id>
 ```
 
-If the ping fails, offer to re-authenticate: `uip is connections edit <connection-id>`
+If the ping fails, offer to re-authenticate: `uip ipe connections edit <connection-id>`

--- a/skills/uipath-rpa-workflows/references/jit-custom-types-schema.md
+++ b/skills/uipath-rpa-workflows/references/jit-custom-types-schema.md
@@ -6,7 +6,7 @@ Use this skill to discover properties and CLR types of custom JIT-compiled types
 
 - Populating an `Assign` activity that targets a custom type property
 - Creating a variable typed to a custom entity
-- Setting properties on an Integration Service entity (e.g., Salesforce, ServiceNow)
+- Setting properties on an Integration Platform & Experiences entity (e.g., Salesforce, ServiceNow)
 - Any time you need to know what properties a custom type exposes and their .NET types
 
 ## Steps

--- a/skills/uipath-rpa-workflows/references/project-structure.md
+++ b/skills/uipath-rpa-workflows/references/project-structure.md
@@ -107,7 +107,7 @@ MyProject/
 | `UiPath.Word.Activities` | Word automation | Read Text, Replace Text, Insert Image, Export to PDF |
 | `UiPath.Testing.Activities` | Testing and assertions | Verify Expression, Verify Are Equal, Generate Test Data |
 | `UiPath.Presentations.Activities` | PowerPoint automation | Add Slide, Replace Text, Insert Image |
-| `UiPath.IntegrationService.Activities` | Integration Service connector runtime | Generic `ConnectorActivity` that consumes metadata from IS connectors (Salesforce, ServiceNow, HubSpot, etc.). Required for any IS connector activity. |
+| `UiPath.IntegrationService.Activities` | Integration Platform & Experiences connector runtime | Generic `ConnectorActivity` that consumes metadata from IPE connectors (Salesforce, ServiceNow, HubSpot, etc.). Required for any IPE connector activity. |
 | `UiPath.Cryptography.Activities` | Encryption/hashing | Encrypt Text, Decrypt Text, Hash File |
 
 ## Version Constraints

--- a/skills/uipath-rpa-workflows/references/validation-and-fixing.md
+++ b/skills/uipath-rpa-workflows/references/validation-and-fixing.md
@@ -18,7 +18,7 @@ Omit `version` to automatically resolve the latest compatible version (preferred
 
 ## Resolving Dynamic Activity Custom Types
 
-Dynamic activities (e.g., Integration Service connectors) retrieved via `uip rpa get-default-activity-xaml` (with `--activity-type-id`) may use **JIT-compiled custom types** for their input/output properties. After the activity is added to the workflow, when you need to discover the property names and CLR types of these custom entities (e.g., to populate an `Assign` activity targeting a custom type property, or to create a variable of a custom type), read the JIT custom types schema:
+Dynamic activities (e.g., Integration Platform & Experiences connectors) retrieved via `uip rpa get-default-activity-xaml` (with `--activity-type-id`) may use **JIT-compiled custom types** for their input/output properties. After the activity is added to the workflow, when you need to discover the property names and CLR types of these custom entities (e.g., to populate an `Assign` activity targeting a custom type property, or to create a variable of a custom type), read the JIT custom types schema:
 
 ```
 Read: file_path="{projectRoot}/.project/JitCustomTypesSchema.json"

--- a/skills/uipath-rpa-workflows/references/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa-workflows/references/xaml-basics-and-rules.md
@@ -337,7 +337,7 @@ VB project with core workflow activities. Shows If/Then/Else branching and Assig
 
 ### Example 2: Package Connector Activity (Office 365 Get Newest Email)
 
-Shows a package-based activity with `ConnectionId` for Integration Service.
+Shows a package-based activity with `ConnectionId` for Integration Platform & Experiences.
 
 ```xml
 <Activity mc:Ignorable="sap sap2010" x:Class="GetNewestEmail"
@@ -377,7 +377,7 @@ Shows a package-based activity with `ConnectionId` for Integration Service.
     </sco:Collection>
   </TextExpression.ReferencesForImplementation>
   <Sequence DisplayName="GetNewestEmail" sap2010:WorkflowViewState.IdRef="Sequence_1">
-    <!-- Activity with ConnectionId for Integration Service -->
+    <!-- Activity with ConnectionId for Integration Platform & Experiences -->
     <umam:GetNewestEmail
       ConnectionAccountName="{x:Null}" ContinueOnError="{x:Null}" Filter="{x:Null}"
       FolderIdBackup="{x:Reference __ReferenceID0}" FreeTextFilter="{x:Null}"
@@ -426,15 +426,15 @@ Shows a package-based activity with `ConnectionId` for Integration Service.
 ```
 
 **Key patterns:**
-- `ConnectionId` attribute holds the Integration Service connection GUID
+- `ConnectionId` attribute holds the Integration Platform & Experiences connection GUID
 - Nullable properties use `{x:Null}` explicitly
 - Complex sub-objects (MailFolderArgument, MailboxArgument) with `BackupSlot` pattern
 - `x:Reference` / `x:Name` for cross-referencing objects within the XAML
 - Multiple package-specific xmlns prefixes (`umam`, `umame`, `umamm`, `usau`)
 
-### Example 3: Integration Service Connector Activity (GitHub Search Repositories)
+### Example 3: Integration Platform & Experiences Connector Activity (GitHub Search Repositories)
 
-Shows the generic `ConnectorActivity` pattern used for Integration Service connectors.
+Shows the generic `ConnectorActivity` pattern used for Integration Platform & Experiences connectors.
 
 ```xml
 <Activity mc:Ignorable="sap sap2010" x:Class="Sequence"
@@ -449,7 +449,7 @@ Shows the generic `ConnectorActivity` pattern used for Integration Service conne
   xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=System.Private.CoreLib"
   xmlns:uiascb="clr-namespace:UiPath.IntegrationService.Activities.SWEntities.CDF573A04A6_search_repositories.Bundle;assembly=CDF573A04A6_search_r.VeKd1XI2qK1X56UO2Br3Ui3"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <!-- Namespaces include Integration Service runtime + connector-specific -->
+  <!-- Namespaces include Integration Platform & Experiences runtime + connector-specific -->
   <TextExpression.NamespacesForImplementation>
     <sco:Collection x:TypeArguments="x:String">
       <!-- Standard imports + IS-specific -->
@@ -472,7 +472,7 @@ Shows the generic `ConnectorActivity` pattern used for Integration Service conne
     </sco:Collection>
   </TextExpression.ReferencesForImplementation>
   <Sequence DisplayName="Sequence" sap2010:WorkflowViewState.IdRef="Sequence_1">
-    <!-- Generic ConnectorActivity for Integration Service -->
+    <!-- Generic ConnectorActivity for Integration Platform & Experiences -->
     <isactr:ConnectorActivity
       Configuration="H4sIAAAAAAAACr1W70/bSBD9V1b+dCcFXwgtPSHx..."
       ConnectionId="93c89540-f260-4150-afbd-43df573a04a6"
@@ -502,9 +502,9 @@ Shows the generic `ConnectorActivity` pattern used for Integration Service conne
 ```
 
 **Key patterns:**
-- `isactr:ConnectorActivity` is the generic IS activity type (`xmlns:isactr="http://schemas.uipath.com/workflow/integration-service-activities/isactr"`)
+- `isactr:ConnectorActivity` is the generic IPE activity type (`xmlns:isactr="http://schemas.uipath.com/workflow/integration-service-activities/isactr"`)
 - `Configuration` holds a base64-encoded GZip-compressed blob — **never construct this manually**, it comes from `uip rpa get-default-activity-xaml`
-- `ConnectionId` is the Integration Service connection GUID
+- `ConnectionId` is the Integration Platform & Experiences connection GUID
 - `UiPathActivityTypeId` identifies the specific connector operation
 - `FieldObjects` define input/output fields with `isactr:FieldObject` elements
 - Output types reference a JIT-generated assembly (e.g., `CDF573A04A6_search_r.VeKd1XI2qK1X56UO2Br3Ui3`)
@@ -555,7 +555,7 @@ Understanding the structure of `isactr:ConnectorActivity` so you know what you c
 | Property | Editable? | Description |
 |----------|-----------|-------------|
 | `Configuration` | **NEVER** | ZIP-compressed, Base64-encoded JSON blob containing the full activity schema (fields, types, connector metadata). This is obtained and computed for you using the `uip rpa get-default-activity-xaml` command. Do not parse, modify, or construct manually. |
-| `ConnectionId` | Yes (replace GUID) | Integration Service connection GUID. Use `uip is connections list [connector-key]` to discover available connections and their IDs. |
+| `ConnectionId` | Yes (replace GUID) | Integration Platform & Experiences connection GUID. Use `uip ipe connections list [connector-key]` to discover available connections and their IDs. |
 | `UiPathActivityTypeId` | **NEVER** | Identifies the specific connector operation. Obtain using `uip rpa get-default-activity-xaml` or `uip rpa find-activities`. |
 | `DisplayName` | Yes | Human-readable activity name for the designer. |
 


### PR DESCRIPTION
## Summary

- **CLI command references renamed**: all `uip is` → `uip ipe` across 15+ skill/reference files
- **Product name rebranded**: "Integration Service" → "Integration Platform & Experiences" in all documentation
- **Directory renamed**: `references/integration-service/` → `references/integration-platform-experiences/`
- **File renamed**: `integration-service.md` → `integration-platform-experiences.md`
- **Anchor links updated**: `#integration-service-ipe` → `#integration-platform--experiences-ipe`

### Files changed (30 files)
- Platform skill definition + 6 integration-service reference docs (renamed + content updated)
- RPA workflows skill + 6 reference files
- Coded workflows skill + reference
- Coded agents references
- 5 activity-docs files (Mail, GSuite, Microsoft365, AzureWVD)
- Root README.md

### Not changed
- XML namespaces (`xmlns:isactr="http://schemas.uipath.com/workflow/integration-service-activities/isactr"`)
- Hyper-V "integration services" references (different product)

### Related PRs
- UiPath/uipcli — ENGCE-56050 (CLI core change)
- UiPath/coder_eval — ENGCE-56050 (eval tasks update)

## Test plan
- [x] Verified zero remaining `uip is` references via grep
- [x] All markdown links and anchors updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)