### PR TITLE
feat(tests): introduce four-type evaluation framework with tag-based test organization

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -1,7 +1,7 @@
-name: E2E Skill Tests
+name: Smoke Skill Tests
 
 concurrency:
-  group: e2e-skills-${{ github.head_ref || github.ref }}
+  group: smoke-skills-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 on:
@@ -16,7 +16,7 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    name: Run skill e2e tests
+    name: Run skill smoke tests
     steps:
       - uses: actions/checkout@v4
 
@@ -59,7 +59,7 @@ jobs:
           bun run build
           cd packages/cli && npm link
 
-      - name: Run e2e smoke tests
+      - name: Run smoke tests
         env:
           SKILLS_REPO_PATH: ${{ github.workspace }}
           API_BACKEND: bedrock
@@ -67,7 +67,7 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           BEDROCK_MODEL: ${{ secrets.BEDROCK_MODEL }}
         working-directory: tests
-        id: e2e
+        id: smoke
         run: |
           coder-eval run tasks/**/*.yaml \
             -e experiments/default.yaml --tags smoke -j 1 -v
@@ -86,5 +86,5 @@ jobs:
           done
 
       - name: Fail if tests failed
-        if: steps.e2e.outcome == 'failure'
+        if: steps.smoke.outcome == 'failure'
         run: exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,26 +189,38 @@ This configures git to use `.githooks/` and enables the skill description valida
 
 ## Testing Skills
 
