### PR TITLE
feat(uipath-maestro-flow): add HITL node reference and task navigation entry

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -321,6 +321,7 @@ Do not run any of these actions without an explicit user selection.
 | **Write `=js:` expressions** | [references/variables-and-expressions.md — Expression System](references/variables-and-expressions.md) |
 | **Orchestrate RPA, agents, apps** | Relevant resource plugin: [rpa](references/plugins/rpa/), [agent](references/plugins/agent/), [agentic-process](references/plugins/agentic-process/), [flow](references/plugins/flow/), [api-workflow](references/plugins/api-workflow/), [hitl](references/plugins/hitl/) |
 | **Embed an AI agent tightly coupled to this flow** | [references/plugins/inline-agent/](references/plugins/inline-agent/) — scaffolded via `uip agent init --inline-in-flow`, node type `uipath.agent.autonomous` |
+| **Add a Human-in-the-Loop (HITL) node** | [references/plugins/hitl/](references/plugins/hitl/) + [references/flow-hitl.md](references/flow-hitl.md) + [/uipath:uipath-human-in-the-loop](/uipath:uipath-human-in-the-loop) |
 | **Create a resource that doesn't exist yet** | Use `core.logic.mock` placeholder — see [CLI: Replace a mock](references/flow-editing-operations-cli.md#replace-a-mock-with-a-real-resource-node) + relevant plugin's `impl.md` |
 | **Add data transform nodes** | [references/plugins/transform/impl.md](references/plugins/transform/impl.md) |
 | **Create a subflow** | [references/plugins/subflow/impl.md](references/plugins/subflow/impl.md) + [JSON: Create a subflow](references/flow-editing-operations-json.md#create-a-subflow) |
@@ -394,10 +395,11 @@ When you finish building or editing a flow, report to the user:
   - [agentic-process](references/plugins/agentic-process/) — Published orchestration processes (`uipath.core.agentic-process.{key}`)
   - [flow](references/plugins/flow/) — Published flows as subprocesses (`uipath.core.flow.{key}`)
   - [api-workflow](references/plugins/api-workflow/) — Published API functions (`uipath.core.api-workflow.{key}`)
-  - [hitl](references/plugins/hitl/) — Human input via UiPath Apps (`uipath.core.hitl.{key}`)
+  - [hitl](references/plugins/hitl/) — App-based human tasks via UiPath Apps (`uipath.core.hitl.{key}`); for inline HITL see [flow-hitl.md](references/flow-hitl.md)
   - [agent](references/plugins/agent/) — Published AI agent resources (`uipath.core.agent.{key}`)
   - [inline-agent](references/plugins/inline-agent/) — Autonomous agent embedded inside the flow project (`uipath.agent.autonomous`), scaffolded via `uip agent init --inline-in-flow`
   - [queue](references/plugins/queue/) — Orchestrator queue item creation
+- **[HITL Node Reference](references/flow-hitl.md)** — Inline Human-in-the-Loop node (`uipath.human-in-the-loop`): schema design, CLI command, edge wiring, runtime variables, and approval/escalation patterns. For the full HITL authoring workflow, use the [uipath-human-in-the-loop](/uipath:uipath-human-in-the-loop) skill.
 - **[Pack / Publish / Deploy](/uipath:uipath-platform)** — Orchestrator deployment only when explicitly requested (uipath-platform skill). Default publish path is Studio Web via `uip solution upload <SolutionDir>` (Step 9).
 
 > **Trouble?** If something didn't work as expected, use `/uipath-feedback` to send a report.

--- a/skills/uipath-maestro-flow/references/flow-hitl.md
+++ b/skills/uipath-maestro-flow/references/flow-hitl.md
@@ -1,0 +1,185 @@
+# HITL (Human-in-the-Loop) Node — Reference
+
+A HITL node pauses a flow and waits for a human to complete a task in UiPath Action Center. When the task is done, the flow resumes on the `completed` output handle.
+
+Internally the node is `uipath.human-in-the-loop` — a `bpmn:UserTask` with `serviceType: Actions.HITL`. The task schema (inputs/outputs/outcomes) is embedded directly in the `.flow` file — no external app, no separate deployment.
+
+---
+
+## When to Add a HITL Node
+
+| Signal in description | HITL use case |
+|---|---|
+| "human reviews / approves / rejects" | Approval gate |
+| "escalate to a person / manager" | Exception escalation |
+| "fill in missing data / enrich" | Data enrichment by human |
+| "compliance sign-off / four-eyes check" | Compliance review |
+| "pause until someone confirms" | Manual confirmation gate |
+
+---
+
+## Schema Design Guide
+
+The `--schema` value defines what data the human task collects. It uses a flat list format (NOT JSON Schema):
+
+```json
+{
+  "inputs":   [{ "name": "fieldName", "type": "string" }],
+  "outputs":  [{ "name": "fieldName", "type": "string" }],
+  "inOuts":   [{ "name": "fieldName", "type": "string" }],
+  "outcomes": [{ "name": "Approve",  "type": "string" }, { "name": "Reject", "type": "string" }]
+}
+```
+
+- **`inputs`** — data passed into the task (read-only for the human)
+- **`outputs`** — data the human fills in and returns to the flow
+- **`inOuts`** — data the human can read and modify
+- **`outcomes`** — named action buttons the human clicks to complete the task
+
+All fields are optional. If omitted, defaults to `outcomes: [{ name: "Submit", type: "string" }]`.
+
+### Approval pattern
+
+```json
+{
+  "inputs":   [{ "name": "invoiceId",     "type": "string" },
+               { "name": "invoiceAmount", "type": "number" }],
+  "outcomes": [{ "name": "Approve", "type": "string" },
+               { "name": "Reject",  "type": "string" }]
+}
+```
+
+### Data enrichment pattern (human fills in missing fields)
+
+```json
+{
+  "inputs":  [{ "name": "rawData",    "type": "string" }],
+  "outputs": [{ "name": "vendorName", "type": "string" },
+              { "name": "costCenter", "type": "string" }],
+  "outcomes": [{ "name": "Submit", "type": "string" }]
+}
+```
+
+### Exception handling pattern
+
+```json
+{
+  "outputs":  [{ "name": "action", "type": "string" },
+               { "name": "reason", "type": "string" }],
+  "outcomes": [{ "name": "Retry",    "type": "string" },
+               { "name": "Skip",     "type": "string" },
+               { "name": "Escalate", "type": "string" }]
+}
+```
+
+---
+
+## CLI Command Reference
+
+Minimal (defaults only):
+
+```bash
+uip flow hitl add <file>
+```
+
+With schema and options:
+
+```bash
+uip flow hitl add flow_files/InvoiceApproval.flow \
+  --schema '{"inputs":[{"name":"invoiceId","type":"string"}],"outcomes":[{"name":"Approve"},{"name":"Reject"}]}' \
+  --label "Invoice Review" \
+  --priority normal \
+  --position 400,200
+```
+
+| Option | Values | Default |
+|---|---|---|
+| `--schema` | JSON string (inputs/outputs/inOuts/outcomes) | `{ outcomes: [{ name: "Submit" }] }` |
+| `--label` | display label on the canvas | `"Human in the Loop"` |
+| `--priority` | `Low` `Medium` `High` | `Low` |
+| `--position` | `x,y` canvas coordinates | `0,0` |
+
+**Output:**
+```json
+{
+  "Result": "Success",
+  "Code": "HitlNodeAdded",
+  "Data": {
+    "NodeId": "invoiceReview1",
+    "NodeType": "uipath.human-in-the-loop",
+    "Label": "Invoice Review",
+    "DefinitionAdded": true
+  }
+}
+```
+
+Note the returned `NodeId` — you need it to wire edges.
+
+---
+
+## After Adding — Wire the Edges
+
+The HITL node has one output handle. Wire it to continue the flow after human completion:
+
+```bash
+# Human completed the task → continue the happy path
+uip flow edge add <file> --source <hitl-node-id>:completed --target <next-node-id>:input
+```
+
+Always wire `completed`.
+
+### Runtime outputs
+
+The HITL node produces two variables after completion:
+
+| Variable | Type | Description |
+|---|---|---|
+| `result` | object | The data the human filled in (matches `outputs` and `inOuts` schema fields) |
+| `status` | string | `"completed"` |
+
+Reference these in subsequent nodes as `$vars.<hitlNodeId>.result` and `$vars.<hitlNodeId>.status`.
+
+---
+
+## Validate After Adding
+
+```bash
+uip flow validate flow_files/<ProjectName>.flow --format json
+```
+
+Always validate after adding the node and wiring its edges.
+
+---
+
+## Full Example — Invoice Approval Flow
+
+**Scenario**: RPA extracts invoice data → human reviews and approves → approved invoices are posted to ERP.
+
+### 1. Add the HITL review node
+
+```bash
+uip flow hitl add flow_files/InvoiceApproval.flow \
+  --schema '{"inputs":[{"name":"invoiceId","type":"string"},{"name":"amount","type":"number"}],"outcomes":[{"name":"Approve"},{"name":"Reject"}]}' \
+  --label "Invoice Review" \
+  --priority Low
+```
+
+Note the returned node id, e.g. `invoiceReview1`.
+
+### 2. Wire the edges
+
+```bash
+# extraction node → HITL review
+uip flow edge add flow_files/InvoiceApproval.flow \
+  --source extractInvoice1:output --target invoiceReview1:input
+
+# HITL completed → post to ERP
+uip flow edge add flow_files/InvoiceApproval.flow \
+  --source invoiceReview1:completed --target postToErp1:input
+```
+
+### 3. Validate
+
+```bash
+uip flow validate flow_files/InvoiceApproval.flow --format json
+```


### PR DESCRIPTION
## Summary

Adds a Human-in-the-Loop node reference to the `uipath-maestro-flow` skill and wires it into the task navigation table.

**Changes:**
- `references/flow-hitl.md` (new) — inline HITL node reference: schema design, `uip flow hitl add` CLI, edge wiring, runtime variables, and approval/escalation patterns
- `SKILL.md` — added `| Add a Human-in-the-Loop (HITL) node |` row to task navigation table; added flow-hitl.md to references section

**Node covered:** `uipath.human-in-the-loop` (OOTB inline form)
- Output handle: `completed` only (cancelled/timeout removed in flow-workbench 102a5a2c)
- Priority: `Low/Medium/High`
- Runtime var: `$vars.<nodeId>.result` and `$vars.<nodeId>.status`

Companion: skills#292 (skill schema/test fixes), uipcli#844 (CLI implementation)