### PR TITLE
feat: add uipath-cas skill for Conversational Agents

### DIFF
--- a/skills/uipath-cas/SKILL.md
+++ b/skills/uipath-cas/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: uipath-cas
+description: "UiPath Conversational Agent Service (CAS) -- discover agents, chat via WebSocket, manage conversations, exchanges, messages, citations, attachments, and user settings through the uip cas CLI. TRIGGER when: user wants to chat with a UiPath agent, interact with conversational agents, list or discover available agents, manage conversations (create, resume, list, delete), review exchanges or messages, upload attachments to conversations, manage CAS user settings, or uses 'uip cas' commands. DO NOT TRIGGER when: user wants to create/build/code a Python agent (use uipath-coded-agents), deploy an agent to Orchestrator (use uipath-platform), or build RPA/flow automations."
+metadata:
+  allowed-tools: Bash, Read, Grep
+---
+
+# UiPath Conversational Agents (CAS)
+
+Interact with UiPath Conversational Agents via the `uip cas` CLI -- discover agents, chat in real time, and manage conversations.
+
+**Prerequisite:** The user must be authenticated. Check with `uip login status --output json`. If not logged in, run `uip login --output json`. Auth credentials are stored at `~/.uipath/.auth`.
+
+## When to Use This Skill
+
+- User wants to **discover** available conversational agents
+- User wants to **chat** with an agent (single message or multi-turn)
+- User wants to **manage conversations** (create, resume, list, update, delete)
+- User wants to **review exchanges or messages** from past conversations
+- User wants to **upload file attachments** to a conversation
+- User wants to **submit feedback** on agent responses
+- User wants to **manage CAS user settings** (name, role, department, timezone)
+- User references `uip cas` commands
+
+## Critical Rules
+
+1. **Always authenticate first.** Run `uip login status --output json` before any CAS command. If not logged in, run `uip login --output json` then `uip login tenant set "<TENANT>" --output json`. Every CAS command requires a valid auth token.
+
+2. **Always use `--output json` on non-chat commands.** All `uip cas agents`, `conversations`, `exchanges`, `messages`, and `user` commands support `--output json` for machine-readable output. The `chat` command does NOT support `--output json` -- it streams text directly to stdout.
+
+3. **Always use single-message mode (`-m`) for programmatic use.** Interactive mode uses Node's `readline` on stdin, which expects a human typing at a terminal. AI agent Bash tool calls have no interactive TTY -- stdin is a pipe or `/dev/null`, causing unreliable buffering, stalled input, and unpredictable output flushing. The `-m` flag is deterministic: send one message, get the response on stdout, process exits. For multi-turn, chain multiple `-m` calls with `--conversation-id`. When an AI agent needs to send a message, always use:
+   ```bash
+   uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> -m "Your message" 2>/dev/null
+   ```
+   Capture stdout for the agent's response text. Never attempt to drive the interactive readline prompt.
+
+4. **Always obtain both agent-id AND folder-id before chatting.** The `chat` command requires both values. Discover them with:
+   ```bash
+   uip cas agents list --output json
+   ```
+   This returns `Id` (agent-id) and `FolderId` (folder-id) for each agent.
+
+5. **Save the conversation-id for multi-turn conversations.** The first `chat` call auto-creates a conversation. Capture the conversation ID from `--verbose` output or create one explicitly:
+   ```bash
+   uip cas conversations create <AGENT_ID> --folder-id <FOLDER_ID> --output json
+   ```
+   Then pass `--conversation-id <ID>` on subsequent calls to retain context across turns.
+
+6. **Expect slower responses for large messages.** Messages over ~90 KB may take significantly longer to process, and the client currently lacks a timeout -- so it can appear to hang. If a large message seems stuck, wait longer before assuming failure. For very large content, consider uploading as a file attachment instead:
+   ```bash
+   uip cas conversations attachments upload <CONV_ID> --file <PATH> --output json
+   ```
+
+7. **Never open concurrent sessions on the same conversation.** Multiple simultaneous WebSocket sessions targeting the same conversation-id cause interleaved messages and unhandled errors. Use one session per conversation at a time.
+
+8. **Do not use `--log-level` on the chat command.** This option conflicts with the global CLI `--log-level` flag and has no effect. Use `--verbose` instead to see tool calls, session events, and label updates on stderr.
+
+9. **stdout = response text, stderr = metadata.** The `chat` command streams the agent's response to stdout. With `--verbose`, session lifecycle events, tool call names, label updates, and citations go to stderr. Parse stdout for the actual response content.
+
+10. **Clean up conversations when done.** Delete conversations that are no longer needed:
+    ```bash
+    uip cas conversations delete <CONV_ID> --output json
+    ```
+
+## Quick Start
+
+### Step 1 -- Authenticate
+
+```bash
+uip login status --output json
+# If not logged in:
+uip login --output json
+uip login tenant set "<TENANT_NAME>" --output json
+```
+
+For non-default environments (e.g., alpha):
+```bash
+uip login --authority "https://alpha.uipath.com" --output json
+```
+
+### Step 2 -- Discover Agents
+
+```bash
+uip cas agents list --output json
+```
+
+Or filter by folder:
+```bash
+uip cas agents list --folder-id <FOLDER_ID> --output json
+```
+
+### Step 3 -- Get Agent Details (optional)
+
+```bash
+uip cas agents get <AGENT_ID> --folder-id <FOLDER_ID> --output json
+```
+
+Returns name, description, process key, version, and welcome title.
+
+### Step 4 -- Send a Single Message
+
+```bash
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> -m "Your question here"
+```
+
+The agent's response streams to stdout.
+
+### Step 5 -- Multi-Turn Conversation
+
+Create a conversation explicitly:
+```bash
+CONV_ID=$(uip cas conversations create <AGENT_ID> --folder-id <FOLDER_ID> --output json | jq -r '.Data.Id')
+```
+
+Send messages on the same conversation:
+```bash
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --conversation-id "$CONV_ID" -m "First question"
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --conversation-id "$CONV_ID" -m "Follow-up question"
+```
+
+The agent retains full context across turns -- tested up to 10 minutes with 2-minute idle gaps between messages.
+
+## Key Concepts
+
+### Data Model Hierarchy
+
+```
+Agent                          (a deployed conversational agent release)
+  |-- Conversation             (a persistent, stateful chat thread)
+        |-- Exchange           (one user-question + agent-response pair)
+              |-- Message      (individual message within an exchange)
+                    |-- ContentPart    (text/markdown content blocks)
+                    |     |-- Citation (source references with URLs)
+                    |-- ToolCall       (agent tool invocations)
+```
+
+### Conversation vs Session
+
+- A **Conversation** is persistent (has a UUID, CRUD-managed, stores message history).
+- A **Session** is a live WebSocket connection to a conversation (ephemeral, created by `chat`, destroyed on disconnect). Multiple sessions can use the same conversation sequentially -- each picks up where the last left off.
+
+## Common Patterns
+
+### Inspect a Past Conversation
+
+```bash
+# List recent conversations
+uip cas conversations list --sort descending --output json
+
+# List exchanges in a conversation
+uip cas exchanges list <CONV_ID> --output json
+
+# Get an exchange with its messages
+uip cas exchanges get <CONV_ID> <EXCHANGE_ID> --output json
+
+# Get a message with citations
+uip cas messages get <CONV_ID> <EXCHANGE_ID> <MSG_ID> --citations --output json
+```
+
+### Upload a File Then Ask About It
+
+```bash
+# Create conversation
+CONV_ID=$(uip cas conversations create <AGENT_ID> --folder-id <FOLDER_ID> --output json | jq -r '.Data.Id')
+
+# Upload file
+uip cas conversations attachments upload "$CONV_ID" --file ./report.pdf --output json
+
+# Ask about the uploaded file
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --conversation-id "$CONV_ID" -m "Summarize the uploaded report"
+```
+
+### Give Feedback on a Response
+
+```bash
+# List exchanges to find the one to rate
+uip cas exchanges list <CONV_ID> --output json
+
+# Submit positive/negative feedback
+uip cas exchanges feedback <CONV_ID> <EXCHANGE_ID> --rating positive --comment "Helpful answer" --output json
+```
+
+### Update User Context
+
+Set user profile so agents have context about who they're talking to:
+```bash
+uip cas user update-settings --name "Jane Doe" --role "Developer" --department "Engineering" --output json
+```
+
+## Anti-Patterns
+
+- **Never use interactive chat mode from an AI agent.** Always use `-m` flag. Interactive mode uses stdin readline designed for human terminals.
+- **Never send multiple concurrent messages to the same conversation.** This causes interleaved responses and unhandled errors.
+- **Don't assume a large message failed just because it's slow.** Messages over ~90 KB take longer and the client has no timeout. Wait before retrying, or upload large content as an attachment.
+- **Never rely on `--log-level` for the chat command.** It is broken due to a naming conflict. Use `--verbose`.
+- **Never skip the authentication check.** CAS commands fail with cryptic errors when not authenticated.
+- **Never parse stderr for response content.** stdout has the response, stderr has metadata/debug output.
+
+## Troubleshooting
+
+| Error / Symptom | Cause | Solution |
+|---|---|---|
+| `Not logged in` or `Client Authorization Failed` | Missing or expired auth token | Run `uip login --output json` |
+| Chat hangs after agent responds | Known SDK issue: socket.io reconnect loop | Process will eventually be killed; known issue being fixed |
+| Chat hangs with no response for a long time | Large message payload (>90 KB) takes longer to process; client has no timeout | Wait longer, or upload large content as an attachment instead |
+| Garbled / interleaved responses | Concurrent sessions on same conversation | Use one session per conversation at a time |
+| `Error creating conversation` | Wrong agent-id or folder-id | Verify with `uip cas agents list --output json` |
+| `--log-level Debug` has no effect on chat | Global CLI flag conflict | Use `--verbose` instead |
+| `AGENT_INVALID_INPUT: No user message found` | Concurrent session race condition | Don't run parallel chats on the same conversation |
+
+## Task Navigation
+
+| I need to... | Read these |
+|---|---|
+| Discover available agents | Quick Start Steps 2-3 |
+| Send a single message to an agent | Quick Start Step 4 |
+| Have a multi-turn conversation | Quick Start Step 5 |
+| Understand the chat WebSocket model | [references/chat-guide.md](references/chat-guide.md) |
+| Manage conversations (CRUD) | [references/conversations-lifecycle-guide.md](references/conversations-lifecycle-guide.md) |
+| Work with exchanges and messages | [references/conversations-lifecycle-guide.md](references/conversations-lifecycle-guide.md) |
+| Upload attachments | [references/conversations-lifecycle-guide.md](references/conversations-lifecycle-guide.md) |
+| Submit feedback | [references/conversations-lifecycle-guide.md](references/conversations-lifecycle-guide.md) |
+| Manage user settings | [references/conversations-lifecycle-guide.md](references/conversations-lifecycle-guide.md) |
+| Full CLI command reference | [references/cas-commands-reference.md](references/cas-commands-reference.md) |
+
+## References
+
+- **[CAS CLI Command Reference](references/cas-commands-reference.md)** -- Every `uip cas` command with parameters and examples
+- **[Chat Guide](references/chat-guide.md)** -- WebSocket chat deep dive: modes, streaming, multi-turn, known limits
+- **[Conversations Lifecycle Guide](references/conversations-lifecycle-guide.md)** -- Conversations, exchanges, messages, attachments, user settings

