### PR TITLE
feat: add Maestro CLI skill for runtime management

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -8,6 +8,6 @@
   "license": "MIT",
   "homepage": "https://github.com/UiPath/skills",
   "repository": "https://github.com/UiPath/skills",
-  "keywords": ["uipath", "automation", "rpa", "workflows", "code", "xaml", "studio", "ui-automation", "ui-testing", "desktop", "browser", "coded-apps", "webapp", "nupkg", "coded-agents", "agent", "langgraph", "llamaindex", "openai-agents"],
+  "keywords": ["uipath", "automation", "rpa", "workflows", "code", "xaml", "studio", "ui-automation", "ui-testing", "desktop", "browser", "coded-apps", "webapp", "nupkg", "coded-agents", "agent", "langgraph", "llamaindex", "openai-agents", "maestro"],
   "skills": "./skills/"
 }

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The repository contains skills for building and managing UiPath automation proje
 | **uipath-coded-agents** | End-to-end toolkit for UiPath coded agents: scaffold, build, run, evaluate, deploy (LangGraph, LlamaIndex, OpenAI Agents, Simple Function) |
 | **uipath-coded-apps** | Build, sync, package, publish, and deploy UiPath Coded Web Applications — push/pull to Studio Web, pack into .nupkg, publish to Orchestrator, deploy to production |
 | **uipath-servo** | Desktop and browser UI automation and testing — click, type, read, verify, screenshot, and extract UI elements |
+| **uipath-maestro** | Manage Maestro process instances — list, inspect, pause, resume, cancel, retry instances; navigate steps; set input/deadline; manage notes and priorities |
 
 ## Multi-Tool Support
 

--- a/hooks/ensure-uip.sh
+++ b/hooks/ensure-uip.sh
@@ -132,3 +132,4 @@ if is_windows; then
   ensure_npm_package @uipath/servo
 fi
 ensure_uip_tool @uipath/rpa-tool
+ensure_uip_tool @uipath/maestro-tool

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -8,7 +8,7 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/ensure-uip.sh\"",
             "timeout": 180,
             "once": true,
-            "statusMessage": "Checking uip, servo and rpa-tool installation..."
+            "statusMessage": "Checking uip, servo, rpa-tool and maestro-tool installation..."
           }
         ]
       }

