### PR TITLE
feat(flow-skill): require registry validation for all nodes in Phase 2

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -27,7 +27,7 @@ Comprehensive guide for creating, editing, validating, and debugging UiPath Flow
 
 ## Critical Rules
 
-1. **Do NOT `registry get` built-in nodes during planning.** The planning guide and node reference already document all OOTB node types with their ports, inputs, and output variables. Only run `uip flow registry get <nodeType> --output json` for **connector nodes**, **resource nodes**, and **unknown/new node types** not in the guides. **Exception:** When building the flow (Step 6), you DO need `registry get` for any node type to populate the `definitions` array in the `.flow` file — definitions must be copied from registry output, never hand-written.
+1. **Do NOT `registry get` built-in nodes during Phase 1 (architectural planning).** The planning guide and node reference already document all OOTB node types with their ports, inputs, and output variables — sufficient for designing flow topology. However, **Phase 2 (implementation resolution) REQUIRES registry validation of all node types**, even OOTB nodes, to confirm ports and inputs match the current product state. Only run connector/resource `registry get` during Phase 1 if needed for decision-making. **Exception:** When building the flow (Step 6), you DO need `registry get` for any node type to populate the `definitions` array in the `.flow` file — definitions must be copied from registry output, never hand-written.
 2. **ALWAYS discover connector capabilities via IS before planning.** Follow Step 4 for every connector node: fetch a connection (4a), call `registry get --connection-id` for enriched metadata (4b), and resolve reference fields via `uip is resources execute list` (4c). Without this, `inputs.detail` will be wrong and `$vars` references will be unresolvable — errors that `flow validate` does not catch.
 3. **ALWAYS check for existing connections** before using a connector node. Run `uip is connections list <connector-key>` — if no connection exists, tell the user before proceeding.
 4. **ALWAYS use `--output json`** on all `uip` commands when parsing output programmatically.
@@ -312,13 +312,14 @@ Present a **short summary in chat** (goal + key nodes + open questions). Tell th
 **Read [references/planning-phase-implementation.md](references/planning-phase-implementation.md)** for the implementation resolution process.
 
 Phase 2 takes the approved architectural plan and resolves all implementation details:
-- Run `uip flow registry search` and `registry get` for connector and resource nodes
+- Validate all node types (OOTB and connector) via `uip flow registry get` to confirm ports, inputs, and outputs
+- Run `uip flow registry search` and `registry get` for connector and resource nodes to resolve exact types
 - Bind Integration Service connections
 - Resolve reference fields via `uip is resources execute list`
 - Validate required fields against user-provided values
 - Replace `<PLACEHOLDER>` values with resolved IDs
 - Replace `core.logic.mock` nodes with real resource nodes (if published)
-- Write `<SolutionName>.impl.plan.md` with resolved details
+- Write `<SolutionName>.impl.plan.md` with resolved details and mermaid diagram
 
 #### 5c. Iterate until approved
 
