### PR TITLE
docs(uipath-rpa): clarify OR embedding workflow in UIA references

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -135,6 +135,7 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 | **Troubleshoot coded errors** | Coded | [coded/coding-guidelines.md § Common Issues](references/coded/coding-guidelines.md) |
 | **Troubleshoot XAML errors** | XAML | [xaml/common-pitfalls.md](references/xaml/common-pitfalls.md) → [validation-guide.md](references/validation-guide.md) |
 | **Understand project structure** | Both | [project-structure.md](references/project-structure.md) |
+| **Build multi-screen UIA XAML workflow** | XAML | [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-parallel-xaml-authoring-guide.md](references/uia-parallel-xaml-authoring-guide.md) |
 
 ## Coded Workflows Quick Reference
 
@@ -232,6 +233,12 @@ The XAML file anatomy template (namespace declarations, root Activity element, b
 - [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) — Flowchart, State Machine, and Long Running Workflow canvas layout with ViewState
 - [xaml/jit-custom-types-schema.md](references/xaml/jit-custom-types-schema.md) — JIT custom type discovery
 
+### Multi-Screen UI Automation Workflows
+
+For XAML workflows targeting 2 or more distinct screens requiring `uia-configure-target`, use the parallel authoring pipeline instead of writing the entire workflow in a single pass. The pipeline chains write agents per screen, overlapping target configuration with XAML generation. See [uia-parallel-xaml-authoring-guide.md](references/uia-parallel-xaml-authoring-guide.md).
+
+Single-screen workflows skip the pipeline — one agent writes the complete file in a single pass.
+
 ## Resolving Packages & Activity Docs
 
 Follow this flow whenever you need to use an activity package:
@@ -263,6 +270,7 @@ Additional UIA procedures and guides:
 - [uia-multi-step-flows.md](references/uia-multi-step-flows.md) — Advancing application state between screens
 - [uia-selector-recovery.md](references/uia-selector-recovery.md) — Fixing selectors that fail at runtime
 - [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) — Target configuration workflow and indication fallback
+- [uia-parallel-xaml-authoring-guide.md](references/uia-parallel-xaml-authoring-guide.md) — Parallel XAML authoring pipeline for multi-screen workflows
 
 ## Completion Output
 

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -237,6 +237,8 @@ The XAML file anatomy template (namespace declarations, root Activity element, b
 
 For XAML workflows targeting 2 or more distinct screens requiring `uia-configure-target`, use the parallel authoring pipeline instead of writing the entire workflow in a single pass. The pipeline chains write agents per screen, overlapping target configuration with XAML generation. See [uia-parallel-xaml-authoring-guide.md](references/uia-parallel-xaml-authoring-guide.md).
 
+- Use split tasks (`Configure-<N>` + `Write-<N>`) with `addBlockedBy` to enforce the chained write model — see the parallel authoring guide.
+
 Single-screen workflows skip the pipeline — one agent writes the complete file in a single pass.
 
 ## Resolving Packages & Activity Docs

--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -40,6 +40,8 @@ See [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for t
 
 ### Multi-Step UI Flows (Advancing Application State)
 
+To interact with targets between capture steps, prefer `uip rpa uia interact click/type` when the target is already registered in the OR (reuses the configured selector, no separate ref system). Fall back to `servo` only for ad-hoc interactions on elements that are not in OR.
+
 See [uia-multi-step-flows.md](uia-multi-step-flows.md).
 
 ---

--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -152,12 +152,9 @@ Every UI automation workflow starts with an **Application Card** (`uix:NApplicat
 
 #### Target Configuration
 
-Follow [uia-configure-target-workflows.md](uia-configure-target-workflows.md) to generate the Application Card's `TargetApp` and each activity's `TargetAnchorable`. The skill returns ready-to-use XAML attributes — copy them exactly into your workflow:
+Follow [uia-configure-target-workflows.md](uia-configure-target-workflows.md) to register the Application Card's screen and each activity's elements in the Object Repository. Then retrieve the XAML snippets using `get-screen-xaml` and `get-elements-xaml`, and embed them directly in the workflow during creation — see the **Embedding OR Entries in XAML Activities** section in [uia-configure-target-workflows.md](uia-configure-target-workflows.md).
 
-- **Screen XAML** → goes into `<uix:NApplicationCard.TargetApp>` as a `<uix:TargetApp ... />` element
-- **Element XAML** → goes into `<uix:NGetText.Target>` (or Click, TypeInto, etc.) as a `<uix:TargetAnchorable ... />` element
-
-When an element is reused across multiple activities, use the same returned XAML snippet for each one.
+Do NOT hand-write `<uix:TargetApp>` or `<uix:TargetAnchorable>` XAML from scratch. Always use the CLI commands to retrieve the correct snippets from the Object Repository.
 
 ### Common Activities
 

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -7,7 +7,7 @@
 **Execute `uia-configure-target` steps inline in the main conversation.** Do NOT delegate the entire skill to a subagent. The skill's internal steps already spawn their own subagents.
 
 Why this matters:
-- **OR references** must be visible in the main conversation to build the final workflow XAML.
+- **OR references** must be visible in the main conversation so they can be embedded into workflow activities as the workflow is created.
 - **Context continuity** — the main conversation tracks which screens and elements are already registered, which avoids duplicate captures and keeps the workflow build coherent.
 
 Read the SKILL.md, then execute each TARGET step yourself. Only spawn `Agent` where the skill explicitly says to (create-selector, improve-selector).
@@ -53,12 +53,9 @@ uip rpa indicate-application --name "<ScreenName>" --description "<ScreenDescrip
 # 2. Indicate elements on that screen (use --parent-id from step 1 result's Data.reference)
 uip rpa indicate-element --name "<ElementName>" --activity-class-name "<TypeInto|Click|GetText|...>" --parent-id "<screen-reference>" --project-dir "<PROJECT_DIR>" --output json --use-studio
 
-# 3. Retrieve OR entries after indication
-uip rpa uia object-repository get-screen-xaml --reference-id "<screen-reference>"
-uip rpa uia object-repository get-elements-xaml --reference-ids "<element-reference-1>,<element-reference-2>"
 ```
 
-Both commands return `{ "Data": { "reference": "..." } }` — use that reference ID for subsequent commands and OR lookups. After indication, Studio regenerates Object Repository files; re-read them to get descriptor paths for your workflow.
+Both commands return `{ "Data": { "reference": "..." } }` — use that reference ID to retrieve XAML snippets and for OR lookups. After indication, Studio regenerates Object Repository files. For coded workflows, re-read `ObjectRepository.cs` to get descriptor paths. For XAML workflows, use the reference IDs to retrieve XAML snippets and embed them into activities as the workflow is created — see **Embedding OR Entries in XAML Activities** below.
 
 <details>
 <summary>Full parameter reference</summary>
@@ -93,3 +90,60 @@ When no App exists in `.objects/`, omit `--parent-id` and `--parent-name` — th
 | `.objects/` has subdirectories but no `.metadata` files | Corrupted/incomplete App from a failed creation | Clear orphan directories and run `indicate-application` without `--parent-id` |
 
 </details>
+
+## Embedding OR Entries in XAML Activities
+
+After registering targets in the Object Repository (via `uia-configure-target` or indication fallback), retrieve the XAML snippets and embed them directly when creating the workflow. This is more reliable than post-creation linking because it works regardless of intermediate validation errors.
+
+### 1. Get the screen XAML for the ApplicationCard
+
+```bash
+uip rpa uia object-repository get-screen-xaml \
+  --reference-id "<SCREEN_REFERENCE_ID>" \
+  --project-dir "<PROJECT_DIR>"
+```
+
+Returns a `<TargetApp>` element. Embed it inside the ApplicationCard:
+
+```xml
+<uix:NApplicationCard.TargetApp>
+  <!-- paste the returned <TargetApp ... /> here (remove the xmlns attribute — it's inherited from the uix prefix) -->
+</uix:NApplicationCard.TargetApp>
+```
+
+### 2. Get element XAML for UI activities
+
+```bash
+uip rpa uia object-repository get-elements-xaml \
+  --reference-ids "<REF_1>,<REF_2>,<REF_3>" \
+  --project-dir "<PROJECT_DIR>"
+```
+
+Returns `<TargetAnchorable>` elements, one per reference ID, separated by `=== Element Name ===` headers. Embed each inside its activity's `.Target` property:
+
+```xml
+<uix:NClick ...>
+  <uix:NClick.Target>
+    <!-- paste the returned <TargetAnchorable ... /> here (remove the xmlns attribute) -->
+  </uix:NClick.Target>
+</uix:NClick>
+
+<uix:NTypeInto ...>
+  <uix:NTypeInto.Target>
+    <!-- paste the returned <TargetAnchorable ... /> here -->
+  </uix:NTypeInto.Target>
+</uix:NTypeInto>
+
+<uix:NGetText ...>
+  <uix:NGetText.Target>
+    <!-- paste the returned <TargetAnchorable ... /> here -->
+  </uix:NGetText.Target>
+</uix:NGetText>
+```
+
+| Parameter | Source |
+|-----------|--------|
+| `<SCREEN_REFERENCE_ID>` | OR screen reference returned by `uia-configure-target` or `indicate-application` |
+| `<REF_1>,<REF_2>,...` | Comma-separated OR element references returned by `uia-configure-target` or `indicate-element` |
+
+When an element is used by multiple activities (e.g., the same field clicked and then typed into), use the same `<TargetAnchorable>` snippet in each activity's `.Target` property.

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -8,7 +8,7 @@
 
 Why this matters:
 - **OR references** must be visible in the main conversation so they can be embedded into workflow activities as the workflow is created.
-- **Context continuity** — the main conversation tracks which screens and elements are already registered, which avoids duplicate captures and keeps the workflow build coherent.
+- **Context continuity** — as the main conversation proceeds, it already knows which screens and elements are registered: the references were returned in earlier turns, and the OR itself is queryable via `object-repository get-screens` / `get-elements`. This is what "knowing what's registered" means here — the in-conversation state plus live OR queries — so duplicate captures are avoided and the workflow build stays coherent.
 
 Read the SKILL.md, then execute each TARGET step yourself. Only spawn `Agent` where the skill explicitly says to (create-selector, improve-selector).
 
@@ -36,7 +36,7 @@ The skill will search the Object Repository for existing matches before creating
 
 ## Rules
 
-**Do NOT manually call low-level `uip rpa uia` CLI commands** (`snapshot capture`, `snapshot filter`, `selector-intelligence get-default-selector`) to build selectors outside of the skill flow. These are internal tools used *by* the skill — calling them directly skips selector improvement and OR registration, producing fragile selectors that aren't tracked in the project.
+**Do NOT manually call low-level `uip rpa uia` CLI commands** (`snapshot capture`, `snapshot filter`, `selector-intelligence get-default-selector`) to build selectors outside of the skill flow. These are internal tools used *by* the skill — calling them directly skips selector improvement and OR registration, producing fragile selectors that aren't registered in the Object Repository.
 
 **Do NOT launch the target application before running `uia-configure-target`.** The skill's first steps capture the top-level window tree and search for the app. Only if the app is not found in the window list should you launch it — and then re-run the capture. Launching preemptively creates duplicate instances and risks targeting the wrong window.
 

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -91,6 +91,24 @@ When no App exists in `.objects/`, omit `--parent-id` and `--parent-name` — th
 
 </details>
 
+## Interacting with a Registered Target
+
+After TARGET-8 returns an OR reference ID, you can drive that target directly from the main conversation using `uia interact` — no servo snapshot, no second ref system. This is the preferred way to advance the application state to the next screen when building multi-step flows.
+
+```bash
+# Click using the OR reference ID returned by create-screen / create-elements
+uip rpa uia interact click --reference-id "<OR_REFERENCE_ID>"
+
+# Type into a target using the OR reference ID
+uip rpa uia interact type --reference-id "<OR_REFERENCE_ID>" --text "hello"
+```
+
+Alternate input forms:
+- `--definition-file-path "<WORK_FOLDER>/Target_N_Definition.json"` — use the definition file (useful before OR registration)
+- `--window-selector "<html ... />" --partial-selector "<webctrl ... />"` — raw selectors (ad-hoc, no OR entry)
+
+See [uia-multi-step-flows.md](uia-multi-step-flows.md) for when to use `uia interact` vs servo and the full capture loop.
+
 ## Embedding OR Entries in XAML Activities
 
 After registering targets in the Object Repository (via `uia-configure-target` or indication fallback), retrieve the XAML snippets and embed them directly when creating the workflow. This is more reliable than post-creation linking because it works regardless of intermediate validation errors.
@@ -147,3 +165,9 @@ Returns `<TargetAnchorable>` elements, one per reference ID, separated by `=== E
 | `<REF_1>,<REF_2>,...` | Comma-separated OR element references returned by `uia-configure-target` or `indicate-element` |
 
 When an element is used by multiple activities (e.g., the same field clicked and then typed into), use the same `<TargetAnchorable>` snippet in each activity's `.Target` property.
+
+### Multi-Screen Workflows: Passing OR Data to Write Agents
+
+For multi-screen XAML workflows using the parallel authoring pipeline, retrieve OR XAML snippets (`get-screen-xaml`, `get-elements-xaml`) immediately after registration and pass them to a write agent's prompt. The write agent embeds `TargetApp` and `TargetAnchorable` snippets using the same patterns shown above. This decouples target configuration from XAML generation, allowing the main conversation to configure the next screen's targets while the write agent works.
+
+See [uia-parallel-xaml-authoring-guide.md](uia-parallel-xaml-authoring-guide.md) for prompt templates and the chained dependency model.

--- a/skills/uipath-rpa/references/uia-debug-workflow.md
+++ b/skills/uipath-rpa/references/uia-debug-workflow.md
@@ -13,6 +13,7 @@
    ```bash
    uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json --use-studio
    ```
+   If the run fails, [`uia-selector-recovery.md`](uia-selector-recovery.md) spawns the `uia-improve-selector` subagent — this is the **only** correct recovery path. Do not hand-edit selectors in the XAML file.
 3. **When done** (success or failure) — **stop the debug session:**
    ```bash
    uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json --use-studio
@@ -27,5 +28,3 @@
    ```
 
 Skipping steps 4-5 causes the next run's open-if-not-open behavior to reuse a stale window in whatever state it was left in, or -- if the selector doesn't match -- to spawn a duplicate instance.
-
-If a selector error occurs during the debug run, see [uia-selector-recovery.md](uia-selector-recovery.md) for the recovery procedure.

--- a/skills/uipath-rpa/references/uia-multi-step-flows.md
+++ b/skills/uipath-rpa/references/uia-multi-step-flows.md
@@ -6,25 +6,63 @@ Some UI elements only become visible after interacting with earlier elements (e.
 >
 > **Do NOT use servo to "test" element interactions** (e.g., verifying autocomplete behavior, checking what happens when you click a button) during the capture phase. Testing happens later, when running the completed workflow. During capture, servo is ONLY for advancing the app to the next screen so you can capture the newly revealed elements.
 
+## Advancing UI State — Two Options
+
+After registering an element in the Object Repository, you often need to interact with it to reveal the next screen's elements. Two CLIs can drive the interaction; prefer `uia interact` whenever possible.
+
+### Preferred: `uia interact` (for configured OR targets)
+
+Once an element is registered in the OR (TARGET-8 complete), use `uia interact click` or `uia interact type` with the OR reference ID. This reuses the exact selector that was validated during target configuration — no separate snapshot, no second ref system, no selector guessing.
+
+```bash
+# Click a configured target by OR reference ID
+uip rpa uia interact click --reference-id "<OR_REFERENCE_ID>"
+
+# Type into a configured target by OR reference ID
+uip rpa uia interact type --reference-id "<OR_REFERENCE_ID>" --text "hello"
+```
+
+Alternate input forms (same result):
+
+```bash
+# Use the definition file directly (before OR registration)
+uip rpa uia interact click --definition-file-path "<WORK_FOLDER>/Target_1_Definition.json"
+uip rpa uia interact type --definition-file-path "<WORK_FOLDER>/Target_1_Definition.json" --text "hello"
+
+# Use raw selectors (ad-hoc, no OR entry required)
+uip rpa uia interact click --window-selector "<html ... />" --partial-selector "<webctrl ... />"
+uip rpa uia interact type --window-selector "<html ... />" --partial-selector "<webctrl ... />" --text "hello"
+```
+
+### Fallback: `servo` (for elements not in OR)
+
+Use servo only when the element is NOT in the Object Repository and doesn't need to be (for example, a transient element you just want to click once to advance state, with no intention of using it in the final workflow).
+
 > **WARNING: Servo refs and UIA snapshot refs are independent numbering systems.** Element `e42` from `uip rpa uia snapshot filter` is NOT the same as `e42` from `servo snapshot`. Always run `servo snapshot <window-ref>` to get servo-specific refs before using `servo click`/`servo type`. Never reuse refs from UIA snapshots in servo commands.
 
-Use the `servo` CLI to interact with already-configured targets and advance the UI, then run `uia-configure-target` again for the newly visible elements:
+```bash
+servo targets
+servo snapshot <window-or-tab-ref>
+servo click <servo-element-ref>
+```
+
+## Multi-Step Capture Loop
 
 1. **Capture current state completely:** Run `uia-configure-target` for ALL elements visible on the current screen. Let the skill run through to TARGET-8 (OR registration) for each element. Do not stop after getting a raw selector.
-2. **Advance the UI** using servo to move to the next state (e.g., click a button to open a form):
-   ```bash
-   # List targets to find the window/tab
-   servo targets
-   # Take a SERVO snapshot to get servo-specific element refs
-   servo snapshot <window-or-tab-ref>
-   # Click to advance UI state (use servo refs, NOT UIA refs)
-   servo click <servo-element-ref>
-   ```
+2. **Advance the UI** to the next state — prefer `uia interact click/type --reference-id "<OR_REF>"` on an element you just registered; fall back to servo only for elements not in OR.
 3. **Capture the new state:** Run `uia-configure-target` again for elements now visible on the new screen (full skill through TARGET-8).
 4. **Repeat** until all workflow targets are registered in the OR.
 
-**Do NOT use `uip rpa run-file` with partial workflows to advance UI state** — the workflow lifecycle may close the target application when execution ends. Servo is stateless: it clicks/types and leaves the app in the resulting state.
+**Do NOT use `uip rpa run-file` with partial workflows to advance UI state** — the workflow lifecycle may close the target application when execution ends. Both `uia interact` and `servo` are stateless: they perform one action and leave the app in the resulting state.
 
-After all targets are captured, build the full workflow in one pass using all the collected OR references.
+## Spawning XAML Write Agents
+
+After completing all `uia-configure-target` calls for a screen (through TARGET-8 for all elements) and retrieving OR XAML snippets via `get-elements-xaml`, spawn a write agent to add that screen's activities to the workflow file. Each write agent depends on the previous one completing — they form a strict chain.
+
+The screen boundary for write agents aligns with the Complete-then-advance rule above: everything configured before the next servo advance belongs to one write agent's scope.
+
+See [uia-parallel-xaml-authoring-guide.md](uia-parallel-xaml-authoring-guide.md) for the full pipeline, prompt templates, and chained dependency model.
+
+After all targets are captured, build the full workflow in one pass using all the collected OR references — unless the workflow spans multiple screens, in which case use the parallel authoring pipeline to chain write agents per screen (see [uia-parallel-xaml-authoring-guide.md](uia-parallel-xaml-authoring-guide.md)).
 
 See also: [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for the `uia-configure-target` skill details and indication fallback commands.

--- a/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
+++ b/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
@@ -1,0 +1,318 @@
+# Parallel XAML Authoring Guide
+
+## When to Use This Guide
+
+- The workflow targets **2 or more distinct screens** requiring target configuration via `uia-configure-target`
+- The workflow is a **XAML workflow** (not a coded workflow in C#)
+- **Single-screen workflows:** skip this pipeline entirely — one agent writes the complete file (scaffolding + activities) in a single pass
+
+## Phase 0: Plan the Workflow
+
+> **CRITICAL:** Complete Phase 0 before spawning any agent. All one-time data (xmlns, activity templates, expression language) must be collected first. Skipping this produces scaffolding with incomplete namespace declarations, causing all subsequent screen agents to fail.
+
+1. **Identify screens.** List each distinct application state the workflow will interact with. A "screen" is a stable UI state where one or more elements need to be targeted — a page, a modal dialog, an inline form, or a panel that appears after an action.
+
+2. **Map actions per screen.** For each screen, list the ordered interactions: which element, what action (Click, TypeInto, SelectItem, GoToUrl), what data value, and any special behavior (dropdown patterns, wait durations, checkbox toggling).
+
+3. **Determine ApplicationCard scope.** Decide whether the workflow uses one ApplicationCard (all screens share the same window or browser tab — the common case for single-app web automation) or multiple (different applications or browser tabs requiring separate ApplicationCards).
+
+4. **Identify element reuse.** Note where the same form appears more than once with different data (for example, a "Save & New" pattern that reopens the same contact form). These screens share OR targets but have separate action sequences and data values — each gets its own write agent.
+
+5. **Collect one-time data** before starting any target configuration:
+
+   a. **Expression language** — read from `project.json` → `expressionLanguage` field (`CSharp` or `VB`).
+
+   b. **Activity templates** — run `uip rpa get-default-activity-xaml` for every activity type the workflow will use:
+   ```bash
+   uip rpa get-default-activity-xaml \
+     --activity-class-name "<FULLY_QUALIFIED_CLASS_NAME>" \
+     --project-dir "<PROJECT_DIR>" \
+     --output json \
+     --use-studio
+   ```
+   Collect templates for: `NApplicationCard`, `NClick`, `NTypeInto`, `NGoToUrl`, `NSelectItem`, and any other activity type the workflow uses. Save all outputs — they are passed verbatim to agent prompts.
+
+   c. **xmlns declarations** — read from an existing `.xaml` file in the project root AND from the `get-default-activity-xaml` output for `NApplicationCard`. Combine the namespace declarations from both sources. This is the complete set needed for the root `<Activity>` element.
+
+   d. **TextExpression imports and references** — same source as xmlns: read from an existing project `.xaml` file and from `get-default-activity-xaml` output. Collect both the `TextExpression.NamespacesForImplementation` and `TextExpression.ReferencesForImplementation` blocks.
+
+   e. **x:Class value** — derived from the output `.xaml` filename per the naming rule in [xaml-basics-and-rules.md](xaml/xaml-basics-and-rules.md): folder separators become underscores, not dots. Root-level `MyWorkflow.xaml` → `x:Class="MyWorkflow"`. Subfolder `Workflows/MyWorkflow.xaml` → `x:Class="Workflows_MyWorkflow"`.
+
+## Phase 1: Scaffolding Agent
+
+1. **When to spawn:** Immediately after the first screen is registered in the Object Repository (TARGET-8 screen creation), before element configuration for that screen begins. The scaffolding agent depends only on the TargetApp XAML from the first screen registration — not on any element targets.
+
+2. **Run mode:** Spawn the scaffolding agent with `run_in_background: true`. Foreground mode blocks the main conversation and defeats the purpose of the parallel pipeline — while the scaffolding agent works, the main conversation must advance the application to the next screen and configure its targets. The scaffolding agent creates a new file with no concurrent access risk, so background mode is safe.
+
+3. **What the agent creates:**
+   - Complete `.xaml` file with `<Activity>` root element, all xmlns declarations, and TextExpression blocks
+   - `NApplicationCard` activity using the template from `get-default-activity-xaml`
+   - `<TargetApp>` embedded inside the ApplicationCard — retrieved via:
+     ```bash
+     uip rpa uia object-repository get-screen-xaml \
+       --reference-id "<SCREEN_REFERENCE_ID>" \
+       --project-dir "<PROJECT_DIR>"
+     ```
+   - Empty `<Sequence DisplayName="Do">` inside the ApplicationCard body — this is where screen agents will insert activities
+
+4. **Post-write verification** (D-09): Run `get-errors` only after the agent writes the file:
+   ```bash
+   uip rpa get-errors \
+     --file-path "<XAML_FILE_PATH>" \
+     --project-dir "<PROJECT_DIR>" \
+     --output json \
+     --use-studio
+   ```
+
+5. **Self-repair** (D-10): If `get-errors` returns errors, fix and re-run. Max 3 fix cycles. After 3 attempts, stop and report remaining errors to the main conversation.
+
+6. **Prompt template:** See [Scaffolding Agent Template](#scaffolding-agent-template) for the complete Agent() call.
+
+> **CRITICAL:** Remove the `xmlns` attribute from the `<TargetApp>` element returned by `get-screen-xaml` before embedding it in the agent prompt. The root `<Activity>` element's namespace declarations already cover it. Duplicate xmlns causes namespace-related validation errors.
+
+## Phase 2: Screen Activity Agents
+
+1. **Spawn precondition** — Do NOT spawn screen N's agent until BOTH conditions are true:
+   - (a) Screen N's element targets are fully configured AND the OR XAML snippets are retrieved via `get-elements-xaml`
+   - (b) The previous write agent (screen N-1, or scaffolding for N=1) has returned a result
+
+2. **Run mode:** Spawn each screen activity agent with `run_in_background: true`. While the agent writes screen N, the main conversation must advance the application to screen N+1 and configure its targets. Wait for the background agent's completion notification before spawning the next screen's agent (the chain requires each agent to read the previous agent's finalized file state).
+
+3. **What the agent does:**
+   - Reads the current `.xaml` file
+   - Locates the inner `<Sequence DisplayName="Do">` element
+   - Inserts its activities immediately before the closing `</Sequence>` tag
+   - Does NOT modify any content before the insertion point
+
+4. **OR snippet retrieval** (per screen, after element OR registration):
+   ```bash
+   uip rpa uia object-repository get-elements-xaml \
+     --reference-ids "<REF_1>,<REF_2>,<REF_3>" \
+     --project-dir "<PROJECT_DIR>"
+   ```
+
+5. **Post-write verification** (D-09): Run `get-errors` only — same command as Phase 1.
+
+6. **Self-repair** (D-10): Same as Phase 1 (max 3 cycles, then report to main conversation).
+
+7. **Prompt template:** See [Screen Activity Agent Template](#screen-activity-agent-template) for the complete Agent() call.
+
+> **CRITICAL:** Remove `xmlns` attributes from all `<TargetAnchorable>` elements returned by `get-elements-xaml` before including them in the agent prompt. The root `<Activity>` element's namespace declarations already cover them.
+
+### Screen Boundaries
+
+A "screen" equals everything configured before advancing the application to the next workflow state via servo. This may include intermediate servo clicks within the same logical state (for example, navigating to a list view to reveal a "New" button before configuring it) — per the Complete-then-advance rule in [uia-multi-step-flows.md](uia-multi-step-flows.md).
+
+All `uia-configure-target` calls for the current workflow state must complete before spawning the write agent for that screen AND before using servo to advance to the next state.
+
+See also: [uia-multi-step-flows.md](uia-multi-step-flows.md) for the Complete-then-advance rule.
+See also: [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for OR embedding patterns and passing OR data to write agents.
+
+### Chained Dependency Model
+
+The write agents form a strict chain — each depends on the previous:
+
+| Agent | Depends on |
+|-------|-----------|
+| Scaffolding agent | First screen OR registration (no element targets needed) |
+| Screen 1 agent | Scaffolding complete + Screen 1 element targets configured |
+| Screen 2 agent | Screen 1 agent complete + Screen 2 element targets configured |
+| Screen N agent | Screen N-1 agent complete + Screen N element targets configured |
+
+The main conversation runs `uia-configure-target` tasks in parallel with the write chain: configure screen N+1 while screen N's write agent is running.
+
+## Phase 3: Finalization
+
+1. **Validate the complete workflow.** After the last write agent completes, run `get-errors` on the full file (D-11):
+   ```bash
+   uip rpa get-errors \
+     --file-path "<XAML_FILE_PATH>" \
+     --project-dir "<PROJECT_DIR>" \
+     --output json \
+     --use-studio
+   ```
+   Do NOT run `run-file` as a validation step — the target application state is not guaranteed to be in the correct starting state after the pipeline.
+
+2. **Add entry point to `project.json`.** Add the new workflow to the `entryPoints[]` array:
+   ```json
+   {
+     "filePath": "WorkflowName.xaml",
+     "uniqueId": "<GENERATE_GUID>",
+     "input": [],
+     "output": []
+   }
+   ```
+   GUID generation is the main conversation's responsibility — not a write agent's — because it modifies a shared project file.
+
+3. **Report completion** to the user per the SKILL.md Completion Output format.
+
+## Prompt Construction Rules
+
+1. Include activity templates **VERBATIM** — paste the XAML from `get-default-activity-xaml` output into the agent prompt. Do not describe or summarize the template.
+2. Include OR snippets **VERBATIM** with human-readable labels — paste the exact `<TargetAnchorable>` XML (with xmlns removed), labeled by element name. Do not summarize selectors.
+3. Describe actions as an **ordered numbered list** with exact data values (for example: "1. TypeInto 'First Name' field: John  2. Click 'Save' button").
+4. Specify interaction patterns **explicitly** for each non-trivial interaction: dropdown selection (Click then TypeInto with `[k(enter)]`), wait durations between actions, checkbox toggling, element reuse across repeated form instances.
+5. Specify **expression-language-specific syntax** for inline expressions. CSharp: `new TimeSpan(0,0,2)` for Delay. VB: `TimeSpan.FromSeconds(2)`. Always match the `expressionLanguage` value from `project.json`.
+6. All context (OR snippets, activity templates, action sequences) goes **inline in the Agent() prompt parameter** as labeled blocks (D-06). Do not pass context via temp `.md` files or any other file-based method.
+7. **Always inline regardless of element count** (D-07). Do not apply a size guardrail or branch on large vs small screens.
+8. Include the **edit instruction** in every screen agent prompt: where to insert (before the closing `</Sequence>` tag of the inner `<Sequence DisplayName="Do">`), and what not to touch (all content before the insertion point).
+9. Include the **validation instruction**: run `get-errors`, fix issues, max 3 fix cycles before reporting to main conversation.
+
+## Edge Cases
+
+### Reused Forms (Same OR Targets, Different Data)
+
+When the same form appears more than once (for example, a "Save & New" pattern that reopens the same contact form), treat the repetitions as screens that share the same `<TargetAnchorable>` snippets but have different action sequences and data values.
+
+**Prefer a single write agent when all of these hold:**
+- The repetitions are back-to-back in the workflow (no intervening pipeline work).
+- They use the same OR targets — no additional target configuration is needed between them.
+- The flow is linear (no branching, no conditional logic the agent would need to reason about).
+
+A single agent appends all repetitions in one pass. This avoids chain overhead (each extra agent adds a validation cycle, a context-window hit, and a round-trip) while producing identical output.
+
+**Split into separate write agents only when:**
+- New OR targets must be configured between repetitions (the main conversation needs to run `uia-configure-target` between agent spawns).
+- The app state must be advanced via `uia interact` or servo between repetitions.
+- The repetitions have structural differences large enough that one prompt would be ambiguous or oversized.
+
+When splitting, each agent appends independently and the later agent's activities follow the earlier's in the file.
+
+### Single-Screen Workflows
+
+Skip the pipeline entirely. Spawn one agent that creates the complete file — scaffolding structure plus all screen activities — in a single pass. The pipeline overhead (separate scaffolding agent, chained dependency tracking) is not justified for a single screen.
+
+### Write Agent Failure
+
+The agent self-repairs in-place (D-10): it calls `get-errors`, reads the errors, and fixes the XAML. Max 3 fix cycles. If errors remain after 3 attempts, stop and report the remaining errors to the main conversation.
+
+Screens 1 through N-1 are already written and valid — no rollback is needed. The main conversation reads the reported error, adjusts the prompt or corrects a selector, and retries screen N's agent. The agent reads the current file state (valid through N-1) and appends from there.
+
+### Background Agent Not Done
+
+Wait for the previous write agent to return a result before spawning the next write agent. Write agents are fast — they perform pure text generation against a well-specified prompt. If a write agent is consistently slower than the time it takes to configure the next screen's targets, the prompt is too large or too ambiguous.
+
+## Anti-patterns
+
+1. Do NOT have a screen activity agent create the file from scratch — the scaffolding agent does that.
+2. Do NOT have a screen activity agent modify activities from earlier screens — insert before the closing `</Sequence>` tag only.
+3. Do NOT spawn a write agent before BOTH its target configuration is complete AND the previous write agent has returned a result.
+4. Do NOT pass unstable selectors (auto-generated numeric IDs, `css-selector` attributes, hash-based class names) to write agents — identify and fix them during target configuration via selector improvement before retrieving OR snippets.
+5. Do NOT describe activities abstractly in the agent prompt (for example, "add a click on the login button") — paste the exact `<TargetAnchorable>` XML and specify the activity type explicitly.
+6. Do NOT duplicate pipeline logic in SKILL.md or other reference files — those files route here; this file is the single source of truth for the pipeline.
+7. Do NOT skip the selector stability gate before passing OR snippets to a write agent. Syntactically valid XAML that uses runtime-broken selectors is harder to debug than a build error.
+8. Do NOT modify the `.xaml` file from the main conversation while a write agent is running. The chained model depends on each agent reading the current valid file state; concurrent edits produce an unknown file state for the next agent.
+9. Do NOT spawn write agents in foreground mode — this blocks the main conversation and serializes the pipeline. Always use `run_in_background: true` so the main conversation can advance the application state and configure the next screen's targets in parallel.
+
+## Prompt Templates
+
+Copy-paste these Agent() call blocks and fill placeholders from your collected data. The Phase sections above describe when and why to spawn each agent.
+
+> **Note:** Use a capable model (for example, `claude-sonnet-4-5` or higher) for write agents — XAML generation requires reliable instruction-following.
+
+### Scaffolding Agent Template
+
+```
+Agent(
+  description: "Create scaffolding XAML file for <WORKFLOW_NAME> with ApplicationCard and empty activity Sequence",
+  mode: "bypassPermissions",
+  run_in_background: true,
+  prompt: """
+Create the file `<OUTPUT_XAML_PATH>` with the following structure:
+
+1. `<Activity>` root element with `x:Class="<X_CLASS_VALUE>"` and these namespace declarations:
+
+<XMLNS_DECLARATIONS>
+
+2. `<TextExpression.NamespacesForImplementation>` block:
+
+<TEXTEXPRESSION_IMPORTS>
+
+3. Inside the Activity body, create an `NApplicationCard` activity using this template (use it as-is as the structural base):
+
+<NAPPLICATIONCARD_TEMPLATE>
+
+4. Inside the NApplicationCard, embed this TargetApp (the `xmlns` attribute has been removed — do not add it back):
+
+<TARGET_APP_XAML>
+
+5. Inside the NApplicationCard body, create a `<Sequence DisplayName="Do">` with no activities inside it.
+
+Expression language: <EXPRESSION_LANGUAGE>
+
+After creating the file, validate:
+
+```bash
+uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+```
+
+If errors exist, fix and re-validate. Max 3 fix attempts. If errors remain after 3 attempts, stop and report the remaining errors.
+"""
+)
+```
+
+**Placeholder reference:**
+
+| Placeholder | Source | When collected |
+|-------------|--------|---------------|
+| `<OUTPUT_XAML_PATH>` | Deterministic from workflow name | Phase 0 |
+| `<X_CLASS_VALUE>` | Derived from filename per `xaml-basics-and-rules.md` naming rule (underscores, not dots) | Phase 0 |
+| `<EXPRESSION_LANGUAGE>` | `project.json` → `expressionLanguage` | Phase 0 |
+| `<NAPPLICATIONCARD_TEMPLATE>` | `uip rpa get-default-activity-xaml --activity-class-name "UiPath.UIAutomationNext.Activities.NApplicationCard" --project-dir "<PROJECT_DIR>" --output json --use-studio` | Phase 0 |
+| `<TARGET_APP_XAML>` | `uip rpa uia object-repository get-screen-xaml --reference-id "<SCREEN_REF_ID>" --project-dir "<PROJECT_DIR>"` — remove the `xmlns` attribute before pasting | After first screen OR registration |
+| `<XMLNS_DECLARATIONS>` | Read from an existing `.xaml` in the project root + `get-default-activity-xaml` output for `NApplicationCard` | Phase 0 |
+| `<TEXTEXPRESSION_IMPORTS>` | Read from an existing `.xaml` in the project root + `get-default-activity-xaml` output (both NamespacesForImplementation and ReferencesForImplementation blocks) | Phase 0 |
+
+### Screen Activity Agent Template
+
+```
+Agent(
+  description: "Add Screen <N> activities to <WORKFLOW_NAME> for <SCREEN_DESCRIPTION>",
+  mode: "bypassPermissions",
+  run_in_background: true,
+  prompt: """
+Edit the file `<OUTPUT_XAML_PATH>`.
+
+1. Read the file and locate the inner `<Sequence DisplayName="Do">` element.
+2. Insert the following activities immediately BEFORE its closing `</Sequence>` tag.
+3. Do NOT modify any content before the insertion point.
+
+Expression language: <EXPRESSION_LANGUAGE>
+
+Activity templates — use these as the structural base for each activity (use them as-is, do not construct from memory):
+
+<ACTIVITY_TEMPLATES>
+
+OR element targets for this screen (xmlns attributes removed — do not add them back):
+
+<ELEMENT_SNIPPETS>
+
+Action sequence — implement in this order:
+
+<ACTION_SEQUENCE>
+
+Interaction patterns for this screen:
+
+<INTERACTION_PATTERNS>
+
+After editing, validate:
+
+```bash
+uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+```
+
+If errors exist, fix and re-validate. Max 3 fix attempts. If errors remain after 3 attempts, stop and report the remaining errors.
+"""
+)
+```
+
+**Placeholder reference:**
+
+| Placeholder | Source | When collected |
+|-------------|--------|---------------|
+| `<OUTPUT_XAML_PATH>` | Same path as scaffolding agent | Phase 0 |
+| `<EXPRESSION_LANGUAGE>` | `project.json` → `expressionLanguage` | Phase 0 |
+| `<ACTIVITY_TEMPLATES>` | `uip rpa get-default-activity-xaml --use-studio` for each activity type used in this screen (NClick, NTypeInto, NGoToUrl, NSelectItem, etc.) | Phase 0 |
+| `<ELEMENT_SNIPPETS>` | `uip rpa uia object-repository get-elements-xaml --reference-ids "<REF_1>,<REF_2>,..." --project-dir "<PROJECT_DIR>"` — remove the `xmlns` attribute from each `<TargetAnchorable>` before pasting; label each with a human-readable element name | Per screen, after element OR registration |
+| `<ACTION_SEQUENCE>` | Ordered numbered list from the Phase 0 plan: element name, action type (Click/TypeInto/SelectItem/etc.), data value | Per screen, from Phase 0 plan |
+| `<INTERACTION_PATTERNS>` | Explicit handling rules: dropdown (Click then TypeInto with `[k(enter)]`), wait durations, checkbox toggling, element reuse across repeated form instances | Per screen, from Phase 0 plan |

--- a/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
+++ b/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
@@ -8,7 +8,7 @@
 
 ## Phase 0: Plan the Workflow
 
-> **CRITICAL:** Complete Phase 0 before spawning any agent. All one-time data (xmlns, activity templates, expression language) must be collected first. Skipping this produces scaffolding with incomplete namespace declarations, causing all subsequent screen agents to fail.
+> **CRITICAL:** Complete Phase 0 before spawning any agent. The orchestrator's job in Phase 0 is to plan screens and actions, then determine the few values agents cannot derive themselves (expression language, x:Class). All other data (activity templates, xmlns, TextExpression, TargetApp XAML, OR element snippets) is retrieved inside the agent — see [Prompt Templates](#prompt-templates).
 
 1. **Identify screens.** List each distinct application state the workflow will interact with. A "screen" is a stable UI state where one or more elements need to be targeted — a page, a modal dialog, an inline form, or a panel that appears after an action.
 
@@ -18,25 +18,29 @@
 
 4. **Identify element reuse.** Note where the same form appears more than once with different data (for example, a "Save & New" pattern that reopens the same contact form). These screens share OR targets but have separate action sequences and data values — each gets its own write agent.
 
-5. **Collect one-time data** before starting any target configuration:
+5. **Determine the two values agents cannot derive themselves:**
 
-   a. **Expression language** — read from `project.json` → `expressionLanguage` field (`CSharp` or `VB`).
+   a. **Expression language** — read from `project.json` → `expressionLanguage` field (`CSharp` or `VB`). Passed to every screen activity agent prompt.
 
-   b. **Activity templates** — run `uip rpa get-default-activity-xaml` for every activity type the workflow will use:
-   ```bash
-   uip rpa get-default-activity-xaml \
-     --activity-class-name "<FULLY_QUALIFIED_CLASS_NAME>" \
-     --project-dir "<PROJECT_DIR>" \
-     --output json \
-     --use-studio
+   b. **x:Class value** — derived from the output `.xaml` filename per the naming rule in [xaml-basics-and-rules.md](xaml/xaml-basics-and-rules.md): folder separators become underscores, not dots. Root-level `MyWorkflow.xaml` → `x:Class="MyWorkflow"`. Subfolder `Workflows/MyWorkflow.xaml` → `x:Class="Workflows_MyWorkflow"`. Passed to the scaffolding agent prompt.
+
+   All other data (activity templates, xmlns, TextExpression blocks, TargetApp XAML, OR element snippets) is retrieved by the agent itself — see the agent prompt templates in [Prompt Templates](#prompt-templates).
+
+6. **Create a split task list** before starting Phase 1. Each screen produces TWO tasks with distinct lifecycles — `Configure-<ScreenName>` (owned by the main conversation, completes when OR registration finishes) and `Write-<ScreenName>` (owned by a background agent, completes on `<task-notification>`). Splitting these prevents the ambiguous "configure done but write running" status that collapses the Task list progress view.
+
    ```
-   Collect templates for: `NApplicationCard`, `NClick`, `NTypeInto`, `NGoToUrl`, `NSelectItem`, and any other activity type the workflow uses. Save all outputs — they are passed verbatim to agent prompts.
+   - Configure-<ScreenName-1>            (main conv)
+   - Write-Scaffold                       (background agent) blockedBy: Configure-<ScreenName-1>
+   - Write-<ScreenName-1>                 (background agent) blockedBy: Write-Scaffold, Configure-<ScreenName-1>
+   - Configure-<ScreenName-2>            (main conv)
+   - Write-<ScreenName-2>                 (background agent) blockedBy: Configure-<ScreenName-2>, Write-<ScreenName-1>
+   - ...
+   - Configure-<ScreenName-N>            (main conv)
+   - Write-<ScreenName-N>                 (background agent) blockedBy: Configure-<ScreenName-N>, Write-<ScreenName-N-1>
+   - Finalize                             (main conv) blockedBy: Write-<ScreenName-N>
+   ```
 
-   c. **xmlns declarations** — read from an existing `.xaml` file in the project root AND from the `get-default-activity-xaml` output for `NApplicationCard`. Combine the namespace declarations from both sources. This is the complete set needed for the root `<Activity>` element.
-
-   d. **TextExpression imports and references** — same source as xmlns: read from an existing project `.xaml` file and from `get-default-activity-xaml` output. Collect both the `TextExpression.NamespacesForImplementation` and `TextExpression.ReferencesForImplementation` blocks.
-
-   e. **x:Class value** — derived from the output `.xaml` filename per the naming rule in [xaml-basics-and-rules.md](xaml/xaml-basics-and-rules.md): folder separators become underscores, not dots. Root-level `MyWorkflow.xaml` → `x:Class="MyWorkflow"`. Subfolder `Workflows/MyWorkflow.xaml` → `x:Class="Workflows_MyWorkflow"`.
+   `Configure-<N+1>` is NOT blocked by `Write-<N>` — this preserves the pipeline's parallelism (configure next while previous writer runs). See [Task Structure](#task-structure) below for the `TaskCreate` / `TaskUpdate` pseudocode and the mandatory `TaskGet` integrity check before each `Agent()` spawn.
 
 ## Phase 1: Scaffolding Agent
 
@@ -44,60 +48,56 @@
 
 2. **Run mode:** Spawn the scaffolding agent with `run_in_background: true`. Foreground mode blocks the main conversation and defeats the purpose of the parallel pipeline — while the scaffolding agent works, the main conversation must advance the application to the next screen and configure its targets. The scaffolding agent creates a new file with no concurrent access risk, so background mode is safe.
 
-3. **What the agent creates:**
-   - Complete `.xaml` file with `<Activity>` root element, all xmlns declarations, and TextExpression blocks
-   - `NApplicationCard` activity using the template from `get-default-activity-xaml`
-   - `<TargetApp>` embedded inside the ApplicationCard — retrieved via:
-     ```bash
-     uip rpa uia object-repository get-screen-xaml \
-       --reference-id "<SCREEN_REFERENCE_ID>" \
-       --project-dir "<PROJECT_DIR>"
-     ```
-   - Empty `<Sequence DisplayName="Do">` inside the ApplicationCard body — this is where screen agents will insert activities
+3. **What the agent retrieves and creates** (the agent does the retrieval — orchestrator does NOT pre-fetch):
+   - Reads `<PROJECT_DIR>/project.json` to obtain `expressionLanguage`.
+   - Reads an existing `.xaml` in the project root (e.g., `Main.xaml`) to extract the root `<Activity>` xmlns declarations and both `<TextExpression.NamespacesForImplementation>` and `<TextExpression.ReferencesForImplementation>` blocks. Copied verbatim into the new file.
+   - Runs `uip rpa get-default-activity-xaml --activity-class-name "UiPath.UIAutomationNext.Activities.NApplicationCard"` for the NApplicationCard template.
+   - Runs `uip rpa uia object-repository get-screen-xaml --reference-id "<SCREEN_REFERENCE_ID>"` for the TargetApp XAML.
+   - Writes the complete `.xaml` file: `<Activity>` root with `x:Class`, namespace declarations, TextExpression blocks, NApplicationCard with embedded TargetApp, and an empty `<Sequence DisplayName="Do">` (open/close form, not self-closing) inside the ApplicationCard body where screen agents will insert activities.
 
-4. **Post-write verification** (D-09): Run `get-errors` only after the agent writes the file:
+4. **Post-write verification** (D-09): The agent runs `get-errors` itself, wrapped with a `timeout`:
    ```bash
-   uip rpa get-errors \
+   timeout 60000 uip rpa get-errors \
      --file-path "<XAML_FILE_PATH>" \
      --project-dir "<PROJECT_DIR>" \
      --output json \
      --use-studio
    ```
 
-5. **Self-repair** (D-10): If `get-errors` returns errors, fix and re-run. Max 3 fix cycles. After 3 attempts, stop and report remaining errors to the main conversation.
+5. **Self-repair** (D-10): If `get-errors` returns errors, fix and re-run. Max 3 fix cycles. After 3 attempts, stop and report remaining errors to the main conversation. **If the CLI itself times out** (Studio unresponsive, validation hung), the agent must report `"Validation unavailable — Studio not responding; file written but unverified."` and exit — never hang.
 
 6. **Prompt template:** See [Scaffolding Agent Template](#scaffolding-agent-template) for the complete Agent() call.
 
-> **CRITICAL:** Remove the `xmlns` attribute from the `<TargetApp>` element returned by `get-screen-xaml` before embedding it in the agent prompt. The root `<Activity>` element's namespace declarations already cover it. Duplicate xmlns causes namespace-related validation errors.
+> **CRITICAL:** The agent must strip the `xmlns` attribute from the `<TargetApp>` element returned by `get-screen-xaml` before embedding it. The root `<Activity>` element's namespace declarations already cover it. Duplicate xmlns causes namespace-related validation errors.
 
 ## Phase 2: Screen Activity Agents
 
-1. **Spawn precondition** — Do NOT spawn screen N's agent until BOTH conditions are true:
-   - (a) Screen N's element targets are fully configured AND the OR XAML snippets are retrieved via `get-elements-xaml`
-   - (b) The previous write agent (screen N-1, or scaffolding for N=1) has returned a result
+1. **Spawn precondition** — Do NOT spawn `Write-<N>` until ALL of the following hold (the orchestrator MUST verify each via `TaskGet` before calling `Agent()`):
+   - (a) `Configure-<N>` is `completed` (screen N's element targets are fully configured and registered in the OR — but the orchestrator does NOT pre-fetch the snippets; the agent fetches them itself via `get-elements-xaml`).
+   - (b) `Write-<N-1>` is `completed` (or `Write-Scaffold` for N=1). **If `Write-<N-1>` is `in_progress`, do NOT spawn — the chain is violated.** See [Waiting for Background Agents](#waiting-for-background-agents).
 
-2. **Run mode:** Spawn each screen activity agent with `run_in_background: true`. While the agent writes screen N, the main conversation must advance the application to screen N+1 and configure its targets. Wait for the background agent's completion notification before spawning the next screen's agent (the chain requires each agent to read the previous agent's finalized file state).
+2. **Run mode:** Spawn each screen activity agent with `run_in_background: true`. While the agent writes screen N, the main conversation must advance the application to screen N+1 and configure its targets (`Configure-<N+1>`) — but it must NOT spawn `Write-<N+1>` until `Write-<N>` is `completed`. The chain requires each agent to read the previous agent's finalized file state.
 
-3. **What the agent does:**
-   - Reads the current `.xaml` file
-   - Locates the inner `<Sequence DisplayName="Do">` element
-   - Inserts its activities immediately before the closing `</Sequence>` tag
-   - Does NOT modify any content before the insertion point
+3. **What the agent does** (the agent retrieves its own data — orchestrator does NOT pre-fetch):
+   - Reads the file and locates the inner `<Sequence DisplayName="Do">`. Ordering safety is enforced upstream by the task queueing model (see [Waiting for Background Agents](#waiting-for-background-agents) — `Write-<N>` cannot spawn until `Write-<N-1>` is `completed`), so the agent treats the file as in a known good state.
+   - Runs `uip rpa get-default-activity-xaml --activity-class-name "<class>"` (with `timeout`) for each activity class in its action list.
+   - Runs `uip rpa uia object-repository get-elements-xaml --reference-ids "<csv>"` (with `timeout`) for the ref IDs in its action list.
+   - Constructs and inserts activities immediately before the closing `</Sequence>` of the inner `<Sequence DisplayName="Do">`. Does NOT modify any content before the insertion point.
 
-4. **OR snippet retrieval** (per screen, after element OR registration):
+4. **Post-write verification** (D-09): Agent runs `get-errors` itself, wrapped with a `timeout`:
    ```bash
-   uip rpa uia object-repository get-elements-xaml \
-     --reference-ids "<REF_1>,<REF_2>,<REF_3>" \
-     --project-dir "<PROJECT_DIR>"
+   timeout 60000 uip rpa get-errors \
+     --file-path "<XAML_FILE_PATH>" \
+     --project-dir "<PROJECT_DIR>" \
+     --output json \
+     --use-studio
    ```
 
-5. **Post-write verification** (D-09): Run `get-errors` only — same command as Phase 1.
+5. **Self-repair** (D-10): Max 3 fix cycles, then report to main conversation. If the CLI times out, the agent reports the timeout explicitly — never hangs.
 
-6. **Self-repair** (D-10): Same as Phase 1 (max 3 cycles, then report to main conversation).
+6. **Prompt template:** See [Screen Activity Agent Template](#screen-activity-agent-template) for the complete Agent() call.
 
-7. **Prompt template:** See [Screen Activity Agent Template](#screen-activity-agent-template) for the complete Agent() call.
-
-> **CRITICAL:** Remove `xmlns` attributes from all `<TargetAnchorable>` elements returned by `get-elements-xaml` before including them in the agent prompt. The root `<Activity>` element's namespace declarations already cover them.
+> **CRITICAL:** The agent must strip `xmlns` attributes from all `<TargetAnchorable>` elements returned by `get-elements-xaml` before embedding them. The root `<Activity>` element's namespace declarations already cover them.
 
 ### Screen Boundaries
 
@@ -112,14 +112,33 @@ See also: [uia-configure-target-workflows.md](uia-configure-target-workflows.md)
 
 The write agents form a strict chain — each depends on the previous:
 
-| Agent | Depends on |
+| Agent | Depends on (`Write-<N>` blockedBy) |
 |-------|-----------|
-| Scaffolding agent | First screen OR registration (no element targets needed) |
-| Screen 1 agent | Scaffolding complete + Screen 1 element targets configured |
-| Screen 2 agent | Screen 1 agent complete + Screen 2 element targets configured |
-| Screen N agent | Screen N-1 agent complete + Screen N element targets configured |
+| Scaffolding agent | `Configure-<Screen 1>` |
+| Screen 1 agent | `Write-Scaffold` + `Configure-<Screen 1>` |
+| Screen 2 agent | `Write-<Screen 1>` + `Configure-<Screen 2>` |
+| Screen N agent | `Write-<Screen N-1>` + `Configure-<Screen N>` |
 
-The main conversation runs `uia-configure-target` tasks in parallel with the write chain: configure screen N+1 while screen N's write agent is running.
+The main conversation runs `Configure-<N+1>` in parallel with `Write-<N>`. `Configure-<N+1>` is NOT blocked by `Write-<N>`.
+
+## Waiting for Background Agents
+
+These three rules govern what the orchestrator may and may not do while a `Write-<N>` agent is running. Violations have produced silent file corruption in past runs (concurrent writes inserting at the same point).
+
+1. **Never spawn `Write-<N>` while `Write-<N-1>` is `in_progress`.** The pipeline is a chain, not a fan-out. Before every `Agent()` call for `Write-<N>`, call `TaskGet` on the predecessor `Write-<N-1>` task. If its status is not `completed`, do NOT spawn. This structurally enforces the chained dependency model.
+
+2. **When idle waiting on a background agent, do not poll.** Specifically forbidden:
+   - `sleep` / `Monitor` + `until` loops / `ScheduleWakeup` / `run_in_background` sentinels that only check status.
+   - Reading the file the agent is writing ("did it grow?").
+   - Re-spawning the agent to "check" it.
+
+   Instead:
+   - **If non-conflicting work exists** (configure next screen's targets, prepare the next prompt, draft the next action list) — do that work.
+   - **If no non-conflicting work remains** — reply to the user with a one-line status (`"Write-<N> running; waiting for completion."`) and stop. The runtime delivers the `<task-notification>` block asynchronously; the next turn will resume on that event.
+
+   Polling burns the prompt cache (each wake reloads the conversation) and the Agent tool guarantees a completion notification — polling adds no correctness, only cost.
+
+3. **Every `<task-notification>` must be acknowledged in the same turn by `TaskUpdate` → `completed` on the matching `Write-<N>` task.** Missing a notification becomes structurally impossible if this rule holds.
 
 ## Phase 3: Finalization
 
@@ -148,15 +167,14 @@ The main conversation runs `uia-configure-target` tasks in parallel with the wri
 
 ## Prompt Construction Rules
 
-1. Include activity templates **VERBATIM** — paste the XAML from `get-default-activity-xaml` output into the agent prompt. Do not describe or summarize the template.
-2. Include OR snippets **VERBATIM** with human-readable labels — paste the exact `<TargetAnchorable>` XML (with xmlns removed), labeled by element name. Do not summarize selectors.
-3. Describe actions as an **ordered numbered list** with exact data values (for example: "1. TypeInto 'First Name' field: John  2. Click 'Save' button").
-4. Specify interaction patterns **explicitly** for each non-trivial interaction: dropdown selection (Click then TypeInto with `[k(enter)]`), wait durations between actions, checkbox toggling, element reuse across repeated form instances.
-5. Specify **expression-language-specific syntax** for inline expressions. CSharp: `new TimeSpan(0,0,2)` for Delay. VB: `TimeSpan.FromSeconds(2)`. Always match the `expressionLanguage` value from `project.json`.
-6. All context (OR snippets, activity templates, action sequences) goes **inline in the Agent() prompt parameter** as labeled blocks (D-06). Do not pass context via temp `.md` files or any other file-based method.
-7. **Always inline regardless of element count** (D-07). Do not apply a size guardrail or branch on large vs small screens.
-8. Include the **edit instruction** in every screen agent prompt: where to insert (before the closing `</Sequence>` tag of the inner `<Sequence DisplayName="Do">`), and what not to touch (all content before the insertion point).
-9. Include the **validation instruction**: run `get-errors`, fix issues, max 3 fix cycles before reporting to main conversation.
+1. **Pass the ref-ID-keyed action list; the agent retrieves its own XAML.** Do NOT paste activity templates, xmlns blocks, TextExpression blocks, TargetApp XAML, or `<TargetAnchorable>` snippets into the agent prompt. The orchestrator constructs a structured action list (see [Action List Format](#action-list-format)); the agent runs `get-default-activity-xaml` and `get-elements-xaml` itself for everything it needs.
+2. Describe actions as a structured list with exact data values (`display_name`, `type`, `reference_id`, optional `text`/`duration_seconds`) — see [Action List Format](#action-list-format). Each action carries enough detail for the agent to construct the activity from the template + OR snippet it retrieves.
+3. Specify interaction patterns **explicitly** for each non-trivial interaction: dropdown selection (Click then TypeInto with `[k(enter)]`), wait durations between actions, checkbox toggling, element reuse across repeated form instances. These go in a per-screen notes block in the prompt.
+4. Specify **expression-language-specific syntax** for inline expressions. CSharp: `<Delay>` uses an `<InArgument x:TypeArguments="x:TimeSpan">` with a `<CSharpValue>` containing `TimeSpan.FromSeconds(N)`. VB: `<Delay Duration="[TimeSpan.FromSeconds(N)]" />`. Always match the `expressionLanguage` value passed in the prompt.
+5. All context (action list, interaction patterns) goes **inline in the Agent() prompt parameter** as labeled blocks (D-06). Do not pass context via temp `.md` files or any other file-based method.
+6. Include the **edit instruction** in every screen agent prompt: where to insert (before the closing `</Sequence>` tag of the inner `<Sequence DisplayName="Do">`), and what not to touch (all content before the insertion point).
+7. Include the **validation instruction**: run `get-errors`, fix issues, max 3 fix cycles before reporting to main conversation.
+8. **Every agent-side CLI call MUST be wrapped with a 60-second Bash `timeout`** (`timeout 60000 uip rpa ...`). On timeout, the agent must fail fast with a clear error, not retry indefinitely. Without this, a stalled `get-errors` (Studio disconnected) will cause the agent to hang for tens of minutes.
 
 ## Edge Cases
 
@@ -180,7 +198,7 @@ When splitting, each agent appends independently and the later agent's activitie
 
 ### Single-Screen Workflows
 
-Skip the pipeline entirely. Spawn one agent that creates the complete file — scaffolding structure plus all screen activities — in a single pass. The pipeline overhead (separate scaffolding agent, chained dependency tracking) is not justified for a single screen.
+Skip the pipeline entirely. Spawn one agent that creates the complete file — scaffolding structure plus all screen activities — in a single pass. The pipeline overhead (separate scaffolding agent, chained dependency ordering across Tasks) is not justified for a single screen.
 
 ### Write Agent Failure
 
@@ -190,23 +208,27 @@ Screens 1 through N-1 are already written and valid — no rollback is needed. T
 
 ### Background Agent Not Done
 
-Wait for the previous write agent to return a result before spawning the next write agent. Write agents are fast — they perform pure text generation against a well-specified prompt. If a write agent is consistently slower than the time it takes to configure the next screen's targets, the prompt is too large or too ambiguous.
+See [Waiting for Background Agents](#waiting-for-background-agents) for the three governing rules. In short: never spawn `Write-<N>` while `Write-<N-1>` is `in_progress` (use `TaskGet` to verify), never poll, and acknowledge every `<task-notification>` with `TaskUpdate` → `completed` in the same turn.
+
+Write agents are typically fast — they perform pure text generation against a structured prompt and a few CLI calls. If an agent is consistently slow (e.g., >5 minutes), suspect a hung CLI call (Studio unresponsive). The 60-second `timeout` wrapper on every agent-side CLI call (Prompt Construction Rule 8) is what prevents this from cascading into 30+ minute hangs.
 
 ## Anti-patterns
 
 1. Do NOT have a screen activity agent create the file from scratch — the scaffolding agent does that.
 2. Do NOT have a screen activity agent modify activities from earlier screens — insert before the closing `</Sequence>` tag only.
-3. Do NOT spawn a write agent before BOTH its target configuration is complete AND the previous write agent has returned a result.
-4. Do NOT pass unstable selectors (auto-generated numeric IDs, `css-selector` attributes, hash-based class names) to write agents — identify and fix them during target configuration via selector improvement before retrieving OR snippets.
-5. Do NOT describe activities abstractly in the agent prompt (for example, "add a click on the login button") — paste the exact `<TargetAnchorable>` XML and specify the activity type explicitly.
-6. Do NOT duplicate pipeline logic in SKILL.md or other reference files — those files route here; this file is the single source of truth for the pipeline.
-7. Do NOT skip the selector stability gate before passing OR snippets to a write agent. Syntactically valid XAML that uses runtime-broken selectors is harder to debug than a build error.
-8. Do NOT modify the `.xaml` file from the main conversation while a write agent is running. The chained model depends on each agent reading the current valid file state; concurrent edits produce an unknown file state for the next agent.
-9. Do NOT spawn write agents in foreground mode — this blocks the main conversation and serializes the pipeline. Always use `run_in_background: true` so the main conversation can advance the application state and configure the next screen's targets in parallel.
+3. Do NOT spawn `Write-<N>` while `Write-<N-1>` is `in_progress`. Check `TaskGet(Write-<N-1>)` first; only spawn if `completed`. Spawning early breaks the chain — the agents will race on the same insertion point.
+4. Do NOT poll for agent completion. No `sleep`, no `Monitor` + `until` loop, no `ScheduleWakeup`, no file-growth checks, no respawning the agent to "see if it's done". Either do non-conflicting work, or reply with a one-line status and stop. The runtime delivers `<task-notification>` asynchronously.
+5. Do NOT paste activity templates, xmlns blocks, TextExpression blocks, TargetApp XAML, or OR `<TargetAnchorable>` snippets into the agent prompt. Pass reference IDs, activity class names, and a structured action list — the agent retrieves its own XAML.
+6. Do NOT pass unstable selectors (auto-generated numeric IDs, `css-selector` attributes, hash-based class names) to write agents — identify and fix them during target configuration via selector improvement before the agent retrieves OR snippets.
+7. Do NOT duplicate pipeline logic in SKILL.md or other reference files — those files route here; this file is the single source of truth for the pipeline.
+8. Do NOT skip the selector stability gate before the agent retrieves OR snippets. Syntactically valid XAML that uses runtime-broken selectors is harder to debug than a build error.
+9. Do NOT modify the `.xaml` file from the main conversation while a write agent is running. The chained model depends on each agent reading the current valid file state; concurrent edits produce an unknown file state for the next agent.
+10. Do NOT spawn write agents in foreground mode — this blocks the main conversation and serializes the pipeline. Always use `run_in_background: true` so the main conversation can configure the next screen's targets in parallel.
+11. Do NOT call agent-side CLI commands without a `timeout` wrapper. A hung Studio causes `get-errors` to block indefinitely — agents must fail fast, not hang.
 
 ## Prompt Templates
 
-Copy-paste these Agent() call blocks and fill placeholders from your collected data. The Phase sections above describe when and why to spawn each agent.
+Copy-paste these Agent() call blocks and fill placeholders. The orchestrator passes only reference IDs, activity class names, and a structured action list — the agent retrieves its own XAML via CLI.
 
 > **Note:** Use a capable model (for example, `claude-sonnet-4-5` or higher) for write agents — XAML generation requires reliable instruction-following.
 
@@ -214,105 +236,177 @@ Copy-paste these Agent() call blocks and fill placeholders from your collected d
 
 ```
 Agent(
-  description: "Create scaffolding XAML file for <WORKFLOW_NAME> with ApplicationCard and empty activity Sequence",
+  description: "Scaffold <WORKFLOW_NAME>",
   mode: "bypassPermissions",
   run_in_background: true,
   prompt: """
-Create the file `<OUTPUT_XAML_PATH>` with the following structure:
+Create a new UiPath XAML workflow file at `<OUTPUT_XAML_PATH>`.
 
-1. `<Activity>` root element with `x:Class="<X_CLASS_VALUE>"` and these namespace declarations:
+## Context (retrieve these yourself — do NOT ask)
 
-<XMLNS_DECLARATIONS>
+1. Read `<PROJECT_DIR>/project.json` to get `expressionLanguage` (`CSharp` or `VB`).
+2. Read `<PROJECT_DIR>/Main.xaml` (or any existing `.xaml` in the project root) to extract the root `<Activity>` xmlns declarations AND both `<TextExpression.NamespacesForImplementation>` and `<TextExpression.ReferencesForImplementation>` blocks. Copy them verbatim into your output.
+3. Fetch the NApplicationCard template:
+   ```bash
+   timeout 60000 uip rpa get-default-activity-xaml \
+     --activity-class-name "UiPath.UIAutomationNext.Activities.NApplicationCard" \
+     --project-dir "<PROJECT_DIR>" \
+     --output json --use-studio
+   ```
+   Use the returned XAML as-is for the NApplicationCard element.
+4. Fetch the TargetApp XAML for the registered screen:
+   ```bash
+   timeout 60000 uip rpa uia object-repository get-screen-xaml \
+     --reference-id "<SCREEN_REFERENCE_ID>" \
+     --project-dir "<PROJECT_DIR>"
+   ```
+   Strip the `xmlns` attribute from the returned `<TargetApp>` element before embedding it inside `<uix:NApplicationCard.TargetApp>`.
 
-2. `<TextExpression.NamespacesForImplementation>` block:
+## File structure requirements
 
-<TEXTEXPRESSION_IMPORTS>
+- Root `<Activity>` with `x:Class="<X_CLASS_VALUE>"` (derived from `<OUTPUT_XAML_PATH>` per the naming rule in [xaml-basics-and-rules.md](xaml/xaml-basics-and-rules.md): folder separators become underscores).
+- `mc:Ignorable="sap sap2010"`, `sap2010:ExpressionActivityEditor.ExpressionActivityEditor="<CSharp|VB>"`, `sap2010:WorkflowViewState.IdRef="ActivityBuilder_1"`.
+- The `<TextExpression.*>` blocks from step 2.
+- A single NApplicationCard from step 3 with TargetApp from step 4 embedded.
+- Inside `<uix:NApplicationCard.Body>` → `<ActivityAction>`, create an empty `<Sequence DisplayName="Do"></Sequence>`. Use open/close form (not self-closing).
 
-3. Inside the Activity body, create an `NApplicationCard` activity using this template (use it as-is as the structural base):
+## Validation
 
-<NAPPLICATIONCARD_TEMPLATE>
-
-4. Inside the NApplicationCard, embed this TargetApp (the `xmlns` attribute has been removed — do not add it back):
-
-<TARGET_APP_XAML>
-
-5. Inside the NApplicationCard body, create a `<Sequence DisplayName="Do">` with no activities inside it.
-
-Expression language: <EXPRESSION_LANGUAGE>
-
-After creating the file, validate:
-
+After writing the file:
 ```bash
-uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
 ```
+If it returns errors, fix and re-validate. Max 3 fix attempts. If the CLI times out (Studio unresponsive), report: "Validation unavailable — Studio not responding; file written but unverified." Do not hang.
 
-If errors exist, fix and re-validate. Max 3 fix attempts. If errors remain after 3 attempts, stop and report the remaining errors.
+## Placeholders
+
+| Placeholder | Value |
+|---|---|
+| <OUTPUT_XAML_PATH> | <fill in> |
+| <X_CLASS_VALUE> | <fill in> |
+| <PROJECT_DIR> | <fill in> |
+| <SCREEN_REFERENCE_ID> | <fill in> |
 """
 )
 ```
-
-**Placeholder reference:**
-
-| Placeholder | Source | When collected |
-|-------------|--------|---------------|
-| `<OUTPUT_XAML_PATH>` | Deterministic from workflow name | Phase 0 |
-| `<X_CLASS_VALUE>` | Derived from filename per `xaml-basics-and-rules.md` naming rule (underscores, not dots) | Phase 0 |
-| `<EXPRESSION_LANGUAGE>` | `project.json` → `expressionLanguage` | Phase 0 |
-| `<NAPPLICATIONCARD_TEMPLATE>` | `uip rpa get-default-activity-xaml --activity-class-name "UiPath.UIAutomationNext.Activities.NApplicationCard" --project-dir "<PROJECT_DIR>" --output json --use-studio` | Phase 0 |
-| `<TARGET_APP_XAML>` | `uip rpa uia object-repository get-screen-xaml --reference-id "<SCREEN_REF_ID>" --project-dir "<PROJECT_DIR>"` — remove the `xmlns` attribute before pasting | After first screen OR registration |
-| `<XMLNS_DECLARATIONS>` | Read from an existing `.xaml` in the project root + `get-default-activity-xaml` output for `NApplicationCard` | Phase 0 |
-| `<TEXTEXPRESSION_IMPORTS>` | Read from an existing `.xaml` in the project root + `get-default-activity-xaml` output (both NamespacesForImplementation and ReferencesForImplementation blocks) | Phase 0 |
 
 ### Screen Activity Agent Template
 
 ```
 Agent(
-  description: "Add Screen <N> activities to <WORKFLOW_NAME> for <SCREEN_DESCRIPTION>",
+  description: "Write <SCREEN_NAME> activities to <WORKFLOW_NAME>",
   mode: "bypassPermissions",
   run_in_background: true,
   prompt: """
-Edit the file `<OUTPUT_XAML_PATH>`.
+Edit the file `<OUTPUT_XAML_PATH>`. Read the file first, then locate the inner `<Sequence DisplayName="Do">` inside `<uix:NApplicationCard.Body>` → `<ActivityAction>` — that is your insertion point.
 
-1. Read the file and locate the inner `<Sequence DisplayName="Do">` element.
-2. Insert the following activities immediately BEFORE its closing `</Sequence>` tag.
-3. Do NOT modify any content before the insertion point.
+## Retrieve your data (do NOT ask)
 
-Expression language: <EXPRESSION_LANGUAGE>
+Expression language: `<EXPRESSION_LANGUAGE>` (`CSharp` or `VB`).
 
-Activity templates — use these as the structural base for each activity (use them as-is, do not construct from memory):
+Activity class names you will use: `<ACTIVITY_CLASS_LIST>` (comma-separated, e.g., `UiPath.UIAutomationNext.Activities.NClick, UiPath.UIAutomationNext.Activities.NTypeInto, System.Activities.Statements.Delay`).
 
-<ACTIVITY_TEMPLATES>
+1. For each activity class name above, fetch its template:
+   ```bash
+   timeout 60000 uip rpa get-default-activity-xaml \
+     --activity-class-name "<class>" \
+     --project-dir "<PROJECT_DIR>" \
+     --output json --use-studio
+   ```
+   Use the returned XAML as the structural base for every instance of that activity type.
 
-OR element targets for this screen (xmlns attributes removed — do not add them back):
+2. Fetch all OR element XAML snippets in a single call:
+   ```bash
+   timeout 60000 uip rpa uia object-repository get-elements-xaml \
+     --reference-ids "<COMMA_SEPARATED_REF_IDS>" \
+     --project-dir "<PROJECT_DIR>"
+   ```
+   Parse the output (separated by `=== <Element Name> ===` headers). For each `<TargetAnchorable>` returned, strip the `xmlns` attribute and add the `uix:` prefix when embedding.
 
-<ELEMENT_SNIPPETS>
+## Action list — implement in this EXACT order
 
-Action sequence — implement in this order:
+Insert the following activities IMMEDIATELY BEFORE the closing `</Sequence>` tag of the inner `<Sequence DisplayName="Do">`. Do NOT modify any content before the insertion point.
 
-<ACTION_SEQUENCE>
+<ACTION_LIST>
 
-Interaction patterns for this screen:
+Each action has fields: `display_name`, `type` (NClick | NTypeInto | Delay | ...), and either `reference_id` (for UI activities) with optional `text` (for NTypeInto) or `duration_seconds` (for Delay).
 
-<INTERACTION_PATTERNS>
+For NClick: wrap the element's `<uix:TargetAnchorable>` inside `<uix:NClick.Target>...</uix:NClick.Target>`.
+For NTypeInto: set `Text` as an attribute on `<uix:NTypeInto>` and wrap the TargetAnchorable in `<uix:NTypeInto.Target>...</uix:NTypeInto.Target>`.
+For Delay with CSharp: `<Delay><Delay.Duration><InArgument x:TypeArguments="x:TimeSpan"><CSharpValue x:TypeArguments="x:TimeSpan">TimeSpan.FromSeconds(N)</CSharpValue></InArgument></Delay.Duration></Delay>` — duration as an InArgument, NOT an attribute.
+For Delay with VB: `<Delay Duration="[TimeSpan.FromSeconds(N)]" />`.
 
-After editing, validate:
+## Validation
 
+After editing:
 ```bash
-uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
 ```
+Fix on error, max 3 attempts. If CLI times out, report the timeout explicitly — do NOT hang.
 
-If errors exist, fix and re-validate. Max 3 fix attempts. If errors remain after 3 attempts, stop and report the remaining errors.
+## Placeholders
+
+| Placeholder | Value |
+|---|---|
+| <OUTPUT_XAML_PATH> | <fill in> |
+| <PROJECT_DIR> | <fill in> |
+| <EXPRESSION_LANGUAGE> | CSharp or VB |
+| <ACTIVITY_CLASS_LIST> | comma-separated fully-qualified activity class names |
+| <COMMA_SEPARATED_REF_IDS> | ref IDs this agent needs snippets for |
+| <ACTION_LIST> | JSON or YAML list — see [Action List Format](#action-list-format) |
 """
 )
 ```
 
-**Placeholder reference:**
+## Action List Format
 
-| Placeholder | Source | When collected |
-|-------------|--------|---------------|
-| `<OUTPUT_XAML_PATH>` | Same path as scaffolding agent | Phase 0 |
-| `<EXPRESSION_LANGUAGE>` | `project.json` → `expressionLanguage` | Phase 0 |
-| `<ACTIVITY_TEMPLATES>` | `uip rpa get-default-activity-xaml --use-studio` for each activity type used in this screen (NClick, NTypeInto, NGoToUrl, NSelectItem, etc.) | Phase 0 |
-| `<ELEMENT_SNIPPETS>` | `uip rpa uia object-repository get-elements-xaml --reference-ids "<REF_1>,<REF_2>,..." --project-dir "<PROJECT_DIR>"` — remove the `xmlns` attribute from each `<TargetAnchorable>` before pasting; label each with a human-readable element name | Per screen, after element OR registration |
-| `<ACTION_SEQUENCE>` | Ordered numbered list from the Phase 0 plan: element name, action type (Click/TypeInto/SelectItem/etc.), data value | Per screen, from Phase 0 plan |
-| `<INTERACTION_PATTERNS>` | Explicit handling rules: dropdown (Click then TypeInto with `[k(enter)]`), wait durations, checkbox toggling, element reuse across repeated form instances | Per screen, from Phase 0 plan |
+The orchestrator composes the action list once per screen agent from the registered OR references and the Phase 0 action plan. No XAML lives in the orchestrator context — only structured metadata.
+
+```json
+[
+  {"display_name": "Click Accounts Nav", "type": "NClick", "reference_id": "xPMFx.../3eZ3506YOEalsrUWRMADfQ"},
+  {"display_name": "Wait for Accounts List", "type": "Delay", "duration_seconds": 3},
+  {"display_name": "Type Account Name", "type": "NTypeInto", "reference_id": "xPMFx.../h0mdnfakSk6gE9v5ZkYNuQ", "text": "Get Cloudy"}
+]
+```
+
+Minimum fields per entry:
+- `display_name` — string. Becomes the activity's `DisplayName`.
+- `type` — `NClick`, `NTypeInto`, `Delay`, `NSelectItem`, `NGoToUrl`, etc.
+- For UI activities: `reference_id` — the OR reference ID. The agent looks up the snippet from the `get-elements-xaml` output it fetches itself.
+- For `NTypeInto`: optional `text` — the text to type.
+- For `Delay`: `duration_seconds` instead of `reference_id`.
+
+## Task Structure
+
+Pseudocode for the per-screen main-conversation flow (apply with `TaskCreate` / `TaskUpdate` / `TaskGet`):
+
+```
+configure_task = TaskCreate(
+  subject: f"Configure-{screen_name}",
+  description: f"Register screen + elements in OR for {screen_name}"
+)
+write_task = TaskCreate(
+  subject: f"Write-{screen_name}",
+  description: f"Insert activities for {screen_name} into {xaml_filename}"
+)
+TaskUpdate(write_task.id, addBlockedBy: [configure_task.id, previous_write_task.id])
+
+# Main conv: do configure work
+TaskUpdate(configure_task.id, status: "in_progress")
+# ...run uia-configure-target, create-elements, etc.
+TaskUpdate(configure_task.id, status: "completed")
+
+# Before spawning write agent: verify predecessor (Waiting for Background Agents, rule 1)
+predecessor = TaskGet(previous_write_task.id)
+if predecessor.status != "completed":
+  raise "Pipeline violation: cannot spawn Write-<N> while Write-<N-1> is in_progress"
+
+TaskUpdate(write_task.id, status: "in_progress")
+Agent(run_in_background: true, ...)
+
+# On <task-notification> arrival for this agent (Waiting for Background Agents, rule 3):
+TaskUpdate(write_task.id, status: "completed")
+```
+
+The scaffolding case is special: `Write-Scaffold` blockedBy `Configure-<Screen 1>` only. `Write-<Screen 1>` blockedBy `Write-Scaffold` AND `Configure-<Screen 1>`.


### PR DESCRIPTION
## Summary
- Aligns `uia-configure-target-workflows.md` around the embed-during-creation workflow: updates the Execution Model bullet and the Indication Fallback paragraph, and fixes a broken section reference (`Linking OR Entries to XAML Activities` → `Embedding OR Entries in XAML Activities`).

## Test plan
- [ ] Read the file end-to-end and confirm no residual references to post-creation linking.