--- a/skills/uipath-maestro/SKILL.md
+++ b/skills/uipath-maestro/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: uipath-maestro
+description: "This skill should be used when the user wants to 'manage Maestro process instances', 'list Maestro processes', 'pause or resume a Maestro instance', 'cancel or retry a Maestro instance', 'navigate a Maestro instance to a specific step', 'manage Maestro incidents', 'check Maestro instance status', 'set Maestro instance input or deadline', 'create notes on a Maestro instance', or when the user asks about UiPath Maestro CLI commands, Maestro runtime management, or orchestrating long-running business processes with Maestro."
+metadata:
+   allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+# UiPath Maestro Runtime Management Assistant
+
+Comprehensive guide for managing UiPath Maestro process instances, processes, and incidents using the `uip maestro` CLI commands.
+
+## When to Use This Skill
+
+- User wants to **list or inspect Maestro process instances**
+- User wants to **pause, resume, cancel, or retry** a Maestro instance
+- User wants to **navigate a Maestro instance** to a specific step (`goto`)
+- User wants to **set input data or a deadline** on a Maestro instance
+- User wants to **create or list notes** on a Maestro instance
+- User wants to **update the priority** of a Maestro instance
+- User wants to **list or view Maestro processes** (deployed process definitions)
+- User wants to **list Maestro incidents** (runtime errors)
+- User asks about **Maestro CLI commands** or Maestro runtime concepts
+
+> **Note:** Maestro processes are authored in UiPath Studio Web (BPMN designer), not via the CLI. The `uip maestro` commands are for **runtime management only** — there is no `init`, `validate`, or `pack` equivalent for Maestro.
+
+## Quick Start
+
+### Step 0 — Resolve the `uip` binary
+
+The `uip` CLI is installed via npm. If `uip` is not on PATH (common in nvm environments), resolve it first:
+
+```bash
+UIP=$(command -v uip 2>/dev/null || npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip
+$UIP --version
+```
+
+Use `$UIP` in place of `uip` for all subsequent commands if the plain `uip` command isn't found.
+
+### Step 1 — Check login status
+
+All `uip maestro` commands require authentication.
+
+```bash
+uip login status --format json
+```
+
+If not logged in:
+```bash
+uip login                                          # interactive OAuth (opens browser)
+uip login --authority https://alpha.uipath.com     # non-production environments
+```
+
+### Step 2 — Install the Maestro tool plugin
+
+The `maestro` command group is provided by the `@uipath/maestro-tool` plugin. Install it if not already present:
+
+```bash
+uip tools install @uipath/maestro-tool
+```
+
+Verify installation:
+```bash
+uip maestro --help
+```
+
+### Step 3 — List process instances
+
+```bash
+uip maestro instances list --format json
+uip maestro instances list --folder-key <key> --format json
+uip maestro instances list --process-key <key> --format json
+```
+
+### Step 4 — Inspect a specific instance
+
+```bash
+uip maestro instances get <instance-id> --format json
+```
+
+### Step 5 — Take action on an instance
+
+```bash
+uip maestro instances pause <instance-id> --format json
+uip maestro instances resume <instance-id> --format json
+uip maestro instances cancel <instance-id> --comment "Reason" --format json
+uip maestro instances retry <instance-id> --format json
+```
+
+## Task Navigation
+
+| I need to... | Read these |
+|---|---|
+| **List/filter process instances** | [references/maestro-commands.md - instances list](references/maestro-commands.md) |
+| **Inspect instance details** | [references/maestro-commands.md - instances get](references/maestro-commands.md) |
+| **Pause/resume/cancel/retry an instance** | [references/maestro-commands.md - Instance Lifecycle](references/maestro-commands.md) |
+| **Navigate an instance to a step** | [references/maestro-commands.md - instances goto](references/maestro-commands.md) |
+| **Set input data or deadline** | [references/maestro-commands.md - instances input/deadline](references/maestro-commands.md) |
+| **Create or list notes** | [references/maestro-commands.md - instances notes](references/maestro-commands.md) |
+| **Update instance priority** | [references/maestro-commands.md - instances update-priority](references/maestro-commands.md) |
+| **List tasks for an instance** | [references/maestro-commands.md - instances list-tasks](references/maestro-commands.md) |
+| **List deployed processes** | [references/maestro-commands.md - processes](references/maestro-commands.md) |
+| **List incidents** | [references/maestro-commands.md - incidents](references/maestro-commands.md) |
+| **Know all Maestro CLI commands** | [references/maestro-commands.md](references/maestro-commands.md) |
+| **Authenticate / manage tenants** | [/uipath:uipath-platform](/uipath:uipath-platform) |
+| **Pack / publish / deploy** | [/uipath:uipath-platform](/uipath:uipath-platform) |
+
+## Key Concepts
+
+### Maestro vs Flow
+
+| Aspect | Flow | Maestro |
+|--------|------|---------|
+| **Authoring** | CLI (`uip flow init`, `.flow` files) | Studio Web (BPMN designer) |
+| **CLI scope** | Full lifecycle (init, validate, pack, debug) | Runtime management only |
+| **CLI prefix** | `uip flow` | `uip maestro` |
+| **Folder parameter** | `--folder-id` | `--folder-key` |
+| **Install** | Built into `@uipath/cli` | Requires `uip tools install @uipath/maestro-tool` |
+
+> **Important:** Maestro uses `--folder-key` (not `--folder-id`). This is a different parameter than what the Flow CLI uses. Get folder keys from `uip or folders list --format json`.
+
+### Instance Lifecycle
+
+Maestro process instances transition through these states:
+
+```
+Running  -->  Paused   (via pause)
+Paused   -->  Running  (via resume)
+Running  -->  Cancelled (via cancel)
+Faulted  -->  Running  (via retry)
+Running  -->  Completed (automatic, on process completion)
+```
+
+### CLI output format
+
+All `uip maestro` commands return structured JSON:
+```json
+{ "Result": "Success", "Code": "...", "Data": { ... } }
+{ "Result": "Failure", "Message": "...", "Instructions": "..." }
+```
+
+Always use `--format json` for programmatic use.
+
+### The `goto` command — quoting the steps array
+
+The `goto` command takes a JSON array as a positional argument. Be careful with shell quoting:
+
+```bash
+# Bash — use single quotes around the JSON array
+uip maestro instances goto <instance-id> '["Step1","Step2"]' --format json
+
+# If your step names contain special characters, escape carefully
+uip maestro instances goto <instance-id> '["Approval Step","Review Step"]' --format json
+```
+
+## References
+
+- **[Maestro CLI Command Reference](references/maestro-commands.md)** — All `uip maestro` subcommands with parameters and examples
+- **[UiPath Platform / Authentication](/uipath:uipath-platform)** — Login, tenants, Orchestrator folders (uipath-platform skill)
+- **[Flow Authoring](/uipath:uipath-flow)** — Flow project creation and editing (uipath-flow skill)

