### PR TITLE
Added skills for Datafabric Coded Agent

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,3 +47,7 @@
 
 # Test skill (reports, manual test automation, manual test execution)
 /skills/uipath-test/ @vaishalisharma-uipath @amoluipath
+
+# Data Fabric skill (CLI entity/record management)
+/skills/uipath-data-fabric/ @aditi-goyal-uipath
+/tests/tasks/uipath-data-fabric/ @aditi-goyal-uipath

--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: uipath-data-fabric
-description: "Build and manage UiPath Data Fabric entities and records via the CLI. TRIGGER when: user asks to create a Data Fabric entity, insert/query/update/delete records, import data from CSV, upload/download files on records, or mentions 'Data Fabric', 'data service', 'uip df'. DO NOT TRIGGER when: user is asking about Orchestrator assets, Integration Service connectors, or general database operations unrelated to UiPath Data Fabric. DO NOT TRIGGER for federated entity creation or external connection setup — not supported."
-user-invokable: true
+description: "[PREVIEW] Data Fabric entity/record CRUD via uip df. Create entities, insert/query/update/delete records, CSV import, file attachments. For Orchestrator→uipath-platform. For Integration Service→uipath-platform."
 ---
 
 # UiPath Data Fabric — Agent Skill
@@ -13,91 +12,67 @@ All operations go through `uip df <subject> <verb> --output json`.
 
 ---
 
-## Login & Tenant Setup
-
-**Default to Production. Only switch environment/org/tenant when explicitly stated in the request.**
-
-- If the request mentions no environment → use the current session (defaults to prod `cloud.uipath.com`)
-- If the request explicitly names an environment/org/tenant → check `uip login status` and re-login if needed
-
-When switching is required:
-1. Check current login: `uip login status --output json` — verify `UIPATH_URL`, `Organization`, and `Tenant`
-2. Re-login with `--authority` only if environment differs:
-   - Alpha: `uip login --authority https://alpha.uipath.com --tenant <tenant>`
-   - Staging: `uip login --authority https://staging.uipath.com --tenant <tenant>`
-   - Production: `uip login --tenant <tenant>` (default, no `--authority` needed)
-3. If already on the right environment but wrong tenant: `uip login tenant set <tenant-name>`
-
-```bash
-# Check current environment, org, and tenant
-uip login status --output json
-
-# Login to Alpha with a specific tenant
-uip login --authority https://alpha.uipath.com --tenant IMDB
-
-# List all available tenants (after login)
-uip login tenant list --output json
-
-# Switch tenant within the same environment
-uip login tenant set IMDB
-```
-
-> **Critical:** The `--tenant` flag on `df` commands does NOT switch the active session tenant.
-> The environment is determined by `UIPATH_URL` in the auth file — always confirm with `login status` before running `df` commands.
-
----
-
 ## When to Use
 
-- Creating or modifying entity schemas (fields, types)
+- Creating or modifying entity schemas (add fields, update metadata)
 - Reading, inserting, updating, or deleting records
 - Filtering records with complex predicates
 - Importing bulk data from CSV files
 - Uploading or downloading file attachments on records
 
-> **Not supported:** Creating federated entities or setting up external connections/connectors is not currently supported — neither via this CLI nor via the UiPath portal. Federated entities are read-only views backed by Integration Service connectors (e.g. Salesforce, Azure AD). If a user asks to create a federated entity or link an entity to an external connector, inform them this is not supported at all.
+---
+
+## Not Supported — Never Attempt These
+
+Respond that the operation is not supported. Do not try to work around it.
+
+| Operation | Response |
+|-----------|----------|
+| Delete an entity | No `entities delete` command exists |
+| Delete / remove a field | Field removal is not supported — the CLI will error |
+| Change a field's data type | Not supported; type is fixed at creation |
+| Create a federated entity | Not supported via CLI or UiPath portal |
+| Write records to a federated entity | Federated entities are read-only |
 
 ---
 
-## Native vs Federated Entities
+## Critical Rules
 
-Data Fabric has two kinds of entities:
+1. **Install the tool first.** If `uip df` returns "unknown command": `uip tools install @uipath/data-fabric-tool` (min version `0.2.0`).
 
-| Kind | Description | Records writable? |
-|------|-------------|-------------------|
-| **Native** | Data stored directly in Data Fabric | Yes — full CRUD |
-| **Federated** | Backed by an external connector (Salesforce, Azure AD, etc.) | Read-only via the connector |
+2. **Verify login and tenant first.** Run `uip login status --output json`. Switch with `uip login tenant set <tenant>` if needed. For full login/environment setup, see the `uipath-platform` skill.
 
-The `entities list` output includes a `Source` column:
-- `Native` — safe to read/write records
-- `Federated (ConnectorName)` — read-only, records managed externally
+3. **Always resolve entity ID first.** Use `entities list` before any operation. Never assume an entity ID.
 
-**Always use `--native-only` when the task involves writing records**, to avoid accidentally targeting a federated entity.
+4. **Field names are technical identifiers** (lowercase, no spaces). Use `fieldName` in field definitions.
 
