### PR TITLE
feat(uipath-human-in-the-loop): update to direct JSON editing model

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-human-in-the-loop
-description: "[PREVIEW] Add Human-in-the-Loop node to a Flow, Maestro, or Coded Agent. Triggers on approval gates, escalations, write-back validation, data enrichment — even without user saying 'HITL'. Designs schema, runs CLI, wires edges."
+description: "[PREVIEW] Add Human-in-the-Loop node to a Flow, Maestro, or Coded Agent. Triggers on approval gates, escalations, write-back validation, data enrichment — even without user saying 'HITL'. Designs schema, writes JSON directly."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
@@ -23,11 +23,12 @@ See [references/hitl-patterns.md](references/hitl-patterns.md) for the full busi
 
 ## Critical Rules
 
-1. **Confirm schema with the user before running the CLI.** Show the designed schema (Step 4) and wait for explicit confirmation — do not call `hitl add` speculatively.
+1. **Confirm schema with the user before writing anything.** Show the designed schema (Step 4) and wait for explicit confirmation.
 2. **Always wire at least the `completed` handle.** A HITL node with no outgoing edge on `completed` blocks the flow. Wire `cancelled` and `timeout` to end nodes or handlers unless the user explicitly defers them.
-3. **Validate after every change.** Run `uip flow validate <file> --output json` after adding the node and again after wiring all edges.
-4. **Always use `--output json`** on all `uip` commands when parsing output programmatically.
+3. **Regenerate `variables.nodes` after adding the node.** Replace the entire `workflow.variables.nodes` array — do not append. See the reference docs for the algorithm.
+4. **Validate after every change.** Run `uip flow validate <file> --output json` after writing the node and edges.
 5. **Read the existing `.flow` file before adding.** Understand which nodes already exist and where the HITL checkpoint belongs in the flow.
+6. **The definition entry is added once.** Check `workflow.definitions` — if `uipath.human-in-the-loop` is already there, do not add it again.
 
 ---
 
@@ -59,10 +60,10 @@ find . -name "agent.json" -maxdepth 4 | head -3
 find . -name "*.bpmn" -maxdepth 4 | head -3
 ```
 
-| Found | Surface | CLI available |
+| Found | Surface | How HITL is added |
 |---|---|---|
-| `.flow` file | **Flow** | Yes — `uip flow hitl add` |
-| `agent.json` | **Coded Agent** | Partial — escalation CLI in-flight |
+| `.flow` file | **Flow** | Write node JSON directly — see reference docs |
+| `agent.json` | **Coded Agent** | Escalation CLI in-flight — guide manually for now |
 | `.bpmn` (Maestro) | **Maestro** | Not yet — guide user manually |
 
 **If the user mentioned a specific file path**, use that directly.
@@ -80,11 +81,12 @@ The flow file path will be `<ProjectName>/flow_files/<ProjectName>.flow`.
 
 ## Step 2 — Read the Business Context
 
-If a `.flow` file already exists, read it to understand the current nodes and edges. Use the Read tool on the `.flow` file path, then identify:
-1. **Where** in the process the human decision point belongs (after which existing node)
+Read the existing `.flow` file to understand current nodes and edges. Use the Read tool on the `.flow` file path, then identify:
+1. **Where** the human decision point belongs (after which existing node)
 2. **What the human needs to see** — data produced by upstream nodes
 3. **What the human must provide back** — data needed by downstream nodes
 4. **What actions they can take** — the named outcome buttons
+5. **Form type**: QuickForm (inline schema) or AppTask (deployed coded app)?
 
 ---
 
@@ -124,6 +126,7 @@ Before designing the schema, ask these focused questions if the business descrip
 | What actions they take | "What are the named actions — e.g. Approve/Reject, or something domain-specific like Accept/Negotiate/Decline?" |
 | Timeout | "How long before the task times out if nobody acts? (default: 24 hours)" |
 | Priority | "Is this normal priority, or high/critical?" |
+| Form type | "Should this use a quick inline form, or a deployed Action Center app?" |
 
 **Common business descriptions → schema translations:**
 
@@ -169,96 +172,31 @@ The CLI accepts this format for `--schema`:
 
 ---
 
-## Step 5 — Run the CLI
+## Step 5 — Write the Node Directly
 
-### Surface: Flow
+### Surface: Flow — QuickForm (inline schema)
 
-**Full sequence:**
+Write the node JSON directly into `workflow.nodes`, add the definition to `workflow.definitions` (once), wire edges into `workflow.edges`, and regenerate `workflow.variables.nodes`.
 
-```bash
-# 1. Add the HITL node
-uip flow hitl add <path-to-flow-file> \
-  --schema '<schema-json>' \
-  --label "<Label>" \
-  --priority normal \
-  --timeout PT24H
+Full reference: **[references/hitl-node-quickform.md](references/hitl-node-quickform.md)** — complete node JSON, definition entry, edge format, `variables.nodes` regeneration algorithm, and four worked schema conversion examples.
 
