### PR TITLE
docs(maestro-flow/hitl): update planning plugin to reference uipath.human-in-the-loop

### DIFF
--- a/skills/uipath-maestro-flow/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/planning-arch.md
@@ -194,7 +194,7 @@ Use this when defining edges. Every edge requires a `sourcePort` and `targetPort
 | `uipath.connector.*` (activities) | `input` | `output`, `error` |
 | `core.action.queue.create` | `input` | `success` |
 | `core.action.queue.create-and-wait` | `input` | `success` |
-| `uipath.human-in-the-loop` | `input` | `completed`, `cancelled`, `timeout` |
+| `uipath.human-in-the-loop` | `input` | `completed` |
 | `uipath.core.human-task.{key}` | `input` | `output` |
 
 > **`error` is an implicit source port** on every action node (any node with `supportsErrorHandling: true`). Wire it whenever the flow needs to survive a failed HTTP call, script exception, transform error, agent fault, etc. — otherwise the flow faults as a whole. This is a **different mechanism** from content-based `inputs.branches` on HTTP. See [Implicit error port on action nodes](flow-file-format.md#implicit-error-port-on-action-nodes) for wiring, when it fires, and the decision matrix vs branches/decision/switch.

--- a/skills/uipath-maestro-flow/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/planning-arch.md
@@ -97,6 +97,7 @@ Each plugin has a `planning.md` with full selection heuristics, ports, key input
 | `core.logic.delay` | [delay](plugins/delay/planning.md) | Pause execution for a duration or until a specific date |
 | `core.action.queue.create` | [queue](plugins/queue/planning.md) | Distribute work to robots — fire-and-forget |
 | `core.action.queue.create-and-wait` | [queue](plugins/queue/planning.md) | Distribute work to robots — wait for result |
+| `uipath.human-in-the-loop` | [hitl](plugins/hitl/planning.md) | Pause flow for a human to review, approve, or fill in data — inline schema, no app required |
 
 ### Control Flow
 
@@ -142,7 +143,7 @@ Resource nodes invoke published UiPath automations. They are tenant-specific and
 | Agentic Process | `uipath.core.agentic-process.{key}` | [agentic-process](plugins/agentic-process/planning.md) |
 | Flow | `uipath.core.flow.{key}` | [flow](plugins/flow/planning.md) |
 | API Workflow | `uipath.core.api-workflow.{key}` | [api-workflow](plugins/api-workflow/planning.md) |
-| Human Task | `uipath.core.hitl.{key}` | [hitl](plugins/hitl/planning.md) |
+| Human Task (app-based) | `uipath.core.human-task.{key}` | [hitl](plugins/hitl/planning.md) |
 
 ### Placeholders
 
@@ -193,6 +194,8 @@ Use this when defining edges. Every edge requires a `sourcePort` and `targetPort
 | `uipath.connector.*` (activities) | `input` | `output`, `error` |
 | `core.action.queue.create` | `input` | `success` |
 | `core.action.queue.create-and-wait` | `input` | `success` |