-Skills are tested end-to-end using [coder_eval](https://github.com/UiPath/coder_eval) — a framework that runs an AI agent against a task and scores the result. Tests live in `tests/tasks/<skill-name>/` and verify that the skill guides the agent to use the correct CLI commands, follow critical rules, and produce valid output.
+Skills are tested using [coder_eval](https://github.com/UiPath/coder_eval) — a framework that runs an AI agent against a task and scores the result. Tests live in `tests/tasks/<skill-name>/` and verify that the skill guides the agent to use the correct CLI commands, follow critical rules, and produce valid output.
+
+There are four test types, distinguished by tags:
+
+| Tag | Purpose | Cadence |
+|-----|---------|---------|
+| `activation` | Does the right skill trigger for the right query? | Every PR |
+| `smoke` | Skill + CLI produces valid output (1-3 simple scenarios) | Every PR |
+| `integration` | Correct output across diverse scenarios, error paths, anti-patterns | Daily |
+| `e2e` | Full lifecycle: Explore -> Plan -> Build -> Validate -> Deploy -> Run | Daily/weekly (check [Dashboard](https://dataexplorer.azure.com/dashboards/20cc55fe-33ae-4973-a951-855e76528219)) |
 
 ### Running Tests
 
 ```bash
 cd tests
-make install   # one-time: install coder-eval from GitHub
-make e2e       # run all smoke tests
-make e2e-flow  # run maestro-flow tests only
+make install       # one-time: install coder-eval from GitHub
+make activation    # run all activation tests
+make smoke         # run all smoke tests
+make integration   # run all integration tests
+make e2e           # run all end-to-end tests
+make test-uipath-maestro-flow  # run all tests for a specific skill
 ```
 
 ### Adding Tests for a Skill
 
 1. Create `tests/tasks/<skill-name>/` matching your skill folder name
-2. Write one YAML task file per capability (e.g., `init_validate.yaml`, `registry_discovery.yaml`)
+2. Add at minimum **1 activation test**, **1 smoke test**, and **1 e2e test** (required for every new skill PR)
 3. Use minimal prompts — the goal is to test the skill's guidance quality, not hand-hold the agent
-4. Tag every task with `smoke` so it runs in CI
+4. Tag every task appropriately: `activation`, `smoke`, `integration`, or `e2e`
 5. Follow the task ID pattern: `skill-<domain>-<capability>`
 
-See `tests/README.md` for the full task YAML template and conventions.
+See `tests/README.md` for the full task YAML template, success criteria reference, and examples from existing tests.
 
 ## Quality Checklist
 
@@ -229,6 +241,12 @@ Before submitting your PR, verify:
 - [ ] Guide files use `-guide.md` suffix
 - [ ] Templates use `-template` suffix
 - [ ] No duplicate content already covered in another skill's references
+
+### Tests
+- [ ] At least 1 activation test in `tests/tasks/<skill-name>/`
+- [ ] At least 1 smoke test in `tests/tasks/<skill-name>/`
+- [ ] At least 1 e2e test in `tests/tasks/<skill-name>/`
+- [ ] All tests tagged appropriately (`activation`, `smoke`, `integration`, or `e2e`)
 
 ### General
 - [ ] CODEOWNERS updated with your GitHub handle

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,22 +1,34 @@
-.PHONY: help install e2e e2e-flow
+.PHONY: help install activation smoke integration e2e
 
 SKILLS_REPO_PATH ?= $(shell cd .. && pwd)
+VENV := .venv
+CODER_EVAL := SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) $(VENV)/bin/coder-eval
+TASKS := $(shell find tasks -name '*.yaml' -type f)
 
-help:  ## Show this help message
-	@echo "Available commands:"
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2}'
+help:  ## Show available commands
+	@grep -E '^[a-zA-Z0-9_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+	  awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-install:  ## Install coder-eval from GitHub
-	uv pip install "coder-eval @ git+https://github.com/UiPath/coder_eval.git"
+install:  ## Install coder-eval into local .venv (requires Python 3.13+)
+	uv venv --python 3.13 $(VENV)
+	uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"
+	@echo ""
+	@echo "See https://github.com/UiPath/coder_eval for environment setup (.env, API keys, etc.)"
 
-e2e:  ## Run all skill e2e tests (smoke)
-	SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) \
-	  coder-eval run tasks/**/*.yaml \
-	  -e experiments/default.yaml --tags smoke -j 1 -v
+activation:  ## Run all activation tests
+	$(CODER_EVAL) run $(TASKS) -e experiments/default.yaml --tags activation -j 1 -v
 
-e2e-flow:  ## Run maestro-flow skill tests only
-	SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) \
-	  coder-eval run tasks/uipath-maestro-flow/*.yaml \
-	  -e experiments/default.yaml -j 1 -v
+smoke:  ## Run all smoke tests
+	$(CODER_EVAL) run $(TASKS) -e experiments/default.yaml --tags smoke -j 1 -v
+
+integration:  ## Run all integration tests
+	$(CODER_EVAL) run $(TASKS) -e experiments/integration.yaml --tags integration -j 1 -v
+
+e2e:  ## Run all end-to-end tests
+	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml --tags e2e -j 1 -v
+
+# Run all tests for a specific skill: make test-uipath-maestro-flow
+test-%:  ## Run all tests for a specific skill
+	$(CODER_EVAL) run $(shell find tasks/$* -name '*.yaml' -type f) -e experiments/default.yaml -j 1 -v
 
 .DEFAULT_GOAL := help

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,12 +1,13 @@
-# Skill E2E Tests
+# Skill Evaluation Tests
 
-End-to-end tests that verify AI agents can correctly use skills from this repository. Tests are defined as [coder_eval](https://github.com/UiPath/coder_eval) task YAML files.
+Tests that verify AI agents can correctly use skills from this repository. Tests are defined as [coder_eval](https://github.com/UiPath/coder_eval) task YAML files.
 
 ## Prerequisites
 
-1. **coder-eval** — install from GitHub:
+1. **coder-eval** — install from GitHub (creates a local `.venv`, requires Python 3.13+):
    ```bash
-   uv pip install "coder-eval @ git+https://github.com/UiPath/coder_eval.git"
+   cd tests
+   make install
    ```
 
 2. **uip CLI** — the UiPath CLI must be available:
@@ -14,26 +15,64 @@ End-to-end tests that verify AI agents can correctly use skills from this reposi
    npm install -g @uipath/cli
    ```
 
-3. **ANTHROPIC_API_KEY** — set in your environment for the agent to run.
+3. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for full `.env` setup instructions.
 
 ## Running Tests
 
 ```bash
 cd tests
 
+# Run all activation tests
+make activation
+
 # Run all smoke tests
+make smoke
+
+# Run all integration tests
+make integration
+
+# Run all e2e tests
 make e2e
 
-# Run maestro-flow skill tests only
-make e2e-flow
+# Run all tests for a specific skill
+make test-uipath-maestro-flow
 
-# Run a single task
+# Run a single task file
 SKILLS_REPO_PATH=$(cd .. && pwd) \
-  coder-eval run tasks/uipath-maestro-flow/init_validate.yaml \
+  .venv/bin/coder-eval run tasks/uipath-maestro-flow/init_validate.yaml \
   -e experiments/default.yaml
 ```
 
 The `SKILLS_REPO_PATH` environment variable defaults to the parent directory (repo root) when using `make`.
+
+## Evaluation Framework
+
+Tests are organized into four types, distinguished by **tags** (not directories). All tests for a skill live together in `tests/tasks/<skill-name>/`.
+
+| Tag | Purpose | Cadence |
+|-----|---------|---------|
+| `activation` | Does the right skill trigger for the right query? | Every PR |
+| `smoke` | Skill + CLI produces valid output (1-3 simple scenarios) | Every PR |
+| `integration` | Correct output across diverse scenarios, error paths, anti-patterns | Daily |
+| `e2e` | Full lifecycle: Explore -> Plan -> Build -> Validate -> Deploy -> Run | Daily/weekly (check [Dashboard](https://dataexplorer.azure.com/dashboards/20cc55fe-33ae-4973-a951-855e76528219))|
+
+### Why tags over directories
+
+All tests for a skill live in one folder (`tests/tasks/<skill-name>/`). Test types are separated by tags and naming conventions — not by directory. This means:
+- Skill authors see all their tests in one place
+- CODEOWNERS maps cleanly per skill
+- A test can carry multiple tags (`[smoke, integration]`)
+- CI filters by `--tags smoke`, not by directory glob
+- Adding a new test type is a tag, not a restructure
+
+### Naming conventions
+
+| Test type | File naming | Examples |
+|-----------|-------------|---------|
+| Activation | `activation_*.yaml` | `activation_triggers.yaml` |
+| Smoke | Descriptive happy-path names | `init_validate.yaml`, `registry_discovery.yaml` |
+| Integration | `error_*.yaml`, `anti_pattern_*.yaml`, `edge_*.yaml` | `error_build_failure.yaml`, `anti_pattern_no_xaml_edit.yaml` |
+| E2E | `e2e_*.yaml` or `lifecycle_*.yaml` | `e2e_full_lifecycle.yaml` |
 
 ## Directory Structure
 
@@ -42,18 +81,64 @@ tests/
 ├── README.md
 ├── Makefile
 ├── experiments/
-│   └── default.yaml              # Shared agent config (plugin, model, tools)
+│   ├── default.yaml              # Activation + Smoke config
+│   ├── integration.yaml          # Integration config (longer timeouts)
+│   └── e2e.yaml                  # E2E config (staging tenant, full lifecycle)
 └── tasks/
     └── <skill-name>/             # One folder per skill
-        └── <capability>.yaml     # One task per capability tested
+        ├── activation_*.yaml     # Activation tests
+        ├── <capability>.yaml     # Smoke tests
+        ├── error_*.yaml          # Integration tests
+        └── e2e_*.yaml            # E2E tests
+```
+
+## Experiment Configs
+
+Experiment files define shared agent defaults per test type. Tasks inherit these defaults and should only override what differs.
+
+| Experiment | Used by | max_iterations | max_turns | task_timeout | turn_timeout |
+|------------|---------|----------------|-----------|--------------|--------------|
+| `default.yaml` | Activation, Smoke | 1 | 20 | 600s | 300s |
+| `integration.yaml` | Integration | 2 | 30 | 900s | 300s |
+| `e2e.yaml` | E2E | 2 | 40 | 1200s | 300s |
+
+Task files should **not** duplicate the full `agent:` block — the experiment provides the defaults. Only specify fields that differ from the experiment:
+
+```yaml
+# Good — no agent block needed when everything matches the experiment defaults
+task_id: skill-flow-init-validate
+tags: [uipath-maestro-flow, smoke, init, validate]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  ...
+
+# Good — only override what differs (max_turns: 14 instead of the default 20)
+task_id: skill-flow-registry-discovery
+tags: [uipath-maestro-flow, smoke, registry]
+
+agent:
+  type: claude-code
+  max_turns: 14
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  ...
 ```
 
 ## Adding Tests for a New Skill
 
 1. Create `tests/tasks/<skill-name>/` matching the skill folder name under `skills/`.
-2. Write one YAML file per capability you want to test.
-3. Use minimal prompts — the goal is to test whether the skill guides the agent correctly.
-4. Tag every task with `smoke` and the skill domain (e.g., `flow`, `platform`, `rpa`).
+2. Add at minimum **1 activation test**, **1 smoke test**, and **1 e2e test** (required for every new skill PR).
+3. Use minimal prompts — the goal is to test whether the skill guides the agent correctly, not to hand-hold it.
+4. Tag every task appropriately: `activation`, `smoke`, `integration`, or `e2e`.
+5. Always include the skill directory name as a tag (e.g., `uipath-maestro-flow`, `uipath-rpa`).
 
 ### Task ID Convention
 
@@ -61,42 +146,252 @@ tests/
 skill-<domain>-<capability>
 ```
 
-Examples: `skill-flow-init-validate`, `skill-platform-queue-operations`
+Examples: `skill-flow-init-validate`, `skill-flow-registry-discovery`, `skill-rpa-activation-triggers`
 
-### Task YAML Template
+### Smoke Test Example
+
+This is `tasks/uipath-maestro-flow/init_validate.yaml` — a smoke test that verifies the agent can create and validate a Flow project:
 
 ```yaml
-task_id: skill-<domain>-<capability>
+task_id: skill-flow-init-validate
 description: >
-  Skill-guided evaluation: agent uses the <skill-name> skill to <what it does>.
-tags: [skill, <domain>, <capability>, smoke]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 20
+  Skill-guided evaluation: agent uses the uipath-maestro-flow skill to create
+  a new UiPath Flow project inside a solution and validate it. Tests whether
+  the skill teaches the correct solution-first workflow and CLI usage.
+tags: [uipath-maestro-flow, smoke, init, validate]
 
 sandbox:
   driver: tempdir
   python: {}
 
 initial_prompt: |
-  <Minimal prompt — describe the goal, not the steps.>
+  Create a new UiPath Flow project called "WeatherAlert" and make sure it
+  validates successfully.
+
+  Save a summary of what you did to report.json with at minimum:
+    {
+      "project_name": "WeatherAlert",
+      "commands_used": ["<list of uip commands you ran>"],
+      "validation_passed": true
+    }
+
+  Important:
+  - The `uip` CLI is already available in the environment.
+  - Do not run `uip flow debug` — just validate locally.
 
 success_criteria:
   - type: command_executed
-    description: "Agent used the expected CLI command"
+    description: "Agent created a solution with uip solution new"
     tool_name: "Bash"
-    command_pattern: '<regex matching the key command>'
+    command_pattern: 'uip\s+solution\s+new'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent initialized a Flow project with uip flow init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+flow\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the .flow file"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
-  # Add file_exists, file_contains, run_command criteria as needed
+  - type: command_executed
+    description: "Agent linked flow project to solution"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+project\s+add'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
 
-max_iterations: 2
+  - type: file_exists
+    description: "Flow file was created inside the solution"
+    path: "WeatherAlert/WeatherAlert/WeatherAlert.flow"
+    weight: 1.5
+    pass_threshold: 1.0
 
-llm_reviewer:
-  enabled: true
+  - type: json_check
+    description: "report.json has correct structure and values"
+    path: "report.json"
+    assertions:
+      - expression: "project_name"
+        operator: equals
+        expected: "WeatherAlert"
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 3
+    weight: 2.0
+    pass_threshold: 0.75
 ```
+
+Key patterns to note:
+- **No `agent:` block** — inherits everything from `experiments/default.yaml`
+- **No `max_iterations` or `llm_reviewer`** — inherited from the experiment config
+- **Minimal prompt** — describes the goal ("create and validate"), not the steps
+- **Multiple criteria types** — `command_executed`, `file_exists`, `json_check` cover different aspects
+- **Weighted scoring** — core commands (`weight: 1.5`) matter more than supporting checks (`weight: 1.0`)
+- **JSON report** — asks the agent to produce structured output for validation
+
+For another example using `file_contains` and `run_command` criteria, see `tasks/uipath-maestro-flow/registry_discovery.yaml`. That test also demonstrates overriding a single field (`agent: max_turns: 14`) from the experiment defaults.
+
+## Success Criteria Reference
+
+Each task defines one or more success criteria. The agent's score is the weighted sum of passing criteria.
+
+### `command_executed`
+
+Verify the agent ran a specific CLI command (matched by regex). From `init_validate.yaml`:
+
+```yaml
+- type: command_executed
+  description: "Agent created a solution with uip solution new"
+  tool_name: "Bash"
+  command_pattern: 'uip\s+solution\s+new'
+  min_count: 1          # minimum times the command must appear
+  weight: 1.5           # scoring weight
+  pass_threshold: 1.0   # fraction of min_count required to pass
+```
+
+### `file_exists`
+
+Verify a file was created in the sandbox. From `init_validate.yaml`:
+
+```yaml
+- type: file_exists
+  description: "Flow file was created inside the solution"
+  path: "WeatherAlert/WeatherAlert/WeatherAlert.flow"
+  weight: 1.5
+  pass_threshold: 1.0
+```
+
+### `file_contains`
+
+Verify a file contains expected strings. From `registry_discovery.yaml`:
+
+```yaml
+- type: file_contains
+  description: "Report contains expected fields"
+  path: "registry_report.json"
+  includes:
+    - "node_types_found"
+    - "commands_used"
+    - "http_node_type"
+    - "script_node_type"
+  weight: 1.5
+  pass_threshold: 1.0
+```
+
+### `json_check`
+
+Validate JSON file structure and values using JSONPath assertions. From `init_validate.yaml`:
+
+```yaml
+- type: json_check
+  description: "report.json has correct structure and values"
+  path: "report.json"
+  assertions:
+    - expression: "project_name"
+      operator: equals
+      expected: "WeatherAlert"
+    - expression: "validation_passed"
+      operator: equals
+      expected: true
+    - expression: "length(commands_used)"
+      operator: gte
+      expected: 3
+  weight: 2.0
+  pass_threshold: 0.75   # at least 75% of assertions must pass
+```
+
+Supported operators: `equals`, `gte`, `lte`, `gt`, `lt`, `contains`.
+
+### `run_command`
+
+Execute an arbitrary shell command and check the exit code. From `registry_discovery.yaml`:
+
+```yaml
+- type: run_command
+  description: "registry_report.json is valid JSON"
+  command: "python -c \"import json; json.load(open('registry_report.json'))\""
+  timeout: 10
+  expected_exit_code: 0
+  weight: 1.0
+  pass_threshold: 1.0
+```
+
+## Weight and Threshold Guidance
+
+**`weight`** controls how much a criterion contributes to the overall score. Use higher weights for the core behavior being tested:
+
+| Weight | When to use | Example from existing tests |
+|--------|-------------|---------------------------|
+| `1.0` | Supporting checks | `--output json` flag used, file is valid JSON |
+| `1.5` | Core behavior | `uip solution new` executed, `.flow` file created |
+| `2.0` | Critical validation | `report.json` has correct structure and values |
+
+**`pass_threshold`** is the fraction of the criterion that must pass. For `json_check` with multiple assertions, `0.75` means 75% of assertions must pass. For most criteria, use `1.0` (all-or-nothing).
+
+## Interpreting Results
+
+After a run, results are written to `tests/runs/<experiment-id>/`:
+
+```
+runs/
+└── <experiment-id>/
+    ├── experiment.md           # Overall summary
+    └── default/
+        ├── variant.md          # Variant-level summary
+        └── <task-id>/
+            └── task.json       # Detailed per-task results
+```
+
+- **`experiment.md`** — high-level pass/fail summary across all tasks
+- **`task.json`** — per-criterion scores, agent transcript, and LLM reviewer output
+
+## Debugging Failures
+
+1. **Read the task result:**
+   ```bash
+   cat runs/*/default/skill-flow-init-validate/task.json | python -m json.tool
+   ```
+
+2. **Check which criteria failed:** Look at the `success_criteria` array in `task.json` — each entry has a `passed` boolean and `score`.
+
+3. **Read the agent transcript:** The `transcript` field in `task.json` shows every agent turn, tool call, and tool result.
+
+4. **Re-run a single task with verbose output:**
+   ```bash
+   SKILLS_REPO_PATH=$(cd .. && pwd) \
+     .venv/bin/coder-eval run tasks/uipath-maestro-flow/init_validate.yaml \
+     -e experiments/default.yaml -v
+   ```
+
+5. **Common failure causes:**
+   - Agent used wrong CLI command or flags -> check the skill's SKILL.md for correctness
+   - Agent didn't activate the skill -> check skill description frontmatter and activation test
+   - Agent ran out of turns -> increase `max_turns` or simplify the prompt
+   - Sandbox issue -> check that `uip` CLI is available in the test environment
+
+## Further Reading
+
+- [coder_eval repository](https://github.com/UiPath/coder_eval) — framework docs, task definition guide, CLI reference
+- [CONTRIBUTING.md](../CONTRIBUTING.md) — skill contribution rules and quality checklist

--- a/tests/experiments/e2e.yaml
+++ b/tests/experiments/e2e.yaml
@@ -1,16 +1,16 @@
-experiment_id: skill-tests-default
-description: "Default experiment for activation and smoke tests — loads the full UiPath skills plugin"
+experiment_id: skill-tests-e2e
+description: "End-to-end tests — full lifecycle with staging tenant connectivity"
 
 defaults:
-  max_iterations: 1
-  task_timeout: 600
+  max_iterations: 2
+  task_timeout: 1200
   turn_timeout: 300
 
   agent:
     type: claude-code
     permission_mode: acceptEdits
     model: claude-sonnet-4-6
-    max_turns: 20
+    max_turns: 40
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
     plugins:
       - type: "local"

--- a/tests/experiments/integration.yaml
+++ b/tests/experiments/integration.yaml
@@ -1,16 +1,16 @@
-experiment_id: skill-tests-default
-description: "Default experiment for activation and smoke tests — loads the full UiPath skills plugin"
+experiment_id: skill-tests-integration
+description: "Integration tests — longer timeouts for complex multi-step scenarios"
 
 defaults:
-  max_iterations: 1
-  task_timeout: 600
+  max_iterations: 2
+  task_timeout: 900
   turn_timeout: 300
 
   agent:
     type: claude-code
     permission_mode: acceptEdits
     model: claude-sonnet-4-6
-    max_turns: 20
+    max_turns: 30
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
     plugins:
       - type: "local"

--- a/tests/tasks/uipath-maestro-flow/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/init_validate.yaml
@@ -3,17 +3,7 @@ description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to create
   a new UiPath Flow project inside a solution and validate it. Tests whether
   the skill teaches the correct solution-first workflow and CLI usage.
-tags: [skill, flow, init, validate, smoke]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  model: claude-sonnet-4-6
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  plugins:
-    - type: "local"
-      path: "$SKILLS_REPO_PATH"
-  max_turns: 20
+tags: [uipath-maestro-flow, smoke, init, validate]
 
 sandbox:
   driver: tempdir
@@ -96,8 +86,3 @@ success_criteria:
         expected: 3
     weight: 2.0
     pass_threshold: 0.75
-
-max_iterations: 2
-
-llm_reviewer:
-  enabled: true

--- a/tests/tasks/uipath-maestro-flow/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/registry_discovery.yaml
@@ -3,16 +3,10 @@ description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to explore
   available Flow node types via the registry. Tests whether the skill teaches
   the correct registry workflow (pull, list/search, get).
-tags: [skill, flow, registry, smoke]
+tags: [uipath-maestro-flow, smoke, registry]
 
 agent:
   type: claude-code
-  permission_mode: acceptEdits
-  model: claude-sonnet-4-6
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  plugins:
-    - type: "local"
-      path: "$SKILLS_REPO_PATH"
   max_turns: 14
 
 sandbox:
@@ -95,8 +89,3 @@ success_criteria:
       - "core.action.script"
     weight: 1.0
     pass_threshold: 1.0
-
-max_iterations: 2
-
-llm_reviewer:
-  enabled: true

--- a/tests/tasks/uipath-maestro-flow/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/slack_channel_description/slack_channel_description.yaml
@@ -1,0 +1,74 @@
+task_id: uipath-flow-slack-channel-description
+description: >
+  Create a UiPath Flow that uses the Slack IS connector to retrieve the
+  channel description of #office-bellevue and outputs it. This is an
+  end-to-end test that exercises connector discovery, connection binding,
+  reference resolution, node configuration, and cloud debug execution.
+tags: [uipath-maestro-flow, e2e, connector, slack]
+
+agent:
+  type: claude-code
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow named "SlackChannelDescription" that retrieves
+  the channel description of #office-bellevue and outputs it.
+
+success_criteria:
+  # ── CLI usage ────────────────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent initialized a Flow project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+flow\s+init\s+.*SlackChannelDescription'
+    min_count: 1
+    weight: 0.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent explored the node registry for Slack connectors"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+flow\s+registry\s+(search|list|get)'
+    min_count: 1
+    require_success: false
+    weight: 0.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed or pinged IS connections"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+connections\s+(list|ping)'
+    min_count: 1
+    require_success: false
+    weight: 0.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent resolved the channel reference"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+execute'
+    min_count: 1
+    require_success: false
+    weight: 0.5
+    pass_threshold: 1.0
+
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/SlackChannelDescription.flow',recursive=True) or glob.glob('**/*.flow',recursive=True); sys.exit(1) if not flows else sys.exit(subprocess.run(['uip','flow','validate',flows[0]]).returncode)\""
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── End-to-end execution ────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow debug runs successfully and output contains the Bellevue office address"
+    command: "python3 $TASK_DIR/check_channel_description.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Replace the single e2e test runner with a structured evaluation framework using four test types (activation, smoke, integration, e2e) distinguished by tags.

Changes:
- Add experiment configs per test type (default, integration, e2e) with appropriate timeouts and turn limits
- Optimize existing test YAMLs to inherit agent config from experiments instead of duplicating it
- Update Makefile with per-type targets and cross-platform file discovery
- Rename CI workflow to smoke-skills.yml (runs smoke tests on PRs only)
- Expand tests/README.md with evaluation framework docs, real examples from existing tests, success criteria reference, and debugging guide
- Add test quality checklist to CONTRIBUTING.md requiring activation, smoke, and e2e tests for new skills
- Added `slack_channel_description` as an e2e test for `uipath-maestro-flow`