### PR TITLE
Fix the 'list-workflow-examples' command examples

### DIFF
--- a/skills/uipath-rpa-workflows/SKILL.md
+++ b/skills/uipath-rpa-workflows/SKILL.md
@@ -340,13 +340,13 @@ Use when activity docs, `find-activities`, `get-default-activity-xaml`, and doma
 
 ```bash
 # Search by service tags (AND logic — all tags must match)
-uip rpa list-workflow-examples --tags '["web"]' --limit 10 --format json
+uip rpa list-workflow-examples --tags web --limit 10 --format json
 
 # Multiple tags narrow down results (AND logic — all tags must match)
-uip rpa list-workflow-examples --tags '["jira", "confluence"]' --limit 10 --format json
+uip rpa list-workflow-examples --tags jira,confluence --limit 10 --format json
 
 # Use prefix to filter by category
-uip rpa list-workflow-examples --tags '["gmail"]' --prefix "email-communication/" --limit 15 --format json
+uip rpa list-workflow-examples --tags gmail --prefix "email-communication/" --limit 15 --format json
 
 # Once you identify relevant examples from the list operation, retrieve XAML content:
 uip rpa get-workflow-example --key "email-communication/add-new-gmail-emails-to-keap-as-contacts.xaml"

--- a/skills/uipath-rpa-workflows/references/cli-reference.md
+++ b/skills/uipath-rpa-workflows/references/cli-reference.md
@@ -38,7 +38,7 @@ Located at `{projectRoot}/.local/docs/packages/{PackageId}/`. See [Step 1.2](../
 | **Search for activities** | `Bash`: `uip rpa find-activities --query "..." [--tags "..."] [--limit N] --format json` | `--query` (required), `--tags`, `--limit` (default 10) |
 | **Get default activity XAML (non-dynamic)** | `Bash`: `uip rpa get-default-activity-xaml --activity-class-name "..."` | `--activity-class-name` (fully qualified) |
 | **Get default activity XAML (dynamic)** | `Bash`: `uip rpa get-default-activity-xaml --activity-type-id "..." [--connection-id "..."]` | `--activity-type-id`, `--connection-id` (optional) |
-| **List workflow examples** | `Bash`: `uip rpa list-workflow-examples --tags '["service1","service2"]' [--prefix "..."] [--limit N] --format json` | `--tags` (JSON array, required), `--prefix` (optional), `--limit` (default 10) |
+| **List workflow examples** | `Bash`: `uip rpa list-workflow-examples --tags service1,service2 [--prefix "..."] [--limit N] --format json` | `--tags` (comma-separated, required), `--prefix` (optional), `--limit` (default 10) |
 | **Get workflow example** | `Bash`: `uip rpa get-workflow-example --key "path/to/example.xaml"` | `--key` (blob path from list results) |
 | **Create new workflow file** | `Write` tool — create a new `.xaml` file with full XAML content | File path, XAML content |
 | **Edit existing workflow** | `Edit` tool — exact string replacement in `.xaml` files | File path, old_string, new_string |


### PR DESCRIPTION
- Claude was passing literal JSON array stringified values: `--tags '["web","confluence"]'`
- The `Commander` module parses and expects string arrays in the form of: `--tags web,confluence`
