### PR TITLE
Add search-templates and template-based project creation to RPA skill

### DIFF
--- a/skills/uipath-rpa-workflows/SKILL.md
+++ b/skills/uipath-rpa-workflows/SKILL.md
@@ -34,6 +34,8 @@ Use the default (table) only when displaying results directly to the user for re
 
 For the full CLI command reference (all tools, parameters, and error recovery), see **[references/cli-reference.md](./references/cli-reference.md)**.
 
+Key commands at a glance: `find-activities`, `get-default-activity-xaml`, `get-errors`, `install-or-update-packages`, `run-file`, `list-workflow-examples`, `get-workflow-example`, `search-templates`. For IS connectors: `is connectors list/get`, `is connections list/create/ping`, `is activities list`, `is resources list/describe/execute`.
+
 ---
 
 ## Supporting References
@@ -138,11 +140,11 @@ If unclear which file to edit, **ask the user** rather than guessing.
 
 ## Phase 0: Environment Readiness
 
-Ensure Studio Desktop is running, connected, and targeting the correct project. See **[references/environment-setup.md](./references/environment-setup.md)** for the full setup procedure (project root detection, Studio verification, authentication).
+Ensure Studio Desktop is running, connected, and targeting the correct project. See **[references/environment-setup.md](./references/environment-setup.md)** for the full setup procedure (project root detection, Studio verification, authentication, project creation).
 
 **Quick check:** Find `project.json` to establish `{projectRoot}`, run `uip rpa list-instances --output json` to verify Studio, and `uip rpa open-project` if needed.
 
-**Expression language for new projects:** Prefer `VisualBasic` for Windows target framework projects.
+**Creating a new project (only when explicitly requested or no project exists):** Use `uip rpa new` with `--template-id` for built-in templates or `--template-package-id` for NuGet template packages (discover them with `uip rpa search-templates`). See [environment-setup.md Step 0.4](./references/environment-setup.md#step-04-creating-a-new-project). Prefer `VisualBasic` expression language for Windows target framework projects.
 
 ## Precondition: Project Context
 

--- a/skills/uipath-rpa-workflows/references/cli-reference.md
+++ b/skills/uipath-rpa-workflows/references/cli-reference.md
@@ -91,6 +91,27 @@ uip rpa focus-activity --output json --use-studio
 
 ---
 
+### search-templates
+
+Search for project templates on configured NuGet feeds. Does not require a project to be open.
+
+```bash
+uip rpa search-templates --query "<SEARCH_TERM>" --output json
+uip rpa search-templates --limit 10 --include-prerelease --output json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `--query` | No | Filter by name or description. Omit to list all available templates |
+| `--limit` | No | Max results (default 20) |
+| `--include-prerelease` | No | Include prerelease versions (default false) |
+
+Returns a JSON array with fields: `packageId`, `version`, `title`, `description`, `authors`, `source`, `tags`.
+
+Use the `packageId` and `version` from results with `uip rpa new --template-package-id` to create a project from that template.
+
+---
+
 ### close-project
 
 Close the current project in Studio.

--- a/skills/uipath-rpa-workflows/references/environment-setup.md
+++ b/skills/uipath-rpa-workflows/references/environment-setup.md
@@ -54,7 +54,9 @@ If you encounter auth errors (401, 403, "not authenticated") during any phase, p
 
 ## Step 0.4: Creating a New Project
 
-When the user needs a brand-new UiPath project (not just a new workflow in an existing project):
+When the user needs a brand-new UiPath project (not just a new workflow in an existing project).
+
+### From a Built-in Template
 
 ```bash
 uip rpa new \
@@ -69,7 +71,7 @@ uip rpa new \
 
 **Note:** `uip rpa new` may return `success: false` but still create the project files (partial success). If it fails, check whether the project directory and `project.json` were created before retrying.
 
-### Parameters
+#### Parameters
 
 | Parameter | Options | Default | Notes |
 |-----------|---------|---------|-------|
@@ -79,6 +81,54 @@ uip rpa new \
 | `--expression-language` | `VisualBasic`, `CSharp` | (template default) | Expression syntax for XAML workflows |
 | `--target-framework` | `Legacy`, `Windows`, `Portable` | (template default) | .NET target framework |
 | `--description` | Any string | (none) | Project description in project.json |
+
+### From a NuGet Template Package
+
+Use when the user asks for a domain-specific template, references a specific template package by name, or wants to browse available templates.
+
+**1. Search for available templates:**
+
+```bash
+uip rpa search-templates --query "<SEARCH_TERM>" --output json
+```
+
+Does not require a project to be open. Returns a JSON array of `TemplateSearchResult` objects:
+
+```json
+[
+  {
+    "packageId": "UiPath.Template.SAPExample",
+    "version": "2.0.0",
+    "title": "SAP Automation Template",
+    "description": "Pre-configured project for SAP GUI automation",
+    "authors": "UiPath",
+    "source": "https://feed.example.com/v3/index.json",
+    "tags": ["SAP", "ERP"]
+  }
+]
+```
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `--query` | string | (none) | Filter by name or description. Omit to list all |
+| `--limit` | integer | 20 | Maximum results |
+| `--include-prerelease` | flag | false | Include prerelease versions |
+
+**2. Create from the chosen template:**
+
+```bash
+uip rpa new \
+  --name "MySAPAutomation" \
+  --location "/path/to/parent/directory" \
+  --template-package-id "<PACKAGE_ID>" \
+  --template-package-version "<VERSION>" \
+  --output json
+```
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|-------|
+| `--template-package-id` | string | (none) | NuGet package ID from `search-templates` results. **Overrides `--template-id` when set** |
+| `--template-package-version` | string | (latest) | Omit to use the latest available version |
 
 ### After Creation
 


### PR DESCRIPTION
## Summary
- Document new `uip rpa search-templates` command (query, limit, include-prerelease params; returns packageId, version, title, description, authors, source, tags)
- Document new `--template-package-id` and `--template-package-version` params on `uip rpa new` (overrides `--template-id` when set)
- Restructure environment-setup.md Step 0.4 into "From a Built-in Template" and "From a NuGet Template Package" sections

Matches UiPath/Studio#27249.

## Test plan
- [ ] Verify `search-templates` section in cli-reference.md has correct param names/types/defaults
- [ ] Verify environment-setup.md two-step workflow (search → create) is clear and copy-paste ready
- [ ] Verify SKILL.md Phase 0 gates project creation on explicit request or missing project
- [ ] Confirm no cross-skill references introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)