### PR TITLE
fix: document array type syntax pitfall in XAML TypeArguments

### DIFF
--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -395,6 +395,30 @@ The same rule applies anywhere a type argument appears: `x:TypeArguments` on `Va
 
 ---
 
+## Invalid Array Syntax in TypeArguments — `x:String()`
+
+**Symptom:** Studio fails to open the workflow with: `Character ')' was unexpected in string 'x:String()'. Invalid XAML type name.`
+
+**Root cause:** VB.NET uses `String()` to declare a string array, but XAML `x:TypeArguments` uses parentheses only for generic type parameters (e.g., `scg:List(x:String)`). Writing `x:String()` is not valid XAML — it is neither a generic nor a recognized type.
+
+**Wrong — VB.NET array syntax does not work in XAML:**
+```xml
+<Variable x:TypeArguments="x:String()" Name="fileList" />
+<OutArgument x:TypeArguments="x:String()">[fileList]</OutArgument>
+<InArgument x:TypeArguments="x:String()">[Directory.GetFiles(folderPath)]</InArgument>
+```
+
+**Correct — use `scg:List(x:String)` for collections:**
+```xml
+<Variable x:TypeArguments="scg:List(x:String)" Name="fileList" />
+<OutArgument x:TypeArguments="scg:List(x:String)">[fileList]</OutArgument>
+<InArgument x:TypeArguments="scg:List(x:String)">[New List(Of String)(Directory.GetFiles(folderPath))]</InArgument>
+```
+
+Note: APIs that return `String[]` (like `Directory.GetFiles()`) must be wrapped in `New List(Of String)(...)` (VB) or `new List<string>(...)` (C#) to match the `List` type.
+
+---
+
 ## Variable Scope and "Not Declared" Errors
 
 **Error:** `"'variableName' is not declared. It may be inaccessible due to its protection level"`

--- a/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
@@ -170,6 +170,21 @@ Add `Variable` elements inside the workflow container's `.Variables` block:
 
 Variables are scoped to their containing activity (Sequence, Flowchart, etc.).
 
+**Collection and array variables:** Use `scg:List(x:String)` for lists, `scg:Dictionary(x:String, x:Int32)` for dictionaries. Do **NOT** use `x:String()` — parentheses in `x:TypeArguments` denote generics, not arrays. VB.NET array syntax (`String()`) is invalid in XAML TypeArguments and causes `Character ')' was unexpected in string 'x:String()'. Invalid XAML type name.` at load time.
+
+```xml
+<!-- WRONG — x:String() is not valid XAML -->
+<Variable x:TypeArguments="x:String()" Name="fileList" />
+
+<!-- CORRECT — use scg:List for collections -->
+<Variable x:TypeArguments="scg:List(x:String)" Name="fileList" />
+```
+
+When converting array-returning APIs (e.g., `Directory.GetFiles()` returns `String[]`), wrap in a `New List(Of String)(...)` (VB) or `new List<string>(...)` (C#) expression:
+```xml
+<InArgument x:TypeArguments="scg:List(x:String)">[New List(Of String)(Directory.GetFiles(folderPath))]</InArgument>
+```
+
 **IMPORTANT — `x:` and `s:` are XML namespace aliases, not separate type systems.**
 `x:String` and `s:String` both refer to `System.String`; the prefix only determines which namespace schema resolves the name. The `x:` XAML language schema registers a small fixed set of types (`x:String`, `x:Int32`, `x:Int64`, `x:Double`, `x:Boolean`, `x:Byte`, `x:Single`, `x:Decimal`, `x:Char`, `x:Object`, `x:TimeSpan`). Any other CLR type — including `DateTime`, `DateTimeOffset`, `Guid`, etc. — is not registered in that schema and must be reached through `s:` (`xmlns:s="clr-namespace:System;assembly=System.Private.CoreLib"`).
 Using `x:DateTime` or `x:DateTimeOffset` produces `Cannot create unknown type` at load time.


### PR DESCRIPTION
## Summary
- Added guidance to `xaml-basics-and-rules.md` (Variables section) explaining that `x:String()` is invalid XAML and `scg:List(x:String)` should be used instead
- Added a full pitfall entry in `common-pitfalls.md` with symptom, root cause, wrong/correct examples, and the `New List(Of String)(...)` wrapping pattern for array-returning APIs
- Triggered by real issue: LLM generated `x:String()` (VB.NET array syntax) in XAML TypeArguments, causing Studio to fail with `Character ')' was unexpected in string 'x:String()'. Invalid XAML type name.`

## Test plan
- [ ] Open a workflow in Studio that uses `scg:List(x:String)` variables — verify no load errors
- [ ] Confirm the XAML examples in both docs are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)