-# Note the NodeId returned in Data.NodeId
-
-# 2. Wire the output handles
-uip flow edge add <file> --source <NodeId>:completed --target <next-node-id>:input
-uip flow edge add <file> --source <NodeId>:cancelled --target <cancel-node-id>:input
-uip flow edge add <file> --source <NodeId>:timeout   --target <timeout-node-id>:input
-
-# 3. Validate
-uip flow validate <file> --format json
-```
-
-**CLI options:**
-
-| Option | Values | Default |
-|---|---|---|
-| `--schema` | JSON string (Step 4 format) | `{ outcomes: [{ name: "Submit" }] }` |
-| `--label` | canvas label | `"Human in the Loop"` |
-| `--priority` | `low` `normal` `high` `critical` | `normal` |
-| `--timeout` | ISO 8601 duration (PT24H, PT48H, P7D) | `PT24H` |
-| `--position` | `x,y` canvas coordinates | `0,0` |
-
-**If no downstream nodes exist yet** for cancelled/timeout, wire them to the nearest end node or omit and note them as TODOs for the user.
-
-**Runtime variables available after the HITL node:**
-- `$vars.<NodeId>.result` — object containing all `outputs` and `inOuts` the human filled in
-- `$vars.<NodeId>.result.<fieldName>` — access individual fields
-- `$vars.<NodeId>.status` — `"completed"`, `"cancelled"`, or `"timeout"`
-
-**How to use HITL output in a downstream script node:**
-
-```javascript
-// In a script node that runs after the HITL node completes
-const reviewResult = $vars.rcaReview1.result;
-const proposedUpdate = reviewResult.proposedUpdate;  // inOut field the human edited
-const reviewNotes = reviewResult.notes;              // output field the human filled in
-
-if ($vars.rcaReview1.status === "completed") {
-    // Use the human-reviewed value for the write-back
-    await updateServiceNow(ticketId, proposedUpdate);
-}
-```
-
-**If no downstream nodes exist yet** for `cancelled`/`timeout`, create placeholder end nodes first:
+After writing, validate:
 
 ```bash
-# Create end nodes for the non-happy paths (note the NodeId from the output)
-uip flow node add <file> uipath.end --label "Cancelled"
-uip flow node add <file> uipath.end --label "Timeout"
-
-# Then wire all three handles (use NodeIds returned from node add)
-uip flow edge add <file> --source <NodeId>:completed --target <next-node-id>:input
-uip flow edge add <file> --source <NodeId>:cancelled --target <cancelledNodeId>:input
-uip flow edge add <file> --source <NodeId>:timeout   --target <timeoutNodeId>:input
+uip flow validate <file> --output json
 ```
 
-**Complete example — invoice approval:**
+### Surface: Flow — AppTask (deployed coded app)
+
+First resolve the app by name via a direct API call (no CLI), then write the node JSON with `inputs.type = "custom"`.
+
+Full reference: **[references/hitl-node-apptask.md](references/hitl-node-apptask.md)** — credential reading, app lookup curl command, complete node JSON, `inputs.app` field mapping.
+
+After writing, validate:
 
 ```bash
