### PR TITLE
docs(uipath-platform): enhance IS skills — pagination, describe, connection UX

### DIFF
--- a/skills/uipath-platform/references/integration-service/agent-workflow.md
+++ b/skills/uipath-platform/references/integration-service/agent-workflow.md
@@ -99,13 +99,14 @@ uip is resources describe "<connector-key>" "<object>" \
   --connection-id "<id>" --operation <Create|List|Retrieve|Update|Delete|Replace> --output json
 ```
 
-The describe command fetches JSON Schema from the IS API (`Accept: application/schema+json`) and returns a compact summary with operations (method, parameters, path) and fields (name, type, required, enums, $ref). Results are cached locally — subsequent calls for the same object are instant.
+Without `--operation`, returns a list of `availableOperations` with a hint to use `--operation`. With `--operation`, returns per-operation detail: `requestFields` (what to send), `responseFields` (what comes back), and `parameters` (path/query params). Results are cached locally — subsequent calls for the same object are instant.
 
-> **Use `--operation`** to filter to the operation you need (e.g., `--operation Create`). This keeps output focused and saves tokens.
+> **Always use `--operation`** to get field-level detail (e.g., `--operation Create`). Without it you only see which operations exist.
 
 | Describe outcome | Action |
 |---|---|
-| Returns `operations` + `fields` | Use field metadata. Proceed to Step 5. |
+| Returns `requestFields` + `responseFields` + `parameters` | Use field metadata. Check `required` flags and `reference` sections. Proceed to Step 5. |
+| Returns `availableOperations` (no `--operation`) | Pick the operation you need, re-run with `--operation`. |
 | Returns error or empty | **Metadata gap** — skip describe, proceed to Step 5 with inferred fields. See [resources.md — Describe Failures](resources.md#describe-failures). |
 
 **Always pass `--connection-id`** for connection-specific metadata including custom fields.
@@ -253,9 +254,10 @@ uip is resources list "uipath-salesforce-sfdc" \
 # 4c. Describe the target resource
 uip is resources describe "uipath-salesforce-sfdc" "Contact" \
   --connection-id "abc-123" --operation Create --output json
-# → operations: [Create], fields: {LastName: required, FirstName: optional, ...}
+# → requestFields: [{name: "LastName", required: true}, {name: "FirstName", required: false}, ...]
+# → responseFields: [{name: "Id"}, {name: "LastName"}, ...]
 
-# 5. No reference fields → skip resolution
+# 5. No reference fields (no fields with "reference" section) → skip resolution
 # 5a. All required fields (LastName) have values → proceed
 
 # 6. Execute

--- a/skills/uipath-platform/references/integration-service/agent-workflow.md
+++ b/skills/uipath-platform/references/integration-service/agent-workflow.md
@@ -10,7 +10,9 @@ Follow these steps in order when the user asks to interact with an external serv
 - Step 4: Discover Capabilities
 - Step 4T: Trigger Metadata (if trigger workflow)
 - Step 5: Resolve Reference Fields
+- Step 5a: Validate Required Fields
 - Step 6: Execute
+- Error Recovery
 - Happy-Path Example (CRUD)
 - Happy-Path Example (Triggers)
 
@@ -20,11 +22,12 @@ Copy and track progress:
 
 ```
 - [ ] Step 1: Find connector (get Key)
-- [ ] Step 2: Find connection (get Id)
+- [ ] Step 2: Find connection (get Id — present options, recommend default)
 - [ ] Step 3: Ping connection (confirm Enabled)
 - [ ] Step 4: Discover capabilities (activities first, then resources)
 - [ ] Step 4T: (Triggers only) Get trigger objects → get trigger metadata
 - [ ] Step 5: Resolve reference fields (if any)
+- [ ] Step 5a: Validate all required fields have values
 - [ ] Step 6: Execute operation
 ```
 
@@ -45,10 +48,11 @@ uip is connectors list --filter "<vendor>" --output json
 uip is connections list "<connector-key>" --output json
 ```
 
-- **Native**: Pick default enabled connection (`IsDefault: Yes`, `State: Enabled`).
-- **HTTP fallback**: Match connection by vendor **Name** (case-insensitive substring).
-- **Multiple**: Present options to the user.
+- **Always present options** to the user. Recommend the default enabled connection (`IsDefault: Yes`, `State: Enabled`) but let the user confirm or choose another.
+- **HTTP fallback**: Match connection by vendor **Name** (case-insensitive substring). Present matches to user.
 - **None**: Ask user to create via `is connections create "<connector-key>"`.
