### PR TITLE
Add --output-filter docs and improve implementation plan format

### DIFF
--- a/skills/uipath-maestro-flow/references/planning-phase-implementation.md
+++ b/skills/uipath-maestro-flow/references/planning-phase-implementation.md
@@ -72,7 +72,7 @@ For each `core.logic.mock` node in the architectural plan:
 
 1. Check if the resource has been published since planning: `uip flow registry search "<name>" --output json`
 2. If published: replace the mock with the real resource node type, update inputs/outputs
-3. If not published: keep the mock and include it in the "Mock Placeholders" section of the output
+3. If not published: keep the mock and note it in the "Open Questions" section for user resolution
 
 ### Step 5 — Replace Placeholders
 
@@ -93,10 +93,9 @@ Generate a `<SolutionName>.impl.plan.md` file in the **solution directory** (sam
 ```markdown
 # <SolutionName> Implementation Plan
 
-## Resolved Node Table
+## Summary
 
-| # | Node ID | Name | Node Type | Inputs | Outputs | Connection ID | Notes |
-| --- | --- | --- | --- | --- | --- | --- | --- |
+2-3 sentences describing what the flow does end-to-end and what was resolved in this phase (connectors bound, resources confirmed, registry validations performed).
 
 ## Flow Diagram (Mermaid)
 
@@ -113,6 +112,11 @@ graph TD
     decision -->|true| end1
 ```
 
+## Resolved Node Table
+
+| # | Node ID | Name | Node Type | Inputs | Outputs | Connection ID | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+
 ## Resolved Edge Table
 
 (Copy from `.arch.plan.md` — update only if node IDs changed due to mock replacement)
@@ -122,20 +126,22 @@ graph TD
 | Connector Key | Connection ID | Activity | Verified |
 | --- | --- | --- | --- |
 
-## Variables
+## Global Variables
 
 (Copy from `.arch.plan.md` Inputs and Outputs section)
-
-## Mock Placeholders (if any)
-
-| Node ID | Intended Resource | Skill to Use | Status |
-| --- | --- | --- | --- |
 
 ## Changes from Architectural Plan
 
 - List what changed between `.arch.plan.md` and this plan
 - Record any node type changes (connector resolutions, mock replacements)
 - Note any port or input field changes discovered during registry validation
+
+## Open Questions
+
+Prefix each with `**[REQUIRED]**` or `**[OPTIONAL]**`. If there are no open questions, write "No open questions — all details resolved."
+
+- **[REQUIRED]** Which connection should be used for the Slack connector?
+- **[OPTIONAL]** Should the retry count be increased from the default?
 ```
 
 #### Column Additions

--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -198,11 +198,14 @@ Every `uip` command accepts:
 | Option | Description | Default |
 |---|---|---|
 | `--output <format>` | Output format: `table`, `json`, `yaml`, `plain` | `table` (interactive), `json` (non-interactive) |
+| `--output-filter <expression>` | JMESPath expression to filter JSON output | -- |
 | `--verbose` | Enable verbose/debug logging | Off |
 | `--help` / `-h` | Display help for the command | -- |
 | `--version` / `-v` | Display CLI version | -- |
 
 > **Always use `--output json`** when calling `uip` commands programmatically. JSON is compact and machine-readable.
+>
+> **Use `--output-filter` to extract specific fields** instead of piping output to `python3`, `jq`, or other post-processing tools. The filter uses [JMESPath](https://jmespath.org/) syntax. Example: `--output json --output-filter "Data[].{id: id, name: name}"`
 
 ## Deployment Lifecycle
 

--- a/skills/uipath-platform/references/integration-service/resources.md
+++ b/skills/uipath-platform/references/integration-service/resources.md
@@ -187,6 +187,28 @@ uip is resources execute create "uipath-salesforce-sfdc" "Coupon" \
 
 > **Update** (PATCH) = change specific fields. **Replace** (PUT) = overwrite entire record. Default to **Update** unless the user says "replace" or "overwrite".
 
+### Filtering Results with `--output-filter`
+
+Use the global `--output-filter` flag with a JMESPath expression to extract specific fields from large responses if possible via JMESPath.
+
+```bash
+# Extract only id, name, and email from a user list
+uip is resources execute list "<CONNECTOR_KEY>" "<OBJECT_NAME>" \
+  --connection-id "<CONNECTION_ID>" \
+  --output json \
+  --output-filter "Data[].{id: id, name: name, email: profile.email}"
+```
+
+Common JMESPath patterns:
+
+| Pattern | Effect |
+|---|---|
+| `Data[]` | Return all records (unwrap the Data envelope) |
+| `Data[].name` | Return just the `name` field from each record |
+| `Data[].{id: id, name: name}` | Return selected fields as objects |
+| `Data[?status=='active']` | Filter records by field value |
+| `Data[0]` | Return only the first record |
+
 ---
 
 ## Read-Only Field Recovery


### PR DESCRIPTION
Document the global --output-filter (JMESPath) CLI option in uipath-platform and integration-service resources. Update the maestro-flow implementation plan template: add summary and open questions sections, rename variables to global variables, remove mock placeholders section, reorder diagram before node table.

Validated via evaluation task:
- Created uipath-flow-output-filter-planning test in coder_eval
- Agent successfully generated DataProcessing.impl.plan.md following the new template structure with all required sections
- Test verifies --output-filter usage with JMESPath expressions for registry discovery (e.g., Data.Node.inputDefinition filters)
- All 11 evaluation criteria passed (perfect score)
- LLM reviewer confirmed proper implementation of new template format