### PR TITLE
docs: document minimum UIA package version for uip rpa uia

### DIFF
--- a/references/activity-docs/UiPath.UIAutomation.Activities/26.3/skills/uia-configure-target/SKILL.md
+++ b/references/activity-docs/UiPath.UIAutomation.Activities/26.3/skills/uia-configure-target/SKILL.md
@@ -39,6 +39,28 @@ If `$WINDOW` is not provided, ask the user which application/window to target.
 
 Derive `$SCREEN_NAME` from `$WINDOW` by converting to Title Case (e.g., "google chrome" → `Google Chrome`).
 
+## TARGET-0: Check UIA Package Version
+
+The `uip rpa uia` subcommands require **`UiPath.UIAutomation.Activities` >= 26.3.1-beta.11555873**. Check the installed version:
+
+```bash
+uip rpa get-versions --package-id UiPath.UIAutomation.Activities --project-dir "$PROJECT_DIR" --format json
+```
+
+Also check `project.json` in `$PROJECT_DIR` for the currently installed version under `dependencies`.
+
+**If the installed version is below `26.3.1-beta.11555873`:** ask the user whether to upgrade using AskUserQuestion:
+
+> "The project's `UiPath.UIAutomation.Activities` package (currently `<installed_version>`) is below the minimum required for `uip rpa uia` CLI features (`26.3.1-beta.11555873`). This upgrade enables object repository management, snapshot capture, and selector intelligence. May I upgrade it?"
+
+If the user approves, run:
+
+```bash
+uip rpa install-or-update-packages --packages '[{"id": "UiPath.UIAutomation.Activities", "version": "26.3.1-beta.11555873"}]' --project-dir "$PROJECT_DIR" --format json
+```
+
+Wait for restore to complete, then continue. If the user declines, warn that `uip rpa uia` commands will fail and fall back to the indication tools (Step 3 in the UI Automation Guide).
+
 ## TARGET-1: Prepare Working Folder
 
 Clean and create:

--- a/skills/uipath-coded-workflows/references/ui-automation-guide.md
+++ b/skills/uipath-coded-workflows/references/ui-automation-guide.md
@@ -7,6 +7,8 @@ Quick reference for UI automation in coded workflows using the `uiAutomation` se
 **Required package:** `UiPath.UIAutomation.Activities`
 **Service accessor:** `uiAutomation` (type `IUiAutomationAppService`)
 
+> **Minimum version for `uip rpa uia` CLI:** The `uip rpa uia` subcommands (snapshot, selector-intelligence, object-repository) require **`UiPath.UIAutomation.Activities` >= 26.3.1-beta.11555873**. If the installed version is older, the subcommands will not appear. Upgrade the package before using any `uip rpa uia` features.
+
 ---
 
 ## Workflow Pattern

--- a/skills/uipath-rpa-workflows/references/ui-automation-guide.md
+++ b/skills/uipath-rpa-workflows/references/ui-automation-guide.md
@@ -6,6 +6,8 @@ Quick reference for UI automation in XAML/RPA workflows using UiPath UIAutomatio
 
 **Required package:** `UiPath.UIAutomation.Activities`
 
+> **Minimum version for `uip rpa uia` CLI:** The `uip rpa uia` subcommands (snapshot, selector-intelligence, object-repository) require **`UiPath.UIAutomation.Activities` >= 26.3.1-beta.11555873**. If the installed version is older, the subcommands will not appear. Upgrade the package before using any `uip rpa uia` features.
+
 ---
 
 ## Key Concepts


### PR DESCRIPTION
## Summary
- Added minimum version callout (`UiPath.UIAutomation.Activities >= 26.3.1-beta.11555873`) to both **RPA** and **coded workflows** UI automation guides — the `uip rpa uia` subcommands (snapshot, selector-intelligence, object-repository) silently don't appear without this version
- Added a **TARGET-0** prerequisite step in `uia-configure-target` SKILL.md that checks the installed version and prompts the user via `AskUserQuestion` to upgrade before proceeding, with a graceful fallback to indication tools if declined

## Test plan
- [ ] Verify `uip rpa uia` subcommands appear when project has UIA >= 26.3.1-beta.11555873
- [ ] Verify TARGET-0 triggers AskUserQuestion when version is below minimum
- [ ] Verify fallback to indication tools works when user declines upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)