+
+> **Do NOT auto-select a connection silently.** Even if there is exactly one default enabled connection, present it to the user: "I found connection **<name>** (default, enabled). Should I use this one?"
 
 See [connections.md — Selecting a Connection](connections.md#selecting-a-connection) for full selection logic.
 
@@ -86,16 +90,25 @@ uip is resources list "<connector-key>" \
 **4c. Describe the target resource** — get field metadata for the matched object:
 
 ```bash
+# All operations + all fields
 uip is resources describe "<connector-key>" "<object>" \
-  --connection-id "<id>" --operation <operation> --output json
+  --connection-id "<id>" --output json
+
+# Filter to a single operation (reduces output size)
+uip is resources describe "<connector-key>" "<object>" \
+  --connection-id "<id>" --operation <Create|List|Retrieve|Update|Delete|Replace> --output json
 ```
+
+The describe command fetches JSON Schema from the IS API (`Accept: application/schema+json`) and returns a compact summary with operations (method, parameters, path) and fields (name, type, required, enums, $ref). Results are cached locally — subsequent calls for the same object are instant.
+
+> **Use `--operation`** to filter to the operation you need (e.g., `--operation Create`). This keeps output focused and saves tokens.
 
 | Describe outcome | Action |
 |---|---|
-| Returns `requiredFields` / `optionalFields` | Use field metadata. Proceed to Step 5. |
-| Returns empty `availableOperations` or "Operation not found" | **Metadata gap** — do not retry with `--refresh`. Skip describe, proceed to Step 5 with inferred fields. See [resources.md — Describe Failures](resources.md#describe-failures). |
+| Returns `operations` + `fields` | Use field metadata. Proceed to Step 5. |
+| Returns error or empty | **Metadata gap** — skip describe, proceed to Step 5 with inferred fields. See [resources.md — Describe Failures](resources.md#describe-failures). |
 
-See [resources.md](resources.md) for why `--connection-id` and `--operation` are critical.
+**Always pass `--connection-id`** for connection-specific metadata including custom fields.
 
 ## Step 4T: Trigger Metadata (if user needs trigger/event configuration)
 
@@ -137,11 +150,17 @@ See [triggers.md](triggers.md) for full trigger domain reference and response fi
 
 ## Step 5: Resolve Reference Fields
 
-**When describe succeeded:** Check output for `referenceFields`. If none exist, skip to Step 6. For each reference field: list the referenced object, collect valid IDs, and present options to the user.
+**When describe succeeded:** Check output for reference fields. If none exist, skip to Step 5a. For each reference field: list the referenced object, collect valid IDs, and present options to the user.
 
 **When describe was unavailable (metadata gap):** Infer references from the user's request — fields ending in `Id` (e.g., `PromotionId`) typically reference the object with the matching base name (`Promotion`). List that object to resolve the ID before executing.
 
-See [resources.md — Reference Fields](resources.md#reference-fields-critical) and [resources.md — Inferring References Without Describe](resources.md#inferring-references-without-describe).
+See [reference-resolution.md — Reference Fields](reference-resolution.md#reference-fields-critical) and [reference-resolution.md — Field Dependency Chains](reference-resolution.md#field-dependency-chains).
+
+## Step 5a: Validate Required Fields
+
+After resolving references, **check every required field** against what the user provided. This is a hard gate — do NOT execute until all required fields have values. If any are missing, ask the user.
+
+See [reference-resolution.md — Validate Required Fields Before Executing](reference-resolution.md#validate-required-fields-before-executing).
 
 ## Step 6: Execute
 
@@ -151,6 +170,41 @@ uip is resources execute <verb> "<connector-key>" "<object>" \
 ```
 
 See [resources.md — Execute Operations](resources.md#execute-operations) for the verb table and options.
+
+---
+
+## Error Recovery
+
+When Step 6 returns a `Failure` result, follow this loop instead of retrying blindly or giving up. The CLI returns the HTTP status in `Message` and the raw vendor error body in `Instructions`.
+
+### Recovery Loop
+
+```
+Execute → Success? → Done
+  ↓ Failure
+Step 6a: Read the failure response
+  - Message — HTTP status (e.g., "400 Bad Request")
+  - Instructions — raw vendor error body (WHAT failed)
+  ↓
+Step 6b: Diagnose using discovery
+  - Field not found → run `is resources describe --operation <op>` to get valid field names
+  - Invalid value → run `is resources execute list` on the referenced object to get valid values
+  - Auth error → run `is connections edit <id>` to re-authenticate, then ping again
+  - Scope error → inform user, connection needs broader permissions
+  - Read-only field → remove the field from --body and retry
+  ↓
+Step 6c: Correct and retry (max 2 retries)
+  - Apply the specific fix from 6b
+  - Re-execute with the corrected query/body
+  - If still failing after 2 retries → present the error, attempted fixes, and suggested manual fix to the user
+```
+
+### Rules
+
+1. **Max 2 semantic retries** — each retry must address a specific diagnosed issue. Not blind retries.
+2. **Never retry the same query unchanged** — if you can't identify what to fix, escalate to the user.
+3. **Discover before guessing** — use `describe` and `list` to find correct field names and values. Do not hallucinate.
+4. **Escalate with context** — when presenting to the user, show: original query, error message, what was tried, and the suggested manual fix.
 
 ---
 
@@ -181,9 +235,10 @@ uip is resources list "uipath-salesforce-sfdc" \
 # 4c. Describe the target resource
 uip is resources describe "uipath-salesforce-sfdc" "Contact" \
   --connection-id "abc-123" --operation Create --output json
-# → requiredFields: [LastName], optionalFields: [FirstName, Email, ...], referenceFields: []
+# → operations: [Create], fields: {LastName: required, FirstName: optional, ...}
 
-# 5. No referenceFields → skip resolution, go straight to execute
+# 5. No reference fields → skip resolution
+# 5a. All required fields (LastName) have values → proceed
 
 # 6. Execute
 uip is resources execute create "uipath-salesforce-sfdc" "Contact" \
@@ -220,5 +275,5 @@ uip is triggers objects "uipath-salesforce-sfdc" CREATED \
 # 4T-c. Get trigger metadata (fields) for AccountHistory
 uip is triggers describe "uipath-salesforce-sfdc" CREATED "AccountHistory" \
   --connection-id "228624" --output json
-# → Returns field definitions (names, types, descriptions)
+# → Returns eventParameters, filterFields, outputFields
 ```

--- a/skills/uipath-platform/references/integration-service/agent-workflow.md
+++ b/skills/uipath-platform/references/integration-service/agent-workflow.md
@@ -171,6 +171,24 @@ uip is resources execute <verb> "<connector-key>" "<object>" \
 
 See [resources.md — Execute Operations](resources.md#execute-operations) for the verb table and options.
 
+### Pagination (list operations)
+
+`execute list` may not return all results. **Always check `Data.Pagination`** in the response:
+
+```bash
+# First page
+uip is resources execute list "<connector-key>" "<object>" \
+  --connection-id "<id>" --output json
+# → Check Data.Pagination.HasMore and Data.Pagination.NextPageToken
+
+# Next page — use nextPage (NOT nextPageToken) as the query param name
+uip is resources execute list "<connector-key>" "<object>" \
+  --connection-id "<id>" --query "nextPage=<value-from-NextPageToken>" --output json
+# → Continue until HasMore is "false" or target item is found
+```
+
+**Stop early** if you find the target item. See [resources.md — Pagination](resources.md#pagination) for full details.
+
 ---
 
 ## Error Recovery

--- a/skills/uipath-platform/references/integration-service/connections.md
+++ b/skills/uipath-platform/references/integration-service/connections.md
@@ -14,7 +14,7 @@ Connections are authenticated sessions for a specific connector. They store cred
 | `Name` | Display name (e.g., "Salesforce Prod", "Apify") |
 | `ConnectorKey` | The connector this connection belongs to |
 | **`State`** | `Enabled` or other status. Only Enabled connections can be used. |
-| **`IsDefault`** | `Yes` or `No`. Prefer the default connection when multiple exist. |
+| **`IsDefault`** | `Yes` or `No`. Recommend the default connection but always let the user confirm. |
 | `Owner` | Who created the connection |
 | `Folder` | Folder this connection belongs to |
 
@@ -22,20 +22,38 @@ Connections are authenticated sessions for a specific connector. They store cred
 
 ## Selecting a Connection
 
+**Always present connections to the user** — do not auto-select silently, even if there is only one default enabled connection. Recommend the default but let the user confirm.
+
 ### For Native Connectors
 
 1. List connections for the connector
-2. Pick the **default** connection (`IsDefault: Yes`)
-3. Check if its **State** is `Enabled`
-4. If not enabled → prompt user to choose another enabled connection
-5. If no connections are enabled → prompt user to create a new one
-6. If no connections exist → prompt user to create one
+2. Present all enabled connections to the user, **recommending** the default (`IsDefault: Yes`, `State: Enabled`):
+   - "I found these connections: 1) **Salesforce Prod** (default, enabled) ← recommended 2) Salesforce Dev (enabled). Which should I use?"
+3. If only one enabled connection exists, still confirm: "I found connection **<name>** (default, enabled). Should I use this one?"
+4. If not enabled → prompt user to re-authenticate via `is connections edit <id>`
+5. If no connections exist → prompt user to create one via `is connections create "<connector-key>"`
 
 ### For HTTP Fallback
 
 1. List connections for `uipath-uipath-http`
 2. Look for a connection whose **Name** contains the target vendor (case-insensitive substring match, e.g., "Apify" matches "Apify", "Apify - Prod", "My Apify Connection")
-3. If one match → use it. If multiple matches → present options to the user.
+3. Present matches to the user. If multiple matches → let them choose.
 4. If no match → present all existing HTTP connections and ask the user to choose, or offer to create a new one
 
 > **Note:** Name-based matching is best-effort. If connection names don't follow vendor naming conventions, present all HTTP connections to the user.
+
+---
+
+## Scope-Related Errors
+
+A connection can be `Enabled` but lack optional OAuth scopes needed for specific activities. This typically surfaces as a **403 Forbidden** error during execute.
+
+**Symptoms:**
+- Connection pings successfully (`State: Enabled`)
+- Execute fails with 403 or a vendor-specific "insufficient permissions" error
+- The same operation works with a different connection that has broader scopes
+
+**Recovery:**
+1. Inform the user that the connection may need broader OAuth scopes for this activity
+2. Re-authorize with broader scopes: `uip is connections edit <connection-id>`
+3. After re-auth, ping again to verify, then retry the operation

--- a/skills/uipath-platform/references/integration-service/integration-service.md
+++ b/skills/uipath-platform/references/integration-service/integration-service.md
@@ -16,8 +16,9 @@ Interact with external services through UiPath Integration Service — discover 
 3. **Resolve reference fields before create/update** — Describe output includes `referenceFields` — list the referenced object to get valid IDs before executing.
 4. **Use `--refresh` once if results are unexpected** — The `list` subcommands cache locally. Retry **once** with `--refresh` when: results are empty, a recently created item is missing, or the user says data should exist. If still empty after refresh, inform the user the data does not exist — do not loop.
 5. **Always ping** — Verify every connection before use, even if it reports "Enabled"
-6. **Prompt, don't assume** — When multiple choices exist (connections, reference values), present options and let the user decide. Only auto-select when there is exactly one valid option.
+6. **Always ask, never auto-select** — Always present connections and reference values to the user for confirmation, even if there is only one option. Recommend the default but let the user confirm.
 7. **Always use `--output json`** for commands whose output you need to parse or act on.
+8. **Use `--operation` on describe** — `is resources describe` returns a compact summary of all operations and fields. Use `--operation Create` to filter to just that operation and reduce output size.
 
 ---
 
@@ -30,7 +31,8 @@ Interact with external services through UiPath Integration Service — discover 
 | Step 1: connector not found | [connectors.md](connectors.md) | HTTP fallback, connector response fields |
 | Step 2: connection selection | [connections.md](connections.md) | Selection logic (native + HTTP), response fields |
 | Step 4: discover activities | [activities.md](activities.md) | Activity discovery, trigger activities, activities vs resources |
-| Steps 4–6: resources | [resources.md](resources.md) | Describe, resolve references, execute CRUD |
+| Steps 4–6: resources | [resources.md](resources.md) | Describe, execute CRUD, pagination, vendor error recovery |
+| Step 5: resolve references | [reference-resolution.md](reference-resolution.md) | Simple refs, dependency chains, inferring, required field validation |
 | Trigger metadata | [triggers.md](triggers.md) | Trigger objects, trigger field metadata, trigger workflow |
 
 ---
@@ -48,9 +50,10 @@ When multiple options exist, present them clearly:
 | Ping returns non-enabled | Run `is connections edit <id>` to re-authenticate, then ping again. If still fails, ask user to choose another connection or create new. |
 | List returns empty after `--refresh` | Inform user the data does not exist. Do not retry. Suggest checking permissions or folder context. |
 | Reference field lookup returns empty | Inform user — the referenced object has no records. Ask if they want to create one or use a different value. |
-| Execute fails with validation error | Re-check describe output for required fields. Verify field types and reference IDs are correct. |
-| Describe returns empty `availableOperations` | Metadata gap — do **not** retry with `--refresh`. Skip describe, attempt execute directly. See [resources.md — Describe Failures](resources.md#describe-failures). |
-| Create fails with `INVALID_FIELD_FOR_INSERT_UPDATE` | Field is read-only/auto-generated. Remove it from `--body`, use alternative writable field, and retry. See [resources.md — Read-Only Field Recovery](resources.md#read-only-field-recovery). |
+| Execute fails with error | Read `Instructions` — the CLI passes through the raw vendor error body. Use it to diagnose and fix. See [agent-workflow.md — Error Recovery](agent-workflow.md#error-recovery). |
+| Describe returns error | Metadata gap — skip describe, attempt execute directly. See [resources.md — Describe Failures](resources.md#describe-failures). |
+| Create fails with read-only field error | Parse the vendor error in `Instructions` for the field name. Remove it from `--body` and retry. |
 | Connector not found | Fall back to HTTP connector (`uipath-uipath-http`). See [connectors.md](connectors.md#http-connector-fallback). |
 | No trigger objects for operation | Check operation name (CREATED/UPDATED/DELETED, uppercase). Verify connector supports events (`hasEvents` in connector list). See [triggers.md](triggers.md). |
 | Trigger metadata empty | Check object name matches exactly from `triggers objects` output. Try with `--connection-id` for custom fields. See [triggers.md](triggers.md). |
+| Execute fails with 403 (scope) | Connection is Enabled but lacks optional scopes for this activity. Re-authorize with broader scopes via `is connections edit <id>`. See [connections.md](connections.md). |

--- a/skills/uipath-platform/references/integration-service/reference-resolution.md
+++ b/skills/uipath-platform/references/integration-service/reference-resolution.md
@@ -1,0 +1,121 @@
+# Reference Resolution
+
+How to resolve reference fields — fields whose values must be looked up from another resource before create/update operations.
+
+> Full command syntax and options: [uip-commands.md — Integration Service](../uip-commands.md#integration-service-is). Domain-specific usage patterns are shown inline below.
+
+## Contents
+- Reference Fields (CRITICAL)
+- Simple Reference Fields (no dependencies)
+- Field Dependency Chains
+- Inferring References Without Describe
+- Validate Required Fields Before Executing
+
+---
+
+## Reference Fields (CRITICAL)
+
+Some fields in the describe response have a `reference` section — their value must be looked up from another resource. For each reference field: list the `referencedObject`, collect the `lookupValue` from results, and present options to the user.
+
+A reference field in the describe output:
+
+```json
+{
+  "field": "departmentId",
+  "referencedObject": "departments",
+  "lookupValue": "id",
+  "hint": "Resolve by executing: is resources execute list ... \"departments\" ..."
+}
+```
+
+### Resolution workflow
+
+```bash
+# 1. Describe → discover reference fields
+uip is resources describe "<connector-key>" "<resource>" \
+  --connection-id "<id>" --operation Create --output json
+
+# 2. Resolve each reference field by listing its referenced object
+uip is resources execute list "<connector-key>" "<referenced-object>" \
+  --connection-id "<id>" --output json
+
+# 3. Execute with resolved IDs
+uip is resources execute create "<connector-key>" "<resource>" \
+  --connection-id "<id>" --body '{"fieldName": "<resolved-id>"}' --output json
+```
+
+**Present options to the user** when multiple matches exist. Use the resolved IDs (not display names) in `--body` or `--query`.
+
+---
+
+## Field Dependency Chains
+
+Some reference fields **depend on other fields** — the child field's valid values are scoped by the parent field's selection. Dependencies are expressed in `reference.path` templates containing `{otherField}` variables that must be substituted.
+
+### How to detect dependencies
+
+Check if `reference.path` contains `{fieldName}` template variables. If so, that field depends on the referenced field. Resolve the parent first.
+
+**CRITICAL: If a parent field value is NOT in the user's prompt, you MUST ask the user for it BEFORE attempting to resolve any child fields.** Do not resolve child fields without a scoped parent — the results will be wrong or ambiguous.
+
+### Dependency chain example
+
+A resource has two reference fields with a dependency chain:
+
+```
+Field A → no template variables in path    → resolve first (list resource, pick value)
+Field B → path contains {Field A}          → resolve after A (list scoped by A's value)
+```
+
+**Wrong** — listing Field B's resource globally returns duplicates from all scopes.
+
+**Correct** — resolve Field A first, then list Field B's resource scoped to Field A's resolved value:
+
+```bash
+# Step 1: Resolve Field A (no dependencies)
+uip is resources execute list "<connector-key>" "<resource-a>" \
+  --connection-id "<id>" --output json
+# → pick value
+
+# Step 2: Resolve Field B scoped to Field A's value
+uip is resources execute list "<connector-key>" "<resource-a>/<resolved-value>/sub-resource" \
+  --connection-id "<id>" --output json
+# → only values valid for this scope
+```
+
+### General rule
+
+When resolving reference fields:
+1. **Sort fields by dependency** — fields with no `{template}` in their reference path come first
+2. **Resolve parent fields** — list the parent resource, pick the value
+3. **Substitute into child path** — replace `{parentField}` in the child's reference path with the resolved value
+4. **Resolve child fields** — list the scoped resource using the substituted path
+
+This pattern applies across all connectors wherever child fields are scoped by parent selections.
+
+---
+
+## Inferring References Without Describe
+
+When describe metadata is unavailable (see [resources.md — Describe Failures](resources.md#describe-failures)), infer reference fields from naming conventions:
+
+- Fields ending in **`Id`** (e.g., `PromotionId`, `AccountId`) typically reference the object with the matching base name (`Promotion`, `Account`).
+- List the inferred object to resolve the ID: `is resources execute list "<connector-key>" "<base-name>" --connection-id "<id>" --output json`
+- Match the user's value by `Name` or `DisplayName` in the results.
+
+---
+
+## Validate Required Fields Before Executing
+
+After resolving references, **check every required field** from the describe response against what the user provided. This is a hard gate — do NOT execute until all required fields have values.
+
+**Process:**
+1. Collect all fields where `required: true` from the describe output
+2. For each required field, check if the user's prompt contains a value for it
+3. If any required field is missing, **ask the user** before proceeding:
+   - List the missing fields with their `displayName` and `description`
+   - For reference fields, explain what kind of value is expected
+   - Wait for the user's response before continuing
+4. Only after all required fields are accounted for, proceed to execute
+
+> **Do NOT guess or skip missing required fields.** A missing required field will cause a runtime error. It is always better to ask than to assume.

--- a/skills/uipath-platform/references/integration-service/reference-resolution.md
+++ b/skills/uipath-platform/references/integration-service/reference-resolution.md
@@ -6,7 +6,7 @@ How to resolve reference fields — fields whose values must be looked up from a
 
 ## Contents
 - Reference Fields (CRITICAL)
-- Simple Reference Fields (no dependencies)
+- Search References (filterPattern)
 - Field Dependency Chains
 - Inferring References Without Describe
 - Validate Required Fields Before Executing
@@ -40,6 +40,8 @@ Some fields in the describe `requestFields` have a `reference` section — their
 | **`reference.lookupNames`** | Fields to match the user's input against (e.g., match "general" against `name`) |
 | **`reference.lookupValue`** | The field to extract as the resolved value (e.g., `id`) |
 | **`reference.path`** | The API path — use `reference.objectName` for the list call |
+| **`reference.filterPattern`** | Search endpoint pattern — substitute the user's input into `{filter}` and pass as `--query`. See [Search References](#search-references-filterpattern). |
+| **`reference.childPath`** | Scoped child path — used for drill-down references (e.g., folder subfolders) |
 
 ### Resolution workflow
 
@@ -61,7 +63,7 @@ uip is resources execute create "<connector-key>" "<resource>" \
   --connection-id "<id>" --body '{"channel": "<resolved-id>"}' --output json
 ```
 
-### Example: Resolving a Slack channel
+### Example: Resolving a Slack channel (list reference)
 
 User says: "Send a message to #general"
 
@@ -76,6 +78,64 @@ User says: "Send a message to #general"
 4. **Use** the `lookupValue` (`id`) → `"C02CAP3LAAG"` in the `--body`
 
 **Present options to the user** when multiple matches exist. Always use the resolved `lookupValue` (not display names) in `--body` or `--query`.
+
+---
+
+## Search References (filterPattern)
+
+Some reference fields point to **search endpoints** that require user input as a query parameter. These have a `filterPattern` property with a `{filter}` placeholder.
+
+### Search reference structure
+
+```json
+{
+  "name": "productId",
+  "displayName": "Product ID",
+  "description": "ID of the product to which the ticket is mapped",
+  "required": false,
+  "reference": {
+    "objectName": "search_products",
+    "lookupNames": ["productCode", "id"],
+    "lookupValue": "id",
+    "path": "/search_products",
+    "filterPattern": "productCode={filter}"
+  }
+}
+```
+
+### How to detect
+
+If `reference.filterPattern` exists, the reference is a **search endpoint** — a plain `list` call without the filter will return no results or an error.
+
+### Resolution workflow (search)
+
+1. **Get the user's search input** — the value they want to look up (e.g., product name, code)
+2. **Substitute into filterPattern** — replace `{filter}` with the user's input
+3. **Pass as `--query`** when listing the referenced object:
+
+```bash
+# filterPattern: "productCode={filter}"
+# User input: "Widget Pro"
+uip is resources execute list "<connector-key>" "search_products" \
+  --connection-id "<id>" --query "productCode=Widget Pro" --output json
+```
+
+4. **Match results** against `lookupNames` and extract `lookupValue` as usual
+
+### Example: Resolving a Zoho Desk product
+
+User says: "Create a ticket for product Widget Pro"
+
+1. **Describe** returns `productId` with `reference.filterPattern: "productCode={filter}"`
+2. **Search** with user input:
+   ```bash
+   uip is resources execute list "uipath-zoho-desk" "search_products" \
+     --connection-id "<id>" --query "productCode=Widget Pro" --output json
+   ```
+   → `{ "productCode": "WP-100", "id": "1892000000056007" }`
+3. **Use** the `lookupValue` (`id`) → `"1892000000056007"` in `--body`
+
+> **If the user doesn't provide a search term**, ask them. Search references cannot be resolved without user input — do NOT call the search endpoint with an empty filter.
 
 ---
 

--- a/skills/uipath-platform/references/integration-service/reference-resolution.md
+++ b/skills/uipath-platform/references/integration-service/reference-resolution.md
@@ -15,36 +15,67 @@ How to resolve reference fields — fields whose values must be looked up from a
 
 ## Reference Fields (CRITICAL)
 
-Some fields in the describe response have a `reference` section — their value must be looked up from another resource. For each reference field: list the `referencedObject`, collect the `lookupValue` from results, and present options to the user.
+Some fields in the describe `requestFields` have a `reference` section — their value must be looked up from another resource before executing.
 
-A reference field in the describe output:
+### Reference structure
 
 ```json
 {
-  "field": "departmentId",
-  "referencedObject": "departments",
-  "lookupValue": "id",
-  "hint": "Resolve by executing: is resources execute list ... \"departments\" ..."
+  "name": "channel",
+  "type": "string",
+  "displayName": "Channel name/ID",
+  "required": true,
+  "reference": {
+    "objectName": "curated_channels?types=public_channel,private_channel",
+    "lookupNames": ["name", "id"],
+    "lookupValue": "id",
+    "path": "/curated_channels?fields=id,name"
+  }
 }
 ```
+
+| Property | Meaning |
+|---|---|
+| **`reference.objectName`** | The resource to list (use as `<object>` in `execute list`). May include query params. |
+| **`reference.lookupNames`** | Fields to match the user's input against (e.g., match "general" against `name`) |
+| **`reference.lookupValue`** | The field to extract as the resolved value (e.g., `id`) |
+| **`reference.path`** | The API path — use `reference.objectName` for the list call |
 
 ### Resolution workflow
 
 ```bash
-# 1. Describe → discover reference fields
+# 1. Describe → find fields with "reference" in requestFields
 uip is resources describe "<connector-key>" "<resource>" \
   --connection-id "<id>" --operation Create --output json
 
-# 2. Resolve each reference field by listing its referenced object
-uip is resources execute list "<connector-key>" "<referenced-object>" \
+# 2. For each reference field, list the referenced object
+#    Use reference.objectName as the object name (including any query params)
+uip is resources execute list "<connector-key>" "<reference.objectName>" \
   --connection-id "<id>" --output json
 
-# 3. Execute with resolved IDs
+# 3. Match the user's input against reference.lookupNames in the results
+#    Extract reference.lookupValue as the resolved ID
+
+# 4. Execute with resolved IDs (not display names)
 uip is resources execute create "<connector-key>" "<resource>" \
-  --connection-id "<id>" --body '{"fieldName": "<resolved-id>"}' --output json
+  --connection-id "<id>" --body '{"channel": "<resolved-id>"}' --output json
 ```
 
-**Present options to the user** when multiple matches exist. Use the resolved IDs (not display names) in `--body` or `--query`.
+### Example: Resolving a Slack channel
+
+User says: "Send a message to #general"
+
+1. **Describe** returns `channel` field with `reference.objectName: "curated_channels?types=public_channel,private_channel"`
+2. **List** the referenced object:
+   ```bash
+   uip is resources execute list "uipath-salesforce-slack" \
+     "curated_channels?types=public_channel,private_channel" \
+     --connection-id "<id>" --output json
+   ```
+3. **Match** "general" against `lookupNames` (`name` field) in results → find `{ "name": "general", "id": "C02CAP3LAAG" }`
+4. **Use** the `lookupValue` (`id`) → `"C02CAP3LAAG"` in the `--body`
+
+**Present options to the user** when multiple matches exist. Always use the resolved `lookupValue` (not display names) in `--body` or `--query`.
 
 ---
 

--- a/skills/uipath-platform/references/integration-service/resources.md
+++ b/skills/uipath-platform/references/integration-service/resources.md
@@ -33,14 +33,35 @@ For reference field resolution (simple refs, dependency chains, required field v
 
 ## Describe Response
 
-The describe command fetches JSON Schema from the IS API (`Accept: application/schema+json`) and returns a compact summary:
+The describe command returns metadata from the raw API. The output depends on whether `--operation` is provided.
 
-| Section | Description |
+### Without `--operation` — operation summary
+
+Returns which operations the resource supports:
+
+| Field | Description |
 |---|---|
-| **operations** | Available operations — each with method, path, description, parameters (name, type, required, description) |
-| **fields** | All fields — each with name, type, required flag, enum values (if any), $ref (if any) |
+| **`availableOperations`** | List of operations — each with `method` (GET/POST/PATCH/PUT/DELETE), `name` (Create/List/etc.), `description`, `curated` (display name) |
+| **`hint`** | Instructs to use `--operation` for field details |
 
-Use `--operation <Create|List|Retrieve|Update|Delete|Replace>` to filter to a single operation and reduce output.
+### With `--operation` — per-operation field detail
+
+Returns the full field breakdown for the specified operation:
+
+| Field | Description |
+|---|---|
+| **`operation`** | Operation info — `method`, `name`, `description`, `path`, `curated` display name |
+| **`parameters`** | Path and query parameters (NOT body fields) — each with `name`, `type` (path/query), `dataType`, `required`, `defaultValue`, `reference` |
+| **`requestFields`** | Fields to send in `--body` — each with `name`, `type`, `displayName`, `required`, `description`, `reference`, `enum` |
+| **`responseFields`** | Fields returned in the response — each with `name`, `type`, `displayName` |
+
+> **Always use `--operation`** to get actionable field detail. Without it you only see which operations exist.
+
+### Key field properties
+
+- **`required: true`** — field must be provided in `--body` or `--query`. Do NOT skip.
+- **`reference`** — field value must be looked up from another resource. See [reference-resolution.md](reference-resolution.md).
+- **`enum`** — field only accepts the listed values (e.g., `["low", "normal", "high"]`).
 
 Results are cached locally. Use `--refresh` to bypass cache after re-auth or schema changes.
 

--- a/skills/uipath-platform/references/integration-service/resources.md
+++ b/skills/uipath-platform/references/integration-service/resources.md
@@ -121,6 +121,13 @@ Common JMESPath patterns:
 
 `uip is resources execute list` may not return all results in a single call. **Always check for pagination** when searching for a specific item or listing all items.
 
+### Pagination rules
+
+1. **Always check `Data.Pagination`** — every `list` response may contain pagination state. Never assume a single page contains all results.
+2. **Complete the pagination loop** — when searching for a specific item, keep paginating until `Data.Pagination.HasMore` is `"false"` or the item is found. Do NOT abandon pagination mid-loop to try alternative APIs (e.g., search endpoints, admin endpoints, HTTP fallback).
+3. **Stop early on match** — if you find the target item in the current page, stop. No need to fetch remaining pages.
+4. **Report not-found only after exhausting all pages** — only conclude an item does not exist after `HasMore` is `"false"` and every page has been checked.
+
 ### Connector pagination
 
 Most IS connectors use the `elements-*` pagination protocol. The CLI returns pagination state nested inside `Data.Pagination`:
@@ -157,7 +164,11 @@ Example response:
 }
 ```
 
-**Stop early:** If you find the target item in the current page, no need to fetch remaining pages.
+### Anti-patterns
+
+- **Do NOT check `Data.nextPage`** — pagination lives at `Data.Pagination.HasMore` and `Data.Pagination.NextPageToken`, not at `Data.nextPage`.
+- **Do NOT abandon pagination to try other APIs** — if you are paginating through `conversations` to find a channel, do not stop mid-loop to call `admin_conversations_search`, `search_all`, or `search_messages`. Complete the loop first.
+- **Do NOT conclude "not found" after one page** — a single page may return only a fraction of the total results. Always check `Data.Pagination.HasMore` before concluding.
 
 ### Query-param pagination (offset/limit)
 

--- a/skills/uipath-platform/references/integration-service/resources.md
+++ b/skills/uipath-platform/references/integration-service/resources.md
@@ -9,20 +9,17 @@ Resources represent the data objects available through a connector (e.g., Salesf
 - Response Fields
 - Describe Response
 - Describe Failures
-- Reference Fields (CRITICAL)
-- Inferring References Without Describe
 - Execute Operations
-- Read-Only Field Recovery
 - Pagination
+- Execute Error Handling
+
+For reference field resolution (simple refs, dependency chains, required field validation), see [reference-resolution.md](reference-resolution.md).
 
 ---
 
 ## Listing and Describing Resources
 
-**Always pass `--connection-id` and `--operation`** to get accurate results:
-
-- `--connection-id` — Returns custom objects/fields specific to that connection. Without it, only standard objects/fields are returned.
-- `--operation` — Filters to resources/fields relevant to the intended action. Without it on describe, you get a summary of available operations instead of field-level details.
+**Always pass `--connection-id`** to get connection-specific metadata including custom objects and fields. Without it, only standard objects/fields are returned.
 
 ## Response Fields
 
@@ -36,141 +33,29 @@ Resources represent the data objects available through a connector (e.g., Salesf
 
 ## Describe Response
 
-When `--operation` is provided:
+The describe command fetches JSON Schema from the IS API (`Accept: application/schema+json`) and returns a compact summary:
 
 | Section | Description |
 |---|---|
-| **requiredFields** | Fields that must be provided for this operation |
-| **optionalFields** | Fields that can optionally be provided |
-| **responseFields** | Fields returned in the response |
-| **referenceFields** | Fields that reference other objects (see below) |
-| **metadataFile** | Cached file path with full field details |
+| **operations** | Available operations — each with method, path, description, parameters (name, type, required, description) |
+| **fields** | All fields — each with name, type, required flag, enum values (if any), $ref (if any) |
 
-When `--operation` is omitted, returns **availableOperations** and a hint to use `--operation` for field-level details.
+Use `--operation <Create|List|Retrieve|Update|Delete|Replace>` to filter to a single operation and reduce output.
+
+Results are cached locally. Use `--refresh` to bypass cache after re-auth or schema changes.
 
 ---
 
 ## Describe Failures
 
-Some resources appear in `resources list --operation Create` but return empty `availableOperations` on describe, or fail with "Operation not found". This is a **server-side metadata gap**, not a cache issue — do not retry with `--refresh`.
+Some resources return an error on describe. This is a **server-side metadata gap** — do not retry with `--refresh`.
 
 **Recovery:**
 
 1. **Skip describe entirely** — do not waste calls retrying.
 2. **Infer fields from user context** — use the field names and values the user provided in their request.
-3. **Infer reference fields from naming** — see [Inferring References Without Describe](#inferring-references-without-describe).
-4. **Attempt execute directly** — let the server validate. If a field is rejected, adjust and retry (see [Read-Only Field Recovery](#read-only-field-recovery)).
-
----
-
-## Reference Fields (CRITICAL)
-
-Some fields in the describe response have a `reference` section — their value must be looked up from another resource. For each reference field: list the `referencedObject`, collect the `lookupValue` from results, and present options to the user.
-
-A reference field in the describe output:
-
-```json
-{
-  "field": "departmentId",
-  "referencedObject": "departments",
-  "lookupValue": "id",
-  "hint": "Resolve by executing: is resources execute list ... \"departments\" ..."
-}
-```
-
-### Example: Creating a Zoho Desk Ticket
-
-```bash
-# 1. Describe → discover referenceFields: departmentId → "departments", contactId → "contacts"
-uip is resources describe "uipath-zoho-desk" "tickets" \
-  --connection-id "<id>" --operation Create --output json
-
-# 2. Resolve references
-uip is resources execute list "uipath-zoho-desk" "departments" --connection-id "<id>" --output json
-# → { "id": "1892000000006907", "name": "Engineering" }
-uip is resources execute list "uipath-zoho-desk" "contacts" --connection-id "<id>" --output json
-# → { "id": "1892000000048009", "name": "John Doe" }
-
-# 3. Execute with resolved IDs
-uip is resources execute create "uipath-zoho-desk" "tickets" \
-  --connection-id "<id>" \
-  --body '{"departmentId": "1892000000006907", "subject": "Bug report", "contactId": "1892000000048009"}' \
-  --output json
-```
-
----
-
-## Field Dependency Chains (Field Actions)
-
-Some reference fields **depend on other fields** — the child field's valid values are scoped by the parent field's selection. The connector's underlying metadata encodes this in `reference.path` using template variables like `{fields.project.key}`.
-
-### How to detect dependencies
-
-When two fields share the same `reference.objectName` (e.g., both reference `"project"`), or when a field's reference path contains `{otherField}`, they form a dependency chain. Resolve them **in order** — parent first, then child using the parent's resolved value.
-
-### Common pattern: Jira project → issue type
-
-The Jira `curated_create_issue` resource has this dependency:
-
-```
-fields.project.key  → reference.path: /project/search                          (no dependency)
-fields.issuetype.id → reference.path: /project/{fields.project.key}/issuetypes (depends on project.key)
-```
-
-**Wrong** — listing `issuetype` globally returns Bug types from ALL projects:
-```bash
-uip is resources execute list "uipath-atlassian-jira" "issuetype" \
-  --connection-id "<id>" --output json
-# → Bug (id=1), Bug (id=10004), Bug (id=12947), ... dozens of duplicates
-```
-
-**Correct** — resolve project first, then list issue types scoped to that project:
-```bash
-# Step 1: Resolve project
-uip is resources execute list "uipath-atlassian-jira" "project" \
-  --connection-id "<id>" --output json
-# → { "key": "ENGCE", "name": "Integration Service", "id": "10845" }
-
-# Step 2: Resolve issue types FOR that project (scoped path)
-uip is resources execute list "uipath-atlassian-jira" "project/ENGCE/issuetypes" \
-  --connection-id "<id>" --output json
-# → { "id": "10004", "name": "Bug" }  ← only issue types valid for ENGCE
-```
-
-### General rule
-
-When resolving reference fields:
-1. **Sort fields by dependency** — fields with no `{template}` in their reference path come first
-2. **Resolve parent fields** — list the parent resource, pick the value
-3. **Substitute into child path** — replace `{parentField}` in the child's reference path with the resolved value
-4. **Resolve child fields** — list the scoped resource using the substituted path
-
-This pattern applies across connectors (Jira, Salesforce, ServiceNow, Zoho, etc.) wherever child fields are scoped by parent selections.
-
----
-
-## Inferring References Without Describe
-
-When describe metadata is unavailable (see [Describe Failures](#describe-failures)), infer reference fields from naming conventions:
-
-- Fields ending in **`Id`** (e.g., `PromotionId`, `AccountId`) typically reference the object with the matching base name (`Promotion`, `Account`).
-- List the inferred object to resolve the ID: `is resources execute list "<connector-key>" "<base-name>" --connection-id "<id>" --output json`
-- Match the user's value by `Name` or `DisplayName` in the results.
-
-### Example: Coupon → Promotion (no describe available)
-
-```bash
-# User wants: create coupon "XYZ" for promotion "Chandu Test"
-# Infer: PromotionId → list Promotion objects
-uip is resources execute list "uipath-salesforce-sfdc" "Promotion" \
-  --connection-id "<id>" --output json
-# → { "Id": "<promotion-id>", "Name": "Summer Sale" }
-
-# Use resolved Id in create
-uip is resources execute create "uipath-salesforce-sfdc" "Coupon" \
-  --connection-id "<id>" \
-  --body '{"CouponCode": "SAVE20", "PromotionId": "<promotion-id>"}' --output json
-```
+3. **Infer reference fields from naming** — see [reference-resolution.md — Inferring References Without Describe](reference-resolution.md#inferring-references-without-describe).
+4. **Attempt execute directly** — let the server validate. If a field is rejected, read the error and adjust.
 
 ---
 
@@ -211,27 +96,77 @@ Common JMESPath patterns:
 
 ---
 
-## Read-Only Field Recovery
-
-Some objects have auto-generated fields that cannot be set on create (e.g., Salesforce `Name` on Coupon, `CaseNumber` on Case). The server returns error `INVALID_FIELD_FOR_INSERT_UPDATE` listing the offending field(s).
-
-**Recovery:**
-
-1. **Parse the error** — extract the field name(s) from `providerMessage.fields`.
-2. **Remove the offending field** from `--body`.
-3. **Find the correct writable field** — the user's intended value often maps to a different field name (e.g., `CouponCode` instead of `Name`). Use domain knowledge or try the most specific field name for the object.
-4. **Retry** the create with corrected fields.
-
-> **Avoid `Name` as a first guess** for specialized Salesforce objects (Coupon, Case, etc.) — it is frequently auto-generated. Prefer object-specific fields like `CouponCode`, `Subject`, `Title`.
-
----
-
 ## Pagination
 
-List operations may return paginated results. Use `--query "limit=50&offset=0"` and increment `offset` by `limit` to page through. Stop when the result set is empty or smaller than the limit.
+`uip is resources execute list` may not return all results in a single call. **Always check for pagination** when searching for a specific item or listing all items.
+
+### Connector pagination
+
+Most IS connectors use the `elements-*` pagination protocol. The CLI returns pagination state nested inside `Data.Pagination`:
+
+- **`Data.Pagination.HasMore`**: `"true"` or `"false"` — indicates if more pages exist
+- **`Data.Pagination.NextPageToken`**: the token value to use for the next page
+
+**IMPORTANT:** The query parameter name is `nextPage` (NOT `nextPageToken`). Pass the value from `Data.Pagination.NextPageToken` as `--query "nextPage=<value>"`.
+
+```bash
+# First page (do not pass pageSize unless the user explicitly requests a specific page size)
+uip is resources execute list "<connector-key>" "<resource>" \
+  --connection-id "<id>" --output json
+# → Check Data.Pagination.HasMore and Data.Pagination.NextPageToken in the JSON response
+
+# Subsequent pages — use nextPage as the query param name (NOT nextPageToken)
+uip is resources execute list "<connector-key>" "<resource>" \
+  --connection-id "<id>" --query "nextPage=<value-from-NextPageToken>" --output json
+# → Continue until Data.Pagination.HasMore is "false" or target item is found
+```
+
+Example response:
+```json
+{
+  "Result": "Success",
+  "Code": "ExecuteOperation",
+  "Data": {
+    "items": [ ... ],
+    "Pagination": {
+      "HasMore": "true",
+      "NextPageToken": "eyJwYWdl..."
+    }
+  }
+}
+```
+
+**Stop early:** If you find the target item in the current page, no need to fetch remaining pages.
+
+### Query-param pagination (offset/limit)
+
+Some resources support `offset`/`limit` via `--query`:
 
 ```bash
 uip is resources execute list "<connector-key>" "<object>" \
   --connection-id "<id>" --query "limit=50&offset=0" --output json
 # → next page: --query "limit=50&offset=50"
 ```
+
+Stop when the result set is empty or smaller than the limit.
+
+### HTTP connector exception
+
+Connectors with key `uipath-uipath-http` do NOT use the `elements-*` pagination headers. These depend on vendor-specific pagination. Handle on a case-by-case basis.
+
+---
+
+## Execute Error Handling
+
+When an execute command fails, the CLI returns:
+- **`Message`**: HTTP status (e.g., `400 Bad Request`)
+- **`Instructions`**: The raw vendor error response body as JSON
+
+### How to diagnose failures
+
+1. **Read `Message`** — the HTTP status code tells you the category (400 = bad request, 403 = forbidden, 404 = not found, etc.)
+2. **Read `Instructions`** — the raw vendor error body tells you WHAT specifically failed (invalid field, missing required value, permission denied, etc.)
+3. **Use discovery to fix** — run `describe` to get valid field names, run `list` to get valid values for reference fields
+4. **Retry with fixes** — apply the specific correction and re-execute (max 2 retries)
+
+For the full recovery loop, see [agent-workflow.md — Error Recovery](agent-workflow.md#error-recovery).


### PR DESCRIPTION
## Summary

Ports improvements from `fix/updating-is-skills` onto current main, **excluding AgentContext** features (will be added separately once CLI support lands).

- **Connection selection**: always present options to user, recommend default, never auto-select silently
- **Describe command**: document JSON Schema API, `--operation` filter, caching behavior
- **Step 5a: Validate Required Fields**: new workflow step — hard gate before execute
- **Reference resolution**: new `reference-resolution.md` with dependency chains, inferring refs, required field validation
- **Pagination**: fix `nextPage` param name (not `nextPageToken`), explicit response structure with `Data.Pagination`
- **Scope-Related Errors**: new section in connections.md for 403 Forbidden recovery
- **Error Recovery**: generic loop (read error → discover → fix → retry, max 2 retries)
- **Error recovery table**: updated for new CLI output format (`Instructions` contains vendor error)

Supersedes the IS portions of `fix/updating-is-skills`.

## Test plan
- [x] All links in navigation tables resolve to existing files
- [x] CLI commands use `--output json` (not `--format json`)
- [x] No AgentContext references in any file
- [x] No cross-skill references

🤖 Generated with [Claude Code](https://claude.com/claude-code)