### PR TITLE
Add InvokeCode Language property pitfall and code style guidelines

### DIFF
--- a/references/activity-docs/UiPath.System.Activities/25.10/activities/InvokeCode.md
+++ b/references/activity-docs/UiPath.System.Activities/25.10/activities/InvokeCode.md
@@ -121,6 +121,44 @@ Code="For Each row As DataRow In dt.Rows&#xA;    row(&quot;Column1&quot;) = row(
 **Required namespace import:** `System.Net`
 **Required assembly reference:** `System.Net.WebClient`
 
+## Code Style Guidelines
+
+InvokeCode content must be clean, readable, and well-structured — even though it lives inside an XML attribute. Never write dense single-line code.
+
+**Rules:**
+1. **Always use multi-line code** — use `&#xA;` for line breaks. One statement per line.
+2. **Add comments** — explain each logical step with VB (`'`) or C# (`//`) comments. Comments also use `&#xA;` for the preceding newline.
+3. **Use descriptive variable names** — `cleaned`, `totalAmount`, `filteredRows` instead of `x`, `t`, `r`.
+4. **Structure consistently** — declare variables first, then logic, then assign output arguments last.
+5. **Indent with spaces** — use 2-4 spaces for blocks (For/Next, If/End If, Using/End Using) to show nesting.
+
+**Bad — single-line, no comments, cryptic names:**
+```xml
+Code="o = i.Trim().ToUpper().Replace(&quot;OLD&quot;, &quot;NEW&quot;)"
+```
+
+**Good — multi-line, commented, descriptive:**
+```xml
+Code="' Remove leading/trailing whitespace&#xA;Dim cleaned As String = rawInput.Trim()&#xA;&#xA;' Normalize to uppercase&#xA;Dim uppercased As String = cleaned.ToUpper()&#xA;&#xA;' Apply text replacement&#xA;result = uppercased.Replace(&quot;OLD&quot;, &quot;NEW&quot;)"
+```
+
+Equivalent VB code:
+```vb
+' Remove leading/trailing whitespace
+Dim cleaned As String = rawInput.Trim()
+
+' Normalize to uppercase
+Dim uppercased As String = cleaned.ToUpper()
+
+' Apply text replacement
+result = uppercased.Replace("OLD", "NEW")
+```
+
+**C# equivalent style:**
+```xml
+Code="// Remove leading/trailing whitespace&#xA;var cleaned = rawInput.Trim();&#xA;&#xA;// Normalize to uppercase&#xA;var uppercased = cleaned.ToUpper();&#xA;&#xA;// Apply text replacement&#xA;result = uppercased.Replace(&quot;OLD&quot;, &quot;NEW&quot;);"
+```
+
 ## When NOT to Use InvokeCode
 
 Stop and switch to a coded workflow when:

--- a/skills/uipath-rpa-workflows/references/common-pitfalls.md
+++ b/skills/uipath-rpa-workflows/references/common-pitfalls.md
@@ -140,6 +140,20 @@ Scope activities (like `ExcelApplicationCard`, `Use Application/Browser`) use `A
 - **TargetSession validation**: `TargetSession.Secondary` (or any non-Current value) requires `UnSafe=True`. Without it, validation fails.
 - **Persistence with isolation**: Using `ResumeInstanceId` with Safe mode (`UnSafe=false`) without persistence support throws `NotSupportedException`.
 
+## InvokeCode Language Property
+
+The `Language` property on `InvokeCode` uses the `UiPath.Core.Activities.NetLanguage` enum, which has **only two valid values**: `VBNet` and `CSharp`.
+
+**Critical:** The project-level `expressionLanguage` in `project.json` uses `"VisualBasic"`, but InvokeCode's `Language` attribute requires `"VBNet"` instead. Do NOT use `"VisualBasic"` — it is not a valid `NetLanguage` value. `"CSharp"` is the same in both.
+
+**What happens:** Using `Language="VisualBasic"` passes Studio validation but fails at runtime:
+```
+Failed to create a 'Language' from the text 'VisualBasic'.
+System.FormatException: VisualBasic is not a valid value for NetLanguage.
+```
+
+**Prevention:** Omit the `Language` attribute entirely — InvokeCode infers it from the project's expression language. If you must set it explicitly, use `"VBNet"` (not `"VisualBasic"`) or `"CSharp"`. See `InvokeCode.md` in `references/activity-docs/UiPath.System.Activities/` for full details.
+
 ## HTTP Request Activity Complexity
 
 The HTTP Request activity (`NetHttpRequest`) has extensive configuration:


### PR DESCRIPTION
## Summary
- Add `InvokeCode Language Property` section to `common-pitfalls.md` documenting the `NetLanguage` enum mismatch (`VBNet`/`CSharp` vs `VisualBasic`/`CSharp`) that causes runtime XAML deserialization errors
- Add `Code Style Guidelines` section to `InvokeCode.md` instructing agents to write multi-line, commented, well-structured inline code with bad vs good examples in both VB.NET and C#

Closes #101

## Test plan
- [ ] Verify the pitfall section in `common-pitfalls.md` clearly communicates that `Language="VisualBasic"` is invalid and `Language="VBNet"` is correct
- [ ] Verify the code style guidelines in `InvokeCode.md` are clear and the escaped XML examples are correct
- [ ] Test with the RPA skill to confirm the agent uses `VBNet` (not `VisualBasic`) when generating InvokeCode activities