-```bash
-# List only native entities
-uip df entities list --native-only --output json
-```
+5. **Records need `Id` for update.** Use `records list` or `records query` to retrieve the record ID before updating.
+
+6. **File fields are separate from record data.** Use `files upload`/`download`, not `records insert`. Field must be type `file`.
+
+7. **CSV headers must match exact field names** (case-sensitive). Use `entities get` to discover field names before importing.
+
+8. **Never create duplicate entities.** Always `entities list` first; reuse if it already exists.
+
+9. **Only work with native entities.** Use `--native-only` before any write operation. Never write to federated entities.
+
+10. **Never attempt entity delete.** No command exists. Respond: *"Deleting entities is not supported via the CLI."*
+
+11. **Never attempt field delete.** Do not pass `removeFields` in `entities update`. Respond: *"Removing fields is not supported via the CLI."*
 
 ---
 
 ## Quick Start
 
 ```bash
-# Check login and active tenant
-uip login status --output json
+# List entities (use --native-only before any write)
+uip df entities list --native-only --output json
 
-# Switch tenant if needed
-uip login tenant set <tenant-name>
-
-# List entities
-uip df entities list --output json
-
-# Get entity details (shows field names and types)
+# Get entity schema (field names and types)
 uip df entities get <entity-id> --output json
 
-# List records
-uip df records list <entity-id> --output json
+# List records (first page)
+uip df records list <entity-id> --limit 50 --output json
 
 # Insert one record
 uip df records insert <entity-id> --body '{"fieldName":"value"}' --output json
@@ -110,38 +85,17 @@ uip df records query <entity-id> \
 
 ---
 
-## Critical Rules
-
-1. **Always resolve org and tenant first.** If the user specifies an org/environment and tenant, run `uip login status` to check the active tenant, then `uip login tenant set <tenant>` to switch if needed. Never assume the active tenant matches the user's intent.
-
-2. **Always resolve entity ID first.** Use `entities list` to discover entities before any operation. Never assume an entity ID.
-
-3. **Entity names are technical names** (lowercase, no spaces). The `--fields` `name` property must follow this convention — spaces are stripped automatically.
-
-4. **Records need `Id` for update/delete.** Use `records list` or `records query` to retrieve the ID of the record you want to modify.
-
-5. **Query uses entity ID, but under the hood resolves entity name.** If query fails with "not found", check that the entity ID is correct with `entities get`.
-
-6. **File fields are separate from record data.** Uploading a file uses `files upload`, not `records insert`. The field must be of type `file`.
-
-7. **Import from CSV.** The CSV header row must match exact field names (case-sensitive). Use `entities get` to discover field names before importing.
-
-8. **Never create duplicate entities.** Always `entities list` first. If an entity with the same name exists, use it.
-
-9. **Only work with native entities.** Use `entities list --native-only` to discover entities before any write operation. Never attempt to insert, update, delete, or import records on a federated entity — it will fail. If asked to create a federated entity or connect to an external source, respond: *"Creating federated entities is not currently supported — neither via the CLI nor the UiPath portal."*
-
----
-
 ## Task Navigation
 
 | Task | Commands to use |
 |------|----------------|
 | Explore what entities exist | `entities list` → `entities get <id>` |
 | Explore only native entities | `entities list --native-only` |
-| Create a new entity | `entities create <name> --fields '[...]'` |
-| Add a field to entity | `entities add-field <id> <field-name> --type <type>` |
-| Remove a field | `entities remove-field <id> <field-name>` |
-| Read records | `records list <entity-id>` |
+| Create a new entity | `entities create <name> --body '{"fields":[{"fieldName":"title","type":"text"}]}'` |
+| Update entity / add fields | `entities update <id> --body '{"addFields":[{"fieldName":"newField","type":"text"}]}'` |
+| Update entity metadata | `entities update <id> --body '{"displayName":"New Name","description":"desc"}'` |
+| Read records (first page) | `records list <entity-id> --limit 50` |
+| Read records (next page) | `records list <entity-id> --cursor <NextCursor>` |
 | Get one record | `records get <entity-id> <record-id>` |
 | Insert records | `records insert <entity-id> --body '{...}'` (or `--file`) |
 | Update records | `records update <entity-id> --body '{"Id":"...","field":"val"}'` |
@@ -149,7 +103,7 @@ uip df records query <entity-id> \
 | Filter/search records | `records query <entity-id> --body '{...}'` |
 | Bulk import from CSV | `records import <entity-id> --file data.csv` |
 | Upload file to record | `files upload <entity-id> <record-id> <field-name> --file path` |
-| Download file | `files download <entity-id> <record-id> <field-name> --output path` |
+| Download file | `files download <entity-id> <record-id> <field-name> --destination path` |
 | Delete file | `files delete <entity-id> <record-id> <field-name>` |
 
 ---
@@ -165,37 +119,30 @@ uip df records query <entity-id> \
 | `boolean` | BIT | true/false |
 | `datetime` | DATETIME2 | Date + time |
 | `date` | DATE | Date only |
-| `file` | NVARCHAR(200) | File attachment (use `files upload/download/delete` to manage) |
+| `file` | NVARCHAR(200) | File attachment (use `files upload/download` to manage) |
 
 ---
 
 ## Workflow: Discover → Act → Verify
 
-**Always follow this pattern:**
-
 1. **Discover** — list entities, get schema, check existing records
-2. **Act** — create/insert/update/delete
+2. **Act** — create/insert/update
 3. **Verify** — re-read to confirm the operation succeeded
 
 ```bash
-# 0. Ensure correct tenant
-uip login status --output json
-uip login tenant set <tenant-name>   # only if needed
-
-# 1. Discover
-uip df entities list --output json
+uip df entities list --native-only --output json
 uip df entities get <entity-id> --output json
-
-# 2. Act
 uip df records insert <entity-id> --body '{"name":"Alice","score":95}' --output json
-
-# 3. Verify
-uip df records list <entity-id> --output json
+uip df records list <entity-id> --limit 50 --output json
+# Use HasNextPage + NextCursor to page through results
+uip df records list <entity-id> --cursor <NextCursor> --output json
 ```
 
 ---
 
 ## Query Request Format
+
+Pass via `--body` or `--file`. Use `--limit` and `--cursor` CLI flags for pagination — not body keys.
 
 ```json
 {
@@ -207,13 +154,13 @@ uip df records list <entity-id> --output json
     ]
   },
   "sortOptions": [{ "fieldName": "score", "isDescending": true }],
