### PR TITLE
docs: add keyboard shortcut workflow patterns and encoding reference

### DIFF
--- a/references/activity-docs/UiPath.UIAutomation.Activities/26.3/activities/KeyboardShortcuts.md
+++ b/references/activity-docs/UiPath.UIAutomation.Activities/26.3/activities/KeyboardShortcuts.md
@@ -46,6 +46,57 @@ Sends one or more keyboard shortcuts to a UI element.
 | `DelayAfter` | Delay after | InArgument | `double` |  |  | Delay (in seconds) after this activity is completed, before next activity starts. The default amount of time is 0.3 seconds. |
 | `DelayBefore` | Delay before | InArgument | `double` |  |  | Delay (in seconds) to wait before executing this activity. The default amount of time is 0.2 seconds. |
 
+## CRITICAL: `Shortcuts` vs `ShortcutsArgument`
+
+This activity has **two** shortcut properties -- using the wrong one causes VB bracket parsing failures:
+
+| XAML attribute | C# type | Bracket behavior | When to use |
+|----------------|---------|------------------|-------------|
+| `Shortcuts` | `string` (plain property) | **Literal text** -- brackets are part of the hotkey encoding | **Always use this** for hardcoded shortcuts |
+| `ShortcutsArgument` | `InArgument<string>` | **VB expression** -- `[...]` parsed as VB, will FAIL | Only for dynamic/variable-driven shortcuts |
+
+**NEVER set `ShortcutsArgument` with hotkey encoding directly** -- the VB parser tries to evaluate `d(hk)` as a function call and throws.
+
+## Hotkey Encoding Format
+
+Every shortcut sequence is wrapped in `[d(hk)]...[u(hk)]` delimiters (shortcut-start / shortcut-end). Inside:
+
+| Token | Meaning | Example |
+|-------|---------|---------|
+| `[d(hk)]` | Start of shortcut sequence | Required at the beginning |
+| `[u(hk)]` | End of shortcut sequence | Required at the end |
+| `[d(ctrl)]` | Hold Ctrl modifier | `[d(ctrl)]a[u(ctrl)]` = Ctrl+A |
+| `[u(ctrl)]` | Release Ctrl modifier | Always pair with `[d(ctrl)]` |
+| `[d(shift)]` | Hold Shift | |
+| `[u(shift)]` | Release Shift | |
+| `[d(alt)]` | Hold Alt | |
+| `[u(alt)]` | Release Alt | |
+| `[d(lwin)]` | Hold Windows key | |
+| `[u(lwin)]` | Release Windows key | |
+| `[k(tab)]` | Press Tab | Use `[k(...)]` for non-printable keys |
+| `[k(enter)]` | Press Enter | |
+| `[k(back)]` | Press Backspace | |
+| `[k(del)]` | Press Delete | |
+| `[k(f1)]`--`[k(f12)]` | Function keys | |
+| `a`, `w`, etc. | Printable character | Plain characters, no brackets |
+| ` ` (literal space) | Press Space | NOT `[k(space)]` |
+
+### Common Examples
+
+| Shortcut | Encoding |
+|----------|----------|
+| Ctrl+A | `[d(hk)][d(ctrl)]a[u(ctrl)][u(hk)]` |
+| Ctrl+C | `[d(hk)][d(ctrl)]c[u(ctrl)][u(hk)]` |
+| Ctrl+Shift+J | `[d(hk)][d(ctrl)d(shift)]j[u(shift)u(ctrl)][u(hk)]` |
+| Alt+F4 | `[d(hk)][d(alt)][k(f4)][u(alt)][u(hk)]` |
+| Shift+Tab | `[d(hk)][d(shift)][k(tab)][u(shift)][u(hk)]` |
+| Enter | `[d(hk)][k(enter)][u(hk)]` |
+| Space | `[d(hk)] [u(hk)]` |
+
+**Multiple modifiers** combine in a single `[d(...)]` block: `[d(alt)d(ctrl)]...[u(ctrl)u(alt)]`.
+
+**Multiple shortcut sequences** are concatenated: `[d(hk)]...[u(hk)][d(hk)]...[u(hk)]`.
+
 ## How to create a new Keyboard Shortcuts
 
 To generate the default XAML for this activity, run the following command:
@@ -53,9 +104,26 @@ To generate the default XAML for this activity, run the following command:
 ```bash
 uip rpa get-default-activity-xaml --activity-class-name UiPath.UIAutomationNext.Activities.NKeyboardShortcuts
 ```