-uip flow init InvoiceApproval
-
-uip flow hitl add InvoiceApproval/flow_files/InvoiceApproval.flow \
-  --schema '{"inputs":[{"name":"invoiceId","type":"string"},{"name":"amount","type":"number"}],"outcomes":[{"name":"Approve","type":"string"},{"name":"Reject","type":"string"}]}' \
-  --label "Invoice Review" \
-  --priority normal
-
-# Returns: { "NodeId": "invoiceReview1", ... }
-
-uip flow edge add InvoiceApproval/flow_files/InvoiceApproval.flow \
-  --source invoiceReview1:completed --target end:input
-
-uip flow validate InvoiceApproval/flow_files/InvoiceApproval.flow --format json
+uip flow validate <file> --output json
 ```
-
-See [references/hitl-patterns.md](references/hitl-patterns.md) for the full business pattern recognition guide and signal tables.
-
----
 
 ### Surface: Coded Agent
 
@@ -288,11 +226,9 @@ response = interrupt(CreateTask(
 # response contains the human's outputs and chosen outcome
 ```
 
----
-
 ### Surface: Maestro
 
-The Maestro HITL CLI is not yet available. Guide the user to add the HITL node manually in the Maestro process designer using the schema from Step 4. Note: in Maestro, field names in `outputs`/`inOuts` must exactly match declared process variable names and types.
+The Maestro HITL CLI is not yet available. Guide the user to add the HITL node manually in the Maestro process designer using the schema from Step 4. In Maestro, field names in `outputs`/`inOuts` must exactly match declared process variable names and types.
 
 ---
 
@@ -311,5 +247,6 @@ After completing the wiring:
 
 ## References
 
-- **[HITL Business Pattern Recognition](references/hitl-patterns.md)** — Signal tables for detecting when a process needs a human checkpoint (approval gates, escalations, write-back validation, data enrichment, compliance). Includes proactive recommendation language and when NOT to recommend HITL.
-- **[HITL Node Reference](../uipath-maestro-flow/references/flow-hitl.md)** — CLI options, schema format, edge wiring, runtime variables, and complete approval flow example.
+- **[QuickForm Node JSON](references/hitl-node-quickform.md)** — Full node JSON, definition entry, edge format, `variables.nodes` regeneration, four schema conversion examples.
+- **[AppTask Node JSON](references/hitl-node-apptask.md)** — App lookup via direct API, node JSON with `inputs.type = "custom"`, app field mapping.
+- **[HITL Business Pattern Recognition](references/hitl-patterns.md)** — Signal tables for detecting when a process needs a human checkpoint. Includes proactive recommendation language and when NOT to recommend HITL.