-  "start": 0,
-  "limit": 50
+  "selectedFields": ["title", "score", "status"]
 }
 ```
 
 - `logicalOperator`: `0` = AND, `1` = OR
 - Operators: `=`, `!=`, `>`, `<`, `>=`, `<=`, `contains`, `not contains`, `startswith`, `endswith`, `in`, `not in`
+- Response includes `HasNextPage` and `NextCursor` — pass `NextCursor` to `--cursor` for the next page
 
 ---
 
@@ -221,24 +168,22 @@ uip df records list <entity-id> --output json
 
 | Error | Cause | Fix |
 |-------|-------|-----|
+| `unknown command: df` | Tool not installed | `uip tools install @uipath/data-fabric-tool` |
 | `Not logged in` | Auth expired | `uip login` |
-| `HTTP 401` | Invalid token | Re-login with required scopes including `DataServiceApiUserAccess` |
+| `HTTP 401` | Invalid token | Re-login; ensure `DataServiceApiUserAccess` scope is present |
 | `HTTP 403` | Permission denied | Ensure account has Data Fabric permissions |
 | `Entity not found` | Wrong entity ID | Run `entities list` to get correct ID |
 | `Record must include 'Id'` | Update missing Id | Add `"Id": "<record-id>"` to the body |
-| `No name property` | Invalid field definition | Each field must have at minimum `{"name":"fieldname"}` |
+| `Each field must include a 'fieldName' string` | Invalid field in `entities create` | Use `{"fieldName":"myfield"}` not `{"name":"myfield"}` |
 | `Entity name resolution failed` | Query/import with bad ID | Verify entity exists with `entities list` |
-| Import errors in CSV | Bad headers or data | Use `entities get` to verify exact field names (case-sensitive) |
-| Write to federated entity | Entity backed by external connector | Use `--native-only` to list native entities; federated entities are read-only |
-| Asked to create federated entity | Not supported anywhere | Respond: "Creating federated entities is not currently supported — neither via the CLI nor the UiPath portal." |
+| Import errors in CSV | Header mismatch | Run `entities get` and check exact field names (case-sensitive) |
+| Write to federated entity | Entity is read-only | Use `--native-only`; federated entities cannot be written to |
 
 ---
 
 ## References
 
-For deeper guidance, read these files only when needed:
-
 - `references/entity-schema.md` — Field definitions, supported types, schema update patterns
 - `references/records-query.md` — Query filter syntax, pagination, sorting examples
-- `references/file-attachments.md` — File field upload/download/delete workflows
+- `references/file-attachments.md` — File field upload/download/delete file
 - `references/bulk-import.md` — CSV format requirements and bulk import patterns

--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -1,0 +1,244 @@
+---
+name: uipath-data-fabric
+description: "Build and manage UiPath Data Fabric entities and records via the CLI. TRIGGER when: user asks to create a Data Fabric entity, insert/query/update/delete records, import data from CSV, upload/download files on records, or mentions 'Data Fabric', 'data service', 'uip df'. DO NOT TRIGGER when: user is asking about Orchestrator assets, Integration Service connectors, or general database operations unrelated to UiPath Data Fabric. DO NOT TRIGGER for federated entity creation or external connection setup — not supported."
+user-invokable: true
+---
+
+# UiPath Data Fabric — Agent Skill
+
+Data Fabric is UiPath's structured data store. Entities are typed schemas;
+records are rows; file fields store binary attachments.
+
+All operations go through `uip df <subject> <verb> --output json`.
+
+---
+
+## Login & Tenant Setup
+
+**Default to Production. Only switch environment/org/tenant when explicitly stated in the request.**
+
+- If the request mentions no environment → use the current session (defaults to prod `cloud.uipath.com`)
+- If the request explicitly names an environment/org/tenant → check `uip login status` and re-login if needed
+
+When switching is required:
+1. Check current login: `uip login status --output json` — verify `UIPATH_URL`, `Organization`, and `Tenant`
+2. Re-login with `--authority` only if environment differs:
+   - Alpha: `uip login --authority https://alpha.uipath.com --tenant <tenant>`
+   - Staging: `uip login --authority https://staging.uipath.com --tenant <tenant>`
+   - Production: `uip login --tenant <tenant>` (default, no `--authority` needed)
+3. If already on the right environment but wrong tenant: `uip login tenant set <tenant-name>`
+
+```bash
+# Check current environment, org, and tenant
+uip login status --output json
+
+# Login to Alpha with a specific tenant
+uip login --authority https://alpha.uipath.com --tenant IMDB
+
+# List all available tenants (after login)
+uip login tenant list --output json
+
+# Switch tenant within the same environment
+uip login tenant set IMDB
+```
+
+> **Critical:** The `--tenant` flag on `df` commands does NOT switch the active session tenant.
+> The environment is determined by `UIPATH_URL` in the auth file — always confirm with `login status` before running `df` commands.
+
+---
+
+## When to Use
+
+- Creating or modifying entity schemas (fields, types)
+- Reading, inserting, updating, or deleting records
+- Filtering records with complex predicates
+- Importing bulk data from CSV files
+- Uploading or downloading file attachments on records
+
+> **Not supported:** Creating federated entities or setting up external connections/connectors is not currently supported — neither via this CLI nor via the UiPath portal. Federated entities are read-only views backed by Integration Service connectors (e.g. Salesforce, Azure AD). If a user asks to create a federated entity or link an entity to an external connector, inform them this is not supported at all.
+
+---
+
+## Native vs Federated Entities
+
+Data Fabric has two kinds of entities:
+
+| Kind | Description | Records writable? |
+|------|-------------|-------------------|
+| **Native** | Data stored directly in Data Fabric | Yes — full CRUD |
+| **Federated** | Backed by an external connector (Salesforce, Azure AD, etc.) | Read-only via the connector |
+
+The `entities list` output includes a `Source` column:
+- `Native` — safe to read/write records
+- `Federated (ConnectorName)` — read-only, records managed externally
+
+**Always use `--native-only` when the task involves writing records**, to avoid accidentally targeting a federated entity.
+
+```bash
+# List only native entities
+uip df entities list --native-only --output json
+```
+
+---
+
+## Quick Start
+
+```bash
+# Check login and active tenant
+uip login status --output json
+
+# Switch tenant if needed
+uip login tenant set <tenant-name>
+
+# List entities
+uip df entities list --output json
+
+# Get entity details (shows field names and types)
+uip df entities get <entity-id> --output json
+
+# List records
+uip df records list <entity-id> --output json
+
+# Insert one record
+uip df records insert <entity-id> --body '{"fieldName":"value"}' --output json
+
+# Query with a filter
+uip df records query <entity-id> \
+  --body '{"filterGroup":{"queryFilters":[{"fieldName":"status","operator":"=","value":"active"}]}}' \
+  --output json
+```
+
+---
+
+## Critical Rules
+
+1. **Always resolve org and tenant first.** If the user specifies an org/environment and tenant, run `uip login status` to check the active tenant, then `uip login tenant set <tenant>` to switch if needed. Never assume the active tenant matches the user's intent.
+
+2. **Always resolve entity ID first.** Use `entities list` to discover entities before any operation. Never assume an entity ID.
+
+3. **Entity names are technical names** (lowercase, no spaces). The `--fields` `name` property must follow this convention — spaces are stripped automatically.
+
+4. **Records need `Id` for update/delete.** Use `records list` or `records query` to retrieve the ID of the record you want to modify.
+
+5. **Query uses entity ID, but under the hood resolves entity name.** If query fails with "not found", check that the entity ID is correct with `entities get`.
+
+6. **File fields are separate from record data.** Uploading a file uses `files upload`, not `records insert`. The field must be of type `file`.
+
+7. **Import from CSV.** The CSV header row must match exact field names (case-sensitive). Use `entities get` to discover field names before importing.
+
+8. **Never create duplicate entities.** Always `entities list` first. If an entity with the same name exists, use it.
+
+9. **Only work with native entities.** Use `entities list --native-only` to discover entities before any write operation. Never attempt to insert, update, delete, or import records on a federated entity — it will fail. If asked to create a federated entity or connect to an external source, respond: *"Creating federated entities is not currently supported — neither via the CLI nor the UiPath portal."*
+
+---
+
+## Task Navigation
+
+| Task | Commands to use |
+|------|----------------|
+| Explore what entities exist | `entities list` → `entities get <id>` |
+| Explore only native entities | `entities list --native-only` |
+| Create a new entity | `entities create <name> --fields '[...]'` |
+| Add a field to entity | `entities add-field <id> <field-name> --type <type>` |
+| Remove a field | `entities remove-field <id> <field-name>` |
+| Read records | `records list <entity-id>` |
+| Get one record | `records get <entity-id> <record-id>` |
+| Insert records | `records insert <entity-id> --body '{...}'` (or `--file`) |
+| Update records | `records update <entity-id> --body '{"Id":"...","field":"val"}'` |
+| Delete records | `records delete <entity-id> <id1> <id2>` |
+| Filter/search records | `records query <entity-id> --body '{...}'` |
+| Bulk import from CSV | `records import <entity-id> --file data.csv` |
+| Upload file to record | `files upload <entity-id> <record-id> <field-name> --file path` |
+| Download file | `files download <entity-id> <record-id> <field-name> --output path` |
+| Delete file | `files delete <entity-id> <record-id> <field-name>` |
+
+---
+
+## Field Types
+
+| User type | SQL type | Notes |
+|-----------|----------|-------|
+| `text` | NVARCHAR(200) | Short strings |
+| `longtext` | NVARCHAR(4000) | Long strings |
+| `number` | INT | Integer |
+| `decimal` | DECIMAL | Floating point |
+| `boolean` | BIT | true/false |
+| `datetime` | DATETIME2 | Date + time |
+| `date` | DATE | Date only |
+| `file` | NVARCHAR(200) | File attachment (use `files upload/download/delete` to manage) |
+
+---
+
+## Workflow: Discover → Act → Verify
+
+**Always follow this pattern:**
+
+1. **Discover** — list entities, get schema, check existing records
+2. **Act** — create/insert/update/delete
+3. **Verify** — re-read to confirm the operation succeeded
+
+```bash
+# 0. Ensure correct tenant
+uip login status --output json
+uip login tenant set <tenant-name>   # only if needed
+
+# 1. Discover
+uip df entities list --output json
+uip df entities get <entity-id> --output json
+
+# 2. Act
+uip df records insert <entity-id> --body '{"name":"Alice","score":95}' --output json
+
+# 3. Verify
+uip df records list <entity-id> --output json
+```
+
+---
+
+## Query Request Format
+
+```json
+{
+  "filterGroup": {
+    "logicalOperator": 0,
+    "queryFilters": [
+      { "fieldName": "status", "operator": "=", "value": "active" },
+      { "fieldName": "score", "operator": ">=", "value": "80" }
+    ]
+  },
+  "sortOptions": [{ "fieldName": "score", "isDescending": true }],
+  "start": 0,
+  "limit": 50
+}
+```
+
+- `logicalOperator`: `0` = AND, `1` = OR
+- Operators: `=`, `!=`, `>`, `<`, `>=`, `<=`, `contains`, `not contains`, `startswith`, `endswith`, `in`, `not in`
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Not logged in` | Auth expired | `uip login` |
+| `HTTP 401` | Invalid token | Re-login with required scopes including `DataServiceApiUserAccess` |
+| `HTTP 403` | Permission denied | Ensure account has Data Fabric permissions |
+| `Entity not found` | Wrong entity ID | Run `entities list` to get correct ID |
+| `Record must include 'Id'` | Update missing Id | Add `"Id": "<record-id>"` to the body |
+| `No name property` | Invalid field definition | Each field must have at minimum `{"name":"fieldname"}` |
+| `Entity name resolution failed` | Query/import with bad ID | Verify entity exists with `entities list` |
+| Import errors in CSV | Bad headers or data | Use `entities get` to verify exact field names (case-sensitive) |
+| Write to federated entity | Entity backed by external connector | Use `--native-only` to list native entities; federated entities are read-only |
+| Asked to create federated entity | Not supported anywhere | Respond: "Creating federated entities is not currently supported — neither via the CLI nor the UiPath portal." |
+
+---
+
+## References
+
+For deeper guidance, read these files only when needed:
+
+- `references/entity-schema.md` — Field definitions, supported types, schema update patterns
+- `references/records-query.md` — Query filter syntax, pagination, sorting examples
+- `references/file-attachments.md` — File field upload/download/delete workflows
+- `references/bulk-import.md` — CSV format requirements and bulk import patterns

--- a/skills/uipath-data-fabric/references/bulk-import.md
+++ b/skills/uipath-data-fabric/references/bulk-import.md
@@ -6,7 +6,11 @@
 uip df records import <entity-id> --file data.csv --output json
 ```
 
