### PR TITLE
Add flow e2e tasks and consolidate test types

### DIFF
--- a/.github/code_review.md
+++ b/.github/code_review.md
@@ -17,14 +17,16 @@ This repo uses [coder_eval](https://github.com/UiPath/coder_eval) to verify that
 **When a PR adds a new skill folder under `skills/`:**
 
 1. Check whether `tests/tasks/<skill-name>/` exists with at least one `.yaml` task file
-2. If tests exist, verify each task file follows conventions (see `tests/README.md`):
+2. If tests exist, verify:
+   - At least one task tagged `smoke` and at least one tagged `e2e` (both required per CONTRIBUTING.md)
+   - Each task's `tags` uses only valid test types: `smoke`, `integration`, or `e2e` — no other test-type tags (e.g., `activation` is not a valid tag)
+   - Each task's `tags` includes the skill directory name (e.g., `uipath-maestro-flow`) as the first tag
    - `task_id` matches the pattern `skill-<domain>-<capability>`
-   - `tags` includes `smoke` (required for CI) and the skill domain
    - The plugin loads in the sandbox — either via `agent.plugins` in the task YAML or inherited from the experiment config in `tests/experiments/default.yaml`
    - `initial_prompt` is minimal — describes the goal, not the steps (the skill should teach the agent)
    - `success_criteria` validates key CLI commands (`command_executed`), output files (`file_exists`, `file_contains`, `json_check`), or both
-   - `max_iterations: 2` and `llm_reviewer.enabled: true` are set
-3. If tests are missing, flag as **Medium** — most skills are not yet test-compliant
+3. If tests are missing entirely, flag as **Medium** — most skills are not yet test-compliant
+4. If tests exist but are missing a `smoke` or `e2e` task, flag as **Medium**
 
 **When a PR substantially changes an existing skill** (new CLI workflows, changed commands):
 - Check whether existing tasks in `tests/tasks/<skill-name>/` still cover the updated behavior

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -67,9 +67,13 @@ jobs:
             7. If the PR adds a new skill folder under `skills/`:
                a. Check that `tests/tasks/<skill-name>/` exists with at least one `.yaml` task file.
                   If missing, flag as **Medium** (most skills are not yet test-compliant).
-               b. If tests exist, verify task files have: `task_id` matching `skill-<domain>-<capability>`,
-                  `tags` including `smoke`, `success_criteria` with at least one check,
-                  and `llm_reviewer.enabled: true`.
+               b. If tests exist, verify:
+                  - At least one task tagged `smoke` and at least one tagged `e2e` (both required).
+                  - Each task's `tags` uses only valid test types: `smoke`, `integration`, or `e2e`.
+                  - Each task's `tags` includes the skill directory name (e.g., `uipath-maestro-flow`) as the first tag.
+                  - `task_id` matches `skill-<domain>-<capability>`.
+                  - `success_criteria` has at least one check.
+                  If smoke or e2e coverage is missing, flag as **Medium**.
 
             8. Check that `CODEOWNERS` includes an entry for any new skill path.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,6 +204,7 @@ There are three test types, distinguished by tags:
 ```bash
 cd tests
 make install       # one-time: install coder-eval from GitHub
+make all           # run all tests (smoke + integration + e2e)
 make smoke         # run all smoke tests
 make integration   # run all integration tests
 make e2e           # run all end-to-end tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,12 +191,11 @@ This configures git to use `.githooks/` and enables the skill description valida
 
 Skills are tested using [coder_eval](https://github.com/UiPath/coder_eval) — a framework that runs an AI agent against a task and scores the result. Tests live in `tests/tasks/<skill-name>/` and verify that the skill guides the agent to use the correct CLI commands, follow critical rules, and produce valid output.
 
-There are four test types, distinguished by tags:
+There are three test types, distinguished by tags:
 
 | Tag | Purpose | Cadence |
 |-----|---------|---------|
-| `activation` | Does the right skill trigger for the right query? | Every PR |
-| `smoke` | Skill + CLI produces valid output (1-3 simple scenarios) | Every PR |
+| `smoke` | Skill triggers correctly, CLI produces valid output (1-5 simple scenarios) | Every PR |
 | `integration` | Correct output across diverse scenarios, error paths, anti-patterns | Daily |
 | `e2e` | Full lifecycle: Explore -> Plan -> Build -> Validate -> Deploy -> Run | Daily/weekly (check [Dashboard](https://dataexplorer.azure.com/dashboards/20cc55fe-33ae-4973-a951-855e76528219)) |
 
@@ -205,7 +204,6 @@ There are four test types, distinguished by tags:
 ```bash
 cd tests
 make install       # one-time: install coder-eval from GitHub
-make activation    # run all activation tests
 make smoke         # run all smoke tests
 make integration   # run all integration tests
 make e2e           # run all end-to-end tests
@@ -215,9 +213,9 @@ make test-uipath-maestro-flow  # run all tests for a specific skill
 ### Adding Tests for a Skill
 
 1. Create `tests/tasks/<skill-name>/` matching your skill folder name
-2. Add at minimum **1 activation test**, **1 smoke test**, and **1 e2e test** (required for every new skill PR)
+2. Add at minimum **1 smoke test** and **1 e2e test** (required for every new skill PR)
 3. Use minimal prompts — the goal is to test the skill's guidance quality, not hand-hold the agent
-4. Tag every task appropriately: `activation`, `smoke`, `integration`, or `e2e`
+4. Tag every task appropriately: `smoke`, `integration`, or `e2e`
 5. Follow the task ID pattern: `skill-<domain>-<capability>`
 
 See `tests/README.md` for the full task YAML template, success criteria reference, and examples from existing tests.
@@ -243,10 +241,9 @@ Before submitting your PR, verify:
 - [ ] No duplicate content already covered in another skill's references
 
 ### Tests
-- [ ] At least 1 activation test in `tests/tasks/<skill-name>/`
 - [ ] At least 1 smoke test in `tests/tasks/<skill-name>/`
 - [ ] At least 1 e2e test in `tests/tasks/<skill-name>/`
-- [ ] All tests tagged appropriately (`activation`, `smoke`, `integration`, or `e2e`)
+- [ ] All tests tagged appropriately (`smoke`, `integration`, or `e2e`)
 
 ### General
 - [ ] CODEOWNERS updated with your GitHub handle

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install activation smoke integration e2e
+.PHONY: help install all smoke integration e2e
 
 SKILLS_REPO_PATH ?= $(shell cd .. && pwd)
 VENV := .venv
@@ -15,8 +15,7 @@ install:  ## Install coder-eval into local .venv (requires Python 3.13+)
 	@echo ""
 	@echo "See https://github.com/UiPath/coder_eval for environment setup (.env, API keys, etc.)"
 
-activation:  ## Run all activation tests
-	$(CODER_EVAL) run $(TASKS) -e experiments/default.yaml --tags activation -j 1 -v
+all: smoke integration e2e  ## Run all tests (smoke + integration + e2e)
 
 smoke:  ## Run all smoke tests
 	$(CODER_EVAL) run $(TASKS) -e experiments/default.yaml --tags smoke -j 1 -v

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,9 @@ Tests that verify AI agents can correctly use skills from this repository. Tests
 ```bash
 cd tests
 
+# Run all tests (smoke + integration + e2e)
+make all
+
 # Run all smoke tests
 make smoke
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,15 +15,12 @@ Tests that verify AI agents can correctly use skills from this repository. Tests
    npm install -g @uipath/cli
    ```
 
-3. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for full `.env` setup instructions.
+3. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for environment setup (`.env`, API keys, etc.).
 
 ## Running Tests
 
 ```bash
 cd tests
-
-# Run all activation tests
-make activation
 
 # Run all smoke tests
 make smoke
@@ -47,32 +44,13 @@ The `SKILLS_REPO_PATH` environment variable defaults to the parent directory (re
 
 ## Evaluation Framework
 
-Tests are organized into four types, distinguished by **tags** (not directories). All tests for a skill live together in `tests/tasks/<skill-name>/`.
+Tests are organized into three types, distinguished by **tags** (not directories). All tests for a skill live together in `tests/tasks/<skill-name>/`.
 
 | Tag | Purpose | Cadence |
 |-----|---------|---------|
-| `activation` | Does the right skill trigger for the right query? | Every PR |
-| `smoke` | Skill + CLI produces valid output (1-3 simple scenarios) | Every PR |
+| `smoke` | Skill triggers correctly, CLI produces valid output (1-5 simple scenarios) | Every PR |
 | `integration` | Correct output across diverse scenarios, error paths, anti-patterns | Daily |
 | `e2e` | Full lifecycle: Explore -> Plan -> Build -> Validate -> Deploy -> Run | Daily/weekly (check [Dashboard](https://dataexplorer.azure.com/dashboards/20cc55fe-33ae-4973-a951-855e76528219))|
-
-### Why tags over directories
-
-All tests for a skill live in one folder (`tests/tasks/<skill-name>/`). Test types are separated by tags and naming conventions — not by directory. This means:
-- Skill authors see all their tests in one place
-- CODEOWNERS maps cleanly per skill
-- A test can carry multiple tags (`[smoke, integration]`)
-- CI filters by `--tags smoke`, not by directory glob
-- Adding a new test type is a tag, not a restructure
-
-### Naming conventions
-
-| Test type | File naming | Examples |
-|-----------|-------------|---------|
-| Activation | `activation_*.yaml` | `activation_triggers.yaml` |
-| Smoke | Descriptive happy-path names | `init_validate.yaml`, `registry_discovery.yaml` |
-| Integration | `error_*.yaml`, `anti_pattern_*.yaml`, `edge_*.yaml` | `error_build_failure.yaml`, `anti_pattern_no_xaml_edit.yaml` |
-| E2E | `e2e_*.yaml` or `lifecycle_*.yaml` | `e2e_full_lifecycle.yaml` |
 
 ## Directory Structure
 
@@ -81,12 +59,11 @@ tests/
 ├── README.md
 ├── Makefile
 ├── experiments/
-│   ├── default.yaml              # Activation + Smoke config
+│   ├── default.yaml              # Smoke config
 │   ├── integration.yaml          # Integration config (longer timeouts)
 │   └── e2e.yaml                  # E2E config (staging tenant, full lifecycle)
 └── tasks/
     └── <skill-name>/             # One folder per skill
-        ├── activation_*.yaml     # Activation tests
         ├── <capability>.yaml     # Smoke tests
         ├── error_*.yaml          # Integration tests
         └── e2e_*.yaml            # E2E tests
@@ -98,7 +75,7 @@ Experiment files define shared agent defaults per test type. Tasks inherit these
 
 | Experiment | Used by | max_iterations | max_turns | task_timeout | turn_timeout |
 |------------|---------|----------------|-----------|--------------|--------------|
-| `default.yaml` | Activation, Smoke | 1 | 20 | 600s | 300s |
+| `default.yaml` | Smoke | 1 | 20 | 600s | 300s |
 | `integration.yaml` | Integration | 2 | 30 | 900s | 300s |
 | `e2e.yaml` | E2E | 2 | 40 | 1200s | 300s |
 
@@ -135,9 +112,9 @@ initial_prompt: |
 ## Adding Tests for a New Skill
 
 1. Create `tests/tasks/<skill-name>/` matching the skill folder name under `skills/`.
-2. Add at minimum **1 activation test**, **1 smoke test**, and **1 e2e test** (required for every new skill PR).
+2. Add at minimum **1 smoke test** and **1 e2e test** (required for every new skill PR).
 3. Use minimal prompts — the goal is to test whether the skill guides the agent correctly, not to hand-hold it.
-4. Tag every task appropriately: `activation`, `smoke`, `integration`, or `e2e`.
+4. Tag every task appropriately: `smoke`, `integration`, or `e2e`.
 5. Always include the skill directory name as a tag (e.g., `uipath-maestro-flow`, `uipath-rpa`).
 
 ### Task ID Convention
@@ -146,7 +123,7 @@ initial_prompt: |
 skill-<domain>-<capability>
 ```
 
-Examples: `skill-flow-init-validate`, `skill-flow-registry-discovery`, `skill-rpa-activation-triggers`
+Examples: `skill-flow-init-validate`, `skill-flow-registry-discovery`
 
 ### Smoke Test Example
 
@@ -249,7 +226,6 @@ Key patterns to note:
 - **Minimal prompt** — describes the goal ("create and validate"), not the steps
 - **Multiple criteria types** — `command_executed`, `file_exists`, `json_check` cover different aspects
 - **Weighted scoring** — core commands (`weight: 1.5`) matter more than supporting checks (`weight: 1.0`)
-- **JSON report** — asks the agent to produce structured output for validation
 
 For another example using `file_contains` and `run_command` criteria, see `tasks/uipath-maestro-flow/registry_discovery.yaml`. That test also demonstrates overriding a single field (`agent: max_turns: 14`) from the experiment defaults.
 
@@ -387,7 +363,7 @@ runs/
 
 5. **Common failure causes:**
    - Agent used wrong CLI command or flags -> check the skill's SKILL.md for correctness
-   - Agent didn't activate the skill -> check skill description frontmatter and activation test
+   - Agent didn't activate the skill -> check skill description frontmatter and smoke test
    - Agent ran out of turns -> increase `max_turns` or simplify the prompt
    - Sandbox issue -> check that `uip` CLI is available in the test environment
 

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -1,5 +1,5 @@
 experiment_id: skill-tests-default
-description: "Default experiment for activation and smoke tests — loads the full UiPath skills plugin"
+description: "Default experiment for smoke tests — loads the full UiPath skills plugin"
 
 defaults:
   max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/api_workflow/api_workflow.yaml
@@ -1,0 +1,44 @@
+task_id: skill-flow-api-workflow
+description: >
+  Create a UiPath Flow that invokes the name-to-age API workflow with the
+  name 'tomasz' and returns his age. Exercises API workflow resource node
+  discovery and wiring.
+tags: [uipath-maestro-flow, e2e, generate, resource, api-workflow]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "NameToAge" that invokes the name-to-age
+  API workflow with the name 'tomasz' and returns his age as an output.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate NameToAge/NameToAge/NameToAge.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow has an API workflow node and debug returns an age"
+    command: "python3 $TASK_DIR/check_api_workflow_flow.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/api_workflow/check_api_workflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/api_workflow/check_api_workflow_flow.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run NameToAge flow and verify output contains a plausible age for 'tomasz'."""
+
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--output", "json"],
+        capture_output=True, text=True, timeout=240,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    # Look for any integer 1-150 in the output (plausible age)
+    output_str = json.dumps(data)
+    ages = [int(m) for m in re.findall(r'\b(\d{1,3})\b', output_str) if 1 <= int(m) <= 150]
+    if not ages:
+        sys.exit(f"FAIL: No plausible age (1-150) in output\n{r.stdout[:1000]}")
+
+    print(f"OK: Flow completed, found age = {ages[0]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/bellevue_weather/bellevue_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/bellevue_weather/bellevue_weather.yaml
@@ -1,0 +1,46 @@
+task_id: skill-flow-bellevue-weather
+description: >
+  Create a UiPath Flow that fetches today's weather in Bellevue from open-meteo,
+  formats a summary with a script, and branches on temperature: if > 60F output
+  'nice day', otherwise 'bring a jacket'. Exercises HTTP, script, and decision nodes.
+tags: [uipath-maestro-flow, e2e, generate, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "BellevueWeather" that gets today's weather
+  in Bellevue from open-meteo, formats a summary with a script, and if the
+  temperature is greater than 60F returns a summary with a message field 'nice day',
+  otherwise the message field should be 'bring a jacket'.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow debug runs and output contains 'nice day' or 'bring a jacket'"
+    command: "python3 $TASK_DIR/check_weather_flow.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/bellevue_weather/check_weather_flow.py
+++ b/tests/tasks/uipath-maestro-flow/bellevue_weather/check_weather_flow.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Run BellevueWeather flow and verify output contains 'nice day' or 'bring a jacket'."""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--output", "json"],
+        capture_output=True, text=True, timeout=90,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    output = json.dumps(data).lower()
+    if "nice day" not in output and "bring a jacket" not in output:
+        sys.exit(f"FAIL: Output missing 'nice day' or 'bring a jacket'\n{r.stdout[:1000]}")
+
+    print("OK: Flow completed with weather message")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/calculator/calculator.yaml
@@ -1,0 +1,44 @@
+task_id: skill-flow-calculator
+description: >
+  Create a UiPath Flow that takes two number inputs and calculates their product
+  using a script node. Exercises input variables, script logic, and output mapping.
+tags: [uipath-maestro-flow, e2e, generate, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "Calculator" that takes two numbers as
+  input and calculates their product. The result should be returned as an
+  output variable.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate Calculator/Calculator/Calculator.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow debug runs and output contains 391 (17 * 23)"
+    command: "python3 $TASK_DIR/check_calculator_flow.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/calculator/check_calculator_flow.py
+++ b/tests/tasks/uipath-maestro-flow/calculator/check_calculator_flow.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Run Calculator flow with injected inputs (17, 23) and verify output contains 391."""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+
+INPUT_A = 17
+INPUT_B = 23
+EXPECTED = INPUT_A * INPUT_B  # 391
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+
+    # Discover input variable names from the .flow file
+    flows = glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
+    if not flows:
+        sys.exit("FAIL: No .flow file found")
+
+    with open(flows[0]) as f:
+        flow = json.load(f)
+
+    variables = flow.get("variables", {}) or flow.get("workflow", {}).get("variables", {})
+    in_vars = [v["id"] for v in variables.get("globals", []) if v.get("direction") in ("in", "inout")]
+    if len(in_vars) < 2:
+        sys.exit(f"FAIL: Expected 2+ input variables, found {len(in_vars)}")
+
+    inputs_json = json.dumps({in_vars[0]: INPUT_A, in_vars[1]: INPUT_B})
+    print(f"Injecting inputs: {inputs_json}")
+
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--inputs", inputs_json, "--output", "json"],
+        capture_output=True, text=True, timeout=90,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    if str(EXPECTED) not in json.dumps(data):
+        sys.exit(f"FAIL: Output missing {EXPECTED} ({INPUT_A} * {INPUT_B})\n{r.stdout[:1000]}")
+
+    print(f"OK: Flow completed, output contains {EXPECTED}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/coded_agent/check_coded_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/coded_agent/check_coded_agent_flow.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Run CountLettersCoded flow and verify output contains 3 (r's in 'counterrevolutionary')."""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--output", "json"],
+        capture_output=True, text=True, timeout=240,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    # 'counterrevolutionary' has 3 r's
+    if str(3) not in json.dumps(data):
+        sys.exit(f"FAIL: Output does not contain 3\n{r.stdout[:1000]}")
+
+    print("OK: Flow completed, output contains 3 (r's in 'counterrevolutionary')")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/coded_agent/coded_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/coded_agent/coded_agent.yaml
@@ -1,0 +1,45 @@
+task_id: skill-flow-coded-agent
+description: >
+  Create a UiPath Flow that uses the CountLetters coded agent to count the
+  number of r's in 'counterrevolutionary' and return the answer. Exercises agent resource
+  node discovery and wiring for coded (vs low-code) agents.
+tags: [uipath-maestro-flow, e2e, generate, resource, agent]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "CountLettersCoded" that uses the
+  CountLetters coded agent to count the number of r's in 'counterrevolutionary'
+  and return the answer.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate CountLettersCoded/CountLettersCoded/CountLettersCoded.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow has an agent node and debug returns the letter count"
+    command: "python3 $TASK_DIR/check_coded_agent_flow.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/dice_roller/check_dice_runs.py
+++ b/tests/tasks/uipath-maestro-flow/dice_roller/check_dice_runs.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Run DiceRoller flow and verify output contains a valid dice roll (1-6)."""
+
+import glob
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--output", "json"],
+        capture_output=True, text=True, timeout=90,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    # Look for any integer 1-6 in the output (valid dice roll)
+    output_str = json.dumps(data)
+    rolls = [int(m) for m in re.findall(r'\b([1-6])\b', output_str)]
+    if not rolls:
+        sys.exit(f"FAIL: No dice value (1-6) in output\n{r.stdout[:1000]}")
+
+    print(f"OK: Flow completed, found dice roll = {rolls[0]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-flow/dice_roller/dice_roller.yaml
@@ -1,0 +1,45 @@
+task_id: skill-flow-dice-roller
+description: >
+  Create a UiPath Flow from scratch that simulates rolling a fair six-sided die.
+  The agent must use the CLI to scaffold the project, discover available node
+  types via the registry, edit the flow JSON to add dice-rolling logic using a
+  Script node, and validate the flow.
+tags: [uipath-maestro-flow, e2e, generate, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "DiceRoller" that simulates rolling a six-sided
+  die and outputs the result.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate DiceRoller/DiceRoller/DiceRoller.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ────────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow runs 5 times and produces valid dice rolls (1-6)"
+    command: "python3 $TASK_DIR/check_dice_runs.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/lowcode_agent/check_lowcode_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/lowcode_agent/check_lowcode_agent_flow.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Run CountLettersLowCode flow and verify output contains 3 (r's in 'counterrevolutionary')."""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--output", "json"],
+        capture_output=True, text=True, timeout=240,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    # 'counterrevolutionary' has 3 r's
+    if str(3) not in json.dumps(data):
+        sys.exit(f"FAIL: Output does not contain 3\n{r.stdout[:1000]}")
+
+    print("OK: Flow completed, output contains 3 (r's in 'counterrevolutionary')")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/lowcode_agent/lowcode_agent.yaml
@@ -1,0 +1,45 @@
+task_id: skill-flow-lowcode-agent
+description: >
+  Create a UiPath Flow that uses the CountLetters low-code agent to count the
+  number of r's in 'counterrevolutionary' and return the answer. Exercises agent resource
+  node discovery and wiring.
+tags: [uipath-maestro-flow, e2e, generate, resource, agent]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "CountLettersLowCode" that uses the
+  CountLetters low-code agent to count the number of r's in 'counterrevolutionary'
+  and return the answer.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate CountLettersLowCode/CountLettersLowCode/CountLettersLowCode.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow has an agent node and debug returns the letter count"
+    command: "python3 $TASK_DIR/check_lowcode_agent_flow.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/rpa_project_euler/check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/rpa_project_euler/check_rpa_flow.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Run ProjectEulerTitle flow and verify output contains 'prime square remainders'."""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--output", "json"],
+        capture_output=True, text=True, timeout=240,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    if "prime square remainders" not in json.dumps(data).lower():
+        sys.exit(f"FAIL: Output missing 'prime square remainders'\n{r.stdout[:1000]}")
+
+    print("OK: Flow completed, output contains 'prime square remainders'")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/rpa_project_euler/rpa_project_euler.yaml
+++ b/tests/tasks/uipath-maestro-flow/rpa_project_euler/rpa_project_euler.yaml
@@ -1,0 +1,45 @@
+task_id: skill-flow-rpa-project-euler
+description: >
+  Create a UiPath Flow that uses the ProjectEuler RPA workflow to retrieve the
+  title for problem 123. Exercises RPA resource node discovery, registry get,
+  and node wiring.
+tags: [uipath-maestro-flow, e2e, generate, resource, rpa]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "ProjectEulerTitle" that uses the
+  ProjectEuler RPA workflow to retrieve the title for problem 123 and
+  return it as an output.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate ProjectEulerTitle/ProjectEulerTitle/ProjectEulerTitle.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow has an RPA node and debug returns the problem title"
+    command: "python3 $TASK_DIR/check_rpa_flow.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/slack_channel_description/check_channel_description.py
+++ b/tests/tasks/uipath-maestro-flow/slack_channel_description/check_channel_description.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Run SlackChannelDescription flow and verify output contains the Bellevue office address."""
+
+import glob
+import json
+import os
+import subprocess
+import sys
+
+ADDRESS_FRAGMENTS = [
+    "700 Bellevue Way NE",
+    "Suite 2000",
+    "Bellevue",
+    "WA 98004",
+]
+
+
+def parse_json(stdout):
+    """Parse JSON from stdout, skipping any non-JSON prefix lines from uip."""
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main():
+    projects = glob.glob("**/project.uiproj", recursive=True)
+    if not projects:
+        sys.exit("FAIL: No project.uiproj found")
+
+    project_dir = os.path.dirname(projects[0])
+    r = subprocess.run(
+        ["uip", "flow", "debug", project_dir, "--output", "json"],
+        capture_output=True, text=True, timeout=90,
+    )
+    if r.returncode != 0:
+        sys.exit(f"FAIL: flow debug exit {r.returncode}\n{r.stderr[:500]}")
+
+    data = parse_json(r.stdout)
+    if data is None:
+        sys.exit(f"FAIL: Could not parse JSON\n{r.stdout[:500]}")
+    if (data.get("Data") or {}).get("finalStatus") != "Completed":
+        sys.exit(f"FAIL: Flow did not complete\n{r.stdout[:1000]}")
+
+    output_text = json.dumps(data).lower()
+    missing = [f for f in ADDRESS_FRAGMENTS if f.lower() not in output_text]
+    if missing:
+        sys.exit(f"FAIL: Output missing address fragments: {missing}\n{r.stdout[:1000]}")
+
+    print("OK: Channel description contains Bellevue office address")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/slack_channel_description/slack_channel_description.yaml
@@ -1,13 +1,16 @@
-task_id: uipath-flow-slack-channel-description
+task_id: skill-flow-slack-channel-description
 description: >
   Create a UiPath Flow that uses the Slack IS connector to retrieve the
   channel description of #office-bellevue and outputs it. This is an
   end-to-end test that exercises connector discovery, connection binding,
   reference resolution, node configuration, and cloud debug execution.
-tags: [uipath-maestro-flow, e2e, connector, slack]
+tags: [uipath-maestro-flow, e2e, generate, connector]
+max_iterations: 1
 
 agent:
   type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   turn_timeout: 1200
 
 sandbox:
@@ -18,47 +21,15 @@ initial_prompt: |
   Create a UiPath Flow named "SlackChannelDescription" that retrieves
   the channel description of #office-bellevue and outputs it.
 
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
 success_criteria:
-  # ── CLI usage ────────────────────────────────────────────────────────────
-  - type: command_executed
-    description: "Agent initialized a Flow project"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+flow\s+init\s+.*SlackChannelDescription'
-    min_count: 1
-    weight: 0.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent explored the node registry for Slack connectors"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+flow\s+registry\s+(search|list|get)'
-    min_count: 1
-    require_success: false
-    weight: 0.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent listed or pinged IS connections"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+connections\s+(list|ping)'
-    min_count: 1
-    require_success: false
-    weight: 0.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent resolved the channel reference"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+execute'
-    min_count: 1
-    require_success: false
-    weight: 0.5
-    pass_threshold: 1.0
-
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip flow validate passes on the flow file"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/SlackChannelDescription.flow',recursive=True) or glob.glob('**/*.flow',recursive=True); sys.exit(1) if not flows else sys.exit(subprocess.run(['uip','flow','validate',flows[0]]).returncode)\""
+    command: "uip flow validate SlackChannelDescription/SlackChannelDescription/SlackChannelDescription.flow"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0


### PR DESCRIPTION
- Add e2e tasks: api_workflow, bellevue_weather, calculator, coded_agent, dice_roller, lowcode_agent, rpa_project_euler, slack_channel_description
- Remove activation test type, consolidate into smoke
- Add `make all` target to run smoke + integration + e2e
- Update docs and PR review rules for three test types (smoke/integration/e2e)