### PR TITLE
fix(uipath-platform): prefer catalog connectors over custom ones

### DIFF
--- a/skills/uipath-platform/references/integration-service/agent-workflow.md
+++ b/skills/uipath-platform/references/integration-service/agent-workflow.md
@@ -37,7 +37,8 @@ uip is connectors list --filter "<vendor>" --output json
 | Outcome | Action |
 |---|---|
 | Single native connector found | Use its **`Key`**. Proceed to Step 2. |
-| Multiple connectors found | Prefer the catalog connector (`uipath-` prefixed key) over custom ones (`custom-`/`design-` prefixed). See [connectors.md — Official vs Custom Connectors](connectors.md#official-vs-custom-connectors). |
+| Multiple connectors, mix of catalog and custom | Drop `custom-`/`design-` prefixed keys, use the `uipath-` prefixed one. See [connectors.md — Official vs Custom Connectors](connectors.md#official-vs-custom-connectors). |
+| Multiple catalog (`uipath-`) connectors | Present the list to the user and ask which one to use. Do NOT auto-select. |
 | Not found | Fall back to HTTP connector (`uipath-uipath-http`). See [connectors.md — HTTP Connector Fallback](connectors.md#http-connector-fallback). |
 
 ## Step 2: Find a Connection

--- a/skills/uipath-platform/references/integration-service/agent-workflow.md
+++ b/skills/uipath-platform/references/integration-service/agent-workflow.md
@@ -36,7 +36,8 @@ uip is connectors list --filter "<vendor>" --output json
 
 | Outcome | Action |
 |---|---|
-| Native connector found | Use its **`Key`**. Proceed to Step 2. |
+| Single native connector found | Use its **`Key`**. Proceed to Step 2. |
+| Multiple connectors found | Prefer the catalog connector (`uipath-` prefixed key) over custom ones (`custom-`/`design-` prefixed). See [connectors.md — Official vs Custom Connectors](connectors.md#official-vs-custom-connectors). |
 | Not found | Fall back to HTTP connector (`uipath-uipath-http`). See [connectors.md — HTTP Connector Fallback](connectors.md#http-connector-fallback). |
 
 ## Step 2: Find a Connection

--- a/skills/uipath-platform/references/integration-service/connectors.md
+++ b/skills/uipath-platform/references/integration-service/connectors.md
@@ -28,12 +28,24 @@ A tenant may have both a **catalog** (official) connector and a **custom** conne
 | `custom-` | Custom tenant connector |
 | `design-` | Custom tenant connector (rare) |
 
-**Always prefer the `uipath-` prefixed connector** unless the user explicitly requests a custom one. If no `uipath-` match exists, fall back to `custom-`/`design-` connectors.
+### Selection rules
+
+1. **Filter out custom connectors first.** Drop any `custom-`/`design-` prefixed keys unless the user explicitly requests a custom connector.
+2. **Single catalog match** → use it automatically.
+3. **Multiple catalog matches** → present the list to the user and ask which one to use. A vendor can have multiple official connectors serving different purposes (e.g., Snowflake DB vs Snowflake Cortex, or multiple Microsoft connectors). Never auto-select in this case.
+4. **No catalog match, only custom** → fall back to `custom-`/`design-` connectors.
 
 ```bash
+# Example: catalog vs custom — auto-select the catalog connector
 uip is connectors list --filter "google sheets" --output json
 # → Key: "uipath-googlesheets-googlesheets"  ← catalog — use this one
 # → Key: "custom-google-sheets-abc"           ← custom — skip unless user asks
+
+# Example: multiple catalog connectors — present choice to user
+uip is connectors list --filter "snowflake" --output json
+# → Key: "uipath-snowflake-db"      Name: "Snowflake DB"
+# → Key: "uipath-snowflake-cortex"  Name: "Snowflake Cortex"
+# → Ask the user which one to use — do NOT auto-select
 ```
 
 ---

--- a/skills/uipath-platform/references/integration-service/connectors.md
+++ b/skills/uipath-platform/references/integration-service/connectors.md
@@ -18,6 +18,26 @@ Connectors are pre-built integrations to external applications. Each connector h
 
 ---
 
+## Official vs Custom Connectors
+
+A tenant may have both a **catalog** (official) connector and a **custom** connector for the same vendor. When `uip is connectors list --filter "<vendor>"` returns multiple results, distinguish them by **Key prefix**:
+
+| Key prefix | Type |
+|---|---|
+| `uipath-` | Catalog (official) connector |
+| `custom-` | Custom tenant connector |
+| `design-` | Custom tenant connector (rare) |
+
+**Always prefer the `uipath-` prefixed connector** unless the user explicitly requests a custom one. If no `uipath-` match exists, fall back to `custom-`/`design-` connectors.
+
+```bash
+uip is connectors list --filter "google sheets" --output json
+# → Key: "uipath-googlesheets-googlesheets"  ← catalog — use this one
+# → Key: "custom-google-sheets-abc"           ← custom — skip unless user asks
+```
+
+---
+
 ## HTTP Connector Fallback
 
 When no native connector exists for a vendor, use the HTTP connector (`uipath-uipath-http`) to call REST APIs directly.


### PR DESCRIPTION
## Summary
- Add "Official vs Custom Connectors" section to `connectors.md` with key-prefix disambiguation rules (`uipath-` = catalog, `custom-`/`design-` = custom)
- Update Step 1 in `agent-workflow.md` to handle multiple connector matches and link to the new section

Context: [Slack thread](https://uipath-product.slack.com/archives/C0AKALK3KB9/p1775235333907999) — tenants with custom connectors (e.g., Google Sheets) alongside official ones caused the agent to potentially pick the wrong connector.

## Test plan
- [ ] Verify agent prefers `uipath-` prefixed connector when multiple matches exist
- [ ] Verify agent falls back to `custom-`/`design-` connector when no catalog connector exists
- [ ] Verify agent asks user when disambiguation is unclear

🤖 Generated with [Claude Code](https://claude.com/claude-code)