--- a/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
@@ -1,0 +1,148 @@
+# HITL AppTask Node — Direct JSON Reference
+
+The AppTask variant uses a deployed coded app (Studio Web) as the task form. Same node type as QuickForm (`uipath.human-in-the-loop`), same three output handles. Difference: `inputs.type = "custom"` and `inputs.app` points to the deployed app.
+
+---
+
+## App Lookup — Direct API Call
+
+The agent resolves the app by name before writing the node JSON. No CLI command. Read credentials from the environment, then call the Orchestrator API directly.
+
+### Step 1 — Read stored credentials
+
+```bash
+# Read from local .env (current dir) or global ~/.uipcli/.env
+ENV_FILE=".env"
+[ ! -f "$ENV_FILE" ] && ENV_FILE="$HOME/.uipcli/.env"
+source "$ENV_FILE"
+
+# Variables now available: UIPATH_URL, UIPATH_ORGANIZATION_ID, UIPATH_ACCESS_TOKEN, UIPATH_TENANT_ID
+```
+
+### Step 2 — List deployed apps and find by name
+
+```bash
+APP_NAME="Invoice Approval"   # The name the user provided
+
+curl -s \
+  "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-apps?state=deployed" \
+  -H "Authorization: Bearer ${UIPATH_ACCESS_TOKEN}" \
+  -H "X-Uipath-Tenantid: ${UIPATH_TENANT_ID}" \
+  -H "Accept: application/json" | \
+  jq --arg name "$APP_NAME" '.deployed[] | select(.deploymentTitle | ascii_downcase | contains($name | ascii_downcase))'
+```
+
+Response shape for each app:
+```json
+{
+  "id": "c0ba97df-8a30-4fe0-b4b4-4611a631d77b",
+  "deploymentTitle": "Invoice Approval",
+  "systemName": "invoice-approval",
+  "deployVersion": 3,
+  "folderPath": "Shared"
+}
+```
+
+Extract: `systemName` → use as `inputs.app.key`, `deploymentTitle` → use as `inputs.app.name`, `folderPath` → use as `inputs.app.folderPath`.
+
+### Step 3 — (Optional) Fetch app schema for field reference
+
+```bash
+curl -s \
+  "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-schema?appSystemName=${SYSTEM_NAME}&version=${DEPLOY_VERSION}" \
+  -H "Authorization: Bearer ${UIPATH_ACCESS_TOKEN}" \
+  -H "X-Uipath-Tenantid: ${UIPATH_TENANT_ID}" \
+  -H "Accept: application/json"
+```
+
+Returns `{ inputs, outputs, inOuts, outcomes }` — the app's declared schema. Use this to understand what data the app expects, but the `.flow` node does not need to enumerate these fields (the app owns its own form).
+
+---
+
+## Full Node JSON
+
+```json
+{
+  "id": "invoiceReview1",
+  "type": "uipath.human-in-the-loop",
+  "typeVersion": "1.0.0",
+  "display": { "label": "Invoice Review" },
+  "ui": { "position": { "x": 474, "y": 144 } },
+  "inputs": {
+    "type": "custom",
+    "channels": [],
+    "recipient": {
+      "channels": ["Email"],
+      "assignee": { "type": "user", "value": "reviewer@company.com" }
+    },
+    "app": {
+      "name": "Invoice Approval",
+      "key": "invoice-approval",
+      "folderPath": "Shared"
+    },
+    "schema": {
+      "inputs": [],
+      "outputs": [],
+      "inOuts": [],
+      "outcomes": [{ "name": "Submit", "type": "string" }]
+    }
+  },
+  "model": { "type": "bpmn:UserTask" }
+}
+```
+
+### `inputs.app` field mapping
+
+| Field | Source | Example |
+|---|---|---|
+| `name` | `deploymentTitle` from app list | `"Invoice Approval"` |
+| `key` | `systemName` from app list | `"invoice-approval"` |
+| `folderPath` | `folderPath` from app list | `"Shared"` |
+
+### `inputs.recipient` options
+
+```json
+// Action Center (default — no specific assignee)
+"recipient": { "channels": ["ActionCenter"], "connections": {}, "assignee": { "type": "group" } }
+
+// Specific user by email
+"recipient": { "channels": ["Email"], "assignee": { "type": "user", "value": "user@company.com" } }
+
+// Everyone in a group
+"recipient": { "channels": ["ActionCenter"], "assignee": { "type": "group", "value": "Finance Team" } }
+```
+
+---
+
+## Definition Entry
+
+Same definition as QuickForm — see [hitl-node-quickform.md](hitl-node-quickform.md) for the full definition block. Add it once to `workflow.definitions`, deduplicated by `nodeType`.
+
+---
+
+## Edge Wiring
+
+Identical to QuickForm. Wire `completed`, `cancelled`, `timeout`:
+
+```json
+{ "id": "invoiceReview1-completed-nextNode1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "nextNode1", "targetPort": "input" },
+{ "id": "invoiceReview1-cancelled-end1-input",      "sourceNodeId": "invoiceReview1", "sourcePort": "cancelled", "targetNodeId": "end1",      "targetPort": "input" },
+{ "id": "invoiceReview1-timeout-end2-input",        "sourceNodeId": "invoiceReview1", "sourcePort": "timeout",   "targetNodeId": "end2",      "targetPort": "input" }
+```
+
+---
+
+## `variables.nodes` — Regenerate After Adding
+
+Same rule as QuickForm — add `result` and `status` entries for the new node, then replace the entire `variables.nodes` array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
+
+---
+
+## Runtime Variables
+
+Same as QuickForm:
+
+| Variable | What it contains |
+|---|---|
+| `$vars.<nodeId>.result` | Outputs the human filled in via the app |
+| `$vars.<nodeId>.status` | `"completed"`, `"cancelled"`, or `"timeout"` |

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -1,0 +1,277 @@
+# HITL QuickForm Node — Direct JSON Reference
+
+The agent writes the `uipath.human-in-the-loop` node directly into the `.flow` file as JSON. No CLI command needed to add the node.
+
+---
+
+## Full Node JSON
+
+```json
+{
+  "id": "invoiceReview1",
+  "type": "uipath.human-in-the-loop",
+  "typeVersion": "1.0.0",
+  "display": { "label": "Invoice Review" },
+  "ui": { "position": { "x": 474, "y": 144 } },
+  "inputs": {
+    "type": "quick",
+    "channels": [],
+    "recipient": {
+      "channels": ["ActionCenter"],
+      "connections": {},
+      "assignee": { "type": "group" }
+    },
+    "priority": "normal",
+    "timeout": "PT24H",
+    "schema": {
+      "id": "a3f7c2d1-8b4e-4f9a-b2c5-6d8e1f3a7b9c",
+      "title": "Invoice Review",
+      "fields": [
+        {
+          "id": "invoiceid",
+          "label": "Invoice ID",
+          "type": "text",
+          "direction": "input",
+          "binding": "=js:$vars.fetchInvoice.result.invoiceId"
+        },
+        {
+          "id": "amount",
+          "label": "Amount",
+          "type": "number",
+          "direction": "input",
+          "binding": "=js:$vars.fetchInvoice.result.amount"
+        },
+        {
+          "id": "notes",
+          "label": "Notes",
+          "type": "text",
+          "direction": "output",
+          "variable": "notes",
+          "required": false
+        },
+        {
+          "id": "decision",
+          "label": "Decision",
+          "type": "text",
+          "direction": "output",
+          "variable": "decision",
+          "required": true
+        }
+      ],
+      "outcomes": [
+        { "id": "approve", "name": "Approve", "isPrimary": true,  "outcomeType": "Positive", "action": "Continue" },
+        { "id": "reject",  "name": "Reject",  "isPrimary": false, "outcomeType": "Negative", "action": "End" }
+      ]
+    }
+  },
+  "model": { "type": "bpmn:UserTask" }
+}
+```
+
+**Required fields:** `id`, `type`, `typeVersion`, `ui.position`
+
+**Node ID rule:** camelCase from the label, strip non-alphanumeric, append `1` (increment to `2`, `3`... until unique among existing node IDs). Example: `"Invoice Review"` → `invoiceReview1`.
+
+---
+
+## Definition Entry
+
+Every `.flow` file must have one definition entry for `uipath.human-in-the-loop` in `workflow.definitions`. Add it exactly once — deduplicate by `nodeType`.
+
+```json
+{
+  "nodeType": "uipath.human-in-the-loop",
+  "version": "1.0.0",
+  "category": "human-task",
+  "tags": ["human-task", "hitl", "human-in-the-loop", "approval"],
+  "sortOrder": 50,
+  "display": {
+    "label": "Human in the Loop",
+    "icon": "users",
+    "shape": "rectangle"
+  },
+  "handleConfiguration": [
+    {
+      "position": "left",
+      "handles": [
+        {
+          "id": "input",
+          "type": "target",
+          "handleType": "input",
+          "constraints": {
+            "forbiddenSourceCategories": ["trigger"],
+            "validationMessage": "Human tasks cannot be directly triggered"
+          }
+        }
+      ],
+      "visible": true
+    },
+    {
+      "position": "right",
+      "handles": [
+        { "id": "completed", "label": "Completed", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } },
+        { "id": "cancelled", "label": "Cancelled", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } },
+        { "id": "timeout",   "label": "Timeout",   "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } }
+      ],
+      "visible": true
+    }
+  ],
+  "model": { "type": "bpmn:UserTask" },
+  "inputDefinition": {
+    "channels": [],
+    "schema": {
+      "inputs": [], "outputs": [], "inOuts": [],
+      "outcomes": [{ "name": "Submit", "type": "string" }]
+    },
+    "timeout": "PT24H",
+    "priority": "normal"
+  },
+  "outputDefinition": {
+    "result": { "type": "object", "description": "Task result data", "source": "=result", "var": "result" },
+    "status": { "type": "string", "description": "Task completion status (completed, cancelled, timeout)", "source": "=status", "var": "status" }
+  }
+}
+```
+
+---
+
+## Edge Wiring
+
+Wire all three output handles. Edge ID format: `{sourceNodeId}-{sourcePort}-{targetNodeId}-{targetPort}` (append `-2`, `-3` on collision).
+
+```json
+{ "id": "invoiceReview1-completed-processApproval1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "processApproval1", "targetPort": "input" },
+{ "id": "invoiceReview1-cancelled-end1-input",             "sourceNodeId": "invoiceReview1", "sourcePort": "cancelled", "targetNodeId": "end1",             "targetPort": "input" },
+{ "id": "invoiceReview1-timeout-end2-input",               "sourceNodeId": "invoiceReview1", "sourcePort": "timeout",   "targetNodeId": "end2",             "targetPort": "input" }
+```
+
+**Always wire `completed`.** A HITL node with no edge on `completed` blocks the flow forever. Wire `cancelled` and `timeout` to end nodes if no specific handler exists.
+
+---
+
+## `variables.nodes` — Regenerate After Every Node Add/Remove
+
+The HITL node exposes two outputs (`result`, `status`). After adding it, **completely replace** `workflow.variables.nodes` by iterating all nodes and collecting their outputs:
+
+```json
+"variables": {
+  "nodes": [
+    {
+      "id": "invoiceReview1.result",
+      "type": "object",
+      "binding": { "nodeId": "invoiceReview1", "outputId": "result" }
+    },
+    {
+      "id": "invoiceReview1.status",
+      "type": "string",
+      "binding": { "nodeId": "invoiceReview1", "outputId": "status" }
+    }
+  ]
+}
+```
+
+Include entries for **all** nodes in the flow, not just the HITL node. Replace the entire array — do not append.
+
+---
+
+## Schema Conversion — Examples
+
+The agent translates the user's business description into the `fields[]` and `outcomes[]` arrays. No CLI needed — apply these rules directly.
+
+### Rules
+
+| What | Rule |
+|---|---|
+| field `id` | lowercase label, spaces→`-`, strip non-alphanumeric. `"Invoice ID"` → `"invoiceid"`, `"Due Date"` → `"due-date"` |
+| `direction` | `inputs[]` items → `"input"`, `outputs[]` → `"output"`, `inOuts[]` → `"inOut"` |
+| field `type` | `"string"` → `"text"`, `"number"` → `"number"`, `"boolean"` → `"boolean"`, `"date"` → `"date"` |
+| `binding` | `"varName"` → `"=js:$vars.<upstream-node-id>.result.<varName>"` (for input/inOut) |
+| `variable` | output/inOut variable name — defaults to `id` if not specified |
+| `required` | omit if false; set `true` for mandatory outputs |
+| `outcomes[0]` | `isPrimary: true`, `outcomeType: "Positive"`, `action: "Continue"` |
+| `outcomes[1+]` | `isPrimary: false`, `outcomeType: "Negative"`, `action: "End"` |
+| `schema.id` | Generate a fresh UUID (e.g. `crypto.randomUUID()` or any UUID v4) |
+
+### Example 1 — Simple approval (inputs only + outcomes)
+
+Business description: *"Reviewer sees invoice ID and amount, clicks Approve or Reject"*
+
+```json
+"fields": [
+  { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "=js:$vars.fetchData1.result.invoiceId" },
+  { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "=js:$vars.fetchData1.result.amount" }
+],
+"outcomes": [
+  { "id": "approve", "name": "Approve", "isPrimary": true,  "outcomeType": "Positive", "action": "Continue" },
+  { "id": "reject",  "name": "Reject",  "isPrimary": false, "outcomeType": "Negative", "action": "End" }
+]
+```
+
+### Example 2 — Write-back validation (inOut — human can edit before confirming)
+
+Business description: *"Human sees the AI-drafted email, can edit it, then clicks Send or Discard"*
+
+```json
+"fields": [
+  { "id": "recipient",  "label": "Recipient",  "type": "text", "direction": "input", "binding": "=js:$vars.draft1.result.recipient" },
+  { "id": "emailbody",  "label": "Email Body", "type": "text", "direction": "inOut", "binding": "=js:$vars.draft1.result.body", "variable": "emailBody" }
+],
+"outcomes": [
+  { "id": "send",    "name": "Send",    "isPrimary": true,  "outcomeType": "Positive", "action": "Continue" },
+  { "id": "discard", "name": "Discard", "isPrimary": false, "outcomeType": "Negative", "action": "End" }
+]
+```
+
+### Example 3 — Data enrichment (output — human fills in missing fields)
+
+Business description: *"Agent couldn't extract vendor name or cost center. Human fills them in and clicks Submit."*
+
+```json
+"fields": [
+  { "id": "rawextract",  "label": "Raw Extract",  "type": "text", "direction": "input",  "binding": "=js:$vars.extract1.result.rawText" },
+  { "id": "vendorname",  "label": "Vendor Name",  "type": "text", "direction": "output", "variable": "vendorName",  "required": true },
+  { "id": "costcenter",  "label": "Cost Center",  "type": "text", "direction": "output", "variable": "costCenter", "required": true }
+],
+"outcomes": [
+  { "id": "submit", "name": "Submit", "isPrimary": true, "outcomeType": "Positive", "action": "Continue" }
+]
+```
+
+### Example 4 — Exception escalation (multiple outcomes + notes output)
+
+Business description: *"If agent confidence is low, escalate. Human sees reasoning and score, can Retry, Skip, or Escalate further."*
+
+```json
+"fields": [
+  { "id": "reasoning",       "label": "Agent Reasoning",  "type": "text",   "direction": "input",  "binding": "=js:$vars.classify1.result.reasoning" },
+  { "id": "confidencescore", "label": "Confidence Score", "type": "number", "direction": "input",  "binding": "=js:$vars.classify1.result.score" },
+  { "id": "notes",           "label": "Notes",            "type": "text",   "direction": "output", "variable": "notes" }
+],
+"outcomes": [
+  { "id": "retry",    "name": "Retry",    "isPrimary": true,  "outcomeType": "Positive", "action": "Continue" },
+  { "id": "skip",     "name": "Skip",     "isPrimary": false, "outcomeType": "Neutral",  "action": "Continue" },
+  { "id": "escalate", "name": "Escalate", "isPrimary": false, "outcomeType": "Negative", "action": "End" }
+]
+```
+
+> **`outcomeType` for middle outcomes:** Use `"Neutral"` when the outcome is neither clearly positive nor negative (e.g., Skip, Defer, Hold).
+
+---
+
+## Runtime Variables
+
+After the HITL node, downstream nodes can reference:
+
+| Variable | Type | What it contains |
+|---|---|---|
+| `$vars.<nodeId>.result` | object | All `output` and `inOut` fields the human filled in |
+| `$vars.<nodeId>.result.<fieldVariable>` | varies | Individual field value (e.g. `$vars.invoiceReview1.result.decision`) |
+| `$vars.<nodeId>.status` | string | `"completed"`, `"cancelled"`, or `"timeout"` |
+
+**In a downstream script node:**
+```javascript
+const result = $vars.invoiceReview1.result;
+if ($vars.invoiceReview1.status === "completed") {
+  await updateSystem(result.vendorName, result.costCenter);
+}
+```


