### PR TITLE
Extract shared ui-automation-guide and deduplicate skill references

### DIFF
--- a/skills/shared/ui-automation-guide.md
+++ b/skills/shared/ui-automation-guide.md
@@ -1,0 +1,33 @@
+# UI Automation Guide (Shared)
+
+Common rules for UI automation across coded workflows (C#) and RPA workflows (XAML). Each skill has its own `ui-automation-guide.md` with skill-specific target finding steps and patterns.
+
+## Mandatory: Generate Targets Before Writing Any UI Code
+
+Before writing ANY target — whether C# (`uiAutomation.Open(...)`, `Descriptors.App.Screen.Element`) or XAML (`<uix:TargetApp>`, `<uix:TargetAnchorable>`):
+
+1. **NEVER hand-write selectors.** Hand-written selectors will have invalid syntax, wrong attribute names, missing required attributes (`SearchSteps`, `ContentHash`, `Reference`), or target the wrong element. They fail validation or break at runtime.
+2. **NEVER guess selector attributes** from HTML/DOM structure, element tag names, or CSS classes. Selectors are generated from the live application tree by probing elements — not from source code inspection.
+3. **ALWAYS follow the target configuration steps** from [uia-configure-target-workflows.md](uia-configure-target-workflows.md). Use the returned XAML/references exactly as provided by the configuration steps. Do not modify selectors, content hashes, or reference IDs.
+
+> This gate applies regardless of how simple the target seems. Even a `<webctrl tag='BODY' />` selector will fail validation without proper attributes. The cost of running target configuration is always lower than debugging hand-written selectors.
+
+---
+
+## Common Pitfalls
+
+- **SelectItem on web dropdowns** — `SelectItem` may fail on custom `<select>` elements. Workaround: use `TypeInto` instead.
+- **ScreenPlay overuse** — UITask/ScreenPlay is non-deterministic and slow. Always try proper selectors first.
+- **Wrong Object Repository references** — never copy references from examples or other projects. Always use `uia-configure-target` to generate them for the current application state.
+- **Launching the app before configuring targets** — do NOT launch the target application before running `uia-configure-target`. The skill captures the window tree first and only launches if the app isn't found. Launching preemptively risks targeting the wrong window.
+- **Using `InjectJsScript` instead of standard activities** — do NOT use `InjectJsScript` when standard UI activities (GetText, Click, TypeInto, ExtractTableData, etc.) with configured targets would work. `InjectJsScript` is a last resort — it's hard to debug, fragile to page changes, and bypasses the Object Repository.
+
+---
+
+## Related Shared Procedures
+
+- [uia-configure-target-workflows.md](uia-configure-target-workflows.md) — Full configure-target workflow, rules, indication fallback
+- [uia-multi-step-flows.md](uia-multi-step-flows.md) — Advancing application state between screens
+- [uia-debug-workflow.md](uia-debug-workflow.md) — Running and debugging UI automation workflows
+- [uia-selector-recovery.md](uia-selector-recovery.md) — Fixing selectors that fail at runtime
+- [uia-prerequisites.md](uia-prerequisites.md) — Package version requirements

--- a/skills/uipath-coded-workflows/references/ui-automation-guide.md
+++ b/skills/uipath-coded-workflows/references/ui-automation-guide.md
@@ -1,6 +1,6 @@
 # UI Automation Guide for Coded Workflows
 
-Quick reference for UI automation in coded workflows using the `uiAutomation` service.
+C#-specific patterns for UI automation using the `uiAutomation` service.
 
 ### Prerequisites
 
@@ -10,6 +10,8 @@ See [../shared/uia-prerequisites.md](../shared/uia-prerequisites.md).
 **Service accessor:** `uiAutomation` (type `IUiAutomationAppService`)
 
 > **For full API details:** always check `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/` first. If unavailable, fall back to the bundled reference at `../../references/activity-docs/UiPath.UIAutomation.Activities/{closest}/coded/` (pick the version folder closest to what is installed in the project).
+
+@../shared/ui-automation-guide.md
 
 ---
 
@@ -36,7 +38,7 @@ formScreen.TypeInto(Descriptors.MyApp.Form.Email, "test@example.com");  // OK
 formScreen.Click(Descriptors.MyApp.Home.Loans);  // FAILS
 ```
 
-**When navigating multi-screen flows:** perform all interactions for one screen before attaching to the next.
+**When navigating multi-screen flows:** perform all interactions for one screen before attaching to the next. See [../shared/uia-multi-step-flows.md](../shared/uia-multi-step-flows.md).
 
 ## Target Resolution
 
@@ -52,7 +54,7 @@ Each method on `UiTargetApp` accepts targets in multiple forms:
 
 **MANDATORY for any workflow that uses `uiAutomation.*` calls.** Follow this decision tree in **strict order** — stop at the first step that yields the descriptor you need.
 
-> **CRITICAL:** Steps 1 → 2 → 3 → 4 MUST be followed sequentially. NEVER skip to Step 4 (UITask).
+> Steps 1 → 2 → 3 → 4 MUST be followed sequentially. NEVER skip to Step 4 (UITask).
 
 ### Step 1 — Check the project's Object Repository
 
@@ -67,15 +69,16 @@ using <ProjectNamespace>.ObjectRepository;
 
 Look in `project.json` → `dependencies` for packages matching `*.UILibrary`, `*.ObjectRepository`, `*.Descriptors`, or `*.UIAutomation`. Inspect with `uip rpa inspect-package --use-studio`.
 
-### Step 3 — Configure the target via `uia-configure-target` skill
+For UILibrary packages, use the **package** namespace, not the project namespace:
+```csharp
+using <PackageNamespace>.ObjectRepository;
+```
 
-See [../shared/uia-configure-target-workflows.md](../shared/uia-configure-target-workflows.md) for the full configure-target workflow, rules, indication fallback, and multi-step UI flows.
+### Step 3 — Configure the target
+
+See [../shared/uia-configure-target-workflows.md](../shared/uia-configure-target-workflows.md) for the full configure-target workflow.
 
 After the skill completes, re-read `ObjectRepository.cs` and search for the returned reference IDs to find the exact `Descriptors.<App>.<Screen>.<Element>` paths.
-
-#### Multi-Step UI Flows (Advancing Application State)
-
-See [../shared/uia-multi-step-flows.md](../shared/uia-multi-step-flows.md).
 
 ### Step 4 — UITask / ScreenPlay (last resort only)
 
@@ -83,20 +86,10 @@ ScreenPlay (`UITask`) is an AI-powered agent that performs UI interactions witho
 
 ---
 
-## Common Pitfalls
+## Coded-Specific Pitfalls
 
-### Web Dropdowns and `SelectItem`
-
-`SelectItem` may fail on web `<select>` dropdowns. **Workaround:** use `TypeInto` instead:
-
-```csharp
-// Instead of: formScreen.SelectItem(Descriptors.MyApp.Form.Term, "12");
-formScreen.TypeInto(Descriptors.MyApp.Form.Term, "12");  // Works reliably
-```
-
-### Screen Handle Mismatch
-
-Using an element descriptor on the wrong screen handle causes `"Target name 'X' is not part of the current screen."`. Always use the correct handle for each screen's elements.
+- **Missing ObjectRepository using** — without `using <ProjectNamespace>.ObjectRepository;`, you get `CS0103: The name 'Descriptors' does not exist in the current context`
+- **Screen handle mismatch** — using an element descriptor on the wrong screen handle causes `"Target name 'X' is not part of the current screen."` Always use the correct handle for each screen's elements.
 
 ---
 
@@ -106,11 +99,9 @@ See [../shared/uia-debug-workflow.md](../shared/uia-debug-workflow.md).
 
    uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json --use-studio
    uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json --use-studio
+
 ---
 
 ## Runtime Selector Failures
 
 See [../shared/uia-selector-recovery.md](../shared/uia-selector-recovery.md).
-
-
-

--- a/skills/uipath-rpa-workflows/references/ui-automation-guide.md
+++ b/skills/uipath-rpa-workflows/references/ui-automation-guide.md
@@ -1,6 +1,6 @@
 # UI Automation Guide for RPA Workflows
 
-Quick reference for UI automation in XAML/RPA workflows using UiPath UIAutomation activities.
+XAML-specific patterns for UI automation using UiPath UIAutomation activities.
 
 ### Prerequisites
 
@@ -9,6 +9,8 @@ See [../shared/uia-prerequisites.md](../shared/uia-prerequisites.md).
 **Required package:** `UiPath.UIAutomation.Activities`
 
 > **For full activity details:** always check `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/` first. If unavailable, fall back to the bundled reference at `../../references/activity-docs/UiPath.UIAutomation.Activities/{closest}/activities/` (pick the version folder closest to what is installed in the project).
+
+@../shared/ui-automation-guide.md
 
 ---
 
@@ -20,21 +22,14 @@ Every UI automation workflow starts with an **Application Card** (`uix:NApplicat
 
 ### Target Configuration
 
-Each UI activity targets an element via the **Target** property, which includes:
-- **Selector** — XML path that uniquely identifies the UI element
-- **Anchor** — optional nearby reference element for more robust targeting
-- **CV (Computer Vision)** — fallback visual targeting using screenshots
-- **Fuzzy selector** — tolerant matching for dynamic attributes
+Follow [uia-configure-target-workflows.md](../shared/uia-configure-target-workflows.md) to generate the Application Card's `TargetApp` and each activity's `TargetAnchorable`. The skill returns ready-to-use XAML attributes — copy them exactly into your workflow:
 
----
+- **Screen XAML** → goes into `<uix:NApplicationCard.TargetApp>` as a `<uix:TargetApp ... />` element
+- **Element XAML** → goes into `<uix:NGetText.Target>` (or Click, TypeInto, etc.) as a `<uix:TargetAnchorable ... />` element
 
-## Configuring Targets (Object Repository)
+When an element is reused across multiple activities, use the same returned XAML snippet for each one.
 
-See [../shared/uia-configure-target-workflows.md](../shared/uia-configure-target-workflows.md) for the full configure-target workflow, rules, indication fallback, and multi-step UI flows.
-
-The skill returns ready-to-use XAML snippets — use them directly in your workflow. When an element is reused across multiple activities, use the same returned snippet for each one.
-
-### Multi-Step UI Flows (Advancing Application State)
+### Multi-Step UI Flows
 
 See [../shared/uia-multi-step-flows.md](../shared/uia-multi-step-flows.md).
 
@@ -54,16 +49,13 @@ See [../shared/uia-multi-step-flows.md](../shared/uia-multi-step-flows.md).
 | **Check App State** | Verifies if a UI element exists (conditional branching) |
 | **Take Screenshot** | Captures a screenshot of an app or element |
 | **Extract Table Data** | Extracts tabular data from a web page or application |
-| **ScreenPlay** | AI-powered UI task execution (last resort for brittle selectors) |
+| **ScreenPlay** | AI-powered UI task execution (last resort — non-deterministic and slow) |
 
 ---
 
-## Common Pitfalls
+## XAML-Specific Pitfalls
 
-- **Missing `xmlns:uix`** — every UIA workflow needs `xmlns:uix="http://schemas.uipath.com/workflow/activities/uix"`
-- **Wrong Object Repository references** — never copy references from examples; always use `uia-configure-target` to get them
-- **SelectItem on web dropdowns** — may fail on custom `<select>` elements; use Type Into as a workaround
-- **ScreenPlay overuse** — UITask/ScreenPlay is non-deterministic and slow; use proper selectors first
+- **Missing `xmlns:uix`** — every UIA workflow needs `xmlns:uix="http://schemas.uipath.com/workflow/activities/uix"` on the root `<Activity>` element
 
 ---
 


### PR DESCRIPTION
## Summary
- Extract common UI automation guidance into `skills/shared/ui-automation-guide.md`
- Deduplicate `ui-automation-guide.md` in coded-workflows and rpa-workflows skills to reference the shared version

## Test plan
- [ ] Verify `skills/shared/ui-automation-guide.md` contains the consolidated content
- [ ] Verify both skill reference files are updated and consistent