+| `uipath.human-in-the-loop` | `input` | `completed`, `cancelled`, `timeout` |
+| `uipath.core.human-task.{key}` | `input` | `output` |
 
 > **`error` is an implicit source port** on every action node (any node with `supportsErrorHandling: true`). Wire it whenever the flow needs to survive a failed HTTP call, script exception, transform error, agent fault, etc. — otherwise the flow faults as a whole. This is a **different mechanism** from content-based `inputs.branches` on HTTP. See [Implicit error port on action nodes](flow-file-format.md#implicit-error-port-on-action-nodes) for wiring, when it fires, and the decision matrix vs branches/decision/switch.
 

--- a/skills/uipath-maestro-flow/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/hitl/impl.md
@@ -22,7 +22,6 @@ This is the preferred option. No registry pull, no app publishing, no tenant dep
   "id": "hitlReview1",
   "type": "uipath.human-in-the-loop",
   "typeVersion": "1.0.0",
-  "ui": { "position": { "x": 600, "y": 144 } },
   "display": { "label": "Invoice Review" },
   "inputs": {
     "type": "quick",

--- a/skills/uipath-maestro-flow/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/hitl/impl.md
@@ -1,33 +1,87 @@
 # HITL Node — Implementation
 
-HITL nodes pause the flow for human input via a UiPath App. Pattern: `uipath.core.human-task.{key}`.
+Two node types implement human-in-the-loop checkpoints. Choose based on whether you need an inline form or an existing deployed app.
 
-## Discovery
+---
+
+## Option 1 — `uipath.human-in-the-loop` (Inline Schema — OOTB)
+
+This is the preferred option. No registry pull, no app publishing, no tenant dependency. Write the node directly into the `.flow` file as JSON.
+
+**Full implementation guide, JSON examples, and schema conversion rules:**
+→ [`uipath-human-in-the-loop` skill — hitl-node-quickform.md](../../../../../uipath-human-in-the-loop/references/hitl-node-quickform.md)
+
+> **Note:** Skills are self-contained. This cross-skill reference is for documentation context only. The agent uses the `uipath-human-in-the-loop` skill to implement HITL nodes. This implementation guide is for implementation-phase topology resolution only — not for schema design or node writing.
+
+### Quick Reference
+
+**Node JSON (minimum viable):**
+
+```json
+{
+  "id": "hitlReview1",
+  "type": "uipath.human-in-the-loop",
+  "typeVersion": "1.0.0",
+  "ui": { "position": { "x": 600, "y": 144 } },
+  "display": { "label": "Invoice Review" },
+  "inputs": {
+    "type": "quick",
+    "schema": {
+      "fields": [
+        { "id": "invoiceId", "label": "Invoice ID", "type": "text",   "direction": "input" },
+        { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input" }
+      ],
+      "outcomes": [
+        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "outcomeType": "Positive", "action": "Continue" },
+        { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "outcomeType": "Negative", "action": "End" }
+      ]
+    },
+    "recipient": { "channels": ["ActionCenter"], "connections": {}, "assignee": { "type": "group" } },
+    "priority": "Low"
+  },
+  "model": { "type": "bpmn:UserTask", "serviceType": "Actions.HITL" }
+}
+```
+
+**Ports:** `input` (target) → `completed` (source)
+
+**Output variables:**
+- `$vars.{nodeId}.result` — object with all `output` / `inOut` fields the human filled in
+- `$vars.{nodeId}.result.{fieldName}` — individual field value
+- `$vars.{nodeId}.status` — `"completed"`
+
+---
+
+## Option 2 — `uipath.core.human-task.{key}` (App-Based)
+
+Use when there is an existing deployed Action Center app that should serve as the task form.
+
+### Discovery
 
 **Published (tenant registry):**
 
 ```bash
-uip maestro flow registry pull --force
-uip maestro flow registry search "uipath.core.human-task" --output json
+uip flow registry pull --force
+uip flow registry search "uipath.core.human-task" --output json
 ```
 
 **In-solution (local, no login required):**
 
 ```bash
-uip maestro flow registry list --local --output json
-uip maestro flow registry get "<nodeType>" --local --output json
+uip flow registry list --local --output json
+uip flow registry get "<nodeType>" --local --output json
 ```
 
 Run from inside the flow project directory. Discovers sibling projects in the same `.uipx` solution.
 
-## Registry Validation
+### Registry Validation
 
 ```bash
 # Published (tenant registry)
-uip maestro flow registry get "uipath.core.human-task.{key}" --output json
+uip flow registry get "uipath.core.human-task.{key}" --output json
 
 # In-solution (local, no login required)
-uip maestro flow registry get "uipath.core.human-task.{key}" --local --output json
+uip flow registry get "uipath.core.human-task.{key}" --local --output json
 ```
 
 Confirm:
@@ -37,15 +91,13 @@ Confirm:
 - `model.serviceType` — `Actions.HITL`
 - `model.bindings.resourceSubType` — the app type
 
-## Adding / Editing
+### Node JSON
 
 For step-by-step add, delete, and wiring procedures, see [flow-editing-operations.md](../../flow-editing-operations.md). Use the JSON structure below for the node-specific `inputs` and `model` fields.
 
 The human task node's output (`$vars.{nodeId}.output`) contains the form data submitted by the user.
 
-## JSON Structure
-
-### Node instance (inside `nodes[]`)
+**Node instance (inside `nodes[]`):**
 
 ```json
 {
@@ -92,9 +144,9 @@ The human task node's output (`$vars.{nodeId}.output`) contains the form data su
 }
 ```
 
-> `resourceKey` takes the form `<FolderPath>.<AppName>` and `resourceSubType` is the app type — confirm both from `uip maestro flow registry get` output.
+> `resourceKey` takes the form `<FolderPath>.<AppName>` and `resourceSubType` is the app type — confirm both from `uip flow registry get` output.
 
-### Top-level `bindings[]` entries (sibling of `nodes`/`edges`/`definitions`)
+**Top-level `bindings[]` entries (sibling of `nodes`/`edges`/`definitions`):**
 
 Add one entry per `(resourceKey, propertyAttribute)` pair. Share entries across node instances that reference the same app — do NOT create duplicates.
 
@@ -123,15 +175,15 @@ Add one entry per `(resourceKey, propertyAttribute)` pair. Share entries across 
 ]
 ```
 
-> **Why both are required.** The registry's `Data.Node.model.context[].value` fields ship as template placeholders (`<bindings.name>`, `<bindings.folderPath>`) — not runtime-resolvable expressions. The runtime reads the node instance's `model.context` and resolves `=bindings.<id>` against the top-level `bindings[]` array. Without these two pieces, `uip maestro flow validate` passes but `uip maestro flow debug` fails with "Folder does not exist or the user does not have access to the folder."
+> **Why both are required.** The registry's `Data.Node.model.context[].value` fields ship as template placeholders (`<bindings.name>`, `<bindings.folderPath>`) — not runtime-resolvable expressions. The runtime reads the node instance's `model.context` and resolves `=bindings.<id>` against the top-level `bindings[]` array. Without these two pieces, `uip flow validate` passes but `uip flow debug` fails with "Folder does not exist or the user does not have access to the folder."
 
 > **Definition stays verbatim.** Do NOT rewrite `<bindings.*>` placeholders inside the `definitions` entry — it is a schema copy, not a runtime input. Critical Rule #7 applies unchanged.
 
-## Use Cases
+### If the app does not exist yet
 
-- **Approval workflows** — manager approval before processing
-- **Data validation** — human reviews extracted data before submission
-- **Exception handling** — human resolves items the automation cannot handle
+Note as `[CREATE NEW] <description>` in the node table and use `core.logic.mock` as a placeholder. The app itself is out of scope for this skill — use the `uipath-coded-apps` skill to build it.
+
+---
 
 ## Common Pattern — Human-in-the-Loop
 
@@ -145,6 +197,7 @@ Manual Trigger -> RPA Process (extract) -> HITL (review) -> Decision (approved?)
 
 | Error | Cause | Fix |
 | --- | --- | --- |
-| Node type not found in registry | App not published or registry stale | If in same solution: run `registry list --local`. Otherwise: run `uip login` then `uip maestro flow registry pull --force` |
+| Node type not found in registry (Option 2) | App not published or registry stale | If in same solution: `uip flow registry list --local`. Otherwise: `uip login` then `uip flow registry pull --force` |
 | Task never completes | Human hasn't submitted the form | Check task assignment in Orchestrator |
 | Output missing expected fields | App form doesn't match expected schema | Verify app form fields match what the flow expects |
+| `completed` port unwired (Option 1) | Missing edge on output handle | Wire the `completed` output handle — an unwired `completed` blocks the flow indefinitely |

--- a/skills/uipath-maestro-flow/references/plugins/hitl/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/hitl/planning.md
@@ -1,62 +1,144 @@
 # HITL Node — Planning
 
-HITL nodes pause the flow and present a UiPath App to a human user for input. The flow resumes when the user submits the form. Published apps appear in the registry after `uip login` + `uip maestro flow registry pull`. **In-solution** (unpublished) apps in sibling projects are discovered via `--local` — no login or publish required.
+The flow needs to pause for a human to review, approve, or fill in data. Two node types serve this need — choose based on form complexity and whether an app already exists.
 
-## Node Type Pattern
+---
 
-`uipath.core.human-task.{key}`
+## Which HITL Node to Use
 
-## When to Use
+| Use case | Node type | Form source |
+| --- | --- | --- |
+| Inline form designed right now (fields + outcomes defined in the flow) | `uipath.human-in-the-loop` | Schema embedded in node inputs — no app needed |
+| Existing coded app or Action Center app | `uipath.core.human-task.{key}` | Deployed app from Orchestrator |
 
-Use a HITL node when the flow needs to pause for human input, approval, or review.
+**Prefer `uipath.human-in-the-loop`** for new flows. It is an OOTB node — no registry discovery, no app publishing, no tenant dependency.
 
-### Selection Heuristics
+---
 
-| Situation | Use HITL? |
+## Option 1 — `uipath.human-in-the-loop` (Inline Schema — OOTB)
+
+Node type: `uipath.human-in-the-loop`
+Available: always — no `uip login` or registry pull required.
+
+### When to Select
+
+| Situation | Select? |
 | --- | --- |
 | Manager approval before processing | Yes |
 | Human reviews extracted data before submission | Yes |
-| Human resolves items the automation cannot handle | Yes |
-| Fully automated processing with no human involvement | No |
-| App in same solution but not yet published | Yes — use `--local` discovery (see below) |
-| App does not exist yet | Create it in the same solution with `uipath-coded-apps`, then use `--local` discovery |
+| Human resolves exceptions the automation cannot handle | Yes |
+| Need a quick form with specific fields and outcomes | Yes |
+| Existing coded/Action Center app should be used | No — use Option 2 |
+| Fully automated processing, no human involvement | No |
 
-## Ports
+### Ports
 
-| Input Port | Output Port(s) |
+| Input port | Output port |
 | --- | --- |
-| `input` | `output`, `error` |
+| `input` | `completed` |
 
-The `error` port is the implicit error port shared with all action nodes — see [Implicit error port on action nodes](../../flow-file-format.md#implicit-error-port-on-action-nodes).
+**The output port must be wired.** A node with no edge on `completed` blocks the flow indefinitely.
 
-## Output Variables
+### Output Variables
 
-- `$vars.{nodeId}.output` — the form data submitted by the user
-- `$vars.{nodeId}.error` — error details if execution fails (`code`, `message`, `detail`, `category`, `status`)
+- `$vars.{nodeId}.result` — object containing all output and inOut fields the human filled in
+- `$vars.{nodeId}.result.{fieldName}` — individual field value
+- `$vars.{nodeId}.status` — `"completed"`
 
-## Discovery
+### Schema Design
+
+The schema defines what the human sees and provides. Three field categories:
+
+| Category | Human can… | Use for |
+| --- | --- | --- |
+| `inputs` | Read only | Context the human needs to decide |
+| `outputs` | Write | Data the automation needs back |
+| `inOuts` | Read + modify | Fields the human can see and optionally correct |
+
+Outcomes are the action buttons (e.g., Approve/Reject). First outcome is primary.
+
+**In the architectural plan**, describe the schema:
+```
+inputs:   [invoiceId (string), amount (number)]
+outputs:  [decision (string, required)]
+outcomes: [Approve, Reject]
+priority: normal
+```
+
+Full JSON format and conversion examples: see [`uipath-human-in-the-loop` skill](../../../../uipath-human-in-the-loop/references/hitl-node-quickform.md).
+
+> **Note:** Skills are self-contained — cross-skill references are for documentation context only. The agent uses the `uipath-human-in-the-loop` skill to implement HITL nodes; this planning guide is for topology selection only.
+
+### Wiring Pattern
+
+```
+[Upstream] -> [HITL] ->|completed| [Continue]
+```
+
+### Common Topology Patterns
+
+**Approval gate:**
+```
+Trigger -> Fetch Data -> HITL (review) ->|completed| Decision (approved?) ->
+  true: Script (process) -> End
+  false: Script (log rejection) -> End
+```
+
+**Exception escalation:**
+```
+Trigger -> Process -> Decision (confidence ok?) ->
+  true: Continue -> End
+  false: HITL (exception review) ->|completed| Script (retry with human input) -> End
+```
+
+### Planning Annotation
+
+In the node table:
+```
+| hitlReview | Invoice Review | human-task | uipath.human-in-the-loop | inputs: [invoiceId, amount] outputs: [decision] outcomes: [Approve, Reject] | result, status |
+```
+
+---
+
+## Option 2 — `uipath.core.human-task.{key}` (App-Based)
+
+Node type: `uipath.core.human-task.{key}`
+Available: tenant-specific resource — requires `uip login` + `uip flow registry pull`.
+
+### When to Select
+
+Use when there is an existing coded app or Action Center app that should be the task form.
+
+### Ports
+
+| Input port | Output port |
+| --- | --- |
+| `input` | `output` |
+
+### Output Variables
+
+- `$vars.{nodeId}.output` — form data submitted by the user
+- `$vars.{nodeId}.error` — error details if execution fails
+
+### Discovery
 
 **Published (tenant registry):**
 
 ```bash
-uip maestro flow registry pull --force
-uip maestro flow registry search "uipath.core.human-task" --output json
+uip flow registry pull --force
+uip flow registry search "uipath.core.human-task" --output json
 ```
-
-Requires `uip login`. Only published apps from your tenant appear.
 
 **In-solution (local, no login required):**
 
 ```bash
-uip maestro flow registry list --local --output json
-uip maestro flow registry get "<nodeType>" --local --output json
+uip flow registry list --local --output json
+uip flow registry get "<nodeType>" --local --output json
 ```
 
 Run from inside the flow project directory. Discovers sibling projects in the same `.uipx` solution.
 
-## Planning Annotation
-
-In the architectural plan:
+### Planning Annotation
 
 - If the app exists: note as `resource: <name> (human-task)`
-- If it does not exist: note as `[CREATE NEW] <description>` with skill `uipath-coded-apps`
+- If it does not exist: note as `[CREATE NEW] <description>` with skill `uipath-coded-apps`, use `core.logic.mock` placeholder

--- a/skills/uipath-maestro-flow/references/plugins/hitl/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/hitl/planning.md
@@ -62,7 +62,7 @@ Outcomes are the action buttons (e.g., Approve/Reject). First outcome is primary
 inputs:   [invoiceId (string), amount (number)]
 outputs:  [decision (string, required)]
 outcomes: [Approve, Reject]
-priority: normal
+priority: Low
 ```
 
 Full JSON format and conversion examples: see [`uipath-human-in-the-loop` skill](../../../../uipath-human-in-the-loop/references/hitl-node-quickform.md).

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -1,0 +1,117 @@
+task_id: skill-flow-hitl-quality-schema-design
+description: >
+  Quality test: agent correctly maps a business description to a quickform
+  schema — right field directions (input/output/inOut), correct outcomes,
+  and priority. Tests C1 (field design) and C2 (outcome design).
+tags: [uipath-maestro-flow, integration, hitl]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  max_turns: 25
+  turn_timeout: 900
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "VendorPOReview" for purchase order review:
+
+  - A manual trigger starts the flow
+  - A script node fetches PO data (mock it — just set variables)
+  - A HITL node lets the procurement officer review the PO:
+      - They can SEE (read-only): PO number, vendor name, total amount
+      - They must FILL IN: their decision (Approve/Reject) and optional notes
+      - They click: Approve (primary) or Reject
+  - A decision node routes on the officer's decision:
+      - Approve → Script node that logs "PO approved"
+      - Reject  → End node
+
+  Use the inline quickform node (uipath.human-in-the-loop).
+  Set priority to High.
+  Wire completed → decision node.
+  Do NOT run flow debug. Validate after building.
+
+  Save a summary to report.json:
+  {
+    "hitl_node_id": "<id>",
+    "schema": {
+      "input_fields":  ["<names of read-only fields>"],
+      "output_fields": ["<names of fields the officer fills in>"],
+      "outcomes":      ["<outcome names>"]
+    },
+    "priority": "<priority set>",
+    "result_variable": "<how the decision node reads the officer's decision>",
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip flow validate VendorPOReview/VendorPOReview/VendorPOReview.flow --format json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "HITL node has input-direction fields (read-only context for reviewer)"
+    path: "VendorPOReview/VendorPOReview/VendorPOReview.flow"
+    includes:
+      - '"direction": "input"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "HITL node has output-direction fields (reviewer fills in)"
+    path: "VendorPOReview/VendorPOReview/VendorPOReview.flow"
+    includes:
+      - '"direction": "output"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow has Approve and Reject outcomes"
+    path: "VendorPOReview/VendorPOReview/VendorPOReview.flow"
+    includes:
+      - "Approve"
+      - "Reject"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Priority is set to High"
+    path: "VendorPOReview/VendorPOReview/VendorPOReview.flow"
+    includes:
+      - '"High"'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "result_variable references $vars.<nodeId>.result"
+    path: "report.json"
+    includes:
+      - "$vars."
+      - ".result"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Schema has at least 2 input fields, at least 1 output field, 2 outcomes"
+    path: "report.json"
+    assertions:
+      - expression: "length(schema.input_fields)"
+        operator: gte
+        expected: 2
+      - expression: "length(schema.output_fields)"
+        operator: gte
+        expected: 1
+      - expression: "length(schema.outcomes)"
+        operator: gte
+        expected: 2
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+    weight: 2.5
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -1,0 +1,97 @@
+task_id: skill-flow-hitl-quality-result-downstream
+description: >
+  Quality test: agent correctly references the HITL node's output via
+  $vars.<nodeId>.result in a downstream node. Tests that the agent knows
+  the result variable path and wires it into a decision or script node.
+tags: [uipath-maestro-flow, integration, hitl]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  max_turns: 25
+  turn_timeout: 900
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "ExpenseApproval" that:
+
+  1. Manual trigger starts the flow
+  2. HITL node — expense review:
+       - Reviewer sees: expense amount, requester name, category (all read-only)
+       - Reviewer fills in: approved (boolean), comments (text, optional)
+       - Outcomes: Approve (primary), Reject
+  3. Script node — reads the reviewer's decision from the HITL result and
+     logs: "Decision: <approved value>, Comments: <comments value>"
+     The script must reference the HITL output via the correct runtime variable path.
+  4. End node
+
+  Wire: Trigger -> HITL ->|completed| Script -> End
+
+  Use the inline quickform node (uipath.human-in-the-loop).
+  Do NOT run flow debug. Validate after building.
+
+  Save a summary to report.json:
+  {
+    "hitl_node_id": "<id>",
+    "result_path": "<full variable path used in the script, e.g. $vars.hitlReview1.result.approved>",
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip flow validate ExpenseApproval/ExpenseApproval/ExpenseApproval.flow --format json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow contains inline HITL node"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"uipath.human-in-the-loop"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow references the HITL result variable"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - "$vars."
+      - ".result"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow has a boolean output field for approved"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"boolean"'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json result_path references $vars and .result"
+    path: "report.json"
+    includes:
+      - "$vars."
+      - ".result"
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json captures hitl_node_id and validation"
+    path: "report.json"
+    assertions:
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+      - expression: "hitl_node_id"
+        operator: not_equals
+        expected: ""
+    weight: 2.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -1,0 +1,81 @@
+task_id: skill-flow-hitl-smoke-node-placed
+description: >
+  Smoke test: agent builds a simple invoice approval flow containing an inline
+  HITL node (uipath.human-in-the-loop). Verifies the node is written directly
+  into the .flow file as JSON and the flow validates.
+tags: [uipath-maestro-flow, smoke, hitl]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  max_turns: 20
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "InvoiceApproval" that:
+  1. Starts with a manual trigger
+  2. Pauses for a finance manager to review and approve an invoice (human-in-the-loop)
+  3. Ends after the review is complete
+
+  The HITL node must use the inline quickform style (uipath.human-in-the-loop),
+  not an external app. The node must show the reviewer: invoice ID and amount.
+  The reviewer clicks Approve or Reject.
+
+  Wire the completed handle to an End node.
+
+  Do NOT run flow debug. Validate the flow after building it.
+
+  Save a summary to report.json:
+  {
+    "flow_file": "<path to the .flow file>",
+    "hitl_node_id": "<id of the HITL node>",
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: file_exists
+    description: "Flow file was created"
+    path: "InvoiceApproval/InvoiceApproval/InvoiceApproval.flow"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow contains the inline HITL node type"
+    path: "InvoiceApproval/InvoiceApproval/InvoiceApproval.flow"
+    includes:
+      - '"uipath.human-in-the-loop"'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow uses quickform schema type"
+    path: "InvoiceApproval/InvoiceApproval/InvoiceApproval.flow"
+    includes:
+      - '"type": "quick"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip flow validate InvoiceApproval/InvoiceApproval/InvoiceApproval.flow --format json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json captures hitl_node_id and validation_passed"
+    path: "report.json"
+    assertions:
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+      - expression: "hitl_node_id"
+        operator: not_equals
+        expected: ""
+    weight: 2.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -1,0 +1,76 @@
+task_id: skill-flow-hitl-smoke-completed-port
+description: >
+  Smoke test: agent wires the HITL node's `completed` output port (not the
+  old `cancelled` or `timeout` ports). Verifies correct edge structure in
+  a three-node approval flow.
+tags: [uipath-maestro-flow, smoke, hitl]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  max_turns: 20
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "PurchaseApproval" with this structure:
+    Manual Trigger -> HITL (manager approves purchase) -> Script (log approval) -> End
+
+  Use the inline quickform HITL node (uipath.human-in-the-loop).
+  The HITL node shows the reviewer: purchase amount and vendor name.
+  Outcomes: Approve and Reject.
+
+  Wire the HITL node's completed handle to the Script node.
+  The Script node logs: "Approval recorded."
+
+  Do NOT run flow debug. Validate after building.
+
+  Save a summary to report.json:
+  {
+    "hitl_node_id": "<id>",
+    "edge_from_hitl": "<sourceHandle used on the HITL edge>",
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: file_exists
+    description: "Flow file was created"
+    path: "PurchaseApproval/PurchaseApproval/PurchaseApproval.flow"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow uses completed as the HITL output handle"
+    path: "PurchaseApproval/PurchaseApproval/PurchaseApproval.flow"
+    includes:
+      - '"completed"'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow does not reference cancelled or timeout handles"
+    path: "PurchaseApproval/PurchaseApproval/PurchaseApproval.flow"
+    excludes:
+      - '"cancelled"'
+      - '"timeout"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip flow validate PurchaseApproval/PurchaseApproval/PurchaseApproval.flow --format json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json records completed as the edge handle"
+    path: "report.json"
+    includes:
+      - "completed"
+    weight: 1.5
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Updates the `uipath-maestro-flow` hitl plugin docs to cover both HITL node types and point to the `uipath-human-in-the-loop` skill for implementation.

**Changes:**
- `references/plugins/hitl/planning.md` — restructured to cover Option 1 (inline `uipath.human-in-the-loop`) and Option 2 (app-based `uipath.core.human-task.{key}`); fixes wrong ports (`output/error` → `completed` only for inline HITL)
- `references/plugins/hitl/impl.md` — adds Option 1 quick reference JSON with correct `fields[]` schema format, `recipient` object, `type: "quick"`; preserves Option 2 bindings detail from main
- `references/planning-arch.md` — updated to reference `uipath-human-in-the-loop` skill for HITL pattern detection

**Key correction:** Option 1 (`uipath.human-in-the-loop`) output port is `completed` only — not `output/error`. These are the app-based node's ports.

Companion: skills#292 (skill schema/test fixes), skills#174 (flow-hitl.md reference), uipcli#844 (CLI)