### PR TITLE
Move uia-prerequisites reference to configure-target-workflows

### DIFF
--- a/skills/shared/uia-configure-target-workflows.md
+++ b/skills/shared/uia-configure-target-workflows.md
@@ -2,6 +2,10 @@
 
 **Always use the `uia-configure-target` skill** to create or find targets in the Object Repository. This skill handles the full flow: snapshot capture, element discovery, selector generation, selector improvement, and OR registration.
 
+## Prerequisites
+
+See [uia-prerequisites.md](uia-prerequisites.md). If the user declines the upgrade, fall back to the [Indication Fallback Commands](#indication-fallback-commands) below.
+
 ## Execution Model
 
 **Execute `uia-configure-target` steps inline in the main conversation.** Do NOT delegate the entire skill to a subagent. The skill's internal steps already spawn their own subagents.

--- a/skills/uipath-coded-workflows/SKILL.md
+++ b/skills/uipath-coded-workflows/SKILL.md
@@ -125,7 +125,6 @@ See [references/operations-guide.md § Initialize a New Project](references/oper
 ### UI Automation References
 
 Shared UIA procedures (used by both coded and RPA skills):
-- [Prerequisites and version check](../shared/uia-prerequisites.md)
 - [Configure target workflows](../shared/uia-configure-target-workflows.md)
 - [Debug workflow procedure](../shared/uia-debug-workflow.md)
 - [Selector recovery](../shared/uia-selector-recovery.md)

--- a/skills/uipath-coded-workflows/references/ui-automation-guide.md
+++ b/skills/uipath-coded-workflows/references/ui-automation-guide.md
@@ -4,8 +4,6 @@ Quick reference for UI automation in coded workflows using the `uiAutomation` se
 
 ### Prerequisites
 
-See [../shared/uia-prerequisites.md](../shared/uia-prerequisites.md).
-
 **Required package:** `UiPath.UIAutomation.Activities`
 **Service accessor:** `uiAutomation` (type `IUiAutomationAppService`)
 

--- a/skills/uipath-rpa-workflows/SKILL.md
+++ b/skills/uipath-rpa-workflows/SKILL.md
@@ -109,7 +109,6 @@ For XAML structure, control flow, and domain-specific patterns not covered by ac
 #### UI Automation References
 
 Shared UIA procedures (used by both coded and RPA skills):
-- [Prerequisites and version check](../shared/uia-prerequisites.md)
 - [Configure target workflows](../shared/uia-configure-target-workflows.md)
 - [Debug workflow procedure](../shared/uia-debug-workflow.md)
 - [Selector recovery](../shared/uia-selector-recovery.md)

--- a/skills/uipath-rpa-workflows/references/ui-automation-guide.md
+++ b/skills/uipath-rpa-workflows/references/ui-automation-guide.md
@@ -4,8 +4,6 @@ Quick reference for UI automation in XAML/RPA workflows using UiPath UIAutomatio
 
 ### Prerequisites
 
-See [../shared/uia-prerequisites.md](../shared/uia-prerequisites.md).
-
 **Required package:** `UiPath.UIAutomation.Activities`
 
 > **For full activity details:** always check `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/` first. If unavailable, fall back to the bundled reference at `../../references/activity-docs/UiPath.UIAutomation.Activities/{closest}/activities/` (pick the version folder closest to what is installed in the project).


### PR DESCRIPTION
## Summary
- Removed direct `uia-prerequisites.md` links from coded and RPA SKILL.md files and their `ui-automation-guide.md` references
- Added a Prerequisites section in `uia-configure-target-workflows.md` that references `uia-prerequisites.md` with a fallback note to indication commands
- Prerequisites are specific to `uia-configure-target`, not general UI automation — this is where the reference belongs

## Test plan
- [ ] Verify no broken links to `uia-prerequisites.md`
- [ ] Verify `uia-configure-target-workflows.md` prerequisite section links resolve correctly