### PR TITLE
Add reference guides for maestro case skill

### DIFF
--- a/skills/uipath-maestro-case/references/global-variable-guide.md
+++ b/skills/uipath-maestro-case/references/global-variable-guide.md
@@ -1,0 +1,112 @@
+# Global Variable Guide
+
+This reference describes how to populate `root.data.uipath.variables.inputOutputs[]` in a case JSON file. The parent skill invokes this procedure after constructing or modifying the case definition.
+
+## Overview
+
+The case JSON tracks all output variables produced by triggers and rule references in `root.data.uipath.variables.inputOutputs[]`. Each entry follows the `UiPathVariable` schema. These represent runtime data slots — each task instance gets its own. This array must be kept in sync with the actual outputs declared across the case — missing entries cause runtime failures.
+
+## UiPathVariable Schema
+
+```typescript
+interface UiPathVariable {
+  name: string;
+  type: string;
+  id?: string;
+  canonicalId?: string;
+  camelizedId?: string;
+  displayName?: string;
+  subType?: string;
+  elementId?: string;
+  default?: unknown;
+  value?: unknown;
+  var?: unknown;
+  source?: unknown;
+  target?: unknown;
+  custom?: boolean;
+  internal?: boolean;
+  body?: unknown;
+  _jsonSchema?: unknown;
+}
+```
+
+## Variable Collection Sources
+
+### Source 1: Trigger Outputs
+
+Location: `nodes[].data.uipath.outputs[]` where `nodes[].type === "case-management:Trigger"`
+
+Triggers that connect to external services (e.g., `Intsvc.EventTrigger`) produce output variables. Each item in the trigger's `outputs[]` array becomes a variable.
+
+For each trigger node, iterate over `node.data.uipath.outputs[]`. Map each output to a `UiPathVariable`:
+
+| Output field | UiPathVariable field |
+|---|---|
+| `id` or `var` | `id` |
+| `name` | `name` |
+| `type` | `type` |
+| node `id` | `elementId` |
+| `body` | `body` |
+| `_jsonSchema` | `_jsonSchema` |
+
+**Example:** A Jira trigger with outputs `response` and `error`:
+```json
+{
+  "id": "response",
+  "name": "response",
+  "type": "jsonSchema",
+  "elementId": "trigger_3WkF0Q",
+  "body": { ... }
+}
+```
+
+### Source 2: Variables Referenced in Rules
+
+Scan entry/exit conditions on stages, tasks, and edges for variable references. Rules that use `rule: "variable-equals"` or similar variable-based conditions reference output variables by ID. If a rule references a variable ID already collected from Source 1, no action is needed. If it references a variable not yet in the collection, add it with the information available from the rule context.
+
+## Variable Collection Procedure
+
+1. Initialize an empty map keyed by variable `id`
+2. Iterate over all trigger nodes → collect from `data.uipath.outputs[]`
+3. Scan all entry/exit conditions across stages, tasks, and edges for variable references
+4. Set `root.data.uipath.variables.inputOutputs` to the collected array
+
+## Orphan Variable Cleanup
+
+After collecting variables, remove orphans — entries that nothing in the case references.
+
+1. Scan the entire case JSON for all variable references by `id` (in rule conditions, task data, etc.)
+2. Build a set of referenced variable IDs
+3. Remove any entry from `root.data.uipath.variables.inputOutputs[]` whose `id` is not in the referenced set
+
+## Updating the JSON
+
+1. Read the case JSON file
+2. Run the variable collection procedure → set `root.data.uipath.variables.inputOutputs`
+3. Run orphan variable cleanup
+4. Preserve all other fields in the JSON unchanged
+5. Write the updated JSON back to the same file path
+
+## Example
+
+**Variables** (from a Jira trigger):
+```json
+"variables": {
+  "inputOutputs": [
+    {
+      "id": "response",
+      "name": "response",
+      "type": "jsonSchema",
+      "elementId": "trigger_3WkF0Q",
+      "body": { "$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": { ... } }
+    },
+    {
+      "id": "error",
+      "name": "Error",
+      "type": "jsonSchema",
+      "elementId": "trigger_3WkF0Q",
+      "body": { "type": "object", "properties": { "code": { "type": "string" }, "message": { "type": "string" }, ... } }
+    }
+  ]
+}
+```

