### PR TITLE
Remove deprecated `uip rpa validate` — replace with `get-errors`

### DIFF
--- a/.claude/rules/content-quality.md
+++ b/.claude/rules/content-quality.md
@@ -32,7 +32,7 @@ This repository's primary audience is AI coding agents, not humans. Write accord
 
 Example:
 ```bash
-uip rpa validate --file-path "<FILE_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa get-errors --file-path "<FILE_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
 ```
 
 ## Cross-Platform Awareness

--- a/agents/uipath-project-discovery-agent.md
+++ b/agents/uipath-project-discovery-agent.md
@@ -294,7 +294,7 @@ Show 1-2 representative code skeletons that demonstrate how to write new code in
 ## Quick Reference
 
 - **Run**: `uip rpa run-file --file-path "{{MAIN_FILE}}" --project-dir "{{PROJECT_DIR}}"`
-- **Validate**: `uip rpa validate --project-dir "{{PROJECT_DIR}}"`
+- **Validate**: `uip rpa get-errors --project-dir "{{PROJECT_DIR}}"`
 - **Key files to read first**: {{TOP_3_FILES}}
 ````
 

--- a/skills/shared/cli-reference.md
+++ b/skills/shared/cli-reference.md
@@ -9,7 +9,7 @@ CLI reference for `uip rpa` -- communicates with UiPath Studio over named pipes 
 ```bash
 uip --help                              # top-level command groups
 uip rpa --help                          # all rpa subcommands
-uip rpa validate --help                 # parameters for a specific command
+uip rpa get-errors --help               # parameters for a specific command
 ```
 
 ---
@@ -119,23 +119,6 @@ No command-specific options.
 ---
 
 ## Commands -- Validation and Execution
-
-### validate
-
-Validate a file or the entire project. Forces Studio to re-analyze the code.
-
-```bash
-uip rpa validate --project-dir "<PROJECT_DIR>" --output json --use-studio
-uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
-
-| Parameter | Required | Default | Description |
-|-----------|----------|---------|-------------|
-| `--file-path` | No | -- | File to validate (relative to project directory). If omitted, validates the whole project. |
-
-`validate` forces re-analysis AND returns errors -- a single command for both. `get-errors` also re-validates by default (use `--skip-validation` for cached-only).
-
----
 
 ### run-file
 

--- a/skills/shared/validation-loop.md
+++ b/skills/shared/validation-loop.md
@@ -16,14 +16,12 @@ After every file create or edit, validate the specific file until clean.
 
 ```
 REPEAT:
-  1. uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+  1. uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
   2. IF 0 errors -> EXIT to Smoke Test
   3. Identify the highest-priority error
   4. Fix one thing (see rule above)
   5. GOTO 1
 ```
-
-**`validate` vs `get-errors`:** Both force re-validation by default. `get-errors` additionally accepts `--skip-validation` to return cached errors without re-analyzing. Either command works in this loop.
 
 **Target the specific file:** Use `--file-path` to validate only the file you changed -- faster than validating the whole project.
 
@@ -37,11 +35,11 @@ REPEAT:
 4. DO NOT assume edits worked without checking.
 5. DO NOT bundle multiple fixes in one iteration. Fix the root cause, re-run, verify. Never add a speculative change alongside the actual fix -- changing two things at once makes it impossible to tell which one resolved the issue or whether the extra change introduced a new problem.
 
-See [cli-reference.md](cli-reference.md) for full `validate` and `run-file` command documentation.
+See [cli-reference.md](cli-reference.md) for full `get-errors` and `run-file` command documentation.
 
 ## Smoke Test
 
-`validate` (static analysis) and `run-file` (runtime compilation) use different validation paths. Some errors -- such as invalid enum values on activity properties -- pass static validation but fail at runtime. Always treat the smoke test as a critical validation step, not just an optional extra.
+`get-errors` (static analysis) and `run-file` (runtime compilation) use different validation paths. Some errors -- such as invalid enum values on activity properties -- pass static validation but fail at runtime. Always treat the smoke test as a critical validation step, not just an optional extra.
 
 After reaching 0 validation errors, run the workflow to catch runtime errors (wrong credentials, missing files, logic bugs) that static validation cannot detect:
 

--- a/skills/uipath-coded-workflows/SKILL.md
+++ b/skills/uipath-coded-workflows/SKILL.md
@@ -114,7 +114,7 @@ See [references/operations-guide.md § Initialize a New Project](references/oper
 12. **ALWAYS ensure required package dependencies are in `project.json`** when using a service. Each service on `CodedWorkflow` requires its corresponding NuGet package — without it you get `CS0103: The name 'xxx' does not exist in the current context`. See the Service-to-Package mapping below.
 13. **Use Coded Source Files for reusable code** — extract models, helper classes, utilities, and shared logic into plain `.cs` files that don't inherit from `CodedWorkflow`. These have NO `.cs.json`, NO entry point, NO fileInfoCollection, and NO `[Workflow]`/`[TestCase]` attribute.
 14. **ALWAYS validate each file until error-free after creating or editing it.** Never consider a file "done" until validation returns no errors. Follow this loop after every create/edit:
-    1. Run `uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>" --output json --use-studio` — this forces Studio to re-analyze the specific file and returns a JSON result with validation status and any errors found
+    1. Run `uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>" --output json --use-studio` — this forces Studio to re-analyze the specific file and returns a JSON result with validation status and any errors found
     2. If errors exist in the response: read the error messages, fix the code, and go back to step 1
     3. Repeat until validation returns zero errors (max 5 fix attempts)
     4. Only then proceed to run the workflow or report success to the user

--- a/skills/uipath-coded-workflows/references/coding-guidelines.md
+++ b/skills/uipath-coded-workflows/references/coding-guidelines.md
@@ -96,7 +96,7 @@ using System.Text.RegularExpressions;  // regex
 - **Escape backslashes in paths** — Use `C:\\path\\file.txt` not `C:\path\file.txt` in input arguments
 
 ### Validation Loop (Critical Rule #14)
-uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>" --output json --use-studio
+uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>" --output json --use-studio
 
 @../shared/validation-loop.md
 

--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -211,7 +211,7 @@ The typical deployment workflow for a UiPath automation:
 
 ```
 1. Develop    → Create/edit coded workflows or RPA projects locally
-2. Validate   → uip rpa validate --use-studio
+2. Validate   → uip rpa get-errors --use-studio
 3. Pack       → uip solution pack
 4. Login      → uip login
 5. Publish    → uip solution publish

--- a/skills/uipath-report-issue/SKILL.md
+++ b/skills/uipath-report-issue/SKILL.md
@@ -75,7 +75,7 @@ Extract from login status: `tenantName`, `organizationName`, `baseUrl` only. **S
 | Skill | Capture |
 |---|---|
 | **Flow** | `uip flow validate <file> --output json`, `.flow` file content (first 150 lines), project directory listing |
-| **Coded Workflows** | `project.json` dependencies section, `uip rpa validate` output, list of `.cs` files |
+| **Coded Workflows** | `project.json` dependencies section, `uip rpa get-errors` output, list of `.cs` files |
 | **RPA Workflows** | `project.json` dependencies section, `uip rpa get-errors` output, list of `.xaml` files |
 | **Agents** | `pyproject.toml`, `bindings.json` (redact connection values), directory listing |
 | **Apps** | `package.json` (name, version, dependencies only), `.uipath/` listing |


### PR DESCRIPTION
## Summary
- `uip rpa validate` has been removed from the CLI — replaced all references with `uip rpa get-errors` across 8 files
- Removed the dedicated `### validate` section from `cli-reference.md` (redundant with existing `### get-errors` section)
- Removed the `validate` vs `get-errors` comparison paragraph from `validation-loop.md`

## Test plan
- [ ] Verify `uip rpa get-errors --help` works as expected
- [ ] Grep the repo for any remaining `uip rpa validate` references