-Response: `{ Code: "RecordsImported", Data: { SuccessCount, FailureCount, Errors } }`
+Response: `{ Code: "RecordsImported", Data: { InsertedRecords, TotalRecords, ErrorFileLink? } }`
+
+- `InsertedRecords` — number of rows successfully imported
+- `TotalRecords` — total rows in the CSV (including failures)
+- `ErrorFileLink` — download URL for a CSV of failed rows (only present if there were failures)
 
 ## CSV Format Requirements
 
@@ -57,5 +61,5 @@ uip df records list <entity-id> --output json
 ## Notes
 
 - Partial success is possible: some rows may import while others fail
-- Check `FailureCount` and `Errors` in the response to identify problem rows
+- Check `InsertedRecords` vs `TotalRecords` to detect failures; download `ErrorFileLink` for the failed-row CSV
 - Large imports are processed server-side; there is no row limit documented but keep files reasonable in size

--- a/skills/uipath-data-fabric/references/bulk-import.md
+++ b/skills/uipath-data-fabric/references/bulk-import.md
@@ -1,0 +1,61 @@
+# Bulk Import Reference
+
+## Import Records from CSV
+
+```bash
+uip df records import <entity-id> --file data.csv --format json
+```
+
+Response: `{ Code: "RecordsImported", Data: { SuccessCount, FailureCount, Errors } }`
+
+## CSV Format Requirements
+
+- **Header row is required** and must exactly match entity field names (case-sensitive)
+- Use `uip df entities get <entity-id> --format json` to discover exact field names before importing
+- System fields (`Id`, `CreatedOn`, `CreatedBy`, `UpdatedOn`, `UpdatedBy`) must NOT appear in the CSV
+
+### Example CSV
+
+```csv
+name,score,active,createdDate
+Alice,95,true,2024-01-15
+Bob,82,true,2024-02-20
+Charlie,74,false,2024-03-05
+```
+
+For the entity with fields: `name` (text), `score` (number), `active` (boolean), `createdDate` (date).
+
+## Full Workflow
+
+```bash
+# 1. Discover entity and field names
+uip df entities list --format json
+uip df entities get <entity-id> --format json   # note exact field names
+
+# 2. Create CSV with matching headers
+cat > /tmp/data.csv <<EOF
+name,score,active
+Alice,95,true
+Bob,82,true
+EOF
+
+# 3. Import
+uip df records import <entity-id> --file /tmp/data.csv --format json
+
+# 4. Verify
+uip df records list <entity-id> --format json
+```
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Import errors in CSV` | Header names don't match field names | Run `entities get` and check exact field names (case-sensitive) |
+| `Entity not found` | Wrong entity ID | Run `entities list` to get correct ID |
+| Row-level errors | Invalid data types (e.g. text in number field) | Check data values match field types |
+
+## Notes
+
+- Partial success is possible: some rows may import while others fail
+- Check `FailureCount` and `Errors` in the response to identify problem rows
+- Large imports are processed server-side; there is no row limit documented but keep files reasonable in size

--- a/skills/uipath-data-fabric/references/bulk-import.md
+++ b/skills/uipath-data-fabric/references/bulk-import.md
@@ -3,7 +3,7 @@
 ## Import Records from CSV
 
 ```bash