--- a/skills/uipath-maestro-case/references/hook-input-guide.md
+++ b/skills/uipath-maestro-case/references/hook-input-guide.md
@@ -1,0 +1,324 @@
+# Hook Input Guide
+
+This reference describes how to populate input values for all task types in a case management JSON file. The parent skill invokes this procedure after building the task JSON structure (see `task-json-builder-guide.md`).
+
+## Non-Connector Tasks (process, action, agent, api-workflow, case-management)
+
+Each input has a `value` field. Set it to the desired string value. Leave as `""` if no value is needed.
+
+```json
+{
+  "name": "Content",
+  "displayName": "Content",
+  "value": "Hello world",
+  "type": "string",
+  "id": "v3YSGGSc9",
+  "var": "v3YSGGSc9",
+  "elementId": "stage_1-tNEHpGDYd"
+}
+```
+
+Use `uip case tasks describe` to discover available inputs:
+
+```bash
+uip case tasks describe --type <TASK_TYPE> --id <ENTITY_KEY> --output json
+```
+
+---
+
+## Connector Activity Inputs (execute-connector-activity)
+
+Use `uip case tasks describe` to discover available inputs:
+
+```bash
+uip case tasks describe --type connector-activity --id <ACTIVITY_TYPE_ID> --connection-id <CONNECTION_UUID> --output json
+```
+
+Activity inputs are structured as JSON objects. Values are set inside `input.body` (not `input.value`). There are up to three input types:
+
+### `body` — Request body fields
+
+Contains the main request fields. Each key in `body` is a field name with an empty string as default.
+
+```json
+{
+  "name": "body",
+  "type": "json",
+  "target": "body",
+  "body": { "comment": "", "summary": "", "description": "" },
+  "var": "vRaNdOmId",
+  "id": "vRaNdOmId",
+  "elementId": "stage_1-tABCDEFGH"
+}
+```
+
+To set values, populate the fields in `body`:
+
+```json
+{
+  "name": "body",
+  "type": "json",
+  "target": "body",
+  "body": { "comment": "Hello world", "summary": "Bug report", "description": "Steps to reproduce..." },
+  "var": "vRaNdOmId",
+  "id": "vRaNdOmId",
+  "elementId": "stage_1-tABCDEFGH"
+}
+```
+
+### `pathParameters` — URL path parameters
+
+Contains parameters embedded in the API path (e.g., issue ID).
+
+```json
+{
+  "name": "pathParameters",
+  "type": "json",
+  "target": "pathParameters",
+  "body": { "issueIdOrKey": "" },
+  "var": "vRaNdOm02",
+  "id": "vRaNdOm02",
+  "elementId": "stage_1-tABCDEFGH"
+}
+```
+
+To set values:
+
+```json
+{
+  "name": "pathParameters",
+  "type": "json",
+  "target": "pathParameters",
+  "body": { "issueIdOrKey": "PROJ-123" },
+  "var": "vRaNdOm02",
+  "id": "vRaNdOm02",
+  "elementId": "stage_1-tABCDEFGH"
+}
+```
+
+### `queryParameters` — URL query parameters
+
+Contains query string parameters.
+
+```json
+{
+  "name": "queryParameters",
+  "type": "json",
+  "target": "queryParameters",
+  "body": { "expand": "" },
+  "var": "vRaNdOm03",
+  "id": "vRaNdOm03",
+  "elementId": "stage_1-tABCDEFGH"
+}
+```
+
+### How values are merged
+
+Values are keyed by input name and shallow-merged into the corresponding `input.body`. Existing fields from enrichment are preserved; provided values overwrite matching keys.
+
+```
+Given input values: {"body": {"comment": "Hello"}, "queryParameters": {"issueIdOrKey": "PROJ-123"}}
+
+inputs[name="body"].body           = { ...existingFields, "comment": "Hello" }
+inputs[name="queryParameters"].body = { ...existingFields, "issueIdOrKey": "PROJ-123" }
+```
+
+**Full example:**
+
+```
+enrichment skeleton:
+  inputs[name="body"].body = { "comment": "", "summary": "" }
+
+provided values:
+  { "body": { "comment": "Hello" } }
+
+result:
+  inputs[name="body"].body = { "comment": "Hello", "summary": "" }
+```
+
+Not all inputs are present for every activity. The `describe` response shows which inputs exist. Only `body` is always present if the activity has request fields.
+
+---
+
+## Connector Trigger Inputs (wait-for-connector)
+
+Use `uip case tasks describe` to discover available parameters:
+
+```bash
+uip case tasks describe --type connector-trigger --id <TRIGGER_TYPE_ID> --connection-id <CONNECTION_UUID> --output json
+```
+
+Trigger inputs have a single `body` input with a different structure from activity inputs.
+
+### Structure
+
+```json
+{
+  "name": "body",
+  "type": "json",
+  "target": "body",
+  "body": {
+    "filters": { "expression": "" },
+    "parameters": { "project": "", "issuetype": "" }
+  },
+  "var": "vRaNdOmId",
+  "id": "vRaNdOmId"
+}
+```
+
+### `parameters` — Event parameters
+
+Key/value pairs that filter which events trigger the case. The available parameter names come from the `describe` response.
+
+To set values, populate the parameter fields:
+
+```json
+"parameters": { "project": "ACEDU", "issuetype": "19238" }
+```
+
+### `filters.expression` — Event filter expression
+
+An optional filter expression that further constrains which events trigger the case. Uses a bracket-based expression syntax.
+
+```json
+"filters": { "expression": "((fields.progress<`222`))" }
+```
+
+Leave as `""` if no filter is needed.
+
+### How values are populated
+
+Event parameters are passed as flat key/value pairs — all values are strings. They populate `body.parameters` directly. The filter expression is a separate field in `body.filters.expression`.
+
+**Example — Jira trigger filtering by project and issue type:**
+
+```json
+{
+  "name": "body",
+  "type": "json",
+  "target": "body",
+  "body": {
+    "filters": { "expression": "" },
+    "parameters": { "project": "ACEDU", "issuetype": "19238" }
+  }
+}
+```
+
+---
+
+## Event Trigger Inputs (trigger node)
+
+Event triggers on the trigger node (not in a stage) use the same input structure as wait-for-connector tasks above, except:
+
+- No `elementId` on the input (trigger inputs don't carry elementId)
+- Same `body.parameters` and `body.filters.expression` structure
+
+See `trigger-json-builder-guide.md` for the full trigger node JSON.
+
+---
+
+## Required Fields
+
+The `describe` response may include `requiredFields` on inputs, listing which sub-fields must be populated:
+
+```json
+{
+  "name": "body",
+  "type": "json",
+  "body": { "comment": "", "summary": "" },
+  "requiredFields": ["summary"]
+}
+```
+
+This means `summary` must have a non-empty value. `requiredFields` is informational — strip it from the task JSON (it is not part of the task data structure), but use it to ensure required values are provided.
+
+---
+
+## Input Value Formats
+
+Input values are not limited to plain strings. The case management runtime supports several expression formats, detected by prefix. This applies to both `input.value` (non-connector tasks) and values inside `input.body` fields (connector tasks).
+
+### String Literal (no prefix)
+
+Plain text with no `=` prefix. Used for hardcoded constant values.
+
+```
+"value": "Hello world"
+"value": "123"
+"value": "true"
+```
+
+### Global Variable Reference (`=vars.`)
+
+Reference a process-level variable or a task output that has been hoisted to root `inputOutputs`. This is the primary way to pass data between tasks.
+
+```
+"value": "=vars.userId"
+"value": "=vars.response.fields.summary"
+"value": "=vars.error.message"
+```
+
+Supports nested property access via dot notation and bracket notation for special characters:
+
+```
+"value": "=vars.response.data.customer[\"account-id\"]"
+"value": "=vars.items[0].name"
+```
+
+### Case Metadata Reference (`=metadata.`)
+
+Reference case-level metadata fields.
+
+```
+"value": "=metadata.caseId"
+"value": "=metadata.caseOwner"
+```
+
+### JavaScript Expression (`=js:`)
+
+Full JavaScript expression for complex calculations. Has access to `vars.*` for variable references.
+
+```
+"value": "=js:vars.quantity * vars.price"
+"value": "=js:vars.items.filter(x => x.status === 'active').length"
+"value": "=js:vars.amount > 1000 ? 'VIP' : 'Standard'"
+```
+
+### Binding Reference (`=bindings.`)
+
+Reference a binding value. Typically used in `data.name`, `data.folderPath`, and connector context — not in task inputs directly.
+
+```
+"value": "=bindings.bXYZ1234"
+```
+
+### Data Fabric Reference (`=datafabric.`)
+
+Reference Data Fabric entity fields. Available when Data Fabric is enabled for the case.
+
+```
+"value": "=datafabric.Customer.Name"
+"value": "=datafabric.Customer.Email"
+```
+
+### Job Attachment Reference (`=orchestrator.JobAttachments`)
+
+Reference file attachments from Orchestrator. Used for file-type inputs.
+
+```
+"value": "=orchestrator.JobAttachments"
+```
+
+### Summary
+
+| Format | Prefix | Example | Use case |
+|---|---|---|---|
+| String literal | none | `Hello world` | Hardcoded constants |
+| Global variable | `=vars.` | `=vars.userId` | Task outputs, process variables |
+| Metadata | `=metadata.` | `=metadata.caseId` | Case-level data |
+| JavaScript | `=js:` | `=js:vars.a + vars.b` | Complex calculations |
+| Binding | `=bindings.` | `=bindings.bXYZ` | Resource references |
+| Data Fabric | `=datafabric.` | `=datafabric.Customer.Name` | Entity data |
+| Job attachment | `=orchestrator.` | `=orchestrator.JobAttachments` | File references |
+
+The `=` prefix signals an expression. Values without `=` are treated as string literals.

--- a/skills/uipath-maestro-case/references/task-json-builder-guide.md
+++ b/skills/uipath-maestro-case/references/task-json-builder-guide.md
@@ -1,0 +1,576 @@
+# Task JSON Builder Guide
+
+This reference describes how to build the task JSON data object for each supported task type in a case management JSON file. The parent skill invokes this procedure when adding tasks to stages.
+
+## Overview
+
+Building a task involves two steps:
+
+1. **Fetch input/output metadata** — Use `uip case tasks describe` to get the input/output schema for a given task type and type ID. This returns what fields the task needs as input and what it produces as output.
+2. **Build the task object** — Construct the full task JSON with generated IDs, element IDs, display names, and the fetched metadata.
+
+## Task Types
+
+| Task type | CLI `--type` value | Description |
+|---|---|---|
+| Process | `process` | Run a UiPath process |
+| Action | `action` | Human action / approval task |
+| Agent | `agent` | Run an AI agent |
+| API Workflow | `api-workflow` | Run an API workflow |
+| Agentic Process | `external-agent` | Run an external agentic process |
+| Case Management | `case-management` | Run a sub-case |
+| Wait for Connector | `wait-for-connector` | Wait for a connector event (trigger) |
+| Execute Connector | `execute-connector-activity` | Execute a connector action |
+| Wait for Timer | `wait-for-timer` | Wait for a time condition |
+
+---
+
+## Step 1: Fetch Input/Output Metadata
+
+Before building the task, fetch its input/output schema to know what fields it expects.
+
+### For process-like tasks (process, agent, action, api-workflow, case-management)
+
+```bash
+uip case tasks describe --type <TASK_TYPE> --id <ENTITY_KEY> --output json
+```
+
+- `--type`: One of `process`, `agent`, `rpa`, `action`, `api-workflow`, `case-management`
+- `--id`: The entityKey (for process types) or action-app ID (for action type)
+
+### For connector tasks
+
+```bash
+uip case tasks describe --type connector-activity --id <ACTIVITY_TYPE_ID> --connection-id <CONNECTION_UUID> --output json
+uip case tasks describe --type connector-trigger --id <TRIGGER_TYPE_ID> --connection-id <CONNECTION_UUID> --output json
+```
+
+- `--id`: The `uiPathActivityTypeId` UUID from the TypeCache
+- `--connection-id`: The connection UUID
+
+### Response format
+
+```json
+{
+  "inputs": [
+    { "name": "Content", "type": "string", "displayName": "Content", "value": "", ... },
+    ...
+  ],
+  "outputs": [
+    { "name": "Error", "type": "jsonSchema", "displayName": "Error", "source": "=Error", ... },
+    ...
+  ]
+}
+```
+
+The `describe` response may include a `required` field on inputs. Strip `required` before building the task JSON — it is not part of the task data structure.
+
+---
+
+## Step 2: Build Task JSON
+
+### ID Generation
+
+- **Task ID**: `t` prefix + 8 random alphanumeric chars (e.g., `tNEHpGDYd`)
+- **Element ID**: `{stageId}-{taskId}` (e.g., `stage_1-tNEHpGDYd`)
+- **Variable IDs for inputs**: `v` prefix + 8 random alphanumeric chars (e.g., `v3YSGGSc9`)
+- **Variable IDs for outputs**: Unique camelCase derived from output name (e.g., `error`, `action`, `comment`). If collision, append counter (e.g., `error1`)
+- **Binding IDs**: `b` prefix + 8 random alphanumeric chars (e.g., `bXYZ1234`)
+
+### UiPathBinding Schema
+
+```typescript
+export interface UiPathBinding {
+  id: string;
+  name: string;
+  type: string;
+  resource: string;           // "Connection" | "process" | "app" | "queue"
+  resourceKey: string;        // e.g., "folderPath.ProcessName" or connection UUID
+  propertyAttribute: string;  // "name" | "folderPath" | "ConnectionId" | "folderKey" | "Key"
+  resourceSubType?: string;   // "ProcessOrchestration" | "Agent" | "Api" | "CaseManagement"
+  default?: string;
+}
+```
+
+### Common BaseTask Fields
+
+Every task shares these fields:
+
+```json
+{
+  "id": "<taskId>",
+  "elementId": "<stageId>-<taskId>",
+  "displayName": "<display name>",
+  "type": "<task type>",
+  "data": { ... },
+  "entryConditions": [
+    {
+      "id": "<conditionId>",
+      "displayName": "Entry condition 1",
+      "rules": [[{ "id": "<ruleId>", "rule": "current-stage-entered" }]]
+    }
+  ]
+}
+```
+
+Optional fields: `shouldRunOnReEntry`, `skipCondition`.
+
+---
+
+## Process-like Tasks
+
+These task types share the same data structure: `process`, `agent`, `api-workflow`, `case-management`.
+
+### Build procedure
+
+1. Generate task ID and element ID
+2. Fetch metadata via `uip case tasks describe --type <TYPE> --id <ENTITY_KEY> --output json`
+3. Create name + folderPath bindings and set `data.name` / `data.folderPath` to `=bindings.<id>` references (see Binding Construction below)
+
+### Task JSON structure
+
+```json
+{
+  "id": "tABCDEFGH",
+  "elementId": "stage_1-tABCDEFGH",
+  "displayName": "Run MyProcess",
+  "type": "process",
+  "data": {
+    "name": "=bindings.bXYZ12345",
+    "folderPath": "=bindings.bABC67890",
+    "inputs": [
+      {
+        "name": "InputArg",
+        "displayName": "InputArg",
+        "value": "",
+        "type": "string",
+        "var": "vRaNdOmId",
+        "id": "vRaNdOmId",
+        "elementId": "stage_1-tABCDEFGH"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "OutputArg",
+        "displayName": "OutputArg",
+        "type": "string",
+        "source": "=OutputArg",
+        "var": "outputArg",
+        "id": "outputArg",
+        "value": "outputArg",
+        "target": "=outputArg",
+        "elementId": "stage_1-tABCDEFGH"
+      },
+      {
+        "name": "Error",
+        "displayName": "Error",
+        "value": "error",
+        "type": "jsonSchema",
+        "source": "=Error",
+        "var": "error",
+        "id": "error",
+        "target": "=error",
+        "elementId": "stage_1-tABCDEFGH",
+        "body": {
+          "type": "object",
+          "properties": {
+            "code": { "type": "string" },
+            "message": { "type": "string" },
+            "detail": { "type": "string" },
+            "category": { "type": "string" },
+            "status": { "type": "number" },
+            "element": { "type": "string" }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### Process-like Binding Construction
+
+Create name + folderPath bindings when building the task. Dedup against existing `root.data.uipath.bindings[]`.
+
+1. Determine `resource`: `"process"` for process/agent/api-workflow/case-management, `"app"` for action
+2. Compute `resourceKey` = `"{folderPath}.{name}"`
+3. Check dedup: does a binding with the same (`default`, `resource`, `resourceKey`) already exist in `root.data.uipath.bindings[]`?
+4. If found, reuse the existing binding ID
+5. If not, create two new bindings and push to `root.data.uipath.bindings[]`:
+   ```json
+   { "id": "b<random>", "name": "name", "type": "string", "resource": "<resource>",
+     "propertyAttribute": "name", "resourceKey": "<folderPath>.<name>", "default": "<name>" }
+   { "id": "b<random>", "name": "folderPath", "type": "string", "resource": "<resource>",
+     "propertyAttribute": "folderPath", "resourceKey": "<folderPath>.<name>", "default": "<folderPath>" }
+   ```
+6. Set `data.name` = `"=bindings.<nameBindingId>"`, `data.folderPath` = `"=bindings.<folderPathBindingId>"`
+
+`resourceSubType` values by task type:
+- `process` → `"ProcessOrchestration"`
+- `agent` → `"Agent"`
+- `api-workflow` → `"Api"`
+- `case-management` → `"CaseManagement"`
+
+**Dedup example:** Two tasks referencing the same process:
+- Task A creates binding `bXYZ` for `"MyProcess"` → `taskA.data.name = "=bindings.bXYZ"`
+- Task B finds `bXYZ` already exists for `("MyProcess", "process", "Shared.MyProcess")` → `taskB.data.name = "=bindings.bXYZ"`
+
+---
+
+## Action Task
+
+Same as process-like, but with additional fields in `data`. Uses `resource: "app"` for bindings (not `"process"`).
+
+```json
+{
+  "type": "action",
+  "data": {
+    "name": "=bindings.bXYZ12345",
+    "folderPath": "=bindings.bABC67890",
+    "taskTitle": "Approval Request",
+    "priority": "Medium",
+    "assignmentCriteria": "user",
+    "inputs": [ ... ],
+    "outputs": [
+      {
+        "name": "Action",
+        "displayName": "Action",
+        "type": "string",
+        "source": "=Action",
+        "options": [
+          { "value": "approve", "label": "approve" },
+          { "value": "reject", "label": "reject" }
+        ],
+        ...
+      },
+      { "name": "Error", ... }
+    ]
+  }
+}
+```
+
+The `Action` output has its type derived from the first outcome of the action schema. Outcome options are included in the `options` array.
+
+Binding construction follows the same process-like pattern above, with `resource: "app"`.
+
+---
+
+## Connector Activity Task (execute-connector-activity)
+
+### Build procedure
+
+1. Generate task ID and element ID
+2. Run `uip case tasks add-connector <FILE> <STAGE_ID> --type activity --type-id <UUID> --connection-id <CONN_UUID> --output json`
+3. Or build manually using enrichment data
+
+### Task JSON structure
+
+```json
+{
+  "id": "tABCDEFGH",
+  "elementId": "stage_1-tABCDEFGH",
+  "displayName": "Get Issue",
+  "type": "execute-connector-activity",
+  "data": {
+    "serviceType": "Intsvc.ExecuteConnectorActivity",
+    "context": [
+      { "name": "connectorKey", "value": "uipath-atlassian-jira", "type": "string" },
+      { "name": "connection", "value": "=bindings.bYrtrMEvs", "type": "string" },
+      { "name": "resourceKey", "value": "0d93ddc9-a512-4b60-8483-4a3a8fbee20e", "type": "string" },
+      { "name": "folderKey", "value": "=bindings.bePaAIvP8", "type": "string" },
+      { "name": "operation", "value": "list", "type": "string" },
+      { "name": "objectName", "value": "curated_get_issue", "type": "string" },
+      { "name": "method", "value": "GET", "type": "string" },
+      { "name": "path", "value": "/api/...", "type": "string" },
+      { "name": "_label", "value": "Get Issue", "type": "string" },
+      {
+        "name": "metadata",
+        "type": "json",
+        "body": {
+          "activityMetadata": { "activity": { "...TypeCache entry..." } },
+          "designTimeMetadata": {
+            "connectorLogoUrl": "icons/...",
+            "activityConfig": { "isCurated": true, "operation": "list" }
+          },
+          "telemetryData": { "connectorKey": "...", "connectorName": "..." },
+          "inputMetadata": {},
+          "errorState": { "hasError": false },
+          "activityPropertyConfiguration": {
+            "configuration": "=jsonString:{...}",
+            "uiPathActivityTypeId": "<uuid>",
+            "errorState": { "issues": [] }
+          }
+        }
+      }
+    ],
+    "inputs": [
+      {
+        "name": "body",
+        "type": "json",
+        "target": "body",
+        "body": { "field1": "", "field2": "" },
+        "var": "vRaNdOmId",
+        "id": "vRaNdOmId",
+        "elementId": "stage_1-tABCDEFGH"
+      },
+      {
+        "name": "pathParameters",
+        "type": "json",
+        "target": "pathParameters",
+        "body": { "issueIdOrKey": "" },
+        "var": "vRaNdOm02",
+        "id": "vRaNdOm02",
+        "elementId": "stage_1-tABCDEFGH"
+      },
+      {
+        "name": "queryParameters",
+        "type": "json",
+        "target": "queryParameters",
+        "body": { "expand": "" },
+        "var": "vRaNdOm03",
+        "id": "vRaNdOm03",
+        "elementId": "stage_1-tABCDEFGH"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "response",
+        "displayName": "Get Issue",
+        "type": "jsonSchema",
+        "source": "=response",
+        "var": "response",
+        "id": "response",
+        "value": "response",
+        "target": "=response",
+        "elementId": "stage_1-tABCDEFGH",
+        "body": { "$schema": "http://json-schema.org/draft-07/schema#", "type": "object", "properties": { "..." } }
+      },
+      {
+        "name": "Error",
+        "displayName": "Error",
+        "value": "error",
+        "type": "jsonSchema",
+        "source": "=Error",
+        "var": "error",
+        "id": "error",
+        "target": "=error",
+        "elementId": "stage_1-tABCDEFGH",
+        "body": { "type": "object", "properties": { "code": { "type": "string" }, "..." } }
+      }
+    ],
+    "bindings": []
+  }
+}
+```
+
+### Key differences from process-like tasks
+
+- Has `serviceType` field (resolved from Elements API, or defaults to `"Intsvc.ExecuteConnectorActivity"`)
+- Has `context[]` array with connector config, binding references, and metadata
+- Has `bindings: []` (task-level, always empty — bindings go to root)
+- Inputs are structured as `body`, `pathParameters`, `queryParameters` (JSON objects with field names as keys)
+- Outputs include per-field entries + `response` (jsonSchema with swagger body) + `Error`
+
+### Connector Binding Construction
+
+Connector bindings are created at task build time because the enrichment context (connector key name, connection UUID, folder key) is only available during this step. Dedup against existing `root.data.uipath.bindings[]`.
+
+1. Check dedup: does a ConnectionId binding with the same (`default`, `resource: "Connection"`, `resourceKey`) already exist?
+2. If found, reuse the existing binding ID
+3. If not, create a ConnectionId binding:
+   ```json
+   { "id": "b<random>", "name": "<connectorKey> connection", "type": "string",
+     "resource": "Connection", "propertyAttribute": "ConnectionId",
+     "resourceKey": "<connectionId>", "default": "<connectionId>" }
+   ```
+4. Same dedup check for FolderKey binding (if the connection has a folder key):
+   ```json
+   { "id": "b<random>", "name": "FolderKey", "type": "string",
+     "resource": "Connection", "propertyAttribute": "folderKey",
+     "resourceKey": "<connectionId>", "default": "<folderKey>" }
+   ```
+5. Push new bindings to `root.data.uipath.bindings[]`
+6. Set context entries to reference bindings:
+   - `connection` → `=bindings.<connectionBindingId>`
+   - `folderKey` → `=bindings.<folderKeyBindingId>`
+
+**Dedup example:** Two connector tasks using the same Jira connection share the same ConnectionId and FolderKey bindings.
+
+---
+
+## Connector Trigger Task (wait-for-connector)
+
+### Build procedure
+
+1. Generate task ID and element ID
+2. Run `uip case tasks add-connector <FILE> <STAGE_ID> --type trigger --type-id <UUID> --connection-id <CONN_UUID> --output json`
+3. Or build manually using enrichment data
+
+### Task JSON structure
+
+```json
+{
+  "id": "tABCDEFGH",
+  "elementId": "stage_1-tABCDEFGH",
+  "displayName": "Issue Created",
+  "type": "wait-for-connector",
+  "data": {
+    "serviceType": "Intsvc.WaitForEvent",
+    "context": [
+      { "name": "connectorKey", "value": "uipath-atlassian-jira", "type": "string" },
+      { "name": "connection", "value": "=bindings.b4Hu9FHiu", "type": "string" },
+      { "name": "resourceKey", "value": "0d93ddc9-a512-4b60-8483-4a3a8fbee20e", "type": "string" },
+      { "name": "folderKey", "value": "=bindings.bNJUKpA2t", "type": "string" },
+      { "name": "operation", "value": "ISSUE_CREATED", "type": "string" },
+      { "name": "objectName", "value": "curated_get_issue", "type": "string" },
+      { "name": "method", "type": "string" },
+      { "name": "path", "type": "string" },
+      {
+        "name": "metadata",
+        "type": "json",
+        "body": {
+          "activityMetadata": { "activity": { "...TypeCache entry..." } },
+          "designTimeMetadata": {
+            "connectorLogoUrl": "icons/...",
+            "activityConfig": { "isCurated": true, "operation": "ISSUE_CREATED" }
+          },
+          "telemetryData": { "connectorKey": "...", "connectorName": "...", "operationType": "" },
+          "inputMetadata": {},
+          "errorState": { "hasError": false },
+          "activityPropertyConfiguration": {
+            "objectName": "curated_get_issue",
+            "eventType": "ISSUE_CREATED",
+            "eventMode": "polling",
+            "configuration": "=jsonString:{...}",
+            "uiPathActivityTypeId": "<uuid>",
+            "errorState": { "issues": [] }
+          }
+        }
+      }
+    ],
+    "inputs": [
+      {
+        "name": "body",
+        "type": "json",
+        "target": "body",
+        "body": {
+          "filters": { "expression": "" },
+          "parameters": { "project": "", "issuetype": "" }
+        },
+        "var": "vRaNdOmId",
+        "id": "vRaNdOmId",
+        "elementId": ""
+      }
+    ],
+    "outputs": [
+      {
+        "name": "response",
+        "displayName": "Issue Created",
+        "type": "jsonSchema",
+        "source": "=response",
+        "var": "response",
+        "id": "response",
+        "value": "response",
+        "target": "=response",
+        "elementId": "",
+        "body": { "$schema": "http://json-schema.org/draft-07/schema#", "..." }
+      },
+      {
+        "name": "Error",
+        "displayName": "Error",
+        "value": "error",
+        "type": "jsonSchema",
+        "source": "=Error",
+        "var": "error",
+        "id": "error",
+        "target": "=error",
+        "elementId": "",
+        "body": { "type": "object", "properties": { "code": { "type": "string" }, "..." } }
+      }
+    ],
+    "bindings": []
+  }
+}
+```
+
+### Key differences from connector activity
+
+- `serviceType` is always `"Intsvc.WaitForEvent"`
+- Context has no `_label` entry
+- Context `method` and `path` are empty (triggers don't have HTTP endpoints)
+- Context `operation` comes from `config.eventOperation` (not resolved via Elements API)
+- `activityPropertyConfiguration` has additional top-level `objectName`, `eventType`, `eventMode` fields
+- Inputs have a single `body` with `filters.expression` and `parameters` (event filter params)
+- Outputs are always: `response` (with optional JSON Schema from swagger) + `Error`
+- Connector bindings: same inline construction as connector activity (see above)
+
+---
+
+## Wait for Timer Task
+
+Simplest task type — no enrichment, no bindings.
+
+```json
+{
+  "id": "tABCDEFGH",
+  "displayName": "Wait 5 minutes",
+  "type": "wait-for-timer",
+  "data": {
+    "timer": "timeDuration",
+    "timeDuration": "PT5M"
+  }
+}
+```
+
+Timer options:
+- `timeDuration`: ISO 8601 duration (e.g., `PT5M`, `PT1H`)
+- `timeDate`: ISO 8601 datetime
+- `timeCycle`: ISO 8601 repeating interval (e.g., `R/PT1S`)
+
+---
+
+## Error Output Schema
+
+All non-case-management tasks include a standard Error output. The body schema is:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "code": { "type": "string" },
+    "message": { "type": "string" },
+    "detail": { "type": "string" },
+    "category": { "type": "string" },
+    "status": { "type": "number" },
+    "element": { "type": "string" }
+  }
+}
+```
+
+Case-management sub-tasks do NOT get outputs (outputs are stripped during enrichment).
+
+---
+
+## Setting Input Values
+
+Setting input values for all task types is documented in `hook-input-guide.md`.
+
+---
+
+## Variable ID Assignment Pipeline
+
+After fetching raw inputs/outputs from enrichment, variable IDs are assigned:
+
+### Inputs
+Each input gets:
+- `id` = `var` = `v` + 8 random alphanumeric chars
+- `elementId` = `{stageId}-{taskId}`
+
+### Outputs
+Each output gets:
+- `id` = `var` = `value` = unique camelCase derived from output `name` (e.g., `"Error"` → `"error"`, `"Action"` → `"action"`)
+- `target` = `={id}`
+- `elementId` = `{stageId}-{taskId}`
+- `body` = resolved from `_jsonSchema` if type is `jsonSchema`
+
+After ID assignment, `_jsonSchema` is removed from the output (moved into `body`).

--- a/skills/uipath-maestro-case/references/trigger-json-builder-guide.md
+++ b/skills/uipath-maestro-case/references/trigger-json-builder-guide.md
@@ -1,0 +1,243 @@
+# Trigger JSON Builder Guide
+
+This reference describes how to build the trigger node JSON data for each supported trigger type in a case management JSON file. The parent skill invokes this procedure when adding triggers to a case.
+
+## Overview
+
+Building a trigger involves:
+
+1. **Generate trigger node** — Create the base node with ID, position, and label
+2. **Populate `data.uipath`** — Set the trigger-type-specific data body (timer config, event enrichment, or empty for manual)
+3. **Register outputs as root variables** — For event triggers, push outputs to `root.data.uipath.variables.inputOutputs[]`
+
+## Trigger Types
+
+| Type | CLI command | `serviceType` | Description |
+|---|---|---|---|
+| Manual | `add-manual` | None (no `uipath` block) | Started manually, no automation |
+| Timer | `add-timer` | `Intsvc.TimerTrigger` | Fires on a time schedule |
+| Event | `add-event` | `Intsvc.EventTrigger` | Fires when a connector event occurs |
+
+---
+
+## Base Trigger Node
+
+All trigger types share this base structure:
+
+```json
+{
+  "id": "trigger_<6-random-chars>",
+  "type": "case-management:Trigger",
+  "position": { "x": -100, "y": 200 },
+  "style": { "width": 96, "height": 96 },
+  "measured": { "width": 96, "height": 96 },
+  "data": {
+    "parentElement": { "id": "root", "type": "case-management:root" },
+    "label": "<display name>"
+  }
+}
+```
+
+### ID Generation
+
+- Trigger ID: `trigger_` prefix + 6 random alphanumeric chars (e.g., `trigger_3WkF0Q`)
+
+### Positioning
+
+- First trigger: `{ x: -100, y: 200 }`
+- Each additional trigger: same x, y incremented by 140 (e.g., 200, 340, 480, ...)
+
+### Display Name
+
+- If provided, use it as `data.label`
+- If not provided, auto-generate as `"Trigger N"` where N = existing trigger count + 1
+
+---
+
+## Manual Trigger
+
+No `data.uipath` block. The base node is the complete trigger.
+
+```json
+{
+  "id": "trigger_AbCdEf",
+  "type": "case-management:Trigger",
+  "position": { "x": -100, "y": 200 },
+  "style": { "width": 96, "height": 96 },
+  "measured": { "width": 96, "height": 96 },
+  "data": {
+    "parentElement": { "id": "root", "type": "case-management:root" },
+    "label": "Trigger 1"
+  }
+}
+```
+
+---
+
+## Timer Trigger
+
+Set `data.uipath` with timer configuration:
+
+```json
+{
+  "id": "trigger_AbCdEf",
+  "type": "case-management:Trigger",
+  "position": { "x": -100, "y": 200 },
+  "style": { "width": 96, "height": 96 },
+  "measured": { "width": 96, "height": 96 },
+  "data": {
+    "parentElement": { "id": "root", "type": "case-management:root" },
+    "label": "Every 5 minutes",
+    "uipath": {
+      "serviceType": "Intsvc.TimerTrigger",
+      "timerType": "timeCycle",
+      "timeCycle": "R/PT5M"
+    }
+  }
+}
+```
+
+### Time Cycle Format
+
+ISO 8601 repeating interval: `R[count]/[start]/duration`
+
+| Example | Meaning |
+|---|---|
+| `R/PT1S` | Every 1 second, infinite |
+| `R/PT5M` | Every 5 minutes, infinite |
+| `R/PT1H` | Every 1 hour, infinite |
+| `R3/PT10S` | Every 10 seconds, 3 times |
+| `R/2026-04-26T10:40:00.000-07:00/PT1H` | Every hour starting at a specific time |
+
+Duration units: `S` (seconds), `M` (minutes), `H` (hours), `D` (days), `W` (weeks).
+
+No bindings or outputs. No enrichment needed.
+
+---
+
+## Event Trigger (Connector)
+
+The most complex trigger type. Requires enrichment from the connector API.
+
+### Build Procedure
+
+1. Generate base trigger node
+2. Fetch enrichment via `uip case tasks describe --type connector-trigger --id <TRIGGER_TYPE_ID> --connection-id <CONNECTION_UUID> --output json`
+3. Build `data.uipath` with context, inputs, and outputs
+4. Root variable registration is handled by `global-variable-guide.md`
+
+### Trigger Node JSON Structure
+
+```json
+{
+  "id": "trigger_3WkF0Q",
+  "type": "case-management:Trigger",
+  "position": { "x": -100, "y": 200 },
+  "style": { "width": 96, "height": 96 },
+  "measured": { "width": 96, "height": 96 },
+  "data": {
+    "parentElement": { "id": "root", "type": "case-management:root" },
+    "label": "Jira Issue Created",
+    "uipath": {
+      "serviceType": "Intsvc.EventTrigger",
+      "context": [
+        { "name": "connectorKey", "value": "uipath-atlassian-jira", "type": "string" },
+        { "name": "connection", "value": "=bindings.bYrtrMEvs", "type": "string" },
+        { "name": "resourceKey", "value": "0d93ddc9-a512-4b60-8483-4a3a8fbee20e", "type": "string" },
+        { "name": "folderKey", "value": "=bindings.bePaAIvP8", "type": "string" },
+        { "name": "operation", "value": "ISSUE_CREATED", "type": "string" },
+        { "name": "objectName", "value": "curated_get_issue", "type": "string" },
+        { "name": "method", "type": "string" },
+        { "name": "path", "type": "string" },
+        {
+          "name": "metadata",
+          "type": "json",
+          "body": {
+            "activityMetadata": { "activity": { "...TypeCache entry..." } },
+            "designTimeMetadata": {
+              "connectorLogoUrl": "icons/...",
+              "activityConfig": { "isCurated": true, "operation": "ISSUE_CREATED" }
+            },
+            "telemetryData": {
+              "connectorKey": "uipath-atlassian-jira",
+              "connectorName": "Jira",
+              "operationType": "",
+              "objectName": "curated_get_issue",
+              "objectDisplayName": "curated get issue",
+              "primaryKeyName": ""
+            },
+            "inputMetadata": {},
+            "errorState": { "hasError": false },
+            "activityPropertyConfiguration": {
+              "objectName": "curated_get_issue",
+              "eventType": "ISSUE_CREATED",
+              "eventMode": "polling",
+              "configuration": "=jsonString:{...}",
+              "uiPathActivityTypeId": "<uuid>",
+              "errorState": { "issues": [] }
+            }
+          }
+        }
+      ],
+      "inputs": [
+        {
+          "name": "body",
+          "type": "json",
+          "target": "body",
+          "body": {
+            "filters": { "expression": "" },
+            "parameters": { "project": "", "issuetype": "" }
+          },
+          "var": "vRaNdOmId",
+          "id": "vRaNdOmId"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "response",
+          "displayName": "Issue Created",
+          "type": "jsonSchema",
+          "source": "=response",
+          "_jsonSchema": null,
+          "var": "response",
+          "value": "response"
+        },
+        {
+          "name": "Error",
+          "displayName": "Error",
+          "type": "jsonSchema",
+          "source": "=Error",
+          "_jsonSchema": null,
+          "var": "error",
+          "value": "error"
+        }
+      ],
+      "bindings": []
+    }
+  }
+}
+```
+
+### Key Differences from Connector Tasks in Stages
+
+Trigger node outputs are **simplified** compared to task outputs:
+- No `body` — the JSON schema lives in root `inputOutputs`, not on the trigger node
+- No `elementId` — trigger inputs/outputs don't carry elementId
+- No `id` or `target` on outputs
+- `_jsonSchema` is always `null` on the trigger node (schema is on the root variable instead)
+
+### Trigger Inputs
+
+- Inputs strip `elementId` (present on task inputs, absent on trigger inputs)
+- Single `body` input with `filters.expression` and `parameters` from event params
+
+### Connector Binding Construction
+
+Same pattern as connector tasks in `task-json-builder-guide.md`. Dedup against existing `root.data.uipath.bindings[]`.
+
+1. Check dedup: does a ConnectionId binding with the same (`default`, `resource: "Connection"`, `resourceKey`) already exist?
+2. If found, reuse the existing binding ID. If not, create a new ConnectionId binding and push to root
+3. Same dedup check for FolderKey binding
+4. Set context `connection` and `folderKey` to `=bindings.<id>` references
+
+The trigger node itself has `bindings: []` (trigger-level, always empty — bindings go to root).


### PR DESCRIPTION
## Summary
- Adds four reference guides under `skills/uipath-maestro-case/references/` to support the maestro case skill (under development)
- **global-variable-guide.md**: How to collect and populate `root.data.uipath.variables.inputOutputs[]` from trigger outputs and rule references, with orphan cleanup
- **task-json-builder-guide.md**: How to build task JSON for all types (process, action, agent, connector activity/trigger, timer) with inline binding construction and dedup
- **trigger-json-builder-guide.md**: How to build trigger node JSON for manual, timer, and event triggers with connector binding construction
- **hook-input-guide.md**: How to populate input values for all task types, including accepted value formats (`=vars.`, `=metadata.`, `=js:`, etc.)

## Test plan
- [ ] Review each reference guide for accuracy against FE source of truth
- [ ] Verify JSON examples match actual case-tool CLI output
- [ ] Confirm binding dedup logic matches FE behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)