### PR TITLE
De-prioritize InjectJsScript in UIA target workflows

### DIFF
--- a/skills/shared/uia-configure-target-workflows.md
+++ b/skills/shared/uia-configure-target-workflows.md
@@ -38,6 +38,8 @@ The skill will search the Object Repository for existing matches before creating
 
 **Do NOT manually call low-level `uip rpa uia` CLI commands** (`snapshot capture`, `snapshot filter`, `selector-intelligence get-default-selector`) to build selectors outside of the skill flow. These are internal tools used *by* the skill — calling them directly skips selector improvement and OR registration, producing fragile selectors that aren't tracked in the project.
 
+**Do NOT use `InjectJsScript` when standard UI activities (GetText, Click, TypeInto, ExtractTableData, etc.) with configured targets would work.** `InjectJsScript` is a last resort — it's hard to debug, fragile to page changes, and bypasses the Object Repository.
+
 **Do NOT launch the target application before running `uia-configure-target`.** The skill's first steps capture the top-level window tree and search for the app. Only if the app is not found in the window list should you launch it — and then re-run the capture. Launching preemptively creates duplicate instances and risks targeting the wrong window.
 
 ## Indication Fallback Commands


### PR DESCRIPTION
## Summary
- Add rule to shared `uia-configure-target-workflows.md` de-prioritizing `InjectJsScript` in favor of standard UI activities (GetText, Click, TypeInto, ExtractTableData) with configured targets
- Both `uipath-coded-workflows` and `uipath-rpa-workflows` reference this shared file, so both skills pick up the guidance

## Test plan
- [ ] Verify agents prefer GetText with configured targets over InjectJsScript for text extraction
- [ ] Confirm InjectJsScript is still usable as a last resort when no standard activity fits