-uip df records import <entity-id> --file data.csv --format json
+uip df records import <entity-id> --file data.csv --output json
 ```
 
 Response: `{ Code: "RecordsImported", Data: { SuccessCount, FailureCount, Errors } }`
@@ -11,7 +11,7 @@ Response: `{ Code: "RecordsImported", Data: { SuccessCount, FailureCount, Errors
 ## CSV Format Requirements
 
 - **Header row is required** and must exactly match entity field names (case-sensitive)
-- Use `uip df entities get <entity-id> --format json` to discover exact field names before importing
+- Use `uip df entities get <entity-id> --output json` to discover exact field names before importing
 - System fields (`Id`, `CreatedOn`, `CreatedBy`, `UpdatedOn`, `UpdatedBy`) must NOT appear in the CSV
 
 ### Example CSV
@@ -29,8 +29,8 @@ For the entity with fields: `name` (text), `score` (number), `active` (boolean),
 
 ```bash
 # 1. Discover entity and field names
-uip df entities list --format json
-uip df entities get <entity-id> --format json   # note exact field names
+uip df entities list --output json
+uip df entities get <entity-id> --output json   # note exact field names
 
 # 2. Create CSV with matching headers
 cat > /tmp/data.csv <<EOF
@@ -40,10 +40,10 @@ Bob,82,true
 EOF
 
 # 3. Import
-uip df records import <entity-id> --file /tmp/data.csv --format json
+uip df records import <entity-id> --file /tmp/data.csv --output json
 
 # 4. Verify
-uip df records list <entity-id> --format json
+uip df records list <entity-id> --output json
 ```
 
 ## Error Handling

--- a/skills/uipath-data-fabric/references/entity-schema.md
+++ b/skills/uipath-data-fabric/references/entity-schema.md
@@ -11,7 +11,7 @@ uip df entities create "MyEntity" \
     {"name":"active","type":"boolean"},
     {"name":"createdDate","type":"date"}
   ]' \
-  --format json
+  --output json
 ```
 
 Response includes `EntityId` — save this for subsequent operations.
@@ -48,10 +48,10 @@ Fields can be added or removed after entity creation:
 
 ```bash
 # Add a field
-uip df entities add-field <entity-id> myNewField --type decimal --format json
+uip df entities add-field <entity-id> myNewField --type decimal --output json
 
 # Remove a field
-uip df entities remove-field <entity-id> myOldField --format json
+uip df entities remove-field <entity-id> myOldField --output json
 ```
 
 **Warning**: Removing a field deletes all data stored in that field for every record.

--- a/skills/uipath-data-fabric/references/entity-schema.md
+++ b/skills/uipath-data-fabric/references/entity-schema.md
@@ -4,17 +4,23 @@
 
 ```bash
 uip df entities create "MyEntity" \
-  --description "Optional description" \
-  --fields '[
-    {"name":"title","type":"text"},
-    {"name":"score","type":"number"},
-    {"name":"active","type":"boolean"},
-    {"name":"createdDate","type":"date"}
-  ]' \
+  --body '{
+    "fields": [
+      {"fieldName":"title","type":"text"},
+      {"fieldName":"score","type":"number"},
+      {"fieldName":"active","type":"boolean"},
+      {"fieldName":"createdDate","type":"date"}
+    ],
+    "displayName": "My Entity",
+    "description": "Optional description"
+  }' \
   --output json
 ```
 
-Response includes `EntityId` — save this for subsequent operations.
+- `fields` array is **required**. Each entry must include `fieldName`.
+- `displayName`, `description`, and `isRbacEnabled` are optional top-level keys.
+- Response: `{ Code: "EntityCreated", Data: { ID: "<entity-id>" } }` — save the ID for subsequent operations.
+- Alternatively use `--file <path>` pointing to a JSON file with the same structure.
 
 ## Supported Field Types
 
@@ -27,38 +33,69 @@ Response includes `EntityId` — save this for subsequent operations.
 | `boolean` | BIT | Flags, status |
 | `datetime` | DATETIME2 | Timestamps |
 | `date` | DATE | Calendar dates |
+| `file` | NVARCHAR(200) | Binary file attachment (manage with `files upload/download/delete`) |
 
 ## Field Definition Object
 
 ```json
 {
-  "name": "fieldName",
+  "fieldName": "myField",
   "type": "text",
   "displayName": "Optional display label",
   "isRequired": false
 }
 ```
 
-- `name` is required and becomes the technical name (lowercase, no spaces)
+- `fieldName` is required and becomes the technical name (lowercase, no spaces)
 - `type` defaults to `"text"` if omitted
 
-## Adding / Removing Fields
+## Not Supported
 
-Fields can be added or removed after entity creation:
+| Operation | Action |
+|-----------|--------|
+| Delete an entity | No command exists — tell the user it is not supported |
+| Remove / delete a field | Not supported — do not pass `removeFields` in `entities update` (CLI errors) |
+| Change a field's data type | Not supported via `updateFields` — type is set at creation only |
+
+---
+
+## Updating an Entity
+
+Use `entities update` to add fields, modify field metadata, or update entity-level properties.
 
 ```bash
-# Add a field
-uip df entities add-field <entity-id> myNewField --type decimal --output json
+# Add new fields to an existing entity
+uip df entities update <entity-id> \
+  --body '{"addFields":[{"fieldName":"priority","type":"number"},{"fieldName":"tags","type":"text"}]}' \
+  --output json
 
-# Remove a field
-uip df entities remove-field <entity-id> myOldField --output json
+# Update entity display name and description
+uip df entities update <entity-id> \
+  --body '{"displayName":"Updated Name","description":"New description"}' \
+  --output json
+
+# Add fields and update metadata in one call
+uip df entities update <entity-id> \
+  --body '{
+    "addFields": [{"fieldName":"region","type":"text"}],
+    "displayName": "Regional Entity"
+  }' \
+  --output json
 ```
 
-**Warning**: Removing a field deletes all data stored in that field for every record.
+Supported keys in the update body:
+
+| Key | Description |
+|-----|-------------|
+| `addFields` | Array of field definition objects to add |
+| `updateFields` | Array of field updates (modify existing field metadata) |
+| `displayName` | New display name for the entity |
+| `description` | New description |
+| `isRbacEnabled` | Toggle RBAC on the entity |
 
 ## System Fields
 
-Every entity has auto-created system fields: `Id`, `CreatedOn`, `CreatedBy`, `UpdatedOn`, `UpdatedBy`. These are read-only and excluded from field manipulation commands.
+Every entity has auto-created system fields: `Id`, `CreatedOn`, `CreatedBy`, `UpdatedOn`, `UpdatedBy`. These are read-only and must not be included in field definitions or CSV imports.
 
 ## Listing and Inspecting Entities
 

--- a/skills/uipath-data-fabric/references/entity-schema.md
+++ b/skills/uipath-data-fabric/references/entity-schema.md
@@ -1,0 +1,85 @@
+# Entity Schema Reference
+
+## Creating an Entity
+
+```bash
+uip df entities create "MyEntity" \
+  --description "Optional description" \
+  --fields '[
+    {"name":"title","type":"text"},
+    {"name":"score","type":"number"},
+    {"name":"active","type":"boolean"},
+    {"name":"createdDate","type":"date"}
+  ]' \
+  --format json
+```
+
+Response includes `EntityId` — save this for subsequent operations.
+
+## Supported Field Types
+
+| User type | SQL equivalent | Use case |
+|-----------|---------------|----------|
+| `text` | NVARCHAR(200) | Short strings, names |
+| `longtext` | NVARCHAR(4000) | Descriptions, notes |
+| `number` | INT | Counts, IDs |
+| `decimal` | DECIMAL | Prices, percentages |
+| `boolean` | BIT | Flags, status |
+| `datetime` | DATETIME2 | Timestamps |
+| `date` | DATE | Calendar dates |
+
+## Field Definition Object
+
+```json
+{
+  "name": "fieldName",
+  "type": "text",
+  "displayName": "Optional display label",
+  "isRequired": false
+}
+```
+
+- `name` is required and becomes the technical name (lowercase, no spaces)
+- `type` defaults to `"text"` if omitted
+
+## Adding / Removing Fields
+
+Fields can be added or removed after entity creation:
+
+```bash
+# Add a field
+uip df entities add-field <entity-id> myNewField --type decimal --format json
+
+# Remove a field
+uip df entities remove-field <entity-id> myOldField --format json
+```
+
+**Warning**: Removing a field deletes all data stored in that field for every record.
+
+## System Fields
+
+Every entity has auto-created system fields: `Id`, `CreatedOn`, `CreatedBy`, `UpdatedOn`, `UpdatedBy`. These are read-only and excluded from field manipulation commands.
+
+## Listing and Inspecting Entities
+
+```bash
+# Discover all entities (shows Source: Native or Federated)
+uip df entities list --output json
+
+# Discover only native entities (recommended before any write operation)
+uip df entities list --native-only --output json
+
+# Get full schema including all fields
+uip df entities get <entity-id> --output json
+```
+
+## Native vs Federated Entities
+
+The `entities list` output includes a `Source` field:
+
+- `Native` — data stored in Data Fabric, full read/write access
+- `Federated (ConnectorName)` — backed by an external connector (e.g. Salesforce, Azure AD), read-only
+
+**Only native entities support record creation, update, delete, and import.**
+
+> Creating federated entities or linking entities to external connectors is **not currently supported**. This cannot be done via the CLI or the UiPath portal.

--- a/skills/uipath-data-fabric/references/file-attachments.md
+++ b/skills/uipath-data-fabric/references/file-attachments.md
@@ -28,9 +28,9 @@ uip df files download <entity-id> <record-id> <field-name> \
   --output json
 ```
 