--- a/skills/uipath-maestro/SKILL.md
+++ b/skills/uipath-maestro/SKILL.md
@@ -30,7 +30,13 @@ Comprehensive guide for managing UiPath Maestro process instances, processes, an
 The `uip` CLI is installed via npm. If `uip` is not on PATH (common in nvm environments), resolve it first:
 
 ```bash
-UIP=$(command -v uip 2>/dev/null || npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip
+if UIP=$(command -v uip 2>/dev/null); then
+  # uip is on PATH, use it directly
+  :
+else
+  # uip not on PATH, resolve via npm
+  UIP=$(npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip
+fi
 $UIP --version
 ```
 

--- a/skills/uipath-maestro/references/maestro-commands.md
+++ b/skills/uipath-maestro/references/maestro-commands.md
@@ -1,0 +1,337 @@
+# uip maestro — CLI Command Reference
+
+All commands require `uip login` first. All commands output `{ "Result": "Success"|"Failure", "Code": "...", "Data": { ... } }`. Use `--format json` for programmatic use.
+
+> **Prerequisite:** Install the Maestro tool plugin: `uip tools install @uipath/maestro-tool`
+
+---
+
+## Instances
+
+Manage Maestro process instances (running, paused, completed, faulted, or cancelled).
+
+### uip maestro instances list
+
+List process instances with optional filters.
+
+```bash
+uip maestro instances list --format json
+uip maestro instances list --folder-key <key> --format json
+uip maestro instances list --process-key <key> --format json
+uip maestro instances list --package-id <id> --format json
+uip maestro instances list --error-code <code> --format json
+uip maestro instances list -l 50 --offset 0 --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--folder-key <key>` | No | Filter by Orchestrator folder key |
+| `--process-key <key>` | No | Filter by process key |
+| `--package-id <id>` | No | Filter by package ID |
+| `--error-code <code>` | No | Filter by error code |
+| `-l <n>` | No | Limit number of results (default varies) |
+| `--offset <n>` | No | Skip first N results for pagination |
+
+### uip maestro instances get
+
+Get details of a specific process instance.
+
+```bash
+uip maestro instances get <instance-id> --format json
+uip maestro instances get <instance-id> --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+### uip maestro instances pause
+
+Pause a running process instance.
+
+```bash
+uip maestro instances pause <instance-id> --format json
+uip maestro instances pause <instance-id> --folder-key <key> --format json
+uip maestro instances pause <instance-id> --comment "Pausing for review" --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+| `--comment <text>` | No | Optional comment explaining the action |
+
+### uip maestro instances resume
+
+Resume a paused process instance.
+
+```bash
+uip maestro instances resume <instance-id> --format json
+uip maestro instances resume <instance-id> --folder-key <key> --format json
+uip maestro instances resume <instance-id> --comment "Resuming after review" --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+| `--comment <text>` | No | Optional comment explaining the action |
+
+### uip maestro instances cancel
+
+Cancel a running or paused process instance.
+
+```bash
+uip maestro instances cancel <instance-id> --format json
+uip maestro instances cancel <instance-id> --comment "No longer needed" --format json
+uip maestro instances cancel <instance-id> --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+| `--comment <text>` | No | Optional comment explaining the cancellation |
+
+### uip maestro instances retry
+
+Retry a faulted process instance.
+
+```bash
+uip maestro instances retry <instance-id> --format json
+uip maestro instances retry <instance-id> --folder-key <key> --format json
+uip maestro instances retry <instance-id> --comment "Retrying after fix" --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+| `--comment <text>` | No | Optional comment explaining the retry |
+
+### uip maestro instances goto
+
+Navigate a process instance to specific step(s). The steps argument is a **JSON array** passed as a positional argument.
+
+```bash
+# Navigate to a single step
+uip maestro instances goto <instance-id> '["StepName"]' --format json
+
+# Navigate to multiple steps
+uip maestro instances goto <instance-id> '["Step1","Step2"]' --format json
+
+# With folder key
+uip maestro instances goto <instance-id> '["ApprovalStep"]' --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `<steps>` | **Yes** | JSON array of step names (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+> **Shell quoting:** Always wrap the JSON array in single quotes in bash to prevent shell expansion. If step names contain single quotes, use `$'...'` syntax or escape accordingly.
+
+### uip maestro instances input
+
+Set input data on a process instance.
+
+```bash
+uip maestro instances input <instance-id> '{"key":"value"}' --format json
+uip maestro instances input <instance-id> '{"approver":"john@example.com","amount":5000}' --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `<input-data>` | **Yes** | JSON object with input key-value pairs (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+### uip maestro instances deadline
+
+Set or update the deadline on a process instance.
+
+```bash
+uip maestro instances deadline <instance-id> "2025-12-31T23:59:59Z" --format json
+uip maestro instances deadline <instance-id> "2025-12-31T23:59:59Z" --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `<deadline>` | **Yes** | ISO 8601 datetime string (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+### uip maestro instances create-note
+
+Create a note on a process instance.
+
+```bash
+uip maestro instances create-note <instance-id> "This is a note" --format json
+uip maestro instances create-note <instance-id> "Escalated to manager" --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `<note-text>` | **Yes** | The note content (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+### uip maestro instances list-notes
+
+List all notes on a process instance.
+
+```bash
+uip maestro instances list-notes <instance-id> --format json
+uip maestro instances list-notes <instance-id> --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+### uip maestro instances update-priority
+
+Update the priority of a process instance.
+
+```bash
+uip maestro instances update-priority <instance-id> <priority> --format json
+uip maestro instances update-priority <instance-id> <priority> --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `<priority>` | **Yes** | New priority value (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+### uip maestro instances list-tasks
+
+List tasks associated with a process instance.
+
+```bash
+uip maestro instances list-tasks <instance-id> --format json
+uip maestro instances list-tasks <instance-id> --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<instance-id>` | **Yes** | The process instance ID (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+---
+
+## Processes
+
+View deployed Maestro process definitions.
+
+### uip maestro processes list
+
+List all deployed Maestro processes.
+
+```bash
+uip maestro processes list --format json
+uip maestro processes list --folder-key <key> --format json
+uip maestro processes list -l 50 --offset 0 --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--folder-key <key>` | No | Filter by Orchestrator folder key |
+| `-l <n>` | No | Limit number of results |
+| `--offset <n>` | No | Skip first N results for pagination |
+
+### uip maestro processes get
+
+Get details of a specific Maestro process.
+
+```bash
+uip maestro processes get <process-key> --format json
+uip maestro processes get <process-key> --folder-key <key> --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<process-key>` | **Yes** | The process key (positional) |
+| `--folder-key <key>` | No | Orchestrator folder key |
+
+---
+
+## Incidents
+
+View runtime incidents (errors) for Maestro processes.
+
+### uip maestro incidents list
+
+List Maestro incidents.
+
+```bash
+uip maestro incidents list --format json
+uip maestro incidents list --folder-key <key> --format json
+uip maestro incidents list -l 50 --offset 0 --format json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--folder-key <key>` | No | Filter by Orchestrator folder key |
+| `-l <n>` | No | Limit number of results |
+| `--offset <n>` | No | Skip first N results for pagination |
+
+---
+
+## Global Options (all commands)
+
+| Option | Description |
+|--------|-------------|
+| `--format json\|yaml\|table` | Output format (default: table in TTY, json otherwise) |
+| `--verbose` | Enable debug logging |
+| `--help` | Show command help |
+
+## Common Workflows
+
+### Monitor a running instance
+
+```bash
+# List running instances
+uip maestro instances list --format json
+
+# Get details of a specific instance
+uip maestro instances get <instance-id> --format json
+
+# Check tasks within the instance
+uip maestro instances list-tasks <instance-id> --format json
+
+# View notes
+uip maestro instances list-notes <instance-id> --format json
+```
+
+### Handle a faulted instance
+
+```bash
+# Find faulted instances (check error-code or inspect each)
+uip maestro instances list --format json
+
+# Inspect the faulted instance
+uip maestro instances get <instance-id> --format json
+
+# Check incidents for error details
+uip maestro incidents list --format json
+
+# Retry after fixing the underlying issue
+uip maestro instances retry <instance-id> --comment "Fixed data issue" --format json
+```
+
+### Navigate an instance past a stuck step
+
+```bash
+# Inspect current state
+uip maestro instances get <instance-id> --format json
+
+# Navigate to specific steps (skipping the stuck step)
+uip maestro instances goto <instance-id> '["NextStep"]' --format json
+
+# Add a note explaining the navigation
+uip maestro instances create-note <instance-id> "Skipped stuck step, navigated to NextStep" --format json
+```

--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -99,6 +99,7 @@ Choose the appropriate operation from the Task Navigation table below.
 | **Use Integration Service** (connectors, connections, activities, resources) | [references/integration-service/integration-service.md](references/integration-service/integration-service.md) |
 | **Full CLI command reference** | [references/uip-commands.md](references/uip-commands.md) |
 | **Build/run/validate coded workflows** | [/uipath-coded-workflows:uipath-coded-workflows](/uipath-coded-workflows:uipath-coded-workflows) |
+| **Manage Maestro process instances** | [/uipath:uipath-maestro](/uipath:uipath-maestro) |
 
 ## Resolving UiPath Studio
 
@@ -191,6 +192,7 @@ The UiPath CLI (`uip`) is a unified command-line tool for interacting with the U
 | **MCP** | `mcp` | Model Context Protocol server | Available |
 | **Coded Agents** | `codedagents` | Python agent lifecycle (setup, exec) | Available |
 | **RPA** | `rpa` | RPA workflow management (create, compile, validate, execute) | Available |
+| **Maestro** | `maestro` | Process instance runtime management (requires `@uipath/maestro-tool`) | Available |
 
 ### Global Options
 

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -106,3 +106,4 @@ Use `--help` to explore these:
 | **RPA** | `uip rpa --help` | RPA workflow management (XAML) |
 | **MCP** | `uip mcp serve` | Start Model Context Protocol server |
 | **Coded Agents** | `uip codedagents --help` | Python-based agent development |
+| **Maestro** | `uip maestro --help` | Maestro process instance runtime management (requires `uip tools install @uipath/maestro-tool`) |


### PR DESCRIPTION
## Summary

- Add new `skills/uipath-maestro/` skill with `SKILL.md` and `references/maestro-commands.md` documenting all `uip maestro` CLI commands (instances, processes, incidents)
- Update `hooks/ensure-uip.sh` to auto-install `@uipath/maestro-tool` on session start
- Add `maestro` keyword to `plugin.json` and cross-link Maestro in the platform skill's CLI reference and task navigation

## Details

The new Maestro skill mirrors the structure of `uipath-flow` but is scoped to **runtime management only** (no init/validate/pack — Maestro processes are authored in Studio Web). It covers:

- **Instances** (13 subcommands): list, get, pause, resume, cancel, retry, goto, input, deadline, create-note, list-notes, update-priority, list-tasks
- **Processes** (2 subcommands): list, get
- **Incidents** (1 subcommand): list

Key documentation includes:
- Shell quoting guidance for the `goto` command's JSON array argument
- `--folder-key` vs `--folder-id` distinction between Maestro and Flow
- Common workflow examples (monitoring, handling faults, navigating stuck instances)

## Test plan

- [ ] Verify `skills/uipath-maestro/SKILL.md` YAML frontmatter parses correctly (name, description, allowed-tools)
- [ ] Verify all cross-links between SKILL.md and references/maestro-commands.md resolve
- [ ] Verify `hooks/ensure-uip.sh` passes `bash -n` syntax check
- [ ] Verify `plugin.json` is valid JSON with `maestro` keyword
- [ ] Verify Maestro appears in `uip-commands.md` Other Tool Groups table
- [ ] Verify Maestro appears in platform `SKILL.md` CLI Overview table and Task Navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)