--- a/skills/uipath-cas/references/cas-commands-reference.md
+++ b/skills/uipath-cas/references/cas-commands-reference.md
@@ -1,0 +1,335 @@
+# CAS CLI Command Reference
+
+Complete reference for all `uip cas` commands. Always use `--output json` for programmatic parsing (except `chat`, which streams text to stdout).
+
+## Global Options
+
+Every `uip` command accepts:
+
+| Option | Description | Default |
+|---|---|---|
+| `--output <format>` | Output format: `table`, `json`, `yaml`, `plain` | `table` (interactive), `json` (non-interactive) |
+| `--output-filter <expr>` | JMESPath expression to filter output | -- |
+| `--log-level <level>` | Log level: `debug`, `info`, `warn`, `error` | `info` |
+| `--log-file <path>` | Write logs to file instead of stderr | -- |
+
+---
+
+## Agents
+
+### `uip cas agents list`
+
+List all available conversational agents.
+
+```bash
+uip cas agents list [--folder-id <ID>] --output json
+```
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `--folder-id <id>` | string | No | Filter agents by folder ID |
+
+**Response fields:** `Id`, `Name`, `Description`, `FolderId`, `ProcessKey`
+
+### `uip cas agents get`
+
+Get detailed information about a specific agent.
+
+```bash
+uip cas agents get <AGENT_ID> --folder-id <FOLDER_ID> --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<agent-id>` | number | Yes | Agent release ID (positional argument) |
+| `--folder-id <id>` | string | Yes | Folder ID containing the agent |
+
+**Response fields:** `Id`, `Name`, `Description`, `FolderId`, `ProcessKey`, `ProcessVersion`, `WelcomeTitle`
+
+---
+
+## Conversations
+
+### `uip cas conversations create`
+
+Create a new conversation with an agent.
+
+```bash
+uip cas conversations create <AGENT_ID> --folder-id <FOLDER_ID> [options] --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<agent-id>` | number | Yes | Agent release ID (positional argument) |
+| `--folder-id <id>` | string | Yes | Folder ID containing the agent |
+| `--label <label>` | string | No | Conversation label |
+| `--autogenerate-label` | flag | No | Auto-generate a label from first message |
+| `--trace-id <id>` | string | No | Trace ID for the conversation |
+| `--run-as-me` | flag | No | Run the agent job as the current user |
+
+**Response fields:** `Id`, `Label`, `CreatedTime`, `AgentId`
+
+### `uip cas conversations list`
+
+List all conversations.
+
+```bash
+uip cas conversations list [options] --output json
+```
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `--page-size <n>` | number | No | Number of conversations per page |
+| `--sort <order>` | string | No | `ascending` or `descending` |
+| `--cursor <token>` | string | No | Pagination cursor from previous response |
+
+**Response fields:** `Id`, `Label`, `CreatedTime`, `LastActivityTime`, `NextCursor`
+
+### `uip cas conversations get`
+
+Get details for a specific conversation.
+
+```bash
+uip cas conversations get <CONVERSATION_ID> --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+
+**Response fields:** `Id`, `Label`, `CreatedTime`, `UpdatedTime`, `LastActivityTime`, `AgentId`, `FolderId`
+
+### `uip cas conversations update`
+
+Update a conversation's properties.
+
+```bash
+uip cas conversations update <CONVERSATION_ID> [options] --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+| `--label <label>` | string | No | New label |
+| `--autogenerate-label` | flag | No | Auto-generate a label |
+| `--job-key <key>` | string | No | Job key to associate |
+| `--local-job-execution` | flag | No | Enable local job execution |
+
+At least one option must be provided.
+
+**Response fields:** `Id`, `Label`, `UpdatedTime`
+
+### `uip cas conversations delete`
+
+Delete a conversation.
+
+```bash
+uip cas conversations delete <CONVERSATION_ID> --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+
+**Response fields:** `Id`, `Status` ("Deleted")
+
+---
+
+## Conversation Attachments
+
+### `uip cas conversations attachments upload`
+
+Upload a file attachment to a conversation.
+
+```bash
+uip cas conversations attachments upload <CONVERSATION_ID> --file <PATH> --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+| `--file <path>` | string | Yes | Path to the file to upload |
+
+**Response fields:** `ConversationId`, `FileName`, `MimeType`, `UploadUri`
+
+### `uip cas conversations attachments get-uri`
+
+Get a pre-signed upload URI for an attachment.
+
+```bash
+uip cas conversations attachments get-uri <CONVERSATION_ID> --file-name <NAME> --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+| `--file-name <name>` | string | Yes | Name of the file |
+
+**Response fields:** `ConversationId`, `FileName`, `UploadUri`, `UploadUrl`, `HttpVerb`, `RequiresAuth`
+
+---
+
+## Exchanges
+
+### `uip cas exchanges list`
+
+List exchanges (conversation turns) for a conversation.
+
+```bash
+uip cas exchanges list <CONVERSATION_ID> [options] --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+| `--page-size <n>` | number | No | Number of exchanges per page |
+| `--sort <order>` | string | No | `ascending` or `descending` |
+| `--message-sort <order>` | string | No | Sort messages within exchanges |
+| `--cursor <token>` | string | No | Pagination cursor |
+
+**Response fields:** `Id`, `CreatedTime`, `UpdatedTime`, `MessageCount`, `FeedbackRating`, `NextCursor`
+
+### `uip cas exchanges get`
+
+Get exchange details with all messages.
+
+```bash
+uip cas exchanges get <CONVERSATION_ID> <EXCHANGE_ID> [options] --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+| `<exchange-id>` | UUID | Yes | Exchange ID (positional argument) |
+| `--message-sort <order>` | string | No | Sort messages: `ascending` or `descending` |
+
+**Response fields:** Array of messages with `ExchangeId`, `MessageId`, `Role`, `ContentPartCount`, `ToolCallCount`, `FeedbackRating`
+
+### `uip cas exchanges feedback`
+
+Submit feedback (rating) for an exchange.
+
+```bash
+uip cas exchanges feedback <CONVERSATION_ID> <EXCHANGE_ID> --rating <RATING> [options] --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID (positional argument) |
+| `<exchange-id>` | UUID | Yes | Exchange ID (positional argument) |
+| `--rating <rating>` | string | Yes | `positive` or `negative` |
+| `--comment <text>` | string | No | Optional feedback comment |
+
+**Response fields:** `ConversationId`, `ExchangeId`, `Rating`, `Comment`, `Status`
+
+---
+
+## Messages
+
+### `uip cas messages get`
+
+Get a specific message with content parts.
+
+```bash
+uip cas messages get <CONVERSATION_ID> <EXCHANGE_ID> <MESSAGE_ID> [options] --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID |
+| `<exchange-id>` | UUID | Yes | Exchange ID |
+| `<message-id>` | UUID | Yes | Message ID |
+| `--citations` | flag | No | Include detailed citation data |
+
+**Without `--citations`:** `MessageId`, `Role`, `CreatedTime`, `UpdatedTime`, `ContentParts` (MIME types), `ToolCalls`, `CitationCount`
+
+**With `--citations`:** Detailed citation data including `ContentPartId`, `MimeType`, `CitationId`, `Offset`, `Length`, source info
+
+### `uip cas messages get-content-part`
+
+Get the data for a specific content part.
+
+```bash
+uip cas messages get-content-part <CONVERSATION_ID> <EXCHANGE_ID> <MESSAGE_ID> <CONTENT_PART_ID> --output json
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<conversation-id>` | UUID | Yes | Conversation ID |
+| `<exchange-id>` | UUID | Yes | Exchange ID |
+| `<message-id>` | UUID | Yes | Message ID |
+| `<content-part-id>` | UUID | Yes | Content part ID |
+
+**Response fields:** `ContentPartId`, `IsInline`, `IsExternal`, `Data`
+
+---
+
+## User Settings
+
+### `uip cas user get-settings`
+
+Get the current user's profile and context settings.
+
+```bash
+uip cas user get-settings --output json
+```
+
+**Response fields:** `UserId`, `Name`, `Email`, `Role`, `Department`, `Company`, `Country`, `Timezone`
+
+### `uip cas user update-settings`
+
+Update user profile and context settings.
+
+```bash
+uip cas user update-settings [options] --output json
+```
+
+| Option | Type | Required | Description |
+|---|---|---|---|
+| `--name <name>` | string | No | User name |
+| `--email <email>` | string | No | Email address |
+| `--role <role>` | string | No | User role |
+| `--department <dept>` | string | No | Department |
+| `--company <company>` | string | No | Company |
+| `--country <country>` | string | No | Country |
+| `--timezone <tz>` | string | No | Timezone |
+
+At least one option must be provided.
+
+**Response fields:** Same as `get-settings`
+
+---
+
+## Chat
+
+### `uip cas chat`
+
+Start a real-time WebSocket chat session with a conversational agent.
+
+```bash
+# Single-message mode (for AI agents / programmatic use)
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> -m "Your message"
+
+# Resume a conversation
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --conversation-id <CONV_ID> -m "Follow-up"
+
+# Interactive mode (human terminal use only)
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --verbose
+```
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `<agent-id>` | number | Yes | Agent release ID (positional argument) |
+| `--folder-id <id>` | string | Yes | Folder ID containing the agent |
+| `--conversation-id <id>` | UUID | No | Resume an existing conversation |
+| `-m, --message <text>` | string | No | Single message (non-interactive mode) |
+| `--verbose` | flag | No | Show tool calls and session events on stderr |
+| `--log-level <level>` | string | No | **Broken** -- conflicts with global flag. Use `--verbose` |
+
+**Output behavior:**
+- **stdout:** Agent response text (streamed in real time)
+- **stderr (with `--verbose`):** Session lifecycle, tool call names, label updates, citations
+
+**Interactive mode commands:** `/quit` or `/exit` to end the session.
+
+> **For AI agents:** Always use `-m` mode. Never attempt to drive the interactive readline prompt.

--- a/skills/uipath-cas/references/chat-guide.md
+++ b/skills/uipath-cas/references/chat-guide.md
@@ -1,0 +1,191 @@
+# Chat Guide
+
+Deep dive on the `uip cas chat` command -- WebSocket architecture, streaming behavior, multi-turn conversations, and known limits discovered through stress testing.
+
+## Chat Modes
+
+### Single-Message Mode (`-m`)
+
+Send one message, receive the response, and exit. This is the correct mode for AI agents and programmatic use.
+
+```bash
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> -m "Your question"
+```
+
+If no `--conversation-id` is provided, a new conversation is auto-created. The agent's response streams to stdout. The process exits after the response completes.
+
+### Interactive Mode (no `-m`)
+
+Opens a readline prompt for multi-turn human conversation over a single persistent WebSocket.
+
+```bash
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --verbose
+```
+
+- Prompt: `You: ` (printed to stderr)
+- Agent responses prefixed with `Agent: ` (on stderr), actual text on stdout
+- Exit with `/quit` or `/exit`
+- Ctrl+C triggers graceful cleanup (endSession + disconnect)
+
+> **AI agents must never use interactive mode.** Interactive mode uses Node's `readline` on stdin, which requires a TTY. AI agent Bash tool calls pipe stdin or use `/dev/null`, causing unreliable buffering, stalled input, and unpredictable output. Always use `-m` flag for deterministic behavior.
+
+## WebSocket Lifecycle
+
+Each chat session follows this lifecycle:
+
+```
+1. Create conversation       (REST API, or auto-created by chat)
+2. Connect WebSocket         (socket.io, wss:// transport)
+3. Start session             (ConversationEvent: startSession)
+4. Session acknowledged      (ConversationEvent: sessionStarted)
+5. For each user message:
+   a. Start exchange         (ConversationEvent: startExchange)
+   b. Send user message      (ConversationEvent: message with user content)
+   c. Receive agent message  (ConversationEvent: message chunks streamed)
+   d. End exchange           (ConversationEvent: endExchange)
+6. End session               (ConversationEvent: endSession)
+7. Disconnect WebSocket
+```
+
+### Connection Details
+
+- **Transport:** WebSocket only (no HTTP polling fallback)
+- **URL:** `wss://<host>/autopilotforeveryone_/websocket_/socket.io`
+- **Auth:** Token refreshed automatically on every connection/reconnection attempt
+- **Reconnection:** Enabled with exponential backoff (200ms initial, 30s max, infinite retries)
+- **Connection timeout:** 5 seconds
+
+## Streaming Output
+
+The chat command writes to two streams:
+
+### stdout (response content)
+
+The agent's actual response text. In single-message mode, capture this for the answer:
+
+```bash
+RESPONSE=$(uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> -m "What is 2+2?" 2>/dev/null)
+echo "$RESPONSE"  # "2 + 2 equals 4."
+```
+
+### stderr (metadata, with `--verbose`)
+
+Session lifecycle events, tool calls, label updates, and citations:
+
+```
+[Created conversation: <UUID>]
+[Session started]
+[Label updated: Topic Summary (auto)]
+[Tool call: Web_Search]
+[Tool call: Web_Search]
+
+--- Citations ---
+  [1] Source Title - https://example.com
+  [2] Another Source - https://example.com/page (page 5)
+```
+
+Without `--verbose`, only errors appear on stderr.
+
+## Multi-Turn Conversations
+
+### Approach 1: Explicit Conversation (recommended for AI agents)
+
+Create a conversation once, then reuse it across multiple `-m` calls:
+
+```bash
+# Create
+CONV_ID=$(uip cas conversations create <AGENT_ID> --folder-id <FOLDER_ID> --output json | jq -r '.Data.Id')
+
+# Turn 1
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --conversation-id "$CONV_ID" -m "My name is Alice"
+
+# Turn 2 (agent remembers Turn 1)
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --conversation-id "$CONV_ID" -m "What is my name?"
+# Response: "Your name is Alice."
+```
+
+Each `-m` call creates a fresh WebSocket session, but the conversation state persists server-side. Context is fully retained across turns.
+
+### Approach 2: Auto-Created Conversation
+
+When you omit `--conversation-id`, the chat command auto-creates a conversation. To continue it, extract the conversation ID from verbose output:
+
+```bash
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> -m "Hello" --verbose 2>&1 | grep "Created conversation"
+# [Created conversation: 7858dd3b-5600-4c56-a98f-f1a1dd7dae0c]
+```
+
+Then pass it on subsequent calls.
+
+## Tool Calls and Interrupts
+
+Agents may invoke tools (e.g., web search, API calls) during their response. With `--verbose`:
+
+```
+[Tool call: Web_Search]
+[Tool call: GetWeather]
+```
+
+Some agents may also request approval for actions via **interrupts**. The CLI auto-approves all interrupts. With `--verbose`:
+
+```
+[Interrupt: ToolApproval]
+  Tool: SendEmail
+```
+
+## Label Auto-Updates
+
+As the conversation progresses, the server may auto-generate labels summarizing the topic:
+
+```
+[Label updated: Travel Planning and Itinerary (auto)]
+```
+
+These appear on stderr with `--verbose` and are informational only.
+
+## Known Limits (from Stress Testing)
+
+These limits were discovered through systematic WebSocket stress testing:
+
+### What Works
+
+| Scenario | Result |
+|---|---|
+| Single-message mode | Reliable, clean response |
+| Multi-turn, same conversation, sequential | Full context retention across turns |
+| Single WebSocket, 2-minute idle gaps | Connection survives via ping/pong keepalive |
+| Single WebSocket, 10+ minutes | Stable, no disconnects |
+| 5 concurrent different conversations | All succeed with correct responses |
+| Conversation resume via `--conversation-id` | Context fully preserved |
+| 33 KB message payload | Processed correctly |
+| Tool calls during response | Rendered correctly with `--verbose` |
+| Citations in response | Footnotes displayed on stderr |
+
+### What Breaks
+
+| Scenario | Symptom | Workaround |
+|---|---|---|
+| Message payload >90 KB | Slow processing; client has no timeout so it appears to hang | Wait longer, or upload large content as an attachment |
+| Concurrent sessions on same conversation | Interleaved messages, `AGENT_INVALID_INPUT` error | One session per conversation |
+| `--log-level` on chat command | Ignored (global flag conflict) | Use `--verbose` |
+| Process exit after chat (SDK bug) | Process hangs due to socket.io reconnect loop | Being fixed; process eventually exits |
+
+### Idle Connection Behavior
+
+The WebSocket uses socket.io's ping/pong keepalive mechanism. Tested idle periods:
+
+- **60 seconds:** Connection survives, agent responds immediately
+- **120 seconds:** Connection survives, full context retention
+- **Multiple 120-second gaps over 10 minutes:** All turns successful
+
+The connection will eventually be closed by the server after extended inactivity (exact timeout depends on server configuration).
+
+## Best Practices for AI Agent Use
+
+1. **Always use `-m` flag** -- never interactive mode
+2. **Redirect stderr** to capture clean response: `2>/dev/null`
+3. **Create conversation explicitly** for multi-turn flows -- don't rely on auto-creation
+4. **Be patient with large messages (>90 KB)** -- they process slower and the client has no timeout; use attachments for very large content
+5. **One session at a time** per conversation -- no parallel sends
+6. **Capture the conversation-id** early and reuse it
+7. **Delete conversations** after completing the task

--- a/skills/uipath-cas/references/conversations-lifecycle-guide.md
+++ b/skills/uipath-cas/references/conversations-lifecycle-guide.md
@@ -1,0 +1,276 @@
+# Conversations Lifecycle Guide
+
+Managing conversations, exchanges, messages, attachments, and user settings through the `uip cas` CLI.
+
+## Conversations
+
+### Create a Conversation
+
+```bash
+uip cas conversations create <AGENT_ID> --folder-id <FOLDER_ID> --output json
+```
+
+Optional flags:
+- `--label "My Chat"` -- set a human-readable label
+- `--autogenerate-label` -- server auto-generates a label from the first message
+- `--trace-id <ID>` -- associate a trace ID for observability
+- `--run-as-me` -- run the agent job as the current authenticated user
+
+**Example:**
+```bash
+uip cas conversations create 79090 --folder-id 666955 --label "Support Chat" --output json
+```
+
+**Response:**
+```json
+{
+  "Result": "Success",
+  "Code": "ConversationCreated",
+  "Data": {
+    "Id": "db4f5183-1fb3-4353-9517-54fa43a16553",
+    "Label": "Support Chat",
+    "CreatedTime": "2025-03-31T02:04:19.080Z",
+    "AgentId": 79090
+  }
+}
+```
+
+### List Conversations
+
+```bash
+uip cas conversations list --output json
+```
+
+Supports pagination:
+```bash
+# First page
+uip cas conversations list --page-size 10 --sort descending --output json
+
+# Next page (use NextCursor from previous response)
+uip cas conversations list --page-size 10 --cursor "<CURSOR_TOKEN>" --output json
+```
+
+### Get Conversation Details
+
+```bash
+uip cas conversations get <CONVERSATION_ID> --output json
+```
+
+Returns full details including `AgentId`, `FolderId`, `Label`, timestamps.
+
+### Update a Conversation
+
+```bash
+uip cas conversations update <CONVERSATION_ID> --label "New Label" --output json
+```
+
+At least one option is required. Available options:
+- `--label <label>` -- change the label
+- `--autogenerate-label` -- auto-generate from content
+- `--job-key <key>` -- associate a job key
+- `--local-job-execution` -- enable local job execution
+
+### Delete a Conversation
+
+```bash
+uip cas conversations delete <CONVERSATION_ID> --output json
+```
+
+Permanently removes the conversation and all its exchanges/messages.
+
+---
+
+## Attachments
+
+### Upload a File
+
+Upload a file to a conversation so the agent can reference it:
+
+```bash
+uip cas conversations attachments upload <CONVERSATION_ID> --file ./document.pdf --output json
+```
+
+The CLI validates the file exists before uploading.
+
+**Response:**
+```json
+{
+  "Result": "Success",
+  "Code": "AttachmentUploaded",
+  "Data": {
+    "ConversationId": "db4f5183-...",
+    "FileName": "document.pdf",
+    "MimeType": "application/pdf",
+    "UploadUri": "https://..."
+  }
+}
+```
+
+### Get Pre-Signed Upload URI
+
+For custom upload workflows, generate a pre-signed URI:
+
+```bash
+uip cas conversations attachments get-uri <CONVERSATION_ID> --file-name "data.csv" --output json
+```
+
+Returns the upload URL, HTTP verb, and whether authentication is required.
+
+### Attachment Workflow
+
+```bash
+# 1. Create conversation
+CONV_ID=$(uip cas conversations create <AGENT_ID> --folder-id <FOLDER_ID> --output json | jq -r '.Data.Id')
+
+# 2. Upload file
+uip cas conversations attachments upload "$CONV_ID" --file ./report.pdf --output json
+
+# 3. Ask the agent about the file
+uip cas chat <AGENT_ID> --folder-id <FOLDER_ID> --conversation-id "$CONV_ID" -m "Summarize the uploaded report"
+```
+
+---
+
+## Exchanges
+
+An exchange represents one user-question + agent-response pair within a conversation.
+
+### List Exchanges
+
+```bash
+uip cas exchanges list <CONVERSATION_ID> --output json
+```
+
+Supports pagination and sorting:
+```bash
+uip cas exchanges list <CONVERSATION_ID> --page-size 5 --sort descending --output json
+```
+
+Also supports message sorting within each exchange:
+```bash
+uip cas exchanges list <CONVERSATION_ID> --message-sort ascending --output json
+```
+
+### Get Exchange with Messages
+
+```bash
+uip cas exchanges get <CONVERSATION_ID> <EXCHANGE_ID> --output json
+```
+
+Returns an array of messages within the exchange, each with:
+- `ExchangeId`, `MessageId`, `Role` (user/assistant)
+- `ContentPartCount`, `ToolCallCount`, `FeedbackRating`
+
+### Submit Feedback
+
+Rate an agent response as positive or negative:
+
+```bash
+uip cas exchanges feedback <CONVERSATION_ID> <EXCHANGE_ID> --rating positive --output json
+
+# With an optional comment:
+uip cas exchanges feedback <CONVERSATION_ID> <EXCHANGE_ID> --rating negative --comment "Answer was inaccurate" --output json
+```
+
+The `--rating` must be `positive` or `negative`.
+
+---
+
+## Messages
+
+Messages are the individual user or assistant messages within an exchange.
+
+### Get a Message
+
+```bash
+uip cas messages get <CONVERSATION_ID> <EXCHANGE_ID> <MESSAGE_ID> --output json
+```
+
+Returns message metadata including role, timestamps, content parts (MIME types), tool calls, and citation count.
+
+### Get a Message with Citations
+
+```bash
+uip cas messages get <CONVERSATION_ID> <EXCHANGE_ID> <MESSAGE_ID> --citations --output json
+```
+
+Returns detailed citation data for each content part:
+- `ContentPartId`, `MimeType`
+- `CitationId`, `Offset`, `Length`
+- Source information (title, URL, page number)
+
+### Get Content Part Data
+
+Retrieve the actual data for a specific content part:
+
+```bash
+uip cas messages get-content-part <CONVERSATION_ID> <EXCHANGE_ID> <MESSAGE_ID> <CONTENT_PART_ID> --output json
+```
+
+Returns:
+- `ContentPartId`, `IsInline`, `IsExternal`
+- `Data` (the actual content if inline)
+
+---
+
+## User Settings
+
+User settings provide context to agents about who they're talking to. Agents may use this information to personalize responses.
+
+### Get Current Settings
+
+```bash
+uip cas user get-settings --output json
+```
+
+Returns: `UserId`, `Name`, `Email`, `Role`, `Department`, `Company`, `Country`, `Timezone`
+
+### Update Settings
+
+```bash
+uip cas user update-settings --name "Jane Doe" --role "Developer" --department "Engineering" --timezone "America/New_York" --output json
+```
+
+Available fields: `--name`, `--email`, `--role`, `--department`, `--company`, `--country`, `--timezone`
+
+At least one field must be provided.
+
+---
+
+## Common Inspection Workflow
+
+To understand what happened in a past conversation:
+
+```bash
+# 1. List conversations to find the one you want
+uip cas conversations list --sort descending --page-size 5 --output json
+
+# 2. List exchanges in that conversation
+uip cas exchanges list <CONVERSATION_ID> --sort ascending --output json
+
+# 3. Get a specific exchange with its messages
+uip cas exchanges get <CONVERSATION_ID> <EXCHANGE_ID> --output json
+
+# 4. Get message details with citations
+uip cas messages get <CONVERSATION_ID> <EXCHANGE_ID> <MESSAGE_ID> --citations --output json
+
+# 5. Get the actual content of a content part
+uip cas messages get-content-part <CONVERSATION_ID> <EXCHANGE_ID> <MESSAGE_ID> <CONTENT_PART_ID> --output json
+```
+
+## Pagination Pattern
+
+List commands that return paginated results include a `NextCursor` field:
+
+```bash
+# First page
+RESULT=$(uip cas conversations list --page-size 10 --output json)
+CURSOR=$(echo "$RESULT" | jq -r '.Data.NextCursor // empty')
+
+# Next page (if cursor is non-empty)
+if [ -n "$CURSOR" ]; then
+  uip cas conversations list --page-size 10 --cursor "$CURSOR" --output json
+fi
+```
+
+The same pattern applies to `exchanges list`.


### PR DESCRIPTION
## Summary
- Adds new `uipath-cas` skill for interacting with UiPath Conversational Agents via the `uip cas` CLI
- Covers agent discovery, real-time WebSocket chat, conversation lifecycle (CRUD), exchanges, messages, citations, attachments, and user settings
- 10 critical rules derived from hands-on WebSocket stress testing encode practical limits and gotchas

## Files
- `skills/uipath-cas/SKILL.md` (230 lines) — main skill with rules, quick start, patterns, troubleshooting
- `skills/uipath-cas/references/cas-commands-reference.md` (335 lines) — full CLI command reference
- `skills/uipath-cas/references/chat-guide.md` (191 lines) — WebSocket chat deep dive with stress test findings
- `skills/uipath-cas/references/conversations-lifecycle-guide.md` (276 lines) — CRUD operations guide

## Key rules from stress testing
- Always use `-m` mode for AI agents (interactive readline is unreliable without a TTY)
- Never open concurrent sessions on the same conversation (causes interleaved messages)
- Large payloads (>90KB) process slowly and the client has no timeout — wait or use attachments
- `--log-level` on chat is broken (conflicts with global flag) — use `--verbose`
- stdout = response text, stderr = metadata

## Test plan
- [x] YAML frontmatter validates (name matches folder, description has TRIGGER/DO NOT TRIGGER)
- [x] All relative links in SKILL.md point to existing reference files
- [x] No cross-skill references
- [x] CLI commands include `--output json` where appropriate
- [x] Anti-patterns section included
- [x] Follows CONTRIBUTING.md conventions (kebab-case files, `-guide.md` suffixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)