### PR TITLE
fix(uipath-rpa): use UiPath activities over .NET built-ins [PILOT-4070]

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -113,6 +113,7 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 20. **[XAML] NEVER touch ViewState** in XAML files — it's designer layout metadata.
 21. **[XAML] Use `get-default-activity-xaml` output** as a starting point — don't construct activity XAML from memory.
 22. **[XAML] MUST read [references/xaml/xaml-basics-and-rules.md](references/xaml/xaml-basics-and-rules.md)** before generating or editing any XAML.
+23. **[XAML] ALWAYS use UiPath activity equivalents** — NEVER use .NET built-in activities (`System.Activities.Statements.ForEach`, `System.Activities.Statements.If`, `System.Activities.Statements.Assign`) when UiPath equivalents exist in `UiPath.System.Activities` or `UiPath.Core.Activities`. The UiPath versions integrate with Studio logging, analytics, and debugging.
 
 ## Task Navigation
 

--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -2,6 +2,20 @@
 
 Common pitfalls that cause validation errors or runtime failures.
 
+## .NET Built-in vs UiPath Activities
+
+NEVER use .NET built-in activities when UiPath equivalents exist. The agent may treat `ForEach`, `Assign`, `If` as "basic .NET plumbing" and use `System.Activities.Statements.*` directly. Always use the UiPath versions instead:
+
+| .NET Built-in (DO NOT USE) | UiPath Equivalent (USE THIS) | Package |
+|----------------------------|------------------------------|---------|
+| `System.Activities.Statements.ForEach<T>` | `UiPath.Core.Activities.ForEach` | `UiPath.System.Activities` |
+| `System.Activities.Statements.If` | `UiPath.Core.Activities.If` | `UiPath.System.Activities` |
+| `System.Activities.Statements.Assign` | `UiPath.Core.Activities.Assign` | `UiPath.System.Activities` |
+| `System.Activities.Statements.While` | `UiPath.Core.Activities.While` | `UiPath.System.Activities` |
+| `System.Activities.Statements.Switch<T>` | `UiPath.Core.Activities.Switch` | `UiPath.System.Activities` |
+
+**Why:** UiPath activities integrate with Studio's logging, analytics, debugging, and activity tracking. The .NET built-in versions bypass all of this and may cause unexpected behavior.
+
 ## Container/Scope Requirements
 
 These activities **must** be placed inside a specific parent scope:


### PR DESCRIPTION
## Summary

- **PILOT-4070** — Agents use .NET built-in `ForEach`/`If`/`Assign` from `System.Activities.Statements` instead of UiPath equivalents from `UiPath.Core.Activities`. Added a critical rule and a mapping table to prevent this.

## Jira Issues

- https://uipath.atlassian.net/browse/PILOT-4070

## Changes

| File | Change |
|------|--------|
| `SKILL.md` | Added XAML rule #23: always use UiPath activity equivalents |
| `common-pitfalls.md` | Added ".NET Built-in vs UiPath Activities" section with DO NOT USE / USE THIS mapping table |

## Also investigated

- **PILOT-4056** (CLI-version-aware: validate vs get-errors) — already resolved, skill uses `get-errors` everywhere with no stale `uip rpa validate` references

## Note

This branch is based on `fix/rpa-skill-docs-from-feedback` (PR #185). After that merges, rebase onto `main`.

## Test plan

- [ ] Verify SKILL.md frontmatter is still valid
- [ ] Verify common-pitfalls.md table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)