### PR TITLE
Add rpa common pitfall with pkgs that end up in proj folder

### DIFF
--- a/skills/uipath-rpa-workflows/SKILL.md
+++ b/skills/uipath-rpa-workflows/SKILL.md
@@ -324,7 +324,7 @@ uip rpa get-default-activity-xaml --activity-type-id "178a864d-90fd-43d3-a305-24
 - `--activity-type-id`: For dynamic activities. Use `uip rpa find-activities --use-studio` to find the exact type ID
 - `--connection-id`: Optional, only used for dynamic activities. Discover available connections using `uip is connections list [connector-key]`
 
-**IMPORTANT — `.Item` child elements:** The default XAML returned by this command may contain `.Item` child elements with `ItemArgument` nodes (e.g., `<activity:SomeActivity.Item><upap:ItemArgument .../></activity:SomeActivity.Item>`). These are internal scaffolding for OverloadGroup (FileName/ResourceFile) switching. **Do NOT copy `.Item` children into your generated XAML.** Instead, set the desired property (e.g., `FileName`) directly on the activity element and omit the `.Item` child. Studio auto-generates the internal structure when it loads the workflow. Including a misconfigured `.Item` child causes `"None of the overload groups have all their required/optional activity arguments configured"` errors. See [common-pitfalls.md](./references/common-pitfalls.md) for details.
+**IMPORTANT — `.Item` child elements:** Do NOT copy `.Item` children with `ItemArgument` nodes into your generated XAML. Set the desired property directly on the activity element. See [common-pitfalls.md — ItemArgument and `.Item` Child Elements](./references/common-pitfalls.md#itemargument-and-item-child-elements-in-overloadgroup-activities) for details.
 
 **For JIT custom types**, read the schema file:
 

--- a/skills/uipath-rpa-workflows/references/common-pitfalls.md
+++ b/skills/uipath-rpa-workflows/references/common-pitfalls.md
@@ -56,7 +56,6 @@ Many activities use `[OverloadGroup]` to define mutually exclusive property sets
 | WorkbookActivityBase | `Workbook` (use open) | `WorkbookPath` (file string) | `WorkbookPathResource` (IResource) |
 | WordDocumentActivity | `FilePath` (string) | `PathResource` (ILocalResource) | — |
 | PDF activities (ReadPDFText, GetPDFPageCount, ExtractPDFPageRange, ManagePDFPassword, ExportPDFPageAsImage, ExtractImagesFromPDF, ReadXPSText) | `FileName` (string) | `ResourceFile` (IResource) | — |
-| PDF convert activities (ConvertHtmlToPDF, ConvertTextToPDF) | `FileName` (string, when InputMode=File) | `ResourceFile` (IResource, when InputMode=File) | `Html`/`Text` (string, when InputMode=Content) |
 
 **Key rule**: Exactly ONE group must have values. Setting properties from multiple groups OR no groups both cause validation errors.
 
@@ -95,6 +94,9 @@ Some properties are only required when another property has a specific value:
 | ExchangeScope (Interactive auth) | `AuthenticationMode = Interactive` | `ApplicationId` must be set |
 | ExchangeScope | `ApplicationId` is set | `DirectoryId` must also be set (and vice versa — both or neither) |
 | WordApplicationScope | `CreateNewFile = true` | Path must be local (not a URL) |
+| ConvertHtmlToPDF, ConvertTextToPDF | `InputMode = File` | `FileName` or `ResourceFile` must be set |
+| ConvertHtmlToPDF | `InputMode = Content` | `Html` must be set |
+| ConvertTextToPDF | `InputMode = Content` | `Text` must be set |
 
 ## Input Method Constraints (UIAutomation)
 
@@ -506,22 +508,3 @@ When reading Excel data with `ReadRangeX`, column types in the resulting `DataTa
 **Workarounds:**
 - Use LINQ with explicit conversion: `dtData.AsEnumerable().Where(Function(row) CDbl(row("Amount")) > 1000).CopyToDataTable()`
 - Convert the column type after reading: loop through rows and convert values, or clone the DataTable with the correct column types
-
-### `uip rpa restore` dumps .nupkg files into the project directory
-
-When calling `uip rpa restore` without `--destination-path`, the command restores NuGet packages directly into the project root directory, polluting it with hundreds of `.nupkg` files. These are cached package files, not project artifacts, and should not be there.
-
-**Always specify `--destination-path`** pointing to a location outside the project directory:
-
-```bash
-# Correct — restore to a temp/cache directory
-uip rpa restore --project-path "{projectRoot}" --destination-path "{projectRoot}/.local/packages" --format json
-
-# Wrong — packages end up in project root
-uip rpa restore --project-path "{projectRoot}" --format json
-```
-
-If you already have `.nupkg` files littering the project root, clean them up:
-```bash
-rm "{projectRoot}"/*.nupkg
-```

--- a/skills/uipath-rpa-workflows/references/validation-and-fixing.md
+++ b/skills/uipath-rpa-workflows/references/validation-and-fixing.md
@@ -61,17 +61,6 @@ DO NOT bundle multiple fixes in one iteration. Fix the root cause, re-run, verif
 
 Expect multiple iteration cycles for complex workflows.
 
-### Stale Validation Cache
-
-Studio may cache validation results internally. If `get-errors` reports persistent errors after multiple edits to the same file — especially OverloadGroup errors that should be resolved by your changes — the cache may be stale. To clear it:
-
-```bash
-uip rpa close-project --project-dir "<PROJECT_DIR>" --format json
-uip rpa open-project --project-dir "<PROJECT_DIR>" --format json
-```
-
-Then re-run `get-errors`. This forces Studio to reload all files from disk and revalidate from scratch.
-
 ## Smoke Test (Optional but Recommended)
 
 **Important:** `get-errors` (Studio validation) and `run-file` (runtime compilation) use different validation paths. Some errors — such as invalid enum values on activity properties — pass Studio validation but fail at runtime. Always treat the smoke test as a critical validation step, not just an optional extra.


### PR DESCRIPTION
We noticed this while testing the PDF activities.

Problem: uip rpa restore without --destination-path dumps all NuGet packages into the project root
 Fix: Always pass --destination-path (e.g., {projectRoot}/.local/packages) to keep packages out of the project directory

UPDATE: fixing more issues
Issue 1: Studio caches validation results and get-errors might miss some errors.
Fix: updated `skills/uipath-rpa-workflows/references/validation-and-fixing.md`

Issue 2: presence of .Item elements may cause "None of the overload groups have all their required/optional activity arguments configured" errors.
Fix: updated `skills/uipath-rpa-workflows/references/common-pitfalls.md` and `skills/uipath-rpa-workflows/SKILL.md`

Issue 3: agent created workflows in subfolders and named them `x:Class="Subfolder.WorkflowName"`; this caused a runtime error because of the dot. Correct version is `x:Class="Subfolder_WorkflowName"`
Fix: added a note in xaml-basics-and-rules.md, under the XAML File Anatomy section