-- If `--destination` is omitted, the file is saved using the original filename or `<field-name>.bin`
+- If `--destination` is omitted, the file is saved as `<record-id>_<field-name>.bin` in the current directory
 
-Response: `{ Code: "FileDownloaded", Data: { OutputPath, ContentType } }`
+Response: `{ Code: "FileDownloaded", Data: { EntityId, RecordId, FieldName, OutputPath } }`
 
 ## Delete a File
 
@@ -38,7 +38,7 @@ Response: `{ Code: "FileDownloaded", Data: { OutputPath, ContentType } }`
 uip df files delete <entity-id> <record-id> <field-name> --output json
 ```
 
-Response: `{ Code: "FileDeleted" }`
+Response: `{ Code: "FileDeleted", Data: { EntityId, RecordId, FieldName } }`
 
 ## Full Workflow
 

--- a/skills/uipath-data-fabric/references/file-attachments.md
+++ b/skills/uipath-data-fabric/references/file-attachments.md
@@ -1,0 +1,59 @@
+# File Attachments Reference
+
+Data Fabric supports file-type fields on entities. Files are stored per-record per-field.
+
+## Prerequisites
+
+The entity must have a field configured for file storage. File fields are defined in the entity schema.
+Use `uip df entities get <entity-id> --format json` to identify file-type fields.
+
+## Upload a File
+
+```bash
+uip df files upload <entity-id> <record-id> <field-name> \
+  --file /path/to/document.pdf \
+  --format json
+```
+
+- `<field-name>` is **case-sensitive** — must match exactly the field name from `entities get`
+- The record must already exist before uploading
+
+Response: `{ Code: "FileUploaded", Data: { EntityId, RecordId, FieldName, FileName } }`
+
+## Download a File
+
+```bash
+uip df files download <entity-id> <record-id> <field-name> \
+  --output /path/to/save/document.pdf \
+  --format json
+```
+
+- If `--output` is omitted, the file is saved using the original filename or `<field-name>.bin`
+
+Response: `{ Code: "FileDownloaded", Data: { OutputPath, ContentType } }`
+
+## Delete a File
+
+```bash
+uip df files delete <entity-id> <record-id> <field-name> --format json
+```
+
+Response: `{ Code: "FileDeleted" }`
+
+## Full Workflow
+
+```bash
+# 1. Discover entity and find a record
+uip df entities list --format json
+uip df entities get <entity-id> --format json      # see field names
+
+uip df records list <entity-id> --format json      # get record IDs
+
+# 2. Upload
+uip df files upload <entity-id> <record-id> attachment \
+  --file report.pdf --format json
+
+# 3. Verify by downloading
+uip df files download <entity-id> <record-id> attachment \
+  --output /tmp/report-verify.pdf --format json
+```

--- a/skills/uipath-data-fabric/references/file-attachments.md
+++ b/skills/uipath-data-fabric/references/file-attachments.md
@@ -5,14 +5,14 @@ Data Fabric supports file-type fields on entities. Files are stored per-record p
 ## Prerequisites
 
 The entity must have a field configured for file storage. File fields are defined in the entity schema.
-Use `uip df entities get <entity-id> --format json` to identify file-type fields.
+Use `uip df entities get <entity-id> --output json` to identify file-type fields.
 
 ## Upload a File
 
 ```bash
 uip df files upload <entity-id> <record-id> <field-name> \
   --file /path/to/document.pdf \
