### PR TITLE
Add Servo state management for multi-page web app target configuration

### DIFF
--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -38,6 +38,14 @@ Before writing ANY target — whether C# (`uiAutomation.Open(...)`, `Descriptors
 
 See [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for the full configure-target workflow, rules, indication fallback, and multi-step UI flows.
 
+### Multi-Page Application State Management
+
+When automating multi-page web applications (e.g., a site with different pages at different URLs), configure separate Object Repository screens for each page. **Use Servo to navigate the browser to the correct page before configuring targets.**
+
+The workflow is: **Servo → bring app to target page → configure targets → Servo → next page → configure targets → ...**
+
+URL wildcards in window selectors (e.g., `url='https://example.com/*'`) match ALL tabs from that domain. Close unwanted tabs before capture to avoid targeting the wrong page. See [uia-configure-target-workflows.md](uia-configure-target-workflows.md) and [uia-multi-step-flows.md](uia-multi-step-flows.md) for full details.
+
 ### Multi-Step UI Flows (Advancing Application State)
 
 See [uia-multi-step-flows.md](uia-multi-step-flows.md).

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -2,6 +2,47 @@
 
 **Always use the `uia-configure-target` skill** to create or find targets in the Object Repository. This skill handles the full flow: snapshot capture, element discovery, selector generation, selector improvement, and OR registration.
 
+## Prerequisite: Ensure Application State with Servo
+
+Before running `uia-configure-target`, the target application must be visible and showing the correct screen/page. **Use Servo to bring the app into the desired state before any capture.**
+
+This is critical for **multi-page web apps** where the URL wildcard (e.g., `url='https://example.com/*'`) matches multiple browser tabs, causing `snapshot capture` to non-deterministically grab the wrong page.
+
+```bash
+# 1. List windows/tabs to find the application
+servo targets
+
+# 2. If the app is not open, launch it, then re-run servo targets
+
+# 3. Take a screenshot to verify current state
+servo screenshot <b-ref or w-ref>
+
+# 4. If on the wrong page/screen, navigate using Servo:
+servo snapshot <b-ref>
+servo type <url-bar-ref> "https://example.com/target-page" --clear-before
+servo type <url-bar-ref> "[k(enter)]"
+# Or click navigation elements to reach the target screen:
+servo click <nav-element-ref>
+
+# 5. Close unwanted tabs that share the same URL pattern
+# (prevents wildcard conflicts during snapshot capture)
+
+# 6. Re-screenshot to confirm correct state before proceeding
+servo screenshot <b-ref or w-ref>
+```
+
+**Multi-page web app loop:** When automating multiple pages on the same site, the workflow is:
+
+```
+For each page:
+  1. Servo → navigate browser to the page URL, verify correct page is showing
+  2. uia-configure-target → configure screen + elements for this page
+  3. Record the screen and element reference IDs
+  4. Repeat for the next page
+```
+
+**Wildcard URL trap:** `get-default-selector` generates URL wildcards like `url='https://example.com/*'`. If multiple tabs match this pattern, `snapshot capture` picks whichever matches first (non-deterministic). Always ensure only ONE matching tab is active before capture.
+
 ## Execution Model
 
 **Execute `uia-configure-target` steps inline in the main conversation.** Do NOT delegate the entire skill to a subagent. The skill's internal steps already spawn their own subagents.

--- a/skills/uipath-rpa/references/uia-multi-step-flows.md
+++ b/skills/uipath-rpa/references/uia-multi-step-flows.md
@@ -1,5 +1,25 @@
 # Multi-Step UI Flows
 
+## Navigating to the Starting Page
+
+Before capturing any targets, use Servo to bring the application to the correct starting state. This is especially important for **multi-page web apps** where URL wildcards in window selectors (e.g., `url='https://example.com/*'`) match multiple browser tabs non-deterministically.
+
+```bash
+# Find the browser tab
+servo targets
+# Navigate to the target page
+servo snapshot <b-ref>
+servo type <url-bar-ref> "https://example.com/target-page" --clear-before
+servo type <url-bar-ref> "[k(enter)]"
+# Verify correct page is showing
+servo screenshot <b-ref>
+# Close any other tabs matching the same URL pattern to prevent wildcard conflicts
+```
+
+See [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for the full prerequisite details.
+
+## Advancing Between Screens
+
 Some UI elements only become visible after interacting with earlier elements (e.g., a compose form appears after clicking "New mail", a confirmation dialog appears after submitting). Since `uia-configure-target` works from the current screen state, you need to **advance the application to each state** before capturing its elements.
 
 > **CRITICAL: Complete-then-advance.** Finish ALL `uia-configure-target` calls for elements visible in the current screen state — including OR registration (the full skill through TARGET-8) — before using servo to advance to the next state. Servo interactions change the app state irreversibly. If you advance before registering, elements from the previous state may no longer be visible, causing OR registration to fail.


### PR DESCRIPTION
## Summary
- Adds a **Prerequisite: Ensure Application State with Servo** section to `uia-configure-target-workflows.md` — documents using Servo to navigate the browser to the correct page before any snapshot capture
- Adds a **Navigating to the Starting Page** section to `uia-multi-step-flows.md` — establishes that Servo should be used to reach the starting state before capturing targets
- Adds **Multi-Page Application State Management** guidance to `ui-automation-guide.md` — summarizes the Servo→capture→configure loop and links to detailed docs
- Documents the **wildcard URL trap** across all three files — explains why `url='https://example.com/*'` causes non-deterministic tab targeting and how to avoid it

## Motivation
When automating multi-page web apps (e.g., demoqa.com with 15+ pages), the `uia-configure-target` flow had no mechanism for ensuring the browser was showing the correct page before capture. The URL wildcard generated by `get-default-selector` matches ALL tabs from the same domain, causing `snapshot capture` to grab whichever tab matches first — often the wrong one. This was discovered during a real automation session where Chrome session restore kept re-opening old tabs, and no amount of killing/restarting Chrome could produce a clean single-tab state.

The fix is to use Servo (which was already available but not referenced in the configure-target flow) to navigate the browser to the correct page before capture. The pattern is: **Servo → bring to page → configure targets → Servo → next page → repeat.**

## Test plan
- [ ] Verify the Servo navigation commands in the prerequisite section work for a multi-tab Chrome session
- [ ] Verify the multi-page loop pattern works end-to-end on a multi-page site (e.g., demoqa.com)
- [ ] Confirm no broken relative links in the updated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)