### PR DESCRIPTION
## Summary

Updates the `uipath-human-in-the-loop` skill to the direct JSON editing model (Rocky's lattice approach).

- **No more `uip flow hitl add` CLI call in Step 5** — agent writes the node JSON directly into `.flow`
- **No more `uip hitl schema` CLI call** — schema conversion rules are embedded as worked examples in the reference docs so the agent learns the pattern
- **App lookup is a direct API call** (no CLI needed) — credential reading + curl examples documented inline
- **Two new reference docs** with copy-paste-ready JSON and four worked conversion examples
- **`variables.nodes` regeneration** documented as a mandatory Critical Rule

## What changed

| File | Change |
|---|---|
| `SKILL.md` | Description, Critical Rules (added #3 regeneration, #6 dedup), Step 2 (form type), Step 3 (form type question), Step 5 (direct JSON), References (removed dead cross-skill link) |
| `references/hitl-node-quickform.md` | New — full node JSON, definition entry, edge format, `variables.nodes` algorithm, 4 worked schema examples |
| `references/hitl-node-apptask.md` | New — direct API lookup, node JSON with `inputs.type=custom`, `inputs.app` field mapping |

## Why no CLI for schema conversion

The schema conversion rules are deterministic and documentable. By embedding four worked examples (simple approval, write-back, data enrichment, escalation), the agent learns the pattern and applies it directly — no round-trip to a CLI command. This is 25% cheaper and 13% faster per Rocky's benchmark.

## Why no CLI for app lookup

The app catalog API is a straightforward authenticated GET. The skill docs show the exact curl command using stored credentials (`~/.uipcli/.env`). No CLI wrapper needed.

## Related
- Rocky's benchmark: https://uipath.atlassian.net/wiki/spaces/Flow/pages/90524124994
- Lattice skill design: https://uipath.atlassian.net/wiki/spaces/Flow/pages/90522583522
- App lookup implementation (Rohan): UiPath/cli#638