### PR TITLE
feat(aops-governance): add uipath-aops-governance skill [PLT-100543]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -55,6 +55,9 @@
 # Diagnostics
 /skills/uipath-diagnostics/ @MarinRzv @dmorosanu @vladimir-cozma @costin-uipath @Stefan-Virgil
 
+# AOps Governance skill
+/skills/uipath-gov-aops-policy/ @UiPath/AuthZ @sriramva-uipath @bansal-anushree @jianjunwang2
+
 # Test skill (reports, manual test automation, manual test execution)
 /skills/uipath-test/ @vaishalisharma-uipath @amoluipath
 

--- a/skills/uipath-gov-aops-policy/SKILL.md
+++ b/skills/uipath-gov-aops-policy/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: uipath-gov-aops-policy
+description: "[PREVIEW] UiPath AOps governance — enforce rules (\"block/restrict/require X\") by mapping intent to a Product policy via `uip gov aops-policy`. Create/update/delete/list/deploy policies to users, groups, tenants. For platform ops→uipath-platform."
+allowed-tools: Bash, Read, Write, Grep, Glob
+---
+
+# UiPath AOps Governance
+
+Skill for managing AOps governance policies and deploying them to users, groups, or tenants via the `uip gov aops-policy` CLI.
+
+> **Terminology.** "AOps" = **Automation Ops** (a.k.a. AutomationOps), UiPath's governance console. An "AOps policy" — managed via `uip gov aops-policy` and this skill — is an **Automation Ops Governance Policy** covering product runtime / design-time behavior (Studio, StudioX, Assistant, Robot, AI Trust Layer, …). This is **distinct from a Governance Access Policy** (identity / role / access control), which this skill does NOT cover.
+
+## When to Use This Skill
+
+Activate on both **explicit policy requests** and **natural-language governance intent** — users rarely say "AOps policy" by name.
+
+**Explicit requests:**
+- User asks to create, update, delete, list, or get a governance policy
+- User asks to deploy a policy to a user, group, or tenant
+- User asks to check the effective (deployed) policy for a user, group, or tenant
+- User asks about `uip gov aops-policy` commands
+- User asks to configure policy field values for a product
+
+**Governance intent (rule/policy patterns without naming the product):**
+- "I want to **block / restrict / disable / disallow** X for my users / team / tenant"
+- "I want to **require / enforce / mandate** X"
+- "I want to **allow only** X / **limit** users to X"
+- "How do I **govern / control / gate** who can do X"
+- "Set up a **rule / guardrail / policy** that does X"
+- "Users / agents / robots should / should not be able to X"
+- "Stop Assistant popping up", "auto-launch Assistant", "disable Marketplace widget" → Assistant policy (see [aops-governance-recipes-guide.md](./references/aops-governance-recipes-guide.md) A-recipes)
+- "Only allow automating outlook.exe / excel.exe", "block regedit / cmd.exe", "whitelist internal URLs", "block emails to gmail" → Robot runtime rules RT-UIA-001 / RT-OUT-001 (R-recipes)
+- "Enforce analyzer before publish", "require release notes", "whitelist our GitHub repos", "force everyone to include our custom analyzer package (ST-USG-027)" → Studio policy (S-recipes)
+- "Hide developer panel in StudioX", "stop citizen devs saving projects locally" → StudioX policy (X-recipes)
+
+These are AOps governance requests — treat them as a `create policy` flow starting at [aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md) Step 1, Case B (intent-based product selection). See the intent-mapping examples below to prime product selection, and [aops-governance-recipes-guide.md](./references/aops-governance-recipes-guide.md) for the field mappings behind each recipe.
+
+## Recognize Governance Intent → Pick a Product Policy
+
+When the user expresses a governance rule without naming a product, your job is to map the **intent keywords** to the right **Product policy**. The bootstrap (every product's `form-template-locale-resource.json`) is the source of truth — always rank products by locale-keyword matches (aops-policy-manage-guide Step 1, Case B). These examples are priors to narrow the search, not a substitute for grepping the locale files:
+
+| User says... | Likely Product | Signal keywords to grep |
+|---|---|---|
+| "block Gemini / Claude / ChatGPT", "restrict which LLMs agents can use", "disable external AI models" | `AITrustLayer` | model names, "provider", "feedback", "region" |
+| "lock down Studio", "disable Studio feedback / telemetry", "restrict Studio packages / activities" | `Development` (Studio) | "feedback", "package", "activity", "publish" |
+| "control StudioX citizen-dev features", "restrict business-user automations" | `Business` (StudioX) | "StudioX", "citizen", "template" |
+| "govern what Robot can run", "restrict attended / unattended runtime" | Robot product (check bootstrap) | "runtime", "process", "attended" |
+| "control Agents / Agent Builder features", "restrict agent tool access" | Agents product (check bootstrap) | "agent", "tool", "builder" |
+| "enforce a tenant-wide default", "apply to everyone in the tenant" | *Any product* — this is a **deployment** signal, not product selection. Route to [aops-policy-deploy-guide.md](./references/aops-policy-deploy-guide.md) after create. | — |
+
+**Workflow for intent-based requests:**
+1. Run the bootstrap (aops-policy-manage-guide Step 1) to materialize every product's schema.
+2. Extract intent keywords from the user's phrasing.
+3. Rank products by `Grep` matches on each product's `form-template-locale-resource.json` (Case B). Present the top 3.
+4. Do NOT hard-code the mapping above — always verify against the live locale files. Product names and fields change per release.
+5. If intent is ambiguous (matches multiple products) or zero products match, ask the user to clarify before proceeding.
+
+## Critical Rules
+
+1. Always use `uip login` before running any `uip gov aops-policy` commands.
+2. Always use the product `name` (identifier) in CLI commands, not the `label` shown to the user.
+3. For `create`: always bootstrap before selecting or confirming a product. Run `uip gov aops-policy template list --output-dir "$SESSION_DIR/products" --output json` — this writes each product's `form-template.json` (whose top-level `product` object holds `{name, label}`), `form-data.json`, and `form-template-locale-resource.json` into `$SESSION_DIR/products/<ProductName>/`. The product catalog is implicit — enumerate products with the `Glob` tool on `$SESSION_DIR/products/*/form-template.json` and read `.product.{name, label}`. Do NOT create a separate `products.json` or run `product list`. Use the bootstrapped schemas to validate the user's chosen product against their stated intent; if the intent's fields live under a different product, suggest that product instead.
+4. For `create`, read the form template, default form data, and locale labels from `$SESSION_DIR/products/<ProductName>/` (produced by the bootstrap). For `update`, the caller creates `$SESSION_DIR` first (see aops-policy-manage-guide update Step 1) and then configure-guide runs `template get` with `--output-form-data` and `--output-template-locale-resource` into the same per-product subfolder. Use the locale file for human-readable labels and the form-data (create) or existing policy data (update) for the working blueprint. Prefer Mode A (intent-based auto-fill) over field-by-field prompting whenever the user supplied any intent. Do not construct policy data JSON manually.
+5. Use the component `key` as the JSON key in policy data — never the label or humanized name.
+6. Write the raw policy data object to the data file — do not wrap it in `{ "data": {...} }`. The final policy data file must match the format of the form-data file produced by `template get --output-form-data`.
+7. Omit optional flags (`--description`, `--priority`, `--availability`) if the user skips them — do not pass empty strings.
+8. Stop and show the error to the user if any command fails.
+9. For `update`: always `get` the existing policy first and show its current values before asking what to change. **Use the existing policy's `Data.data` as the update blueprint** (`jq '.Data.data' > "$SESSION_DIR/existing-policy-data.json"`) — NOT the product's default `form-data.json`. Using the product defaults as the update blueprint would silently wipe every non-default setting the user previously configured.
+10. For `delete`: always `get` the policy and show a summary, then ask for explicit confirmation before running the delete command.
+11. **Prompt only for missing information.** If the user's original request already supplied a value (product, policy name, description, priority, or field intent), use it silently. Do not re-confirm values the user already provided. Confirm unchanged defaults is never required — silence means "keep defaults".
+12. **Single confirmation gate per mutation.** Exactly one yes/no review precedes each `create`, `update`, or `delete` call. Do not add intermediate yes/no gates (no per-page confirmation, no "save this configuration?" after configure). The caller in [aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md) owns the final review.
+13. **Never ask the user to edit this skill.** Do not suggest that the user add their request as an example to `SKILL.md`, a reference file, or any other part of the skill. The user's job is to describe what they want governed; your job is to execute the existing flow (bootstrap → Case A/B → configure → review → create). If the user's intent does not map to any product after the bootstrap + locale grep, ask them to clarify the rule or pick a product from the list — do NOT propose skill edits as a workaround.
+14. **Deployment precedence is User > Group > Tenant.** Pick the narrowest scope that matches the user's ask. "Apply to one person" → user-level deployment. "Exception for team X" → group-level (the tenant rule still covers everyone else). "Everyone in the tenant" → tenant-level. See [aops-policy-deploy-guide.md — Deployment precedence](./references/aops-policy-deploy-guide.md#deployment-precedence).
+15. **Every create/update review MUST show Priority + the current #1 holder.** Before the single review gate, run `uip gov aops-policy list --product-name "$PRODUCT_NAME" --order-by priority --order-direction asc --output json` — even when the user already supplied a priority — and cite the policy at priority 1 (name + GUID) next to the proposed priority in the review block, along with a one-line rank-impact note ("placed last — does not reorder existing winners" vs. "outranks <name> at the group level"). Omitting this row silently lets the user approve a priority whose group-level consequences they never saw. Exact format: [aops-policy-manage-guide.md — Step 4](./references/aops-policy-manage-guide.md#step-4--final-review-before-create-single-confirmation-gate).
+16. **Every create/update review MUST include a clickable `Policy data` link with the full absolute path to `$SESSION_DIR/aops-policy-data.json`.** Render it as a markdown link (`[aops-policy-data.json](/absolute/path/to/.../aops-policy-data.json)`) using the **resolved absolute path** — never a relative path, a literal `<SESSION_DIR>` placeholder, or a `~/` path. Run `realpath` (or equivalent) to resolve. This is the user's only chance to inspect every composed field (including defaults not surfaced in the changed-settings diff) before the mutation runs. Reviews without this link are incomplete — do not call `create` / `update` after an incomplete review. Exact format: [aops-policy-manage-guide.md — Step 4](./references/aops-policy-manage-guide.md#step-4--final-review-before-create-single-confirmation-gate) and [Step 5](./references/aops-policy-manage-guide.md#step-5--final-review-before-update-single-confirmation-gate).
+17. **Do NOT show an `Availability:` row in the create/update review unless the user explicitly supplied a value.** Availability is the offline grace period (in days) during which a client (Studio, Assistant, etc.) keeps applying the cached copy of this policy when it cannot reach Automation Ops. It is almost always left at the server default, and surfacing it as `(none)` adds noise to the review. When the user did supply it, show it inline alongside Priority (e.g. `Priority: 4, Availability: 30`) rather than as a standalone row. Semantics: must be an integer > 0; sending `0` causes the server to normalize to `30`; when multiple products contribute to a merged policy response, the smallest `availability` across contributors wins.
+
+## Quick Start
+
+These steps are for **creating a new policy from scratch**. For existing policies or targeted operations, jump straight to the relevant guide via the [Task Navigation](#task-navigation) table below.
+
+### Step 0 — Verify the `uip` CLI
+
+```bash
+which uip && uip --version
+```
+
+If not installed (both commands fail):
+```bash
+npm install -g @uipath/uipcli
+```
+
+### Step 1 — Check login status
+
+All `uip gov aops-policy` commands require authentication.
+
+```bash
+uip login status --output json
+```
+
+If not logged in:
+```bash
+uip login                                          # interactive OAuth (opens browser)
+uip login --authority https://alpha.uipath.com     # non-production environments
+```
+
+### Step 2 — Create a session directory and bootstrap every product's schema
+
+Isolate scratch files for this run in a session directory, then fetch every product's form template, default form data, and locale resource in a single call (Critical Rule #3).
+
+```bash
+SESSION_DIR="./aops-sessions/$(date +%Y%m%d-%H%M%S)-$(uuidgen | cut -c1-8 | tr '[:upper:]' '[:lower:]')"
+mkdir -p "$SESSION_DIR/products"
+uip gov aops-policy template list --output-dir "$SESSION_DIR/products" --output json
+```
+
+This writes `form-template.json`, `form-data.json`, and `form-template-locale-resource.json` into `$SESSION_DIR/products/<ProductName>/` for every product. The product catalog is implicit — enumerate products with `Glob` on `$SESSION_DIR/products/*/form-template.json` and read `.product.{name, label}`.
+
+See [configure-aops-policy-data-guide.md — Step 1](./references/configure-aops-policy-data-guide.md) for the full bootstrap procedure.
+
+### Step 3 — Select the product
+
+Two cases, per [aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md):
+
+- **Case A — user named the product.** Use it silently (Critical Rule #11). Validate that the user's stated intent maps to fields in that product's schema; if not, suggest the better-fitting product.
+- **Case B — infer from intent.** Extract intent keywords and use `Grep` against every product's `form-template-locale-resource.json` to rank matches. Present the top 3 and let the user confirm. See the intent-mapping table above for priors.
+
+### Step 4 — Configure policy data
+
+Prefer **Mode A (intent-based auto-fill)** over **Mode B (field-by-field prompting)** whenever the user supplied any intent (Critical Rule #4).
+
+- Walk the form.io component tree in `form-template.json`.
+- Apply user intent to matching components using their `key` (never the label — Critical Rule #5).
+- Look up labels from `form-template-locale-resource.json` when surfacing choices to the user.
+- Write the resulting raw object to `$SESSION_DIR/aops-policy-data.json` — do NOT wrap it in `{ "data": {...} }` (Critical Rule #6).
+
+See [configure-aops-policy-data-guide.md](./references/configure-aops-policy-data-guide.md) for the full component-tree traversal.
+
+### Step 5 — Single review gate
+
+Show only the **changed** values (not unchanged defaults) and require an explicit `yes`. This is the only confirmation gate in the entire create flow (Critical Rule #12). Use the canonical wording from [Confirmation-gate wording](#confirmation-gate-wording) below.
+
+The review block MUST include:
+- A `Priority` row with (a) the proposed priority number, (b) the current #1 holder's policy name and GUID, and (c) a one-line rank-impact note (Critical Rule #15).
+- A `Policy data` row with a clickable markdown link to the composed `$SESSION_DIR/aops-policy-data.json` — using the resolved path, not a `<SESSION_DIR>` placeholder (Critical Rule #16).
+
+See [aops-policy-manage-guide.md — Step 4 review template](./references/aops-policy-manage-guide.md#step-4--final-review-before-create-single-confirmation-gate) for the exact format. If you skipped the priority-landscape `list` call in Step 3, run it before showing the review — the user cannot consent to the rank impact without seeing whose position the new policy is landing behind.
+
+### Step 6 — Create
+
+```bash
+uip gov aops-policy create \
+  --product-name "<PRODUCT_NAME>" \
+  --name "<POLICY_NAME>" \
+  --input "$SESSION_DIR/aops-policy-data.json" \
+  --output json
+```
+
+Omit `--description`, `--priority`, `--availability` if the user did not supply them (Critical Rule #7). Stop and surface the error if the command fails (Critical Rule #8).
+
+### Step 7 — Post-create choice
+
+Use `AskUserQuestion` to offer next steps. See **Completion Output** below for the exact dropdown.
+
+## Anti-patterns
+
+- Do NOT construct policy data JSON manually or guess field keys — every key and nested structure must be derived from the form.io component tree in `form-template.json`, and every value must start from `form-data.json` (create) or `Data.data` (update). Hand-written JSON silently drops or mis-names fields, producing policies that look fine to the CLI but do nothing at runtime.
+- Do NOT guess field labels from the component `key` — humanizing the key (e.g., `feedbackEnabled` → "Feedback Enabled") is often wrong. Look the label up in `form-template-locale-resource.json` first.
+- Do NOT shortcut the bootstrap by running `template get` for a single product in the create flow — you need every product's schema in `$SESSION_DIR/products/` to rank intent matches against live locale files (Rule #3).
+- Do NOT pick a product from the intent-mapping table above without also grepping the live locale files — product names and fields drift per release. The table is a prior, not the answer.
+- Do NOT dismiss a "block / restrict / require / enforce" request as out of scope because the user didn't say the word "policy" — these are governance intents that belong to this skill.
+- Do NOT write runtime-rule policies (RT-UIA-001 application/URL lists, RT-OUT-001 email blocklist) with empty parameter arrays. The rules are enabled by default but enforce nothing until their `AllowedApplications` / `BlockedURLs` / `BlockedEmails` lists are populated. If the user's intent didn't supply values, surface the no-op to them before creating. See [aops-governance-recipes-guide.md — R1/R2/R3](./references/aops-governance-recipes-guide.md#robot-runtime-analyzer-recipes).
+- Do NOT deploy a product policy to a license type that doesn't include that product (e.g. an Assistant policy to the `Unattended` license type — it only covers Robot). Check the license-type → product coverage in [aops-policy-commands.md — license-type list](./references/aops-policy-commands.md#uip-gov-aops-policy-license-type-list) before building the tenant assignment file.
+- Do NOT assume enforcing a Studio policy activates the default Workflow Analyzer rule set. Once governance is enforced, every built-in rule becomes DISABLED unless explicitly listed in `Analyzer.EmbeddedRulesConfig.Rules` with `IsEnabled: true`. If the user asks to "enforce Workflow Analyzer" without naming rules, ask which rules matter or apply a CoE baseline and confirm — do not save an empty `Rules` array. See [aops-governance-recipes-guide.md — S3](./references/aops-governance-recipes-guide.md#s3--enable-and-configure-workflow-analyzer-rules).
+- Do NOT promise a cloud policy will apply to clients that aren't Interactively Signed-In to Orchestrator. Studio / StudioX / Assistant connected via unattended or service-account sign-in ignore cloud-deployed policies. If a user reports "my policy isn't taking effect", check the client's sign-in mode before debugging the policy contents.
+
+## Task Navigation
+
+| I need to... | Read these |
+| --- | --- |
+| **Create a new policy from intent** | Quick Start + [aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md) (Case B) + [configure-aops-policy-data-guide.md](./references/configure-aops-policy-data-guide.md) |
+| **Create a policy when the user named the product** | [aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md) (Case A) + [configure-aops-policy-data-guide.md](./references/configure-aops-policy-data-guide.md) |
+| **Update an existing policy** | [aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md) — blueprint from `Data.data`, NOT `form-data.json` (Rule #9) |
+| **Delete a policy** | [aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md) — show summary + explicit `yes` (Rule #10) |
+| **List policies** | [aops-policy-manage-guide.md — List](./references/aops-policy-manage-guide.md) |
+| **Get a single policy by GUID** | [aops-policy-manage-guide.md — Get](./references/aops-policy-manage-guide.md) |
+| **Deploy a policy to a user / group / tenant** | [aops-policy-deploy-guide.md](./references/aops-policy-deploy-guide.md) |
+| **Query what policy is deployed to a tenant** | [aops-policy-deployed-guide.md](./references/aops-policy-deployed-guide.md) — use `get` |
+| **Query what rules effectively apply to me** | [aops-policy-deployed-guide.md](./references/aops-policy-deployed-guide.md) — use `list` |
+| **Find a canonical recipe for a common governance intent** | [aops-governance-recipes-guide.md](./references/aops-governance-recipes-guide.md) — check here first; apply the recipe's product + field mapping before field-by-field prompting |
+| **Configure individual field values (form.io traversal)** | [configure-aops-policy-data-guide.md](./references/configure-aops-policy-data-guide.md) |
+| **Recognize a governance intent** | Intent-mapping table at the top of this SKILL.md |
+| **Pick the right product for an intent** | Bootstrap (Step 2) + `Grep` on locale files (Rule #3) + intent-mapping table |
+
+## Key Concepts
+
+### Bootstrap and the implicit product catalog
+
+`uip gov aops-policy template list --output-dir <dir>` writes every product's `form-template.json`, `form-data.json`, and `form-template-locale-resource.json` into `<dir>/<ProductName>/`. There is no separate `product list` step — enumerate products by globbing the bootstrapped directory and reading the top-level `product` object from each `form-template.json`. This is the source of truth (Critical Rule #3).
+
+### Case A vs Case B
+
+- **Case A** — the user named the product. Use it silently; validate intent against its schema.
+- **Case B** — the user described a rule but did not name a product. Rank products by `Grep` matches on each `form-template-locale-resource.json`. Present top 3.
+
+### Deployed policy vs effective rules
+
+| Command | Returns | Use when |
+|---------|---------|----------|
+| `deployed-policy get` | Tenant-level deployed policy assignment for a `(licenseType, product, tenant)` | "What policy is deployed to this tenant?" |
+| `deployed-policy list` | Effective rule values for the calling user after the user → group → tenant chain | "What rules actually apply to me?" |
+
+See [aops-policy-deployed-guide.md](./references/aops-policy-deployed-guide.md).
+
+### Product name vs product label
+
+The product `name` is the CLI identifier (e.g., `Development`, `AITrustLayer`). The `label` is the human display string. Always pass `name` to CLI flags; surface `label` only in user-facing messages (Critical Rule #2).
+
+### Session directory
+
+Scratch space for a single run: `./aops-sessions/<YYYYMMDD-HHMMSS>-<short-uuid>/`. Holds bootstrapped product schemas under `products/<ProductName>/`, the working `aops-policy-data.json`, and (for update) `existing-policy-data.json`. Reuse `$SESSION_DIR` across related operations such as configure → deploy.
+
+### Priority rules
+
+Priority is **NOT** what decides which policy wins across user / group / tenant — that's the resolution chain (User > Group > Tenant), which is determined by scope, not by Priority. Priority only ever matters as a **tie-breaker within the same level**, and in practice it only actually breaks ties at the **group level**:
+
+| Level | Can multiple policies compete for the same product? | Role of Priority |
+|-------|-----------------------------------------------------|------------------|
+| User   | No — each `(user, product)` has at most one assignment. | None. Priority has no effect. |
+| Group  | **Yes** — a user can belong to multiple groups, each with its own policy for the same product. | **Tie-breaker.** Lowest priority number wins among the competing group assignments. |
+| Tenant | No — each `(tenant, product, licenseType)` has exactly one assignment. | None. Priority has no effect. |
+
+Outside of the group-level tie-breaker, Priority is essentially an admin-facing ordering hint (it controls the order policies appear in the Automation Ops catalog / `aops-policy list`, not which one applies at runtime).
+
+**Practical consequence for the create flow:** default a new policy to the **largest existing priority + 1** (i.e. place it *last*), so creation never silently reorders the group-level tie-breaker outcome for existing users. Only lower the number when the user explicitly asks for the new policy to outrank specific existing policies at the group level. Always explain this before prompting for a priority value. See also [Deployed policy vs effective rules](#deployed-policy-vs-effective-rules) for how scope resolution works.
+
+### Confirmation-gate wording
+
+Every mutation runs through a single yes/no review (Critical Rule #12). Use these templates verbatim so wording stays consistent across the skill:
+
+| Operation | Template |
+|-----------|----------|
+| Create | `Create policy "<POLICY_NAME>" for <PRODUCT_LABEL>? (yes / no / keep editing)` |
+| Update | `Apply update to policy "<POLICY_NAME>"? (yes / no / keep editing)` |
+| Delete | `Delete policy "<POLICY_NAME>"? This cannot be undone. (yes / no)` |
+| Deploy (any subject) | `Apply these changes to <SUBJECT_NAME>? (yes / no)` |
+| Deployment delete-all | `Delete all policy assignments for <SUBJECT_NAME>? This cannot be undone. (yes / no)` |
+| Tenant remove | `Remove <PRODUCT_LABEL> assignment from <TENANT_NAME>? This cannot be undone. (yes / no)` |
+
+`keep editing` is treated the same as `no` — route the user back to the relevant step (metadata / field-configure / subject-pick) and re-enter the review gate only after the change is applied.
+
+### Mode A vs Mode B (policy data configuration)
+
+- **Mode A (auto-fill)** — prefer whenever the user supplied any intent. Walk the form.io tree and apply the intent to matching components automatically.
+- **Mode B (field-by-field)** — fall back only when the user has no stated intent or explicitly asks to see every field.
+
+See [configure-aops-policy-data-guide.md](./references/configure-aops-policy-data-guide.md).
+
+## Completion Output
+
+When you finish a mutating operation, report:
+
+1. **Operation & result** — e.g., `Created policy <name> (GUID: <guid>) for product <productName>`.
+2. **Session directory** — print `$SESSION_DIR` so the user can inspect bootstrapped schemas and the `aops-policy-data.json` that was submitted.
+3. **Non-default fields set** — summary of fields the user configured vs. ones that stayed at defaults. (Omit this line after `delete`.)
+4. **Next step** — use `AskUserQuestion` to present a dropdown with these options (single post-mutation gate, per Critical Rule #12):
+
+| Option | Action |
+|--------|--------|
+| **Deploy to a user** | Hand off to [aops-policy-deploy-guide.md](./references/aops-policy-deploy-guide.md) with subject = user. |
+| **Deploy to a group** | Hand off to [aops-policy-deploy-guide.md](./references/aops-policy-deploy-guide.md) with subject = group. |
+| **Deploy to the tenant** | Hand off to [aops-policy-deploy-guide.md](./references/aops-policy-deploy-guide.md) with subject = tenant. |
+| **List policies to verify** | Run `uip gov aops-policy list --output json` and show the new/updated entry. |
+| **Query effective rules** | Run `deployed-policy list` (or `get`) per [aops-policy-deployed-guide.md](./references/aops-policy-deployed-guide.md). |
+| **Something else** (last option) | Accept free-form string input and act on it (e.g., "just leave it", "export the policy data", "create another one"). |
+
+Do not run any of these actions automatically. Wait for the user's selection.
+
+**Per-operation adjustments to the dropdown:**
+- After `create` or `update`: offer all options above.
+- After `deploy`: replace the three Deploy options with a single **Verify deployment** option that runs `deployed-policy get <licenseType> <productName> <tenantIdentifier>` to confirm the assignment took effect. Keep **Query effective rules** (via `deployed-policy list`) as the follow-up check for chain-resolved values.
+- After `delete`: offer only **List policies to verify** and **Something else**.
+
+## References
+
+- **[aops-policy-commands.md](./references/aops-policy-commands.md)** — Single source of truth for every `uip gov aops-policy` subcommand, its flags, input/output shapes, and authentication modes (including S2S token acquisition). Every other guide links here for command details rather than inlining them.
+- **[aops-policy-manage-guide.md](./references/aops-policy-manage-guide.md)** — Full CRUD lifecycle: list, get, create, update, delete. Owns the single final-review gate before every mutation. Documents Case A (user-named product) vs Case B (intent-based selection).
+- **[configure-aops-policy-data-guide.md](./references/configure-aops-policy-data-guide.md)** — Form.io component-tree traversal, locale lookups for human-readable labels, Mode A (intent-based auto-fill) vs Mode B (field-by-field), and the bootstrap of every product's schema into `$SESSION_DIR/products/`.
+- **[aops-policy-deploy-guide.md](./references/aops-policy-deploy-guide.md)** — Assign policies to user / group / tenant via `deployment <subject> configure --input`. Non-interactive: the agent builds the assignment JSON, calls `configure --input`, and verifies with `deployment <subject> get`.
+- **[aops-policy-deployed-guide.md](./references/aops-policy-deployed-guide.md)** — Query the single effective policy (`get`) vs every applicable rule for the calling user (`list`). Positional argument reference (`<LICENSE_TYPE> <PRODUCT_NAME> <TENANT_ID>`) and S2S flag semantics (`--s2s-token`, `--user-id`, `--tenant-only`).

--- a/skills/uipath-gov-aops-policy/references/aops-governance-recipes-guide.md
+++ b/skills/uipath-gov-aops-policy/references/aops-governance-recipes-guide.md
@@ -1,0 +1,226 @@
+# Governance Recipes Guide
+
+Common governance intents mapped to the product policy and fields that implement them. Use these as **priors** for Mode A auto-fill in [configure-aops-policy-data-guide.md](./configure-aops-policy-data-guide.md) — always grep the live `form-template-locale-resource.json` for the listed keywords to confirm the field keys still exist in the current template version before writing values.
+
+> **How to use this file.** When the user's intent matches a recipe, apply its field mapping first, then fall back to general locale grep for anything unmapped. Do NOT hard-code these keys without verifying them in the current template — product fields drift between template versions (22.4, 23.10, 24.10.1, ...).
+
+---
+
+## Prerequisites that shape every recipe
+
+These platform-level conditions affect whether a deployed policy actually takes effect. Verify them before creating policies, and surface them to the user if unmet:
+
+1. **Interactive Sign-In is required on the client.** Studio / StudioX / Assistant must be connected to Orchestrator via Interactive Sign-In for a cloud-deployed policy to apply. A machine running under an unattended/service account without interactive login will not pick up the policy. If the user asks "why isn't my policy taking effect?", check this first.
+2. **Runtime governance is off until the tenant's first Robot policy is deployed.** All RT-* runtime rules (R1–R3 below) require runtime governance to be enabled at the tenant level. The Automation Ops UI shows a banner "Runtime governance is disabled" until the first Robot policy is deployed — enabling it is tenant-wide from that moment (see R4).
+3. **Enforcing a Studio governance policy disables every built-in Analyzer rule by default.** Once a Studio policy is enforced, the default rule set does not ship with it — each rule must be listed explicitly in `Analyzer.EmbeddedRulesConfig.Rules` with `IsEnabled: true`. Silently enforcing governance without enumerating rules is a common reason CoEs report "our analyzer got quieter after we rolled out governance" (see S3).
+4. **Legacy file-based governance is overridden on deployment.** An Automation Ops policy supersedes any local or JSON governance file on the developer's machine. If the org already has a legacy JSON governance file, import it via the Automation Ops UI before rolling out a new policy so existing rules are not lost.
+
+---
+
+## How recipes are structured
+
+Each recipe lists:
+
+- **Intent keywords** — user phrases that trigger it (feed these to `Grep` against the locale resource).
+- **Product** — the `product.name` to pass to `--product-name` on `create`.
+- **Fields** — candidate component `key`s and the values that implement the rule.
+- **Notes** — empty-parameter warnings, license-type compatibility, template-version hints.
+
+Field names below reflect the doc's example JSON; the live `form-template.json` for your tenant may use slightly different keys. Always verify against the bootstrapped schema.
+
+---
+
+## Assistant recipes
+
+### A1 — Minimize Assistant while a process is running
+
+- **Intent keywords:** "stop Assistant popping up", "Assistant keeps appearing", "Assistant pops up during runs", "minimize Assistant while running", "don't interrupt users when a bot runs"
+- **Product:** Assistant policy
+- **Fields:** `MinimizeAssistantWhileRunning: true` (under Feature Toggles).
+- **Notes:** Requires users to sign into Assistant with interactive sign-in for the policy to apply. No parameters — simple toggle.
+
+### A2 — Auto-launch Assistant at Windows startup
+
+- **Intent keywords:** "Assistant should start with Windows", "launch Assistant automatically", "make sure users never miss a scheduled job"
+- **Product:** Assistant policy
+- **Fields:** `AutoLaunchAssistant: true`.
+- **Notes:** Opposite intent (do NOT auto-launch) → `false`.
+
+### A3 — Disable the UiPath Marketplace widget
+
+- **Intent keywords:** "disable Marketplace widget", "stop users installing from Marketplace", "block community automations in Assistant", "only allow vetted automations"
+- **Product:** Assistant policy
+- **Fields:** `Widgets.UiPath.Marketplace.Widget: false`.
+- **Notes:** All-or-nothing — there is no per-item allow-list for Marketplace. To offer specific Marketplace automations, download, vet, and republish through Orchestrator or Automation Hub instead.
+
+### A4 — Block custom widgets and external widget feeds
+
+- **Intent keywords:** "only allow official widgets", "block custom widgets", "don't let users add widget feeds"
+- **Product:** Assistant policy
+- **Fields:**
+  - `Widgets.AllowCustomWidgets: false`
+  - `Widgets.UseOfficialWidgetFeed: false` (only Orchestrator feed allowed).
+- **Notes:** Useful as a pair when the goal is "no widget installs outside corporate-hosted feed."
+
+### A5 — Curate individual widget availability
+
+- **Intent keywords:** "enable Apps widget", "disable Automation Store widget", "show only the Apps widget in Assistant"
+- **Product:** Assistant policy
+- **Fields:** individual toggles under `Widgets`, e.g. `UiPath.Apps.Widget`, `UiPath.AutomationStore.Widget`.
+- **Notes:** After deploying, users may need to sign out/in of Assistant for new widgets to appear. Apps widget also requires at least one published App to be visible.
+
+---
+
+## Robot (Runtime Analyzer) recipes
+
+### R1 — RT-UIA-001 application/URL allow-list
+
+- **Intent keywords:** "only allow automating Outlook and Excel", "block automation of cmd.exe / regedit / Start Menu", "restrict which apps robots can automate", "whitelist these applications"
+- **Product:** Robot policy
+- **Fields:** `RT-UIA-001` rule under `RuntimeAnalyzer`:
+  - `AllowedApplications: ["outlook.exe", "excel.exe", ...]` (allow-list mode)
+  - `BlockedApplications: ["cmd.exe", "regedit.exe", ...]` (block-list mode)
+  - `Action: "Error"` (default — stops the robot at runtime on violation)
+- **Notes:** **Do NOT deploy RT-UIA-001 with empty lists — it enforces nothing.** If the user names apps, populate the list; if they don't, surface that the rule will be a no-op and ask what to include. Test in a non-production tenant first; an overly tight allow-list can halt production jobs.
+
+### R2 — RT-UIA-001 web URL allow/block-list
+
+- **Intent keywords:** "only allow internal domains", "block automation of gmail.com / facebook.com", "restrict web automation to *.internalcompany.com"
+- **Product:** Robot policy
+- **Fields:** `RT-UIA-001`:
+  - `AllowedURLs: ["*.internalcompany.com"]` (allow-list)
+  - `BlockedURLs: ["*facebook.com*", "*gmail.com*"]` (block-list)
+  - `Action: "Error"`
+- **Notes:** Same empty-list warning as R1. Use broad patterns carefully — `*gmail.com*` is safer than a bare `gmail.com` to avoid matching unrelated substrings.
+
+### R3 — RT-OUT-001 email recipient blocklist
+
+- **Intent keywords:** "block robots from emailing gmail/yahoo", "stop bots emailing external domains", "no robot emails outside @mycompany.com", "prevent data leak via email"
+- **Product:** Robot policy
+- **Fields:** `RT-OUT-001` rule under `RuntimeAnalyzer`:
+  - `BlockedEmails: ["*@gmail.com", "*@yahoo.com"]` (pattern list)
+  - `Action: "Error"`
+- **Notes:** Same empty-list warning — `BlockedEmails: []` enforces nothing. Blocks the specific Mail / GSuite / Office365 activity packages the rule covers; other email channels (API-based integrations) are not caught by this rule.
+
+### R4 — Enable runtime governance (prerequisite)
+
+- **Intent keywords:** (any runtime-rule intent above) — and the tenant has never deployed a Robot policy.
+- **Product:** Robot policy
+- **Notes:** Runtime governance is off until the first Robot policy is deployed to the tenant. The Automation Ops UI surfaces a "Runtime governance is disabled" banner; the agent should warn the user before the first deployment so they know the effect is tenant-wide from that moment on.
+
+---
+
+## Studio (design-time) recipes
+
+### S1 — Gate Publish/Run on Workflow Analyzer
+
+- **Intent keywords:** "enforce analyzer before publish", "block publish if analyzer errors", "require clean analyzer before running"
+- **Product:** Studio policy (`Development` or equivalent)
+- **Fields:** `Design.EnforceAnalyzerBeforePublish: true`, `Design.EnforceAnalyzerBeforeRun: true`.
+- **Notes:** With these on, any Analyzer rule at `ErrorLevel: "Error"` stops publish/run. Pair with specific rule configs (S3).
+
+### S2 — Require release notes and source-control check-in
+
+- **Intent keywords:** "require release notes on publish", "must check in before publish", "enforce versioning discipline"
+- **Product:** Studio policy
+- **Fields:** `Design.EnforceReleaseNotes: true`, `Design.EnforceCheckInBeforePublish: true`.
+
+### S3 — Enable and configure Workflow Analyzer rules
+
+- **Intent keywords:** "enforce naming conventions", "require camelCase variables", "block hardcoded credentials", "enforce our coding standards"
+- **Product:** Studio policy
+- **Fields:** `Analyzer.EmbeddedRulesConfig.Rules` — array of `{Id, IsEnabled, Parameters, ErrorLevel}`. Well-known rule IDs:
+  - `ST-NMG-001` — variable / argument / activity naming regex. Parameter: `Regex` (e.g. `^[a-z][A-Za-z0-9]*$`).
+  - `ST-SEC-*` — security rules (hardcoded credentials, untrusted sources).
+  - `ST-USG-027` — Required Packages. Parameter: `Packages` — semicolon- or version-suffixed list (e.g. `MyCompany.CustomRulesPackage>=1.0.0`). Used to force developers to include a custom NuGet-packaged analyzer rule.
+- **Notes:**
+  - **Built-in rules are DISABLED by default once governance is enforced.** Every rule you want active must appear in the array with `IsEnabled: true` and a valid `ErrorLevel`. If the user asks you to "enforce Workflow Analyzer" without naming rules, do NOT deploy — ask which rules matter, or apply a CoE baseline (e.g. `ST-NMG-001`, `ST-SEC-*`, `ST-USG-027`) and confirm with the user before saving.
+  - `Analyzer.AllowEdit: false` (default) prevents local overrides. Set to `true` only if the user explicitly wants developers to toggle rules locally.
+  - Set `ErrorLevel: "Error"` for blocking issues, `"Warning"` for stylistic ones. Pair `Error` rules with S1 (`EnforceAnalyzerBeforePublish`) so violations actually block publish.
+  - Runtime rules (R1–R3) are a safety net — always pair with design-time Studio rules so violations are caught at design time first, not only at runtime.
+
+### S4 — Source-control repository whitelist
+
+- **Intent keywords:** "only allow our corporate GitHub", "whitelist these repositories", "block pushing to unauthorized repos"
+- **Product:** Studio policy
+- **Fields:** `SourceControl.AllowedRepositories: ["https://github.com/MyOrg/Repo1.git", ...]`, `SourceControl.AllowEditRepositories: false`.
+- **Notes:** `AllowEditRepositories: false` prevents developers from adding repos; the `AllowedRepositories` list is exhaustive.
+
+### S5 — Restrict package sources (feeds)
+
+- **Intent keywords:** "block public Marketplace feed", "only allow internal NuGet", "no external packages", "use only our vetted feed"
+- **Product:** Studio policy
+- **Fields:**
+  - `Feeds.OfficialFeed: false` (disable UiPath public feed)
+  - `Feeds.MarketplaceFeed: false`
+  - `Feeds.AllowUserDefinedFeeds: false`
+  - `Feeds.CustomFeeds: ["OrchestratorTenantFeed"]` (or an internal URL)
+- **Notes:** Pair with S3 `ST-USG-027` to force a custom NuGet-packaged analyzer rule to be included in every project.
+
+### S6 — Export analyzer results for CI/CD
+
+- **Intent keywords:** "capture analyzer output", "save analysis results for audits", "feed analyzer results into pipelines"
+- **Product:** Studio policy
+- **Fields:** `Design.ExportAnalyzerResults: true`.
+- **Notes:** Each analyzer run writes a JSON report into the project folder; a CI job can aggregate these.
+
+---
+
+## StudioX (Citizen Developer) recipes
+
+### X1 — Hide the developer panel from citizen devs
+
+- **Intent keywords:** "lock down StudioX", "citizen devs shouldn't see developer activities", "hide advanced activities"
+- **Product:** StudioX policy (`Business` or equivalent)
+- **Fields:** `ShowDeveloperPanel: false`.
+
+### X2 — Hide specific activities from StudioX
+
+- **Intent keywords:** "hide Execute Macro", "block WriteRange for business users", "remove these activities from StudioX"
+- **Product:** StudioX policy
+- **Fields:** `ActivitiesToHide: "UiPath.Excel.Activities.Business.WriteRangeX, UiPath.Core.Activities.ExecuteMacro"` (comma-separated activity namespaces).
+
+### X3 — Prevent StudioX as an ad-hoc runtime
+
+- **Intent keywords:** "stop users running the same automation repeatedly in StudioX", "force promotion to Orchestrator", "limit consecutive runs"
+- **Product:** StudioX policy
+- **Fields:** `PermittedConsecutiveRunsWithNoChange: 2` (or similar low integer). After the cap, further runs from StudioX are blocked.
+
+### X4 — Force projects off the local PC
+
+- **Intent keywords:** "don't let citizen devs save to C:", "all projects must go to Orchestrator personal workspace", "no local project storage"
+- **Product:** StudioX policy
+- **Fields:** `AllowSavingProjectLocally: false`.
+- **Notes:** Ensure a valid Orchestrator personal workspace or shared location is configured via the Locations tab in the same policy — otherwise users can't save anywhere.
+
+---
+
+## Deployment recipe — precedence and narrowest scope
+
+When the user asks for a scope-limited rule:
+
+- "Apply to one user only" → deploy at **user** level. Overrides group and tenant for that user.
+- "Apply to the X team / group" → deploy at **group** level. Overrides tenant for group members.
+- "Apply to everyone in this tenant" → deploy at **tenant** level (with a `(product, licenseType)` key). Base-layer default.
+- "Exception for team X that ignores the tenant rule" → deploy a different policy at group level; tenant-level rule still applies to non-members.
+
+Order of effective resolution: **User > Group > Tenant > (no policy)**. See [aops-policy-deploy-guide.md — Deployment precedence](./aops-policy-deploy-guide.md#deployment-precedence) for the decision flow.
+
+---
+
+## Anti-patterns
+
+- Do NOT write runtime-rule policies (RT-UIA-001, RT-OUT-001) with empty parameter arrays — the rule is enabled by default but enforces nothing until populated. Surface this to the user if their intent didn't list any apps / URLs / emails.
+- Do NOT assume a recipe's field `key`s match the live template without grepping. Template versions (22.4 → 23.10 → 24.10.1) occasionally rename or add fields. Verify against `form-template-locale-resource.json` before writing.
+- Do NOT deploy an Assistant-product policy to a license type that doesn't include Assistant (e.g. `Unattended Robot` → Robot only). See [license-type list output](./aops-policy-commands.md#uip-gov-aops-policy-license-type-list) for the product coverage per license type.
+- Do NOT pair "block Marketplace widget" with "allow these specific Marketplace items" — the toggle is all-or-nothing. Re-host vetted automations in a controlled feed instead.
+- Do NOT assume enforcing a Studio policy activates the default Workflow Analyzer rule set. Governance turns EVERY built-in rule off by default — you must enumerate each rule in `Analyzer.EmbeddedRulesConfig.Rules` with `IsEnabled: true`. An empty `Rules` array = zero analyzer enforcement.
+- Do NOT deploy a cloud policy expecting it to apply to clients that aren't Interactively Signed-In to Orchestrator. Unattended / service-account Studio or Assistant installs ignore cloud policies — the user must use Interactive Sign-In.
+
+---
+
+## Related references
+
+- [configure-aops-policy-data-guide.md](./configure-aops-policy-data-guide.md) — Mode A auto-fill consumes these recipes as priors before general locale grep.
+- [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md) — user / group / tenant precedence and license-type compatibility.
+- [aops-policy-commands.md — license-type list](./aops-policy-commands.md#uip-gov-aops-policy-license-type-list) — authoritative mapping of license type `name` → products.

--- a/skills/uipath-gov-aops-policy/references/aops-policy-commands.md
+++ b/skills/uipath-gov-aops-policy/references/aops-policy-commands.md
@@ -1,0 +1,456 @@
+# uip gov aops-policy — CLI Command Reference
+
+Single source of truth for every `uip gov aops-policy` subcommand, its flags, and its output shape. All commands output `{ "Result": "Success"|"Failure", "Code": "...", "Data": { ... } }`. Use `--output json` for programmatic use — every command in this skill must pass it.
+
+> For task workflows (create / update / delete / deploy / query), see the matching `*-guide.md`. This file only documents the command surface.
+
+---
+
+## uip gov aops-policy list
+
+List policies (optionally filtered by product).
+
+```bash
+uip gov aops-policy list --output json
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--product-name <PRODUCT_NAME>` | no | Filter by product name (identifier, not label) |
+| `--product-label <PRODUCT_LABEL>` | no | Filter by product label |
+| `--search <TERM>` | no | Search by name |
+| `--limit <N>` | no | Page size (default: 20) |
+| `--offset <N>` | no | Page index, 0-based (default: 0) |
+| `--order-by <FIELD>` | no | Sort field (e.g. `priority`, `name`) |
+| `--order-direction <asc\|desc>` | no | Sort direction |
+
+**Output:** `Data` is an array of `PolicyDto`. Each entry has `identifier`, `name`, `productName`, `priority`, and `availability`. `productName` is a flat string (the product identifier) — not a nested `product.{name,label}` object. An empty array means no policies matched.
+
+---
+
+## uip gov aops-policy get
+
+Fetch a single policy by GUID. Always run before `update` or `delete`.
+
+```bash
+uip gov aops-policy get <POLICY_IDENTIFIER> --output json
+```
+
+**Output:** `Data` is a `PolicyDto` with `identifier`, `name`, `productName`, `priority`, `availability`, and `data`. `Data.data` is the full form-data blueprint — save it to reuse as the update input (see [aops-policy-manage-guide.md — Update](./aops-policy-manage-guide.md#update-a-policy)).
+
+---
+
+## uip gov aops-policy create
+
+Create a new policy.
+
+```bash
+uip gov aops-policy create \
+  --name "<POLICY_NAME>" \
+  --product-name "<PRODUCT_NAME>" \
+  --input "<SESSION_DIR>/aops-policy-data.json" \
+  --output json
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name <POLICY_NAME>` | yes | Policy display name. Must be non-empty. |
+| `--product-name <PRODUCT_NAME>` | yes | Product identifier (name, not label). |
+| `--input <PATH>` | no | Path to the policy-data JSON. This is the filled form-data blueprint — a flat key/value object, with no `{ "data": {...} }` wrapper; the CLI wraps it under `{ data: ... }` before submission. Omit only when the policy has no data payload. |
+| `--description <TEXT>` | no | Free-form description. Omit entirely if unset — do not pass an empty string. |
+| `--priority <N>` | no | Integer rank used **only as a group-level tie-breaker** when a user is in multiple groups with competing policies for the same product — then the lowest priority number wins. Priority does NOT determine user / group / tenant precedence (that's the scope-resolution chain) and has no effect at the user or tenant level. See [SKILL.md — Priority rules](../SKILL.md#priority-rules). |
+| `--availability <DAYS>` | no | Offline grace period — the number of days the client (e.g. Studio, Assistant) will keep applying the cached copy of this policy when it cannot reach Automation Ops. Integer > 0. Sending `0` is normalized by the server to `30`. When multiple products contribute to a merged policy response, the smallest `availability` across contributors is used. Only pass when the user explicitly supplies a value — otherwise rely on the server default. |
+
+**Output:** `Data.identifier` (new policy GUID), `Data.name`, `Data.productName` (confirmed product identifier — flat string, not a nested object).
+
+---
+
+## uip gov aops-policy update
+
+Update an existing policy. **Full replacement, not a patch** — every field you want to keep must be passed again, including `--name`, `--product-name`, `--description`, `--priority`, `--availability`, AND `--input`. Omitting any of these flags CLEARS that field on the server. `--product-name` must match the policy's existing product (changing product on update is not supported).
+
+```bash
+uip gov aops-policy update \
+  --identifier "<POLICY_IDENTIFIER>" \
+  --name "<POLICY_NAME>" \
+  --product-name "<PRODUCT_NAME>" \
+  --description "<DESCRIPTION>" \
+  --priority <N> \
+  --input "<SESSION_DIR>/aops-policy-data.json" \
+  --output json
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--identifier <GUID>` | yes | Target policy GUID (from `list` or `get`). |
+| `--name <POLICY_NAME>` | yes | Policy name. Required on every update — pass the existing value to preserve it, or a new value to change it. |
+| `--product-name <PRODUCT_NAME>` | yes | Must match the policy's existing product (changing product on update is not supported). |
+| `--description <TEXT>` | conditional | **Full-replace**: omitting this flag CLEARS the description on the server. To preserve the existing value, re-pass it from `policy get`. |
+| `--priority <N>` | conditional | **Full-replace**: omitting this flag CLEARS priority on the server. To preserve the existing value, re-pass it from `policy get`. |
+| `--availability <DAYS>` | conditional | Offline grace period in days (see [create](#uip-gov-aops-policy-create) for semantics). **Full-replace**: omitting this flag CLEARS availability on the server. To preserve the existing value, re-pass it from `policy get`. |
+| `--input <PATH>` | conditional | **Full-replace**: omitting this flag CLEARS the data payload. To preserve existing data, save `Data.data` from `policy get` to a file and re-pass it. Points at the raw form-data object (no `{ "data": {...} }` wrapper). |
+
+> **Template upgrade in progress.** `update` fails with a `template upgrade in progress` error if the underlying Form.io template is being migrated; retry once the upgrade completes.
+
+**Output:** `Data` carries the updated policy's `identifier`, `name`, and `productName`.
+
+---
+
+## uip gov aops-policy delete
+
+Delete a policy. **Destructive — cannot be undone.** Always run `get` first and confirm with the user.
+
+```bash
+uip gov aops-policy delete <POLICY_IDENTIFIER> --output json
+```
+
+> **Fails if the policy is still assigned.** Deletion is blocked if the policy is referenced by any tenant, user, or group assignment. Clear the references first — run `deployment tenant|user|group remove` (or `configure` with a filtered list) on every subject — then retry delete.
+
+**Output:** `Result: "Success"` on deletion. `Data.Status` is `"Deleted"` and `Data.identifier` echoes the deleted GUID.
+
+---
+
+## uip gov aops-policy product list
+
+List products that support governance policies. Products are read-only — registered by the governance service, not created via the CLI.
+
+```bash
+uip gov aops-policy product list --output json
+```
+
+**Output:** `Data` is an array of product entries. Each entry has `identifier` (GUID), `name`, and `label`. Pass `name` (not `label`) to `--product-name`, `template get`, and every `deployment ... configure` entry; `label` is the human-readable display string.
+
+## uip gov aops-policy product get
+
+Fetch a single product record to confirm a product name exists before using it.
+
+```bash
+uip gov aops-policy product get <PRODUCT_NAME_OR_GUID> --output json
+```
+
+The positional argument accepts either the product `name` (e.g. `StudioX`) or its GUID.
+
+**Output:** `Data` has `identifier`, `name`, `label`.
+
+> In the create flow, prefer the bootstrap from `template list` over `product list`. The bootstrap materializes every product's full schema plus catalog metadata in one call — see [configure-aops-policy-data-guide.md — Step 1](./configure-aops-policy-data-guide.md#step-1--bootstrap-load-all-products-and-their-templates-create-flow-only).
+
+---
+
+## uip gov aops-policy license-type list
+
+List license types available to the organization. Required for tenant deployment, where assignments are keyed by `(product, licenseType)`.
+
+```bash
+uip gov aops-policy license-type list --output json
+```
+
+**Output:** `Data` is an array. Each entry has `identifier` (GUID) and `name` (e.g. `Attended`, `Unattended`).
+
+Sample rendering:
+
+```text
+Available license types:
+  1. Attended        (identifier: a1b2c3d4-0000-0000-0000-0000000000A1)
+  2. Unattended      (identifier: a1b2c3d4-0000-0000-0000-0000000000A2)
+```
+
+> **Two different identifiers — do not confuse them:**
+> - For `deployment tenant configure` entries, the JSON `licenseTypeIdentifier` field takes the license type's **`identifier` (GUID)** from `license-type list`.
+> - For `deployed-policy get` / `deployed-policy list`, the positional `<licenseType>` argument takes the license type's **`name`** (e.g. `Attended`).
+
+---
+
+## uip gov aops-policy template list
+
+Fetch every product's form template, default form data, and locale resource in one call. This is the create-flow bootstrap.
+
+```bash
+uip gov aops-policy template list --output-dir "<SESSION_DIR>/products" --output json
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--output-dir <DIR>` | yes | Directory where per-product subfolders are written. |
+
+**Output:** writes three files per product into `<output-dir>/<ProductName>/`:
+
+| File | Purpose |
+|------|---------|
+| `form-template.json` | Raw form.io DTO returned by the governance API. Top-level `.product` object `{name, label}` is the catalog entry. |
+| `form-data.json` | Fillable blueprint — a flat key/value object generated from the template. Display-only components (`hidden`, `button`, `submit`, `htmlelement`, `content`) are omitted. Fields without an explicit default get a type-appropriate default: `false` for checkbox, `[]` for editgrid, `{}` for selectboxes, and `null` for text/select. |
+| `form-template-locale-resource.json` | Locale-resolved reference. Every product-scoped locale key is replaced with its English string; a sibling `<prop>-key` preserves the original key for traceability. `defaultData.data` is replaced with a flat, annotated per-field map `{ value, type, label, description?, tooltip? }`. Select and selectboxes option labels appear under `template.components[...].values[].label`. Cross-product keys (e.g. `AutomationOps.submit`) are left unresolved. |
+
+Per-product failures are collected and do not abort; the command exits non-zero only if every product fails. Do NOT create a separate `products.json` — enumerate products with `Glob` on `<output-dir>/*/form-template.json`.
+
+> **Template versions.** Templates are versioned per product release (e.g. `22.4`, `23.10`, `24.10.1`). The CLI returns the template matching the current product release in the target org. Governance knobs present only in a newer template will be silently ignored by older Studio/Assistant/Robot installs. If the user mentions a specific product version, confirm the returned template's version matches before configuring rules that depend on newer knobs. Run `uip gov aops-policy template list --help` to discover any version-selection flag available on your CLI build.
+
+---
+
+## uip gov aops-policy template get
+
+Fetch a single product's template (update flow — product already known). The positional argument takes the product `name` or `identifier` (GUID).
+
+```bash
+uip gov aops-policy template get <PRODUCT_NAME> \
+  --output-form-data "<DIR>/form-data.json" \
+  --output-template-locale-resource "<DIR>/form-template-locale-resource.json" \
+  --output json \
+  | jq '.Data.template' > "<DIR>/form-template.json"
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--output-form-data <PATH>` | no | Write the fillable form-data blueprint JSON (the object you edit and submit back on create/update). |
+| `--output-template-locale-resource <PATH>` | no | Write the locale-resolved template reference JSON (open this to understand every field, its options, descriptions, tooltips, and validation rules). |
+
+**Output:**
+- When both output flags are passed, `Data` has `formDataFile` and `templateLocaleResourceFile` — the absolute paths of the written files.
+- When neither output flag is passed, the template and form-data are returned inline as `Data.template` and `Data.formData` (useful for piping or scripting). If `Data.template` is missing in this mode, stop and surface the error.
+
+---
+
+## uip gov aops-policy deployment {user|group|tenant}
+
+Deployment subcommands assign policies to a subject. For the full workflow, see [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md).
+
+### Input file shape
+
+The `--input` payload is an array of per-product assignments. Semantics are the same for all three subjects; the tenant variant adds `licenseTypeIdentifier`.
+
+| Subject | JSON shape |
+|---------|------------|
+| `user`  | `[{ "productIdentifier": "<PRODUCT_NAME>", "policyIdentifier": "<POLICY_GUID>\|null" }, ...]` |
+| `group` | `[{ "productIdentifier": "<PRODUCT_NAME>", "policyIdentifier": "<POLICY_GUID>\|null" }, ...]` |
+| `tenant` | `[{ "productIdentifier": "<PRODUCT_NAME>", "licenseTypeIdentifier": "<LICENSE_TYPE_GUID>", "policyIdentifier": "<POLICY_GUID>\|null" }, ...]` |
+
+- `productIdentifier` — product `name` (not label). See [product list](#uip-gov-aops-policy-product-list).
+- `licenseTypeIdentifier` (tenant only) — license type **`identifier` (GUID)** from `license-type list`, not the `name` and not the label. See [license-type list](#uip-gov-aops-policy-license-type-list).
+- `policyIdentifier`:
+  - a GUID → assign that policy for this product (and license type, for tenants)
+  - `null` → **No Policy** (explicitly overrides any inherited policy)
+  - **Omit the entry entirely** → inherit (user/group inherits from tenant; tenant inherits from global)
+
+### deployment {user|group|tenant} list
+
+List subjects with existing policy assignments.
+
+```bash
+uip gov aops-policy deployment user   list --output json
+uip gov aops-policy deployment group  list --output json
+uip gov aops-policy deployment tenant list --output json
+```
+
+Optional: `--limit <N>` (default 20), `--offset <N>` (zero-based page index, default 0). Tenant variant also accepts `--product-name <PRODUCT_NAME>` to scope results to tenants with an assignment for that product.
+
+**Output:** `Data` is an array.
+- User entries: `identifier`, `name`, and `source` (the identity-provider source — e.g. `cloud`, `local`, `aad`). This is **not** a full IdP roster; it includes only users the governance service has already seen.
+- Group entries: `identifier`, `name`, `source`. Typically only groups that have at least one policy override are returned.
+- Tenant entries: `identifier`, `name`, and `tenantPolicies[]`. Each policy entry carries `productIdentifier`, `licenseTypeIdentifier` (GUID), and `policyIdentifier`.
+
+### deployment {user|group|tenant} get
+
+Fetch current assignments for a subject. Returns only **explicit** overrides at the queried level — no chain resolution. Returns an empty array when the subject has no overrides. For the effective runtime policy after chain resolution, use `deployed-policy get`.
+
+```bash
+uip gov aops-policy deployment user   get <USER_ID>   --output json
+uip gov aops-policy deployment group  get <GROUP_ID>  --output json
+uip gov aops-policy deployment tenant get <TENANT_ID> --output json
+```
+
+**Output:**
+- User/group `get`: `Data` is an array of `{ productIdentifier, policyIdentifier }`.
+- Tenant `get`: `Data` is `{ identifier, name, tenantPolicies: [ { productIdentifier, licenseTypeIdentifier, policyIdentifier } ] }`.
+
+### deployment {user|group|tenant} configure
+
+Apply assignments non-interactively via `--input`. **FULL-REPLACE, not merge** — entries not in the input file are removed from the subject. To preserve existing assignments while adding new ones, seed the input from `deployment <subject> get`.
+
+```bash
+uip gov aops-policy deployment user configure "<USER_ID>" \
+  --user "<USER_DISPLAY_NAME>" \
+  --source "<IDP_SOURCE>" \
+  --input "<SESSION_DIR>/user-policies.json" \
+  --output json
+
+uip gov aops-policy deployment group configure "<GROUP_ID>" \
+  --group "<GROUP_DISPLAY_NAME>" \
+  --source "<IDP_SOURCE>" \
+  --input "<SESSION_DIR>/group-policies.json" \
+  --output json
+
+uip gov aops-policy deployment tenant configure "<TENANT_ID>" \
+  --tenant-name "<TENANT_NAME>" \
+  --input "<SESSION_DIR>/tenant-policies.json" \
+  --output json
+```
+
+**Subject-specific configure flags:**
+
+| Subject | Display-name flag | Extra flags | Notes |
+|---------|-------------------|-------------|-------|
+| user    | `--user <NAME>`   | `--source <SRC>` (default `local`; e.g. `cloud`, `aad`) | Display name stored alongside the override (surfaced in audit logs / UI). |
+| group   | `--group <NAME>`  | `--source <SRC>` (default `local`)                      | Display name stored alongside the override. |
+| tenant  | `--tenant-name <NAME>` | —                                                  | Must match the tenant's name in the governance service (from `tenant get`/`tenant list`). |
+
+> **Do NOT use `--user-name` or `--group-name`** — those flags do not exist. The user variant takes `--user`; the group variant takes `--group`. Only the tenant variant uses `--tenant-name`.
+
+> Do NOT launch `configure` without `--input` — that path is not supported.
+
+### deployment {user|group} delete
+
+Remove **all** policy assignments for a user or group. **Destructive.** Always confirm first.
+
+```bash
+uip gov aops-policy deployment user  delete "<USER_ID>"  --output json
+uip gov aops-policy deployment group delete "<GROUP_ID>" --output json
+```
+
+- `user delete` — equivalent to `user configure` with an empty array; the user falls back to group/tenant inheritance for all products.
+- `group delete` — removes the group and all of its policy overrides from governance state. The group itself remains in the upstream identity provider.
+
+**Output:** `Data.Status` = `"Deleted"`, `Data.identifier` echoes the subject GUID.
+
+### deployment tenant remove
+
+Remove a tenant's assignment for a single product (optionally one license type). **Destructive.** Internally this is a client-side read-modify-write — the CLI runs `get` → filters out the matching entry → calls `configure` — so it is not atomic. Fails fast with `No matching policy assignment to remove` when nothing matches.
+
+```bash
+uip gov aops-policy deployment tenant remove "<TENANT_ID>" \
+  --product-name "<PRODUCT_NAME>" \
+  --output json
+```
+
+Add `--license-type <LICENSE_TYPE_NAME>` to remove only one license-type entry for the product. Omit it to remove every license-type entry for the product.
+
+> **Concurrency warning.** Because this is a client-side `get → filter → save`, any concurrent change to the same tenant's assignments between the read and the save will be overwritten. Do not run `tenant remove` concurrently against the same tenant.
+
+**Output:** `Data.removed` lists the entries that were dropped; `Data.tenantPolicies` is the post-removal assignment snapshot (useful for audit).
+
+---
+
+## uip gov aops-policy deployed-policy get
+
+Return the single effective deployed policy for a `(licenseType, product, tenant)` tuple — the one policy that actually applies after the user → group → tenant inheritance chain has been walked and any 'No Policy' pins have been honored. Uses the caller's `uip login` token by default.
+
+```bash
+uip gov aops-policy deployed-policy get \
+  "<LICENSE_TYPE>" "<PRODUCT_NAME>" "<TENANT_ID>" \
+  --output json
+```
+
+**Positional arguments (all required):**
+
+| Position | Argument | Description |
+|----------|----------|-------------|
+| 1 | `<LICENSE_TYPE>` | License type `name` (e.g. `Attended`, `Unattended`) — matches a `name` from `license-type list`. |
+| 2 | `<PRODUCT_NAME>` | Product `name` — identifier, not label (e.g. `StudioX`, `Development`) — matches a `name` from `product list`. |
+| 3 | `<TENANT_ID>` | Tenant GUID — from `deployment tenant list`. |
+
+**Resolution modes (mutually exclusive):**
+
+1. **Default (user-token)** — no flags. Resolves using the caller's own `uip login` identity.
+2. **S2S + `--user-id <GUID>`** — resolves for a specific user (service-to-service call).
+3. **S2S + `--tenant-only`** — resolves tenant-level policy only, skipping user/group overrides.
+
+Modes 2 and 3 require an S2S token (read from the `UIP_S2S_TOKEN` environment variable, or passed via `--s2s-token`).
+
+**Optional flags:**
+
+| Flag | Description |
+|------|-------------|
+| `--s2s-token <TOKEN>` | S2S bearer token. Overrides the user token from `uip login`. Required for `--user-id` or `--tenant-only`. Prefer setting `UIP_S2S_TOKEN` in the environment — the CLI reads it automatically so the token never lands in shell history. See [Authentication](#authentication). |
+| `--user-id <GUID>` | Look up the effective policy for a specific user (runs the full user→group→tenant walk). Requires `--s2s-token`. |
+| `--tenant-only` | Bypass the user/group chain — return the tenant-level assignment only. Requires `--s2s-token`. |
+
+**Output:** `Data` is the resolved policy — `policyIdentifier`, `name`, and `data` (the resolved policy's data payload). When no rule matches and no default exists, the service returns `204` and `Data` is `{ "Message": "No policy applies." }` — surface that message to the user. Use `deployed-policy list` to see every applicable policy, not just the one that won.
+
+---
+
+## uip gov aops-policy deployed-policy list
+
+List every policy that applies to a `(licenseType, product, tenant)` for the calling user, in priority order. Unlike `get`, which returns only the single effective (top-priority) policy, `list` shows every applicable entry — useful for understanding why a particular policy wins. **User token only — does NOT accept `--s2s-token`.** Returns an empty array when nothing applies.
+
+```bash
+uip gov aops-policy deployed-policy list \
+  "<LICENSE_TYPE>" "<PRODUCT_NAME>" "<TENANT_ID>" \
+  --output json
+```
+
+**Output:** `Data` is an array of applicable policies in priority order. Each entry has `policyIdentifier`, `name`, `priority`, and `source` (one of `User`, `Group`, `Tenant` — the level that contributed this entry). To inspect applicable policies for another user, log in as that user, or call `deployed-policy get --s2s-token --user-id <id>` for their single effective policy.
+
+---
+
+## Authentication
+
+All `uip gov aops-policy` commands require an authenticated session. Two modes are supported.
+
+### User token (uip login)
+
+Interactive OAuth — default for all commands.
+
+```bash
+uip login                                          # production (opens browser)
+uip login --authority https://alpha.uipath.com     # non-production environments
+uip login status --output json                     # verify logged-in state
+```
+
+The token is stored by the CLI and used automatically for every subsequent command. Covers all subcommands except the S2S-only `deployed-policy get --user-id` and `deployed-policy get --tenant-only` modes.
+
+### S2S token
+
+Required for the two server-to-server modes of `deployed-policy get`:
+- `--user-id <GUID>` — look up another user's deployed policy.
+- `--tenant-only` — explicitly bypass chain resolution.
+
+**Acquisition (one-time):**
+
+1. In the target tenant's Admin → **External Applications**, register a new confidential application with the `AOps.Write` (or equivalent governance) scope.
+2. Exchange the application's client-credentials for a bearer token via the tenant's OAuth token endpoint (see your tenant admin docs).
+3. Export the token in the caller's shell before running the command. Prefer the `UIP_S2S_TOKEN` environment variable — the CLI picks it up automatically, so it never appears on the command line or in shell history:
+   ```bash
+   export UIP_S2S_TOKEN="<TOKEN>"
+   ```
+4. Run S2S-mode calls without any token flag — the CLI reads `UIP_S2S_TOKEN` directly. Fall back to `--s2s-token "$UIP_S2S_TOKEN"` only if you need to override the env-var value for a single call.
+
+**When NOT to use:**
+- `deployed-policy list` rejects `--s2s-token` — use the user token (from `uip login`) instead.
+- All other commands accept the user token; prefer `uip login` unless S2S is explicitly required.
+
+---
+
+## Global options
+
+All `uip` commands support:
+
+- `--output json|yaml|table` — programmatic vs display output. **Always pass `--output json` when the output is parsed.**
+- `--help` — list the subcommand's flags. Run any command with `--help` to discover additional options beyond those listed here.
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | User token expired or missing | Run `uip login` (or re-export `UIP_S2S_TOKEN` for S2S modes) and retry |
+| `command not found: uip` | UiPath CLI not installed | `npm install -g @uipath/uipcli` |
+| `unknown productIdentifier` | Used the product label instead of the `name` | Re-fetch via [product list](#uip-gov-aops-policy-product-list) and pass the `name` field |
+| `unknown licenseTypeIdentifier` | Used the license type `name` or label instead of its `identifier` (GUID) in a tenant assignment | Re-fetch via [license-type list](#uip-gov-aops-policy-license-type-list) and copy the `identifier` field |
+| `unknown policyIdentifier` (GUID) | Stale or wrong GUID | Re-run `list` and copy the `identifier` from the result |
+| `missing licenseTypeIdentifier in tenant entries` | Tenant assignment entry omitted `licenseTypeIdentifier` | Add it to every tenant-subject entry (required key) |
+| `deployed-policy list rejects --s2s-token` | `list` mode does not accept S2S tokens | Remove `--s2s-token`; re-run under `uip login` |
+| `--user-id passed without --s2s-token` | S2S-only mode called with user token | Either drop `--user-id` (query caller's own policy) or set `UIP_S2S_TOKEN` in the environment (or pass `--s2s-token "$UIP_S2S_TOKEN"`) |
+| `template get returned no template` | Product fetch failed (auth, transient network) | Retry; if persistent, verify `uip login status` and the product name |
+| `template upgrade in progress` on `update` | Underlying Form.io template is migrating | Retry the `update` once the upgrade completes |
+| `Policy created but not effective` | Policy has no deployment | Deploy via [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md) — a created policy only sits in the catalog until assigned |
+| `Cannot delete policy — still assigned` | Policy referenced by tenant/user/group assignments | Run `deployment <subject> remove` (or `configure` with a filtered list) on every subject that references the policy, then retry `delete` |
+| `unknown flag --user-name` / `--group-name` / `--policy-identifier` / `--user-identifier` / `--data-file` | Flag was renamed | Use the current flag: `--user` (user configure), `--group` (group configure), `--identifier` (policy update), `--user-id` (deployed-policy get), `--input` (create/update, deployment configure) |

--- a/skills/uipath-gov-aops-policy/references/aops-policy-deploy-guide.md
+++ b/skills/uipath-gov-aops-policy/references/aops-policy-deploy-guide.md
@@ -1,0 +1,358 @@
+# Policy Deploy Guide
+
+Assign policies to a user, group, or tenant by writing a JSON assignment file and passing it to `deployment <subject> configure --input`.
+
+> **Non-interactive.** The agent drives the full flow. Build the JSON file from the user's stated intent (or prompt them to choose per product), call `configure --input`, then verify with `deployment <subject> get`. Do NOT launch `configure` without `--input` — that path is removed.
+
+## Prerequisites
+
+- User must be logged in — see [aops-policy-commands.md — Authentication](./aops-policy-commands.md#authentication).
+- You have the target subject identifier (user / group / tenant GUID). If not, use the matching `list` subcommand — see [aops-policy-commands.md — deployment](./aops-policy-commands.md#uip-gov-aops-policy-deployment-usergrouptenant).
+- You have a session directory for scratch files. Reuse `$SESSION_DIR` from the configure-policy-data session if one exists, or create a new one:
+  ```bash
+  SESSION_DIR="./aops-sessions/$(date +%Y%m%d-%H%M%S)-$(uuidgen | cut -c1-8 | tr '[:upper:]' '[:lower:]')"
+  mkdir -p "$SESSION_DIR"
+  ```
+- For every deployment subcommand's flags, see [aops-policy-commands.md — deployment](./aops-policy-commands.md#uip-gov-aops-policy-deployment-usergrouptenant).
+
+---
+
+## Input file shape
+
+| Subject | JSON shape |
+|---------|------------|
+| user   | `[{ "productIdentifier": "<PRODUCT_NAME>", "policyIdentifier": "<POLICY_GUID>\|null" }, ...]` |
+| group  | `[{ "productIdentifier": "<PRODUCT_NAME>", "policyIdentifier": "<POLICY_GUID>\|null" }, ...]` |
+| tenant | `[{ "productIdentifier": "<PRODUCT_NAME>", "licenseTypeIdentifier": "<LICENSE_TYPE_GUID>", "policyIdentifier": "<POLICY_GUID>\|null" }, ...]` |
+
+Semantics:
+
+- `productIdentifier` — product `name` (not label). See [aops-policy-commands.md — product list](./aops-policy-commands.md#uip-gov-aops-policy-product-list).
+- `licenseTypeIdentifier` (tenant only) — license type **`identifier` (GUID)** from `license-type list`, not the `name` and not the label. See [aops-policy-commands.md — license-type list](./aops-policy-commands.md#uip-gov-aops-policy-license-type-list).
+- `policyIdentifier`:
+  - a policy GUID → assign that policy to this product (and license type, for tenants)
+  - `null` → **No Policy** explicitly (overrides any inherited policy)
+  - **Omit the entry entirely** → inherit (user/group inherits from tenant; tenant inherits from global)
+
+---
+
+## Deployment precedence
+
+When the same product has assignments at multiple scopes, the narrowest wins:
+
+> **User > Group > Tenant**
+
+- A **user** assignment (including explicit `null` = No Policy) overrides any group or tenant assignment for that product.
+- A **group** assignment overrides the tenant assignment for that product (for members of that group).
+- A **tenant** assignment is the org-wide default for a `(product, licenseType)` pair.
+- A product with no assignment at any scope → inherits the global default (no policy enforced).
+
+**Decision hint:** pick the narrowest scope that matches the user's ask.
+
+> **Precedence is NOT Priority.** The User > Group > Tenant chain above is pure scope resolution — AOps walks it and picks the first level that has an assignment for the product. The policy's `--priority` value is a separate concept and plays no role here. Priority only breaks ties **within the group level**, when a single user belongs to multiple groups that each have their own policy for the same product. See [SKILL.md — Priority rules](../SKILL.md#priority-rules).
+
+| User's ask | Correct scope |
+|-----------|---------------|
+| "Apply only to Alice" / "exception for jdoe" | user |
+| "Apply to the Developers team" / "everyone in group X" | group |
+| "Everyone in the tenant" / "org-wide default" | tenant |
+| "Everyone except Alice" | tenant + user-level `null` override for Alice |
+
+> **Do not deploy at a broader scope than requested.** If the user says "only for Alice", do not touch tenant or group — a tenant change affects every other user who currently inherits from it.
+
+## License-type → product compatibility
+
+Tenant deployments are keyed by `(product, licenseType)`. Not every license carries every product — deploying a policy to a `(product, licenseType)` pair whose license does not include that product is a no-op. Common license → product mappings:
+
+| License type | Products included |
+|--------------|-------------------|
+| RPA Developer | Studio, StudioX, Assistant, Robot |
+| Automation Developer | Studio, StudioX, Assistant, Robot |
+| Citizen Developer | StudioX, Assistant, Robot |
+| Attended Robot | Assistant, Robot |
+| Unattended Robot | Robot |
+| Tester | Studio, Robot |
+
+> Always check the live list via `uip gov aops-policy license-type list --output json` — org-specific license types may exist. See [aops-policy-commands.md — license-type list](./aops-policy-commands.md#uip-gov-aops-policy-license-type-list).
+
+If the user asks to deploy (for example) an Assistant policy to the `Unattended Robot` license, push back — Unattended Robot has no Assistant slot, so the assignment will have no effect.
+
+---
+
+## Subject decision matrix
+
+| User intent | Subject | Section |
+|-------------|---------|---------|
+| "Apply to Alice" / a named individual | user | [3.1](#31-deploy-to-a-user) |
+| "Apply to the Developers group" / named team | group | [3.2](#32-deploy-to-a-group) |
+| "Apply to everyone in the tenant" | tenant | [3.3](#33-deploy-to-a-tenant) |
+| "Apply to a license type org-wide" (requires licenseType) | tenant | [3.3](#33-deploy-to-a-tenant) |
+
+---
+
+## 3.1 Deploy to a user
+
+### Step 1 — Identify the user
+
+Run `uip gov aops-policy deployment user list --output json` (see [commands reference](./aops-policy-commands.md#deployment-usergrouptenant-list)).
+
+Parse `Data` (an array). Each entry has `identifier`, `name`, and `source` — the identity-provider source (e.g. `cloud`, `local`, `aad`). Display as a numbered list:
+
+```text
+Governance users:
+  1. alice@example.com    (source: cloud)    <USER_ID>
+  2. bob@example.com      (source: cloud)    <USER_ID>
+```
+
+- If only one user exists, use it automatically and inform the user.
+- If one entry's `name` matches the current login (from `uip login status`), suggest it as the default.
+- The list contains only users the governance service has already seen — it is not a full IdP roster. If the target user is missing, ask the caller to supply the user GUID and display name directly.
+
+Store the chosen user's `identifier` as `$USER_ID`, its `name` as `$USER_DISPLAY_NAME`, and its `source` as `$USER_SOURCE`. Both `$USER_DISPLAY_NAME` and `$USER_SOURCE` are passed to `configure` in the next step.
+
+### Step 2 — Pick policies per product (prompt only for missing information)
+
+**Skip rule:** if the user's original request already named the product(s) and policy(s) to assign, use those directly — do not re-ask.
+
+1. Run `uip gov aops-policy product list --output json` to enumerate products (show `label` and `name`, no internal flags).
+2. For each product the user wants to assign, run `uip gov aops-policy list --product-name "<PRODUCT_NAME>" --output json` to list candidate policies. Auto-match to the user's stated intent; prompt only if the intent is ambiguous or missing.
+3. Fetch the current assignments to build the diff: `uip gov aops-policy deployment user get "$USER_ID" --output json`. **Do NOT prompt for confirmation here** — confirmation happens at Step 4 only.
+
+### Step 3 — Write the assignment file
+
+```bash
+cat > "$SESSION_DIR/user-policies.json" <<'EOF'
+[
+  { "productIdentifier": "AITrustLayer", "policyIdentifier": "<POLICY_GUID>" },
+  { "productIdentifier": "Development",  "policyIdentifier": null }
+]
+EOF
+```
+
+> Only include products whose assignment should change. Omitted products keep their current assignment (inherit from tenant). Use `null` to explicitly clear an assignment (No Policy).
+
+### Step 4 — Final review before configure (single confirmation gate)
+
+This is the **only** yes/no confirmation in the user-deploy flow (Critical Rule #12). Present the full assignment file plus a diff vs the current state:
+
+```text
+Deploying policies to <USER_DISPLAY_NAME>:
+  AI Trust Layer  →   aitl-test-policy   (<POLICY_ID>)
+  Studio          →   (No Policy)
+Omitted products inherit from the tenant.
+
+Apply these changes to <USER_DISPLAY_NAME>? (yes / no)
+```
+
+Do NOT proceed without an explicit `yes`.
+
+### Step 5 — Save the assignments
+
+> **FULL-REPLACE semantics.** `configure` is not a merge. Any product not listed in `$SESSION_DIR/user-policies.json` is removed from the user's override list, and the user falls back to group/tenant inheritance for that product. To preserve existing overrides, seed the input file from `deployment user get "$USER_ID"` before adding or editing entries.
+
+```bash
+uip gov aops-policy deployment user configure "$USER_ID" \
+  --user "$USER_DISPLAY_NAME" \
+  --source "$USER_SOURCE" \
+  --input "$SESSION_DIR/user-policies.json" \
+  --output json
+```
+
+The flag is `--user`, **not** `--user-name`. `--source` defaults to `local`; pass the identity-provider source from the `list` entry (e.g. `cloud`, `aad`) so the stored override stays consistent with the upstream identity record.
+
+### Step 6 — Verify
+
+```bash
+uip gov aops-policy deployment user get "$USER_ID" --output json
+```
+
+`Data` is an array of `{ productIdentifier, policyIdentifier }`. Show the saved per-product assignments and confirm they match the plan.
+
+---
+
+## 3.2 Deploy to a group
+
+### Step 1 — Identify the group
+
+Run `uip gov aops-policy deployment group list --output json`. Parse `Data` (an array). Each entry has `identifier`, `name`, and `source` (the IdP source). Display as a numbered list and let the user pick. Store the chosen group's `identifier` as `$GROUP_ID`, its `name` as `$GROUP_DISPLAY_NAME`, and its `source` as `$GROUP_SOURCE`.
+
+> If the group is not yet registered in the governance system, it will not appear in `deployment group list`. Ask the user to supply the group identifier and name directly from their organization directory, and store those values as `$GROUP_ID` and `$GROUP_DISPLAY_NAME` (with `$GROUP_SOURCE` set from the IdP) before proceeding.
+
+### Step 2 — Pick policies per product (prompt only for missing information)
+
+Same as [3.1 Step 2](#step-2--pick-policies-per-product-prompt-only-for-missing-information): enumerate products, list candidate policies per product, auto-match to intent, fetch current assignments via `deployment group get "$GROUP_ID"` for the diff.
+
+### Step 3 — Write the assignment file
+
+```bash
+cat > "$SESSION_DIR/group-policies.json" <<'EOF'
+[
+  { "productIdentifier": "AITrustLayer", "policyIdentifier": "<POLICY_GUID>" },
+  { "productIdentifier": "Development",  "policyIdentifier": null }
+]
+EOF
+```
+
+Same semantics as the user variant — include only products whose assignment should change.
+
+### Step 4 — Final review before configure (single confirmation gate)
+
+```text
+Deploying policies to <GROUP_DISPLAY_NAME>:
+  AI Trust Layer  →   aitl-test-policy   (<POLICY_ID>)
+  Studio          →   (No Policy)
+Omitted products inherit from the tenant.
+
+Apply these changes to <GROUP_DISPLAY_NAME>? (yes / no)
+```
+
+Do NOT proceed without an explicit `yes`.
+
+### Step 5 — Save the assignments
+
+> **FULL-REPLACE semantics.** Any product not listed in `$SESSION_DIR/group-policies.json` is removed from the group's override list; its members then fall back to tenant inheritance (unless a per-user override exists). To preserve existing overrides, seed the input from `deployment group get "$GROUP_ID"` first.
+
+```bash
+uip gov aops-policy deployment group configure "$GROUP_ID" \
+  --group "$GROUP_DISPLAY_NAME" \
+  --source "$GROUP_SOURCE" \
+  --input "$SESSION_DIR/group-policies.json" \
+  --output json
+```
+
+The flag is `--group`, **not** `--group-name`. `--source` defaults to `local`; pass the upstream IdP source (e.g. `cloud`, `aad`) from the `list` entry.
+
+### Step 6 — Verify
+
+```bash
+uip gov aops-policy deployment group get "$GROUP_ID" --output json
+```
+
+`Data` is an array of `{ productIdentifier, policyIdentifier }`. Show the saved per-product assignments and confirm they match the plan.
+
+---
+
+## 3.3 Deploy to a tenant
+
+### Step 1 — Identify the license type
+
+Tenant deployments are keyed by `(product, licenseType)`. List license types via `uip gov aops-policy license-type list --output json` — see [aops-policy-commands.md — license-type list](./aops-policy-commands.md#uip-gov-aops-policy-license-type-list) for the full output shape and sample rendering.
+
+> **Use the license type's `identifier` (GUID) — not its `name`, not its label — as `licenseTypeIdentifier` in tenant assignment entries.** The `name` is only accepted by `deployed-policy get` / `deployed-policy list` as the positional `<licenseType>` argument.
+
+### Step 2 — Identify the tenant
+
+```bash
+uip gov aops-policy deployment tenant list --output json
+```
+
+Optional flags: `--product-name <PRODUCT_NAME>`, `--limit <N>`, `--offset <N>`.
+
+Parse `Data` (an array). Each tenant entry has `identifier`, `name`, and `tenantPolicies[]` — the current assignments, each keyed by `(productIdentifier, licenseTypeIdentifier, policyIdentifier)`. Let the user pick, then store the chosen tenant's `identifier` as `$TENANT_ID` and `name` as `$TENANT_NAME`.
+
+### Step 3 — Pick policies per `(product, licenseType)`
+
+1. For each `(product, licenseType)` pair the user wants to assign, run `uip gov aops-policy list --product-name "<PRODUCT_NAME>" --output json` and pick a policy (or match the user's intent).
+2. Fetch current assignments: `uip gov aops-policy deployment tenant get "$TENANT_ID" --output json`.
+
+### Step 4 — Write the assignment file
+
+```bash
+cat > "$SESSION_DIR/tenant-policies.json" <<'EOF'
+[
+  { "productIdentifier": "AITrustLayer", "licenseTypeIdentifier": "<NOLICENSE_GUID>",    "policyIdentifier": "<POLICY_GUID>" },
+  { "productIdentifier": "Development",  "licenseTypeIdentifier": "<DEVELOPMENT_GUID>",  "policyIdentifier": null }
+]
+EOF
+```
+
+> `licenseTypeIdentifier` is the GUID from `license-type list` (`Data[].identifier`), NOT the license-type `name`. Resolve each license type's GUID from Step 1 before writing the file.
+
+### Step 5 — Final review before configure (single confirmation gate)
+
+```text
+Deploying policies to <TENANT_NAME>:
+  AI Trust Layer  / NoLicense    →   aitl-default  (<POLICY_ID>)
+  Studio          / Development  →   (No Policy)
+Omitted (product, licenseType) pairs keep their current assignment.
+
+Apply these changes to <TENANT_NAME>? (yes / no)
+```
+
+Do NOT proceed without an explicit `yes`.
+
+### Step 6 — Save the assignments
+
+> **FULL-REPLACE semantics.** Any `(product, licenseType)` pair not listed in `$SESSION_DIR/tenant-policies.json` is removed from the tenant and reverts to "no pin". To preserve existing assignments, seed the input file from `deployment tenant get "$TENANT_ID"` before editing.
+
+```bash
+uip gov aops-policy deployment tenant configure "$TENANT_ID" \
+  --tenant-name "$TENANT_NAME" \
+  --input "$SESSION_DIR/tenant-policies.json" \
+  --output json
+```
+
+### Step 7 — Verify
+
+```bash
+uip gov aops-policy deployment tenant get "$TENANT_ID" --output json
+```
+
+`Data` is `{ identifier, name, tenantPolicies: [ { productIdentifier, licenseTypeIdentifier, policyIdentifier } ] }`.
+
+---
+
+## Remove assignments
+
+> **Destructive.** Always show the current assignments (`deployment <subject> get`) and get explicit `yes` confirmation before running `delete` or `remove`.
+
+### Remove all policy assignments for a user or group
+
+Use `delete` to strip every assignment in one call. The subject itself remains in the governance system; only the policy mappings are removed.
+
+```bash
+uip gov aops-policy deployment user  delete "$USER_ID"  --output json
+uip gov aops-policy deployment group delete "$GROUP_ID" --output json
+```
+
+Confirmation prompt (verbatim): `Delete all policy assignments for <SUBJECT_NAME>? This cannot be undone. (yes / no)`
+
+### Remove a tenant's assignment for one product (optionally one license type)
+
+Use `remove` for scoped removal. Prefer `remove` over re-running `configure` with `policyIdentifier: null` when the goal is to drop the mapping entirely (setting `null` keeps an explicit "No Policy" override, which still wins over inherited assignments at a higher scope).
+
+```bash
+uip gov aops-policy deployment tenant remove "$TENANT_ID" \
+  --product-name "$PRODUCT_NAME" \
+  --output json
+```
+
+Add `--license-type <LICENSE_TYPE_NAME>` to remove only one license-type entry for that product. Omit it to remove every license-type entry for the product.
+
+Confirmation prompt (verbatim): `Remove <PRODUCT_LABEL> assignment from <TENANT_NAME>? This cannot be undone. (yes / no)`
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | User token expired or missing | `uip login` and retry — see [aops-policy-commands.md — Authentication](./aops-policy-commands.md#authentication) |
+| `unknown productIdentifier` | Used the product label instead of its `name` | Re-run `uip gov aops-policy product list --output json` and pass the `name` field |
+| `unknown licenseTypeIdentifier` | Used the license `name` or label instead of its `identifier` (GUID) | Re-run `uip gov aops-policy license-type list --output json` and copy the `identifier` field (GUID) |
+| `unknown policyIdentifier` (GUID) | Stale or wrong policy GUID | Re-run `uip gov aops-policy list --product-name "<PRODUCT_NAME>" --output json` and copy the `identifier` |
+| `missing licenseTypeIdentifier in tenant entries` | Tenant entry omitted `licenseTypeIdentifier` | Add it to every tenant-subject entry (required key) |
+| `configure rejects the JSON` | Any of the above + malformed array | Validate with `jq type` and `jq '.[0] | keys'` before resubmitting |
+| `unknown flag --user-name` / `--group-name` | Flag renamed | Use `--user` (user configure) or `--group` (group configure). Only `tenant configure` uses `--tenant-name`. |
+| Existing assignments disappear after `configure` | Treated `configure` as merge | `configure` is FULL-REPLACE — seed the input file from `deployment <subject> get` before adding/modifying entries |
+| `deployment user list` / `group list` returns no results | Subject not onboarded to the governance system | Instruct the user to onboard the subject first; for groups, fall back to supplying the GUID directly from the organization directory |
+| User cannot provide a tenant identifier | Tenant GUID unknown | Retrieve from Orchestrator or UiPath Cloud portal |
+| `null` assignment still inherited at a higher scope | User assumed `null` removed the mapping | `null` means explicit "No Policy" (overrides inheritance); use `tenant remove` (or omit the entry) to restore inheritance |
+
+---
+
+## Related commands
+
+- [aops-policy-commands.md](./aops-policy-commands.md) — every deployment flag and output shape used above.
+- [aops-policy-manage-guide.md](./aops-policy-manage-guide.md) — create the policy before deploying it.
+- [aops-policy-deployed-guide.md](./aops-policy-deployed-guide.md) — verify assignment took effect, or query effective rules after chain resolution.

--- a/skills/uipath-gov-aops-policy/references/aops-policy-deployed-guide.md
+++ b/skills/uipath-gov-aops-policy/references/aops-policy-deployed-guide.md
@@ -1,0 +1,135 @@
+# Policy Deployment Query Guide
+
+Query the **single effective deployed policy** for a `(licenseType, product, tenant)` tuple, or the **full list of applicable policies** ordered by priority, for the calling user (or a named user via S2S).
+
+> **Terminology — read before using.**
+> - `deployed-policy get` returns the **single effective policy** — the one policy that actually applies after the user → group → tenant inheritance chain has been walked and any 'No Policy' pins have been honored. The default mode resolves for the caller's own identity; the S2S `--user-id` mode resolves for a named user; the S2S `--tenant-only` mode skips user/group overrides and returns only the tenant assignment.
+> - `deployed-policy list` returns **every applicable policy** for the caller, in priority order. Use this to see why a particular policy wins — not just the winner.
+> - "Which policy actually applies?" → `get`. "Which policies are in play, and in what order?" → `list`.
+
+## Prerequisites
+
+1. User must be logged in — see [aops-policy-commands.md — Authentication](./aops-policy-commands.md#authentication).
+2. For `--user-id` or `--tenant-only` modes of `get`: an S2S token is required — see [aops-policy-commands.md — S2S token](./aops-policy-commands.md#s2s-token).
+3. All commands require three positional arguments: `<LICENSE_TYPE> <PRODUCT_NAME> <TENANT_ID>`. For flag/positional details, see [aops-policy-commands.md — deployed-policy get](./aops-policy-commands.md#uip-gov-aops-policy-deployed-policy-get) / [deployed-policy list](./aops-policy-commands.md#uip-gov-aops-policy-deployed-policy-list).
+
+---
+
+## Step 1 — Collect required inputs
+
+If the user has not provided the positional values, ask **one at a time** in this order — resolve each before moving to the next:
+
+1. `License type?` — if unknown, run `uip gov aops-policy license-type list --output json` and let the user pick by `name` (e.g. `Attended`, `Unattended`), not by `identifier` (GUID) or label. `deployed-policy get/list` take the `name` as the `<licenseType>` positional argument. Store as `$LICENSE_TYPE`.
+2. `Product name (identifier)?` — run `uip gov aops-policy product list --output json` if unknown.
+3. `Tenant identifier (GUID)?` — if unknown, run `uip gov aops-policy deployment tenant list --output json` and let the user pick from tenants that already have policy assignments. Store as `$TENANT_ID`.
+4. **For specific-user lookup only:** `User identifier (GUID)?` — run `uip gov aops-policy deployment user list --output json` if unknown (each entry carries `identifier`, `name`, `source`). Store as `$USER_ID`. Then ensure the S2S bearer token is available — set `UIP_S2S_TOKEN` in the caller's environment so the CLI picks it up automatically (see [aops-policy-commands.md — S2S token](./aops-policy-commands.md#s2s-token)).
+
+Proceed to the matching query below.
+
+---
+
+## Get the effective deployed policy (default — caller's own identity)
+
+Returns the single effective policy for the caller for the given `(licenseType, product, tenant)` — the policy that remains after the user → group → tenant inheritance chain has been walked. Uses the caller's `uip login` token. To look up another user's effective policy, add `--s2s-token --user-id`; to skip user/group overrides and see only the tenant-level assignment, add `--s2s-token --tenant-only`.
+
+```bash
+uip gov aops-policy deployed-policy get \
+  "$LICENSE_TYPE" "$PRODUCT_NAME" "$TENANT_ID" \
+  --output json
+```
+
+Parse `Data` — it carries `policyIdentifier`, `name`, and `data` — and display:
+
+```text
+Effective policy:
+  Policy name:     <NAME>
+  Policy ID:       <POLICY_IDENTIFIER>
+  Product:         <PRODUCT_NAME>
+  License type:    <LICENSE_TYPE>
+  Tenant:          <TENANT_ID>
+  Data payload:    <DATA — pretty-print or attach as a link to a saved file>
+```
+
+If `Data` is `{ "Message": "No policy applies." }`, `null`, `{}`, or absent, inform the user that no policy applies for this `(licenseType, product, tenant)`. This happens when no rule matches and no default exists — the service returns HTTP 204.
+
+---
+
+## Get the effective deployed policy for a specific user (S2S)
+
+Requires an S2S bearer token. Returns the effective policy for the named user after the full user → group → tenant chain is walked.
+
+```bash
+export UIP_S2S_TOKEN="<TOKEN>"          # CLI reads this automatically
+
+uip gov aops-policy deployed-policy get \
+  "$LICENSE_TYPE" "$PRODUCT_NAME" "$TENANT_ID" \
+  --user-id "$USER_ID" \
+  --output json
+```
+
+The flag is `--user-id`, **not** `--user-identifier`.
+
+---
+
+## Get the tenant-level policy only (S2S)
+
+Explicitly bypasses any user/group chain consideration. Requires an S2S bearer token.
+
+```bash
+export UIP_S2S_TOKEN="<TOKEN>"          # CLI reads this automatically
+
+uip gov aops-policy deployed-policy get \
+  "$LICENSE_TYPE" "$PRODUCT_NAME" "$TENANT_ID" \
+  --tenant-only \
+  --output json
+```
+
+---
+
+## List every applicable policy for the calling user
+
+Returns every policy that applies to the caller for the given `(licenseType, product, tenant)`, in priority order. Unlike `get`, which returns only the single effective (top-priority) policy, `list` surfaces every applicable entry so you can see why a particular policy wins. **User token only — does NOT accept `--s2s-token`.** Returns an empty array when nothing applies.
+
+```bash
+uip gov aops-policy deployed-policy list \
+  "$LICENSE_TYPE" "$PRODUCT_NAME" "$TENANT_ID" \
+  --output json
+```
+
+Parse `Data` (an array of applicable policies in priority order). Each entry has `policyIdentifier`, `name`, `priority`, and `source` — one of `User`, `Group`, or `Tenant`. Render as a table:
+
+```text
+Applicable policies (highest-precedence first):
+  Source    Priority   Name                           Policy ID
+  User      20         Restricted StudioX Policy      <POLICY_ID>
+  Tenant    10         Baseline StudioX Policy        <POLICY_ID>
+```
+
+Use this when the user asks:
+
+- "Why is this policy winning for me?"
+- "What is my effective policy, and where does each entry come from?"
+- "Which of my policy settings came from tenant vs group vs user?"
+
+To inspect applicable policies for another user, log in as that user, or call `deployed-policy get --s2s-token --user-id <id>` (note: `get` returns only the single effective policy, not the full list).
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | User token expired (or S2S token missing/expired for S2S modes) | `uip login` for user-token modes; re-export `UIP_S2S_TOKEN` for S2S modes — see [aops-policy-commands.md — Authentication](./aops-policy-commands.md#authentication) |
+| `Data` is `{ "Message": "No policy applies." }` / `null` / `{}` on `get` | Service returned HTTP 204 — no rule matched and no default exists | Inform the user; confirm the tenant has a deployment via [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md) |
+| `Data` is `[]` on `list` | No policies apply in this context | Inform the user; verify that the user, product, and license type are all valid in the calling tenant |
+| `--user-id` rejected / `unknown flag --user-identifier` | Called without an S2S token, or used the old flag name | The flag is `--user-id`, not `--user-identifier`. Either drop `--user-id` (query the caller's own policy) or `export UIP_S2S_TOKEN="<TOKEN>"` before the call (fallback: pass `--s2s-token "$UIP_S2S_TOKEN"`) |
+| `--tenant-only` rejected | Passed without `--s2s-token` | Same as above — `--tenant-only` is an S2S-only mode |
+| `--s2s-token` rejected on `list` | `deployed-policy list` does not accept S2S tokens | Remove `--s2s-token`; re-run under `uip login` |
+| User cannot provide a tenant identifier | Tenant GUID unknown | Retrieve from Orchestrator or UiPath Cloud portal |
+
+---
+
+## Related commands
+
+- [aops-policy-commands.md](./aops-policy-commands.md) — full `deployed-policy` command reference and authentication modes.
+- [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md) — assign a policy before querying it.

--- a/skills/uipath-gov-aops-policy/references/aops-policy-manage-guide.md
+++ b/skills/uipath-gov-aops-policy/references/aops-policy-manage-guide.md
@@ -1,0 +1,425 @@
+# Policy Management Guide
+
+Full CRUD lifecycle for AOps governance policies: list, get, create, update, and delete.
+
+## Prerequisites
+
+- User must be logged in — see [aops-policy-commands.md — Authentication](./aops-policy-commands.md#authentication).
+- Session directory convention: `./aops-sessions/<YYYYMMDD-HHMMSS>-<short-uuid>/` (see [SKILL.md — Session directory](../SKILL.md#session-directory)).
+- For CLI flag details on every subcommand mentioned below, see [aops-policy-commands.md](./aops-policy-commands.md).
+
+**Related guides:** [configure-aops-policy-data-guide.md](./configure-aops-policy-data-guide.md) (policy data authoring) · [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md) (assignment to subjects).
+
+---
+
+## List policies
+
+For all flags and output shape, see [aops-policy-commands.md — list](./aops-policy-commands.md#uip-gov-aops-policy-list).
+
+Parse `Data` (an array of `PolicyDto`, each with `identifier`, `name`, `productName`, `priority`, `availability`) and display as a table:
+
+```text
+  #  Name                    Product        Priority  ID
+  1  My Studio Policy        Development    1         <POLICY_ID>
+  2  AI Trust Default        AITrustLayer   5         <POLICY_ID>
+```
+
+If `Data` is empty, inform the user that no policies were found. Run `uip gov aops-policy product list` to resolve each `productName` identifier to its human-readable `label` for the table.
+
+---
+
+## Get a policy
+
+Always run before `update` or `delete`. For flags, see [aops-policy-commands.md — get](./aops-policy-commands.md#uip-gov-aops-policy-get).
+
+Parse `Data` (`identifier`, `name`, `productName`, `priority`, `availability`, `data`) and display:
+
+```text
+Name:         <NAME>
+Product:      <PRODUCT_LABEL> (name: <PRODUCT_NAME>)
+Priority:     <PRIORITY>
+Description:  <DESCRIPTION or "(none)">
+ID:           <POLICY_ID>
+```
+
+---
+
+## Create a policy
+
+Follow these steps in order.
+
+### Step 1 — Bootstrap and verify product
+
+Before selecting a product, run the bootstrap described in [configure-aops-policy-data-guide.md — Step 1](./configure-aops-policy-data-guide.md#step-1--bootstrap-load-all-products-and-their-templates-create-flow-only). This creates `$SESSION_DIR` and populates `$SESSION_DIR/products/<PRODUCT_NAME>/{form-template.json,form-data.json,form-template-locale-resource.json}` for every product. Each `form-template.json`'s top-level `.product` object `{name, label, ...}` is the catalog entry — no separate `products.json` exists.
+
+After bootstrap completes, choose the product using the matrix below:
+
+| Situation | Action | Store as |
+|-----------|--------|----------|
+| User named the product explicitly (e.g. *"create a Studio policy"*) | Case A — resolve + verify | `$PRODUCT_NAME` (name, not label) |
+| User described a rule but did not name a product | Case B — rank by intent keywords | `$PRODUCT_NAME` after confirmation |
+
+#### Case A — user named the product
+
+1. Match the user's phrase case-insensitively against `.product.label` or `.product.name` across `$SESSION_DIR/products/*/form-template.json` (use the `Glob` tool, then `Read` each `.product`). Call the matched entry the **chosen product**.
+2. Extract **intent keywords** from the user's prompt (e.g. "Gemini", "feedback", "region", "default action").
+3. Use the **`Grep` tool** (Claude's built-in — NOT `Bash(grep …)`, which prompts for permission every call) to search `$SESSION_DIR/products/<CHOSEN>/form-template-locale-resource.json` for fields whose `label` or `description` matches any intent keyword. Set `glob` to the specific file path, `-i: true`, `output_mode: "content"`.
+4. Use the **`Grep` tool** again across `$SESSION_DIR/products/*/form-template-locale-resource.json` to find the same keywords in every other product's locale resource.
+5. Decide:
+   - Chosen product matches the intent (or the user gave no specific intent) → proceed silently. Store the chosen product's `name` as `$PRODUCT_NAME`.
+   - Another product matches and the chosen product does not → ask:
+     ```text
+     You asked for <CHOSEN_LABEL>, but the settings you described
+     (<MATCHED_KEYWORDS>) live under <BETTER_LABEL>.
+     Use <BETTER_LABEL> instead? (yes / no / pick another product)
+     ```
+     Store the user's confirmed product's `name` as `$PRODUCT_NAME`.
+
+#### Case B — user did not name a product
+
+1. If the user's prompt contains intent keywords, use the **`Grep` tool** across `$SESSION_DIR/products/*/form-template-locale-resource.json` with `-i: true` and `output_mode: "count"` to rank every product by how many keywords match. Show the top 3 with a short reason:
+   ```text
+   Best matches for your request:
+      1. AI Trust Layer        (name: AITrustLayer)    — matched: "Gemini", "Claude"
+      2. Studio                (name: Development)     — matched: "feedback"
+      3. StudioX               (name: Business)        — no direct match
+   Which product would you like to create a policy for? (1-3, or ask to see all)
+   ```
+2. If there are no intent keywords, enumerate products via `Glob` on `$SESSION_DIR/products/*/form-template.json` and `Read` `.product.{name,label}` from each. Display only `label` and `name`:
+   ```text
+   Available products:
+      1. AI Trust Layer        (name: AITrustLayer)
+      2. Studio                (name: Development)
+      3. StudioX               (name: Business)
+      ...
+   Which product would you like to create a policy for?
+   ```
+
+Store the confirmed product's `name` as `$PRODUCT_NAME`.
+
+### Step 2 — Configure policy data
+
+Follow [configure-aops-policy-data-guide.md](./configure-aops-policy-data-guide.md) starting at **Step 2**. The bootstrap from Step 1 has already written `$SESSION_DIR/products/$PRODUCT_NAME/{form-template.json,form-data.json,form-template-locale-resource.json}` — the agent only needs to read these files, not re-fetch them.
+
+On completion: `$SESSION_DIR/aops-policy-data.json` is set and ready, and the configure-guide has also produced a change-summary block for use in Step 4.
+
+### Step 3 — Collect policy metadata (prompt only for missing fields)
+
+**Skip rule:** if the user's original prompt already supplied a value for a metadata field (name, description, priority, availability), use it silently — only prompt for fields the user did not mention. Either way, always run the priority-landscape fetch below (needed for the Step 4 review's current-#1 citation) before moving to Step 4.
+
+**Always fetch the priority landscape, even when the user supplied a priority.** The review gate in Step 4 must cite the current #1 holder (the group-level tie-breaker winner today) next to the proposed priority — the user can only consent to the impact if they see whose position the new policy is landing behind or ahead of. Store the result as `$PRIORITY_LANDSCAPE` for reuse in Step 4.
+
+When suggesting a priority (only when the user did not supply one), link [SKILL.md — Priority rules](../SKILL.md#priority-rules) when prompting so the user knows what Priority actually does — in particular, that it is **NOT** what picks between user / group / tenant assignments (that's the resolution chain), and only acts as a tie-breaker at the **group level** when a user belongs to multiple groups with competing policies for the same product.
+
+Fetch the current priority landscape:
+
+```bash
+uip gov aops-policy list \
+  --product-name "$PRODUCT_NAME" \
+  --order-by priority \
+  --order-direction asc \
+  --output json
+```
+
+Parse `Data` (array of policy entries, each with `identifier`, `name`, `productName`, `priority`) and display with explicit rank labels. Frame the "wins" language as a group-level concept so the user doesn't mistake Priority for the scope-resolution chain:
+
+```text
+Existing policies for <PRODUCT_LABEL>, ordered by priority (ascending):
+  priority 1   Strict AI Trust        <POLICY_ID>   ← group-level tie-breaker winner today
+  priority 2   Internal Default       <POLICY_ID>
+  priority 5   Legacy Overrides       <POLICY_ID>
+
+Priority only matters when a user is assigned multiple of these policies via
+different groups. Picking user- or tenant-level assignments is unaffected.
+```
+
+If no policies exist yet for this product, say so and note that Priority is unused until at least two policies exist AND a user is assigned both via different groups.
+
+Then suggest defaults and let the user accept (press Enter) or override. Present all three in a single block with a one-line rationale for the priority suggestion:
+
+```text
+Proposed policy metadata — press Enter to accept, or reply with overrides:
+
+  Name:         <SUGGESTED_NAME, e.g. "AI Trust Layer — Restrictive">
+  Description:  <SUGGESTED_DESCRIPTION>
+  Priority:     <MAX_EXISTING + 1>    ← placed last, so creating this policy does not
+                                        silently reorder the group-level tie-breaker
+                                        for users already assigned existing policies.
+                                        Reply with a lower number to outrank specific
+                                        policies at the group level.
+```
+
+Suggestion rules:
+- **Name:** derive from the product label plus the user's intent (e.g. `"Studio — Dev Team Default"`). If intent is unclear, use `"<PRODUCT_LABEL> Policy"`.
+- **Description:** one sentence summarizing the notable non-default settings; if there are none, use `"Default <PRODUCT_LABEL> policy."`.
+- **Priority:** default to `(max existing priority for this product) + 1` — i.e. place the new policy last. This is the safe default because creating a new policy can never change the effective group-level winner for any existing user. If no existing policies for this product, default to `1`. Only suggest a lower number when the user explicitly says they want the new policy to beat a named existing one at the group level — in that case propose `(target policy's priority) - 1` or lower and call out which specific existing policy the new one will outrank.
+
+Required: `$POLICY_NAME` must be non-empty. If the user clears it, re-prompt.
+Optional: omit `--description`, `--priority`, and `--availability` from the create command if the user did not provide them. Do NOT prompt for `--availability` proactively — it is the offline grace period (in days) during which the client (Studio, Assistant, etc.) keeps applying the cached copy of the policy when it cannot reach Automation Ops. Most users leave it at the server default. Only pass `--availability` when the user explicitly supplied a value; it must be an integer > 0 (sending `0` causes the server to normalize to `30`). See [aops-policy-commands.md — create](./aops-policy-commands.md#uip-gov-aops-policy-create) for the full flag description.
+
+### Step 4 — Final review before create (single confirmation gate)
+
+**Expect from configure-guide:** `$SESSION_DIR/aops-policy-data.json` (the saved blueprint, produced by configure-guide Step 8) and a change-summary block (produced by configure-guide Step 9). Configure-guide does NOT prompt — all confirmation consolidates here.
+
+This is the **only** yes/no confirmation in the create flow (Critical Rule #12). Present the complete policy plus a clickable link to the saved policy data file so the user can open it, scan every field, and decide.
+
+> **MANDATORY (Critical Rule #16):** the `Policy data` row is required in every review — not optional, not conditional on whether the user asked for it. It is the user's only chance to review the full composed JSON before the mutation runs, and it is often requested after creation as well. A review without this row is incomplete; do NOT proceed to `create` until it is added and the user has confirmed.
+
+```text
+Review policy to be created:
+
+  Name:         <POLICY_NAME>
+  Product:      <PRODUCT_LABEL> (name: <PRODUCT_NAME>)
+  Description:  <DESCRIPTION or "(none)">
+  Priority:     <PRIORITY or "(suggested: MAX_EXISTING+1)">
+                Current #1 holder (group-level tie-breaker winner today):
+                  "<NAME_AT_PRI_1>" (priority 1, <POLICY_ID_AT_PRI_1>)
+                Rank impact: <"placed last — does not reorder existing group-level winners"
+                              | "outranks <LIST_OF_POLICIES_WITH_HIGHER_PRIORITY_NUMBERS> at the group level"
+                              | "no existing policies — Priority is unused until ≥2 exist and a user is in multiple groups">
+
+  Policy data:  [aops-policy-data.json](<ABSOLUTE_PATH_TO_SESSION_DIR>/aops-policy-data.json)
+
+  Changed settings (vs defaults):
+    feedback-enabled             false   (was: true)
+    default-action               Warning (was: Error)
+  Unchanged fields: 14 kept at defaults.
+
+Open the linked file to see every field.
+Create policy "<POLICY_NAME>" for <PRODUCT_LABEL>? (yes / no / keep editing)
+```
+
+Populate `<NAME_AT_PRI_1>` and `<POLICY_ID_AT_PRI_1>` from `$PRIORITY_LANDSCAPE` (the `list` result from Step 3). If no existing policies exist for this product, replace the "Current #1 holder" line with `Current #1 holder: (none — this will be the first policy for <PRODUCT_LABEL>)`. If the current #1 holder IS the policy being updated (update flow), say `Current #1 holder: this policy (unchanged)`.
+
+Render the `Policy data` line using markdown link syntax with the **resolved absolute path** to `aops-policy-data.json` (e.g. `[aops-policy-data.json](/Users/alice/work/aops-sessions/20260421-150621-d0d3e5e9/aops-policy-data.json)`). Run `realpath "$SESSION_DIR/aops-policy-data.json"` (or equivalent) to get the absolute path — do NOT emit a relative path, a literal `<SESSION_DIR>` placeholder, or a `~/` path. In IDE environments the link is clickable and opens the file directly.
+
+Do NOT include an `Availability:` row in the review — it is a product-specific enum, almost always left unset, and when unset it adds noise. Only include availability in the review when the user explicitly supplied a value (in which case show it inline, not as its own row, e.g. `Priority: 4, Availability: 30`). `keep editing` is treated the same as `no`: route back to the relevant step (metadata → Step 3, form-data → configure-guide Step 5) and re-enter this gate only after the change is applied. Do NOT run `create` until the user confirms `yes`.
+
+### Step 5 — Create the policy
+
+For flags, see [aops-policy-commands.md — create](./aops-policy-commands.md#uip-gov-aops-policy-create).
+
+```bash
+uip gov aops-policy create \
+  --name "$POLICY_NAME" \
+  --product-name "$PRODUCT_NAME" \
+  --input "$SESSION_DIR/aops-policy-data.json" \
+  --output json
+```
+
+Include `--description`, `--priority`, and/or `--availability` only when the user provided them. Parse the response:
+
+- `Data.identifier` → `$POLICY_ID`
+- `Data.productName` → `$PRODUCT_IDENTIFIER` (flat string, not nested)
+
+### Step 6 — Report success and explain the deployment step
+
+```text
+Policy created successfully.
+  Name:       <POLICY_NAME>
+  ID:         <POLICY_ID>
+  Product:    <PRODUCT_LABEL>
+  Priority:   <PRIORITY or "(none)">
+  Composed:   [aops-policy-data.json](./aops-sessions/<SESSION_ID>/aops-policy-data.json)
+
+⚠ This policy is NOT yet effective. Creating a policy only registers it in the
+  catalog — nothing will apply it to anyone until you deploy it.
+
+Deployment targets (in order of chain resolution, highest precedence first):
+  1. User    — applies to one named user; overrides group and tenant.
+  2. Group   — applies to every member of a group; overrides tenant.
+  3. Tenant  — applies to every user in the tenant for a given (product, license type);
+               the baseline when no user- or group-level assignment wins.
+
+How AOps resolves the effective policy for a given user:
+  • It walks User → Group → Tenant and picks the FIRST level that has an
+    assignment for that product. Priority is NOT consulted here — scope is.
+  • Priority only matters AT the group level: if the user is in multiple
+    groups that each have a policy for the same product, the group policy
+    with the lowest priority number wins.
+  • At the user level and the tenant level there is at most one assignment
+    per product (per license type for tenant), so Priority never applies.
+
+Would you like to deploy this policy now?
+  - Yes, to a user
+  - Yes, to a group
+  - Yes, to a tenant (requires license type)
+  - Not now (policy stays in the catalog but has no effect)
+```
+
+Render the `Composed` line with the actual resolved session path (same substitution rule as Step 4).
+
+If the user picks a deployment target, continue to [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md) — reuse `$SESSION_DIR`. If they decline, stop and remind them the policy is inactive until deployed.
+
+---
+
+## Update a policy
+
+### Step 1 — Identify the policy and create the session directory
+
+1. If the user did not provide a policy identifier, run `list` (above) and ask them to pick one. Store as `$POLICY_IDENTIFIER`.
+2. Create the session directory that will hold all scratch files for this update. The update flow skips the bootstrap, so the caller — not configure-guide Step 1 — owns the session directory:
+   ```bash
+   SESSION_DIR="./aops-sessions/$(date +%Y%m%d-%H%M%S)-$(uuidgen | cut -c1-8 | tr '[:upper:]' '[:lower:]')"
+   mkdir -p "$SESSION_DIR"
+   ```
+3. Proceed to Step 2.
+
+### Step 2 — Get current values and extract the existing data blueprint
+
+```bash
+uip gov aops-policy get "$POLICY_IDENTIFIER" --output json > "$SESSION_DIR/current-policy.json"
+```
+
+Display the current values (name, product, priority, description, availability) so the user can see what they are changing.
+
+**Extract the existing policy's data as the update blueprint** — this is the object the user will edit, and any fields not touched must retain their existing values (NOT revert to product defaults):
+
+```bash
+jq '.Data.data' "$SESSION_DIR/current-policy.json" > "$SESSION_DIR/existing-policy-data.json"
+```
+
+> **Critical:** on update, the blueprint is the existing policy's `data` object — NOT the product's default `form-data.json`. Using the product defaults would silently wipe every non-default setting the user previously configured. Only use form-data defaults as a fallback for brand-new fields added to the product template after the policy was originally created.
+
+### Step 3 — Determine what to change (prompt only for missing information)
+
+**Skip rule:** if the user's original request already specified what to change (e.g. *"update policy X to set priority 3"* or *"add Gemini to the disabled models in policy X"*), apply that intent directly — do not re-ask. Only prompt when the user said `"update policy X"` with no details.
+
+The fields the user may change are: name, description, priority, availability, or policy data (field values). The product cannot be changed on update.
+
+### Step 4 — If updating policy data
+
+Follow [configure-aops-policy-data-guide.md](./configure-aops-policy-data-guide.md) with these update-flow overrides:
+
+- **Skip Step 1 (bootstrap) entirely** — the product is already known, so there is no need to fetch every product's schema. Jump straight to Step 2 and fetch only this product's template into `$SESSION_DIR/products/$PRODUCT_NAME/`.
+- **Override the blueprint** for Step 2 and Step 7: use `$SESSION_DIR/existing-policy-data.json` (from Step 2 above) as the working `$POLICY_DATA` — NOT `form-data.json`. This preserves every setting the user previously configured.
+- **Use existing policy values as "current"** in prompts. When Mode A/B shows a field's current value, show the existing value, not the product default. Label the schema default separately only if the user asks.
+- **Handle schema drift gracefully.** If the existing data is missing a key present in the current `form-data.json` (field added to the template after the policy was created), fill the gap from `form-data.json` and flag it in the final review as "new field: <KEY> = <DEFAULT>".
+- **Changed-settings diff is vs. the existing policy**, not vs. product defaults. The final review shows what differs between `$SESSION_DIR/existing-policy-data.json` and `$SESSION_DIR/aops-policy-data.json`.
+
+On completion: `$SESSION_DIR/aops-policy-data.json` is set and ready, and every previously configured value the user did not touch is preserved.
+
+### Step 5 — Final review before update (single confirmation gate)
+
+**Expect from configure-guide (if Step 4 ran):** updated `$SESSION_DIR/aops-policy-data.json` and a change-summary diffed against `existing-policy-data.json`.
+
+This is the **only** yes/no confirmation in the update flow (Critical Rule #12). Show before/after for every changed field.
+
+> **MANDATORY (Critical Rule #16):** the `Policy data` row is required in every update review — not optional. A review without this row is incomplete; do NOT proceed to `update` until it is added and the user has confirmed.
+
+```text
+Review policy update:
+
+  Name:         <POLICY_NAME>       (was: <OLD_NAME>)
+  Product:      <PRODUCT_LABEL> (unchanged)
+  Description:  <DESCRIPTION>       (was: <OLD_DESCRIPTION>)
+  Priority:     <PRIORITY>          (was: <OLD_PRIORITY>)  ← reminder: group-level tie-breaker only; lower number wins when a user is in multiple groups with competing policies for this product
+
+  Policy data:  [aops-policy-data.json](<ABSOLUTE_PATH_TO_SESSION_DIR>/aops-policy-data.json)
+
+  Changed settings (vs existing policy data):
+    feedback-enabled             false   (was: true)
+  Unchanged fields: 15 kept at existing values.
+
+  New fields added by schema drift (if any):
+    <KEY>                        <DEFAULT>   (new — filled from product default)
+
+Open the linked file to see every field.
+Apply update to policy "<POLICY_NAME>"? (yes / no / keep editing)
+```
+
+For each metadata row, show `(unchanged)` instead of `(was: ...)` when the user did not change that field. Only show the schema-drift block when Step 4 filled in at least one new field. `keep editing` is treated the same as `no`: route back to Step 3 or Step 4 and re-enter this gate only after the change is applied. Do NOT run `update` until the user confirms `yes`.
+
+### Step 6 — Run update
+
+> `update` is a **full replacement**, not a patch. Every field you want to keep must be passed again — including `--description`, `--priority`, `--availability`, and `--input`. Omitting any of these flags CLEARS that field on the server. See [aops-policy-commands.md — update](./aops-policy-commands.md#uip-gov-aops-policy-update) for the full flag reference.
+
+```bash
+uip gov aops-policy update \
+  --identifier "$POLICY_IDENTIFIER" \
+  --name "$POLICY_NAME" \
+  --product-name "$PRODUCT_NAME" \
+  --description "$DESCRIPTION" \
+  --priority "$PRIORITY" \
+  --input "$SESSION_DIR/aops-policy-data.json" \
+  --output json
+```
+
+Re-pass every field the user wants to preserve. For any field the user did not change, read the existing value from `$SESSION_DIR/current-policy.json` (saved in Step 2) and pass it through unchanged. Always include `--input "$SESSION_DIR/aops-policy-data.json"` — this is the blueprint produced from `existing-policy-data.json` plus the user's edits, and omitting it wipes the data payload on the server. Only drop `--description`, `--priority`, or `--availability` when the user has explicitly asked to clear that field. `--product-name` must match the policy's existing product.
+
+### Step 7 — Report success
+
+```text
+Policy updated successfully.
+  Name:    <POLICY_NAME>
+  ID:      <POLICY_ID>
+  Product: <PRODUCT_LABEL>
+```
+
+---
+
+## Delete a policy
+
+> **Destructive.** This cannot be undone.
+
+### Step 1 — Identify the policy
+
+If the user did not provide a policy identifier, run `list` and ask them to pick one. Store as `$POLICY_IDENTIFIER`.
+
+### Step 2 — Get and display the policy
+
+```bash
+uip gov aops-policy get "$POLICY_IDENTIFIER" --output json
+```
+
+Display:
+
+```text
+About to delete:
+  Name:     <POLICY_NAME>
+  Product:  <PRODUCT_LABEL>
+  ID:       <POLICY_ID>
+```
+
+### Step 3 — Confirm with the user
+
+Ask verbatim: `Delete policy "<POLICY_NAME>"? This cannot be undone. (yes / no)`
+
+If the user answers anything other than `yes` (or `y`), abort and inform them that deletion was cancelled.
+
+### Step 4 — Delete
+
+```bash
+uip gov aops-policy delete "$POLICY_IDENTIFIER" --output json
+```
+
+### Step 5 — Confirm
+
+```text
+Policy "<POLICY_NAME>" deleted successfully.
+```
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | User token expired or missing | `uip login` and retry — see [aops-policy-commands.md — Authentication](./aops-policy-commands.md#authentication) |
+| `Policy not found` / `unknown policyIdentifier` | Stale or wrong GUID | Re-run `list` and copy the `identifier` from the result |
+| `Priority conflict` / duplicate priority | Another policy for the same product already holds that priority | Pick a different number; see [SKILL.md — Priority rules](../SKILL.md#priority-rules) |
+| `template get returned no template` | Product schema fetch failed (auth, transient network) | Retry; if persistent, verify `uip login status --output json` and the product name |
+| `list returned empty` | No policies match the filter | Drop the filter or offer to create a new policy |
+| `--name is required` on `update` | `update` is full-replacement; name was omitted | Pass `--name "$POLICY_NAME"` with the existing value to preserve it |
+| `--product-name does not match existing product` | Attempt to change product on update | Product cannot be changed on update; delete + recreate instead |
+| `--input contents wrapped in {"data":{...}}` | Blueprint was wrapped by hand | Write the raw flat object (Critical Rule #6) — CLI wraps automatically |
+| `description` / `priority` / `availability` / `data` silently cleared after update | Flag was omitted on `update` | All update flags are full-replace; re-pass every field to preserve — see [aops-policy-commands.md — update](./aops-policy-commands.md#uip-gov-aops-policy-update) |
+| `template upgrade in progress` on `update` | Template is being migrated | Retry once the upgrade completes |
+
+---
+
+## Related commands
+
+- [aops-policy-commands.md](./aops-policy-commands.md) — every flag and output shape used above.
+- [configure-aops-policy-data-guide.md](./configure-aops-policy-data-guide.md) — how `$SESSION_DIR/aops-policy-data.json` is produced.
+- [aops-policy-deploy-guide.md](./aops-policy-deploy-guide.md) — what to do after a successful `create` or `update`.

--- a/skills/uipath-gov-aops-policy/references/configure-aops-policy-data-guide.md
+++ b/skills/uipath-gov-aops-policy/references/configure-aops-policy-data-guide.md
@@ -1,0 +1,375 @@
+# Configure Policy Form Data — Form.io Parsing Guide
+
+How to fetch a product's form template, walk the component tree, collect policy settings from the user using natural language, and produce a ready-to-submit policy data JSON.
+
+## Prerequisites
+
+- User must be logged in — see [aops-policy-commands.md — Authentication](./aops-policy-commands.md#authentication).
+- `$PRODUCT_NAME` is known (resolved by [aops-policy-manage-guide.md — Step 1](./aops-policy-manage-guide.md#step-1--bootstrap-and-verify-product) for create, or from `policy get` for update).
+- `$SESSION_DIR` is set. For the create flow, Step 1 below creates it; for the update flow, the caller ([aops-policy-manage-guide.md — Update Step 1](./aops-policy-manage-guide.md#step-1--identify-the-policy-and-create-the-session-directory)) creates it before invoking this guide.
+- For every CLI subcommand mentioned below, see [aops-policy-commands.md](./aops-policy-commands.md).
+
+---
+
+## Overview
+
+AOps policy settings are a JSON object defined by a **form.io schema** (`FormTemplateDto.template`), shipped with flat default values. This guide covers the interactive, field-by-field configuration workflow — using natural-language prompts, the locale file for labels, and the form-data file for defaults.
+
+---
+
+## Step 1 — Bootstrap: Load All Products and Their Templates (create flow only)
+
+> **Applies only to the create flow.** The update flow already knows the product from the existing policy — skip directly to Step 2 and fetch only that product's template.
+
+Create a session directory to isolate files for this configuration run:
+
+```bash
+SESSION_DIR="./aops-sessions/$(date +%Y%m%d-%H%M%S)-$(uuidgen | cut -c1-8 | tr '[:upper:]' '[:lower:]')"
+mkdir -p "$SESSION_DIR"
+```
+
+This produces a path like `./aops-sessions/20260416-143022-a1b2c3d4`.
+
+### 1.1 — Fetch every product's template, form data, and locale in one call
+
+```bash
+mkdir -p "$SESSION_DIR/products"
+uip gov aops-policy template list --output-dir "$SESSION_DIR/products" --output json
+```
+
+For the full flag reference, see [aops-policy-commands.md — template list](./aops-policy-commands.md#uip-gov-aops-policy-template-list). The command writes three files per product into `$SESSION_DIR/products/<PRODUCT_NAME>/`:
+
+- `form-template.json` — raw form.io DTO returned by the governance API. Its top-level `.product` object carries `{name, label}` and is the authoritative product catalog entry.
+- `form-data.json` — fillable blueprint with defaults for every field. Display-only components (`hidden`, `button`, `submit`, `htmlelement`, `content`) are omitted. Fields without an explicit default get a type-appropriate default: `false` for checkbox, `[]` for editgrid, `{}` for selectboxes, and `null` for text/select.
+- `form-template-locale-resource.json` — locale-resolved reference. Every product-scoped locale key is replaced with its English string; a sibling `<prop>-key` preserves the original key for traceability. `defaultData.data` is a flat per-field map `{value, type, label, description?, tooltip?}`, and select/selectboxes option labels live under `template.components[...].values[].label`.
+
+Per-product fetch failures are collected by the CLI and do not abort the run; the command only exits non-zero if every product fails.
+
+> **Product catalog is implicit.** There is no `products.json` — each `form-template.json`'s top-level `product` object IS the catalog entry. The caller enumerates products via the `Glob` tool on `$SESSION_DIR/products/*/form-template.json` and reads `.product.{name, label}` from each file.
+
+After Step 1, the session directory looks like:
+
+```text
+$SESSION_DIR/
+└── products/
+    ├── <PRODUCT_NAME_1>/
+    │   ├── form-template.json   # .product.{name,label,...} is the catalog entry
+    │   ├── form-data.json
+    │   └── form-template-locale-resource.json
+    ├── <PRODUCT_NAME_2>/
+    │   └── ...
+```
+
+Once `$PRODUCT_NAME` is confirmed by the caller, proceed to Step 2 using `$SESSION_DIR/products/$PRODUCT_NAME/` as the working directory.
+
+---
+
+## Step 2 — Load Form Template, Form Data, and Locale
+
+For the **create flow**, the bootstrap (Step 1) already produced all three files under `$SESSION_DIR/products/$PRODUCT_NAME/`. No new CLI call is needed — read the files directly.
+
+For the **update flow**, the product is known from the existing policy. `$SESSION_DIR` is already set by the caller (see [aops-policy-manage-guide.md — Update Step 1](./aops-policy-manage-guide.md#step-1--identify-the-policy-and-create-the-session-directory)) — do NOT create a new session directory here, or `$SESSION_DIR/existing-policy-data.json` will end up in a different folder. Only create the per-product subfolder and fetch that product's template. For flags, see [aops-policy-commands.md — template get](./aops-policy-commands.md#uip-gov-aops-policy-template-get):
+
+```bash
+PRODUCT_DIR="$SESSION_DIR/products/$PRODUCT_NAME"
+mkdir -p "$PRODUCT_DIR"
+
+uip gov aops-policy template get "$PRODUCT_NAME" \
+  --output-form-data "$PRODUCT_DIR/form-data.json" \
+  --output-template-locale-resource "$PRODUCT_DIR/form-template-locale-resource.json" \
+  --output json \
+  | jq '.Data.template' > "$PRODUCT_DIR/form-template.json"
+```
+
+Either way, the three working files are:
+
+| File | Source | Purpose |
+|------|--------|---------|
+| `$SESSION_DIR/products/$PRODUCT_NAME/form-template.json` | Written by `template list`, or extracted via `jq '.Data.template'` on `template get` | Form.io schema — defines field types, options, validation, and structure |
+| `$SESSION_DIR/products/$PRODUCT_NAME/form-data.json` | Written by CLI (`template list`, or `template get --output-form-data`) | Flat key-value object with default values for every policy field |
+| `$SESSION_DIR/products/$PRODUCT_NAME/form-template-locale-resource.json` | Written by CLI (`template list`, or `template get --output-template-locale-resource`) | Per-field object with `value`, `type`, `label`, and `description` — locale-resolved from the form template |
+
+Read `$SESSION_DIR/products/$PRODUCT_NAME/form-template.json` for the form.io schema used in Step 3.
+
+**Choose the working `$POLICY_DATA` blueprint based on the flow:**
+
+- **Create flow:** read `$SESSION_DIR/products/$PRODUCT_NAME/form-data.json` as `$POLICY_DATA`. Every field not explicitly changed keeps its product default.
+- **Update flow:** read `$SESSION_DIR/existing-policy-data.json` (extracted by the caller via `jq '.Data.data'` on `policy get`) as `$POLICY_DATA`. Every field not explicitly changed keeps the value from the existing policy — NOT the product default. Using `form-data.json` as the update blueprint would silently wipe every non-default setting the user previously configured. If a key appears in `form-data.json` but not in the existing policy data (schema drift — new field added to the template after the policy was created), fill the gap from `form-data.json` and flag the new field to the user in the final review.
+
+Read `$SESSION_DIR/products/$PRODUCT_NAME/form-template-locale-resource.json` as your field metadata map. Each entry looks like:
+
+```json
+{
+  "gemini-control-toggle": {
+    "value": true,
+    "type": "checkbox",
+    "label": "Gemini",
+    "description": "Disabling models will impact genAI features across products..."
+  }
+}
+```
+
+Use `label` as the display name and `description` as the hint when prompting the user. Use `type` to determine the prompt style (Step 5). Use `value` as the pre-populated default.
+
+---
+
+## Step 3 — Traverse the Component Tree
+
+The form.io schema has a root `components[]` array. Components nest recursively. Use a depth-first traversal.
+
+### Container types — recurse, do not prompt
+
+| `type` | Children field | Notes |
+|--------|---------------|-------|
+| `panel` | `components[]` | Announce the panel title as a section header |
+| `tabs` | `components[]` — each child has its own `components[]` | Announce each tab label as a sub-section |
+| `columns` | `columns[]` — each column has `components[]` | Recurse silently, no header |
+| `fieldset` | `components[]` | Recurse silently, no header |
+| `well` | `components[]` | Recurse silently, no header |
+| `editgrid` | `components[]` (row template) + data is an array | See [editgrid handling](#step-6--editgrid-repeating-rows) below |
+
+### Display-only types — skip entirely
+
+`htmlelement`, `content`, `button`, `submit`
+
+### Input types — prompt the user
+
+`checkbox`, `radio`, `select`, `selectboxes`, `textfield`, `textarea`, `number`, `currency`, `email`, `url`, `phoneNumber`, `datetime`
+
+---
+
+## Step 4 — Use Locale Resource for Labels
+
+The `$SESSION_DIR/products/$PRODUCT_NAME/form-template-locale-resource.json` file already contains resolved, human-readable `label` and `description` for every field — this work is done by the CLI. No additional i18n key lookup is needed.
+
+For each field in `form-template-locale-resource.json`:
+
+- Use `label` as the display name shown to the user
+- Use `description` as the hint (if present), appended as `(hint: <DESCRIPTION>)`
+- Use `type` to determine the prompt style (Step 5)
+- Use `value` as the pre-populated default
+
+Iterate `form-template-locale-resource.json` in form-template order — the CLI writes its entries in the same order as the form template component tree, so a straight iteration gives the user-facing ordering.
+
+---
+
+## Step 5 — Choose Interaction Mode
+
+Decide the interaction mode from the user's original request. **Prefer Mode A whenever the user supplied any intent** — only fall back to Mode B when the user's request has no configurable signal at all.
+
+| Situation | Mode | Action |
+|-----------|------|--------|
+| User supplied intent keywords (*"disable Gemini and Claude"*, *"restrict to US and EU"*, etc.) | A | Grep locale resource + auto-fill matched fields |
+| User named only the product (*"create a policy for Studio"*) | B | Paginated field-by-field prompting |
+| User explicitly asked *"show me every field"* | B | Paginated field-by-field prompting |
+| Mode A left required fields unset or some intent phrases unmapped | A → B for those fields only | See Mode A fallback below |
+
+### Mode A — Intent-based auto-fill (preferred — default)
+
+If the user's original prompt describes how to configure the policy, or names specific fields to change, do NOT prompt field-by-field.
+
+0. **Recipe lookup first.** Before grepping the locale file, check [aops-governance-recipes-guide.md](./aops-governance-recipes-guide.md) for a recipe whose intent keywords match the user's ask. If a recipe matches, apply its product + field mapping directly to `$POLICY_DATA` — the recipes give you the correct `key` and value without locale-string guessing. Only proceed to step 1 below for intents not covered by any recipe, or for recipe-matched intents whose parameter values (e.g. `BlockedEmails`, `AllowedApplications`) still need to be extracted from the user's phrasing.
+1. Use the **`Grep` tool** (Claude's built-in — NOT `Bash(grep …)`, which prompts for permission every call) against `$SESSION_DIR/products/$PRODUCT_NAME/form-template-locale-resource.json` to find `label` / `description` entries matching the user's stated intent. Set `-i: true` (case-insensitive) and `output_mode: "content"`. Use the `Read` tool on the same file if you need surrounding structure to resolve a `key`.
+2. Apply those values directly to `$POLICY_DATA` (skip Step 6 editgrid prompts unless the user's intent referenced a grid). Leave every unmatched field at its default (create) or existing value (update).
+3. **Required-field sweep.** For each field with `validate.required: true`, confirm `$POLICY_DATA` contains a non-empty value. If a required field is unset (create flow, default is empty) or cleared by the user's intent, drop to Mode B for that single field only — do not silently produce invalid data.
+4. **Runtime-rule empty-parameter check.** For runtime analyzer rules (e.g. `RT-UIA-001`, `RT-OUT-001`) and workflow analyzer allow/block-list rules, enabling the rule without populating its parameter array (`AllowedApplications`, `BlockedApplications`, `AllowedURLs`, `BlockedURLs`, `BlockedEmails`, etc.) produces a no-op policy that enforces nothing. If the user's intent names the rule but does not specify the list contents, STOP and ask for the list explicitly rather than saving an empty array. Do not silently write a do-nothing policy.
+5. Jump to **Step 7 — Build the Output JSON**. The remaining steps (Step 8 Save, Step 9 Summary) run in their numbered order.
+
+Prompt the user only if a specific field they clearly referenced is ambiguous (e.g. they said "restrict Claude" but there are two Claude-related fields). Do not confirm unchanged defaults — silence means "keep defaults".
+
+**Fallback — intent doesn't match any field.** If the `Grep` search returns no matches for an intent keyword in the locale resource (e.g. they said "block region X" but the product has no region field), stop and tell the user exactly which phrases could not be mapped. Do not silently drop them. Ask: *"I couldn't find fields for `<PHRASES>` under `<PRODUCT_LABEL>`. Would you like to (a) proceed without those settings, (b) pick a different product, or (c) enter field values manually?"*. If **some** intent phrases matched and others did not, apply the matches and ask the same three-way question only for the unmapped phrases — do not discard the partial auto-fill.
+
+If the caller's final review is rejected and the user asks to adjust specific fields, fall back to Mode B for those fields only.
+
+### Mode B — Paginated interactive prompting
+
+If the user did not provide intent, prompt them **one page at a time**, up to 10 fields per page. Do not prompt field-by-field one at a time — this is too slow for forms with 20+ fields.
+
+For each page:
+
+1. Group prompts by the enclosing panel or tab title. Announce each group:
+   ```text
+   ── Feedback settings ──
+   ```
+2. Show up to 10 input fields with their label, hint (if present), default value, and expected answer format.
+3. After the 10th field on the page, stop and ask: `Press Enter to accept all defaults on this page, or reply with any changes (e.g. "feedback-enabled: no, default-action: Warning").`
+4. Parse the user's reply, update `$POLICY_DATA`, and move to the next page.
+5. Continue until every input field has been shown.
+
+For each input field, show:
+
+- Humanized label (and hint if present)
+- Current default value (or "not set" if absent)
+- Expected answer format for the field type (see below)
+
+### checkbox
+
+```text
+Feedback enabled [default: yes]
+Enable or disable feedback? (yes / no, or press Enter to keep default)
+```
+
+Map answers: `yes`/`true`/`1`/`on` → `true`; `no`/`false`/`0`/`off` → `false`.
+
+### radio
+
+```text
+Default action [default: Error]
+Options:
+  1. Error
+  2. Warning
+  3. Info
+Choose an option by number or name, or press Enter to keep default:
+```
+
+Use the option's `value` (not its `label`) when writing to `$POLICY_DATA`.
+
+### select
+
+Same prompt shape as radio.
+
+### selectboxes
+
+```text
+Allowed regions [defaults: US: yes, EU: yes, APAC: no]
+For each region, enter yes or no (or press Enter to keep all defaults):
+  US   [yes]:
+  EU   [yes]:
+  APAC [no]:
+```
+
+Result is an object: `{ "US": true, "EU": true, "APAC": false }`.
+
+### textfield / textarea
+
+```text
+Rule code [default: RULE001]
+Enter a value, or press Enter to keep default:
+```
+
+If `validate.required` is `true` and the user provides an empty value, re-prompt: `This field is required. Please enter a value:`.
+
+### number / currency
+
+```text
+Priority [default: 10]
+Enter an integer, or press Enter to keep default:
+```
+
+Reject non-numeric input and re-prompt.
+
+### datetime
+
+```text
+Expiry date [default: none]
+Enter a date (YYYY-MM-DD), or press Enter to keep default:
+```
+
+---
+
+## Step 6 — editgrid (Repeating Rows)
+
+An `editgrid` stores an array of row objects. Each row's shape is defined by the grid's child `components[]`.
+
+1. **Show existing rows** from `$POLICY_DATA[KEY]` (from defaultData). Number them starting at 1.
+2. **Ask the user** which rows they want to modify (by number), or none.
+3. For each row chosen: prompt field-by-field using the grid's child components (same rules as above).
+4. **Add rows:** If `disableAddingRemovingRows` is `false` (or absent), ask after existing rows: `Add a new row? (yes / no)`
+   - If yes, collect all fields for the new row, then ask again (max 20 new rows).
+5. **Remove rows:** If `disableAddingRemovingRows` is `false`, ask: `Remove any existing rows? Enter row numbers to remove, or press Enter to skip.`
+
+**Preserve each row's `identifier` field** if the row template's `components[]` declares a field named `identifier` and the existing row has a non-empty value for it — that identifier binds deployment-time references to the row. Do NOT regenerate it on edit. If a brand-new row is added, generate a fresh identifier per the product's conventions (usually a short slug of the row's primary display field; check existing rows for pattern).
+
+---
+
+## Step 7 — Build the Output JSON
+
+After collecting all answers, assemble `$POLICY_DATA`. The structure must be a flat key-value object — the same format as `$SESSION_DIR/products/$PRODUCT_NAME/form-data.json` produced by `template get --output-form-data`:
+
+```json
+{
+  "feedback-enabled": true,
+  "default-action": "Warning",
+  "orchestrator-library-feed-enabled": false,
+  "embedded-rules-config-rules": [
+    {
+      "identifier": "rule1",
+      "is-enabled-embedded-rules-config-rules": true,
+      "code-embedded-rules-config-rules": "RULE001"
+    }
+  ]
+}
+```
+
+Rules:
+
+- **Create flow:** include every key from `$SESSION_DIR/products/$PRODUCT_NAME/form-data.json` — defaults for unchanged fields.
+- **Update flow:** include every key from `$SESSION_DIR/existing-policy-data.json` so no previously configured value is dropped. For any key present in `form-data.json` but absent from the existing policy data, add it using the form-data default (schema drift — new field added since the policy was created).
+- Do not add keys that are not in the schema (`form-template.json`).
+- Use the component's `key` as the JSON key — not the label.
+- Preserve types: boolean fields must be `true`/`false` (not `"true"`/`"false"`).
+- Do NOT wrap the object in `{ "data": {...} }` — the CLI `create --input` / `update --input` wraps it automatically.
+
+---
+
+## Step 8 — Save to File
+
+Write the final `$POLICY_DATA` object to `$SESSION_DIR/aops-policy-data.json` (session-scoped, not product-scoped — only one policy is created per session). The format must be identical to `$SESSION_DIR/products/$PRODUCT_NAME/form-data.json` — a flat JSON object, no envelope.
+
+Use the `Write` tool to serialize `$POLICY_DATA` directly to `$SESSION_DIR/aops-policy-data.json`. Do NOT wrap the object in `{ "data": {...} }` — the CLI wraps it automatically.
+
+Sanity-check the saved file:
+
+```bash
+jq 'type' "$SESSION_DIR/aops-policy-data.json"                                       # must print "object"
+jq 'keys | length' "$SESSION_DIR/aops-policy-data.json"                              # must match the schema-expected field count
+diff <(jq -S 'keys' "$SESSION_DIR/aops-policy-data.json") \
+     <(jq -S 'keys' "$SESSION_DIR/products/$PRODUCT_NAME/form-data.json")            # create flow: should be empty (same key set)
+```
+
+For the update flow, the third check should compare against `$SESSION_DIR/existing-policy-data.json` plus any schema-drift keys — not against `form-data.json`.
+
+The file must exist before Step 9 runs, because the caller's final-review gate (and the subsequent CLI mutation) both consume it.
+
+---
+
+## Step 9 — Prepare Change Summary and Return to Caller
+
+Build a summary of every value the user changed and hand it to the caller. **Do NOT prompt for yes/no here** — the caller ([aops-policy-manage-guide.md](./aops-policy-manage-guide.md)) owns the single final-review gate before the CLI mutation runs.
+
+**Baseline for the diff depends on the flow:**
+
+- **Create flow:** diff against product defaults from `form-data.json`.
+- **Update flow:** diff against the existing policy's data from `$SESSION_DIR/existing-policy-data.json`. Also call out any schema-drift fields (new keys filled from product defaults).
+
+```text
+Policy data summary — changed from <defaults | existing policy>:
+
+  feedback-enabled             false   (was: true)
+  default-action               Warning (was: Error)
+  orchestrator-library-feed-enabled  false   (was: true)
+
+Unchanged fields: 14 fields kept at their defaults.
+```
+
+**Return control to caller.** At this point the configure guide's work is done. Hand two things back to the caller and stop without prompting:
+
+1. **Path:** `$SESSION_DIR/aops-policy-data.json` (render as a clickable markdown link so the user can open it from the upcoming review gate).
+2. **Change summary:** the block above, verbatim.
+
+The caller ([aops-policy-manage-guide.md — Create Step 4](./aops-policy-manage-guide.md#step-4--final-review-before-create-single-confirmation-gate) for the create flow, [Update Step 5](./aops-policy-manage-guide.md#step-5--final-review-before-update-single-confirmation-gate) for the update flow) inlines both into the single review gate. If the caller's review is rejected and the user asks to adjust specific fields, the caller routes back to Step 5 (Mode B for those fields) or Step 7 (metadata-only re-serialization) here.
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `template list` bootstrap fails or writes no product folders | Every per-product fetch failed | Stop. Show the CLI error. Verify `uip login status` and network; rerun the bootstrap |
+| `template get` returns no `template` field (update flow) | Product fetch failed for this product | Stop. Show the CLI error. Verify the product name matches a catalog entry |
+| `template.components` is empty or absent | Product has no configurable fields | Inform the user. Use `defaultData` as-is and skip to Step 8 |
+| User provides invalid type for a field (e.g. text for `number`) | Type mismatch in Mode B answer | Re-prompt: `Invalid input. Expected <TYPE>. Please try again:` |
+| User enters blank for a required field | `validate.required: true` and empty value | Re-prompt: `This field is required. Please enter a value:` |
+| Mode A partial match (some intent phrases unmapped) | Some user keywords found no locale-resource hits | Apply the matched phrases; ask the three-way question (proceed without / pick different product / enter manually) for the unmapped phrases only |
+| `$POLICY_DATA` keys diverge from `form-data.json` | Accidental extra key or missing schema key | Stop. Diff via the `jq keys` check in Step 8. Drop unknown keys; re-fill missing keys from the blueprint |
+| User asks to skip all fields | No intent + no default override | Use the full default data object without changes and proceed to Step 8 |

--- a/tests/tasks/uipath-gov-aops-policy/deployed_policy_smoke.yaml
+++ b/tests/tasks/uipath-gov-aops-policy/deployed_policy_smoke.yaml
@@ -1,0 +1,99 @@
+task_id: skill-gov-aops-policy-deployed-policy-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-gov-aops-policy skill to
+  query the deployed policy for a given license type / product / tenant
+  tuple, and also list every applicable policy. Tests the three-positional
+  argument order of `deployed-policy get <licenseType> <productName>
+  <tenant>` and guards against the legacy `--user-identifier` flag name.
+
+  Platform note: the smoke test runs without an authenticated tenant, so
+  `uip gov aops-policy` commands that hit the service will fail with an
+  auth error. That is acceptable — what matters is that the agent invokes
+  the correct commands with the correct flags.
+tags: [uipath-gov-aops-policy, smoke, deployed-policy]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Determine which AOps governance policy is currently in effect for the
+  caller identity with license type `Attended`, product `StudioX`, and
+  tenant `00000000-0000-0000-0000-000000000000`. Also list every
+  applicable policy (in priority order) that could resolve for this
+  caller. Use the uipath-gov-aops-policy skill.
+
+  Save a summary to report.json in the current working directory with at
+  minimum:
+    {
+      "license_type": "Attended",
+      "product_name": "StudioX",
+      "tenant": "00000000-0000-0000-0000-000000000000",
+      "deployed_policy_get_command": "<exact uip gov aops-policy deployed-policy get command you ran>",
+      "deployed_policy_list_command": "<exact uip gov aops-policy deployed-policy list command you ran>",
+      "commands_used": ["<list of uip commands you attempted>"]
+    }
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live governance
+    tenant in this environment. Commands will fail with auth errors — that
+    is expected. Run each command once, record the result (success or
+    error) in report.json, and move on. Do NOT retry or attempt to login.
+  - Use --output json on every uip gov aops-policy command.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy deployed-policy get` with three positional args in order (licenseType productName tenant)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+get\s+["'']?Attended["'']?\s+["'']?StudioX["'']?\s+["'']?[\w-]+["'']?\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy deployed-policy list` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json uses the current CLI namespace and flag names (no legacy `uip admin aops-policy` or `--user-identifier`)"
+    path: "report.json"
+    includes:
+      - "uip gov aops-policy deployed-policy"
+    excludes:
+      - "uip admin aops-policy"
+      - "--user-identifier"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure and at least 2 commands used"
+    path: "report.json"
+    assertions:
+      - expression: "license_type"
+        operator: equals
+        expected: "Attended"
+      - expression: "product_name"
+        operator: equals
+        expected: "StudioX"
+      - expression: "length(deployed_policy_get_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(deployed_policy_list_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 2
+    weight: 1.5
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-gov-aops-policy/deployment_discovery_smoke.yaml
+++ b/tests/tasks/uipath-gov-aops-policy/deployment_discovery_smoke.yaml
@@ -1,0 +1,110 @@
+task_id: skill-gov-aops-policy-deployment-discovery-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-gov-aops-policy skill to
+  discover deployment subjects — list governance users, fetch one user's
+  assignments, and list tenants with assignments. Tests the canonical
+  list→get chain and guards against flag-rename regressions
+  (`--user-name` → `--user`, `--user-identifier` → `--user-id`) and the
+  deprecated `Data.result` response-shape reference.
+
+  Platform note: the smoke test runs without an authenticated tenant, so
+  `uip gov aops-policy` commands that hit the service will fail with an
+  auth error. That is acceptable — what matters is that the agent invokes
+  the correct commands with the correct flags.
+tags: [uipath-gov-aops-policy, smoke, deployment, discovery]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  A tenant admin wants to audit AOps governance deployment state. List
+  every governance user, list every tenant that has assignments, then
+  pick the first user from the user list and fetch that user's current
+  policy assignments. Use the uipath-gov-aops-policy skill.
+
+  Save a summary to report.json in the current working directory with at
+  minimum:
+    {
+      "user_list_command": "<exact uip gov aops-policy deployment user list command you ran>",
+      "user_get_command": "<exact uip gov aops-policy deployment user get command you ran>",
+      "tenant_list_command": "<exact uip gov aops-policy deployment tenant list command you ran>",
+      "chosen_user_id": "<id of the user you picked, or 'none' if the list command returned nothing>",
+      "commands_used": ["<list of uip commands you attempted>"]
+    }
+
+  If `deployment user list` fails with auth error, still call
+  `deployment user get <PLACEHOLDER_ID>` once with any placeholder user
+  identifier so the list→get chain is exercised. Record the placeholder
+  in `chosen_user_id`.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live governance
+    tenant in this environment. Commands will fail with auth errors — that
+    is expected. Run each command once, record the result (success or
+    error) in report.json, and move on. Do NOT retry or attempt to login.
+  - Use --output json on every uip gov aops-policy command.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy deployment user list` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy deployment user get <USER_ID>` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+get\s+["'']?[\w-]+["'']?\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy deployment tenant list` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+tenant\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json uses the current CLI namespace and current flag names (no legacy `--user-name`, `--user-identifier`, or `Data.result`)"
+    path: "report.json"
+    includes:
+      - "uip gov aops-policy"
+    excludes:
+      - "uip admin aops-policy"
+      - "--user-name"
+      - "--user-identifier"
+      - "Data.result"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure with at least 3 commands used"
+    path: "report.json"
+    assertions:
+      - expression: "length(user_list_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(user_get_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(tenant_list_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 3
+    weight: 1.5
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-gov-aops-policy/discover_catalog_smoke.yaml
+++ b/tests/tasks/uipath-gov-aops-policy/discover_catalog_smoke.yaml
@@ -1,0 +1,89 @@
+task_id: skill-gov-aops-policy-catalog-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-gov-aops-policy skill to
+  discover the governance catalog — list AOps products and license types.
+  Tests whether the skill teaches the correct CLI namespace
+  (`uip gov aops-policy`, not the legacy `uip admin aops-policy`), the
+  `--output json` convention, and that `license-type list` is reachable
+  under the current subcommand tree.
+
+  Platform note: the smoke test runs without an authenticated tenant, so
+  `uip gov aops-policy` commands that hit the service will fail with an
+  auth error. That is acceptable — what matters is that the agent invokes
+  the correct commands with the correct flags.
+tags: [uipath-gov-aops-policy, smoke, catalog]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  A tenant admin wants a catalog snapshot of AOps governance before
+  creating any new policies. List every available product and every
+  available license type, then save the result. Use the
+  uipath-gov-aops-policy skill to produce the output.
+
+  Save a summary to report.json in the current working directory with at
+  minimum:
+    {
+      "product_list_command": "<exact uip gov aops-policy product list command you ran>",
+      "license_type_list_command": "<exact uip gov aops-policy license-type list command you ran>",
+      "commands_used": ["<list of uip commands you attempted>"]
+    }
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live governance
+    tenant in this environment. Commands will fail with auth errors — that
+    is expected. Run each command once, record the result (success or
+    error) in report.json, and move on. Do NOT retry or attempt to login.
+  - Use --output json on every uip gov aops-policy command.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy product list` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+product\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy license-type list` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+license-type\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json references the current CLI namespace (`uip gov aops-policy`), not the legacy `uip admin aops-policy`"
+    path: "report.json"
+    includes:
+      - "uip gov aops-policy"
+    excludes:
+      - "uip admin aops-policy"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure and at least two commands used"
+    path: "report.json"
+    assertions:
+      - expression: "length(product_list_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(license_type_list_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 2
+    weight: 1.5
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-gov-aops-policy/list_policies_smoke.yaml
+++ b/tests/tasks/uipath-gov-aops-policy/list_policies_smoke.yaml
@@ -1,0 +1,87 @@
+task_id: skill-gov-aops-policy-list-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-gov-aops-policy skill to
+  list AOps governance policies for a given product. Tests whether the
+  skill teaches the correct CLI namespace (`uip gov aops-policy`, not the
+  legacy `uip admin aops-policy`), the `--output json` convention, and
+  the product-identifier-vs-label discipline (Critical Rule #2).
+
+  Platform note: the smoke test runs without an authenticated tenant, so
+  `uip gov aops-policy` commands that hit the service will fail with an
+  auth error. That is acceptable — what matters is that the agent invokes
+  the correct commands with the correct flags.
+tags: [uipath-gov-aops-policy, smoke, list]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  A tenant admin wants to see every AOps governance policy registered for
+  the `AITrustLayer` product, ordered by priority ascending. Use the
+  uipath-gov-aops-policy skill to produce the result.
+
+  Save a summary to report.json in the current working directory with at
+  minimum:
+    {
+      "product_name": "AITrustLayer",
+      "list_command": "<the exact uip gov aops-policy list command you ran>",
+      "commands_used": ["<list of uip commands you attempted>"]
+    }
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live governance
+    tenant in this environment. Commands will fail with auth errors — that
+    is expected. Run each command once, record the result (success or
+    error) in report.json, and move on. Do NOT retry or attempt to login.
+  - Use --output json on every uip gov aops-policy command.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy list` with --product-name AITrustLayer"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+list\s+.*--product-name\s+["'']?AITrustLayer'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on the list command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json references the current CLI namespace (`uip gov aops-policy`), not the legacy `uip admin aops-policy`"
+    path: "report.json"
+    includes:
+      - "uip gov aops-policy"
+    excludes:
+      - "uip admin aops-policy"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure and values"
+    path: "report.json"
+    assertions:
+      - expression: "product_name"
+        operator: equals
+        expected: "AITrustLayer"
+      - expression: "length(list_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 1
+    weight: 1.5
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-gov-aops-policy/template_bootstrap_smoke.yaml
+++ b/tests/tasks/uipath-gov-aops-policy/template_bootstrap_smoke.yaml
@@ -1,0 +1,84 @@
+task_id: skill-gov-aops-policy-template-bootstrap-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-gov-aops-policy skill to
+  bootstrap AOps governance policy templates for all products into a
+  session directory. Tests whether the skill teaches the correct
+  `template list --output-dir` command (Critical Rule #3) — a single call
+  that writes `form-template.json`, `form-data.json`, and
+  `form-template-locale-resource.json` per product — instead of looping
+  `product list` + per-product `template get`.
+
+  Platform note: the smoke test runs without an authenticated tenant, so
+  `uip gov aops-policy` commands that hit the service will fail with an
+  auth error. That is acceptable — what matters is that the agent invokes
+  the correct commands with the correct flags.
+tags: [uipath-gov-aops-policy, smoke, template, bootstrap]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I am starting a new AOps governance policy authoring session. Bootstrap
+  the policy-form templates for every product into `./session/products/`
+  so I can review which products are available and inspect their form
+  schemas. Use the uipath-gov-aops-policy skill.
+
+  Save a summary to report.json in the current working directory with at
+  minimum:
+    {
+      "bootstrap_command": "<exact uip gov aops-policy template list command you ran>",
+      "output_dir": "./session/products",
+      "commands_used": ["<list of uip commands you attempted>"]
+    }
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live governance
+    tenant in this environment. Commands will fail with auth errors — that
+    is expected. Run each command once, record the result (success or
+    error) in report.json, and move on. Do NOT retry or attempt to login.
+  - Use --output json on every uip gov aops-policy command where applicable.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip gov aops-policy template list` with --output-dir pointing at ./session/products"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+template\s+list\s+.*--output-dir\s+["'']?\.?/?session/products'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json references the current CLI namespace and did NOT fall back to per-product `template get` or `product list` bootstrap path (Critical Rule #3)"
+    path: "report.json"
+    includes:
+      - "uip gov aops-policy template list"
+    excludes:
+      - "uip admin aops-policy"
+      - "aops-policy product list"
+      - "aops-policy template get"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure and at least one command used"
+    path: "report.json"
+    assertions:
+      - expression: "length(bootstrap_command)"
+        operator: gte
+        expected: 10
+      - expression: "output_dir"
+        operator: contains
+        expected: "session/products"
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 1
+    weight: 1.5
+    pass_threshold: 0.75


### PR DESCRIPTION
## Summary

Adds the `uipath-gov-aops-policy` skill — an end-to-end guide for managing AOps governance policies and deploying them to users, groups, or tenants via the `uip gov aops-policy` CLI.

### Skill layout

- **`SKILL.md`** — identity, critical rules, quick-start, and navigation into the references below.
- **`references/aops-policy-commands.md`** — authoritative CLI reference. Every subcommand's flags, positional arguments, and output shape (`list`, `get`, `create`, `update`, `delete`, `product list|get`, `license-type list`, `template list|get`, `deployment {user,group,tenant} {list,get,configure,delete,remove}`, `deployed-policy {get,list}`), plus authentication (user token + S2S) and a debug table.
- **`references/aops-policy-manage-guide.md`** — full CRUD lifecycle. Create lists products, shows the existing priority landscape, and suggests defaults; update/delete require fetching current values first and getting explicit confirmation. Documents `update`'s FULL-REPLACE semantics (omitting `--description` / `--priority` / `--availability` / `--input` clears those fields server-side).
- **`references/configure-aops-policy-data-guide.md`** — form.io template traversal. `template list` bootstraps `form-template.json` / `form-data.json` / `form-template-locale-resource.json` per product into the session dir. Two composition modes: intent-based auto-fill from the user's prompt, or paginated prompting.
- **`references/aops-policy-deploy-guide.md`** — non-interactive deployment via `deployment <subject> configure --input <path>` for user / group / tenant. Documents the JSON input shape, license-type discovery via `license-type list` (use `identifier` GUID in tenant entries — not `name`), FULL-REPLACE semantics on `configure`, `--user`/`--group`/`--source` flags (renamed from `--user-name`/`--group-name`), and confirmation-gated remove/delete.
- **`references/aops-policy-deployed-guide.md`** — `deployed-policy get` (single effective policy after user → group → tenant walk; default mode uses the caller's login token, S2S `--user-id` resolves for a named user, S2S `--tenant-only` skips user/group overrides) and `deployed-policy list` (every applicable policy in priority order, user-token only).
- **`references/aops-governance-recipes-guide.md`** — catalog of common end-user asks mapped to concrete policy configurations.
- **CODEOWNERS** — entry added for the skill path.

### Key behaviors documented

- Deployment precedence: User > Group > Tenant.
- Priority is a group-level tie-breaker only; does not determine scope precedence.
- `availability` is the offline grace period (in days) during which a client keeps applying the cached policy when it cannot reach AOps; integer > 0; `0` is server-normalized to `30`; smallest value across contributors wins on merged responses.
- `create`/`update` data-file convention: raw flat key/value object, **not** wrapped in `{ "data": {...} }` — the CLI wraps it.
- `update`, `deployment configure`, and `deployment tenant remove` are all FULL-REPLACE operations — seed from `get` first to preserve existing state.
- Policy `delete` fails if the policy is still assigned to any subject.

## Test plan

- [ ] `SKILL.md` frontmatter is valid YAML; `name` matches the folder name.
- [ ] `description` is under 250 chars (run `hooks/validate-skill-descriptions.sh` if available).
- [ ] `uip gov aops-policy product list --output json` and `license-type list --output json` parse cleanly.
- [ ] End-to-end create: `template list` bootstrap → configure form-data → `create --input` → verify with `get`.
- [ ] End-to-end update: `get` → edit blueprint → `update --identifier ... --input` → re-fetch and confirm preserved fields.
- [ ] End-to-end user deploy: build assignment JSON → `deployment user configure --user <NAME> --source <SRC> --input <PATH>` → verify with `deployment user get`.
- [ ] End-to-end tenant deploy: `license-type list` → build JSON with `licenseTypeIdentifier` (GUID) → `deployment tenant configure --tenant-name <NAME> --input <PATH>` → verify.
- [ ] `deployed-policy get` (default, `--s2s-token --user-id`, `--s2s-token --tenant-only`) all return usable output; `deployed-policy list` returns applicable entries with `source`/`priority`.
- [ ] `delete` is blocked when assignments still reference the policy; succeeds after removing references.
- [ ] No `/tmp/`, absolute paths, or secrets in committed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)