### PR TITLE
fix(flow-skill): fix subflow variable access docs

### DIFF
--- a/skills/uipath-maestro-flow/references/plugins/subflow/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/subflow/impl.md
@@ -23,10 +23,10 @@ Confirm: input port `input`, output ports `output` and `error`.
     "position": { "x": 432, "y": 144 },
     "size": { "width": 96, "height": 96 }
   },
-  "display": { "label": "Validate & Transform" },
+  "display": { "label": "Add Numbers", "icon": "layers" },
   "inputs": {
-    "inputData": "=js:$vars.fetchData.output.body",
-    "threshold": 100
+    "a": 2,
+    "b": 3
   },
   "model": { "type": "bpmn:SubProcess" }
 }
@@ -47,15 +47,50 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
           "typeVersion": "1.0.0",
           "display": { "label": "Start" },
           "inputs": {},
-          "model": { "type": "bpmn:StartEvent" }
+          "outputs": {
+            "output": {
+              "type": "object",
+              "description": "Data passed when manually triggering the workflow.",
+              "source": "null",
+              "var": "output"
+            }
+          },
+          "model": { "type": "bpmn:StartEvent", "entryPointId": "unique-uuid-here", "isDefaultEntryPoint": true }
         },
         {
-          "id": "validate",
+          "id": "script1",
           "type": "core.action.script",
           "typeVersion": "1.0.0",
-          "display": { "label": "Validate" },
+          "display": { "label": "Add Numbers" },
           "inputs": {
-            "script": "const data = $vars.inputData;\nif (!data || !data.items) throw new Error('Invalid data');\nreturn { valid: true, count: data.items.length };"
+            "script": "return { result: $vars.subflow1Start.output.a + $vars.subflow1Start.output.b };"
+          },
+          "outputs": {
+            "output": {
+              "type": "object",
+              "description": "The return value of the script",
+              "source": "=result.response",
+              "var": "output"
+            },
+            "error": {
+              "type": "object",
+              "description": "Error information if the script fails",
+              "source": "=result.Error",
+              "var": "error",
+              "schema": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "required": ["code", "message", "detail", "category", "status"],
+                "properties": {
+                  "code": { "type": "string" },
+                  "message": { "type": "string" },
+                  "detail": { "type": "string" },
+                  "category": { "type": "string" },
+                  "status": { "type": "integer" }
+                },
+                "additionalProperties": false
+              }
+            }
           },
           "model": { "type": "bpmn:ScriptTask" }
         },
@@ -66,7 +101,7 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
           "display": { "label": "End" },
           "inputs": {},
           "outputs": {
-            "result": { "source": "=js:$vars.validate.output" }
+            "result": { "source": "=js:$vars.script1.output.result" }
           },
           "model": { "type": "bpmn:EndEvent" }
         }
@@ -76,12 +111,12 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
           "id": "sf-e1",
           "sourceNodeId": "subflow1Start",
           "sourcePort": "output",
-          "targetNodeId": "validate",
+          "targetNodeId": "script1",
           "targetPort": "input"
         },
         {
           "id": "sf-e2",
-          "sourceNodeId": "validate",
+          "sourceNodeId": "script1",
           "sourcePort": "success",
           "targetNodeId": "subflow1End",
           "targetPort": "input"
@@ -90,20 +125,24 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
       "variables": {
         "globals": [
           {
-            "id": "inputData",
-            "direction": "in",
-            "type": "object"
-          },
-          {
-            "id": "threshold",
+            "id": "a",
             "direction": "in",
             "type": "number",
-            "defaultValue": 50
+            "defaultValue": 0,
+            "triggerNodeId": "subflow1Start"
+          },
+          {
+            "id": "b",
+            "direction": "in",
+            "type": "number",
+            "defaultValue": 0,
+            "triggerNodeId": "subflow1Start"
           },
           {
             "id": "result",
             "direction": "out",
-            "type": "object"
+            "type": "number",
+            "defaultValue": 0
           }
         ],
         "nodes": []
@@ -117,10 +156,12 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
 
 1. Every subflow **must** have its own Start node (`core.trigger.manual`) and End node (`core.control.end`)
 2. Subflow `variables.globals` with `direction: "in"` map to the parent node's `inputs`
-3. Subflow `variables.globals` with `direction: "out"` map to the parent node's outputs, accessible via `$vars.{subflowNodeId}.output`
-4. Parent-scope `$vars` are **not** visible inside the subflow — pass values explicitly via inputs
-5. Subflows can be nested (subflow inside subflow), up to 3 levels
-6. Each subflow has its own `nodes`, `edges`, and `variables` sections
+3. Subflow `in` variables **must** have `triggerNodeId` set to the subflow's Start node ID — this makes them accessible via `$vars.{startNodeId}.output.{varId}`
+4. Subflow `variables.globals` with `direction: "out"` map to the parent node's outputs, accessible via `$vars.{subflowNodeId}.output` in the parent flow
+5. Parent-scope `$vars` are **not** visible inside the subflow — pass values explicitly via inputs
+6. Subflow nodes must have inline `outputs` defined on them (Start node needs `outputs.output`, Script nodes need `outputs.output` and `outputs.error`)
+7. Subflows can be nested (subflow inside subflow), up to 3 levels
+8. Each subflow has its own `nodes`, `edges`, and `variables` sections
 
 ## Creating a Subflow
 
@@ -130,7 +171,9 @@ For the step-by-step procedure, see [JSON: Create a subflow](../../flow-editing-
 
 | Error | Cause | Fix |
 | --- | --- | --- |
+| `$vars.inputData` undefined inside subflow script | Missing `triggerNodeId` on subflow `in` variable, or using `$vars.{varId}` directly | Add `triggerNodeId: "{startNodeId}"` to each `in` variable and access via `$vars.{startNodeId}.output.{varId}` |
 | `$vars.parentNode` undefined inside subflow | Parent scope not accessible | Pass values via subflow `in` variables |
 | Subflow output is null | Missing output mapping on subflow's End node | Map all `out` variables in the End node's `outputs` |
-| Missing Start/End node | Subflow lacks required trigger or end | Add `core.trigger.manual` and `core.control.end` to the subflow |
+| Script output is null | Missing inline `outputs` on script node | Add `outputs.output` and `outputs.error` inline on the script node |
+| Missing Start/End node | Subflow lacks required trigger or end | Add `core.trigger.manual` (with `outputs` and `entryPointId`) and `core.control.end` to the subflow |
 | Nesting limit exceeded | Subflow nested more than 3 levels deep | Flatten the structure or use resource nodes for deeper composition |

--- a/skills/uipath-maestro-flow/references/variables-and-expressions.md
+++ b/skills/uipath-maestro-flow/references/variables-and-expressions.md
@@ -51,7 +51,7 @@ Workflow variables are declared in `variables.globals`. Each has a **direction**
   schema?: object         // JSON Schema (draft-07) for complex types
   defaultValue?: unknown  // Initial value (must match type)
   description?: string    // Human-readable description
-  triggerNodeId?: string  // Trigger node this input is associated with (root flows only)
+  triggerNodeId?: string  // Trigger node this input is associated with (works in both root flows and subflows)
 }
 ```
 


### PR DESCRIPTION
- Update subflow/impl.md with correct triggerNodeId usage, inline outputs on Start/Script nodes, and proper $vars.{startNodeId}.output.{varId} access pattern based on a verified working reference flow.
- Update variables-and-expressions.md: triggerNodeId works in both root flows and subflows, not root flows only.