@@ -434,7 +435,7 @@ For Orchestrator deployment when explicitly requested, see [references/flow-comm
 ## Anti-Patterns
 
 - **Never guess node schemas** — use the planning guide for OOTB nodes, `registry get` for connector/unknown nodes. Guessed port names or input fields cause silent wiring failures.
-- **Never `registry get` built-in nodes** — the planning guide already documents all OOTB node types with ports and inputs. Redundant registry calls waste tokens and time.
+- **Never `registry get` built-in nodes during Phase 1 planning** — the planning guide already documents all OOTB node types with ports and inputs. Redundant lookups waste tokens. However, Phase 2 **requires** registry validation of all node types to confirm the current product state before building.
 - **Never skip IS discovery for connector nodes** — the registry tells you a node exists; only IS tells you what operations and fields it supports. Skipping this is the #1 cause of broken connector nodes.
 - **Never edit `content/*.bpmn`** — it is auto-generated from the `.flow` file and will be overwritten.
 - **Never run `flow debug` as a validation step** — debug executes the flow with real side effects. Use `flow validate` for checking correctness.

--- a/skills/uipath-maestro-flow/references/planning-phase-implementation.md
+++ b/skills/uipath-maestro-flow/references/planning-phase-implementation.md
@@ -4,24 +4,43 @@ Resolve all implementation details for the approved architectural plan. This pha
 
 > **Prerequisite:** The user must have explicitly approved the architectural plan (`.arch.plan.md`) before starting this phase.
 >
-> **Skip the resolution steps (1–7)** if the flow uses only OOTB nodes (Script, HTTP, Decision, Switch, Loop, Merge, End, Terminate, Delay, Transform, Mock). OOTB nodes do not require registry lookups, connection binding, or reference resolution — proceed directly to the build step. The node catalog and wiring reference below are still needed for building.
+> **Always validate with the registry,** even for OOTB nodes. This phase ensures that every node type (built-in or connector-based) is confirmed against the current registry state. Port names, input requirements, and output schemas can change — do not assume OOTB nodes match the planning guides without verification.
 
 ---
 
 ## Implementation Resolution Process
 
-### Step 1 — Identify Nodes Needing Resolution
+### Step 1 — Identify Nodes and Validate with Registry
 
-Scan the approved `.arch.plan.md` node table and connector summary. Identify:
+Scan the approved `.arch.plan.md` node table and connector summary. Validate each node type against the registry to confirm ports, inputs, and outputs are current:
 
 | Category | How to identify | Action |
 | --- | --- | --- |
-| Connector nodes | Node type starts with `uipath.connector.*` or Notes say "connector:" | Run Steps 2a–2d |
-| Resource nodes | Node type starts with `uipath.core.*` or Notes say "resource:" | Run Step 3 |
-| Mock placeholders | Node type is `core.logic.mock` | Run Step 4 |
-| OOTB nodes | Everything else | No resolution needed |
+| Connector nodes | Node type starts with `uipath.connector.*` or Notes say "connector:" | Run Steps 2a–2d (bind connection, resolve reference fields, validate required inputs) |
+| Resource nodes | Node type starts with `uipath.core.*` or Notes say "resource:" | Run Step 3 (registry search, confirm node type) |
+| Mock placeholders | Node type is `core.logic.mock` | Run Step 4 (check if published, replace if available) |
+| OOTB nodes | Everything else (Script, HTTP, Decision, Loop, etc.) | Run Step 1a below (validate with registry) |
 
-If no nodes need resolution, skip to Step 6.
+**All nodes, including OOTB, must be validated via registry in Step 1a before proceeding.**
+
+#### Step 1a — Validate All OOTB Node Types with Registry
+
+Even built-in nodes can change. Confirm each OOTB node type against the registry:
+
+```bash
+uip flow registry pull --force
+uip flow registry get <nodeType> --output json
+```
+
+For each OOTB node type in your plan, record:
+- Input port names (must match `targetPort` in edges)
+- Output port names (must match `sourcePort` in edges)
+- Required input fields (`required: true` in `inputDefinition`)
+- Output variable schema (`outputDefinition`)
+
+Example: If your plan shows `core.action.script`, run `uip flow registry get core.action.script --output json` and confirm the expected port names (`input`, `success`) and that `script` input is required.
+
+Update your node table if any ports or required fields differ from the planning guide.
 
 ### Step 2 — Resolve Connector Nodes
 
@@ -125,6 +144,21 @@ Generate a `<SolutionName>.impl.plan.md` file in the **solution directory** (sam
 | # | Node ID | Name | Node Type | Inputs | Outputs | Connection ID | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 
+## Flow Diagram (Mermaid)
+
+Copy the mermaid diagram from `.arch.plan.md`, then update node labels if any node types changed due to mock replacement or connector resolution. Use the same diagram from architectural planning — it remains the visual reference for the flow structure.
+
+```mermaid
+graph TD
+    trigger(Manual Trigger)
+    action1[Resolved Action 1]
+    decision{Resolved Decision}
+    end1(Done)
+    trigger -->|output| action1
+    action1 -->|success| decision
+    decision -->|true| end1
+```
+
 ## Resolved Edge Table
 
 (Copy from `.arch.plan.md` — update only if node IDs changed due to mock replacement)
@@ -146,6 +180,8 @@ Generate a `<SolutionName>.impl.plan.md` file in the **solution directory** (sam
 ## Changes from Architectural Plan
 
 - List what changed between `.arch.plan.md` and this plan
+- Record any node type changes (connector resolutions, mock replacements)
+- Note any port or input field changes discovered during registry validation
 ```
 
 #### Column Additions
@@ -159,12 +195,14 @@ The implementation plan adds these columns beyond the architectural plan:
 
 Present a short summary in chat:
 
-1. How many nodes were resolved
-2. Any mock placeholders remaining
-3. Any required fields that need user input
-4. Any connections that need to be created
+1. Registry validation results — confirm all OOTB node ports and inputs match the plan
+2. How many connector/resource nodes were resolved
+3. Any port or input field changes discovered during validation
+4. Any mock placeholders remaining
+5. Any required fields that need user input
+6. Any connections that need to be created
 
-Tell the user to review `<SolutionName>.impl.plan.md`. Do NOT proceed to the build step until the user explicitly approves.
+Tell the user to review `<SolutionName>.impl.plan.md`, including the updated mermaid diagram and registry confirmations. Do NOT proceed to the build step until the user explicitly approves.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove universal skip for OOTB nodes — require registry validation for all node types in Phase 2
- Add Step 1a to confirm port names, inputs, and outputs against current registry state
- Ensure Phase 2 implementation plan includes mermaid diagram for visual verification
- Update approval checklist to include registry validation results and diagram review

## Changes
The planning-phase-implementation.md file now:
1. Eliminates the "skip if OOTB" guidance that allowed agents to bypass registry validation
2. Mandates validation of all node types (Script, HTTP, Decision, Loop, etc.) with `uip flow registry get`
3. Includes mermaid diagram in the `.impl.plan.md` output template for visual reference
4. Updates the approval checklist to reflect registry confirmations

## Why
Even OOTB nodes can change across versions. Port names, input requirements, and output schemas are not static. Validating against the registry ensures the implementation plan matches the current product state before building.

🤖 Generated with [Claude Code](https://claude.com/claude-code)