+
+## XAML Template
+
+```xml
+<!-- IMPORTANT: Use the plain "Shortcuts" attribute (string), NOT "ShortcutsArgument" (InArgument).
+     The [d(hk)]...[u(hk)] encoding is literal text, not a VB expression. -->
+<uix:NKeyboardShortcuts
+    ActivateBefore="True"
+    ClickBeforeMode="None"
+    DisplayName="Keyboard Shortcut — Ctrl+A (Select All)"
+    HealingAgentBehavior="SameAsCard"
+    InteractionMode="HardwareEvents"
+    Shortcuts="[d(hk)][d(ctrl)]a[u(ctrl)][u(hk)]"
+    Version="V5" />
+```
+
 ## Notes
 
 - This activity must be placed inside a **Use Application/Browser** (`NApplicationCard`) scope.
 - Supports sending multiple shortcuts in sequence, with configurable delay between them.
 - Use `ActivateBefore` to ensure the target element has focus before sending shortcuts.
 - The `ClickBeforeMode` property allows clicking the element before sending the shortcuts to ensure focus.
+- `InteractionMode="HardwareEvents"` is the most reliable mode for keyboard shortcuts.

--- a/skills/uipath-servo/references/special-keys.md
+++ b/skills/uipath-servo/references/special-keys.md
@@ -13,6 +13,8 @@ Special key syntax for `servo type` -- key names, modifiers, and combination pat
 - Supported with **HardwareEvents** (default) and **WebBrowserDebugger**. Other input methods: support varies by target application.
 - Escape a literal `[` by writing `[[`.
 - Mix text and special keys: `"Hello[k(enter)]World"` types "Hello", presses Enter, types "World".
+- **Space key:** Use a literal space character ` `, NOT `[k(space)]`. Example: Ctrl+Space = `[d(ctrl)] [u(ctrl)]`.
+- All key names must be **lowercase**: `ctrl`, `shift`, `enter` -- not `Ctrl`, `SHIFT`, `Enter`.
 
 ## Key Reference
 
@@ -40,13 +42,135 @@ Use UiPath key names, not full names:
 | Page Down | `pgdn` | `pagedown` |
 | Insert | `ins` | `insert` |
 
