### PR TITLE
feat(skill-validation): enforce 1024-character description limit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Pre-commit hook: validate skill descriptions
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+bash "$REPO_ROOT/hooks/validate-skill-descriptions.sh"

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,21 @@
+name: Validate Skills
+
+on:
+  pull_request:
+    paths:
+      - 'skills/*/SKILL.md'
+      - '.github/workflows/validate-skills.yml'
+
+jobs:
+  validate-descriptions:
+    runs-on: ubuntu-latest
+    name: Validate skill descriptions
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check description lengths
+        run: |
+          FILES=$(git diff origin/${{ github.base_ref }}...HEAD --name-only --diff-filter=ACM | grep 'skills/.*/SKILL\.md$' || true)
+          bash hooks/validate-skill-descriptions.sh $FILES

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,6 +174,16 @@ Hooks are defined in `hooks/hooks.json` and run during plugin lifecycle events (
 - Keep hooks idempotent — safe to run multiple times
 - Set appropriate timeouts (default: 180 seconds)
 
+### Git Hooks
+
+This repository uses pre-commit hooks to validate skill descriptions (1024-character limit). To enable them:
+
+```bash
+bash scripts/setup-hooks.sh
+```
+
+This configures git to use `.githooks/` and enables the skill description validator.
+
 ## Quality Checklist
 
 Before submitting your PR, verify:
@@ -181,6 +191,7 @@ Before submitting your PR, verify:
 ### SKILL.md
 - [ ] Frontmatter has `name` matching the folder name
 - [ ] Frontmatter `description` includes both TRIGGER and DO NOT TRIGGER conditions
+- [ ] Frontmatter `description` is under 1024 characters (enforced by pre-commit hook)
 - [ ] Critical Rules section exists with numbered, actionable rules
 - [ ] CLI commands include exact flags and `--output json` where appropriate
 - [ ] Anti-patterns / "What NOT to Do" section is included for non-trivial skills

--- a/hooks/validate-skill-descriptions.sh
+++ b/hooks/validate-skill-descriptions.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Validate skill description lengths
+# Enforces 1024-character limit on all SKILL.md descriptions
+#
+# Usage:
+#   validate-skill-descriptions.sh [file1 file2 ...]
+# If no files specified, checks staged files (for pre-commit hook)
+
+set -e
+
+LIMIT=1024
+FAILED=0
+
+# Determine which files to check
+if [ "$#" -eq 0 ]; then
+  # Pre-commit mode: check staged SKILL.md files
+  FILES=$(git diff --cached --name-only --diff-filter=ACM | grep 'skills/.*/SKILL\.md$' || true)
+else
+  # Explicit mode: use provided files
+  FILES="$@"
+fi
+
+for file in $FILES; do
+  if [ ! -f "$file" ]; then
+    continue
+  fi
+
+  # Extract description from frontmatter
+  desc=$(sed -n 's/^description: "\(.*\)"$/\1/p' "$file" | head -1)
+
+  # Also handle descriptions without surrounding quotes
+  if [ -z "$desc" ]; then
+    desc=$(sed -n 's/^description: \(.*\)$/\1/p' "$file" | head -1)
+  fi
+
+  len=${#desc}
+
+  if [ "$len" -gt "$LIMIT" ]; then
+    echo "❌ $file: description exceeds $LIMIT characters ($len chars)"
+    FAILED=1
+  else
+    echo "✓ $file: $len chars"
+  fi
+done
+
+if [ "$FAILED" -eq 1 ]; then
+  echo ""
+  echo "Skill description validation failed. Descriptions must be ≤ $LIMIT characters."
+  echo "Edit the 'description' field in SKILL.md frontmatter and try again."
+  exit 1
+fi
+
+exit 0

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Setup git hooks for this repository
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# Configure git to use .githooks directory
+git config core.hooksPath .githooks
+
+echo "✓ Git hooks configured to use .githooks/"
+echo "  Pre-commit validation enabled for skill descriptions"


### PR DESCRIPTION
Add pre-commit hook and GitHub Action to validate skill description lengths against the 1024-character limit defined in skill-structure rules. Prevents skills from being committed or merged if descriptions exceed the limit.

- hooks/validate-skill-descriptions.sh: local validation script
- .github/workflows/validate-skills.yml: CI validation on PR
- .git/hooks/pre-commit: install with: ln -sf ../../hooks/validate-skill-descriptions.sh .git/hooks/pre-commit