-  --format json
+  --output json
 ```
 
 - `<field-name>` is **case-sensitive** — must match exactly the field name from `entities get`
@@ -24,18 +24,18 @@ Response: `{ Code: "FileUploaded", Data: { EntityId, RecordId, FieldName, FileNa
 
 ```bash
 uip df files download <entity-id> <record-id> <field-name> \
-  --output /path/to/save/document.pdf \
-  --format json
+  --destination /path/to/save/document.pdf \
+  --output json
 ```
 
-- If `--output` is omitted, the file is saved using the original filename or `<field-name>.bin`
+- If `--destination` is omitted, the file is saved using the original filename or `<field-name>.bin`
 
 Response: `{ Code: "FileDownloaded", Data: { OutputPath, ContentType } }`
 
 ## Delete a File
 
 ```bash
-uip df files delete <entity-id> <record-id> <field-name> --format json
+uip df files delete <entity-id> <record-id> <field-name> --output json
 ```
 
 Response: `{ Code: "FileDeleted" }`
@@ -44,16 +44,16 @@ Response: `{ Code: "FileDeleted" }`
 
 ```bash
 # 1. Discover entity and find a record
-uip df entities list --format json
-uip df entities get <entity-id> --format json      # see field names
+uip df entities list --output json
+uip df entities get <entity-id> --output json      # see field names
 
-uip df records list <entity-id> --format json      # get record IDs
+uip df records list <entity-id> --output json      # get record IDs
 
 # 2. Upload
 uip df files upload <entity-id> <record-id> attachment \
-  --file report.pdf --format json
+  --file report.pdf --output json
 
 # 3. Verify by downloading
 uip df files download <entity-id> <record-id> attachment \
-  --output /tmp/report-verify.pdf --format json
+  --destination /tmp/report-verify.pdf --output json
 ```

--- a/skills/uipath-data-fabric/references/records-query.md
+++ b/skills/uipath-data-fabric/references/records-query.md
@@ -3,10 +3,17 @@
 ## Basic List (All Records)
 
 ```bash
-uip df records list <entity-id> --limit 50 --offset 0 --output json
+# First page
+uip df records list <entity-id> --limit 50 --output json
+
+# Next page — pass NextCursor value from previous response
+uip df records list <entity-id> --limit 50 --cursor <NextCursor> --output json
 ```
 
-Response: `{ TotalCount: N, Records: [...] }`
+Response: `{ TotalCount, Records, HasNextPage, NextCursor?, CurrentPage?, TotalPages? }`
+
+- Use `HasNextPage` to check if more records exist
+- Pass the `NextCursor` string value to `--cursor` to fetch the next page
 
 ## Filtered Query
 
@@ -16,7 +23,18 @@ uip df records query <entity-id> \
   --output json
 ```
 
-### Query Request Schema
+Pagination for query also uses `--limit` and `--cursor` flags — not body keys.
+
+```bash
+# Query with pagination
+uip df records query <entity-id> \
+  --body '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"score","operator":">=","value":"80"}]}}' \
+  --limit 100 \
+  --cursor <NextCursor> \
+  --output json
+```
+
+### Query Body Schema
 
 ```json
 {
@@ -30,11 +48,11 @@ uip df records query <entity-id> \
   },
   "sortOptions": [
     { "fieldName": "score", "isDescending": true }
-  ],
-  "start": 0,
-  "limit": 100
+  ]
 }
 ```
+
+> `start` and `limit` are **not** valid body keys — use `--limit` and `--cursor` CLI flags instead.
 
 ### Operators
 
@@ -55,7 +73,7 @@ uip df records query <entity-id> \
 - `0` = AND (all filters must match)
 - `1` = OR (any filter must match)
 
-### Nested Groups
+### Nested Filter Groups
 
 ```json
 {
@@ -93,16 +111,32 @@ uip df records insert <entity-id> --body '[{"name":"Alice","score":95},{"name":"
 uip df records insert <entity-id> --file records.json --output json
 ```
 
+Single insert response: `{ Code: "RecordInserted", Data: { ...record } }`
+
+Batch insert response: `{ Code: "RecordsBatchInserted", Data: { SuccessCount, FailureCount, SuccessRecords, FailureRecords } }`
+
 ## Update Records
 
 Records must include the `Id` field:
 
 ```bash
+# Single record update
 uip df records update <entity-id> --body '{"Id":"<record-id>","score":100}' --output json
+
+# Batch update (array, each must include Id)
+uip df records update <entity-id> \
+  --body '[{"Id":"<id1>","score":100},{"Id":"<id2>","score":90}]' \
+  --output json
 ```
+
+Single update response: `{ Code: "RecordUpdated", Data: { ...record } }`
+
+Batch update response: `{ Code: "RecordsBatchUpdated", Data: { SuccessCount, FailureCount, SuccessRecords, FailureRecords } }`
 
 ## Delete Records
 
 ```bash
 uip df records delete <entity-id> <id1> <id2> <id3> --output json
 ```
+
+Response: `{ Code: "RecordsDeleted", Data: { SuccessCount, FailureCount, SuccessRecords, FailureRecords } }`

--- a/skills/uipath-data-fabric/references/records-query.md
+++ b/skills/uipath-data-fabric/references/records-query.md
@@ -3,7 +3,7 @@
 ## Basic List (All Records)
 
 ```bash
-uip df records list <entity-id> --limit 50 --offset 0 --format json
+uip df records list <entity-id> --limit 50 --offset 0 --output json
 ```
 
 Response: `{ TotalCount: N, Records: [...] }`
@@ -13,7 +13,7 @@ Response: `{ TotalCount: N, Records: [...] }`
 ```bash
 uip df records query <entity-id> \
   --body '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"status","operator":"=","value":"active"}]}}' \
-  --format json
+  --output json
 ```
 
 ### Query Request Schema
@@ -84,13 +84,13 @@ uip df records query <entity-id> \
 
 ```bash
 # Single record
-uip df records insert <entity-id> --body '{"name":"Alice","score":95}' --format json
+uip df records insert <entity-id> --body '{"name":"Alice","score":95}' --output json
 
 # Multiple records (array)
-uip df records insert <entity-id> --body '[{"name":"Alice","score":95},{"name":"Bob","score":82}]' --format json
+uip df records insert <entity-id> --body '[{"name":"Alice","score":95},{"name":"Bob","score":82}]' --output json
 
 # From JSON file
-uip df records insert <entity-id> --file records.json --format json
+uip df records insert <entity-id> --file records.json --output json
 ```
 
 ## Update Records
@@ -98,11 +98,11 @@ uip df records insert <entity-id> --file records.json --format json
 Records must include the `Id` field:
 
 ```bash
-uip df records update <entity-id> --body '{"Id":"<record-id>","score":100}' --format json
+uip df records update <entity-id> --body '{"Id":"<record-id>","score":100}' --output json
 ```
 
 ## Delete Records
 
 ```bash
-uip df records delete <entity-id> <id1> <id2> <id3> --format json
+uip df records delete <entity-id> <id1> <id2> <id3> --output json
 ```

--- a/skills/uipath-data-fabric/references/records-query.md
+++ b/skills/uipath-data-fabric/references/records-query.md
@@ -1,0 +1,108 @@
+# Records Query Reference
+
+## Basic List (All Records)
+
+```bash
+uip df records list <entity-id> --limit 50 --offset 0 --format json
+```
+
+Response: `{ TotalCount: N, Records: [...] }`
+
+## Filtered Query
+
+```bash
+uip df records query <entity-id> \
+  --body '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"status","operator":"=","value":"active"}]}}' \
+  --format json
+```
+
+### Query Request Schema
+
+```json
+{
+  "selectedFields": ["fieldA", "fieldB"],
+  "filterGroup": {
+    "logicalOperator": 0,
+    "queryFilters": [
+      { "fieldName": "score", "operator": ">=", "value": "80" }
+    ],
+    "filterGroups": []
+  },
+  "sortOptions": [
+    { "fieldName": "score", "isDescending": true }
+  ],
+  "start": 0,
+  "limit": 100
+}
+```
+
+### Operators
+
+| Operator | Applies to | Example |
+|----------|-----------|---------|
+| `=` | All types | `"value":"active"` |
+| `!=` | All types | Null check when value is empty |
+| `>`, `<`, `>=`, `<=` | Numbers, dates | `"value":"2024-01-01"` |
+| `contains` | Text | `"value":"part"` |
+| `not contains` | Text | |
+| `startswith` | Text | |
+| `endswith` | Text | |
+| `in` | All | `"value":"a,b,c"` |
+| `not in` | All | |
+
+### logicalOperator
+
+- `0` = AND (all filters must match)
+- `1` = OR (any filter must match)
+
+### Nested Groups
+
+```json
+{
+  "filterGroup": {
+    "logicalOperator": 1,
+    "filterGroups": [
+      {
+        "logicalOperator": 0,
+        "queryFilters": [
+          { "fieldName": "status", "operator": "=", "value": "active" },
+          { "fieldName": "score", "operator": ">", "value": "50" }
+        ]
+      },
+      {
+        "logicalOperator": 0,
+        "queryFilters": [
+          { "fieldName": "priority", "operator": "=", "value": "high" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Insert Records
+
+```bash
+# Single record
+uip df records insert <entity-id> --body '{"name":"Alice","score":95}' --format json
+
+# Multiple records (array)
+uip df records insert <entity-id> --body '[{"name":"Alice","score":95},{"name":"Bob","score":82}]' --format json
+
+# From JSON file
+uip df records insert <entity-id> --file records.json --format json
+```
+
+## Update Records
+
+Records must include the `Id` field:
+
+```bash
+uip df records update <entity-id> --body '{"Id":"<record-id>","score":100}' --format json
+```
+
+## Delete Records
+
+```bash
+uip df records delete <entity-id> <id1> <id2> <id3> --format json
+```

--- a/tests/tasks/uipath-data-fabric/e2e_entity_record_lifecycle.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_entity_record_lifecycle.yaml
@@ -1,0 +1,140 @@
+task_id: skill-datafabric-e2e-entity-record-lifecycle
+description: >
+  E2E lifecycle test: agent performs a complete Data Fabric CRUD cycle against
+  a live tenant — checks login, discovers or creates a test entity, inserts
+  records, queries with a filter, updates one record, verifies the update, then
+  deletes the test records. Tests the full Discover → Act → Verify workflow.
+tags: [uipath-data-fabric, e2e, entities, records]
+
+agent:
+  type: claude-code
+  max_turns: 40
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Perform a complete Data Fabric CRUD lifecycle using the uipath-data-fabric skill.
+
+  Steps (follow in order, use --output json on every uip df command):
+
+  1. Check login: run `uip login status --output json`. Do NOT re-login — use
+     whatever tenant is currently active.
+
+  2. Discover entities: list native-only entities. If an entity named
+     "CodeEvalTest" already exists, use its ID. If not, create it with:
+       - label (text)
+       - score (number)
+       - active (boolean)
+
+  3. Insert two records:
+       - { "label": "alpha", "score": 10, "active": true }
+       - { "label": "beta",  "score": 5,  "active": false }
+     Save the record IDs from the insert responses.
+
+  4. Query records where active = true. Confirm at least one result is returned.
+
+  5. Update the "alpha" record: set score to 99.
+     Use the record ID from step 3 in the update body as "Id".
+
+  6. Verify the update: fetch the record with `records get` and confirm score = 99.
+
+  7. Delete only the two records you inserted (use the IDs from step 3).
+
+  Save a report to report.json:
+  {
+    "entity_id": "<ID of CodeEvalTest entity>",
+    "entity_existed_already": <true or false>,
+    "records_inserted": ["<id1>", "<id2>"],
+    "query_result_count": <number of records returned by active=true query>,
+    "updated_record_id": "<ID of alpha record>",
+    "score_after_update": <score value from records get>,
+    "records_deleted": ["<id1>", "<id2>"]
+  }
+
+  Do NOT ask for approval or confirmation.
+  Do NOT pause between steps.
+  Do NOT delete the entity itself — only delete the two records you inserted.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent verified login status before any operation"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed native-only entities"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+entities\s+list\s+.*--native-only'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted at least 2 records"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+insert'
+    min_count: 2
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent queried records with a filter body"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+query'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent updated a record"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+update'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the update with records get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+get'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deleted the test records"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+delete'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Report confirms full lifecycle completed with correct values"
+    path: "report.json"
+    assertions:
+      - expression: "length(records_inserted)"
+        operator: gte
+        expected: 2
+      - expression: "score_after_update"
+        operator: equals
+        expected: 99
+      - expression: "query_result_count"
+        operator: gte
+        expected: 1
+      - expression: "length(records_deleted)"
+        operator: gte
+        expected: 2
+    weight: 3.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-data-fabric/smoke_entity_commands.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_entity_commands.yaml
@@ -11,6 +11,8 @@ sandbox:
   python: {}
 
 initial_prompt: |
+  Before starting, load the uipath-data-fabric skill and follow its workflow.
+
   I need to set up a "Products" entity in Data Fabric with the following fields:
   - name (text)
   - price (decimal)
@@ -28,8 +30,10 @@ initial_prompt: |
   }
 
   Important:
-  - The uip CLI is available but may not be connected to a live Data Fabric
-    tenant. Run the commands anyway and capture whatever output or errors occur.
+  - The uip CLI is available but is NOT connected to a live Data Fabric tenant
+    in this environment. Commands will fail with auth errors — that is expected.
+    Run each command once, record the result (success or error) in report.json,
+    and move on. Do NOT retry or attempt to login.
   - Use --output json on every uip df command.
   - Do NOT delete the entity.
 

--- a/tests/tasks/uipath-data-fabric/smoke_entity_commands.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_entity_commands.yaml
@@ -1,0 +1,83 @@
+task_id: skill-datafabric-smoke-entity-commands
+description: >
+  Smoke test: agent uses the uipath-data-fabric skill to list native entities
+  and create a new entity with typed fields. Tests that the skill teaches
+  correct entity command syntax: --body with fieldName keys (not --fields),
+  --native-only flag, and --output json on all commands.
+tags: [uipath-data-fabric, smoke, entities]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I need to set up a "Products" entity in Data Fabric with the following fields:
+  - name (text)
+  - price (decimal)
+  - inStock (boolean)
+  - releaseDate (date)
+
+  First check what entities already exist (native entities only), then create
+  the Products entity if it does not exist yet.
+
+  Save a summary to report.json:
+  {
+    "commands_used": ["<list of uip df commands you ran>"],
+    "entity_create_body": { "fields": [ ... ] },
+    "entity_id": "<ID returned, or 'error: <message>' if command failed>"
+  }
+
+  Important:
+  - The uip CLI is available but may not be connected to a live Data Fabric
+    tenant. Run the commands anyway and capture whatever output or errors occur.
+  - Use --output json on every uip df command.
+  - Do NOT delete the entity.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed native entities only (--native-only flag required)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+entities\s+list\s+.*--native-only'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used entities create with --body (not --fields flag)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+entities\s+create\s+.*--body'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip df commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Entity body uses fieldName key (not name key)"
+    path: "report.json"
+    includes:
+      - "fieldName"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct shape with at least 2 commands used"
+    path: "report.json"
+    assertions:
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 2
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_records_commands.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_records_commands.yaml
@@ -11,6 +11,8 @@ sandbox:
   python: {}
 
 initial_prompt: |
+  Before starting, load the uipath-data-fabric skill and follow its workflow.
+
   There is a "MovieReviews" entity in Data Fabric with entity ID "abc-123-def".
   It has fields: title (text), rating (number), watched (boolean).
 
@@ -32,8 +34,10 @@ initial_prompt: |
   }
 
   Important:
-  - The uip CLI is available but may not be connected to a live Data Fabric
-    tenant. Run the commands anyway and capture whatever output or errors occur.
+  - The uip CLI is available but is NOT connected to a live Data Fabric tenant
+    in this environment. Commands will fail with auth errors — that is expected.
+    Run each command once, record the result (success or error) in report.json,
+    and move on. Do NOT retry or attempt to login.
   - Use --output json on every uip df command.
   - Do NOT delete the entity or attempt entities delete.
 

--- a/tests/tasks/uipath-data-fabric/smoke_records_commands.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_records_commands.yaml
@@ -1,0 +1,106 @@
+task_id: skill-datafabric-smoke-records-commands
+description: >
+  Smoke test: agent uses the uipath-data-fabric skill to insert, query, and
+  update records in a given entity. Tests correct records command syntax:
+  --body JSON for insert/update, Id field required for updates, filterGroup
+  for queries, and cursor-based pagination (--limit/--cursor, not --offset).
+tags: [uipath-data-fabric, smoke, records]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  There is a "MovieReviews" entity in Data Fabric with entity ID "abc-123-def".
+  It has fields: title (text), rating (number), watched (boolean).
+
+  Do the following steps in order:
+  1. Insert a record: { title: "Inception", rating: 9, watched: true }
+  2. Insert a second record: { title: "Dune", rating: 8, watched: false }
+  3. Query for all records where watched = true
+  4. List the first page of all records (limit 10)
+  5. Update the Inception record — set rating to 10.
+     (Use the record ID from the insert response to do the update.)
+
+  Save a summary to report.json:
+  {
+    "commands_used": ["<list of uip df commands you ran in order>"],
+    "insert_body_example": { ... the JSON body passed to records insert ... },
+    "query_filter": { ... the filterGroup JSON used for the watched=true query ... },
+    "pagination_method": "<'cursor' or 'offset'>",
+    "update_includes_id": true
+  }
+
+  Important:
+  - The uip CLI is available but may not be connected to a live Data Fabric
+    tenant. Run the commands anyway and capture whatever output or errors occur.
+  - Use --output json on every uip df command.
+  - Do NOT delete the entity or attempt entities delete.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent inserted a record using records insert --body"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+insert\s+.*--body'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent queried records using records query"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+query\s+'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed records with --limit flag (cursor pagination)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+list\s+.*--limit'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent updated a record using records update --body"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+update\s+.*--body'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on all uip df commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+.*--output\s+json'
+    min_count: 3
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Query uses filterGroup syntax (not direct SQL-style filter)"
+    path: "report.json"
+    includes:
+      - "filterGroup"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Agent used cursor pagination and included Id in update body"
+    path: "report.json"
+    assertions:
+      - expression: "pagination_method"
+        operator: equals
+        expected: "cursor"
+      - expression: "update_includes_id"
+        operator: equals
+        expected: true
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Adds Skills for @uipath/data-fabric-tool package (uip df) CLI with full CRUD commands:

df entities list/get/create/delete/add-field/update field
df records list/get/insert/update/delete/query/import
df files upload/download/delete
https://uipath.atlassian.net/browse/DS-7644
https://uipath.atlassian.net/wiki/spaces/CC/pages/90518585507/Design+Document+Data+Fabric+CLI+Tool+SDK+Integration+for+Coding+Agents