+## Modifier Combinations
+
+| Pattern | Syntax | Example |
+|---------|--------|---------|
+| Single modifier | `[d(mod)]key[u(mod)]` | `[d(ctrl)]c[u(ctrl)]` = Ctrl+C (copy) |
+| Multiple modifiers | `[d(m1)][d(m2)]key[u(m2)][u(m1)]` | `[d(ctrl)][d(shift)]a[u(shift)][u(ctrl)]` = Ctrl+Shift+A |
+| Modifier + special key | `[d(mod)][k(key)][u(mod)]` | `[d(alt)][k(f4)][u(alt)]` = Alt+F4 |
+| Key sequence | Chain in one string | `[d(ctrl)]a[u(ctrl)][k(del)]` = Select all + delete |
+
+## Common Workflow Patterns
+
+Keyboard shortcuts are often faster and more reliable than clicking through menus. Prefer shortcuts when confident they work in the target app.
+
+### Text Editing
+
+```bash
+# Select all and delete (clear a field)
+servo type e3 "[d(ctrl)]a[u(ctrl)][k(del)]"
+
+# Replace field text: select all, delete, type new value
+servo type e3 "[d(ctrl)]a[u(ctrl)][k(del)]new text here"
+
+# Undo / Redo
+servo type e3 "[d(ctrl)]z[u(ctrl)]"             # Undo
+servo type e3 "[d(ctrl)]y[u(ctrl)]"             # Redo
+
+# Copy / Paste
+servo type e3 "[d(ctrl)]c[u(ctrl)]"             # Copy
+servo type e3 "[d(ctrl)]v[u(ctrl)]"             # Paste
+
+# Find on page (works in browsers, editors, most apps)
+servo type e3 "[d(ctrl)]f[u(ctrl)]"
+servo type e5 "search term[k(enter)]"
+
+# Find and Replace
+servo type e3 "[d(ctrl)]h[u(ctrl)]"
+```
+
+### Navigation
+
+```bash
+# Tab between form fields
+servo type e3 "value1[k(tab)]value2[k(tab)]value3"
+
+# Shift+Tab to go back a field
+servo type e3 "[d(shift)][k(tab)][u(shift)]"
+
+# Page up/down for fast scrolling
+servo type e3 "[k(pgdn)]"
+servo type e3 "[k(pgup)]"
+
+# Home/End to jump to start/end of line
+servo type e3 "[k(home)]"
+servo type e3 "[k(end)]"
+
+# Ctrl+Home/End to jump to start/end of document
+servo type e3 "[d(ctrl)][k(home)][u(ctrl)]"
+servo type e3 "[d(ctrl)][k(end)][u(ctrl)]"
+```
+
+### Browser Shortcuts
+
+```bash
+# New tab
+servo type e3 "[d(ctrl)]t[u(ctrl)]"
+
+# Close tab
+servo type e3 "[d(ctrl)]w[u(ctrl)]"
+
+# Address bar focus (then type URL + Enter)
+servo type e3 "[d(ctrl)]l[u(ctrl)]"
+
+# Refresh page
+servo type e3 "[k(f5)]"
+```
+
+### Modifier + Click (via servo click --modifiers)
+
+```bash
+# Ctrl+click for multi-select in lists/tables
+servo click e5 --modifiers Ctrl
+
+# Shift+click for range-select
+servo click e5 --modifiers Shift
+
+# Ctrl+Shift+click
+servo click e5 -m "Ctrl,Shift"
+```
+
+## Type Into Pitfalls
+
+When using `servo type` with regular text (not just special keys), be aware of these interactions:
+
+### Newlines trigger Enter
+
+Typing a newline character in `servo type` sends an Enter key press. In messaging apps (Slack, Teams, etc.), this **sends the message** instead of creating a new line.
+
+```bash
+# WRONG -- sends "Line 1" as a message, then types "Line 2" into a new message
+servo type e3 "Line 1\nLine 2"
+
+# CORRECT -- use Shift+Enter for a newline within the message
+servo type e3 "Line 1[d(shift)][k(enter)][u(shift)]Line 2"
+```
+
+**Newline key by app context:**
+- **Slack, Teams, chat apps:** Shift+Enter = newline, Enter = send
+- **Excel, Google Sheets:** Alt+Enter = newline within cell, Enter = move to next cell
+- **Word, Notepad, most editors:** Enter = newline (no workaround needed)
+
+### Auto-bulleted lists
+
+Apps like Slack, Teams, PowerPoint, and Word auto-add bullets when pressing Enter in a list context. If you also type a bullet character, you get doubled bullets (`- - Item`).
+
+```bash
+# WRONG in Slack/Teams -- double bullets
+servo type e3 "- Item 1[d(shift)][k(enter)][u(shift)]- Item 2"
+
+# CORRECT -- only add bullet for first item, app adds rest
+servo type e3 "- Item 1[d(shift)][k(enter)][u(shift)]Item 2"
+```
+
 ## Examples
 
 ```
 servo type e3 "[k(enter)]"                       # press Enter
 servo type e3 "[d(ctrl)]a[u(ctrl)]"              # Ctrl+A (select all)
-servo type e3 "[d(alt)k(f4)u(alt)]"              # Alt+F4 (close window)
-servo type e3 "[d(shift)k(left)k(left)u(shift)]" # Shift+Left x2 (select 2 chars)
+servo type e3 "[d(alt)][k(f4)][u(alt)]"          # Alt+F4 (close window)
+servo type e3 "[d(shift)][k(left)][k(left)][u(shift)]" # Shift+Left x2 (select 2 chars)
 servo type e3 "Hello[k(enter)]World"             # type Hello, press Enter, type World
 servo type e3 "[[k(enter)]"                      # types literal "[k(enter)]"
 ```


### PR DESCRIPTION
## Summary
- **Servo `special-keys.md`**: Added practical keyboard shortcut workflow patterns (text editing, navigation, browser shortcuts, modifier+click), type-into pitfalls (newline/Enter gotcha in chat apps, auto-bulleted list handling), modifier combination syntax table, and space key / lowercase key name notes.
- **26.3 `KeyboardShortcuts.md` activity doc**: Added the full hotkey encoding format reference, `Shortcuts` vs `ShortcutsArgument` critical distinction, XAML template, and common examples — all previously only documented in the 26.2 version.

Patterns sourced from Autopilot's `UiActions.ts` and `AppActDescription.ts`.

## Test plan
- [ ] Verify special-keys.md renders correctly and examples use valid servo syntax
- [ ] Verify KeyboardShortcuts.md hotkey encoding examples match 26.2 reference
- [ ] Spot-check a few servo type commands from the new workflow patterns section

## TODO

- [ ] Update activities repo
- [ ] Use 26.3.1-beta.11569242 

🤖 Generated with [Claude Code](https://claude.com/claude-code)