### PR TITLE
feat: add uipath-rpa-legacy skill

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -38,5 +38,8 @@
 /skills/uipath-maestro-flow/references/plugins/connector/ @baishalighosh @chandusailella @bai-uipath @rockymadden
 /skills/uipath-maestro-flow/references/plugins/connector-trigger/ @baishalighosh @chandusailella @bai-uipath @rockymadden
 
+# Legacy RPA skill
+/skills/uipath-rpa-legacy/ @roalexandru
+
 # Diagnostics
 /skills/uipath-diagnostics/ @MarinRzv @dmorosanu @vladimir-cozma @costin-uipath @Stefan-Virgil

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -27,11 +27,30 @@ High-level view of what each specialist owns. **Do not describe internal flows o
 | Skill | What it owns | Handles auth? | Handles deploy? |
 |---|---|---|---|
 | `uipath-rpa` | RPA workflows (XAML and C# coded): create, edit, build, run, debug. Owns **all** UI automation authoring end-to-end. | No (relies on Studio) | **No** — defer to `uipath-platform` |
+| `uipath-rpa-legacy` | Legacy RPA workflows (.NET Framework 4.6.1, XAML only). **Existing legacy projects only** — never for new projects unless user explicitly requests legacy. | No | **No** — defer to `uipath-platform` |
 | `uipath-agents` | AI agents — code-based (LangGraph / LlamaIndex / OpenAI Agents) and low-code (`agent.json`) | Yes (`uip login`) | **Yes** — end-to-end |
 | `uipath-coded-apps` | Web apps (`.uipath/` dir): build, sync, package, publish, deploy | Yes (`uip login`) | **Yes** — end-to-end |
 | `uipath-maestro-flow` | `.flow` files orchestrating RPA, agents, apps | Yes (`uip login`) | **Partial** — Studio Web by default; `uipath-platform` for Orchestrator |
 | `uipath-platform` | Auth, Orchestrator resources, solution lifecycle (pack/publish/deploy), Integration Service, Test Manager | Yes (auth hub) | **Yes** — the deploy destination |
 | `uipath-servo` | Interact with live desktop/browser UI: click, type, screenshot, inspect. For app launching, ad-hoc exploration, post-build verification. Does NOT author workflows or generate selectors — that's `uipath-rpa`. | No auth | **No** |
+
+## RPA skill routing
+
+Two RPA skills exist. Pick the right one:
+
+| Signal | Route to |
+|---|---|
+| `project.json` has `"targetFramework": "Legacy"` or no `targetFramework` field | `uipath-rpa-legacy` |
+| `project.json` has any other `targetFramework` (e.g., `"Portable"`, `"Windows"`) | `uipath-rpa` |
+| No existing project + user explicitly asks for legacy | `uipath-rpa-legacy` |
+| No existing project + no legacy request | `uipath-rpa` (default for all new projects) |
+| macOS host | `uipath-rpa` — cross-platform target only (Windows target not available on macOS) |
+| Windows host | `uipath-rpa` — user can choose Windows or cross-platform target |
+
+**Rules:**
+1. Never suggest `uipath-rpa-legacy` for new projects unless the user explicitly requests legacy.
+2. On macOS, only cross-platform automation is supported — always route to `uipath-rpa`.
+3. On Windows, `uipath-rpa` supports both Windows and cross-platform targets.
 
 ## Step 1 — Upfront elicitation
 
@@ -101,7 +120,11 @@ Always use **VB.NET** for XAML workflows. Note this in the plan. Do not ask.
 
 ## Step 2 — Detect multi-skill tasks
 
-Emit a multi-skill plan when the request clearly spans more than one specialist. Known patterns:
+Emit a multi-skill plan when the request clearly spans more than one specialist.
+
+> **Legacy projects:** If the project is legacy (see "RPA skill routing" above), substitute `uipath-rpa-legacy` for `uipath-rpa` in the patterns below.
+
+Known patterns:
 
 ### RPA build + deploy to Orchestrator
 
@@ -168,16 +191,17 @@ User wants to build a UI automation AND observe it running on the live app.
 Probe the project context:
 
 ```bash
-echo "=== CWD ===" && ls -1 project.json *.cs *.xaml *.py pyproject.toml flow_files/*.flow .uipath/ app.config.json .venv/ 2>/dev/null; echo "=== PARENT ===" && ls -1 ../project.json ../*.cs ../*.xaml ../pyproject.toml 2>/dev/null; echo "=== DONE ==="
+echo "=== CWD ===" && ls -1 project.json *.cs *.xaml *.py pyproject.toml flow_files/*.flow .uipath/ app.config.json .venv/ 2>/dev/null; echo "=== PARENT ===" && ls -1 ../project.json ../*.cs ../*.xaml ../pyproject.toml 2>/dev/null; echo "=== FRAMEWORK ===" && cat project.json 2>/dev/null | grep -o '"targetFramework"[^,}]*' || echo "targetFramework: not found"; echo "=== DONE ==="
 ```
 
 | Filesystem signal | Plan skill |
 |---|---|
-| `.cs` AND/OR `.xaml` files AND `project.json` | `uipath-rpa` |
+| `.xaml` files + `project.json` with `targetFramework: "Legacy"` or absent | `uipath-rpa-legacy` |
+| `.xaml` AND/OR `.cs` files + `project.json` with any other `targetFramework` | `uipath-rpa` |
 | `flow_files/*.flow` | `uipath-maestro-flow` |
 | `.uipath/` or `app.config.json` | `uipath-coded-apps` |
 | `.venv/` AND `pyproject.toml` with uipath dependency | `uipath-agents` |
-| `project.json` only (no `.cs`/`.xaml`) | `uipath-rpa` (the skill detects project type internally) |
+| `project.json` only (no `.cs`/`.xaml`) | Check `targetFramework` — `"Legacy"` or absent → `uipath-rpa-legacy`; otherwise → `uipath-rpa` |
 
 **Multiple signals?** Go back to Step 2 and emit a multi-skill plan.
 
@@ -325,3 +349,4 @@ Save as `YYYY-MM-DD-<feature-name>.md`:
 13. **Do not leak internal jargon or implementation details into user-facing questions.** Never mention "Servo", "snapshot", "hand-wire", "AutomationId", "selector candidate", "autonomous capture", "target configuration", "wire up later", or other internal terms. Never expose the runtime / framework / language stack in option labels or descriptions: no "Python agent", "Coded web app", "React / Angular / Vue", "LangGraph / LlamaIndex". Use the product category instead — "AI Agent", "Application", "RPA workflow". Speak in plain developer language: "the live app", "Studio", "elements", "selectors", "inspect", "discover". Implementation details are the specialist skill's concern, not the user's.
 14. **Do not inject the user's domain or app name into the question text.** Ask "What kind of application are we automating?" — not "What kind of HR application…". "Is the app open on your machine?" — not "Is the HR app open…". The domain is captured in the plan header; keeping questions generic makes them reusable and prevents the agent from sounding like it's reading back a template.
 15. **Do not omit `Execution autonomy` from the plan header, and do not leave `Stop conditions` empty when autonomy is `autonomous`.** Downstream specialists rely on both to decide whether to interrupt. If the user did not answer the autonomy question, default to `autonomous` for simultaneous mode and note that choice in Decisions & Trade-offs. Populate Stop conditions with the hard blockers realistic for this specific plan (auth, app state, element-capture limits, missing resources) — do not leave a generic placeholder.
+16. **Do not route new projects to `uipath-rpa-legacy`.** Legacy is for existing .NET Framework 4.6.1 projects only. New projects always go to `uipath-rpa` unless the user explicitly asks for legacy.

--- a/skills/uipath-rpa-legacy/SKILL.md
+++ b/skills/uipath-rpa-legacy/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: uipath-rpa-legacy
+description: "[PREVIEW] Legacy UiPath RPA (.NET Framework 4.6.1, XAML) via uip rpa-legacy CLI. TRIGGER: project.json targetFramework 'Legacy' or absent; user mentions legacy. For Windows/cross-platform→uipath-rpa."
+---
+
+# Legacy RPA Workflow Architect
+
+Legacy UiPath RPA projects: .NET Framework 4.6.1, VB.NET expressions, classic activities (no "X" suffix). Uses `uip rpa-legacy` CLI (standalone, no Studio IPC needed).
+
+## Critical Rules
+
+1. **Discover before writing** — for built-in activities (If, Assign, TryCatch, LogMessage, etc.), use XAML from `_BUILT-IN-ACTIVITIES.md` directly. For all others, run `find-activities` + `type-definition` first.
+2. **Validate frequently** — for Sequences with well-known activities, write the full XAML then validate once. For Flowcharts/StateMachines/unfamiliar activities, validate after each addition. Always validate after edits to existing files.
+3. **Absolute paths only** — store `{projectRoot}` as an absolute path at Phase 0. Pass it to every CLI command. **Never use `cd`.**
+4. **Fix by category** — Package → Structure → Type → Properties → Logic. This order prevents cascading errors.
+5. **Activity docs for gotchas, CLI for precision** — read package docs (Excel.md, Mail.md) for gotchas before using those packages. Run `find-activities` only for activities not in `_BUILT-IN-ACTIVITIES.md`.
+6. **Always use `--output json`** — for any CLI output you need to parse. **Never suppress stderr** (`2>/dev/null`) — error details are in the JSON output.
+7. **Never guess enum values or property names** — always use `find-activities` + `type-definition`. CLI discovery is mandatory for valid XAML.
+8. **Never use modern assemblies** — use `assembly=mscorlib` (not `System.Private.CoreLib`). Use `[bracket]` expressions in VB.NET projects, `<mca:CSharpValue>` in C# projects.
+9. **Never generate Flowchart/StateMachine without ViewState** — Studio stacks all nodes at (0,0) without it.
+10. **Never retry failing CLI commands blindly** — diagnose the root cause before retrying.
+
+---
+
+## Request Router
+
+| Request | Action | Key Reference |
+|---------|--------|---------------|
+| Choose architecture | Sequence vs REFramework vs Dispatcher/Performer | [project-organization-guide.md](./references/project-organization-guide.md) |
+| Create workflow | Phase 0 → Discovery → Generate | [xaml-basics-and-rules.md](./references/xaml-basics-and-rules.md) |
+| Edit workflow | Phase 0 → Discovery → Edit | [xaml-basics-and-rules.md](./references/xaml-basics-and-rules.md) |
+| Validate file | `uip rpa-legacy validate "{projectRoot}/File.xaml" --output json` | [validation-and-fixing.md](./references/validation-and-fixing.md) |
+| Validate project | `uip rpa-legacy validate "{projectRoot}" --output json` | [validation-and-fixing.md](./references/validation-and-fixing.md) |
+| Package (optional) | `uip rpa-legacy package "{projectRoot}" -o "{dir}"` | [cli-reference.md](./references/cli-reference.md) |
+| Debug | `uip rpa-legacy debug "{projectRoot}/File.xaml"` | [cli-reference.md](./references/cli-reference.md) |
+| Create new project | Create project.json with right packages | [project-structure.md](./references/project-structure.md) |
+| Create test data | Generate Excel/CSV/JSON/types for testing | [test-data-guide.md](./references/test-data-guide.md) |
+| Organize project | Folder structure, naming, libraries | [project-organization-guide.md](./references/project-organization-guide.md) |
+| Add error handling | TryCatch, Retry Scope, exception classification | [error-handling-guide.md](./references/error-handling-guide.md) |
+| Fix/build selectors | Selector anatomy, dynamic selectors, anchors | [selector-guide.md](./references/selector-guide.md) |
+| Create tests | Test design, mock testing, verification | [testing-guide.md](./references/testing-guide.md) |
+
+If unclear which file to edit, **ask the user**.
+
+---
+
+## Phase 0: Environment
+
+1. Find `project.json` → establish `{projectRoot}` **as absolute path**
+2. Read `project.json` → verify `targetFramework: "Legacy"` (or absent = Legacy)
+3. Note `expressionLanguage` (VB.NET or C#)
+4. Note project shape: count `.xaml` files, list `dependencies` keys and versions — use this to avoid re-discovering packages and activities already explored earlier in conversation
+5. Run `uip rpa-legacy validate "{projectRoot}" --output json` to trigger **package restore** (required before `find-activities` works)
+
+No Studio needed. See [environment-setup.md](./references/environment-setup.md) for details.
+
+---
+
+## Phase 1: Discovery
+
+**Start with the minimum. Add more only as needed.**
+
+1. Read [_BUILT-IN-ACTIVITIES.md](./references/activity-docs/_BUILT-IN-ACTIVITIES.md) — complete XAML for If, Assign, Sequence, TryCatch, ForEach, While, Switch, Throw, LogMessage, InvokeCode, ForEachRow, etc. **No CLI calls needed for these.**
+
+2. Read [xaml-basics-and-rules.md](./references/xaml-basics-and-rules.md) — XAML structure, baseline assembly references, safety rules.
+
+3. **Only if you need non-built-in activities** (Excel, Mail, HTTP, PDF, etc.):
+   - Run `find-activities "{projectRoot}" --query "..." --output json` for each — use returned `XamlSnippet`
+   - Run `type-definition` for any enums in the results
+   - Read the relevant package doc ([Excel.md](./references/activity-docs/Excel.md), [Mail.md](./references/activity-docs/Mail.md), etc.) for gotchas
+
+4. **Only if Flowchart/StateMachine**: read [_XAML-GUIDE.md](./references/activity-docs/_XAML-GUIDE.md) for ViewState layout
+
+**Stop here.** Don't read more files unless you hit a problem during validation. Additional references if needed: [_PATTERNS.md](./references/activity-docs/_PATTERNS.md) (VB.NET expressions), [common-pitfalls.md](./references/common-pitfalls.md) (gotchas), [_INVOKE-CODE.md](./references/activity-docs/_INVOKE-CODE.md) (InvokeCode details), [_REFRAMEWORK.md](./references/activity-docs/_REFRAMEWORK.md) (REFramework), `uip docsai ask "..."` (official docs), `WebSearch` (community).
+
+5. **If the task involves design decisions**, read the relevant guide on demand:
+   - Error handling strategy → [error-handling-guide.md](./references/error-handling-guide.md)
+   - UI selectors → [selector-guide.md](./references/selector-guide.md)
+   - Project structure / libraries → [project-organization-guide.md](./references/project-organization-guide.md)
+   - Advanced data manipulation (RegEx, LINQ, JObject) → [data-manipulation-guide.md](./references/data-manipulation-guide.md)
+   - Orchestrator integration (queues, assets, triggers) → [orchestrator-guide.md](./references/orchestrator-guide.md)
+   - Test design / debugging → [testing-guide.md](./references/testing-guide.md)
+
+See [discovery-workflow.md](./references/discovery-workflow.md) for the full step-by-step procedure.
+
+---
+
+## Phase 2: Generate or Edit
+
+### Before Writing ANY XAML
+
+- [ ] Read relevant activity doc (behavioral context)
+- [ ] Run `find-activities` for every activity — use returned `XamlSnippet` + `XmlnsDeclaration` as starting point
+- [ ] Run `type-definition` for every enum/complex type (exact values)
+- [ ] Read [xaml-basics-and-rules.md](./references/xaml-basics-and-rules.md) for XAML structure
+- [ ] Read [common-pitfalls.md](./references/common-pitfalls.md) for gotchas
+
+### Choose Workflow Type
+
+| Pattern | Use When |
+|---------|----------|
+| **Sequence** | Linear step-by-step, no branching |
+| **Flowchart** | Branching decisions, loops with conditions, complex control flow |
+| **StateMachine** | Distinct states with transitions (REFramework, approval workflows) |
+
+### Flowchart/StateMachine: Plan Layout FIRST
+
+Before writing XAML for Flowchart or StateMachine:
+1. List all nodes and connections
+2. Assign coordinates per layout guide in [_XAML-GUIDE.md](./references/activity-docs/_XAML-GUIDE.md)
+3. Map True/False branch paths (Flowchart) or transition routes (StateMachine)
+
+**ViewState is MANDATORY** — without it, Studio stacks all nodes at (0,0).
+
+### CREATE Checklist
+
+- [ ] Root `<Activity>` has `mva:VisualBasic.Settings="{x:Null}"` (VB projects)
+- [ ] xmlns uses `assembly=mscorlib` (not `System.Private.CoreLib`)
+- [ ] VB.NET: `[bracket]` notation for expressions
+- [ ] Classic activity names (no "X" suffix)
+- [ ] All 16 baseline assembly references present (see [xaml-basics-and-rules.md](./references/xaml-basics-and-rules.md))
+- [ ] All 21 baseline namespace imports present
+- [ ] Package-specific assembly refs + namespace imports added for every activity package used
+- [ ] Flowchart/StateMachine: `xmlns:av` declared, ViewState on every node
+- [ ] Scope activities: `ActivityAction<T>` body pattern (see [common-pitfalls.md](./references/common-pitfalls.md))
+
+### EDIT Checklist
+
+- [ ] Read current XAML content before editing
+- [ ] Use `Edit` tool with exact `old_string` match
+- [ ] Flowchart/StateMachine: read existing ViewState positions, place new nodes with ≥110px vertical / ≥200px horizontal clearance
+- [ ] Validate after every edit
+
+---
+
+## Phase 3: Validate & Fix
+
+```
+LOOP (per-file during iteration):
+  validate "{projectRoot}/File.xaml" → 0 errors? → next activity
+                                     → errors?   → categorize → fix → validate again
+
+FINAL (before completing):
+  validate "{projectRoot}" → 0 errors across entire project? → DONE
+```
+
+**Fix order:** Package → Structure → Type → Properties → Logic
+
+| Category | Fix Strategy |
+|----------|-------------|
+| **Package** | Ask user to install in Studio (no CLI install command) |
+| **Structure** | Read XAML around error → Edit to fix XML |
+| **Type** | `type-definition` for exact enum/type values |
+| **Properties** | `find-activities --include-type-definitions` for exact property names |
+| **Logic** | Check expression language, consult `_PATTERNS.md`, use `debug` |
+
+When stuck: `docsai ask` → `WebSearch` → ask user.
+
+See [validation-and-fixing.md](./references/validation-and-fixing.md) for detailed procedures and common error scenarios.
+
+---
+
+## Phase 4: Debug
+
+**Only when the user asks to test/run the workflow.** Do not auto-trigger. Suggest it after completing validation: _"Would you like me to run the workflow to test it?"_
+
+**Always validate before debugging** — don't debug a file with compilation errors.
+
+```bash
+# Basic execution
+uip rpa-legacy debug "{projectRoot}/Main.xaml"
+
+# With input arguments
+uip rpa-legacy debug "{projectRoot}/Main.xaml" -i '{"in_FilePath": "C:\\data.xlsx", "in_Count": 5}'
+
+# Capture result to file
+uip rpa-legacy debug "{projectRoot}/Main.xaml" -i '{"in_FilePath": "C:\\data.xlsx"}' --result-path /tmp/result.json --log-level error
+```
+
+**Reading results:**
+- Exit code 0 → success: read `Data.Output` for out-argument values
+- Exit code 1 → failure: read `Data.Error` for diagnostics:
+  - `Error.ActivityDisplayName` + `Error.XamlFile` → locate the problem
+  - `Error.ExceptionType` + `Error.Message` → understand it
+  - `Error.StackTrace` → full call chain
+  - `Data.ErrorLog` → all error-level robot log entries for context
+
+**Fix-and-retry loop:** edit XAML → validate → debug again.
+
+See [cli-reference.md](./references/cli-reference.md) for all options.
+
+---
+
+## Phase 5: Response Checklist
+
+- [ ] File path of created/edited workflow
+- [ ] Brief description of what the workflow does
+- [ ] Key activities and logic
+- [ ] Packages required (note manual installs)
+- [ ] Per-file validation passed during development
+- [ ] Whole-project validation passed (`validate "{projectRoot}"`)
+- [ ] Limitations and next steps
+- [ ] Manual actions needed (package install, connection setup)
+
+---
+
+## Quick Reference
+
+### CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `uip rpa-legacy find-activities <path> --query "..." [--exact] --output json` | Find activities, class names, arguments, **XAML snippet, xmlns** |
+| `uip rpa-legacy type-definition <path> --type "..." --output json` | Inspect types, enum values, properties |
+| `uip rpa-legacy validate <file-or-project-path> --output json` | Validate single file or entire project |
+| `uip rpa-legacy find-package --query "..." --output json` | Search NuGet feeds for packages |
+| `uip rpa-legacy package <path> -o <dir>` | Package into .nupkg (optional) |
+| `uip rpa-legacy debug <xaml-path> -i '...'` | Execute via UiRobot |
+| `uip docsai ask "question" --output json` | Search UiPath documentation |
+
+Full reference: [cli-reference.md](./references/cli-reference.md)
+
+### Reference Files
+
+| File | Content |
+|------|---------|
+| [cli-reference.md](./references/cli-reference.md) | All CLI commands, parameters, error recovery |
+| [discovery-workflow.md](./references/discovery-workflow.md) | Detailed discovery steps, troubleshooting |
+| [environment-setup.md](./references/environment-setup.md) | Project root detection, legacy verification |
+| [project-structure.md](./references/project-structure.md) | Legacy project layout, project.json schema |
+| [xaml-basics-and-rules.md](./references/xaml-basics-and-rules.md) | XAML anatomy, expressions, safety rules |
+| [common-pitfalls.md](./references/common-pitfalls.md) | Dangerous defaults, scope patterns, gotchas |
+| [validation-and-fixing.md](./references/validation-and-fixing.md) | Validate & fix loop, error scenarios |
+| [test-data-guide.md](./references/test-data-guide.md) | Excel, CSV, JSON, top 10 file types and UiPath types |
+| [error-handling-guide.md](./references/error-handling-guide.md) | Exception classification, TryCatch patterns, Retry Scope, ContinueOnError |
+| [selector-guide.md](./references/selector-guide.md) | Selector anatomy, dynamic selectors, anchors, validation checklist |
+| [project-organization-guide.md](./references/project-organization-guide.md) | Folder conventions, naming, Config.xlsx, libraries, single responsibility |
+| [data-manipulation-guide.md](./references/data-manipulation-guide.md) | RegEx, advanced LINQ, JObject/JArray, StringBuilder, type conversions |
+| [orchestrator-guide.md](./references/orchestrator-guide.md) | Queue lifecycle, asset types, logging levels, triggers, environments |
+| [testing-guide.md](./references/testing-guide.md) | Test design, verification activities, mock testing, debugging strategy |
+
+### Activity Docs (`references/activity-docs/`)
+
+| File | Content |
+|------|---------|
+| `_BUILT-IN-ACTIVITIES.md` | **Top 20 activities with complete XAML — no find-activities needed** |
+| `_INDEX.md` | Master index with adoption rankings |
+| `_PATTERNS.md` | VB.NET cheat sheet, DataTable ops, error handling |
+| `_XAML-GUIDE.md` | XAML internals, Flowchart/StateMachine layout guides |
+| `_COMMON-PITFALLS.md` | Real-world gotchas by package |
+| `_INVOKE-CODE.md` | InvokeCode: properties, templates, compilation |
+| `_REFRAMEWORK.md` | REFramework template structure and customization |
+| `_DU-PROCESS.md` | Document Understanding pipeline template |
+| `AllActivities.md` | Complete legacy activity catalog |
+| `{Package}.md` | Per-package docs (Excel, Mail, System, UIAutomation, etc.) |
+

--- a/skills/uipath-rpa-legacy/references/activity-docs/ActiveDirectory.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/ActiveDirectory.md
@@ -1,0 +1,25 @@
+# UiPath Active Directory Activities - Legacy Reference
+
+## Overview
+Directory services integration for user/group management.
+
+---
+
+## STATUS: DEPRECATED
+
+**This package has moved to an external repository:**
+https://github.com/UiPath/it-automation
+
+No active development in the main Activities repository. Users should reference the external GitHub repository for current Active Directory activities.
+
+---
+
+## Historical Activities (before migration)
+- User management (Create, Modify, Delete, Get users)
+- Group management (Create, Add/Remove members)
+- OU management
+- Authentication/credential operations
+
+## Key Dependency
+- System.DirectoryServices / System.DirectoryServices.AccountManagement
+- LDAP connectivity to domain controller

--- a/skills/uipath-rpa-legacy/references/activity-docs/AllActivities.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/AllActivities.md
@@ -1,0 +1,1136 @@
+# UiPath Legacy Activities - Complete Catalog
+
+> **Scope**: Legacy/Classic XAML activities only. No modern "X" suffix, no portable, no coded workflows.
+
+---
+
+## 1. UiPath.System.Activities (v26.2.0) — 93.6% adoption
+
+### Workflow Control (Foundation)
+| Activity | Description |
+|----------|-------------|
+| `Assign` | Assigns a value to a variable or argument |
+| `Delay` | Pauses execution for specified TimeSpan |
+| `Log Message` | Writes message to Robot execution log (Trace/Info/Warn/Error/Fatal) |
+| `Message Box` | Displays message dialog to user |
+| `Comment Out` | Disables contained activities (design-time only) |
+| `Invoke Workflow File` | Invokes another .xaml workflow with input/output arguments |
+| `Invoke Process` | Invokes a published process/package |
+| `Invoke Code` | Executes inline VB.NET or C# code |
+| `Sequence` | Sequential container for activities |
+| `Flowchart` | Flow-based container with decision nodes |
+| `State Machine` | State-based workflow container |
+| `Try Catch` | Exception handling with catch blocks by exception type |
+| `Retry Scope` | Retries child activities on failure (configurable count/interval) |
+| `Throw` | Throws a specified exception |
+| `Rethrow` | Re-throws caught exception (inside Catch block) |
+| `For Each` | Iterates over collection items |
+| `For Each Row` | Iterates over DataTable rows |
+| `While` | Loops while condition is true |
+| `Do While` | Loops at least once, then while condition is true |
+| `Switch` | Multi-branch switch on expression value |
+| `If` | Conditional branch (Then/Else) |
+| `Break` | Exits innermost loop |
+| `Continue` | Skips to next iteration of loop |
+| `Parallel` | Executes branches in parallel |
+| `Parallel For Each` | Iterates collection with parallel execution |
+| `Pick` | Waits for one of multiple triggers, executes first |
+| `Pick Branch` | Individual branch inside Pick |
+| `Interruptible While` | While loop that can be interrupted by triggers |
+| `Terminate Workflow` | Terminates workflow execution |
+
+### Orchestrator - Assets & Credentials
+| Activity | Description |
+|----------|-------------|
+| `Get Asset` | Gets Orchestrator asset value (Text/Bool/Int/Credential) |
+| `Set Asset` | Sets Orchestrator asset value |
+| `Get Credential` | Gets username+password from Orchestrator Credential asset |
+| `Set Credential` | Sets Orchestrator Credential asset |
+
+### Orchestrator - Queues
+| Activity | Description |
+|----------|-------------|
+| `Add Queue Item` | Adds item to Orchestrator queue |
+| `Add Transaction Item` | Adds item and sets status to InProgress |
+| `Get Transaction Item` | Gets next available queue item for processing |
+| `Set Transaction Status` | Sets queue item status (Success/Failed/Abandoned) |
+| `Set Transaction Progress` | Updates progress info on transaction |
+| `Get Queue Items` | Retrieves queue items with filtering |
+| `Bulk Add Queue Items` | Adds DataTable rows to queue |
+| `Delete Queue Items` | Deletes items from queue |
+| `Postpone Transaction Item` | Defers transaction to later time |
+| `Wait Queue Item` | Waits for queue item status change |
+| `Queue Trigger` | Trigger that fires on new queue items |
+
+### Orchestrator - Jobs & Storage
+| Activity | Description |
+|----------|-------------|
+| `Start Job` | Starts a process job on Orchestrator |
+| `Stop Job` | Stops a running job |
+| `Get Jobs` | Lists jobs with filtering |
+| `Should Stop` | Checks if current job has been requested to stop |
+| `Upload Storage File` | Uploads file to Orchestrator Storage Bucket |
+| `Download Storage File` | Downloads file from Storage Bucket |
+| `Delete Storage File` | Deletes file from Storage Bucket |
+| `List Storage Files` | Lists files in Storage Bucket |
+| `Read Storage Text` | Reads text content from Storage Bucket |
+| `Write Storage Text` | Writes text content to Storage Bucket |
+| `Raise Alert` | Raises alert in Orchestrator |
+
+### Compression
+| Activity | Description |
+|----------|-------------|
+| `Compress/Zip Files` | Compresses files into ZIP archive |
+| `Extract/Unzip Files` | Extracts files from ZIP archive |
+
+### DataTable
+| Activity | Description |
+|----------|-------------|
+| `Build Data Table` | Creates DataTable with column definitions (wizard) |
+| `Add Data Row` | Adds row to DataTable |
+| `Remove Data Row` | Removes row from DataTable |
+| `Add Data Column` | Adds column to DataTable |
+| `Remove Data Column` | Removes column from DataTable |
+| `Clear Data Table` | Removes all rows from DataTable |
+| `Filter Data Table` | Filters DataTable by column conditions |
+| `Sort Data Table` | Sorts DataTable by column |
+| `Merge Data Table` | Merges two DataTables |
+| `Join Data Tables` | Joins two DataTables (Inner/Left/Full) |
+| `Lookup Data Table` | Looks up value in DataTable by key |
+| `Output Data Table` | Converts DataTable to formatted string |
+| `Generate Data Table` | Creates DataTable from structured text |
+| `Remove Duplicate Rows` | Removes duplicate rows from DataTable |
+| `For Each Row` | Iterates over DataTable rows |
+| `Get Row Item` | Gets cell value by column name/index |
+
+### Collections
+| Activity | Description |
+|----------|-------------|
+| `Append Item To List` | Appends an item to a List and returns the index |
+| `Create List` | Creates a new empty List of specified type |
+| `Read List Item` | Reads an item from a List at specified index |
+| `Update List Item` | Updates an item in a List at specified index |
+| `Append Item To Collection` | Appends one or more items to an ICollection |
+| `Build Collection` | Builds a new collection from individual items |
+| `Exists In Collection` | Checks if item exists in collection, returns bool and index |
+| `Filter Collection` | Filters a collection based on criteria |
+| `Remove From Collection` | Removes item(s) from collection by item, index, or all |
+| `Merge Collections` | Merges two collections into one |
+
+### Text Handling
+| Activity | Description |
+|----------|-------------|
+| `Change Case` | Changes text case (Lower, Upper, Sentence, Title) |
+| `Combine Text` | Concatenates text strings with separator |
+| `Extract Text` | Extracts text between strings, emails, URLs, or from HTML |
+| `Find And Replace` | Finds and replaces text in a string |
+| `Split Text` | Splits text by separator (comma, newline, space, tab, etc.) |
+| `Extract Date Time` | Parses date/time from text with culture support |
+
+### Date/Time
+| Activity | Description |
+|----------|-------------|
+| `Add Or Subtract From Date` | Adds/subtracts seconds/minutes/hours/days/weeks/months/years |
+| `Format Date As Text` | Formats DateTime to string with culture |
+| `Get Next Or Previous Date` | Gets next/previous occurrence of a day |
+
+### Dialog/Input
+| Activity | Description |
+|----------|-------------|
+| `Input Dialog` | Displays input dialog box, returns user-typed value |
+| `Custom Input` | Shows custom HTML form dialog, returns string result |
+| `Select File` | File picker dialog |
+| `Select Folder` | Folder picker dialog |
+| `Ask When Run` | Prompts user for a value at runtime |
+
+### File System
+| Activity | Description |
+|----------|-------------|
+| `Delete File` | Deletes a file from disk |
+| `File Exists` | Checks if file exists, returns bool |
+| `Get File Info` | Returns FileInfo for a file path |
+| `Delete Folder` | Deletes a folder from disk |
+| `Folder Exists` | Checks if folder exists, returns bool |
+| `Get Folder Info` | Returns folder information |
+| `Rename File` | Renames a file |
+| `Rename Folder` | Renames a folder |
+| `Copy Folder` | Copies a folder recursively |
+| `Move Folder` | Moves a folder |
+| `Get Last Downloaded File` | Monitors download folder for newest file |
+
+### Process/Code
+| Activity | Description |
+|----------|-------------|
+| `Execute PowerShell` | Executes PowerShell commands/scripts with parameters |
+| `Invoke Power Shell` | Alternative PowerShell invocation |
+| `Invoke VBScript` | Executes VBScript code |
+| `Invoke Code` | Executes inline VB.NET or C# code |
+| `Invoke COM Method` | Calls a method on a COM object by ProgID or CLSID |
+
+### Workflow Control
+| Activity | Description |
+|----------|-------------|
+| `Multiple Assign` | Assigns multiple variables in a single activity |
+| `If Else If` | Multi-branch conditional (if/else if/else) |
+
+### Credentials
+| Activity | Description |
+|----------|-------------|
+| `Get Username Password` | Gets credentials from Windows Credential Manager or Orchestrator |
+
+### Triggers
+| Activity | Description |
+|----------|-------------|
+| `Trigger Scope` | Container for event-driven triggers with scheduling modes |
+| `File Change Trigger` | Fires when file system changes detected |
+| `Process Start Trigger` | Fires when a process starts |
+| `Process End Trigger` | Fires when a process ends |
+| `Notify Global Variable Changed` | Notifies when global variable changes |
+
+### Regex
+| Activity | Description |
+|----------|-------------|
+| `Is Match` | Tests if string matches regex pattern |
+| `Matches` | Returns all regex matches from string |
+| `Replace` | Regex-based find and replace |
+
+---
+
+## 2. UiPath.UIAutomation.Activities (v26.1.0) — 92.6% adoption
+
+### Mouse
+| Activity | Description |
+|----------|-------------|
+| `Click` | Clicks UI element (single/double/down/up, left/right/middle) |
+| `Double Click` | Double-clicks a UI element |
+| `Hover` | Hovers mouse over a UI element |
+| `Click Image` | Clicks on image match found in UI |
+| `Hover Image` | Hovers over image match in UI |
+| `Click Text` | Clicks on OCR-recognized text in UI |
+| `Click OCR Text` | Clicks text found by OCR engine |
+| `Mouse Scroll` | Scrolls mouse wheel on element |
+
+### Keyboard
+| Activity | Description |
+|----------|-------------|
+| `Type Into` | Types text into a UI element with special key support |
+| `Type Secure Text` | Types SecureString into element (passwords) |
+| `Send Hotkey` | Sends keyboard shortcut (Ctrl+C, Alt+F4, etc.) |
+| `Set Text` | Sets text value of element via attribute |
+
+### Element Search
+| Activity | Description |
+|----------|-------------|
+| `Find Element` | Finds a UI element by selector, returns UiElement |
+| `Element Exists` | Checks if element exists, returns bool (no exception on timeout) |
+| `Find Children` | Finds child elements matching filter criteria |
+| `Find Relative Element` | Finds element at relative offset from target |
+| `Get Ancestor` | Navigates up N levels in element hierarchy |
+| `Wait Element Appear` | Waits until element appears (adaptive polling) |
+| `Wait Element Vanish` | Waits until element disappears |
+| `On Element Appear` | Trigger: fires when element appears |
+| `On Element Vanish` | Trigger: fires when element vanishes |
+| `Element Scope` | Container that finds element once for child activities |
+| `Indicate On Screen` | Highlights element for user to see |
+| `Find Image Matches` | Finds all occurrences of template image in screen |
+
+### Element Attributes
+| Activity | Description |
+|----------|-------------|
+| `Get Text` | Gets text content of UI element |
+| `Get Full Text` | Gets full text using FullText method |
+| `Get Visible Text` | Gets visible/rendered text using Native method |
+| `Get Value` | Gets value attribute of element |
+| `Set Value` | Sets value attribute of element |
+| `Get Attribute` | Gets any named attribute of element |
+| `Set Attribute` | Sets any named attribute of element |
+| `Select Item` | Selects item from dropdown/listbox by text |
+| `Select Multiple Items` | Selects multiple items from multi-select control |
+| `Check` | Checks/unchecks checkbox or radio button |
+| `Wait Attribute` | Waits until element attribute matches value (wildcards) |
+| `Get Position` | Gets element screen coordinates as Rectangle |
+
+### Actions
+| Activity | Description |
+|----------|-------------|
+| `Activate` | Brings window to foreground |
+| `Set Focus` | Sets keyboard focus to element |
+| `Highlight` | Draws colored box around element for debugging |
+| `Take Screenshot` | Captures element or region as Image |
+| `Save Image` | Saves Image object to file |
+| `Load Image` | Loads image from file |
+| `Set Clipping Region` | Sets visible region of element |
+| `Block User Input` | Blocks keyboard/mouse input during execution |
+
+### Clipboard
+| Activity | Description |
+|----------|-------------|
+| `Get From Clipboard` | Gets text from system clipboard |
+| `Set To Clipboard` | Sets text to system clipboard |
+| `Copy Selected Text` | Copies currently selected text (Ctrl+C) |
+
+### Data Scraping
+| Activity | Description |
+|----------|-------------|
+| `Extract Structured Data` | Scrapes structured/tabular data from UI into DataTable |
+| `Extract Data` | Legacy data extraction |
+
+### Window/Process
+| Activity | Description |
+|----------|-------------|
+| `Close Window` | Closes a window |
+| `Close Tab` | Closes a browser tab |
+| `Start Process` | Starts an executable |
+| `Get Active Window` | Gets the currently active/foreground window |
+
+### Scope Activities
+| Activity | Description |
+|----------|-------------|
+| `Open Browser` | Opens browser (IE/Chrome/Firefox/Edge) and provides scope |
+| `Open Application` | Launches application and provides window scope |
+| `Attach Browser` | Attaches to existing browser window |
+| `Attach Window` | Attaches to existing application window |
+| `Browser Scope` | Targets browser by selector or browser variable |
+| `Window Scope` | Targets window by selector or window variable |
+
+### OCR/Image
+| Activity | Description |
+|----------|-------------|
+| `Get OCR Text` | Extracts text from element using OCR engine |
+| `Find OCR Text Position` | Finds position of OCR text in element |
+| `Wait Image Appear` | Waits for image to appear on screen |
+| `Wait Image Vanish` | Waits for image to disappear |
+
+### SAP
+| Activity | Description |
+|----------|-------------|
+| `Click SAP` | Clicks SAP GUI element |
+| `Select SAP Item` | Selects item in SAP control |
+| `Expand Tree` | Expands SAP tree node |
+| `Collapse Tree` | Collapses SAP tree node |
+| `Select SAP Date` | Selects date in SAP calendar control |
+
+### Citrix
+| Activity | Description |
+|----------|-------------|
+| `Click Text` | Clicks OCR-recognized text (Citrix/RDP) |
+| `Type Into (image)` | Types into image-based target |
+
+---
+
+## 3. UiPath.Excel.Activities (v3.5.0) — 90.2% adoption
+
+### Scope
+| Activity | Description |
+|----------|-------------|
+| `Excel Application Scope` | Opens workbook via COM Interop, provides scope for child activities |
+
+### Interop Activities (require Excel Application Scope)
+| Activity | Description |
+|----------|-------------|
+| `Read Range` | Reads cell range into DataTable |
+| `Write Range` | Writes DataTable to cell range |
+| `Read Cell` | Reads single cell value |
+| `Write Cell` | Writes value to single cell |
+| `Read Cell Formula` | Gets formula text from cell |
+| `Read Row` | Reads entire row as IEnumerable |
+| `Read Column` | Reads entire column as IEnumerable |
+| `Append Range` | Appends DataTable after last row |
+| `Select Range` | Selects/highlights a cell range |
+| `Get Selected Range` | Returns currently selected range address |
+| `Get Table Range` | Gets range address of named table |
+| `Auto Fill Range` | Auto-fills pattern in range |
+| `Copy Paste Range` | Copies and pastes cell range |
+| `Create Table` | Creates formatted table from range |
+| `Create Pivot Table` | Creates pivot table from data |
+| `Refresh Pivot Table` | Refreshes pivot table data |
+| `Filter Table` | Applies filter to table |
+| `Sort Table` | Sorts table data |
+| `Delete Range` | Deletes cells in range |
+| `Delete Column` | Deletes column(s) |
+| `Insert Column` | Inserts column(s) |
+| `Insert/Delete Rows` | Inserts or deletes rows |
+| `Insert/Delete Columns` | Inserts or deletes columns |
+| `Remove Duplicates Range` | Removes duplicate rows from range |
+| `Lookup Range` | VLOOKUP-style lookup in range |
+| `Copy Sheet` | Copies worksheet within/between workbooks |
+| `Get Workbook Sheets` | Lists all sheet names |
+| `Get Cell Color` | Gets cell background color |
+| `Set Range Color` | Sets cell background color |
+| `Execute Macro` | Executes VBA macro by name |
+| `Invoke VBA` | Invokes VBA code from .bas file |
+
+### Portable Activities (no Excel required)
+| Activity | Description |
+|----------|-------------|
+| `Read Range (Workbook)` | Reads range from .xlsx file using ClosedXML |
+| `Write Range (Workbook)` | Writes to .xlsx file using ClosedXML |
+| `Read Cell (Workbook)` | Reads single cell from file |
+| `Write Cell (Workbook)` | Writes single cell to file |
+| `Read Cell Formula (Workbook)` | Gets formula from cell in file |
+| `Read Row (Workbook)` | Reads row from file |
+| `Read Column (Workbook)` | Reads column from file |
+| `Append Range (Workbook)` | Appends data to file |
+| `Create Table (Workbook)` | Creates table in file |
+| `Create Pivot Table (Workbook)` | Creates pivot table in file |
+| `Get Table Range (Workbook)` | Gets table range from file |
+| `Get Sheets (Workbook)` | Lists sheets in file |
+| `Set Range Color (Workbook)` | Sets cell color in file |
+| `Get Cell Color (Workbook)` | Gets cell color from file |
+| `Create New Workbook` | Creates new .xlsx file |
+
+### CSV Activities
+| Activity | Description |
+|----------|-------------|
+| `Read CSV` | Reads CSV file into DataTable |
+| `Write CSV` | Writes DataTable to CSV file |
+| `Append To CSV` | Appends DataTable rows to existing CSV |
+
+---
+
+## 4. UiPath.Mail.Activities (v2.8.0) — 77.7% adoption
+
+### SMTP
+| Activity | Description |
+|----------|-------------|
+| `Send SMTP Mail Message` | Sends email via SMTP with attachments, HTML body |
+
+### IMAP
+| Activity | Description |
+|----------|-------------|
+| `Get IMAP Mail Messages` | Retrieves emails from IMAP server with filtering |
+| `Delete IMAP Mail Message` | Deletes email from IMAP server |
+| `Move IMAP Mail Message` | Moves email between IMAP folders |
+
+### POP3
+| Activity | Description |
+|----------|-------------|
+| `Get POP3 Mail Messages` | Retrieves emails from POP3 server (inbox only) |
+
+### Exchange
+| Activity | Description |
+|----------|-------------|
+| `Send Exchange Mail Message` | Sends email via Exchange Web Services |
+| `Get Exchange Mail Messages` | Retrieves emails from Exchange with filtering |
+| `Delete Mail` | Deletes email from Exchange |
+| `Move Message To Folder` | Moves email between Exchange folders |
+| `Save Exchange Attachments` | Saves email attachments to disk |
+| `Exchange Scope` | Connection container for Exchange activities |
+
+### Outlook
+| Activity | Description |
+|----------|-------------|
+| `Send Outlook Mail Message` | Sends email via Outlook COM with importance/sensitivity |
+| `Get Outlook Mail Messages` | Retrieves emails from Outlook folders |
+| `Delete Outlook Mail Message` | Deletes Outlook email |
+| `Move Outlook Message` | Moves Outlook email between folders |
+| `Mark Outlook Mail As Read` | Toggles read/unread status |
+| `Reply To Outlook Mail Message` | Sends reply via Outlook |
+| `Save Attachments` | Saves Outlook email attachments |
+| `Save Outlook Mail Message` | Saves email as .msg file |
+| `Set Outlook Mail Categories` | Assigns categories/flags to email |
+| `Outlook Mail Message Trigger` | Trigger for incoming Outlook emails |
+
+### Lotus Notes
+| Activity | Description |
+|----------|-------------|
+| `Send Lotus Notes Mail Message` | Sends email via Lotus Notes COM |
+| `Get Lotus Notes Mail Messages` | Retrieves emails from Lotus Notes |
+| `Delete Lotus Notes Mail Message` | Deletes Lotus Notes email |
+| `Move Lotus Notes Mail Message` | Moves Lotus Notes email |
+
+---
+
+## 5. UiPath.Web.Activities (v2.4.0) — 33.9% adoption
+
+### HTTP
+| Activity | Description |
+|----------|-------------|
+| `HTTP Request` | Modern HTTP client with auth, retry, proxy, SSL config |
+| `HTTP Client` | Legacy REST client (RestSharp-based) with OAuth1 support |
+| `SOAP Request` | SOAP 1.1/1.2 web service client from WSDL |
+
+### JSON
+| Activity | Description |
+|----------|-------------|
+| `Deserialize JSON` | Parses JSON string to typed object |
+| `Deserialize JSON Array` | Parses JSON string to JArray |
+| `Serialize JSON` | Serializes object to JSON string |
+
+### XML
+| Activity | Description |
+|----------|-------------|
+| `Deserialize XML` | Parses XML string to XDocument |
+| `Get XML Nodes` | Extracts all nodes from XML document |
+| `Get Nodes` | Extracts root element's child nodes |
+| `Execute XPath` | Executes XPath query on XML document |
+| `Get XML Node Attributes` | Gets attributes from XML node |
+
+---
+
+## 6. UiPath.Database.Activities (v1.8.1) — 22.7% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Connect` | Opens ADO.NET database connection |
+| `Disconnect` | Closes database connection |
+| `Execute Query` | Runs SELECT SQL, returns DataTable |
+| `Execute Non Query` | Runs INSERT/UPDATE/DELETE, returns affected row count |
+| `Insert Data Table` | Inserts DataTable rows into database table |
+| `Bulk Insert` | High-performance bulk insert using SqlBulkCopy |
+| `Bulk Update` | Bulk update existing rows |
+| `Start Transaction` | Transaction scope with auto-commit/rollback |
+
+---
+
+## 7. UiPath.Credentials.Activities (v1.5.0) — 22.3% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Get Secure Credential` | Gets username + SecureString password from Windows Credential Manager |
+| `Get Credential` | Gets username + plain string password from Credential Manager |
+| `Add Credential` | Stores credential in Windows Credential Manager |
+| `Delete Credential` | Removes credential from Credential Manager |
+| `Request Credential` | Shows Windows credential prompt dialog |
+
+---
+
+## 8. UiPath.MicrosoftOffice365.Activities (v3.8.0) — 17.5% adoption
+
+### Scope
+| Activity | Description |
+|----------|-------------|
+| `Microsoft Office 365 Scope` | OAuth2 authentication container for all O365 activities |
+
+### Mail
+| Activity | Description |
+|----------|-------------|
+| `Send Mail` | Sends email via Microsoft Graph API |
+| `Delete Mail` | Deletes email |
+| `Forward Mail` | Forwards email |
+| `Reply To Mail` | Replies to email |
+| `Move Mail` | Moves email between folders |
+| `Set Mail Categories` | Assigns categories to email |
+
+### Calendar
+| Activity | Description |
+|----------|-------------|
+| `Create Event` | Creates calendar event with attendees |
+| `Modify Event` | Updates calendar event |
+| `Delete Event` | Deletes calendar event |
+| `Add Attendee` | Adds attendee to event |
+| `Add Location` | Adds location to event |
+| `Add Attachment` | Adds attachment to event |
+| `Search Events` | Queries calendar events |
+| `Get Calendars` | Lists available calendars |
+| `Find Meeting Times` | Finds optimal meeting times |
+| `RSVP` | Responds to meeting invitation |
+
+### Excel Online
+| Activity | Description |
+|----------|-------------|
+| `Read Range` | Reads from Excel Online worksheet |
+| `Write Range` | Writes to Excel Online worksheet |
+| `Read Cell` | Reads single cell from online workbook |
+| `Write Cell` | Writes single cell to online workbook |
+| `Read Row` | Reads row from online workbook |
+| `Read Column` | Reads column from online workbook |
+| `Append Range` | Appends data to online worksheet |
+| `Paste Range` | Pastes data with method (values/formulas) |
+| `Clear Range` | Clears range contents |
+| `Copy Range` | Copies range within workbook |
+| `Copy Sheet` | Copies worksheet |
+| `Delete Rows` | Deletes rows |
+| `Delete Column` | Deletes column |
+| `Insert Rows` | Inserts rows |
+| `Insert Column` | Inserts column |
+| `Create Table` | Creates formatted table |
+| `Get Table Range` | Gets table data range |
+| `Create Workbook` | Creates new online workbook |
+| `Delete Sheet` | Deletes worksheet |
+| `Rename Sheet` | Renames worksheet |
+| `Add Sheet` | Adds new worksheet |
+| `Get Sheets` | Lists worksheets |
+| `Get Cell Color` | Gets cell background color |
+| `Set Range Color` | Sets cell background color |
+| `VLookup Range` | VLOOKUP operation |
+
+### OneDrive/SharePoint
+| Activity | Description |
+|----------|-------------|
+| `Upload File` | Uploads file to OneDrive/SharePoint |
+| `Download File` | Downloads file from OneDrive/SharePoint |
+| `Delete Item` | Deletes file or folder |
+| `Create Folder` | Creates new folder |
+| `Find Files And Folders` | Searches by name or query |
+| `Get Item` | Gets file metadata |
+| `Copy Item` | Copies file or folder |
+| `Move Item` | Moves file or folder |
+| `Share Item` | Creates sharing link |
+| `Export As PDF` | Exports document to PDF |
+
+### SharePoint Lists
+| Activity | Description |
+|----------|-------------|
+| `Get List Info` | Gets list metadata |
+| `Get List Items` | Gets list items as DataTable |
+| `Add List Items` | Adds items to list |
+| `Update List Item` | Updates list item properties |
+| `Delete List Item` | Deletes list item |
+
+### Planner
+| Activity | Description |
+|----------|-------------|
+| `Create Plan` | Creates Planner plan |
+| `Get Plan` | Gets plan details |
+| `List Plans` | Lists group plans |
+| `Create Task` | Creates Planner task |
+| `Get Task` | Gets task details |
+| `List Tasks` | Lists tasks |
+| `Update Task` | Modifies task |
+| `Delete Task` | Deletes task |
+| `Create Bucket` | Creates bucket in plan |
+| `Delete Bucket` | Deletes bucket |
+| `List Buckets` | Lists buckets |
+
+### Groups
+| Activity | Description |
+|----------|-------------|
+| `Create Group` | Creates Microsoft 365 group |
+| `Delete Group` | Deletes group |
+| `Get Group` | Gets group details |
+| `List Groups` | Lists all groups |
+
+---
+
+## 9. UiPath.Testing.Activities (v25.10.0) — 16.1% adoption
+
+### Assertions
+| Activity | Description |
+|----------|-------------|
+| `Verify Expression` | Asserts boolean expression is true |
+| `Verify Expression With Operator` | Compares two values with operator (=, <>, >, <, Contains, RegexMatch) |
+| `Verify Range` | Verifies value is within or outside a numeric range |
+| `Verify Control Attribute` | Verifies output attribute of an activity |
+
+### Document Comparison
+| Activity | Description |
+|----------|-------------|
+| `Compare PDF Documents` | Compares two PDFs, generates visual diff |
+| `Compare Text` | Compares two strings, generates HTML diff report |
+| `Create Comparison Rule` | Creates regex/wildcard rule for ignoring dynamic content |
+
+### Test Data Queues
+| Activity | Description |
+|----------|-------------|
+| `Get Test Data Queue Item` | Gets next item from Orchestrator test data queue |
+| `Get Test Data Queue Items` | Batch retrieves items with filtering |
+| `Add Test Data Queue Item` | Adds item to test data queue |
+| `Bulk Add Test Data Queue` | Adds DataTable rows to queue |
+| `Delete Test Data Queue Items` | Deletes items from queue |
+
+### Test Data Generation
+| Activity | Description |
+|----------|-------------|
+| `Random String` | Generates random string (lower/upper/camel/mixed) |
+| `Random Number` | Generates random number in range with decimals |
+| `Random Date` | Generates random date in range |
+| `Random Value` | Selects random line from text file |
+| `Given Name` | Generates random first name |
+| `Last Name` | Generates random last name |
+| `Address` | Generates random address |
+
+### Other
+| Activity | Description |
+|----------|-------------|
+| `Attach Document` | Attaches file as test evidence in Orchestrator |
+
+---
+
+## 10. UiPath.PDF.Activities (v4.0.1) — 15.5% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Read PDF Text` | Extracts native text layer from PDF |
+| `Read PDF With OCR` | Extracts text from scanned PDF using OCR engine |
+| `Export PDF Page As Image` | Converts single PDF page to image (PNG/JPG/BMP/GIF/TIFF) |
+| `Extract Images From PDF` | Extracts all embedded images from PDF |
+| `Extract PDF Page Range` | Extracts page range into new PDF |
+| `Join PDF` | Merges multiple PDF files into one |
+| `Manage PDF Password` | Sets/removes user and owner passwords |
+| `Get PDF Page Count` | Returns number of pages in PDF |
+| `Convert Text To PDF` | Converts plain text to PDF |
+| `Convert HTML To PDF` | Converts HTML to PDF with headers/footers |
+| `Convert Email To PDF` | Converts MailMessage to PDF |
+| `Read XPS Text` | Extracts text from XPS document (desktop only) |
+| `Read XPS With OCR` | OCR text extraction from XPS (desktop only) |
+
+---
+
+## 11. UiPath.Word.Activities (v2.5.0) — 10.1% adoption
+
+### Scope
+| Activity | Description |
+|----------|-------------|
+| `Word Application Scope` | Opens Word document via COM, provides scope |
+
+### COM Activities (require Word Application Scope)
+| Activity | Description |
+|----------|-------------|
+| `Append Text` | Appends text to document with optional newline |
+| `Read Text` | Reads entire document text |
+| `Replace Text` | Finds and replaces text (max 256 chars) |
+| `Add Image` | Inserts image at position (relative to document/bookmark/text) |
+| `Insert Data Table` | Inserts DataTable as Word table |
+| `Insert Hyperlink` | Inserts clickable hyperlink |
+| `Set Bookmark Content` | Replaces bookmark text |
+| `Export To PDF` | Exports document as PDF |
+| `Save As` | Saves in different format (docx/docm/doc/html/rtf/txt) |
+| `Replace Picture` | Replaces image by alt text |
+| `Paste From Clipboard` | Pastes clipboard content at position |
+| `Get Sensitivity Label` | Gets document sensitivity/classification label |
+| `Add Sensitivity Label` | Sets document sensitivity label |
+
+### Portable Activities (no Word required, Xceed-based)
+| Activity | Description |
+|----------|-------------|
+| `Create New Document` | Creates blank .docx/.docm file |
+| `Read Text (Document)` | Reads entire document text without COM |
+| `Append Text (Document)` | Appends text to document |
+| `Replace Text (Document)` | Finds and replaces text |
+| `Add Image (Document)` | Inserts image at position |
+| `Insert Data Table (Document)` | Inserts DataTable as table |
+| `Insert Hyperlink (Document)` | Inserts hyperlink |
+| `Set Bookmark Content (Document)` | Replaces bookmark text |
+
+---
+
+## 12. UiPath.Terminal.Activities (v2.9.1) — 4.8% adoption
+
+### Session
+| Activity | Description |
+|----------|-------------|
+| `Terminal Session` | Connection scope for all terminal activities (3270/5250/VT) |
+
+### Basic Operations
+| Activity | Description |
+|----------|-------------|
+| `Get Text` | Gets full terminal screen text |
+| `Get Cursor Position` | Returns current cursor row/column (1-based) |
+| `Send Control Key` | Sends function/control key (F1-F24, Enter, Tab, PA1-3, etc.) |
+
+### Field-Based
+| Activity | Description |
+|----------|-------------|
+| `Get Field` | Gets field text by index, label, or following text |
+| `Set Field` | Sets field text by index, label, or following text |
+| `Wait Field Text` | Waits until field contains specified text |
+| `Wait Screen Text` | Waits until screen contains specified text |
+
+### Coordinate-Based
+| Activity | Description |
+|----------|-------------|
+| `Get Text At Position` | Gets text at row/column with optional length |
+| `Get Field At Position` | Gets field text at row/column |
+| `Set Field At Position` | Sets field at row/column |
+| `Get Screen Area` | Gets text from rectangular region |
+| `Get Color At Position` | Gets display color at row/column |
+| `Move Cursor` | Moves cursor to row/column |
+| `Move Cursor To Text` | Finds text and moves cursor to it |
+| `Find Text In Screen` | Searches screen for text, returns position |
+| `Wait Text At Position` | Waits for text at specific row/column |
+| `Wait Screen Ready` | Waits for terminal ready state |
+
+### Advanced
+| Activity | Description |
+|----------|-------------|
+| `Send Keys` | Sends text/key sequence to terminal |
+| `Send Keys Secure` | Sends SecureString to terminal (passwords) |
+
+---
+
+## 13. UiPath.FTP.Activities (v1.5.0) — 4.5% adoption
+
+### Scope
+| Activity | Description |
+|----------|-------------|
+| `FTP Session` (WithFtpSession) | Connection scope for FTP/FTPS/SFTP |
+
+### Operations
+| Activity | Description |
+|----------|-------------|
+| `Download Files` | Downloads files from FTP server |
+| `Upload Files` | Uploads files to FTP server |
+| `Delete` | Deletes remote file or folder |
+| `Move Item` | Moves/renames remote file |
+| `Directory Exists` | Checks if remote directory exists |
+| `File Exists` | Checks if remote file exists |
+| `Enumerate Objects` | Lists remote directory contents |
+
+---
+
+## 14. UiPath.GSuite.Activities (v3.8.0) — 3.9% adoption
+
+### Gmail
+| Activity | Description |
+|----------|-------------|
+| `Send Email` | Sends email via Gmail API |
+| `Get Email List` | Retrieves emails with filtering |
+| `Get Newest Email` | Gets latest unread email |
+| `Get Email By ID` | Retrieves specific email |
+| `Get Email Thread` | Gets entire email thread |
+| `Download Email` | Downloads email as attachment |
+| `Download Attachments` | Extracts email attachments |
+| `Reply To Email` | Sends reply |
+| `Forward Email` | Forwards email |
+| `Delete Email` | Permanently deletes email |
+| `Archive Email` | Archives email |
+| `Mark As Read/Unread` | Changes read status |
+| `Apply Email Labels` | Tags email with labels |
+| `Remove Email Labels` | Removes labels from email |
+| `Get Label` | Gets label details |
+| `Get Labels List` | Lists all labels |
+| `Turn On/Off Automatic Replies` | Out-of-office management |
+
+### Google Drive
+| Activity | Description |
+|----------|-------------|
+| `Get File List` | Lists files/folders with filtering |
+| `Upload Files` | Uploads files to Drive |
+| `Create Folder` | Creates new folder |
+| `Create Document` | Creates Google Doc |
+| `Create Spreadsheet` | Creates Google Sheet |
+| `Get File/Folder` | Gets item details |
+| `Download File` | Downloads file |
+| `Copy File` | Duplicates file |
+| `Rename File/Folder` | Renames item |
+| `Move File` | Moves to different folder |
+| `Delete File/Folder` | Deletes item |
+| `Share File/Folder` | Shares with users/groups |
+| `Get Permissions` | Lists sharing permissions |
+| `Update Permission` | Modifies access level |
+| `Delete Permission` | Removes sharing |
+
+### Google Sheets
+| Activity | Description |
+|----------|-------------|
+| `Read Range` | Reads range into DataTable |
+| `Write Range` | Writes DataTable to range |
+| `Read Cell` | Reads single cell |
+| `Write Cell` | Writes single cell |
+| `Read Row` | Reads entire row |
+| `Write Row` | Writes to row |
+| `Read Column` | Reads column |
+| `Write Column` | Writes to column |
+| `Get Cell Color` | Gets cell background color |
+| `Set Range Color` | Sets cell background color |
+| `Copy Paste Range` | Copies range |
+| `Auto Fill Range` | Auto-fills pattern |
+| `Delete Range` | Deletes range |
+| `Delete Rows` | Deletes rows |
+| `Delete Column` | Deletes column |
+| `Delete Sheet` | Deletes sheet |
+| `Add Sheet` | Adds new sheet |
+| `Rename Sheet` | Renames sheet |
+| `For Each Row` | Iterates rows |
+| `For Each Sheet` | Iterates sheets |
+
+### Google Docs
+| Activity | Description |
+|----------|-------------|
+| `Get Document` | Gets document structure |
+| `Read Text` | Reads document text |
+| `Write Text` | Inserts text |
+| `Find And Replace Text` | Find/replace with regex support |
+| `Delete Text` | Removes text |
+| `Insert Image` | Embeds image |
+| `Fill Template` | Template variable substitution |
+
+### Calendar
+| Activity | Description |
+|----------|-------------|
+| `Create Event` | Creates calendar event |
+| `Get Event List` | Lists events in date range |
+| `Get Event By ID` | Gets event details |
+| `Modify Event` | Updates event |
+| `Delete Event` | Removes event |
+| `RSVP` | Responds to invitation |
+| `Forward Event` | Shares event |
+| `Get Calendars` | Lists accessible calendars |
+
+### Tasks
+| Activity | Description |
+|----------|-------------|
+| `Create Task` | Creates task |
+| `Get Tasks` | Lists tasks |
+| `Update Task` | Modifies task |
+| `Complete Task` | Marks task complete |
+| `Delete Task` | Removes task |
+| `Create Task List` | Creates task list |
+| `Get Task Lists` | Lists task lists |
+| `Rename Task List` | Renames list |
+
+### Apps Script
+| Activity | Description |
+|----------|-------------|
+| `Run Script` | Executes Google Apps Script function |
+
+---
+
+## 15. UiPath.Cognitive.Activities (v1.8.0) — 3.8% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Google Text Analysis` | Sentiment/entity extraction via Google Cloud NLP |
+| `Google Text Translate` | Text translation via Google Translate |
+| `Microsoft Text Analysis` | Sentiment/key phrases via Azure Text Analytics |
+| `IBM Watson Text Analysis` | Text analysis via IBM Watson NLU |
+| `IBM Watson NLU Text Analysis` | Enhanced Watson NLU analysis |
+| `Stanford CoreNLP Text Analysis` | Local Stanford NLP analysis |
+| `Stanford CoreNLP Get Components` | Parsed component extraction |
+| `Stanford CoreNLP Get OpenIE` | Open Information Extraction triples |
+| `Stanford CoreNLP Get Sentence Sentiment` | Per-sentence sentiment |
+
+---
+
+## 16. UiPath.Presentations.Activities (v2.5.0) — 3.3% adoption
+
+### Scope
+| Activity | Description |
+|----------|-------------|
+| `PowerPoint Application Scope` | Opens presentation via COM, provides scope |
+
+### COM Activities (require scope)
+| Activity | Description |
+|----------|-------------|
+| `Insert Slide` | Inserts new slide (beginning/end/specific position) |
+| `Delete Slide` | Deletes slide at position |
+| `Copy Paste Slide` | Copies/moves slide between presentations |
+| `Insert Text` | Inserts text into shape on slide |
+| `Find And Replace Text` | Find/replace across presentation |
+| `Replace Shape With Data Table` | Replaces shape with DataTable as table |
+| `Replace Shape With Media` | Replaces shape with audio/video |
+| `Paste Into Slide` | Pastes clipboard content into slide |
+| `Insert File` | Embeds file as object in slide |
+| `Format Slide Content` | Modifies shape z-index, font size, name |
+| `Run Macro` | Executes VBA macro |
+| `Save As PDF` | Exports presentation as PDF |
+| `Save As` | Saves in different format (pptx/pptm/ppt) |
+| `Add Sensitivity Label` | Sets document sensitivity label |
+| `Get Sensitivity Label` | Gets document sensitivity label |
+
+### Portable (no PowerPoint required)
+| Activity | Description |
+|----------|-------------|
+| `Create New Presentation` | Creates blank .pptx file |
+| `Add Text To Slide` | Adds text to shape in slide |
+| `Insert Slide (Document)` | Inserts slide in file |
+| `Delete Slide (Document)` | Deletes slide from file |
+| `Find And Replace (Document)` | Find/replace in file |
+| `Replace Shape With Data Table (Document)` | Inserts table in file |
+| `Replace Shape With Media (Document)` | Inserts media in file |
+| `Format Slide Content (Document)` | Formats content in file |
+
+---
+
+## 17. UiPath.IntelligentOCR.Activities (v7.0.1) — 3.0% adoption
+
+### Digitization
+| Activity | Description |
+|----------|-------------|
+| `Digitize Document` | Converts document to DOM with OCR text extraction |
+| `Load Taxonomy` | Loads document taxonomy definition from file |
+
+### Classification
+| Activity | Description |
+|----------|-------------|
+| `Classify Document Scope` | Container for classification child activities |
+| `Intelligent Keyword Classifier` | Cloud keyword-vector classification |
+| `Keyword Based Classifier` | Local keyword classification (deprecated) |
+| `DU App Classifier` | ML-based classification via DU App |
+| `Present Classification Station` | Human validation UI for classification |
+
+### Extraction
+| Activity | Description |
+|----------|-------------|
+| `Data Extraction Scope` | Container for extraction child activities |
+| `DU App Extractor` | ML-based field extraction via DU App |
+| `Form Extractor` | Template-based position extraction |
+| `Intelligent Form Extractor` | Enhanced form extraction for handwriting |
+| `Regex Based Extractor` | Rule-based extraction with regex patterns |
+| `Export Extraction Results` | Converts ExtractionResult to DataSet |
+
+### Validation
+| Activity | Description |
+|----------|-------------|
+| `Present Validation Station` | Human validation UI for extraction results |
+
+### Training
+| Activity | Description |
+|----------|-------------|
+| `Train Classifiers Scope` | Container for training classifier children |
+| `Train Extractors Scope` | Container for training extractor children |
+| `Keyword Based Classifier Trainer` | Trains keyword classifier |
+| `Intelligent Keyword Classifier Trainer` | Trains vector keyword classifier |
+| `DU App Extractor Trainer` | Trains DU App extraction model |
+
+### Orchestrator / Redaction
+| Activity | Description |
+|----------|-------------|
+| `Create Document Validation Artifacts` | Uploads for external validation |
+| `Retrieve Document Validation Artifacts` | Downloads validated results |
+| `Redact Document` | Redacts sensitive data from documents |
+
+---
+
+## 18. UiPath.Form.Activities (v26.0.0) — 2.5% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Show Form` | Displays form (async or modal) with field bindings |
+| `Close Form` | Closes an open form |
+| `Hide Form` | Minimizes/hides form without closing |
+| `Bring Form To Front` | Restores hidden form |
+| `Get Form Fields` | Reads current field values from form |
+| `Set Form Fields` | Sets field values in form |
+| `Change Form Properties` | Modifies form size, position, title at runtime |
+| `Execute Script` | Runs JavaScript in form context |
+| `Form Trigger` | Listens for form events (click, change, message) |
+| `Show Callout` | Displays popup near UI element |
+
+---
+
+## 19. UiPath.Cryptography.Activities (v1.5.0) — 3.2% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Encrypt File` | Encrypts file with symmetric key (AES/DES/3DES/RC2/Rijndael) |
+| `Decrypt File` | Decrypts file with symmetric key |
+| `Encrypt Text` | Encrypts text string |
+| `Decrypt Text` | Decrypts text string |
+| `Keyed Hash File` | HMAC hash of file (SHA256/SHA384/SHA512/MD5) |
+| `Keyed Hash Text` | HMAC hash of text |
+| `PGP Sign File` | Signs file with PGP private key |
+| `PGP Clear Sign File` | Clear-signs file (readable + signature) |
+| `PGP Verify` | Verifies PGP signature |
+| `PGP Generate Key Pair` | Generates PGP public/private key pair |
+
+---
+
+## 20. UiPath.Python.Activities (v1.5.0) — 3.0% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Python Scope` | Initializes Python runtime (path, version, x86/x64) |
+| `Load Script` | Loads .py file as Python module |
+| `Run Script` | Executes Python code string |
+| `Invoke Method` | Calls method on Python object |
+| `Get Object` | Converts PythonObject to .NET type |
+
+---
+
+## 21. UiPath.OmniPage.Activities (v2.0.1) — 1.1% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `OmniPage OCR` | OCR text extraction using OmniPage engine (Language, Profile, DPI, Handwriting) |
+
+---
+
+## 22. UiPath.Java.Activities (v1.3.0) — <3% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Java Scope` | Initializes JVM (JRE/JDK path) |
+| `Load Jar` | Loads JAR file into classpath |
+| `Invoke Java Method` | Calls static or instance Java method |
+| `Create Java Object` | Instantiates Java class |
+| `Convert Java Object` | Converts JavaObject to .NET type |
+| `Get Java Field` | Reads field from Java object |
+
+---
+
+## 23. UiPath.SAP.BAPI.Activities (v2.2.2) — <3% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `SAP Application Scope` | SAP connection container (AppServer, SystemNumber, Client) |
+| `Open Connection` | Explicit connection establishment |
+| `Close Connection` | Connection cleanup |
+| `Invoke SAP BAPI` | Executes SAP BAPI/RFC function with dynamic parameters |
+
+---
+
+## 24. UiPath.Persistence.Activities (v1.4.0) — 1.1% adoption
+
+| Activity | Description |
+|----------|-------------|
+| `Create Form Task` | Creates human task in Action Center with form |
+| `Wait For Form Task And Resume` | SUSPENDS workflow until form completed |
+| `Create External Task` | Creates task for external system |
+| `Wait For External Task And Resume` | SUSPENDS until external completion |
+| `Create App Task` | Creates app-level task |
+| `Wait For App Task And Resume` | SUSPENDS until app task done |
+| `Start Job And Get Reference` | Starts job with tracking reference |
+| `Wait For Job And Resume` | SUSPENDS until job completes |
+| `Add Queue Item And Get Reference` | Adds queue item with reference |
+| `Wait For Queue Item And Resume` | SUSPENDS until queue item processed |
+| `Resume After Delay` | SUSPENDS for duration, releases robot |
+| `Assign Tasks` | Assigns tasks to users/groups |
+| `Complete Task` | Marks task finished |
+| `Forward Task` | Routes task to another user |
+| `Get Form Tasks` | Retrieves form tasks |
+| `Get Task Data` | Gets task details |
+| `Get App Tasks` | Retrieves app tasks |
+| `Add Task Comment` | Appends notes to task |
+| `Update Task Labels` | Modifies task tags |
+| `Configure Task Timer` | Sets time constraints |
+
+---
+
+## 25. Other UiPath Packages (< 2% adoption)
+
+### UiPath.Vision.Activities (v4.0.1)
+| Activity | Description |
+|----------|-------------|
+| `Microsoft OCR` | OCR via Azure Computer Vision |
+| `Google OCR` | OCR via Google Cloud Vision |
+| `ABBYY OCR` | OCR via local ABBYY FineReader |
+| `Tesseract OCR` | OCR via open-source Tesseract |
+
+### UiPath.ImageProcessing (v24.10.1)
+| Activity | Description |
+|----------|-------------|
+| `Find All` | Locates all template matches in image |
+| `Find First` | Locates first template match |
+| `Compare` | Computes image similarity score |
+| `Are Different` | Boolean image difference check |
+
+### UiPath.CommunicationsMining.Activities (v1.7.0)
+| Activity | Description |
+|----------|-------------|
+| `Create CM Validation Action` | Creates Action Center task for CM |
+| `Create CM Validation Artifacts` | Uploads training data |
+| `Retrieve CM Validation Artifacts` | Downloads validated data |
+| `Wait For CM Validation Action` | Waits for human review |
+
+### UiPath.WorkflowEvents.Activities (v3.33.0)
+| Activity | Description |
+|----------|-------------|
+| `App Request Trigger` | Listens for app workflow invocation requests |
+| `Handle App Request` | Executes and responds to request |
+| `Send Interim Result` | Pushes intermediate status |
+
+### UiPath.MobileAutomation.Activities (v25.10.0)
+| Activity | Description |
+|----------|-------------|
+| `Connect` | Connects to mobile device via Appium |
+| `Disconnect` | Disconnects from device |
+| `Get Devices` | Lists configured devices |
+| `Get Applications` | Lists configured apps |
+| *(UI actions via MobileTarget selectors)* | Tap, swipe, type, get text, etc. |
+
+### UiPath.ComplexScenarios (v1.5.2)
+| Activity | Description |
+|----------|-------------|
+| *(18 StudioX scenario templates)* | Pre-built file/email/Excel workflow patterns |

--- a/skills/uipath-rpa-legacy/references/activity-docs/Cognitive.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Cognitive.md
@@ -1,0 +1,32 @@
+# UiPath Cognitive Activities - Legacy Reference
+
+## Overview
+AI/ML text analysis and translation via cloud cognitive services. Package: `UiPath.Cognitive.Activities`.
+
+---
+
+## Activities
+
+| Activity | Service | Key I/O |
+|----------|---------|---------|
+| `GoogleTextAnalysis` | Google Cloud NLP | Text, Key -> Sentiment, Magnitude, Entities, KeyPhrases |
+| `GoogleTextTranslate` | Google Translate | Text, Key, SourceLanguage, TargetLanguage -> TranslatedText |
+| `MicrosoftTextAnalysis` | Azure Text Analytics | Text, Key -> Sentiment, KeyPhrases |
+| `IbmWatsonTextAnalysis` | IBM Watson NLU | Text, Key -> Sentiment, Entities |
+| `IbmWatsonNluTextAnalysis` | IBM Watson NLU v2 | Text, Key -> Detailed NLU analysis |
+| `StanfordCoreNlpTextAnalysis` | Stanford CoreNLP | Text -> Sentiment, Entities, Components |
+| `StanfordCoreNlpGetComponents` | Stanford CoreNLP | Text -> Parsed components |
+| `StanfordCoreNlpGetOpenIE` | Stanford CoreNLP | Text -> Open IE triples |
+| `StanfordCoreNlpGetSentenceSentiment` | Stanford CoreNLP | Text -> Per-sentence sentiment |
+
+---
+
+## Critical Gotchas
+
+1. **API keys required** for each cloud service (Google, Microsoft, IBM) - not bundled
+2. **Network connectivity mandatory** for all cloud services
+3. **Different result structures** per provider - not normalized
+4. **Legacy .NET 4.5.2 package** - consider modern AI activities for new projects
+5. **Stanford CoreNLP** can run locally (no API key needed) but requires Java runtime
+6. **Rate limiting** applies per cloud provider - handle 429 responses
+7. **Sentiment scores range differently**: Google (-1 to 1), Azure (0 to 1), Watson (varies)

--- a/skills/uipath-rpa-legacy/references/activity-docs/CommunicationsMining.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/CommunicationsMining.md
@@ -1,0 +1,28 @@
+# UiPath Communications Mining Activities - Legacy Reference
+
+## Overview
+Data validation workflows for Communications Mining AI engine (email/chat classification). Package: `UiPath.CommunicationsMining.Activities`.
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `CreateCommunicationsMiningValidationAction` | Create Action Center task | ActionTitle, ActionPriority, ActionCatalogue -> CreatedValidationAction |
+| `CreateCommunicationsMiningValidationArtifacts` | Upload training data | OrchestratorBucketFolderPath |
+| `RetrieveCommunicationsMiningValidationArtifacts` | Download validated data | ContentValidationData, RemoveDataFromStorage -> StreamResult |
+| `WaitForCommunicationsMiningValidationAction` | Wait for human review | (blocks until Action Center complete) |
+
+---
+
+## Critical Gotchas
+
+1. **Requires Communications Mining tenant/project setup** in UiPath platform
+2. **Action Center integration** for human-in-the-loop validation workflows
+3. **Bearer token authentication** for CM API calls
+4. **Cloud storage bucket path required** for artifact storage
+5. **Async operations** - must handle task lifecycle properly
+6. **Discovery client needs OAuth configuration** for API endpoints
+7. **Streaming predictions** via CM API client for real-time classification
+8. **Depends on**: UiPath.DocumentProcessing.Contracts, UiPath.DocumentUnderstanding.Persistence

--- a/skills/uipath-rpa-legacy/references/activity-docs/ComplexScenarios.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/ComplexScenarios.md
@@ -1,0 +1,74 @@
+# UiPath ComplexScenarios Activities - Legacy Reference
+
+## Overview
+Pre-built workflow scenario templates for common automation tasks (StudioX). Package: `UiPath.ComplexScenarios.Activities`. **#23 by adoption (3%)**.
+
+---
+
+## Scenario Categories
+
+### File/Folder Scenarios (7)
+| Scenario | Purpose | Requires |
+|----------|---------|----------|
+| `AddCurrentDateToFileAndMove` | Append date to filename, move to "Processed" | FileInfo + Excel workspace |
+| `AddCurrentDateToFilesInFolder` | Batch: date-stamp multiple files | IEnumerable\<FileInfo\> + workspace |
+| `CopyFileInfoToExcel` | Extract file metadata to Excel | FileInfo + workspace |
+| `DeleteFolder` | Delete folder recursively | (always available) |
+| `GroupByFileCreationDate` | Organize files by creation date | FileInfo + workspace |
+| `GroupByFileSize` | Organize files by size | FileInfo + workspace |
+| `GroupByFileType` | Organize files by extension | FileInfo + workspace |
+
+### Email Scenarios (8)
+| Scenario | Purpose | Requires |
+|----------|---------|----------|
+| `CopyEmailsToExcel` | Extract inbox to Excel (From, To, Subject, CC, Bcc, Body) | IMailQuickHandle + workspace |
+| `CreateContactsDatabase` | Extract unique sender addresses | IMailQuickHandle + workspace |
+| `DownloadEmailAttachments` | Save all attachments from inbox | IMailQuickHandle |
+| `EmailFilesInFolder` | Send folder contents as attachments | IMailQuickHandle |
+| `EmailFolderBackup` | Backup email folder | IMailQuickHandle |
+| `ForwardEmail` | Forward messages | IMailQuickHandle |
+| `MoveMail` | Move to another folder | IMailQuickHandle |
+| `ReplyToEmail` | Reply to messages | IMailQuickHandle |
+
+### Excel/Office Scenarios (3)
+| Scenario | Purpose | Requires |
+|----------|---------|----------|
+| `FillFormFromExcel` | Read Excel data, fill forms | Workspace |
+| `MergeRanges` | Merge Excel ranges | Workspace |
+| `PasteExcelChartIntoPowerPoint` | Copy chart to PowerPoint slide | IPresentationQuickHandle + workspace |
+
+---
+
+## Architecture
+
+Three base class variants determine when scenarios appear:
+- **DefaultScenarioDefinition** - Always shown (e.g., DeleteFolder)
+- **ExtendedScenarioDefinition\<T\>** - Shown when argument type T matched, workspace optional
+- **WorkspaceScenarioDefinition\<T\>** - Shown when argument type T matched AND Excel workspace available
+
+---
+
+## Critical Gotchas
+
+### Visibility/Matching
+1. **Scenarios only appear when argument types match exactly** - `IMailQuickHandle` vs generic mail interfaces must match precisely
+2. **WorkspaceScenario variants require open Excel workspace** - silently hidden if no Excel file open
+3. **Type metadata matching** checks `TypesMetadata.WorkspaceWorkbookMetadata` - not just any IWorkbook
+
+### Email Scenarios
+4. **CopyEmailsToExcel uses scratchpad cells A1:F1** for temporary data before appending - cells must be managed between iterations
+5. **CreateContactsDatabase deduplicates with DeleteRowsOption.Duplicates** - order may be affected
+6. **EmailFilesInFolder has hardcoded Subject="Requested Files" and Body="See Attachments"** - cannot customize
+7. **OutlookForEachMail vs ForEachEmailX** used inconsistently across scenarios - different property names
+
+### File Scenarios
+8. **Folder selection via UI dialog** (`IoSystemHelpers.TryGetSelectedFolderPathExpression()`) - returns false if user cancels, producing NO activities (silent failure)
+9. **File metadata extraction**: Folder returns parent directory only, not full path; date format follows system locale
+
+### Office Scenarios
+10. **PasteExcelChartIntoPowerPoint uses clipboard** (Windows-specific) - requires active Excel and PowerPoint instances
+11. **Scenario explicitly excluded from some builds** - check build .targets for availability
+
+### General
+12. **Expression language dependency** - scenario builders generate VB or C# expressions based on project language; manual edits must match
+13. **These are StudioX design-time scenarios** - not runtime activities you add to XAML directly

--- a/skills/uipath-rpa-legacy/references/activity-docs/Credentials.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Credentials.md
@@ -1,0 +1,45 @@
+# UiPath Credentials Activities - Community Reference
+
+## Overview
+Windows Credential Manager integration for storing/retrieving credentials. Package: `UiPath.Credentials.Activities` (from Community.Activities repo).
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `GetSecureCredential` | Get credential (SecureString password) | Target (required), CredentialType, PersistanceType -> Username (string), Password (SecureString) |
+| `GetCredential` | Get credential (plain string password) | Target (required), CredentialType, PersistanceType -> Username, Password (string) |
+| `AddCredential` | Store new credential | Target (required), Username, Password/SecurePassword, CredentialType, PersistanceType |
+| `DeleteCredential` | Remove stored credential | Target (required), CredentialType, PersistanceType |
+| `RequestCredential` | Prompt user for credentials | Target -> Username, Password/SecurePassword |
+
+---
+
+## Enums
+
+### CredentialType
+- `Generic` (default) - Generic credential
+- `DomainPassword` - Domain/Windows credential
+- `DomainCertificate` - Certificate-based
+
+### PersistanceType (note spelling)
+- `Session` - Current login session only
+- `LocalComputer` - Machine-level persistence
+- `Enterprise` (default) - Domain/roaming profile
+
+---
+
+## Critical Gotchas
+
+1. **GetSecureCredential preferred over GetCredential** - returns SecureString instead of plain text password
+2. **Target is the credential name/key** in Windows Credential Manager - must match exactly
+3. **PersistanceType spelled "Persistance"** (typo in codebase, not "Persistence") - use as-is
+4. **Enterprise persistence** roams with domain profile - available on any domain-joined machine
+5. **Session persistence** lost on logout - temporary storage only
+6. **RequestCredential shows Windows credential dialog** - blocks workflow until user responds
+7. **Windows Credential Manager only** - not cross-platform (Windows desktop only)
+8. **GetCredential returns Result (bool)** - true if credential found, false if not
+9. **DeleteCredential silently succeeds** if credential doesn't exist
+10. **Credential names are case-insensitive** in Windows Credential Manager

--- a/skills/uipath-rpa-legacy/references/activity-docs/Cryptography.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Cryptography.md
@@ -1,0 +1,82 @@
+# UiPath Cryptography Activities - Community Reference
+
+## Overview
+Encryption, decryption, hashing, and PGP operations. Package: `UiPath.Cryptography.Activities` (from Community.Activities repo).
+
+---
+
+## Activities
+
+### Symmetric Encryption
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `EncryptFile` | Encrypt file with symmetric key | InputFilePath, OutputFilePath, Key/SecureKey, Algorithm, Encoding (default UTF-8) |
+| `DecryptFile` | Decrypt file with symmetric key | InputFilePath, OutputFilePath, Key/SecureKey, Algorithm, Encoding |
+| `EncryptText` | Encrypt text string | Input (string), Key/SecureKey, Algorithm, Encoding -> Result (string) |
+| `DecryptText` | Decrypt text string | Input (string), Key/SecureKey, Algorithm, Encoding -> Result (string) |
+
+### Hashing (HMAC)
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `KeyedHashFile` | HMAC hash of file | InputFilePath, Key/SecureKey, Algorithm, Encoding -> Result (string, hex) |
+| `KeyedHashText` | HMAC hash of text | Input (string), Key/SecureKey, Algorithm, Encoding -> Result (string, hex) |
+
+### PGP (Pretty Good Privacy)
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `PgpSignFile` | Sign file with PGP private key | InputFilePath, OutputFilePath, PrivateKeyFilePath, PrivateKeyPassphrase, Armor |
+| `PgpClearSignFile` | Clear-sign file (readable + signature) | InputFilePath, OutputFilePath, PrivateKeyFilePath, PrivateKeyPassphrase |
+| `PgpVerify` | Verify PGP signature | InputFilePath, PublicKeyFilePath -> IsAuthentic (bool) |
+| `PgpGenerateKeyPair` | Generate PGP key pair | Identity, Passphrase, PublicKeyFilePath, PrivateKeyFilePath, KeyLength, ExpirationDate |
+
+---
+
+## Encryption Algorithms
+- AES (default, recommended)
+- DES (legacy, weak)
+- RC2 (legacy)
+- Rijndael (AES variant)
+- TripleDES (3DES, legacy)
+
+## Hash Algorithms (for HMAC)
+- HMACSHA256 (default, recommended)
+- HMACSHA384
+- HMACSHA512
+- HMACMD5 (weak, avoid)
+- HMACRIPEMD160
+
+---
+
+## Critical Gotchas
+
+### Key Management
+1. **Key/SecureKey are overload groups** - provide one or the other, not both
+2. **SecureKey (SecureString) recommended** over plaintext Key for security
+3. **Key is used as password for key derivation** - not used directly as encryption key
+4. **Encoding must match between encrypt and decrypt** - default UTF-8
+
+### Algorithm Selection
+5. **Use AES** for new implementations - DES/RC2/3DES are legacy and weak
+6. **DES key is only 56 bits** - trivially breakable by modern standards
+7. **AES-256 is the default** and recommended choice
+
+### File Operations
+8. **InputFilePath and OutputFilePath cannot be the same** for file encryption/decryption
+9. **Output file is overwritten** if it exists
+10. **Large files processed in memory** - may cause OutOfMemoryException for very large files
+
+### PGP
+11. **PGP key files must be in standard OpenPGP format** (.asc for ASCII-armored, .pgp/.gpg for binary)
+12. **Armor=true produces ASCII output** (text-safe); false produces binary
+13. **PgpVerify returns IsAuthentic=false** (not exception) for invalid signatures
+14. **PgpGenerateKeyPair KeyLength** options: 1024 (weak), 2048 (minimum), 4096 (recommended)
+15. **ExpirationDate** - null means key never expires
+
+### Hashing
+16. **Hash results are hex-encoded strings** (lowercase)
+17. **HMAC requires a key** - unlike simple hashing, HMAC provides authentication
+18. **HMACMD5 is cryptographically weak** - use HMACSHA256+ for security
+
+### Encoding
+19. **Encoding parameter** defaults to UTF-8 but must match across encrypt/decrypt
+20. **Binary files should use appropriate encoding** or base64 wrapper

--- a/skills/uipath-rpa-legacy/references/activity-docs/Database.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Database.md
@@ -1,0 +1,79 @@
+# UiPath Database Activities - Community Reference
+
+## Overview
+Database integration via ADO.NET providers. Supports any database with a .NET data provider (SQL Server, Oracle, MySQL, PostgreSQL, SQLite, ODBC, OleDB). Package: `UiPath.Database.Activities` (from Community.Activities repo).
+
+---
+
+## Activities
+
+### Connection Management
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `DatabaseConnect` | Open database connection | ProviderName (required), ConnectionString OR ConnectionSecureString (overload groups), Output: DatabaseConnection |
+| `DatabaseDisconnect` | Close connection | DatabaseConnection |
+| `DatabaseTransaction` | Transaction scope with auto-commit/rollback | ProviderName, ConnectionString, ExistingDbConnection, UseTransaction (default true), Body (child activities) |
+
+### Query Execution
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `ExecuteQuery` | Run SELECT statements | Sql (required), CommandType (Text/StoredProcedure/TableDirect), Parameters, TimeoutMS, Output: DataTable |
+| `ExecuteNonQuery` | Run INSERT/UPDATE/DELETE | Sql (required), CommandType, Parameters, TimeoutMS, Output: AffectedRecords (int) |
+
+### Data Operations
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `InsertDataTable` | Insert DataTable rows into table | TableName (required), DataTable (required), Output: AffectedRecords (int) |
+| `BulkInsert` | High-performance bulk insert | TableName (required), DataTable (required), Output: AffectedRecords (long) |
+| `BulkUpdate` | Bulk update existing rows | TableName, DataTable, ColumnNames |
+
+### Common Properties (inherited from DatabaseExecute/DatabaseRowActivity)
+- `ExistingDbConnection` (DatabaseConnection) - Reuse existing connection
+- `ConnectionString` (string) OR `ConnectionSecureString` (SecureString) - New connection
+- `ProviderName` (string) - ADO.NET provider (e.g., "System.Data.SqlClient", "Oracle.ManagedDataAccess.Client")
+- `ContinueOnError` (bool) - Suppress exceptions
+- `TimeoutMS` (int) - Command timeout in milliseconds
+- `Parameters` (Dictionary<string, Argument>) - SQL parameters with direction support
+
+---
+
+## Critical Gotchas
+
+### Connection Management
+1. **If ExistingDbConnection is null, a new connection is created and disposed per activity** - each activity opens/closes its own connection unless you pass ExistingDbConnection
+2. **ConnectionString OR ConnectionSecureString** - overload groups, cannot provide both
+3. **ProviderName is REQUIRED** for new connections - must match installed ADO.NET provider exactly
+4. **ConnectionValidation** checks: either ExistingDbConnection OR (ConnectionString + ProviderName) must be provided
+
+### SQL Injection Risk
+5. **Use Parameters dictionary for parameterized queries** - never concatenate user input into Sql string
+6. **Parameters support direction** (In/Out/InOut) - useful for stored procedures with output parameters
+7. **Parameter type inferred from ArgumentType** at runtime
+
+### Timeout
+8. **TimeoutMS must be >= 0** - negative values throw ArgumentException
+9. **TimeoutMS is COMMAND timeout** (not connection timeout) - affects query execution time
+10. **Default is 0** (which means provider default, typically 30 seconds for SQL Server)
+
+### Transaction Handling
+11. **DatabaseTransaction UseTransaction=true (default)** - wraps Body in transaction
+12. **Auto-rollback on exception** - if Body throws, transaction rolls back
+13. **Auto-commit on success** - if Body completes, transaction commits
+14. **DatabaseTransaction is hidden in NETSTANDARD** builds (`[Browsable(false)]`)
+
+### BulkInsert
+15. **BulkInsert returns long** (not int) - for large datasets
+16. **BulkInsert uses SqlBulkCopy** internally for SQL Server - much faster than InsertDataTable
+17. **BulkInsert supports logging** via IExecutorRuntime if available
+
+### Data Type Mapping
+18. **DataTable column types must match database column types** - type mismatch causes runtime errors
+19. **NULL handling** - DBNull.Value vs null in DataTable cells
+20. **InsertDataTable uses SqlDataAdapter** internally - generates INSERT statements per row (slower than BulkInsert)
+
+### Provider-Specific Issues
+21. **Oracle requires Oracle.ManagedDataAccess.Client** provider (or legacy Oracle.DataAccess.Client)
+22. **MySQL requires MySql.Data.MySqlClient** (or MySqlConnector)
+23. **PostgreSQL requires Npgsql** provider
+24. **ODBC/OleDB** work but with limited parameter support
+25. **Provider DLLs must be accessible** to the UiPath Robot process at runtime

--- a/skills/uipath-rpa-legacy/references/activity-docs/Excel.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Excel.md
@@ -1,0 +1,101 @@
+# UiPath Excel Activities - Legacy Reference
+
+## Overview
+Excel automation with three access modes: Portable (file-based, no Excel required), Interop (COM, requires Excel), and Modern StudioX. Package: `UiPath.Excel.Activities`.
+
+---
+
+## Fundamental Split: Portable vs Interop vs Modern
+
+| Aspect | Portable (WorkbookFile) | Interop (ExcelApplicationScope) | Modern (ExcelProcessScopeX) |
+|--------|------------------------|---------------------------------|-----------------------------|
+| Excel Required | NO | YES | YES |
+| Library | ClosedXML / NPOI | COM Interop | COM + IExcelProcess |
+| File Lock | None | Full (locked) | Full |
+| Macros | NO | YES | YES |
+| Formatting | Limited | Full | Full |
+| Performance | Fast (no UI) | Slower (COM overhead) | Configurable |
+| Scope Needed | None (standalone) | ExcelApplicationScope | ExcelProcessScopeX + ExcelApplicationCard |
+
+**CRITICAL: Cannot mix patterns in same workflow**
+
+**CRITICAL: Scope activities require `ActivityAction<T>` body** — you cannot place child activities directly inside `ExcelApplicationScope`, `ExcelProcessScopeX`, or `ExcelApplicationCard`. Each requires a `.Body` property containing `ActivityAction` with a `DelegateInArgument`. See [common-pitfalls.md](../common-pitfalls.md#scope-activities-require-activityaction-body-critical-for-xaml-generation) for the complete XAML template and all scope body patterns.
+
+---
+
+## Key Activities
+
+### Portable (No Excel)
+ReadRange, ReadCell, ReadCellFormula, ReadRow, ReadColumn, WriteRange, WriteCell, AppendRange, CreateTable, CreatePivotTable, GetTableRange, GetSheets, SetRangeColor, GetCellColor, CreateNewWorkbook
+
+### CSV (Portable)
+ReadCsvFile, WriteCsvFile, AppendCsvFile - DelimitatorOptions: Comma, Semicolon, Pipe, Caret, Tab
+
+### Interop (ExcelApplicationScope children)
+ExcelReadRange, ExcelWriteCell, ExcelWriteRange, ExcelAppendRange, ExcelSelectRange, ExcelAutoFillRange, ExcelCopyPasteRange, ExcelCreateTable, ExcelFilterTable, ExcelSortTable, ExcelDeleteRange, ExcelInsertColumn, ExcelDeleteColumn, ExcelRemoveDuplicatesRange, ExcelLookUpRange, ExcelCopySheet, ExecuteMacro, InvokeVBA
+
+### Modern StudioX (ExcelApplicationCard children)
+ReadRangeX, WriteCellX, WriteRangeX, AppendRangeX, SelectRangeX, ClearRangeX, CreateTableX, SortX, FilterX, DeleteRowsX, InsertRowsX, VLookupX, SaveExcelFileX, SaveAsPdfX, FormatRangeX, ExecuteMacroX, InvokeVBAX
+
+---
+
+## Critical Gotchas
+
+### COM Object Cleanup
+1. **Zombie Excel processes** - All COM objects must be explicitly released via `Marshal.ReleaseComObject()` or `DisposeWithReleaseComObject()` extension
+2. **If body activity crashes, Excel process may remain open**
+3. **InstanceCachePeriod (default 3000ms)** - Time Excel instance stays cached between activities
+
+### Range Handling
+4. **Single cell "A1" in ReadRangeX extends to entire sheet** - `extendSingleCellRanges: true` by default reads ALL data from A1 onward
+5. **Multi-area ranges NOT supported** - `"A1:B10,D1:E10"` throws InvalidRange
+6. **Full row**: `"1:5"`, Full column: `"A:C"`
+
+### Sheet Names
+7. **Sheet name is REQUIRED** and default is "Sheet1"
+8. **Invalid chars**: `[ ] * ? : / \` - throws validation error
+9. **Max 31 characters** per Excel spec
+10. **Case sensitivity varies** - File-based: insensitive, Interop: can be sensitive
+
+### Data Type Coercion (ExcelValue)
+11. **Empty cell returns null** (not empty string)
+12. **Dates stored as doubles** (serial numbers since 1900) - region-dependent
+13. **DateTime conversion depends on system locale**
+14. **OriginalValue vs OriginalDisplayValue** - raw (15) vs formatted ($15.00)
+
+### Password Protection
+15. **Two password types**: Password (read protection) vs EditPassword (write-reserved)
+16. **Cannot set both Password and SecurePassword** simultaneously
+
+### Workbook Scope
+17. **AutoSave=true (default)** can corrupt file if not closed properly
+18. **.xls files cannot use ClosedXML** - handled by NPOI in Portable mode or COM Interop. Legacy `WithWorkbook`/`OpenWorkbook` force Interop for .xls; modern Portable path uses NPOI instead.
+19. **ReadOnly mode** - AutoSave disabled automatically
+
+### CSV Quirks
+20. **DelimitatorOptions** (note spelling "Delimitator" not "Delimiter")
+21. **IgnoreQuotes option** - when true, parser doesn't treat quotes as field delimiters
+22. **Default encoding is system encoding** - specify "UTF-8" explicitly for portability
+
+### Macro/VBA
+23. **MacroSetting must be EnableAll** or macros won't run
+24. **InvokeVBA .bas file must be VB6 compatible** - injected into workbook VBProject at runtime
+25. **Macro parameters are object[]** - order matters, complex types may not serialize
+
+### File Conflicts
+26. **FileConflictResolution**: Overwrite (close without saving), UseExisting, SaveAndReplace, Throw
+27. **Default behavior depends on ExistingProcessAction** - can silently drop changes
+
+### Deprecated Activities
+- OpenWorkbook, CloseWorkbook, WithWorkbook (legacy)
+- ExcelForEachRow v1 (use ExcelForEachRowX)
+- CreatePivotTableX v1 (use v2)
+
+### Additional Validated Gotchas
+27. **Single cell "A1" extends ONLY when no colon** - "A1" expands to full used range, but "A1:A1" does NOT expand (treated as explicit range)
+28. **ForEachRowX disables AutoSave during iteration** then re-enables; crash mid-iteration may leave AutoSave disabled
+29. **.xlsb (binary workbook) not supported in Portable mode** - always requires Interop
+30. **ClosedXML formula evaluation is limited** - unsupported formulas fall back to cached/stale values via GetRichText()
+31. **Range address string max 255 characters** - limits multi-area ranges via COM
+32. **Protected/locked sheets throw ExcelException** - check `ProtectContents && cellRange.Locked`
+33. **Cell "A0" treated as "A:A" by ClosedXML** - known bug workaround in codebase

--- a/skills/uipath-rpa-legacy/references/activity-docs/FTP.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/FTP.md
@@ -1,0 +1,75 @@
+# UiPath FTP Activities - Community Reference
+
+## Overview
+FTP/FTPS/SFTP file transfer activities. Package: `UiPath.FTP.Activities` (from Community.Activities repo).
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `WithFtpSession` | FTP connection scope (container) | Host (required), Port, Username, Password/SecurePassword, FtpsMode (None/Explicit/Implicit), SftpMode (bool), ClientCertificatePath/Password, AcceptAllCertificates, Body |
+| `DownloadFiles` | Download files from FTP | RemotePath (required), LocalPath (required), Recursive, Create (create local dirs), Overwrite |
+| `UploadFiles` | Upload files to FTP | LocalPath (required), RemotePath (required), Recursive, Create (create remote dirs) |
+| `Delete` | Delete remote file/folder | RemotePath (required) |
+| `MoveItem` | Move/rename remote file | RemotePath (required), NewPath (required) |
+| `DirectoryExists` | Check if remote dir exists | RemotePath -> Exists (bool) |
+| `FileExists` | Check if remote file exists | RemotePath -> Exists (bool) |
+| `EnumerateObjects` | List remote directory contents | RemotePath -> Files (FtpObjectInfo[]) |
+
+---
+
+## WithFtpSession Properties
+
+### Connection
+- `Host` (string, required) - FTP server hostname
+- `Port` (int) - Server port (default: 21 for FTP, 22 for SFTP)
+- `Username` (string) - Login username
+- `Password` (string) OR `SecurePassword` (SecureString) - Login password
+
+### Protocol
+- `FtpsMode` (enum): None, Explicit (FTPES), Implicit (FTPS)
+- `SftpMode` (bool) - Use SFTP (SSH-based) instead of FTP
+- `UseBinaryMode` (bool) - Binary vs ASCII transfer mode
+
+### Security
+- `ClientCertificatePath` (string) - Client certificate file
+- `ClientCertificatePassword` (string/SecureString) - Certificate password
+- `AcceptAllCertificates` (bool) - Skip certificate validation (INSECURE)
+
+---
+
+## Critical Gotchas
+
+### Connection
+1. **All FTP activities MUST be inside WithFtpSession** - constraint enforced
+2. **FTP vs FTPS vs SFTP are different protocols** - FtpsMode controls FTP/FTPS, SftpMode switches to SFTP entirely
+3. **Port defaults**: FTP=21, FTPS/Explicit=21, FTPS/Implicit=990, SFTP=22
+4. **AcceptAllCertificates=true is a security risk** - bypasses SSL certificate validation
+
+### File Operations
+5. **DownloadFiles Overwrite flag** - if false, existing local files are skipped (not error)
+6. **DownloadFiles/UploadFiles Recursive** - recurse into subdirectories
+7. **DownloadFiles/UploadFiles Create** - create target directories if they don't exist
+8. **RemotePath uses forward slashes** (/) regardless of server OS
+9. **LocalPath uses system path separators**
+
+### Transfer Mode
+10. **UseBinaryMode=true recommended** for non-text files - ASCII mode can corrupt binary data
+11. **ASCII mode converts line endings** between platforms (CRLF <-> LF)
+
+### SFTP Specific
+12. **SFTP uses SSH protocol** - completely different from FTP/FTPS
+13. **SFTP may require SSH key authentication** (not just username/password)
+14. **SFTP doesn't support FtpsMode** - setting both SftpMode=true and FtpsMode is ignored
+
+### Error Handling
+15. **ContinueOnError** inherited from base - suppresses exceptions
+16. **File permission errors** common on remote servers - check server-side permissions
+17. **Timeout issues** on large file transfers - ensure network stability
+
+### Known Community Issues
+18. **Passive mode vs Active mode** - some firewalls block active FTP; passive mode is default
+19. **UTF-8 filename encoding** - some servers don't support UTF-8 filenames
+20. **EnumerateObjects returns FtpObjectInfo[]** with Name, FullName, Type (File/Directory), Size, LastModified

--- a/skills/uipath-rpa-legacy/references/activity-docs/Forms.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Forms.md
@@ -1,0 +1,81 @@
+# UiPath Forms Activities - Legacy Reference
+
+## Overview
+HTML/FormIo-based forms for user interaction. Supports async/modal display, field binding, events, and triggers. Package: `UiPath.Forms.Activities`.
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `ShowFormActivity` | Display form (async or modal) | FormId, InstanceName, Arguments (Dict), Width, Height, Left, Top, Title, IsAsync (default true) |
+| `CloseFormActivity` | Close open form | FormId, InstanceName |
+| `HideFormActivity` | Minimize/hide form | FormId, InstanceName |
+| `BringFormToFrontActivity` | Restore hidden form | FormId, InstanceName |
+| `GetFormFieldsActivity` | Read current field values | FormId, InstanceName, Arguments (Dict\<string, OutArgument\>) |
+| `SetFormFieldsActivity` | Set field values | FormId, InstanceName, Arguments (Dict\<string, InArgument\>) |
+| `ChangeFormPropertiesActivity` | Modify form at runtime | FormId, InstanceName, Height, Width, Title, WindowState, TopMost |
+| `ExecuteScriptActivity` | Run JavaScript in form | FormId, InstanceName, Source (JS code) |
+| `FormTriggerActivity<T>` | Listen for form events | FormId, InstanceName, Event (e.g., "button1.click"), MessageId |
+| `ShowCalloutActivity` | Popup near UI element | Target/UiElement, AutomaticallyCloseAfter, all ShowForm args |
+
+---
+
+## FormIo Type Mapping
+
+| FormIo Component | C# Type |
+|-----------------|---------|
+| Checkbox | bool |
+| Number / Currency | double |
+| Password | SecureString |
+| DataGrid / EditGrid | DataTable |
+| DateTime | DateTime |
+| Date | DateOnly |
+| Time | TimeOnly |
+| Survey / DataMap | Dictionary\<string, string\> |
+| Select (multiple) | IEnumerable\<string\> |
+| Select (single) | string |
+| Default | string |
+
+---
+
+## Critical Gotchas
+
+### Form Display
+1. **IsAsync=true (default)** - returns immediately; form runs in background
+2. **IsAsync=false** - blocks workflow until form closes
+3. **DuplicateBehavior=ReuseExisting** by default - same FormId+InstanceName reuses form
+4. **FormSelectorNotUnique exception** if FormId+InstanceName conflict exists
+
+### Arguments Binding
+5. **Arguments dictionary maps field IDs to workflow variables** (In/Out/InOut)
+6. **Global variables** bound via `GlobalVariables.PropertyName` regex pattern
+7. **Type coercion** uses `Convert.ChangeType()` - arrays parsed via string splitting
+8. **Complex types/objects fail** with FormsRuntimeException(InvalidArgument)
+
+### Platform Limitations
+9. **ExternalHost (Assistant/Robot)**: HTML forms only - FormIo/native forms throw NotSupportedException
+10. **Desktop**: Requires WebView2 runtime installed
+11. **WebSocket URI hardcoded** to `ws://127.0.0.1:29831` (not localhost, to avoid IPv6 2-second timeout)
+
+### Async Patterns
+12. **async void methods with #pragma warning disable** - unhandled exceptions are catastrophic
+13. **Try/catch wraps to TaskCompletionSource.SetException()** for safety
+
+### Timeouts
+14. **FormLoadTimeout = 10 seconds** - configurable but soft-enforced
+15. **GetValueTimeout / InitializeTimeout = 10 seconds**
+
+### Form Selection
+16. **Wildcard-based matching** - missing selector fields match any value
+17. **Multiple matches throw exception** (not silent failure)
+
+### Form Files
+18. **Extension**: `.uiform` (native FormIo) or `.html` (raw HTML)
+19. **Form ID resolution** via Constants.IdMapFileName probed relative to assembly
+
+### Callout Activity
+20. **ShowCalloutActivity integrates with UIAutomationNext** for target tracking
+21. **Defaults**: Width=300, Height=280, ShowMargin=false, ShowInTaskbar=false
+22. **ContinueOnError=true by default** (unlike ShowFormActivity)

--- a/skills/uipath-rpa-legacy/references/activity-docs/GSuite.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/GSuite.md
@@ -1,0 +1,74 @@
+# UiPath GSuite Activities - Legacy Reference
+
+## Overview
+Google Workspace integration: Gmail, Drive, Sheets, Docs, Calendar, Tasks, Forms, Apps Script. Package: `UiPath.GSuite.Activities`.
+
+---
+
+## Activity Counts by Service
+- **Gmail**: 18 activities (send, receive, delete, archive, labels, triggers)
+- **Google Drive**: 25 activities (upload, download, share, labels, permissions)
+- **Google Sheets**: 25 activities (read/write range/cell/row/column, format, iterate)
+- **Google Docs**: 7 activities (read/write/replace text, insert image, template fill)
+- **Google Calendar**: 8+ activities (create/modify/delete events, RSVP, calendars)
+- **Google Tasks**: 10 activities (create/complete/delete tasks and lists)
+- **Google Forms**: 2 activities + 2 triggers (form info, responses)
+- **Apps Script**: 1 activity (RunScript)
+
+---
+
+## Authentication
+- All activities use **Connection Service** pattern (ConnectionId argument)
+- **OAuth2 scopes** declared per activity via `RequiredScopes` property
+- **Connector types**: GmailConnector, GoogleDriveConnector, GoogleSpreadsheetsConnector, GoogleDocsConnector, GoogleTasksConnector, GoogleWorkspaceConnector
+
+---
+
+## Critical Gotchas
+
+### Gmail
+1. **GmailMessage.Attachments property is OBSOLETE and never populated** - must use DownloadAttachments activity separately
+2. **Labels stored as base64-encoded JSON** - AllLabels property is serialized GmailLabel[]
+3. **Email governance** - validates recipients against organization blocklists (skipped for drafts)
+4. **Address format**: Standard email format, parsed by Google API
+
+### Google Drive
+5. **ConflictResolution has 5 values**: Replace, Fail, Rename, AddSeparate (allows duplicate names in Drive), UseExisting (return existing item)
+6. **OverwriteExistingFile property is OBSOLETE** - use ConflictResolution enum instead
+7. **SingleFileToUpload is OBSOLETE** - use MultipleFilesToUpload
+8. **Drive label operations** require enterprise workspace (not personal accounts)
+
+### Google Sheets
+9. **A1 notation for ranges** - same as Excel (e.g., "Sheet1!A1:B10")
+10. **WriteMode**: Overwrite, Append (add below), Insert (insert rows)
+11. **Cell color format**: RGB hex "#RRGGBB"
+12. **HeaderRow boolean** affects DataTable column naming
+
+### Google Docs
+13. **ReadMode options**: AllText, ParagraphIndex, ParagraphContent, TextAfterIndex
+14. **WriteMode options**: End, Index, ReplaceAll
+15. **FindAndReplace MatchMode**: ExactMatch, Contains, RegularExpression
+
+### Google Calendar
+16. **Recurrence uses RRULE format** (RFC 5545) - complex string syntax
+17. **SendUpdates enum**: None, Owner, All - controls notification behavior
+18. **DeleteEventType**: ThisEvent, ThisAndFollowing, AllInstances (recurring events)
+
+### Apps Script
+19. **DevMode uses script PROJECT ID** vs production uses DEPLOYMENT ID - completely different IDs
+20. **Scopes are user-specified** (not predefined like other services)
+
+### Connection Service
+21. **Bindings version locked at V2.1** - breaking changes require major version bump
+22. **Legacy non-connection-service activities still exist** in Non-Portable folder
+23. **BackupSlot<T> pattern** for migrating obsolete properties to new ones
+
+### Persistence Activities (Triggers/Waits)
+24. **WaitFor* activities** use bookmark resumption pattern (long-running workflows)
+25. **Marked with [PersistentActivity]** attribute
+26. **Different from NewEmailReceived triggers** (ITriggerActivity vs IPersistenceActivity)
+
+### Item Arguments
+27. **DriveItemArgument** for file/folder selection - supports BrowserItemId (from remote browser) and ManualEntryId
+28. **FolderArgument** for Gmail folders
+29. **GTaskArgument** for task list/parent references

--- a/skills/uipath-rpa-legacy/references/activity-docs/Google-Speech.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Google-Speech.md
@@ -1,0 +1,25 @@
+# UiPath Google Speech Activities - Community Reference
+
+## Overview
+Google Cloud Speech-to-Text and Text-to-Speech integration. Package: `UiPath.Google.Activities` (from Community.Activities Integrations).
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `GoogleSpeechToText` | Convert speech to text | Confidence (0-1, required), Language (required), ServiceAccountFile (required) -> Text (string) |
+| `GoogleTextToSpeech` | Convert text to speech | Text (required), LanguageCode (required), Gender (Male/Female), ServiceAccountFile (required) |
+
+---
+
+## Critical Gotchas
+
+1. **Google Cloud Platform service account required** - ServiceAccountFile is path to JSON key file
+2. **Confidence threshold (0-1)** - lower values accept more uncertain transcriptions
+3. **Language codes** in BCP-47 format (e.g., "en-US", "fr-FR", "ja-JP")
+4. **GenderType enum** maps to Google's SsmlVoiceGender (Male/Female)
+5. **SpeechToText uses microphone input** - has WPF SpeechControl UI element
+6. **Billing required** on Google Cloud project for API access
+7. **Network connectivity required** - cloud-only, no offline mode

--- a/skills/uipath-rpa-legacy/references/activity-docs/ImageProcessing.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/ImageProcessing.md
@@ -1,0 +1,32 @@
+# UiPath ImageProcessing Activities - Legacy Reference
+
+## Overview
+Low-level image template matching and comparison via P/Invoke to native C++ libraries. Package: `UiPath.ImageProcessing`.
+
+---
+
+## Key Operations
+
+| Method | Purpose | Key Parameters | Returns |
+|--------|---------|----------------|---------|
+| `Images.FindAll` | Locate template in image | target Bitmap, toFind Bitmap, threshold (0-1) | Collection\<TemplateMatch\> |
+| `Images.FindFirst` | Find single match | target, toFind, threshold | TemplateMatch |
+| `Images.Compare` | Image similarity score | image1, image2, CalculationMode | double (0-1) |
+| `Images.AreDifferent` | Boolean difference check | image1, image2, checkRects, excludeRects | bool |
+
+### TemplateMatch Properties
+- Location (Point), Percentage (match confidence), Scale
+
+---
+
+## Critical Gotchas
+
+1. **P/Invoke to native C++ DLL** - requires matching platform (x86/x64) and OS
+2. **Bitmap must be kept in memory** during operation (LockBits/UnlockBits pattern)
+3. **Threshold tuning critical** - too low = false positives, too high = missed matches
+4. **Resolution-sensitive** - template matching fails on different screen resolutions
+5. **Brightness/contrast sensitive** - minor UI changes can break matching
+6. **No managed alternative** - difficult to debug native code issues
+7. **FindMode**: Basic vs Enhanced algorithms (Enhanced slower but more accurate)
+8. **templateScaleFactor** - adjust template size for different display scales (DPI awareness)
+9. **CancellationToken support** for async cancellation

--- a/skills/uipath-rpa-legacy/references/activity-docs/IntelligentOCR.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/IntelligentOCR.md
@@ -1,0 +1,113 @@
+# UiPath IntelligentOCR (Document Understanding) Activities - Legacy Reference
+
+> **See also**: [_DU-PROCESS.md](_DU-PROCESS.md) — the Document Understanding Process template that uses these activities in a complete pipeline
+
+## Overview
+Legacy Document Understanding framework: digitize, classify, extract, validate, train, and redact documents. Package: `UiPath.IntelligentOCR.Activities`. **#24 by adoption (2.97%)**.
+
+---
+
+## Activity Architecture
+
+All activities follow a **scope + child** pattern:
+- **Scopes** (ClassifyDocumentScope, DataExtractionScope, TrainClassifiersScope, TrainExtractorsScope) contain child activities
+- **Children** (classifiers, extractors, trainers) run inside their respective scopes
+- **Standalone** activities (DigitizeDocument, LoadTaxonomy, ValidationStation, etc.) run independently
+
+---
+
+## Core Activities
+
+### Digitization
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `DigitizeDocument` | OCR + DOM creation | DocumentPath (req), DegreeOfParallelism (def 1), DetectCheckboxes (def true), OCREngine (ActivityDelegate) -> DocumentObjectModel, DocumentText |
+| `LoadTaxonomy` | Load taxonomy definition | (hardcoded path) -> Taxonomy (DocumentTaxonomy) |
+
+### Classification
+| Activity | Type | Key Arguments |
+|----------|------|---------------|
+| `ClassifyDocumentScope` | Scope | DocumentText, DocumentObjectModel, DocumentPath, Taxonomy (all req) -> ClassificationResults[] |
+| `IntelligentKeywordClassifier` | Child | LearningFilePath OR LearningData, Endpoint, ApiKey, TimeoutMs (def 100,000), UsePageNumbers, PerformDocumentSplitting |
+| `KeywordBasedClassifier` | Child (DEPRECATED) | LearningFilePath OR LearningData |
+| `DuAppClassifier` | Child | SelectedProject (req), SelectedVersion, SelectedTag, TimeoutMs (def 15,000) |
+| `PresentClassificationStation` | Standalone | AutomaticClassificationResults, DocumentObjectModel/Text/Path, Taxonomy (all req), EnablePageReorderging (typo in name) |
+
+### Data Extraction
+| Activity | Type | Key Arguments |
+|----------|------|---------------|
+| `DataExtractionScope` | Scope | ClassificationResult, DocumentText/ObjectModel/Path, Taxonomy (req), FormatValuesIfPossible, ApplyGenerativeValidation |
+| `DuAppExtractor` | Child | SelectedProject (req), SelectedVersion, SelectedTag, TimeoutMs (def 15,000) |
+| `FormExtractor` | Child | Endpoint (req), ApiKey, MinOverlapPercentage (def 65), Timeout (def 100,000), SerializedTemplates |
+| `RegexBasedExtractor` | Child | Configuration (JSON, req), Timeout (def 2,000), UseVisualAlignment |
+| `ExportExtractionResults` | Standalone | ExtractionResult (req), IncludeConfidence, IncludeOCRConfidence -> DataSet |
+
+### Validation
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `PresentValidationStation` | Human validation UI | AutomaticExtractionResults, DocumentObjectModel/Text/Path, Taxonomy (req), FieldsValidationConfidence (0-100), DisplayMode (Compact/Expanded) |
+
+### Training
+| Activity | Type | Key Arguments |
+|----------|------|---------------|
+| `TrainClassifiersScope` | Scope | HumanValidatedData OR HumanValidatedClassificationData, DocumentText/ObjectModel/Path (req) |
+| `TrainExtractorsScope` | Scope | HumanValidatedData (req), DocumentText/ObjectModel/Path (req) |
+| `KeywordBasedClassifierTrainer` | Child | LearningFilePath OR LearningData |
+| `IntelligentKeywordClassifierTrainer` | Child | LearningFilePath OR LearningData |
+| `DuAppExtractorTrainer` | Child | SelectedProject (req), ActionInput (req) |
+
+### Redaction & Orchestrator
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `RedactDocument` | Redact sensitive data | DocumentPath, DocumentObjectModel (req), ExtractionResults OR WordsToRedact, FillColor, OutputFile |
+| `CreateDocumentValidationArtifacts` | Upload for external validation | FolderPath (req), DocumentPath/Text/ObjectModel, Taxonomy |
+| `RetrieveDocumentValidationArtifacts` | Download validated results | ContentValidationDataInput (req), DownloadFolderPath |
+
+---
+
+## Critical Gotchas
+
+### Setup & Dependencies
+1. **Requires CoreIPC 2.0.1+** - validated at CacheMetadata; throws InvalidOperationException at runtime if missing
+2. **Requires UIAutomation >= 19.8** for DigitizeDocument
+3. **PDF license required** for Digitize, FormExtractor, and Redaction (`PdfLicenseManager.EnsureValidLicense()`)
+4. **OCR engine must be explicitly wired** as ActivityDelegate in DigitizeDocument
+
+### LoadTaxonomy
+5. **TaxonomyFilePath is HARDCODED** - no activity argument to override; reads from `HardCodedPaths.DefaultTaxonomyFilePath`
+6. **Large taxonomies (100+ doc types) slow to load** - comprehensive metadata extraction on every call
+
+### Classification
+7. **ClassifyDocumentScope must contain at least one classifier child** - empty scope fails
+8. **LearningFilePath OR LearningData** - must specify one, not both, not neither (validation error)
+9. **KeywordBasedClassifier is DEPRECATED** - should not be placed in TrainClassifiersScope
+10. **UsePageNumbers without PerformDocumentSplitting** generates warning
+
+### Extraction
+11. **RegexBasedExtractor Configuration cannot be empty array** - validation error
+12. **Variable-bound Configuration skips validation** - assumes correctness
+13. **If document type ID in regex config doesn't match, returns empty results SILENTLY**
+14. **FormExtractor MinOverlapPercentage must be >0** - range 50-100 sensible
+15. **RegexBasedExtractor default timeout (2000ms)** may be insufficient for complex patterns
+
+### Validation Station
+16. **FieldsValidationConfidence must be 0-100 or null** - values outside throw InvalidOperationException
+17. **EnablePageReorderging (typo!)** must be true if results contain reordered page ranges
+18. **UI may timeout** if user doesn't interact - activity hangs if Classification/Validation Station crashes
+
+### Training
+19. **ALL child classifiers/extractors must have PersistenceId set** and mapped in taxonomy configuration
+20. **TrainClassifiersScope: HumanValidatedData OR HumanValidatedClassificationData** - not both, not neither
+21. **If using HumanValidatedClassificationData, Taxonomy is REQUIRED**
+22. **Training is incremental** - learning data grows over time and may impact performance
+
+### Redaction
+23. **Must specify ExtractionResults OR WordsToRedact** - not both, not neither
+24. **Word matching is case-sensitive**
+25. **Redaction is permanent** - output file overwrites; no undo
+
+### DU App Activities
+26. **SelectedProject is always REQUIRED** - validation fails if empty
+27. **Default timeout 15,000ms** may be insufficient for large documents
+28. **Dropdown lists empty if DU App service unreachable** - no fallback
+29. **Training jobs are async at service** - activity returns when enqueued, not completed

--- a/skills/uipath-rpa-legacy/references/activity-docs/Java.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Java.md
@@ -1,0 +1,60 @@
+# UiPath Java Activities - Community Reference
+
+## Overview
+Execute Java code and interact with Java objects from UiPath workflows. Package: `UiPath.Java.Activities` (from Community.Activities repo).
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `JavaScope` | Container - initialize JVM | Path (JRE/JDK install), Body |
+| `LoadJar` | Load JAR file into classpath | JarPath (required), Output: loaded into scope |
+| `InvokeJavaMethod` | Call static/instance method | Instance (JavaObject, null for static), MethodName (required), TargetType (class name for static), InputParameters (object[]) -> Result (JavaObject) |
+| `CreateJavaObject` | Instantiate Java class | TargetType (class name, required), InputParameters (object[]) -> Result (JavaObject) |
+| `ConvertJavaObject` | Convert JavaObject to .NET | JavaObject, TypeArgument -> typed result |
+| `GetJavaField` | Read field from Java object | Instance (JavaObject), FieldName (required), TargetType (class for static fields) -> Result (JavaObject) |
+
+---
+
+## JavaScope Configuration
+- `Path` (string) - Path to JRE/JDK installation (e.g., `C:\Program Files\Java\jre1.8.0_291`)
+- All Java activities must be inside JavaScope
+
+---
+
+## Critical Gotchas
+
+### JavaScope
+1. **All Java activities MUST be inside JavaScope** - container required
+2. **JRE/JDK must be installed** on the machine - not bundled
+3. **JAVA_HOME or explicit Path** required for JVM initialization
+4. **JVM architecture must match** - 32-bit JRE for x86 workflows, 64-bit for x64
+
+### JAR Loading
+5. **LoadJar must be called before using classes from that JAR**
+6. **Multiple JARs can be loaded** - each LoadJar adds to classpath
+7. **JAR dependency resolution** - all dependent JARs must also be loaded
+
+### Method Invocation
+8. **Static methods**: set Instance=null, TargetType to fully qualified class name
+9. **Instance methods**: set Instance to JavaObject, TargetType not needed
+10. **InputParameters are positional** (object array) - order and types must match Java method signature
+11. **Method overloading** resolved by parameter count and types
+
+### Type Conversion
+12. **ConvertJavaObject maps**: Java String -> .NET string, int/long -> int/long, boolean -> bool
+13. **Complex Java objects remain as JavaObject** - must use ConvertJavaObject for .NET types
+14. **Arrays**: Java arrays can map to .NET arrays via ConvertJavaObject
+15. **JavaObject is opaque** from .NET side - use GetJavaField or InvokeJavaMethod to access
+
+### Performance
+16. **JNI bridge overhead** - each call crosses JVM/.NET boundary
+17. **Minimize cross-boundary calls** - do heavy work in Java, return results
+18. **JVM startup time** - first JavaScope invocation is slow (~1-3 seconds)
+
+### Error Handling
+19. **Java exceptions wrapped** in .NET exceptions - check InnerException for Java stack trace
+20. **ClassNotFoundException** if JAR not loaded or class name misspelled
+21. **NoSuchMethodException** if method signature doesn't match

--- a/skills/uipath-rpa-legacy/references/activity-docs/Mail.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Mail.md
@@ -1,0 +1,101 @@
+# UiPath Mail Activities - Legacy Reference
+
+## Overview
+Email automation supporting 6 protocols: SMTP, IMAP, POP3, Exchange/O365, Outlook (COM), Lotus Notes (COM). Package: `UiPath.Mail.Activities`.
+
+---
+
+## Protocol Support Matrix
+
+| Protocol | Send | Receive | Delete | Move | Mark Read | Drafts | Shared Mailbox | Trigger | COM |
+|----------|------|---------|--------|------|-----------|--------|----------------|---------|-----|
+| SMTP | Y | - | - | - | - | - | - | - | - |
+| IMAP | - | Y | Y | Y | Y | - | - | Y | - |
+| POP3 | - | Y | Y* | - | - | - | - | - | - |
+| Exchange | Y | Y | Y | Y | Y | Y | Y | - | - |
+| Outlook | Y | Y | Y | Y | Y | Y | - | Y | Y |
+| Lotus Notes | Y | Y | Y | Y | - | - | - | - | Y |
+
+*POP3: delete only via `DeleteMessages` flag on retrieval
+
+---
+
+## Key Activities & Arguments
+
+### SMTP - SendMail
+- **Inputs**: Email, Password/SecurePassword, Server, Port, SecureConnection, To/Cc/Bcc (semicolon-separated), Subject, Body, Files, IsBodyHtml
+- **Output**: StatusCode (string, e.g. "250")
+- **SecureConnection**: None, Auto, SslOnConnect, StartTls, StartTlsWhenAvailable
+
+### IMAP - GetIMAPMailMessages
+- **Inputs**: Email, Password, Server, Port, MailFolder (default "Inbox"), FilterExpression, OnlyUnreadMessages (default true), Top (default 30)
+- **Output**: Messages (List\<MailMessage\>)
+- **FilterExpressionCharacterSet**: default US-ASCII (use UTF-8 for non-ASCII)
+
+### POP3 - GetPOP3MailMessages
+- **Inputs**: Email, Password, Server, Port, DeleteMessages (default false), Top (default 30)
+- **Output**: Messages (List\<MailMessage\>)
+
+### Exchange
+- **SendExchangeMail**: Server, ExchangeVersion (2007-2021), AuthenticationType (Basic/OAuth2/Interactive), ApplicationId, DirectoryId
+- **GetExchangeMailMessages**: CustomFolder (default "Inbox"), SharedMailbox, FilterExpression (requires Exchange2010+)
+- **AuthTypes**: Basic, OAuth2, Interactive (requires ApplicationId)
+
+### Outlook (COM Interop)
+- **SendOutlookMail**: Account, SentOnBehalfOfName, Importance, Sensitivity, IsDraft
+- **GetOutlookMailMessages**: Account, Folder, OnlyUnreadMessages, Top
+- **SaveAttachementsOutlook**: Note typo in class name (historical)
+
+### Modern X-Activities (Connection Service)
+- **SendMailX**: Account (IMailQuickHandle), IsDraft (default true - doesn't send!)
+- **ForEachEmailX**: NumberOfEmailsLimit (default 100, 0=all), RetrieveAttachments (default true)
+- **SaveMailAttachmentsX**: Filter (regex), ExcludeInlineAttachments, OverwriteExisting
+
+---
+
+## Critical Gotchas
+
+### Authentication
+1. **OAuth works on direct activity properties but NOT via Integration Service connections** - UseOAuth parameter IS functional when set directly on SMTP/IMAP/POP3 activities (enables SASL XOAUTH2). However, it's **hardcoded false** in the Connection Service path (TODO PRODACTV-4005). Pass OAuth token as Password and set UseOAuth=true directly.
+2. **SecurePassword takes precedence** over Password if length > 0. Note: SMTP's SendMail lacks `[OverloadGroup]` on Password/SecurePassword, so both can be set simultaneously (unlike IMAP/POP3).
+3. **Addresses are semicolon-separated** (`;`) - NOT comma-separated. **Exception: Lotus Notes uses commas** (`SplitCommaSeparatedEntries`)
+4. **Interactive auth requires ApplicationId** - validation error if missing
+
+### SMTP Specific
+5. **Attachments CLEARED when replying** - `if(action != MailAction.Forward) mailMessage.Attachments.Clear()`
+6. **ContinueOnError** only skips RuleViolationException, NOT SmtpCommandException
+
+### POP3 Specific
+7. **No folder support** - POP3 is stateless, only downloads from inbox
+8. **DeleteMessages permanent** - Once deleted on retrieval, cannot be recovered
+
+### Exchange Specific
+9. **ExchangeVersion 2007 doesn't support FilterExpression** - validation error
+10. **FilterByMessageIds** is Exchange-specific format, not standard message IDs
+
+### Outlook COM Specific
+11. **PiP (Process in Process) used for session isolation** - When Robot runs in PiP mode (separate session), MainSessionServer.exe proxies COM calls to the main user session. Not specifically about 64-bit, but about session access to Outlook.
+12. **Converts relative attachment paths to absolute** automatically
+13. **Orphaned processes** possible if parent crashes (PiP process relies on timeout)
+
+### Lotus Notes Specific
+14. **Folder syntax is Lotus-specific**: `($Inbox)`, `(Drafts)` - NOT standard paths
+15. **32-bit execution required** or PiP COM proxy
+
+### Governance
+16. **Email blocklist validation** - SendMail validates To/Cc/Bcc against organization blocklists
+17. **RuleViolationException is NOT continuable** (IsContinuableException returns false)
+18. **Skipped for drafts** (IsDraft=true)
+
+### Attachment Handling
+19. **Inline attachments in AlternateViews** - SaveMailAttachments includes LinkedResources unless ExcludeInlineAttachments=true
+20. **Double-counting possible** - AlternateViews + Attachments may have duplicates
+
+### Additional Discovered Gotchas
+23. **OAuth2 silently falls back to password auth** - If OAuth2 authentication fails, code catches AuthenticationException and falls back to username/password. This can mask OAuth misconfiguration.
+24. **Outlook session conflict** - `CanExecuteForCurrentUserInCurrentSession()` returns false if Outlook is open in another session. Activity will fail silently.
+25. **NTLM auth requires explicit handling** - MailKit dropped implicit NTLM; code explicitly checks for NTLM mechanism with fallback.
+
+### Certificate Handling
+21. **IgnoreCRL** disables certificate revocation list checking (security risk)
+22. **StartTlsWhenAvailable** falls back to plaintext if server doesn't support (dangerous)

--- a/skills/uipath-rpa-legacy/references/activity-docs/MicrosoftOffice365.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/MicrosoftOffice365.md
@@ -1,0 +1,84 @@
+# UiPath Microsoft Office 365 Activities - Legacy Reference
+
+## Overview
+Office 365 integration via Microsoft Graph API: Mail, Calendar, Excel Online, OneDrive, SharePoint, Planner, Groups. Package: `UiPath.MicrosoftOffice365.Activities`.
+
+---
+
+## Authentication Types
+| Type | Use Case |
+|------|----------|
+| InteractiveToken | User-interactive OAuth (browser popup) - default |
+| UsernameAndPassword | Direct credentials (limited by Azure policy) |
+| IntegratedWindowsAuthentication | Windows SSPI/Kerberos |
+| ApplicationIdAndSecret | App-only OAuth (client credentials) |
+| ApplicationIdAndCertificate | Certificate-based app auth |
+| IntegrationService | UiPath Orchestrator Connection Service |
+
+**Required**: Azure App Registration with Client ID, appropriate permissions granted
+
+---
+
+## Activity Groups
+
+### Mail (6 activities)
+SendMail, DeleteMail, ForwardMail, ReplyToMail, MoveMail, SetMailCategories
+
+### Calendar (10 activities)
+CreateEvent, ModifyEvent, DeleteEvent, AddAttendee, AddLocation, AddAttachment, SearchEvents, GetCalendars, FindMeetingTimes, Rsvp
+
+### Excel Online (15+ activities)
+ReadRange, WriteCell, WriteRange, ReadCell, ReadRow, ReadColumn, AppendRange, PasteRange, ClearRange, CopyRange, DeleteRows, InsertRows, CreateTable, GetSheets, VLookupRange, etc.
+
+### OneDrive/SharePoint Files (10 activities)
+UploadFile, DownloadFile, DeleteItem, CreateFolder, FindFilesAndFolders, GetItem, CopyItem, MoveItem, ShareItem, ExportAsPdf
+
+### SharePoint Lists (5 activities)
+GetListInfo, GetListItems, AddListItems, UpdateListItem, DeleteListItem
+
+### Planner (11 activities)
+CreatePlan, GetPlan, ListPlans, CreateTask, GetTask, ListTasks, UpdateTask, DeleteTask, CreateBucket, DeleteBucket, ListBuckets
+
+### Groups (4 activities)
+CreateGroup, DeleteGroup, GetGroup, ListGroups
+
+---
+
+## Critical Gotchas
+
+### Scope (Container)
+1. **All activities MUST be inside Office365ApplicationScope** (Classic design) - enforced via HasParentType constraint. Modern portable activities use Integration Service connections instead.
+2. **Scope auto-calculates minimum required permissions** from child activities
+3. **Token cache stored encrypted** at `%APPDATA%\UiPath\authentication\office365.tokens.msalcache.bin3` (DPAPI encrypted). Other caches: `drive.graph.tokens.msalcache.bin3`, `graph.tokens.msalcache.bin3`
+
+### Authentication
+4. **Personal accounts have limited functionality** - no Search API (Microsoft Graph platform limit, enforced server-side), limited Graph endpoints
+5. **Shared mailbox uses `UseSharedMailbox` boolean + `Mailbox` property** on the activity (NOT separate ".Shared" scope names as sometimes documented)
+6. **User.Read typically required** for Graph /me endpoint
+7. **Token refresh automatic** via MSAL library
+
+### Excel Online
+8. **Sheet references by name** (not ID)
+9. **Range notation must be Excel format** (A1:D10)
+10. **ValuesType** affects formula preservation: Values, Formulas, Text
+11. **Default sheet name "Sheet1"** assumed if not specified
+
+### OneDrive/SharePoint
+12. **ConflictBehavior**: Replace, Fail, Rename for name conflicts
+13. **Checkin property** enables version control for SharePoint documents
+14. **Metadata DataTable** for adding SharePoint column metadata
+15. **Search API not supported for personal accounts** - SupportsSearchApi() checks account type
+
+### Graph API Batching
+16. **BatchingService handles max 20 items per batch** (Graph API limit)
+17. **ForEach loop optimization** via IO365ForEachBatchingServiceManager
+18. **Reduces API calls** for bulk operations
+
+### Mail Governance
+19. **Email blocklist enforcement** on SendMail (same as other mail activities)
+20. **ConfigLocation property** controls where activity configuration stored
+
+### Multi-Account Support
+21. **Account parameter** available on File and Mail activities for delegated access
+22. **Defaults to connection user** if not specified
+23. **Shared mailbox** specified via connection metadata

--- a/skills/uipath-rpa-legacy/references/activity-docs/MobileAutomation.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/MobileAutomation.md
@@ -1,0 +1,35 @@
+# UiPath Mobile Automation Activities - Legacy Reference
+
+## Overview
+Mobile device automation for iOS/Android via Appium server. Package: `UiPath.MobileAutomation.Activities`.
+
+---
+
+## Key Components
+
+| Component | Purpose |
+|-----------|---------|
+| `MobileService` | Runtime service managing connections |
+| `Device` / `DeviceBuilder` | Target mobile device configuration |
+| `Application` / `ApplicationBuilder` | App to automate |
+| `Connection` | Connection settings (Appium URL, capabilities) |
+| `MobileTarget` / `SelectorTarget` | UI element selector types |
+
+## Connection Methods
+- `ConnectAsync(Device, Application, ConnectOptions)`
+- `GetDevices()` / `GetApplications()`
+
+---
+
+## Critical Gotchas
+
+1. **Requires running Appium server** (local or cloud like SauceLabs/BrowserStack)
+2. **Device farm credentials needed** for cloud-hosted devices
+3. **Selector creation complex** for cross-platform (iOS vs Android selectors differ)
+4. **Live Run requires MDM** (Mobile Device Manager) process running
+5. **Design-time only shows in MDM** - headless at runtime
+6. **Hybrid web/native apps** require switching context (internal Driver scripts)
+7. **IPC communication** for MDM integration
+8. **Session timeouts** vary by cloud provider - keep-alive may be needed
+9. **Screen resolution differences** affect coordinate-based actions
+10. **iOS requires XCUITest driver**, Android requires UIAutomator2/Espresso

--- a/skills/uipath-rpa-legacy/references/activity-docs/OmniPage.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/OmniPage.md
@@ -1,0 +1,60 @@
+# UiPath OmniPage OCR Activities - Legacy Reference
+
+## Overview
+OmniPage OCR engine for text extraction from images/documents. Package: `UiPath.OmniPage.Activities`. **#29 by adoption (1.12%)**.
+
+---
+
+## Activity: OmniPageOCR
+
+### Input Arguments
+| Argument | Type | Default | Notes |
+|----------|------|---------|-------|
+| `Image` | Image | REQUIRED | Image to OCR |
+| `Language` | string | "auto" | BCP-47 code or "auto" for detection |
+| `Profile` | OCRProfile | None | None, Screen, Scan, Legacy |
+| `ExtractWords` | bool | false | Extract individual words |
+| `ExtractHandprintedText` | bool | false | Handwriting extraction |
+| `Scale` | double | 1.0 | Image scaling factor |
+| `BundleType` | OmniPageBundleType | Basic | Basic or Extended bundle |
+
+### Output Arguments
+| Argument | Type | Notes |
+|----------|------|-------|
+| `Text` | string | Extracted text |
+
+### OCR Profiles
+- **None** - No preprocessing
+- **Screen** - Optimized for screen captures (auto-set for screen scraping)
+- **Scan** - Optimized for scanned documents (auto-set ComputeSkewAngle=true)
+- **Legacy** - Legacy processing mode
+
+### Bundle Types
+- **Basic** - Standard OCR functionality
+- **Extended** - Advanced features (requires Extended bundle installed)
+
+---
+
+## Critical Gotchas
+
+### Installation
+1. **CoreIPC 2.0.1+ REQUIRED** - throws InvalidOperationException at runtime if missing
+2. **Bundle folder must be installed** - missing bundle causes validation error ("Bundle not installed")
+3. **Extended bundle requires separate installation** - Basic bundle is default
+
+### Compatibility
+4. **Emgu (OpenCV) version incompatibility** - OmniPage v1.19.2+ required for UiPath 24.6+; validates against full list of incompatible package versions
+5. **IOCR 6.19+, OCRActivities 3.20+ incompatible** with older OmniPage versions
+
+### Configuration
+6. **Language "auto" may produce suboptimal results** for mixed-language documents - set specific language
+7. **Scale factor has no validation bounds** - very high/low values degrade accuracy
+8. **ExtractHandprintedText significantly increases processing time** - disable if not needed
+9. **Profile auto-selected for Document vs Screen** usage context:
+   - Document: ComputeSkewAngle=true, Profile=Scan
+   - Screen: ComputeSkewAngle=false, Profile=Screen
+   - Manual override not exposed in scrape UI
+
+### Performance
+10. **Images automatically converted to PNG byte arrays** internally - no format control
+11. **NoopExecution mode** exists (Browsable=false) - returns empty results without processing; for testing only

--- a/skills/uipath-rpa-legacy/references/activity-docs/PDF.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/PDF.md
@@ -1,0 +1,86 @@
+# UiPath PDF Activities - Legacy Reference
+
+## Overview
+PDF reading, manipulation, and conversion. Uses UiPath.DocumentUnderstanding.Digitizer (NOT iTextSharp). Package: `UiPath.PDF.Activities`.
+
+---
+
+## Activities
+
+### Text Extraction
+| Activity | Key Arguments | Output |
+|----------|---------------|--------|
+| `ReadPDFText` | FileName, Password, Range (default "All"), PreserveFormatting | Text (string) |
+| `ReadPDFWithOCR` | FileName, Password, Range, ImageDpi (Low/Medium/High), DegreeOfParallelism | Text (string) |
+| `ReadXPSText` | Same as ReadPDFText (desktop only) | Text |
+| `ReadXPSWithOCR` | Same as ReadPDFWithOCR (desktop only) | Text |
+
+### Image Operations
+| Activity | Key Arguments | Output |
+|----------|---------------|--------|
+| `ExportPDFPageAsImage` | FileName, Password, PageNumber (1-based), ImageDpi, OutputFileName | OutputFile (ILocalResource) |
+| `ExtractImagesFromPDF` | FileName, Password, ImageExtension (PNG/JPEG/TIFF/BMP/GIF), OutputFolderName | OutputFiles |
+
+### Page Manipulation
+| Activity | Key Arguments | Output |
+|----------|---------------|--------|
+| `ExtractPDFPageRange` | FileName, Password, Range, OutputFileName | OutputFile |
+| `JoinPDF` | FileList (string[]) or IndividualResourceFileList, OutputFileName | OutputFile |
+| `GetPDFPageCount` | FileName, Password | PageCount (int) |
+
+### Password Management
+| Activity | Key Arguments | Output |
+|----------|---------------|--------|
+| `ManagePDFPassword` | FileName, OldUserPassword, NewUserPassword, OldOwnerPassword, NewOwnerPassword | OutputFile |
+
+### Conversion (NET5+)
+| Activity | Key Arguments | Output |
+|----------|---------------|--------|
+| `ConvertTextToPDF` | Text, FontSize (12), TextAlignment (Justify) | OutputFile |
+| `ConvertHtmlToPDF` | Html, Scale (1.0), PaperSize (A4), HeaderHtml, FooterHtml | OutputFile |
+| `ConvertEmailToPDF` | Email (MailMessage) | OutputFile |
+
+---
+
+## Critical Gotchas
+
+### Password-Protected PDFs
+1. **User Password** restricts opening (must provide to view)
+2. **Owner Password** restricts editing but allows viewing
+3. **Owner password required to change passwords** - throws `NoOwnerRightsException` otherwise
+4. **New passwords cannot match each other** or existing passwords
+
+### OCR
+5. **No automatic OCR fallback** - ReadPDFText won't fall back to OCR on scanned PDFs
+6. **OCR engine must be explicitly wired** in workflow (no built-in engine)
+7. **Empty page handling** - returns empty string (no exception)
+8. **DegreeOfParallelism** auto-capped to max(1, CPUs - 1)
+
+### Page Ranges
+9. **Format**: `"1,3-5,7"` (comma-separated, dash for ranges). Also supports keywords: `All`, `End`, `^` (start), `$` (end). Examples: `"1-End"`, `"^-$"`
+10. **"All"** is the default (extracts all pages)
+11. **Throws FormatException** on invalid range syntax
+
+### Image DPI
+12. **Low=96, Medium=150, High=270** DPI
+13. **Max pixel constraints**: 3000px width, 4000px height (auto-scaled down)
+14. **Higher DPI = better OCR but slower**
+
+### JoinPDF
+15. **Requires at least 2 files** - validation error otherwise
+16. **Must provide FileList OR ResourceFileList** (not both)
+
+### License
+17. **Runtime license check** via `PdfLicenseManager.EnsureValidLicense()` - will fail without valid license
+
+### XPS Activities
+18. **Desktop-only** (`#if !NETPORTABLE_UIPATH`) - not available in portable workflows
+
+### Additional Validated Gotchas
+21. **ImageDpi enum maxes at 270 (High), not 300** - combined with 3000x4000 pixel cap, large pages get lower effective DPI
+22. **ReadPDFText PreserveFormatting defaults to false** - text extraction without formatting produces garbled output for multi-column layouts
+23. **Underlying library is Docotic.Pdf and PdfPig** (not iTextSharp) - commercial library with embedded license
+
+### File Resources
+19. **Dual-mode inputs**: All activities accept both file paths (string) and IResource objects via OverloadGroups
+20. **Auto-generated output filename** if OutputFileName not provided

--- a/skills/uipath-rpa-legacy/references/activity-docs/Presentations.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Presentations.md
@@ -1,0 +1,72 @@
+# UiPath Presentations (PowerPoint) Activities - Legacy Reference
+
+## Overview
+PowerPoint automation with COM Interop and OpenXml (portable). Package: `UiPath.Presentations.Activities`.
+
+---
+
+## Activities
+
+### COM-based (require PowerPointApplicationScope)
+| Activity | Key Arguments | Output |
+|----------|---------------|--------|
+| `PowerPointApplicationScope` | PresentationPath, Password, EditPassword, CreateIfNotExists, AutoSave, TemplatePath | Container scope |
+| `InsertSlide` | SlideMasterName, LayoutName, InsertType (SpecifiedIndex/Beginning/End), InsertPosition | InsertedAtPosition (1-based) |
+| `DeleteSlide` | DeletePosition (1-based) | |
+| `CopyPasteSlide` | SourcePresentation, SlideToCopy, DestinationPresentation, WhereToInsert, Move | |
+| `InsertTextInPresentation` | SlideIndex (1-based), ShapeName, Text, ClearExistingText | |
+| `FindAndReplaceTextInPresentation` | SearchFor, ReplaceWith, MatchCase, WholeWordsOnly, ReplaceAll | NumberOfReplacements |
+| `ReplaceShapeWithDataTable` | SlideIndex, ShapeName, TableToInsert, AppendMode, ExcludeHeaders | |
+| `ReplaceShapeWithMedia` | SlideIndex, ShapeName, Media (path), Left/Top/Width/Height (EMUs) | |
+| `PasteIntoSlide` | SlideIndex, ShapeName, position/size | |
+| `InsertFile` | SlideIndex, ShapeName, FilePath, IconLabel | |
+| `FormatSlideContent` | SlideIndex, ShapeName + child modifications (ZIndex, FontSize, ShapeName change) | |
+| `RunMacro` | MacroName + child RunMacroArgument activities | Result (object) |
+| `SavePresentationAsPdf` | PdfPath, ReplaceExisting | Auto-adds .pdf |
+| `SavePresentationFileAs` | FilePath, SaveAsFileType (.pptx/.pptm/.ppt), ReplaceExisting | |
+| `AddSensitivityLabel` | SensitivityLabel, Justification | |
+| `GetSensitivityLabel` | | SensitivityLabel |
+
+### Portable/OpenXml (no PowerPoint required)
+PptDocumentCreateNew, PptDocumentAddTextToSlide, PptDocumentInsertSlide, PptDocumentDeleteSlide, PptDocumentFindAndReplaceTextInPresentation, PptDocumentReplaceShapeWithDataTable, PptDocumentReplaceShapeWithMedia, PptDocumentFormatSlideContent
+
+---
+
+## Critical Gotchas
+
+### Slide Indexing
+1. **Both COM and OpenXml UiPath APIs expose 1-based indexing** to users (SlideIndex=1 is first slide)
+2. **OpenXml internally converts to 0-based** for SDK array access, but this is transparent to users
+3. **InsertPosition outputs are 1-based** in both modes
+
+### COM Interop
+4. **All COM activities MUST be inside PowerPointApplicationScope** - constraint enforced at design time
+5. **MarshalHelpers.ReleaseComObject()** used for cleanup with retry on known COM errors
+6. **PowerPointRefCountInstanceManager** prevents premature COM cleanup
+
+### Position/Size in EMUs
+7. **Left/Top must be >= 0**, Width/Height must be >= 50 (English Metric Units)
+8. **EMUs are NOT pixels** - 1 inch = 914400 EMUs
+
+### Find & Replace
+9. **WholeWordsOnly=true requires ONLY alphanumeric SearchFor** - fails otherwise
+10. **COM version allows empty ReplaceWith; OpenXml REQUIRES it** (not optional)
+
+### DataTable Operations
+11. **TableAppendMode**: CreateNewTable (replace shape), AppendToTable, OverwriteExistingData
+12. **StartRow/StartColumn are 0-based for append mode**
+
+### Template Handling
+13. **Supported template extensions**: .potx, .potm, .pptx, .pptm
+14. **Default embedded template** included in assembly resources for PptDocumentCreateNew
+
+### CopyPasteSlide
+15. **Moving within same presentation** - if destination < source, deletion index adjusted automatically
+
+### AutoSave
+16. **AutoSave=true (default)** saves on scope exit
+17. **OpenXml activities call SaveChanges()** after each modification internally
+
+### File Formats
+18. **SaveAsFileType**: XmlPresentation (.pptx), MacroEnabledPresentation (.pptm), OldPresentation (.ppt)
+19. **Extension auto-added** if missing

--- a/skills/uipath-rpa-legacy/references/activity-docs/Python.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Python.md
@@ -1,0 +1,66 @@
+# UiPath Python Activities - Community Reference
+
+## Overview
+Execute Python scripts and interact with Python objects from UiPath workflows. Package: `UiPath.Python.Activities` (from Community.Activities repo).
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `PythonScope` | Container - initialize Python runtime | Path (Python install), Target (x86/x64), Version (Auto/Python_27/35/36/37/38/39/310), WorkingFolder, Body |
+| `LoadScript` | Load Python script file | File (path to .py), Output: PythonObject (script module) |
+| `RunScript` | Execute Python code string | Code (string), Output: PythonObject (result) |
+| `InvokeMethod` | Call method on Python object | Instance (PythonObject), Name (method name), InputParameters (object[]), Output: PythonObject (return value) |
+| `GetObject` | Convert PythonObject to .NET type | PythonObject, TypeArgument (target .NET type), Output: typed result |
+
+---
+
+## PythonScope Configuration
+
+### Key Properties
+- `Path` (string) - Path to Python installation (e.g., `C:\Python39`)
+- `Target` (enum) - x86 or x64 (must match Python installation)
+- `Version` (enum) - Auto, Python_27, Python_35, Python_36, Python_37, Python_38, Python_39, Python_310
+- `WorkingFolder` (string) - Working directory for Python scripts
+- `LibraryPath` (string) - Additional library paths (added to sys.path)
+
+---
+
+## Critical Gotchas
+
+### PythonScope
+1. **All Python activities MUST be inside PythonScope** - container required
+2. **Target (x86/x64) must match Python installation** - mixing causes load failure
+3. **Version Auto** tries to detect, but explicit version is safer
+4. **Python must be installed** on the machine - not bundled with activities
+5. **PATH environment variable** may need to include Python directory
+
+### Host Process
+6. **Python runs in separate host process** (UiPath.Python.Host.exe / UiPath.Python.Host32.exe)
+7. **32-bit host (Host32)** for x86 Python, 64-bit for x64
+8. **Host process crash** can orphan Python processes
+9. **IPC communication** between workflow and Python host - adds latency
+
+### Script Execution
+10. **RunScript executes code string** - use for inline Python code
+11. **LoadScript loads .py file** - returns module as PythonObject
+12. **InvokeMethod calls function** on loaded module or object
+13. **InputParameters are positional** (object array) - order matters
+
+### Type Conversion
+14. **GetObject converts PythonObject to .NET type** - limited type mapping:
+    - Python int/float -> .NET int/double
+    - Python str -> .NET string
+    - Python list -> .NET object[] or List<T>
+    - Python dict -> .NET Dictionary<string, object>
+    - Complex objects may not convert cleanly
+15. **PythonObject is opaque** - cannot inspect properties from .NET side without GetObject
+16. **Large data transfers are slow** due to IPC serialization
+
+### Environment
+17. **Virtual environments** - set Path to venv's python.exe parent directory
+18. **pip packages** must be installed in the Python environment being used
+19. **sys.path** extended with WorkingFolder and LibraryPath
+20. **Multiple PythonScopes** in same workflow may conflict - use one scope per Python environment

--- a/skills/uipath-rpa-legacy/references/activity-docs/SAP-BAPI.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/SAP-BAPI.md
@@ -1,0 +1,43 @@
+# UiPath SAP BAPI Activities - Legacy Reference
+
+## Overview
+SAP system integration via BAPI (Business API) remote function calls. Package: `UiPath.SAP.BAPI.Activities`.
+
+---
+
+## Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `SapApplicationScope` | Connection container (NativeActivity) | AppServer, SystemNumber, Client, StatefulConnection |
+| `SapOpenConnection` | Explicit connection | (within scope) |
+| `SapCloseConnection` | Cleanup | (within scope) |
+| `InvokeSapBapi` | Execute BAPI function | BapiName, SelectedArgumentList, OptionalArguments, AllArguments |
+| `InvokeBAPI` | Legacy variant | Similar to InvokeSapBapi |
+
+### SapApplicationScope Arguments
+- `AppServer` (string) - SAP application server hostname
+- `SystemNumber` (string) - SAP system number (e.g., "00")
+- `Client` (string) - SAP client ID (e.g., "800")
+- `StatefulConnection` (bool) - Session mode (stateful vs stateless)
+
+### InvokeSapBapi Arguments
+- `BapiName` (string) - RFC function module name
+- `BapiDescription` (string) - Display metadata
+- `SelectedArgumentList` (IList\<BapiArgumentUiModel\>) - Dynamic parameters
+- Return types: BapiReturn, BapiReturn1, BapiReturn2
+
+---
+
+## Critical Gotchas
+
+1. **SAP .NET Connector (NCo) must be installed** on the machine - not bundled
+2. **BAPI metadata discovery is slow** on first access (requires live SAP connection)
+3. **Dynamic argument handling** - BapiArgumentUiModel maps types via DataTypeEnum
+4. **Return structure varies by BAPI** - Bapi_Ret1 vs Bapi_Ret2 have different fields
+5. **Must run within SapApplicationScope** - constraint enforced
+6. **Designer wizard requires live SAP connection** at design time for BAPI selection
+7. **StatefulConnection** - if true, SAP maintains session context between calls
+8. **DataTable results** for table-type BAPI parameters
+9. **Authorization** - SAP user must have RFC authorization for called BAPIs
+10. **Transaction handling** - BAPI_TRANSACTION_COMMIT must be called explicitly for stateful changes

--- a/skills/uipath-rpa-legacy/references/activity-docs/System.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/System.md
@@ -1,0 +1,153 @@
+# UiPath System Activities - Legacy Reference
+
+## Overview
+Core system-level activities for collections, text handling, dates, dialogs, file system, processes, workflow control, credentials, and triggers. Package: `UiPath.System.Activities`.
+
+---
+
+## Activity Categories
+
+### Collection/List Activities
+| Activity | Returns | Key Gotcha |
+|----------|---------|------------|
+| `AppendItemToList<T>` | int (index) | Returns 0-based index |
+| `CreateList<T>` | IList\<T\> | Creates empty List\<T\> |
+| `ReadListItem<T>` | T | **Silent null return on out-of-bounds** - no exception thrown |
+| `UpdateListItem<T>` | - | Generic update |
+| `AppendItemToCollection<T>` | List\<T\> | Throws `NotSupportedException` for fixed-size collections (arrays) |
+| `BuildCollection<T>` | List\<T\> | **Cannot use both `NextItems` and `Items` simultaneously** |
+| `ExistsInCollection<T>` | bool + int | Index=-1 if not found; Item must be non-null |
+| `FilterCollection<T>` | List\<T\> | If Result not bound, **modifies collection in-place** |
+| `RemoveFromCollection<T>` | List\<T\> | Mutually exclusive: RemoveAllElements vs Item vs Index |
+| `MergeCollections<T>` | List\<T\> | Reference-checks to decide in-place vs new list |
+
+### Text Handling Activities
+| Activity | Returns | Key Gotcha |
+|----------|---------|------------|
+| `ExtractText` | string + IEnumerable | FirstMatch is `[Browsable(false)]`; Results has all matches |
+| `FindAndReplace` | string | Standard find/replace |
+| `SplitText` | IEnumerable\<string\> | NewLine uses 3-element array: `\r\n`, `\r`, `\n` |
+| `ChangeCase` | string | SentenceCase is culture-dependent (uses regex with Unicode) |
+| `CombineText` | string | Concatenation with separator |
+| `ExtractDateTime` | DateTime | Multiple culture support |
+
+### Date/Time Activities
+| Activity | Returns | Units |
+|----------|---------|-------|
+| `AddOrSubtractFromDate` | DateTime | Seconds, Minutes, Hours, Days, Weeks, Months, Years |
+| `FormatDateAsText` | string | Culture-aware formatting |
+| `GetNextOrPreviousDate` | DateTime | Next/previous day/date occurrence |
+
+### Dialog/Input Activities
+| Activity | Returns | Key Gotcha |
+|----------|---------|------------|
+| `InputDialog` | dynamic | **Result type dynamically bound at CacheMetadata** from Result.ArgumentType; type conversion has fallback chain |
+| `CustomInput` | string | Default 800x600; uses separate worker process |
+| `SelectFile` | string | File dialog |
+| `SelectFolder` | string | Folder dialog |
+| `AskWhenRun<T>` | T | **Infinite retry loop on conversion failure**; uses reflection to find parent activity |
+
+### File System Activities
+| Activity | Key Gotcha |
+|----------|------------|
+| `DeleteFileX` | Direct File.Delete |
+| `GetFileInfoX` | Returns FileInfo |
+| `FileExistsX` | Returns bool |
+| `GetLastDownloadedFile` | **Creates folder if doesn't exist**; IgnoreFiles is comma-separated extensions; default timeout 300s |
+
+### Process Activities
+| Activity | Key Gotcha |
+|----------|------------|
+| `ExecutePowerShell` | Parameter names prefixed differently from PowerShellVariables ("Global."); InArgument\<bool\> with null = switch parameter |
+| `InvokeVBScript` | Windows-only VBScript execution |
+| `InvokeCode` | CacheMetadata checks compilation errors |
+
+### Workflow Control
+| Activity | Key Gotcha |
+|----------|------------|
+| `MultipleAssign` | Uses Activity.Implementation pattern (not CodeActivity); validates each assignment's Value/To |
+| `IfElseIf` / `IfElseIfV2` | All non-Else blocks must have Condition |
+
+### Credential Activities
+| Activity | Key Gotcha |
+|----------|------------|
+| `GetUsernamePasswordX` | Sources: CredentialsManager or Orchestrator; **timeout passed in milliseconds (value * 1000)**; uses separate CancellationTokenSource |
+
+### Trigger Activities
+| Activity | Key Gotcha |
+|----------|------------|
+| `TriggerScope` | Complex scheduling: Sequential, SequentialCollapse, SequentialDrop, OneTime; event queue filtering |
+| `FileChangeTrigger` v1/v2/v3 | Version evolution; v3 is newest |
+| `ProcessStartTrigger` v1/v2 | v2 is newer |
+| `ProcessEndTrigger` v1/v2 | v2 is newer |
+
+---
+
+## Critical Gotchas
+
+1. **ReadListItem\<T\> silent failure** - Returns null/default on out-of-bounds instead of throwing
+2. **InputDialog dynamic typing** - Result type determined at design time from ArgumentType, not runtime
+3. **FilterCollection in-place mutation** - Without Result bound, modifies original collection
+4. **RemoveFromCollection bitwise AND bug** - Uses `&` instead of `&&` on line 49 (works but technically incorrect)
+5. **AskWhenRun reflection fragility** - Searches parent activity by expression Id matching
+6. **ExecutePowerShell version detection** - Registry-based; parameter/variable name prefixing prevents collisions
+7. **TriggerScope queue modes** - SequentialCollapse removes all but last from same trigger; OneTime cancels all triggers after first event
+
+## Platform Constraints
+- `#if !NETPORTABLE_UIPATH`: InputDialog, CustomInput, InvokeComMethod, File activities
+- `#if NET6_0_OR_GREATER`: Text/Date standard activities
+- `#if NET6WINDOWS`: IfElseIf marked `[Browsable(false)]`
+
+## Orchestrator Activities (MISSING FROM MANY REFERENCES - CRITICAL)
+
+### Assets & Credentials
+| Activity | Key Arguments | Gotcha |
+|----------|---------------|--------|
+| `Get Asset` | AssetName -> Value (object) | Returns object type; cast to String/Int/Bool as needed |
+| `Set Asset` | AssetName, Value | Asset must exist and type must match |
+| `Get Credential` | AssetName -> Username, Password (SecureString) | Orchestrator credential assets only |
+| `Set Credential` | AssetName, Username, Password | |
+
+### Queues
+| Activity | Key Arguments | Gotcha |
+|----------|---------------|--------|
+| `Add Queue Item` | QueueName, ItemInformation (Dictionary), Priority, DeferDate, DueDate | ItemInformation values must be serializable |
+| `Get Transaction Item` | QueueName -> TransactionItem | Returns null if queue empty (check for Nothing!) |
+| `Set Transaction Status` | TransactionItem, Status (Success/Failed/Abandoned), Reason | Must be called for every transaction |
+| `Add Transaction Item` | QueueName, ItemInformation -> TransactionItem | Combines Add + Get in one call |
+| `Bulk Add Queue Items` | QueueName, DataTable | Column names become field names |
+| `Should Stop` | -> bool | Check periodically in loops for graceful stop |
+
+### Storage Buckets
+| Activity | Key Arguments | Gotcha |
+|----------|---------------|--------|
+| `Upload Storage File` | BucketName, FilePath, BlobFilePath | BlobFilePath is the remote key/path |
+| `Download Storage File` | BucketName, BlobFilePath, LocalPath | |
+| `List Storage Files` | BucketName, Directory -> IEnumerable | |
+| `Read/Write Storage Text` | BucketName, BlobFilePath, Content | UTF-8 encoding |
+
+### Jobs
+| Activity | Key Arguments | Gotcha |
+|----------|---------------|--------|
+| `Start Job` | ProcessName, RobotName -> JobId | Requires Orchestrator connection |
+| `Should Stop` | -> bool | Returns true if stop requested from Orchestrator |
+
+## GenericValue Conversion Traps (CRITICAL)
+- **To bool**: null/empty → `false`; ANY other non-boolean string → `true` (not false!). `new GenericValue("hello")` → `true`
+- **To int/double/decimal**: null → `0` (silent, no error)
+- **To DateTime**: null → `DateTime.MinValue` (Jan 1, 0001)
+- **Comparison**: `"10" > "9"` → `False` (string/lexicographic comparison)
+- **Fix**: Avoid GenericValue. Use strongly-typed variables. Always explicitly convert.
+
+## Date Format Registry Caching
+- Short/long date formats read from `HKCU\Control Panel\International` and cached for entire process lifetime
+- Changing Windows date settings during execution has NO effect until Robot restart
+
+## Regex Infinite Timeout
+- Regex Replace activity uses `Regex.InfiniteMatchTimeout` when TimeoutMS not set
+- Complex patterns with catastrophic backtracking will hang forever
+
+## Common Patterns
+- **[RequiredArgument]** - Must be provided at design time
+- **ContinueOnError** - Suppresses exceptions (InvokeComMethod returns null, TriggerScope calls HandleFault)
+- **Telemetry** - All activities have conditional telemetry with `ENABLE_DEFAULT_TELEMETRY` preprocessor

--- a/skills/uipath-rpa-legacy/references/activity-docs/Terminal.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Terminal.md
@@ -1,0 +1,120 @@
+# UiPath Terminal Activities - Legacy Reference
+
+## Overview
+Terminal emulation for mainframe/AS400/UNIX systems. Supports 9 emulation types and 10 providers. Package: `UiPath.Terminal.Activities`.
+
+---
+
+## Terminal Types
+| Type | Use Case |
+|------|----------|
+| Terminal3270 | IBM Mainframe |
+| Terminal5250 | IBM AS/400 |
+| TerminalVT | UNIX/VT100/VT220 |
+| TerminalHP | HP Terminals |
+| TerminalANSI | ANSI Standard |
+| TerminalSCOANSI | SCO ANSI |
+| TerminalLinux | Linux Console |
+| TerminalT653X | Televideo 653X |
+| TerminalWYSE | Wyse Terminals |
+
+## Providers
+| Provider | Connection Modes | Notes |
+|----------|-----------------|-------|
+| Attachmate Reflection | Profile + Host | Most common |
+| IBM Personal Communications | Profile only | Legacy |
+| Micro Focus Rumba | Profile only | |
+| Rocket BlueZone | Profile + Host | |
+| IBM EHLLAPI (Generic) | Low-Level only | Raw API, requires DLL |
+| Attachmate EXTRA | Profile only | |
+| Reflection for UNIX | Profile only | |
+| Reflection for IBM | Profile + Host | |
+| UiPath (New) | Host only | Current default |
+
+---
+
+## Activities (22 total)
+
+### Session Management
+| Activity | Key Arguments |
+|----------|---------------|
+| `TerminalSession` | ConnectionString (JSON), ExistingConnection, SSHUserName, SSHPassword, CloseConnection (default true) |
+
+### Basic Screen Operations
+| Activity | In/Out | Defaults |
+|----------|--------|----------|
+| `GetText` | -> Text (full screen) | Timeout: 5000ms, Delay: 300ms |
+| `SendControlKey` | Key (enum) -> | Delay: 1000ms |
+| `GetCursorPosition` | -> Row, Column (1-based) | |
+
+### Field-Based (by Index, LabeledBy, or FollowedBy)
+| Activity | In/Out |
+|----------|--------|
+| `GetField` | Criteria -> Text |
+| `SetField` | Criteria, Text -> |
+| `WaitFieldText` | Criteria, Text, MatchCase -> | Timeout: 30,000ms |
+| `WaitScreenText` | Text, MatchCase -> | Timeout: 30,000ms |
+
+### Coordinate-Based (row/column, 1-based)
+| Activity | In/Out |
+|----------|--------|
+| `GetTextAtPosition` | Row, Col, Length -> Text |
+| `GetFieldAtPosition` | Row, Col -> Text |
+| `SetFieldAtPosition` | Row, Col, Text -> |
+| `GetScreenArea` | Row, Col, EndRow, EndCol -> Text |
+| `GetColorAtPosition` | Row, Col -> Color |
+| `MoveCursor` | Row, Col -> |
+| `MoveCursorToText` | Text -> Row, Col |
+| `FindTextInScreen` | Text -> Row, Col |
+| `WaitTextAtPosition` | Row, Col, Text -> | Timeout: 30,000ms |
+| `WaitScreenReady` | -> | Timeout: 30,000ms |
+
+### Advanced
+| Activity | In/Out |
+|----------|--------|
+| `SendKeys` | Keys (string) -> |
+| `SendKeysSecure` | SecureText (SecureString) -> |
+
+---
+
+## Critical Gotchas
+
+### Session Management
+1. **All activities MUST be inside TerminalSession** body - constraint enforced
+2. **ConnectionString is JSON** with single quotes (apostrophes) instead of double quotes
+3. **CloseConnection=true (default)** - auto-closes on exit
+4. **OutputConnection** allows reusing connection across multiple TerminalSession scopes
+5. **SSH support** via SSHUserName + SSHPassword (SecureString) arguments
+
+### Coordinates
+6. **1-based indexing** for all row/column coordinates (NOT 0-based)
+7. **SetFieldAtPosition has BackwardsCompatible flag** - auto-detected from StackTrace for new activities
+
+### Field Identification Priority
+8. **Index takes precedence** if provided
+9. **LabeledBy/FollowedBy** used only when Index not set
+10. **InvalidIndex = -1**, BackwardsCompatibleIndex = -999
+
+### Keyboard & Screen
+11. **KeyboardLocked state** - WaitScreenReady throws when terminal is locked by application
+12. **SendKeysSecure** unmarshals SecureString temporarily, zeros memory after use
+13. **WaitMode**: NONE (no wait), READY (wait for screen ready, default), COMPLETE (wait for full idle)
+
+### Encoding
+14. **44 character encodings supported** (42 IBM EBCDIC variants + UTF-8 + ASCII)
+15. **InternalEncoding** must match mainframe code page (e.g., IBM037 for US English)
+
+### Timing
+16. **Default delay 300ms** (post-action pause) - critical for terminal sync
+17. **SendControlKey delay 1000ms** - higher because function keys cause screen transitions
+18. **Connection timeout 50,000ms** (50 seconds)
+19. **Wait timeouts 30,000ms** (30 seconds)
+
+### COM Interop
+20. **Attachmate, BlueZone, IBM providers use COM Interop** - require software installed
+21. **TurboSoft (TTerm)** is the modern native provider with managed wrapper
+22. **Proxy support**: Tunnel, SOCKS4, SOCKS4A, SOCKS5
+
+### Double-Width Characters
+23. **DBCS (Double-Byte Character Set)** support for Chinese/Japanese
+24. **TerminalField.DoubleWidth flag** indicates DBCS field

--- a/skills/uipath-rpa-legacy/references/activity-docs/Testing.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Testing.md
@@ -1,0 +1,95 @@
+# UiPath Testing Activities - Legacy Reference
+
+## Overview
+Test assertions, data generation, document comparison, and test data queue management. Package: `UiPath.Testing.Activities`.
+
+---
+
+## Assertion Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `VerifyExpression` | Assert boolean is true | Expression (bool), ContinueOnFailure (default true) |
+| `VerifyExpressionWithOperator` | Compare two values | FirstExpression, SecondExpression, Operator |
+| `VerifyRange` | Value within/outside range | Expression, LowerLimit, UpperLimit, VerificationType (IsWithin/IsNotWithin) |
+| `VerifyControlAttribute` | Verify activity output | ActivityToTest, OutputArgument, Expression, Operator |
+
+### Comparison Operators
+Equality (=), Inequality (<>), GreaterThan (>), GreaterThanOrEqual (>=), LessThan (<), LessThanOrEqual (<=), Contains, RegexMatch
+
+---
+
+## Document Comparison (NET5+)
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `ComparePdfDocuments` | Diff two PDFs | BaselinePath, TargetPath, ComparisonType (Line/Word/Character), Rules, IncludeImages |
+| `CompareText` | Diff two strings | BaselineText, TargetText, ComparisonType, OutputFilePath (HTML) |
+| `CreateComparisonRule` | Custom ignore rules | RuleName, ComparisonRuleType (Regex/Wildcard), Pattern, UsePlaceholder |
+
+### Comparison Output
+- `Result` (bool): True if equivalent
+- `Differences` (IEnumerable\<Difference\>): Each with Operation (Inserted/Deleted/Equal) and Text
+- `SemanticDifferences`: AI analysis when InterpretDifferencesWithAutopilot=true
+
+---
+
+## Test Data Queue Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `GetTestDataQueueItem` | Get next item | QueueName, MarkConsumed (default true) |
+| `GetTestDataQueueItems` | Batch fetch with filter | QueueName, Status (All/OnlyConsumed/OnlyNotConsumed), Top, Skip |
+| `NewAddTestDataQueueItem` | Add single item | QueueName, ItemInformation (Dict\<string, InArgument\>) |
+| `BulkAddTestDataQueue` | Add from DataTable | QueueName, QueueItemsDataTable |
+| `DeleteTestDataQueueItems` | Delete items | TestDataQueueItems (must have valid Ids) |
+| ~~`AddTestDataQueueItem`~~ | **OBSOLETE** | Use NewAddTestDataQueueItem instead |
+
+---
+
+## Test Data Generation
+
+| Activity | Output | Key Arguments |
+|----------|--------|---------------|
+| `RandomString` | string | Case (Lower/Upper/Camel/Mixed), Length (default 10) |
+| `RandomNumber` | decimal | Min, Max, Decimals (default 0) |
+| `RandomDate` | DateTime | MinDate, MaxDate |
+| `RandomValue` | string | FilePath (one value per line, random selection) |
+| `GivenName` | string | (from predefined list) |
+| `LastName` | string | (from predefined list) |
+| `Address` | Dict\<string, string\> | Country, City (both hidden in designer) |
+
+---
+
+## Critical Gotchas
+
+### Assertions
+1. **ContinueOnFailure=true by default in designer activities** - assertions don't stop workflow; set to false for strict testing. **Note**: Coded workflow API defaults to `false` (opts?.ContinueOnError ?? false)
+2. **Screenshot capture** available on both success and failure (separate flags, both default false)
+3. **VerifyControlAttribute cannot be nested** inside another VerifyControlAttribute
+4. **Type compatibility validated at CacheMetadata** - incompatible types cause design-time errors
+5. **RegexMatch operator** uses full .NET regex engine
+
+### Document Comparison
+6. **ComparePdfDocuments creates visual diff PDFs** - `{filename}_result.pdf` for both baseline and target
+7. **CompareText creates HTML diff report** at OutputFilePath (default "differences.html")
+8. **Rules (regex/wildcard)** allow ignoring dynamic content (dates, IDs)
+9. **Semantic analysis (Autopilot)** provides AI explanation separate from byte-level diff
+
+### Test Data Queues
+10. **Requires Orchestrator** - all queue operations go through IOrchestratorService
+11. **MarkConsumed=true** prevents item from being returned again
+12. **Batch fetch max 1000** items per internal API call
+13. **Top=0 treated as null** (no limit)
+14. **Delete requires valid Ids** - items must be previously retrieved
+15. **BulkAdd DataTable columns must be unique** - throws InvalidArgumentsException
+16. **Queue items stored as JSON** in Orchestrator
+
+### Test Data Generation
+17. **RandomValue reads from file** - file must exist with line-delimited values
+18. **Address Country/City inputs hidden in designer** but available programmatically
+19. **RandomDate validates MinDate < MaxDate** (skipped for expression arguments)
+
+### Misc
+20. **AttachDocument** uploads file to Orchestrator as test evidence
+21. **CoverageMergeActivity is internal** (Browsable=false) - for test framework infrastructure only

--- a/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-BalaReva-Excel.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-BalaReva-Excel.md
@@ -1,0 +1,120 @@
+# BalaReva Excel Activities - Legacy Reference
+
+## Overview
+Third-party Excel activities with advanced formatting, charts, and cell-level control. Two packages: `BalaReva.Excel.Activities` (COM, requires Excel - **38 activities**) and `BalaReva.EasyExcel.Activities` (library-based, no Excel). **#19 (3.4%) and #26 (1.2%) by adoption**.
+
+Source: [UiPath Marketplace](https://marketplace.uipath.com/listings/balareva-xl-activities)
+
+---
+
+## BalaReva.Excel.Activities - All 38 Activities (from Marketplace)
+
+### Charts (4)
+| Activity | Purpose |
+|----------|---------|
+| `Pie Chart` | Generate pie chart from data |
+| `Column Chart` | Generate column chart |
+| `Line Chart` | Generate line chart |
+| `Bar Chart` | Generate bar chart |
+
+### Comments (4)
+| Activity | Purpose |
+|----------|---------|
+| `Add Comment` | Insert comment into cell |
+| `Get Comment` | Extract comment text |
+| `Delete Comment` | Remove comment from cell |
+| `Show/Hide Comment` | Toggle comment visibility |
+
+### Cell Operations (7)
+| Activity | Purpose |
+|----------|---------|
+| `Copy Data to Clipboard` | Transfer cell data to clipboard |
+| `Clipboard To DataTable` | Convert clipboard to DataTable |
+| `Delete Data` | Clear/remove cell contents from range |
+| `Merge Cells` | Combine cell ranges with alignment |
+| `UnMerge Cells` | Separate merged cells |
+| `Change Cell Type` | Format numbers for currency/percentage/date/decimal |
+| `Format Cells` | Comprehensive formatting (alignment, orientation, font) |
+
+### Row/Column (4)
+| Activity | Purpose |
+|----------|---------|
+| `Hide/Unhide Column` | Toggle column visibility |
+| `Hide/Unhide Row` | Toggle row visibility |
+| `AutoFit Columns` | Auto-adjust column widths |
+| `AutoFit Rows` | Auto-adjust row heights |
+
+### Sheet Management (8)
+| Activity | Purpose |
+|----------|---------|
+| `Add Sheet` | Create new worksheet |
+| `Delete Sheet` | Remove worksheet |
+| `Rename Work Sheet` | Change sheet name |
+| `Copy To File` | Copy worksheet between files |
+| `Copy To WorkBook` | Copy worksheet within workbook |
+| `HideUnhide` | Toggle sheet visibility |
+| `Protect UnProtect` | Enable/disable sheet protection |
+| `Get Sheets Name` | List all sheet names |
+
+### Content Operations (5)
+| Activity | Purpose |
+|----------|---------|
+| `Find Replace` | Find and replace text in range |
+| `Remove Duplicates` | Eliminate duplicate rows (multi-column) |
+| `Hyperlink Remove` | Strip hyperlinks from range |
+| `Insert Table Format` | Create formatted table (28 styles) |
+| `Set Table Format` | Modify existing table format |
+
+### Images & Export (4)
+| Activity | Purpose |
+|----------|---------|
+| `Insert Image` | Place image at position |
+| `Insert Image At Cell` | Position image in specific cell |
+| `Extract Graph Image` | Export chart as image (BMP/GIF/JPG/PNG) |
+| `Export WorkBook` | Save as PDF or XPS |
+
+### Workbook (2)
+| Activity | Purpose |
+|----------|---------|
+| `Create WorkBook` | Generate new Excel file |
+| `Set Password` | Add password protection |
+
+---
+
+## BalaReva.EasyExcel.Activities
+
+Similar activities but uses **EPPlus/ClosedXML libraries** instead of COM Interop. Key difference: **does NOT require Excel installed**.
+
+---
+
+## BalaReva.Excel vs EasyExcel
+
+| Aspect | BalaReva.Excel | BalaReva.EasyExcel |
+|--------|---------------|-------------------|
+| Excel Required | YES (COM) | NO (library) |
+| Performance | Slower (COM) | Faster |
+| Process Risk | Zombie EXCEL.EXE | None |
+| .xls Support | Yes | No (.xlsx only) |
+| Chart Support | Full (4 chart types) | Limited |
+| Image Export | Yes (Extract Graph Image) | Limited |
+
+---
+
+## Critical Gotchas (Forum-Verified)
+
+### Compatibility Issues
+1. **v2019.10.1 incompatible with UiPath 2019.10.3** - [Forum](https://forum.uipath.com/t/balareva-excel-activities-v2019-10-1-problems/237430): "none of the activities actually work"
+2. **EasyExcel only works for 'windows-legacy' projects** - [Forum](https://forum.uipath.com/t/unable-to-install-bala-reva-easy-excel-packages/517950): won't install in Windows or cross-platform projects
+3. **Change Cell Type errors with .xlsx** - [Forum](https://forum.uipath.com/t/change-cell-type-error-while-using-balareva-easy-excel-activities/261970)
+
+### Activity-Specific Issues
+4. **AutoFit fails**: "AutoFit method of Range class failed" - [Forum](https://forum.uipath.com/t/balareva-excel-activities-autofit/282792)
+5. **Format Cells vertical alignment**: "Unable to set the HorizontalAlignment property" error when setting vertical alignment
+6. **Export WorkBook not working** - [Forum](https://forum.uipath.com/t/export-workbook-not-working-balareva-excel-activities/331344)
+7. **Extract Hyperlinks locks Excel** - [Forum](https://forum.uipath.com/t/balareva-enterprise-easyexcel-activities-extract-hyperlinks-problem/409437): document stays locked
+
+### General
+8. **Don't mix with UiPath built-in Excel** in same workflow - assembly/version conflicts
+9. **COM version leaves orphaned EXCEL.EXE** on crash - same issue as UiPath built-in
+10. **Free for community** but enterprise version (BalaReva Enterprise) has separate licensing
+11. **Also available**: [Graph Activities for Excel Charts](https://marketplace.uipath.com/listings/balareva-excel-graph-activities) - separate specialized chart package

--- a/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-Microsoft-WF4.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-Microsoft-WF4.md
@@ -1,0 +1,84 @@
+# Microsoft.Activities & Extensions - Legacy Reference
+
+## Overview
+Windows Workflow Foundation 4 (WF4) supplemental activities and testing helpers by Ron Jacobs (Microsoft). Package: `Microsoft.Activities` v1.8.9.17 and `Microsoft.Activities.Extensions`. **#11 (15.1%) and #12 (12.5%) by adoption**. Source: [CodePlex (archived)](http://wf.codeplex.com/). NuGet package inspected directly.
+
+---
+
+## Why 15% Adoption?
+
+The high adoption is mostly **legacy inertia** - these packages were popular in early UiPath (2016-2019) before UiPath had equivalents for many WF4 operations. Many existing projects still reference them. UiPath now provides built-in alternatives for most functionality.
+
+---
+
+## Microsoft.Activities (v1.8.9.17)
+
+### Package Contents (from NuGet inspection)
+- `Microsoft.Activities.dll` (Net40, Net401)
+- `Microsoft.Activities.Design.dll` (designers)
+- `Microsoft.Activities.NuGet.dll` (tools)
+
+### Key Activities & Classes (from package metadata + documentation)
+| Activity/Class | Purpose | UiPath Equivalent |
+|----------------|---------|-------------------|
+| `LoadActivity` | Dynamically load XAML workflow from file | Invoke Workflow File |
+| `LoadAndInvokeWorkflow` | Load + execute XAML at runtime | Invoke Workflow File |
+| `InvokeWorkflow` | Simplified workflow invocation with args | Invoke Workflow File |
+| `DelayUntilTime` | Delay until specific time of day | Delay + DateTime logic |
+| `AddToDictionary<K,V>` | Add item to dictionary | Assign activity |
+| `RemoveFromDictionary<K,V>` | Remove from dictionary | Invoke Method |
+| `ClearDictionary<K,V>` | Clear all dictionary entries | Assign activity |
+| `GetWorkflowXaml` | Get XAML definition string | (no equivalent) |
+| `StringConcat` | Concatenate strings | Assign + String.Concat |
+| `RegexMatch` | Regex pattern matching | System.Text.RegularExpressions |
+| `RegexReplace` | Regex find/replace | Matches activity |
+| `RegexMatches` | Return all regex matches | Matches activity |
+| `RegexIsMatch` | Test if regex matches | Is Match activity |
+| `GetFromDictionary<K,V>` | Get value by key | Assign + dict(key) |
+| `KeyExistsInDictionary<K,V>` | Check if key exists | dict.ContainsKey() |
+| `StringConcat` | Concatenate strings | Assign + String.Concat |
+
+### Why 15% Adoption (The Real Reason)
+UiPath's classic designer originally lacked built-in dictionary manipulation activities. `AddToDictionary`, `GetFromDictionary`, `KeyExistsInDictionary` were **the standard way** to work with dictionaries in XAML. The REFramework and early Academy templates included these packages, propagating them across thousands of projects. This is **legacy inertia** - UiPath now has all equivalents built-in.
+
+### Extension Methods (non-activity helpers)
+- `WorkflowArguments` - Simplified dictionary building for workflow arguments
+- Task-based async helpers for WF4
+
+---
+
+## Microsoft.Activities.Extensions (v2.0.6.9)
+
+### Key Features
+| Feature | Purpose | UiPath Equivalent |
+|---------|---------|-------------------|
+| `WorkflowApplicationTest` | Unit test helper wrapping WorkflowApplication | UiPath Testing Framework |
+| `WorkflowInvokerTest` | Simplified test invocation | Testing activities |
+| `StateMachineStateTracker` | Track state machine transitions and history | (no equivalent - useful for debugging) |
+| `MemoryTrackingParticipant` | In-memory execution event capture | Log Message / Output panel |
+| `WorkflowEpisode` | Resume workflows from persistence points | (built into UiPath runtime) |
+| `ActivityStateQuery` extensions | Detailed activity execution tracing | UiPath logs |
+
+---
+
+## Critical Gotchas
+
+### Compatibility
+1. **.NET Framework 4.0/4.0.1 ONLY** - will NOT work with .NET 5+/6+ projects (UiPath Windows-modern)
+2. **Abandoned since 2013** - last NuGet update was v1.8.9.17 (2011 for Microsoft.Activities)
+3. **CodePlex source is archived** - no bug fixes, no updates, no support
+4. **Can conflict with UiPath's workflow engine** - both use System.Activities; assembly binding redirects may clash
+
+### Why NOT to Use
+5. **UiPath has built-in equivalents** for almost everything:
+   - Dictionary operations: use `Assign` activity
+   - Dynamic workflow loading: use `Invoke Workflow File`
+   - Delay until time: use `Delay` with calculated TimeSpan
+   - String operations: use `Assign` with VB.NET/C# expressions
+6. **Testing helpers don't work** with UiPath's custom workflow host (different runtime)
+7. **StateMachineStateTracker is the only unique feature** - useful for debugging state machines but available nowhere else
+
+### Migration
+8. **New projects should NOT add these packages** - use UiPath built-in activities instead
+9. **Existing projects**: gradually replace Microsoft.Activities calls with UiPath equivalents during maintenance
+10. **If you see these in a project**: the project is likely legacy (pre-2020) and may need broader modernization

--- a/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-Persistence.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-Persistence.md
@@ -1,0 +1,140 @@
+# UiPath Persistence Activities - Legacy Reference
+
+## Overview
+Long-running workflow persistence: suspend, wait for human/external input, resume. Package: `UiPath.Persistence.Activities`. **#28 by adoption (1.1%)**. Official UiPath package. Source: [UiPath Docs](https://docs.uipath.com/action-center/automation-cloud/latest/user-guide/persistence-activities).
+
+---
+
+## All Activities (20 total, from official docs)
+
+### Form Tasks (Action Center)
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `Create Form Task` | Create human task with form | TaskTitle, TaskPriority, TaskCatalog, FormData (Dict\<String,Argument\>), Reference, Labels, GenerateInputFields, OrchestratorFolderPath -> TaskObject (FormTaskData) |
+| `Wait For Form Task And Resume` | **SUSPEND** until form completed | TaskObject (req), StatusMessage, TimeoutMS (def 30000) -> TaskAction (string), TaskObject (updated) |
+| `Create Form` | Design form in Studio | (form designer integration) |
+
+### External Tasks
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `Create External Task` | Create task for external system | TaskTitle, TaskPriority, TaskCatalog, TaskData (JSON) -> TaskObject |
+| `Wait For External Task And Resume` | **SUSPEND** until external completion | TaskObject -> TaskAction, TaskData |
+
+### App Tasks
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `Create App Task` | Create app-level task | TaskTitle, TaskPriority -> TaskObject |
+| `Wait For App Task And Resume` | **SUSPEND** until app task done | TaskObject -> TaskAction |
+
+### Job/Queue Persistence
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `Start Job And Get Reference` | Start job, get tracking ref | ProcessName, InputArguments -> JobReference |
+| `Wait For Job And Resume` | **SUSPEND** until job completes | JobReference -> OutputArguments |
+| `Add Queue Item And Get Reference` | Add to queue, get ref | QueueName, Priority, ItemInformation -> QueueItemReference |
+| `Wait For Queue Item And Resume` | **SUSPEND** until queue item processed | QueueItemReference -> QueueItemData |
+
+### Timer
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `Resume After Delay` | **SUSPEND** for duration, release robot | ResumeTime (DateTime) OR Delay (TimeSpan) |
+
+### Task Management (non-suspending)
+| Activity | Purpose |
+|----------|---------|
+| `Assign Tasks` | Assign tasks to users/groups |
+| `Complete Task` | Mark task as finished |
+| `Forward Task` | Route task to another user |
+| `Get Form Tasks` | Retrieve form tasks |
+| `Get Task Data` | Get task details |
+| `Get App Tasks` | Retrieve app tasks |
+| `Add Task Comment` | Append notes to task |
+| `Update Task Labels` | Modify task tags |
+| `Configure Task Timer` | Set time constraints |
+
+---
+
+## How Suspension Works
+1. Workflow hits `Wait For * And Resume` activity
+2. **Entire workflow state serialized** to Orchestrator database
+3. **Robot license released** - robot freed for other jobs
+4. External condition met (human completes form, job finishes, timer expires)
+5. Orchestrator triggers resume - **can be on a different machine**
+6. State deserialized, execution continues
+
+---
+
+## Create Form Task - Detailed Arguments (from docs)
+
+### Input
+| Argument | Type | Description |
+|----------|------|-------------|
+| `TaskTitle` | String | Title shown in Action Center |
+| `TaskPriority` | TaskPriority | Low, Medium, High, Critical |
+| `TaskCatalog` | String | Catalog for grouping tasks |
+| `FormData` | Dictionary\<String, Argument\> | In/Out/InOut arguments mapped to form fields. **Out and InOut arguments are mapped back after completion.** |
+| `Reference` | String | Reference ID for grouping related actions |
+| `Labels` | String | Tags for filtering (naming restrictions apply) |
+| `GenerateInputFields` | Boolean | Auto-generate form fields from FormData entries |
+| `EnableBulkEdit` | Boolean | Enable bulk completion from Action Center |
+| `OrchestratorFolderPath` | String | Orchestrator folder (empty = current) |
+
+### Output
+| Argument | Type | Description |
+|----------|------|-------------|
+| `TaskObject` | FormTaskData | Pass to Wait For Form Task And Resume |
+
+---
+
+## Critical Gotchas (Docs + Community Verified)
+
+### Orchestrator Required
+1. **Only works when running from Orchestrator** - Studio debug simulates suspension, not real persist/resume
+2. **Process must be "Orchestration Process"** (long-running background type) - set in Studio project settings
+3. **Requires Orchestrator 2020.10+** for full support
+4. **Action Center licensing** required for form tasks
+
+### Serialization (THE #1 FAILURE CAUSE)
+5. **ALL variables in scope at suspension must be serializable** - this breaks most first attempts
+6. **NOT serializable**: UiElement, Browser, Application handles, COM objects, open file handles
+7. **Cannot have open Application/Browser Scope** across a suspension point
+8. **DataTable is serializable** but fails with non-serializable column types (e.g., Image columns)
+9. **Custom .NET objects** must be `[Serializable]` or implement `ISerializable`
+
+### State Across Suspension
+10. **No UI context preserved** - logged-in apps, browser sessions, open windows all lost
+11. **Must re-authenticate** everything after resume
+12. **Local file paths may not exist** on resume machine - use Orchestrator storage buckets
+13. **Resume After Delay releases robot license** - unlike regular Delay which holds it
+
+### Form Tasks
+14. **FormData uses Dictionary\<String, Argument\>** not Dictionary\<String, Object\> - Argument type has Direction (In/Out/InOut)
+15. **Out/InOut arguments mapped back** to workflow after task completion - this is how you get user input
+16. **GenerateInputFields** auto-creates form fields from FormData - convenient but limited customization
+17. **Form schema changes break pending tasks** - plan schema updates carefully
+18. **StatusMessage** displayed in Orchestrator alongside suspended workflow
+
+### Best Practices
+19. **Save data to Orchestrator assets/queues** before suspension - not to local variables
+20. **Keep variables minimal at suspension points** - fewer serialization issues
+21. **Use Reference field** to group related tasks for easier management
+22. **Test in Orchestrator** (not just Studio) - suspension behavior is fundamentally different
+
+### Persistence Trigger Types (from source code)
+- `QueueItem` (1) - Resume when queue item processed
+- `Job` (2) - Resume when child job completes
+- `Task` (3) - Resume when Action Center task completed
+- `Timer` (4) - Resume at specific time
+
+### Design-Time Rules
+23. **ST-DBP-027**: Warning when persistence activities inside ForEach loops - loop iterator state complicates serialization
+24. **NoPersistScope constraint**: Persistence activities CANNOT be inside NoPersistScope/Retry Scope - design-time validation error
+25. **Task title max 512 characters** - validated by FormTaskCreateRequest
+26. **Debug mode skips persistence** - Studio detects platform ("Studio", "StudioX", "StudioPro", "CommandLine") and polls instead of persisting
+
+### Serializable Types That Work
+`String`, `Int32`, `Int64`, `Boolean`, `DateTime`, `Double`, `Decimal`, `DataTable`, `Dictionary<string, object>`, `JObject`, `JArray`, `String[]`, basic .NET collections
+
+### Run Job with Suspend Mode
+- RunJob activity has `ExecutionMode` enum: None (fire-and-forget), Busy (poll, robot stays), Suspend (persist, robot freed)
+- Suspend mode internally uses `StartJobAndGetReference` + `WaitForJobAndResume` with `TriggerType = Job`

--- a/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-SharePoint.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/ThirdParty-SharePoint.md
@@ -1,0 +1,105 @@
+# UiPathTeam SharePoint Activities - Legacy Reference
+
+## Overview
+Community SharePoint integration (Online + On-Premises) via REST API. Package: `UiPathTeam.SharePoint.Activities`. **#14 by adoption (4.9%)**. Source: [GitHub](https://github.com/UiPath-Services/UiPathTeam.SharePoint.Activities). Community-supported (not official UiPath enterprise support).
+
+---
+
+## All Activities (33 total, from source code)
+
+### SharePoint Application Scope (REQUIRED parent)
+All activities must be inside this scope. Authentication container.
+
+**Authentication Types:**
+- **Online** - SharePoint Online with user credentials (Username + Password)
+- **AppOnly** - Client ID + Client Secret (app-only auth, no user credentials)
+- **AzureApp** - Azure App Registration to impersonate user (AzureApplicationID + AzureAppPermissions + Username + Password). SharePoint Online only.
+- **WebLogin** - Browser popup for 3rd-party IdP or MFA (prompts user first run)
+- **Windows** - On-prem NTLM/Kerberos (Domain + Username + Password)
+- **ADFS** - On-prem Active Directory Federation Services
+
+**Key Properties:** Url (site URL, required), AuthMode, Username, Password/SecurePassword, ClientId, ClientSecret, Domain, AzureApplicationID, QueryGrouping (batch queries)
+
+### Library Activities (13)
+| Activity | Key Arguments | Notes |
+|----------|---------------|-------|
+| `Upload File` | RelativeUrl (req), LocalPath (req), PropertiesToAdd (dict), AllowOperationsOnASPXFiles | Blocks ASPX upload by default |
+| `Upload Large File` | RelativeUrl, LocalPath | For files >250MB |
+| `Get File` (Download) | RelativeUrl (req), LocalPath | If LocalPath empty, saves to project root |
+| `Create Folder` | LibraryName (req), RelativeUrl (req) | |
+| `Delete` | RelativeUrl (req) | Deletes file or folder |
+| `Check In File` | RelativeUrl | Version control checkin |
+| `Check Out File` | RelativeUrl | Version control checkout |
+| `Discard Checkout` | RelativeUrl | Cancel checkout |
+| `Get Children Names` | RelativeUrl | List folder contents |
+| `Move Item` | SourceUrl, DestinationUrl | Move file/folder |
+| `Rename Item` | RelativeUrl, NewName | |
+| `Create File` | (base class for Upload) | |
+
+### List Activities (7)
+| Activity | Key Arguments | Notes |
+|----------|---------------|-------|
+| `Get List Items` (ReadListItems) | ListName (req), CAMLQuery | Output: Dictionary[] OR DataTable (overload groups) |
+| `Add List Item` | ListName (req), PropertiesToAdd (dict) | |
+| `Update List Items` | ListName, ItemId, PropertiesToUpdate | |
+| `Delete List Items` | ListName, ItemIds | |
+| `Add List Item Attachments` | ListName, ItemId, FilePaths | |
+| `Get List Item Attachments` | ListName, ItemId | |
+| `Delete List Item Attachments` | ListName, ItemId, FileNames | |
+
+### Permission Activities (3)
+| Activity | Key Arguments | Notes |
+|----------|---------------|-------|
+| `Add Permission` | RelativeUrl, PrincipalId, RoleDefinition | |
+| `Get Permissions` | RelativeUrl | Returns permission list |
+| `Remove Permission` | RelativeUrl, PrincipalId | |
+
+### User/Group Activities (6)
+| Activity | Key Arguments | Notes |
+|----------|---------------|-------|
+| `Get User` | Username | Output: SharePointUser |
+| `Get All Users From Group` | GroupName | Output: List\<User\> |
+| `Add User To Group` | Username, GroupName | |
+| `Remove User From Group` | Username, GroupName | |
+| `Create Group` | GroupName, Description | |
+| `Remove Group` | GroupName | |
+
+### Utility Activities (3)
+| Activity | Purpose |
+|----------|---------|
+| `Get TimeZone` | Get SharePoint site timezone |
+| `Get Web Login User` | Get current authenticated user |
+| `Sign Out` | End authentication session |
+
+---
+
+## Critical Gotchas (Source-Code Verified + Community Reports)
+
+### Authentication (MAJOR ISSUES)
+1. **Microsoft deprecating legacy auth** - App-Only with client secret may stop working for SharePoint Online. Consider Azure AD certificate auth or Microsoft Graph.
+2. **401 Unauthorized common** - [Forum reports](https://forum.uipath.com/t/uipathteam-sharepoint-activities-sharepoint-application-scope-401-unauthorized/515006): check tenant settings, app permissions, and auth mode compatibility
+3. **Windows auth failure on robots** - [Forum](https://forum.uipath.com/t/windows-authentication-failure-uipathteam-sharepoint-activities/332491): service account must have SharePoint access
+4. **"Sign-in name or password does not match"** - [Forum](https://forum.uipath.com/t/uipathteam-sharepoint-activities-authentication-exception/578289): common with MFA-enabled tenants; use WebLogin or AzureApp auth instead
+5. **WebLogin prompts user** on first run - not suitable for unattended robots
+
+### QueryGrouping / Batch Queries
+6. **QueryGrouping was NOT implemented** - README explicitly states this. Activities that don't support batch queries validate against this setting.
+7. **Activities check parent scope** - Every activity validates it's inside SharePointApplicationScope via constraint
+
+### CAML Queries (NOT SQL!)
+8. **CAML is XML-based** - NOT SQL syntax. Example:
+```xml
+<View><Query><Where><Eq><FieldRef Name='Title'/><Value Type='Text'>MyDoc</Value></Eq></Where></Query></View>
+```
+9. **5000-item list view threshold** - SharePoint blocks queries returning >5000 items. Use indexed columns + CAML paging with `<RowLimit>` element.
+
+### File Operations
+10. **RelativeUrl is site-relative** (e.g., `/sites/MySite/Shared Documents/file.docx`) - NOT absolute URL
+11. **ASPX files blocked by default** - `AllowOperationsOnASPXFiles` must be explicitly enabled
+12. **Upload Large File** required for files >250MB - regular Upload File has size limit
+13. **V2.0 uses REST API** (not legacy CSOM) - breaking change from v1.x
+
+### General
+14. **Community package** - no UiPath enterprise support; community forum only
+15. **Url must be SITE URL** (e.g., `https://tenant.sharepoint.com/sites/MySite`) not page/library URL
+16. **Get List Items returns Dictionary[] OR DataTable** - overload groups, pick one output type

--- a/skills/uipath-rpa-legacy/references/activity-docs/UIAutomation.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/UIAutomation.md
@@ -1,0 +1,147 @@
+# UiPath UIAutomation Activities - Legacy Reference
+
+## Overview
+Legacy desktop UI automation for Windows. Click, type, find elements, manage windows/browsers. Package: `UiPath.UIAutomation.Activities`.
+
+---
+
+## Input Methods
+
+| Method | Constant | Speed | Reliability | Special Keys | Notes |
+|--------|----------|-------|-------------|--------------|-------|
+| Hardware Events (default) | SYNTHESIZE_INPUT | Slow | Most reliable | YES | Acquires input lock, blocks user input |
+| Window Messages | WINDOW_MESSAGES | Fast | Least reliable | YES | Best for classic Win32 apps |
+| UI Automation API | API | Medium | Very reliable | **NO** | SimulateClick/SimulateType; bypasses input |
+
+**CRITICAL: Cannot use SimulateClick AND SendWindowMessages simultaneously**
+**SimulateType + special keys produces design-time WARNING** (not hard error)
+
+---
+
+## Key Activities
+
+### Mouse
+| Activity | Key Arguments | Defaults |
+|----------|---------------|----------|
+| `Click` | ClickType (Single/Double/Down/Up), MouseButton (Left/Right/Middle), KeyModifiers, CursorPosition, SimulateClick, SendWindowMessages | AlterIfDisabled=true |
+| `Hover` | CursorPosition, SimulateHover, SendWindowMessages | Hover duration ~1000ms |
+
+### Keyboard
+| Activity | Key Arguments | Defaults |
+|----------|---------------|----------|
+| `TypeInto` | Text, SimulateType, SendWindowMessages, Activate, ClickBeforeTyping, EmptyField, DelayBetweenKeys | Activate=true, AlterIfDisabled=true |
+| `TypeSecureText` | SecureText (SecureString) | Special keys escaped in non-Simulate mode |
+| `SendHotkey` | Key, SpecialKey, KeyModifiers | Activate=true |
+
+### Element Search
+| Activity | Key Arguments | Key Gotcha |
+|----------|---------------|------------|
+| `Element Exists` | Target | **Returns false instead of throwing on timeout** |
+| `Find Children` | Target, Filter, Scope | Returns lazy IEnumerable |
+| `Find Relative` | Target, CursorPosition (offset) | Returns first element at coordinates |
+| `Get Ancestor` | Target, UpLevels | Returns null at root |
+| `Wait Element Appear` | Target, WaitVisible, WaitActive | Adaptive polling: 50ms -> 200ms -> 1000ms |
+| `Wait Element Vanish` | Target, WaitNotVisible | Returns silently on timeout |
+
+### Element Attributes
+| Activity | Key Arguments | Notes |
+|----------|---------------|-------|
+| `Get Text` / `Get Value` | Target | Wraps GetAttribute("text") |
+| `Get Attribute` | Target, Attribute | Returns null if attribute doesn't exist |
+| `Set Value` | Target, Text | Uses SetAttribute("text") |
+| `Select Item` | Target, Item | Exact match usually required |
+| `Select Multiple Items` | Target, MultipleItems, AddToSelection | |
+| `Check` | Target, Action (Check/Uncheck/Toggle) | Toggle reads current state first |
+| `Wait Attribute` | Attribute, AttributeValue | Supports wildcards (* and ?); polls every 100ms |
+| `Get Position` | Target | Returns Rectangle (screen coordinates) |
+
+### Actions
+| Activity | Purpose |
+|----------|---------|
+| `Activate` | Bring window to foreground |
+| `Set Focus` | Set keyboard focus (doesn't foreground) |
+| `Highlight` | Debug visualization (blocking for duration) |
+| `Take Screenshot` | Capture element as Image |
+
+### Scopes
+| Activity | Key Arguments |
+|----------|---------------|
+| `Open Browser` | Url, BrowserType (IE/Chrome/Firefox/Edge), Private, NewSession, Hidden, CommunicationMethod |
+| `Open Application` | Selector, FileName, Arguments, WorkingDirectory |
+| `Window Scope` | Selector OR Window (mutually exclusive) |
+| `Browser Scope` | Selector OR Browser (mutually exclusive) |
+
+---
+
+## Special Key Syntax (TypeInto)
+```
+[k(end)]        - End key
+[k(home)]       - Home key
+[k(del)]        - Delete key
+[k(backspace)]  - Backspace
+[k(enter)]      - Enter
+[k(tab)]        - Tab
+[k(escape)]     - Escape
+[k(ctrl+a)]     - Ctrl+A (press+release)
+[d(ctrl)]       - Ctrl down
+[u(ctrl)]       - Ctrl up
+[k(F1)]         - Function key F1-F12
+```
+
+---
+
+## Critical Gotchas
+
+### AlterIfDisabled Default
+1. **AlterIfDisabled=true by default** on Click, TypeInto, SetValue, SelectItem, Check - can interact with disabled/grayed controls unexpectedly
+
+### TypeInto Specifics
+2. **SimulateType CANNOT handle special keys** - fails validation if `[k(...)]` syntax detected
+3. **EmptyField uses hardcoded sequence**: `[k(end)d(shift)k(home)u(shift)k(del)]` - may fail for multi-line. **CRITICAL: EmptyField is silently ignored when SimulateType=true** - only works with hardware events and SendWindowMessages
+4. **DelayBetweenKeys max 1000ms** - validation error if exceeded
+5. **Activate=true by default** - may cause unwanted window switches
+
+### Selector Issues
+6. **Selector matching is fragile** - UI changes invalidate selectors
+7. **Placeholders** `{varName}` resolved at runtime - null variables cause failures
+8. **Closest matches** can return wrong element if multiple similar elements exist
+9. **Closest matches disabled in Exists** activity (returns false cleanly)
+
+### Click Specifics
+10. **SimulateClick cannot CLICK_DOUBLE with BTN_RIGHT or BTN_MIDDLE**
+11. **SimulateClick doesn't acquire input lock** - others do
+12. **CursorMotionType** affects how cursor moves (straight line, smooth, etc.)
+
+### Timing
+13. **Default timeout ~30,000ms** (30 seconds) across most activities
+14. **DelayBefore/DelayAfter are sequential** (Thread.Sleep internally)
+15. **WaitUiElementAppear adaptive polling**: 50ms -> 200ms -> 1000ms
+16. **Exists returns false instead of throwing** on timeout
+
+### Browser Scope
+17. **NewSession=true (default)** creates new browser process (slower but isolated)
+18. **NewSession=false** reuses existing browser (faster, shared state/cookies)
+19. **Private mode** may disable extensions/drivers
+20. **CommunicationMethod**: Native (UiPath driver) vs WebDriver (Selenium-based)
+
+### Window/Browser Scope Validation
+21. **Must set either Selector OR Window/Browser** - not both, not neither
+22. **If Window/Browser set, SearchScope cannot be set**
+
+### Image-Based Activities
+23. **Template matching** (not AI) - sensitive to resolution, brightness, minor UI changes
+24. **Slower than selector-based** - use only for unstable selectors
+
+### Error Handling
+25. **ContinueOnError=false by default** - exceptions thrown
+26. **Governance exceptions never suppressed** even with ContinueOnError=true
+
+### Additional Validated Gotchas
+27. **OpenBrowser defaults to IE** - BrowserType default is `BrowserType.IE`
+28. **Hover has fixed 1000ms duration** - hardcoded, not configurable
+29. **Default timeouts**: Timeout=30,000ms, DelayAfter=300ms, DelayBefore=200ms, OpenBrowser=60s
+30. **AlterIfDisabled NOT passed to node in hardware events mode for TypeInto** (but IS passed for Click) - inconsistent behavior
+31. **CursorMotionType.Smooth only works with hardware events** - has no effect with SimulateClick or SendWindowMessages
+32. **Data Scraping hardcodes ContinueOnError=true** - extraction failures produce empty DataTable, no error
+33. **SimulateClick MV3 workaround** - hidden project setting `EnableWorkaroundForSimulateClickMV3` (default false) needed for Chrome Manifest V3 extensions
+34. **Image OCR uses hardcoded 5-pixel offset** - can cause incorrect crops on small images

--- a/skills/uipath-rpa-legacy/references/activity-docs/Vision-OCR.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Vision-OCR.md
@@ -1,0 +1,37 @@
+# UiPath Vision/OCR Activities - Legacy Reference
+
+## Overview
+OCR and document recognition with multiple engine support. Package: `UiPath.Vision.Activities`.
+
+---
+
+## OCR Engines
+
+| Engine | Type | Requirements |
+|--------|------|-------------|
+| Microsoft Azure Computer Vision | Cloud | Azure API key + endpoint |
+| Google Cloud Vision | Cloud | Google API key |
+| ABBYY FRE / FRE12 | Local | ABBYY FineReader Engine installed |
+| Tesseract (Legacy) | Local | Tesseract binaries (bundled or installed) |
+
+## Key Classes
+- `OCRInput` / `OCROutput` - Standard I/O models
+- `NormalizedOcrResult` - Unified output (Region -> Line -> Word hierarchy)
+- `VisionImage` - Bitmap wrapper with format detection
+- `EnginePreprocessor` / `EnginePostProcessor` - Image pre/post processing
+
+---
+
+## Critical Gotchas
+
+1. **Multiple engines with different accuracy/speed** - Azure/Google better for most cases; ABBYY best for structured docs
+2. **Preprocessing critical** for OCR quality - deskew, contrast enhancement, noise removal
+3. **Cloud engines require API keys** and network connectivity
+4. **Local engines (ABBYY, Tesseract) require separate installation**
+5. **Output normalization loses engine-specific metadata** (confidence scores vary by engine)
+6. **Language support varies by engine** - check engine docs for supported languages
+7. **Image DPI affects quality** - 300 DPI recommended minimum for OCR
+8. **EmguCV (OpenCV wrapper)** used for image preprocessing
+9. **Polly library** for retry/resilience on cloud API calls
+10. **IPC/hosting model** for service isolation (OCR runs in separate process)
+11. **ReadApiV3 models** for Microsoft Read API response mapping (async operation)

--- a/skills/uipath-rpa-legacy/references/activity-docs/Web.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Web.md
@@ -1,0 +1,108 @@
+# UiPath Web Activities - Legacy Reference
+
+## Overview
+HTTP/REST, SOAP, JSON, and XML activities. Package: `UiPath.Web.Activities`.
+
+---
+
+## Activities
+
+### HTTP/REST
+| Activity | Purpose | Key Gotcha |
+|----------|---------|------------|
+| `NetHttpRequest` | Modern HTTP client (.NET HttpClient) | Default timeout 10,000ms |
+| `HttpClient` | Legacy REST client (RestSharp) | Default timeout 6,000ms |
+| `SoapClient` | SOAP 1.1/1.2 client | Hard-coded timeout 60,000ms |
+
+### JSON
+| Activity | Purpose |
+|----------|---------|
+| `DeserializeJson<T>` | JSON string to typed object |
+| `DeserializeJsonArray` | JSON string to JArray |
+| `SerializeJson` | Object to JSON string |
+
+### XML
+| Activity | Purpose |
+|----------|---------|
+| `DeserializeXml` | XML string to XDocument |
+| `GetXMLNodes` / `GetNodes` | Extract nodes from XML |
+| `ExecuteXPath` | XPath query on XML |
+| `GetXMLNodeAttributes` | Get attributes from node |
+
+---
+
+## NetHttpRequest - Full Configuration
+
+### Authentication Types
+- **None** - No auth
+- **BasicUsernamePassword** - RFC 7617 Base64(username:password)
+- **OAuthToken** - Bearer token in Authorization header
+- **NegotiatedAuthentication** - Windows/Kerberos (SocketsHttpHandler.Credentials)
+
+### Request Body Types
+- None, Text, FormUrlEncoded, MultipartFormData, Binary, Stream
+
+### Retry Policy
+- **None** - No retry
+- **Basic** - Fixed delay (default 500ms) between retries
+- **ExponentialBackoff** - Delay = InitialDelay x (Multiplier ^ attempt) + optional jitter
+- **Default retry codes**: 408, 429, 500, 502, 503, 504
+- **Retry-After header respected** (seconds or HTTP-date format)
+- **MaxRetryAfterDelay** caps server-suggested delay (default 30s)
+
+### Response Handling
+- **SaveResponseAsFile** - Save binary response to disk
+- **FileOverwrite**: AutoRename, Replace, Discard
+- **Default encoding**: UTF-8 (customizable via TextPayloadEncoding)
+
+---
+
+## Critical Gotchas
+
+### Timeouts
+1. **NetHttpRequest default: 10,000ms** (10 seconds) - often too low for slow APIs. Property has typo: `TimeoutInMiliseconds` (single 'l')
+2. **Legacy HttpClient default: 6,000ms** (6 seconds) - very aggressive
+3. **SoapClient: 60,000ms hard-coded** - no override available
+4. **Platform can override** via WebApiTestingServiceContext.TimeoutInMiliseconds
+
+### SSL/TLS
+5. **DisableSslVerification=false (default)** - validates full chain
+6. **When disabled**: callback returns true regardless of SSL errors (security risk)
+7. **Client certificates**: PFX/PKCS12 file OR certificate subject from Windows store
+8. **TLS protocol options**: Automatic (system default), Tls12, Tls13
+
+### Redirect Handling
+9. **FollowRedirects=true (default)** with MaxRedirects=3
+10. **SocketsHttpHandler.AllowAutoRedirect** explicitly set to false by default, overridden by config
+
+### Proxy
+11. **WebProxyConfiguration**: Address, BypassOnLocal, BypassList (supports wildcards like "*.example.com")
+12. **ProxyCredentials** for authenticated proxies
+
+### Multipart/Form-Data
+13. **Files NOT disposed until MultipartContent disposed** with request
+14. **ContentType inferred from filename extension** or explicit MIME type
+
+### SOAP Specific
+15. **SOAPAction header format differs** between SOAP 1.1 (quoted) and 1.2 (in Content-Type)
+16. **Action synthesized** from namespace + operation name if not in WSDL
+17. **Default namespace fallback**: "http://tempuri.org"
+
+### JSON Serialization
+18. **Uses Newtonsoft.Json** (not System.Text.Json)
+19. **DeserializeJson<T>** - TypeNameHandling setting can be security risk if processing untrusted JSON
+20. **DateParseHandling** affects how date strings are interpreted (DateTime vs DateTimeOffset vs None)
+
+### Cookie Handling
+21. **EnableCookies=true by default** - CookieContainer maintained per session
+22. **Request-style cookies** (semicolon-separated) normalized before adding to container
+
+### Legacy HttpClient vs NetHttpRequest
+23. **HttpClient (legacy)** uses RestSharp; supports OAuth1 (ConsumerKey/Secret/Token)
+24. **NetHttpRequest (modern)** uses .NET HttpClient; does NOT support OAuth1
+25. **Prefer NetHttpRequest** for new workflows
+
+### Additional Validated Gotchas
+26. **NetHttpRequest ContinueOnError defaults to TRUE** - HTTP errors silently swallowed by default; set to false for strict error handling
+27. **SoapClient timeout is NOT user-configurable** - hardcoded 60s constant with no activity property override
+28. **SSL bypass differs between legacy and modern** - Legacy HttpClient blindly returns true for all SSL errors; NetHttpRequest only bypasses when DisableSslVerification=true AND checks for actual errors

--- a/skills/uipath-rpa-legacy/references/activity-docs/Word.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/Word.md
@@ -1,0 +1,76 @@
+# UiPath Word Activities - Legacy Reference
+
+## Overview
+Word automation with COM Interop (requires Word) and Portable (Xceed.Words.NET, no Word needed). Package: `UiPath.Word.Activities`.
+
+---
+
+## Activities
+
+### Windows/COM (require WordApplicationScope)
+| Activity | Key Arguments | Notes |
+|----------|---------------|-------|
+| `WordApplicationScope` | FilePath, CreateNewFile, AutoSave, ReadOnly, Password, EditPassword | Container for all COM activities |
+| `WordAppendText` | Text, NewLine (default true) | |
+| `WordReadText` | Output: Text | Reads entire document |
+| `WordReplaceText` | Search (max 255 chars), Replace (max 255 chars), ReplaceAll | |
+| `WordAddImage` | ImagePath, Position (Start/End/Before/After/Replace), InsertRelativeTo | |
+| `WordInsertDataTable` | DataTable | Default position: Start |
+| `WordInsertHyperlink` | TextToDisplay, Address, TextToSearchFor | |
+| `WordSetBookmarkContent` | BookmarkName, BookmarkText | Max 40 chars for name |
+| `WordExportToPdf` | FilePath, ReplaceExisting | |
+| `WordSaveAs` | FilePath, SaveAsFileType (docx/docm/doc/html/rtf/txt) | |
+| `WordReplacePicture` | PicturePath, PictureAltText | Throws if alt text not found |
+| `WordPasteFromClipboard` | Text, PasteOption (EmbedData/LinkData/Picture) | |
+| `WordGetSensitivityLabel` | Output: SensitivityLabel | |
+| `WordAddSensitivityLabel` | SensitivityLabel, Justification | |
+
+### Portable (no Word required, Xceed-based)
+| Activity | Key Arguments | Notes |
+|----------|---------------|-------|
+| `DocumentCreateNew` | FilePath, ConflictResolution (Replace/Fail/Skip) | .docx/.docm only |
+| `DocumentReadText` | FilePath | |
+| `DocumentAppendText` | FilePath, Text, NewLine | |
+| `DocumentReplaceText` | FilePath, Search, Replace | |
+| `DocumentAddImage` | FilePath, ImagePath, positional args | |
+| `DocumentInsertDataTable` | FilePath, DataTable | |
+| `DocumentInsertHyperlink` | FilePath, TextToDisplay, Address | |
+| `DocumentSetBookmarkContent` | FilePath, BookmarkName, BookmarkText | |
+
+---
+
+## Critical Gotchas
+
+### COM Object Management
+1. **Must release COM objects** via `Marshal.ReleaseComObject()` - failing leaves Word processes
+2. **RPC Server retry** - Error 0x8001010A retries up to 3 times with 100ms delay when Word is busy
+3. **DisplayAlerts suppressed** during SaveAs/ExportPdf to prevent dialogs in unattended mode
+
+### AutoSave
+4. **AutoSave=true (default)** saves after EACH operation - performance impact
+5. **Only saves if NOT ReadOnly** mode
+6. **Portable (FileDocument)** only saves on close if content hash changed
+
+### Text Limits
+7. **Search text max 256 characters** (WordReplaceText validation: `text.Length > 256`)
+8. **TextToSearch max 256 characters** (DocumentActivity validation)
+9. **Bookmark name max 40 characters**
+
+### Positional Insert Constraints
+10. **InsertRelativeTo=Document**: Position can only be Start or End
+11. **InsertRelativeTo=Bookmark**: Position can only be Start or End
+12. **InsertRelativeTo=Text**: Supports Occurrence (All/First/Last/Specific)
+
+### ReadOnly Mode
+13. **Changes execute but don't persist** in ReadOnly mode - no error thrown
+
+### SharePoint/URL Documents
+14. **Cannot create new file at URL** (CreateNewFile must be false)
+15. **SharePoint URLs auto-sanitized** via `.SanitizeWordSharePointUrl()`
+
+### No Template Support
+16. **Activities don't support .dotx templates** - must create blank then modify
+
+### Dependencies
+17. **Xceed.Words.NET** for portable (no COM)
+18. **Microsoft.Office.Interop.Word** for Windows (COM, embedded interop types)

--- a/skills/uipath-rpa-legacy/references/activity-docs/WorkflowEvents.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/WorkflowEvents.md
@@ -1,0 +1,34 @@
+# UiPath WorkflowEvents Activities - Legacy Reference
+
+## Overview
+App-triggered workflow invocation and two-way communication via SignalR. Package: `UiPath.WorkflowEvents.Activities`.
+
+---
+
+## Key Activities
+
+| Activity | Purpose | Key Arguments |
+|----------|---------|---------------|
+| `AppRequestTrigger` | Listen for app workflow requests | ConnectionMode (RobotJS/Cloud), Arguments (output) |
+| `HandleAppRequest` | Execute and respond to request | Arguments (from trigger), Timeout |
+| `SendInterimResult` | Push intermediate status | (mid-execution update to app) |
+
+### Supporting Activities
+- `OpenAppsPage` / `OpenAppsUrl` - Navigation
+- `CloseAppsPopOver` / `ResetAppsValues` - UI state
+- `ShowAppsToast` / `ShowHideAppsSpinner` - Notifications
+- `SubmitAction` - Form submission
+- `DetectChangesActivity` - Change detection
+
+---
+
+## Critical Gotchas
+
+1. **Heartbeat required every 30 seconds** or connection drops
+2. **SignalR idle timeout: 90 seconds** - connection terminated if no activity
+3. **Workflow context must serialize/deserialize cleanly** for data transfer
+4. **Remote execution requires IPC bridge** setup
+5. **Apps UI state must sync with workflow state** - race conditions possible
+6. **Serialization failures break request handling** silently
+7. **ConnectionMode**: RobotJS (local) vs Cloud (Orchestrator-mediated)
+8. **SignalR timeout configurable**: SignalRTimeoutMS = 90,000ms default

--- a/skills/uipath-rpa-legacy/references/activity-docs/_BUILT-IN-ACTIVITIES.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_BUILT-IN-ACTIVITIES.md
@@ -1,0 +1,425 @@
+# Built-in Activities — Complete XAML Reference
+
+**No `find-activities` or `type-definition` needed for these activities.** Use the XAML snippets below directly.
+
+All VB.NET examples. For C# projects, replace `[expression]` brackets with `<mca:CSharpValue>` wrappers.
+
+---
+
+## Group 1: WF4 Built-in Activities
+
+Default namespace `http://schemas.microsoft.com/netfx/2009/xaml/activities` — no xmlns prefix needed.
+
+### 1. If
+
+```xml
+<If Condition="[age >= 18]" DisplayName="Check Age" sap2010:WorkflowViewState.IdRef="If_1">
+  <If.Then>
+    <Sequence DisplayName="Then">
+      <!-- activities when true -->
+    </Sequence>
+  </If.Then>
+  <If.Else>
+    <Sequence DisplayName="Else">
+      <!-- activities when false -->
+    </Sequence>
+  </If.Else>
+</If>
+```
+
+Properties: `Condition` (InArgument Boolean), `If.Then` (single activity), `If.Else` (optional, single activity). Wrap multiple activities in a Sequence.
+
+### 2. Assign
+
+```xml
+<Assign DisplayName="Set Counter" sap2010:WorkflowViewState.IdRef="Assign_1">
+  <Assign.To>
+    <OutArgument x:TypeArguments="x:Int32">[counter]</OutArgument>
+  </Assign.To>
+  <Assign.Value>
+    <InArgument x:TypeArguments="x:Int32">[counter + 1]</InArgument>
+  </Assign.Value>
+</Assign>
+```
+
+Properties: `Assign.To` (OutArgument — target variable), `Assign.Value` (InArgument — source expression). Both need matching `x:TypeArguments`.
+
+### 3. Sequence
+
+```xml
+<Sequence DisplayName="Main Sequence" sap2010:WorkflowViewState.IdRef="Sequence_1">
+  <Sequence.Variables>
+    <Variable x:TypeArguments="x:String" Name="filePath" />
+    <Variable x:TypeArguments="x:Int32" Name="counter" Default="0" />
+    <Variable x:TypeArguments="sd:DataTable" Name="dtData" />
+  </Sequence.Variables>
+  <!-- child activities execute top to bottom -->
+</Sequence>
+```
+
+Properties: `Sequence.Variables` (local variables scoped to this Sequence), child activities in order.
+
+### 4. TryCatch
+
+```xml
+<TryCatch DisplayName="Try Catch" sap2010:WorkflowViewState.IdRef="TryCatch_1">
+  <TryCatch.Try>
+    <Sequence DisplayName="Try">
+      <!-- activities that may throw -->
+    </Sequence>
+  </TryCatch.Try>
+  <TryCatch.Catches>
+    <Catch x:TypeArguments="uic:BusinessRuleException" sap2010:WorkflowViewState.IdRef="Catch`1_1">
+      <ActivityAction x:TypeArguments="uic:BusinessRuleException">
+        <ActivityAction.Argument>
+          <DelegateInArgument x:TypeArguments="uic:BusinessRuleException" Name="exception" />
+        </ActivityAction.Argument>
+        <Sequence DisplayName="Catch BusinessRuleException">
+          <!-- use [exception.Message] to access the error -->
+        </Sequence>
+      </ActivityAction>
+    </Catch>
+    <Catch x:TypeArguments="s:Exception" sap2010:WorkflowViewState.IdRef="Catch`1_2">
+      <ActivityAction x:TypeArguments="s:Exception">
+        <ActivityAction.Argument>
+          <DelegateInArgument x:TypeArguments="s:Exception" Name="exception" />
+        </ActivityAction.Argument>
+        <Sequence DisplayName="Catch System.Exception">
+          <!-- generic catch-all -->
+        </Sequence>
+      </ActivityAction>
+    </Catch>
+  </TryCatch.Catches>
+  <TryCatch.Finally>
+    <!-- cleanup activities (always runs) -->
+  </TryCatch.Finally>
+</TryCatch>
+```
+
+**Required xmlns for exception types:**
+```xml
+xmlns:s="clr-namespace:System;assembly=mscorlib"
+xmlns:uic="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+```
+
+Each `Catch` needs `ActivityAction<ExceptionType>` with `DelegateInArgument` named `exception`. Order matters — put specific catches first.
+
+### 5. Flowchart
+
+```xml
+<Flowchart DisplayName="Main Flowchart" sap2010:WorkflowViewState.IdRef="Flowchart_1">
+  <Flowchart.StartNode>
+    <x:Reference>__ReferenceID0</x:Reference>
+  </Flowchart.StartNode>
+
+  <FlowStep x:Name="__ReferenceID0">
+    <!-- activity here -->
+    <FlowStep.Next>
+      <x:Reference>__ReferenceID1</x:Reference>
+    </FlowStep.Next>
+  </FlowStep>
+
+  <!-- Do NOT add trailing <x:Reference> for child nodes here — they are already direct children -->
+</Flowchart>
+```
+
+See `_XAML-GUIDE.md` for ViewState layout guide (MANDATORY for Flowcharts).
+
+### 6. ForEach
+
+```xml
+<ForEach x:TypeArguments="x:String" DisplayName="For Each" sap2010:WorkflowViewState.IdRef="ForEach`1_1">
+  <ForEach.Values>
+    <InArgument x:TypeArguments="scg:IEnumerable(x:String)">[myList]</InArgument>
+  </ForEach.Values>
+  <ActivityAction x:TypeArguments="x:String">
+    <ActivityAction.Argument>
+      <DelegateInArgument x:TypeArguments="x:String" Name="item" />
+    </ActivityAction.Argument>
+    <Sequence DisplayName="Body">
+      <!-- use [item] to access current element -->
+    </Sequence>
+  </ActivityAction>
+</ForEach>
+```
+
+**Required xmlns:** `xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"`
+
+`x:TypeArguments` sets the element type. Body is `ActivityAction<T>` with DelegateInArgument named `item`.
+
+### 7. While
+
+```xml
+<While DisplayName="While Loop" sap2010:WorkflowViewState.IdRef="While_1">
+  <While.Condition>
+    <mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="counter &lt; 10" />
+  </While.Condition>
+  <Sequence DisplayName="Body">
+    <!-- loop body -->
+  </Sequence>
+</While>
+```
+
+**Required xmlns:** `xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities"`
+
+Condition uses `VisualBasicValue<Boolean>` with `ExpressionText` (not bracket notation).
+
+### 8. DoWhile
+
+```xml
+<DoWhile DisplayName="Do While" sap2010:WorkflowViewState.IdRef="DoWhile_1">
+  <DoWhile.Condition>
+    <mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="hasMore" />
+  </DoWhile.Condition>
+  <Sequence DisplayName="Body">
+    <!-- runs at least once -->
+  </Sequence>
+</DoWhile>
+```
+
+Same as While but body executes before condition check.
+
+### 9. Switch
+
+```xml
+<Switch x:TypeArguments="x:String" Expression="[status]" DisplayName="Switch" sap2010:WorkflowViewState.IdRef="Switch`1_1">
+  <ui:LogMessage x:Key="Active" Message="[&quot;Status is Active&quot;]" DisplayName="Log Active" />
+  <ui:LogMessage x:Key="Closed" Message="[&quot;Status is Closed&quot;]" DisplayName="Log Closed" />
+  <Switch.Default>
+    <ui:LogMessage Message="[&quot;Unknown status: &quot; &amp; status]" DisplayName="Log Default" />
+  </Switch.Default>
+</Switch>
+```
+
+`x:TypeArguments` sets the switch type. Cases use `x:Key="value"`. `Switch.Default` for the default case.
+
+### 10. Throw
+
+```xml
+<Throw Exception="[New BusinessRuleException(&quot;Invalid data&quot;)]" DisplayName="Throw" sap2010:WorkflowViewState.IdRef="Throw_1" />
+```
+
+Use short-form class names (namespace must be imported). For complex messages, assign to a variable first then `[New BusinessRuleException(errorMsg)]`.
+
+### 11. Rethrow
+
+```xml
+<Rethrow DisplayName="Rethrow" sap2010:WorkflowViewState.IdRef="Rethrow_1" />
+```
+
+No properties. Use inside a Catch block to re-throw the caught exception.
+
+### 12. Delay
+
+```xml
+<Delay Duration="[TimeSpan.FromSeconds(5)]" DisplayName="Delay" sap2010:WorkflowViewState.IdRef="Delay_1" />
+```
+
+`Duration` is `InArgument<TimeSpan>`. Common: `TimeSpan.FromSeconds(N)`, `TimeSpan.FromMinutes(N)`, `TimeSpan.FromMilliseconds(N)`.
+
+### 13. Parallel
+
+```xml
+<Parallel DisplayName="Parallel" sap2010:WorkflowViewState.IdRef="Parallel_1">
+  <Sequence DisplayName="Branch 1">
+    <!-- first parallel branch -->
+  </Sequence>
+  <Sequence DisplayName="Branch 2">
+    <!-- second parallel branch -->
+  </Sequence>
+</Parallel>
+```
+
+Direct child activities execute in parallel. No ActivityAction pattern — just list branches as children.
+
+### 14. FlowDecision (inside Flowchart)
+
+```xml
+<FlowDecision x:Name="__ReferenceID1" DisplayName="Has Data?">
+  <FlowDecision.Condition>
+    <mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="dtData.Rows.Count > 0" />
+  </FlowDecision.Condition>
+  <FlowDecision.True>
+    <x:Reference>__ReferenceID2</x:Reference>
+  </FlowDecision.True>
+  <FlowDecision.False>
+    <x:Reference>__ReferenceID3</x:Reference>
+  </FlowDecision.False>
+</FlowDecision>
+```
+
+### 15. FlowSwitch (inside Flowchart)
+
+```xml
+<FlowSwitch x:TypeArguments="x:String" x:Name="__ReferenceID4" DisplayName="Route by Type"
+  Expression="[documentType]">
+  <FlowStep x:Key="Invoice">
+    <x:Reference>__ReferenceID5</x:Reference>
+  </FlowStep>
+  <FlowStep x:Key="Receipt">
+    <x:Reference>__ReferenceID6</x:Reference>
+  </FlowStep>
+  <FlowSwitch.Default>
+    <x:Reference>__ReferenceID7</x:Reference>
+  </FlowSwitch.Default>
+</FlowSwitch>
+```
+
+---
+
+## Group 2: UiPath Core Activities
+
+All use `xmlns:ui="http://schemas.uipath.com/workflow/activities"`.
+
+### 16. LogMessage
+
+```xml
+<ui:LogMessage DisplayName="Log Message" sap2010:WorkflowViewState.IdRef="LogMessage_1"
+  Message="[&quot;Processing item: &quot; &amp; itemName]"
+  Level="Info" />
+```
+
+| Property | Type | Values |
+|----------|------|--------|
+| `Message` | InArgument(Object) | Any expression — converted via `.ToString()` |
+| `Level` | LogLevel enum | `Trace`, `Info`, `Warn`, `Error`, `Fatal` |
+
+### 17. InvokeCode
+
+```xml
+<ui:InvokeCode Code="result = input.Trim().ToUpper()" Language="VBNet"
+  DisplayName="Invoke Code" sap2010:WorkflowViewState.IdRef="InvokeCode_1">
+  <ui:InvokeCode.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <InArgument x:TypeArguments="x:String" x:Key="input">[rawText]</InArgument>
+      <OutArgument x:TypeArguments="x:String" x:Key="result">[cleanText]</OutArgument>
+    </scg:Dictionary>
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+```
+
+| Property | Type | Values |
+|----------|------|--------|
+| `Code` | String | VB.NET or C# method body (not class/module wrapper) |
+| `Language` | NetLanguage enum | `VBNet`, `CSharp` |
+| `Arguments` | Dictionary(String, Argument) | In/Out/InOut arguments keyed by name |
+| `ContinueOnError` | InArgument(Boolean) | Suppresses runtime errors only (compilation errors always throw) |
+
+**Required xmlns:** `xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"`
+
+See `_INVOKE-CODE.md` for full reference (generated code structure, compilation details, gotchas).
+
+### 18. InvokeWorkflowFile
+
+```xml
+<ui:InvokeWorkflowFile DisplayName="Invoke Process.xaml"
+  WorkflowFileName="Workflows\Process.xaml" UnSafe="False"
+  sap2010:WorkflowViewState.IdRef="InvokeWorkflowFile_1">
+  <ui:InvokeWorkflowFile.Arguments>
+    <InArgument x:TypeArguments="x:String" x:Key="in_FilePath">[inputPath]</InArgument>
+    <OutArgument x:TypeArguments="x:Boolean" x:Key="out_Success">[wasSuccessful]</OutArgument>
+  </ui:InvokeWorkflowFile.Arguments>
+</ui:InvokeWorkflowFile>
+```
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `WorkflowFileName` | InArgument(String) | Relative path from project root |
+| `UnSafe` | Boolean | `True` = isolated execution |
+| `Arguments` | Dictionary | Keys match target workflow's argument names |
+| `Timeout` | InArgument(TimeSpan) | Optional execution timeout |
+| `ContinueOnError` | InArgument(Boolean) | Continue on invocation failure |
+
+### 19. ForEachRow
+
+```xml
+<ui:ForEachRow DisplayName="For Each Row" sap2010:WorkflowViewState.IdRef="ForEachRow_1"
+  DataTable="[dtData]">
+  <ui:ForEachRow.Body>
+    <ActivityAction x:TypeArguments="sd:DataRow">
+      <ActivityAction.Argument>
+        <DelegateInArgument x:TypeArguments="sd:DataRow" Name="CurrentRow" />
+      </ActivityAction.Argument>
+      <Sequence DisplayName="Body">
+        <!-- use [CurrentRow("ColumnName").ToString()] to access cell values -->
+      </Sequence>
+    </ActivityAction>
+  </ui:ForEachRow.Body>
+</ui:ForEachRow>
+```
+
+**Required xmlns:** `xmlns:sd="clr-namespace:System.Data;assembly=System.Data"`
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `DataTable` | InArgument(DataTable) | Table to iterate |
+| `Body` | ActivityAction(DataRow) | DelegateInArgument named `CurrentRow` |
+
+### 20. AddDataRow
+
+```xml
+<!-- Add row from array -->
+<ui:AddDataRow DisplayName="Add Data Row" sap2010:WorkflowViewState.IdRef="AddDataRow_1"
+  DataTable="[dtTable]">
+  <ui:AddDataRow.ArrayRow>
+    <InArgument x:TypeArguments="x:Object[]">[New Object() {"Value1", 123, True}]</InArgument>
+  </ui:AddDataRow.ArrayRow>
+</ui:AddDataRow>
+```
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `DataTable` | InOutArgument(DataTable) | Table to add row to |
+| `ArrayRow` | InArgument(Object[]) | Array of column values |
+| `DataRow` | InArgument(DataRow) | Alternative: existing DataRow (mutually exclusive with ArrayRow) |
+
+### 21. BuildDataTable — Use InvokeCode Instead
+
+`BuildDataTable` exists but its `TableInfo` property is a complex .NET DataTable XML schema generated by Studio's designer wizard. It is **not practical to construct manually** — the XML includes XSD schema declarations, namespace URIs, column type metadata, and assembly-qualified type names.
+
+**Recommended: create DataTables with InvokeCode:**
+
+```xml
+<ui:InvokeCode Language="VBNet" DisplayName="Build DataTable"
+  sap2010:WorkflowViewState.IdRef="InvokeCode_BDT"
+  Code="Dim dt As New DataTable(&quot;Results&quot;)&#xA;dt.Columns.Add(&quot;Name&quot;, GetType(String))&#xA;dt.Columns.Add(&quot;Amount&quot;, GetType(Double))&#xA;dt.Columns.Add(&quot;IsActive&quot;, GetType(Boolean))&#xA;dt.Columns(&quot;Name&quot;).MaxLength = 100&#xA;result = dt">
+  <ui:InvokeCode.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <OutArgument x:TypeArguments="sd:DataTable" x:Key="result">[dtResults]</OutArgument>
+    </scg:Dictionary>
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+```
+
+**The VB.NET code inside** (readable form):
+```vb
+Dim dt As New DataTable("Results")
+dt.Columns.Add("Name", GetType(String))
+dt.Columns.Add("Amount", GetType(Double))
+dt.Columns.Add("IsActive", GetType(Boolean))
+dt.Columns("Name").MaxLength = 100
+result = dt
+```
+
+**To also add initial rows**, append to the code:
+```vb
+dt.Rows.Add("Alice", 100.50, True)
+dt.Rows.Add("Bob", 0, False)
+dt.Rows.Add(DBNull.Value, DBNull.Value, DBNull.Value)  ' null row for edge case testing
+```
+
+**Why not BuildDataTable:** The `TableInfo` XML format is the output of `DataTable.WriteXml(writer, XmlWriteMode.WriteSchema)` — a verbose XSD schema that requires precise namespace declarations, column metadata, and assembly-qualified type names. Studio's GUI generates this automatically; manual construction is error-prone and not worth the effort.
+
+---
+
+## Required xmlns Summary
+
+These xmlns are needed beyond the baseline when using activities above:
+
+| xmlns | Needed For |
+|-------|-----------|
+| `xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities"` | While/DoWhile conditions (VisualBasicValue) |
+| `xmlns:sd="clr-namespace:System.Data;assembly=System.Data"` | ForEachRow (DataRow), DataTable variables |
+| `xmlns:s="clr-namespace:System;assembly=mscorlib"` | TryCatch (System.Exception), DateTime |
+| `xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"` | ForEach (IEnumerable), InvokeCode Arguments |
+| `xmlns:uic="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"` | TryCatch (BusinessRuleException) |

--- a/skills/uipath-rpa-legacy/references/activity-docs/_COMMON-PITFALLS.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_COMMON-PITFALLS.md
@@ -1,0 +1,296 @@
+# UiPath Legacy Activities - Common Real-World Pitfalls
+
+## Purpose
+Gotchas reported by the community and discovered in source code that go beyond typical documentation. These are the issues developers hit in production.
+
+---
+
+## Excel (Classic - ExcelApplicationScope)
+
+### Zombie Excel Processes
+- **Problem**: Invisible `EXCEL.EXE` processes accumulate, especially after exceptions mid-workflow
+- **Root cause**: COM objects not released when workflow crashes before Dispose runs
+- **Fix**: Use Kill Process for `EXCEL.EXE` in a Finally block. The codebase has 207+ `DisposeWithReleaseComObject` calls showing this is a known hard problem
+
+### Dates Read as Serial Numbers (45678 instead of date)
+- **Problem**: Read Range returns OLE Automation doubles instead of dates
+- **Root cause**: Excel stores dates internally as doubles since 1900. `PreserveFormat=false` returns raw numbers
+- **Fix**: Set `PreserveFormat=true`, or convert with `DateTime.FromOADate(doubleValue)`
+
+### Read Range Returns Empty DataTable
+- **Problem**: Activity succeeds but DataTable is empty
+- **Root cause**: Sheet name mismatch (case/whitespace), malformed range, or file locked by open Excel
+- **Fix**: Verify sheet name with Get Workbook Sheets first. Use `""` for range to read entire used range. Close Excel before running
+
+### Write Range Overwrites Formatting
+- **Problem**: Cell formatting (colors, fonts, borders) lost after Write Range
+- **Root cause**: Classic Write Range strips formatting by default
+- **Fix**: Use Write Cell in loop for small updates, or use Interop-based writing with Visible=true
+
+### ClosedXML Formula Evaluation is Limited (Portable)
+- **Problem**: Formulas return stale/wrong values in Portable mode
+- **Root cause**: ClosedXML cannot evaluate all Excel formulas; falls back to cached values via GetRichText()
+- **Fix**: Use Interop mode (ExcelApplicationScope) for formula-dependent workflows
+
+---
+
+## UIAutomation (Classic - Click, TypeInto, Selectors)
+
+### TypeInto Missing or Wrong Characters
+- **Problem**: Characters dropped, wrong, or special chars interpreted as modifiers
+- **Root cause**: `{`, `}`, `[`, `]`, `+`, `^`, `%`, `~` are SendKeys modifier chars. SimulateType may be too fast.
+- **Fix**: Escape special chars: `{{}`, `{}}`, `{+}`. Add `DelayBetweenKeys` (50ms). For passwords use Type Secure Text
+
+### TypeInto at Wrong Cursor Position
+- **Problem**: Text inserted in middle of existing content instead of replacing
+- **Root cause**: EmptyField may not work on all controls. Cursor position unpredictable.
+- **Fix**: Set `EmptyField=true` AND prepend `[k(ctrl+a)]` to select all before typing
+
+### EmptyField Silently Ignored with SimulateType
+- **Problem**: Field not cleared despite EmptyField=true
+- **Root cause**: Source code only runs EmptyField sequence for hardware events and SendWindowMessages, NOT for SimulateType/API mode
+- **Fix**: Use hardware events (default) or SendWindowMessages when EmptyField is needed
+
+### Selector Works in Studio, Fails on Robot/Orchestrator
+- **Problem**: Element not found in production despite working in development
+- **Root cause**: Different resolution, DPI scaling, user session (interactive vs service), window state. RDP disconnect loses UI.
+- **Fix**: Use SimulateClick/SimulateType (don't depend on screen). Keep RDP alive. Use consistent resolution. Avoid `idx` attribute.
+
+### Dynamic Selectors Break Over Time
+- **Problem**: Selectors with timestamps, session IDs, or changing indices fail
+- **Root cause**: Dynamic attributes like `aaname` containing runtime values, `idx` being position-dependent
+- **Fix**: Use wildcards (`*`) for dynamic parts. Prefer `AutomationId` or `name`. Use Anchor Base for relative positioning. Avoid `idx`.
+
+### OpenBrowser Defaults to Internet Explorer
+- **Problem**: Workflows default to IE which is deprecated
+- **Root cause**: `BrowserType` default is `BrowserType.IE` in source code
+- **Fix**: Always explicitly set BrowserType to Chrome, Firefox, or Edge
+
+---
+
+## Mail (Classic - SMTP/IMAP/POP3/Exchange/Outlook)
+
+### SMTP Authentication Fails with Gmail/Microsoft 365
+- **Problem**: Login rejected despite correct credentials
+- **Root cause**: Google/Microsoft disabled "Less Secure Apps". OAuth2 now required.
+- **Fix**: Use App Passwords (Gmail) or configure Azure AD App Registration with SMTP.Send permission (M365). Set UseOAuth=true and pass OAuth token as Password.
+
+### SMTP SSL/TLS Port Mismatch
+- **Problem**: Connection fails with SSL errors
+- **Root cause**: Port 587 requires STARTTLS (`SecureConnection=StartTls`). Port 465 requires implicit SSL. Port 25 is unencrypted.
+- **Fix**: Use Port 587 + StartTls for most SMTP servers. Classic SMTP activity may not support implicit SSL on port 465.
+
+### Attachment Paths Not Found on Robot
+- **Problem**: Attachment path valid in Studio but not on production Robot
+- **Root cause**: Relative paths resolve differently on Robot vs Studio
+- **Fix**: Always use absolute paths. Use `Path.Combine(Environment.CurrentDirectory, filename)`
+
+### Addresses Must Use Semicolons (Not Commas)
+- **Problem**: Multiple recipients not receiving emails
+- **Root cause**: Address separator is `;` not `,` for all protocols EXCEPT Lotus Notes (which uses commas)
+- **Fix**: `"user1@mail.com;user2@mail.com"` - semicolons only
+
+---
+
+## Web (Classic - HTTP Request, SOAP)
+
+### HTTP Request Returns Error Despite Correct Setup
+- **Problem**: 403/401 errors with valid credentials
+- **Root cause**: Missing required headers (`User-Agent`, `Accept`), expired token, or wrong `Content-Type`
+- **Fix**: Add `User-Agent` header. Match `Content-Type` exactly. Verify with Postman first, replicate exact headers.
+
+### HTTP Request ContinueOnError Defaults to TRUE
+- **Problem**: HTTP errors silently swallowed; workflow continues with null/empty response
+- **Root cause**: `NetHttpRequest.ContinueOnError = true` by default in source code
+- **Fix**: Explicitly set `ContinueOnError=false` to get exceptions on 4xx/5xx responses
+
+### Legacy HttpClient Very Short Timeout (6 seconds)
+- **Problem**: Requests timeout on slow APIs
+- **Root cause**: Default timeout is only 6,000ms. NetHttpRequest default is 10,000ms. Both often too low.
+- **Fix**: Increase TimeoutMS to 30,000-60,000ms for production APIs
+
+### SOAP Client Timeout Not Configurable
+- **Problem**: SOAP requests timeout at 60 seconds with no way to increase
+- **Root cause**: Hardcoded `60,000ms` constant in HttpSoapRequestLogic, no exposed property
+- **Fix**: No workaround via activity properties. For long-running SOAP calls, consider using HTTP Request with manual SOAP envelope construction.
+
+---
+
+## PDF (Classic)
+
+### Read PDF Text Returns Empty String
+- **Problem**: Activity returns `""` for a PDF that clearly has content
+- **Root cause**: PDF contains scanned images, not text layer. `ReadPDFText` only extracts native text.
+- **Fix**: Use `Read PDF With OCR` with an OCR engine (Tesseract, UiPath Document OCR). Check if text is selectable in Adobe Reader.
+
+### Read PDF Text Returns Garbled/Out-of-Order Text
+- **Problem**: Text is present but columns are mixed, lines out of order
+- **Root cause**: PDF internal text stream doesn't match visual layout. Multi-column layouts especially problematic.
+- **Fix**: Set `PreserveFormatting=true` (off by default!). Or use Read PDF With OCR for better layout handling.
+
+---
+
+## Database (Community)
+
+### "Unable to find requested .NET Framework Data Provider"
+- **Problem**: Connection fails with provider not found error
+- **Root cause**: Missing database driver, or 32-bit vs 64-bit mismatch with UiPath Robot
+- **Fix**: Install correct bitness driver (64-bit for modern UiPath). For Oracle use `Oracle.ManagedDataAccess` NuGet. Check `machine.config` for provider registration.
+
+### Connection Works in Studio, Fails on Robot
+- **Problem**: Same connection string fails in production
+- **Root cause**: Different ODBC/OLE DB drivers installed, Windows credentials differ (Integrated Security)
+- **Fix**: Use explicit credentials, not `Integrated Security=true`. Ensure drivers installed on Robot machine.
+
+### Execute Query vs Execute Non Query Confusion
+- **Problem**: SELECT returns no data, or INSERT returns DataTable
+- **Root cause**: Using wrong activity for the SQL operation type
+- **Fix**: `Execute Query` for SELECT (returns DataTable). `Execute Non Query` for INSERT/UPDATE/DELETE (returns row count).
+
+---
+
+## Credentials
+
+### Get Credential Fails on Robot Server
+- **Problem**: Works on developer machine but fails on production Robot
+- **Root cause**: Windows Credential Manager is per-user. Robot service account doesn't have the stored credential.
+- **Fix**: Use Orchestrator Assets (Credential type) instead. If must use Windows CM, log in as Robot service account and store credential there.
+
+---
+
+## Python (Community - PythonScope)
+
+### Python Scope Fails to Find Installation
+- **Problem**: "Python not found" error
+- **Root cause**: Wrong Path or Version. 32-bit vs 64-bit mismatch. TargetPlatform must match Python installation.
+- **Fix**: Set full path to `python.exe`. Match Version exactly. Set TargetPlatform to x64 for 64-bit Python.
+
+### Python Script Works Locally but Fails in UiPath
+- **Problem**: Script runs fine in command line but errors in PythonScope
+- **Root cause**: Virtual environment not activated, working directory different, packages not installed globally
+- **Fix**: Point Path to virtualenv's `python.exe`. Use absolute paths in scripts. Install packages globally or in the specific env.
+
+---
+
+## FTP (Community)
+
+### Download/Upload Hangs or Timeouts
+- **Problem**: Connection established but transfers hang
+- **Root cause**: Passive vs Active mode mismatch; firewall blocking data channel ports
+- **Fix**: Toggle UsePassiveMode. Ensure firewall allows passive port range (1024-65535). Use SFTP (port 22) when possible.
+
+---
+
+## GenericValue Traps (System)
+
+### String Comparison Instead of Numeric
+- **Problem**: `"10" > "9"` returns False
+- **Root cause**: GenericValue does string comparison (lexicographic), not numeric
+- **Fix**: Explicitly convert: `CInt(genericValue)`, `CDbl(genericValue)`. Avoid GenericValue in new projects; use strongly-typed variables.
+
+### DataTable Column Name Issues
+- **Problem**: "Column X does not belong to table" after reading data
+- **Root cause**: Column names have trailing/leading whitespace, or case mismatch in filter expressions
+- **Fix**: Trim column names: `col.ColumnName = col.ColumnName.Trim()`. Use column index `row(0)` when names unreliable. Use bracket notation for spaces: `[Column Name]`.
+
+### GenericValue Boolean Conversion Trap (DANGEROUS)
+- **Problem**: `new GenericValue("hello")` converted to bool returns `True`. ANY non-null, non-empty, non-boolean string → `True`
+- **Root cause**: Source code `GenericValue.cs` line 89: if `Convert.ToBoolean` fails, the catch block returns `true` (not false!)
+- **Fix**: NEVER rely on implicit GenericValue-to-bool conversion. Always explicitly compare: `If myVar.ToString() = "True"`. Better yet, avoid GenericValue entirely and use strongly-typed variables.
+
+### GenericValue Null Conversion Traps
+- **Problem**: Silent data loss on null values
+- **Root cause**: `GenericValue(null)` → int returns `0`, → DateTime returns `DateTime.MinValue` (Jan 1, 0001), → double returns `0.0`. No errors thrown.
+- **Fix**: Always check for null/empty before converting: `If Not String.IsNullOrEmpty(myGenericValue.ToString())`
+
+---
+
+## HIDDEN DANGEROUS DEFAULTS (Source Code Verified)
+
+### Activities That Default ContinueOnError=TRUE (silent failures)
+These activities SWALLOW all errors by default. Your workflow will continue as if they succeeded:
+
+| Activity | Package | Impact |
+|----------|---------|--------|
+| `NetHttpRequest` (HTTP Request) | Web | HTTP 500/timeout → empty response, no error |
+| `Data Scraping` wizard output | UIAutomation | Extraction failure → empty DataTable |
+| `ShowCallout` | Forms | Callout display failure → silently ignored |
+
+**Fix**: Always explicitly set `ContinueOnError=False` on HTTP Request activities unless you're checking status codes manually.
+
+### Excel AutoSave=TRUE Causes Performance Disasters in Loops
+- **Problem**: 1000 Write Cell operations = 1000 disk writes
+- **Root cause**: `AutoSave=true` by default on ExcelApplicationScope. Every single activity triggers `Document.Save()`
+- **Fix**: Set `AutoSave=false` on ExcelApplicationScope, then add a single Save Workbook at the end. The `ExcelForEachRowX` activity internally disables AutoSave during iteration for this exact reason.
+
+### Excel DisplayAlerts/ScreenUpdating Left in Bad State After Crash
+- **Problem**: After workflow crash, Excel stays in "frozen" state or silently overwrites files
+- **Root cause**: Operations temporarily set `DisplayAlerts=false` and `ScreenUpdating=false` on the COM app. Crash before restore leaves Excel broken.
+- **Fix**: Use Try-Finally to ensure Excel state is restored. Consider Kill Process as cleanup.
+
+### CSV Encoding Varies by Platform (Encoding.Default trap)
+- **Problem**: Same CSV file produces different results on different machines
+- **Root cause**: `Encoding.Default` returns system ANSI code page on .NET Framework but UTF-8 on .NET Core. Locale-dependent.
+- **Fix**: Always explicitly specify encoding: `"UTF-8"` in CSV activities. Never rely on defaults.
+
+### CSV Delimiter Depends on System Culture
+- **Problem**: CSV activities produce different delimiters on different machines
+- **Root cause**: `CultureInfo.CurrentUICulture` used for CSV configuration internally
+- **Fix**: Always explicitly set the `Delimitator` (note spelling) property. Don't rely on system defaults.
+
+---
+
+## DATE/LOCALE TRAPS
+
+### Date Formats Cached from Windows Registry for Entire Process
+- **Problem**: Date parsing/formatting uses stale format if Windows settings change
+- **Root cause**: Short/long date formats read from `HKCU\Control Panel\International` and cached in static fields for process lifetime (never refreshed)
+- **Fix**: Don't change date format settings during Robot execution. If needed, restart Robot process.
+
+### Outlook Mail Filter Depends on Windows Date Format
+- **Problem**: Outlook date filters silently return no results
+- **Root cause**: Filter reads `sShortDate` from registry. If your filter date format doesn't match Windows-configured short date format, Outlook filtering fails silently.
+- **Fix**: Format dates in Outlook filter expressions to match the system's short date format.
+
+---
+
+## PROCESS/MEMORY SAFETY
+
+### COM Singleton Reference Counting (Excel, Word, PowerPoint)
+- **Problem**: One crashed activity corrupts COM state for all subsequent activities in same process
+- **Root cause**: All three Office apps use process-wide singleton `ComAppReferenceCountManager`. Delayed cleanup via `Task.Factory.StartNew` can race with new scope creation. Falls back to `Process.Kill()` as last resort.
+- **Fix**: Wrap all Office scope activities in Try-Finally. Use Kill Process as safety net. Don't run multiple Excel/Word/PowerPoint scopes concurrently.
+
+### Mail Session Server Orphan Processes
+- **Problem**: `UiPath.Mail.MainSessionServer.exe` runs forever after Robot disconnects
+- **Root cause**: Server uses `await Task.Delay(int.MaxValue)` in infinite loop. Only terminates if parent PID argument is passed correctly.
+- **Fix**: Monitor for orphaned MainSessionServer.exe processes. Kill after workflow completion if needed.
+
+### Regex with Infinite Timeout
+- **Problem**: Complex regex patterns can hang workflow indefinitely
+- **Root cause**: `System.Activities` Regex Replace uses `Regex.InfiniteMatchTimeout` when TimeoutMS not specified
+- **Fix**: Always set TimeoutMS on Regex activities. Test regex patterns for catastrophic backtracking.
+
+### Terminal Infinite Wait on Unresponsive Server
+- **Problem**: Workflow hangs forever waiting for terminal response
+- **Root cause**: Terminal operations use `Timeout.Infinite` when no timeout specified in 3 code paths
+- **Fix**: Always set explicit TimeoutMS on all terminal activities. Never rely on defaults.
+
+---
+
+## SILENT ERROR SWALLOWING (Design-Time)
+
+### HTTP Request Designer Hides Configuration Errors
+- **Problem**: Incorrectly configured HTTP requests show no warnings at design time
+- **Root cause**: Four separate empty `catch { }` blocks in HttpRequestWindow.xaml.cs silently eat configuration errors
+- **Fix**: Always test HTTP requests manually (e.g., in Postman) before relying on the designer configuration.
+
+### Connection Service Resolution Silently Fails
+- **Problem**: Mail connection falls back to null ConnectionId without warning
+- **Root cause**: Empty `catch (Exception) { }` in BaseMailConnectionServiceActivities when resolving connection bindings
+- **Fix**: Test connection resolution explicitly in a separate workflow step before using in production.
+
+### Office365 Token Storage Silently Fails
+- **Problem**: Token refresh/storage operations fail without any indication
+- **Root cause**: OrchestratorGlobalAssetStore catches and ignores HttpClientFramework.ApiServiceException on delete, get, list, and folder operations
+- **Fix**: Monitor Orchestrator logs for token-related errors. Test auth flow end-to-end.

--- a/skills/uipath-rpa-legacy/references/activity-docs/_DU-PROCESS.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_DU-PROCESS.md
@@ -1,0 +1,340 @@
+# UiPath Document Understanding Process Template - Complete Reference
+
+## Overview
+The Document Understanding Process is a **fully functional Studio template** for processing documents through a complete pipeline: digitize, classify, validate classification, extract data, validate extraction, train models, and export results. It comes with built-in retry logic, error handling, multi-robot synchronization, and Action Center integration.
+
+**Source**: [UiPath Docs](https://docs.uipath.com/document-understanding/automation-suite/2024.10/classic-user-guide/du-process) | [Forum Announcement](https://forum.uipath.com/t/document-understanding-process-new-studio-template/330234)
+
+**Key Design**: One job per document (not bulk). Requires a **dispatcher** to feed queue items.
+
+---
+
+## 1. File Structure (from Desktop Template)
+
+```
+DocumentUnderstandingProcess/
+├── Main-ActionCenter.xaml              # Entry point for UNATTENDED (Action Center validation)
+├── Main-Attended.xaml                  # Entry point for ATTENDED (local Validation Station)
+├── project.json                        # Project config (supportsPersistence=true!)
+│
+├── Data/
+│   ├── Config.xlsx                     # Configuration (Settings/Constants/Assets)
+│   └── ExampleDocuments/
+│       └── MergedDocuments.pdf         # Sample multi-page document
+│
+├── DocumentProcessing/
+│   ├── taxonomy.json                   # Document taxonomy definition
+│   └── IntelligentKeywordLearningFile.json  # Classifier training data
+│
+├── Framework/                          # Processing pipeline (numbered for execution order)
+│   ├── 00_ReadConfigFile.xaml          # Read Config.xlsx → Dictionary
+│   ├── 10_InitializeProcess.xaml       # Load taxonomy + Orchestrator assets
+│   ├── 15_GetTransactionItem.xaml      # Get queue item + extract TargetFile
+│   ├── 20_Digitize.xaml               # OCR → Document Object Model + Text
+│   ├── 30_Classify.xaml               # Auto-classify document type
+│   ├── 35_ClassificationBussinessRuleValidation.xaml  # Validate classification
+│   ├── 40_TrainClassifiers.xaml        # Train classifier with validated data
+│   ├── 50_Extract.xaml                # Extract field values
+│   ├── 55_ExtractionBussinessRuleValidation.xaml      # Validate extraction
+│   ├── 60_TrainExtractors.xaml         # Train extractor with validated data
+│   ├── 70_Export.xaml                 # Export results (Excel example)
+│   ├── 80_EndProcess.xaml             # Mark transaction successful
+│   ├── ERR_AbortProcess.xaml           # Handle fatal process errors
+│   ├── ERR_HandleDocumentError.xaml    # Handle per-document errors
+│   └── ReusableWorkflows/
+│       ├── SetTransactionStatus.xaml   # Set queue item Success/Failed
+│       ├── SetTransactionProgress.xaml # Update progress in Orchestrator
+│       ├── InvoicePostProcessing.xaml  # Invoice-specific validation rules
+│       ├── LockFile.xaml              # File lock for multi-robot sync
+│       ├── UnlockFile.xaml            # File unlock
+│       ├── GetWritePermission.xaml     # Queue-based semaphore acquire
+│       └── GiveUpWritePermission.xaml  # Queue-based semaphore release
+│
+├── UserGuide/
+│   └── Document Understanding Process - User Guide.pdf
+│
+└── Exceptions_Screenshots/             # (optional) Error screenshots
+```
+
+---
+
+## 2. Two Entry Points: Attended vs Action Center
+
+| | Main-Attended.xaml | Main-ActionCenter.xaml |
+|---|-------------------|----------------------|
+| **`in_UseQueue`** | `False` (default) | `True` (default) |
+| **Validation** | Local Validation Station (desktop UI) | Action Center (Orchestrator web UI) |
+| **Persistence** | Not required | `supportsPersistence=true` required |
+| **Robot Type** | Attended or unattended | Unattended (long-running) |
+| **Human-in-loop** | User sees validation dialog | User completes tasks in Action Center |
+| **Queue** | Optional | Required |
+
+### Main.xaml Arguments
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `in_TargetFile` | InArgument\<String\> | | Path to document to process |
+| `in_UseQueue` | InArgument\<Boolean\> | True/False | Whether using Orchestrator queues |
+
+---
+
+## 3. Processing Pipeline (Step by Step)
+
+```
+00_ReadConfigFile → 10_Initialize → 15_GetTransactionItem
+                                          ↓
+    ┌─────── FOR EACH CLASSIFIED DOCUMENT ────────┐
+    │                                               │
+    │  20_Digitize → 30_Classify                   │
+    │       ↓                                       │
+    │  35_ClassificationValidation                  │
+    │       ↓ (if manual needed)                    │
+    │  [Classification Station / Action Center]     │
+    │       ↓                                       │
+    │  40_TrainClassifiers (with validated data)    │
+    │       ↓                                       │
+    │  50_Extract → 55_ExtractionValidation         │
+    │       ↓ (if manual needed)                    │
+    │  [Validation Station / Action Center]         │
+    │       ↓                                       │
+    │  60_TrainExtractors (with validated data)     │
+    │       ↓                                       │
+    │  70_Export → 80_EndProcess                    │
+    │                                               │
+    └───────────────────────────────────────────────┘
+           ↓ (on error)
+    ERR_HandleDocumentError (per-document)
+    ERR_AbortProcess (fatal/process-level)
+```
+
+---
+
+## 4. Workflow Details
+
+### 00_ReadConfigFile.xaml
+- Reads Config.xlsx Settings + Constants sheets into Dictionary\<String, String\>
+- Calculates `MaxAttempts` (minimum 1) and `RetryInterval` from config
+- **No retry mechanism** — config file must be accessible
+
+### 10_InitializeProcess.xaml
+- **LoadTaxonomy** from `taxonomy.json`
+- Reads Assets sheet → fetches each from Orchestrator via **Get Robot Asset**
+- If asset fetch fails but key exists in config: silently continues (fallback value)
+- If asset fetch fails and key missing: throws (asset is required)
+- Wrapped in **RetryScope** for Orchestrator connectivity issues
+
+### 15_GetTransactionItem.xaml
+- **Get Transaction Item** from Orchestrator queue
+- Extracts `TargetFile` from `TransactionItem.SpecificContent["TargetFile"]`
+- **Copies ALL SpecificContent into Config dictionary** for process-wide access
+- Wrapped in RetryScope
+
+### 20_Digitize.xaml
+- **DigitizeDocument** activity with embedded OCR engine
+- Default: **UiPath Document OCR** (cloud API)
+- DegreeOfParallelism=-1 (unlimited parallel page processing)
+- Has config-specific `MaxExecutionAttemptsDigitize` override
+- **Warning**: OCR is API-based and incurs costs on retry
+
+### 30_Classify.xaml
+- **ClassifyDocumentScope** with **IntelligentKeywordClassifier**
+- Uses learning file from `DocumentProcessing/IntelligentKeywordLearningFile.json`
+- Pre-configured for: Receipt, Invoice, W-9, Certificate-of-filing
+- Returns ClassificationResult[] with confidence scores
+
+### 35_ClassificationBussinessRuleValidation.xaml (Flowchart)
+- Checks `AlwaysValidateClassification` config flag
+- FlowSwitch on DocumentTypeId for type-specific rules
+- Sets `AutoClassificationSuccess` = False to trigger manual validation
+- **Customization point**: Add your classification business rules here
+
+### 40_TrainClassifiers.xaml
+- **File locking** mechanism for multi-robot synchronization:
+  1. LockFile.xaml copies classifier file with `.lock` suffix
+  2. TrainClassifiersScope writes to lock copy
+  3. UnlockFile.xaml moves lock copy back (Overwrite=True)
+- **ContinueOnError=True** on training (prefer losing training data over blocking extraction)
+- **ContinueOnError=False** on unlock (critical — failure blocks ALL future training)
+
+### 50_Extract.xaml
+- **DataExtractionScope** with configured extractors
+- Extractor choice depends on document type (Form Extractor, ML Extractor, Regex)
+- Has config-specific `MaxExecutionAttemptsExtract` override
+
+### 55_ExtractionBussinessRuleValidation.xaml (Flowchart)
+- Checks `AlwaysValidateExtraction` config flag
+- FlowSwitch on DocumentTypeId
+- **Invoice case**: Calls InvoicePostProcessing.xaml with validation rules:
+  1. Verify mandatory fields extracted
+  2. Verify Quantity × Unit Price = Line Amount per row
+  3. Verify sum of Line Amounts = Net Amount
+  4. Verify Net Amount + charges = Total
+  5. Verify field confidence thresholds
+- Sets `AutoExtractionSuccess` = False for manual validation
+
+### 60_TrainExtractors.xaml
+- **TrainExtractorsScope** with human-validated data
+- ContinueOnError=True (prefer export over training loss)
+
+### 70_Export.xaml
+- **ExportExtractionResults** → DataSet (IncludeConfidence=True)
+- Default: Writes each DataTable to Excel sheet
+- Output path: `ExportsFolder/DocumentId_StartPage-EndPage.xlsx`
+- **Example only** — real implementations should use Data Service or database
+
+### 80_EndProcess.xaml
+- Calls SetTransactionStatus with Success
+- Customization point for post-export logic
+
+---
+
+## 5. Error Handling
+
+### Two Error Handlers
+| Handler | Scope | Triggered By | Default Action |
+|---------|-------|-------------|----------------|
+| `ERR_HandleDocumentError.xaml` | Per-document | Exception during document processing | Log warning, continue to next document |
+| `ERR_AbortProcess.xaml` | Process-level | Fatal exception (init failure, queue error) | Log error, terminate process |
+
+### Exception Types (same as REFramework)
+- **BusinessRuleException**: Data problem → skip document, don't retry
+- **System.Exception**: Technical problem → can retry with reinitialization
+
+### SetTransactionStatus (Flowchart)
+- **Success**: Both exceptions null → Set status "Successful"
+- **Business Exception**: BusinessRuleException or DocumentRejectedByUserException → Status "Failed", ErrorType "Business"
+- **System Exception**: Any other exception → Status "Failed", ErrorType "Application"
+
+---
+
+## 6. Multi-Robot Synchronization
+
+Two mechanisms for concurrent access to training files:
+
+### File Locking (used by default for classifier training)
+1. `LockFile.xaml`: Copy file with `.lock` suffix → work on copy
+2. `UnlockFile.xaml`: Move copy back → overwrite original
+- **Risk**: Two robots writing simultaneously → one's training data lost
+
+### Queue-Based Semaphore (alternative)
+1. Create Orchestrator queue with SINGLE item, no auto-retry
+2. `GetWritePermission.xaml`: Loop until queue item obtained (= semaphore acquired)
+3. `GiveUpWritePermission.xaml`: Mark item successful + recreate it (= semaphore released)
+- **Stronger guarantee** but requires Orchestrator queue setup
+
+---
+
+## 7. Dependencies (Current Template)
+
+```json
+{
+  "UiPath.DocumentUnderstanding.ML.Activities": "[1.9.1]",
+  "UiPath.Excel.Activities": "[2.11.4]",
+  "UiPath.IntelligentOCR.Activities": "[5.0.2]",
+  "UiPath.System.Activities": "[21.10.2]",
+  "UiPath.UIAutomation.Activities": "[21.10.3]"
+}
+```
+
+Additional assembly references: `UiPath.Persistence.Activities`, `UiPath.OmniPage.Activities`, `UiPath.PDF.Activities`, `UiPath.DocumentProcessing.Contracts`, `UiPath.OCR.Contracts`
+
+**Key**: `supportsPersistence: true` in project.json (required for Action Center mode)
+
+---
+
+## 8. Taxonomy Structure (taxonomy.json)
+
+Pre-configured document types:
+
+| Document Type ID | Category |
+|-----------------|----------|
+| `Semi-StructuredDocuments.Financial.Receipt` | Receipts |
+| `Semi-StructuredDocuments.Financial.Invoice` | Invoices (with line items table) |
+| `StructuredDocuments.LendingForms.W-9` | US tax form |
+| `Documents.Other.Certificate-of-filing` | Filing certificates |
+
+### Invoice Fields (example)
+- **Header**: Vendor Name, Address, VAT Number, Invoice No, PO No, Invoice Date, Due Date
+- **Amounts**: Net Amount, Tax Amount, Total, Discount, Shipping Charges
+- **Line Items Table**: Line Number, Description, Quantity, Unit Price, Line Amount, Part Number
+- **Payment**: Terms, Currency
+
+Supported languages: 26 (EN, DE, FR, ES, RU, ZH, JA, etc.)
+
+---
+
+## 9. Config.xlsx Key Settings
+
+| Setting | Purpose | Default |
+|---------|---------|---------|
+| `MaxExecutionAttempts` | Default retry count | 3 |
+| `RetryInterval` | Seconds between retries | 5 |
+| `MaxExecutionAttemptsDigitize` | Digitization-specific retries | (overrides default) |
+| `MaxExecutionAttemptsClassify` | Classification-specific retries | (overrides default) |
+| `MaxExecutionAttemptsExtract` | Extraction-specific retries | (overrides default) |
+| `AlwaysValidateClassification` | Force manual classification review | True/False |
+| `AlwaysValidateExtraction` | Force manual extraction review | True/False |
+| `DocumentUnderstandingQueueName` | Orchestrator queue name | |
+| `DocumentUnderstandingQueuePath` | Orchestrator queue folder | |
+| `ClassifierLearningFilePath` | Path to classifier training file | |
+| `ExportsFolder` | Output folder for exported results | |
+| `logKey` | Auto-generated GUID+timestamp for log tracking | |
+
+---
+
+## 10. Critical Gotchas
+
+### Architecture
+1. **One job per document** — NOT bulk processing. Requires dispatcher to populate queue.
+2. **supportsPersistence=true required** for Action Center mode — set in project.json
+3. **Process.xaml does NOT exist at root** — business logic is inside the numbered Framework workflows
+4. **NOT a State Machine** — unlike REFramework, this is a Sequence/Flowchart pipeline
+
+### OCR & Digitization
+5. **OCR is API-based (cloud)** — incurs costs on every call, including retries
+6. **DegreeOfParallelism=-1** means unlimited — can hit API rate limits
+7. **"Input document not found"** — [common error](https://forum.uipath.com/t/document-understanding-process-download-document/738008) when path resolution fails
+8. **.NET framework missing** — [reported issue](https://forum.uipath.com/t/document-understanding-error-install-missing-frameworks-for-net/727634) with template setup
+
+### Classification & Extraction
+9. **Classifiers and extractors are process-dependent** — must configure for YOUR document types
+10. **IntelligentKeywordClassifier needs training data** — `IntelligentKeywordLearningFile.json` must be populated
+11. **ML Extractor failures** — [common](https://forum.uipath.com/t/machine-learning-extractor-failed-in-50-extract-document-understanding-template/539547) with wrong API keys or model configuration
+12. **Taxonomy must match exactly** — DocumentTypeId in taxonomy.json must match classifier configuration
+
+### Training & Synchronization
+13. **Training data CAN be lost** — ContinueOnError=True on training; two robots writing simultaneously overwrites
+14. **UnlockFile ContinueOnError=False** — if unlock fails, ALL future training blocked
+15. **Queue semaphore requires setup** — single-item queue with NO auto-retry
+
+### Validation
+16. **InvoicePostProcessing uses EN-US culture** — decimal ".", thousand "," — will fail for other locales
+17. **"Do NOT use InvoicePostProcessing as-is"** — template annotation warns it's for demos only
+18. **AlwaysValidateClassification/Extraction** — set True during development, tune confidence thresholds for production
+
+### Action Center Mode
+19. **Requires Orchestrator 2021.10+** for full Action Center support
+20. **Persistence activities serialize workflow state** — all variables at suspension point must be serializable
+21. **Cannot have open UI scopes** across Action Center suspension points
+
+---
+
+## 11. Customization Checklist
+
+- [ ] **Config.xlsx**: Set queue name, asset names, retry parameters
+- [ ] **taxonomy.json**: Define YOUR document types and fields via Taxonomy Manager
+- [ ] **30_Classify.xaml**: Configure classifiers for your document types
+- [ ] **50_Extract.xaml**: Configure extractors for your document types
+- [ ] **35_ClassificationBussinessRuleValidation.xaml**: Add classification rules
+- [ ] **55_ExtractionBussinessRuleValidation.xaml**: Add extraction validation rules
+- [ ] **70_Export.xaml**: Replace Excel export with your target system (DB, API, Data Service)
+- [ ] **Dispatcher workflow**: Create separate workflow to populate queue with TargetFile paths
+- [ ] Choose entry point: Main-Attended.xaml (local) or Main-ActionCenter.xaml (Orchestrator)
+- [ ] Train classifiers with sample documents before production
+
+---
+
+## Sources
+- [UiPath Docs - Document Understanding Process Template](https://docs.uipath.com/document-understanding/automation-suite/2024.10/classic-user-guide/du-process)
+- [UiPath Forum - DU Process Template Announcement](https://forum.uipath.com/t/document-understanding-process-new-studio-template/330234)
+- [UiPath Docs - About DU Process](https://docs.uipath.com/activities/other/latest/document-understanding/about-document-understanding-process-studio-template)
+- Desktop template: `C:\Users\alexandru.roman\Documents\UiPath\legacy_tests\DocumentUnderstandingProcess\`

--- a/skills/uipath-rpa-legacy/references/activity-docs/_INDEX.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_INDEX.md
@@ -1,0 +1,70 @@
+# UiPath Legacy Activities Reference - Index
+
+Reference documents for writing **legacy** UiPath RPA workflows (XAML). Each file documents activities, arguments, gotchas, and patterns.
+
+**SCOPE: Windows-Legacy (.NET Framework 4.6.1) activities only.** Not Windows-compatibility or cross-platform variants. When a package has both legacy and "X" suffix activities, only the legacy versions are documented (e.g., `ExcelReadRange` not `ReadRangeX`, `SendMail` not `SendMailX`).
+
+---
+
+## Core Activity Packages
+
+| File | Package | Key Activities |
+|------|---------|----------------|
+| [System.md](System.md) | UiPath.System.Activities | Collections, Text, Dates, Dialogs, Files, PowerShell, Triggers |
+| [UIAutomation.md](UIAutomation.md) | UiPath.UIAutomation.Activities | Click, Type, Find Element, Selectors, Browser/Window scope |
+| [Excel.md](Excel.md) | UiPath.Excel.Activities | Read/Write Range/Cell, Workbook/Application Scope, CSV, Macros |
+| [Mail.md](Mail.md) | UiPath.Mail.Activities | SMTP, IMAP, POP3, Exchange, Outlook |
+| [Web.md](Web.md) | UiPath.WebAPI.Activities | HTTP Request, SOAP, JSON, XML |
+| [MicrosoftOffice365.md](MicrosoftOffice365.md) | UiPath.MicrosoftOffice365.Activities | Graph API: Mail, Calendar, Excel Online, OneDrive, SharePoint |
+| [Testing.md](Testing.md) | UiPath.Testing.Activities | Assertions, PDF/Text comparison, test data queues |
+| [PDF.md](PDF.md) | UiPath.PDF.Activities | Read PDF Text, OCR, Extract Pages, Join, Password |
+| [Word.md](Word.md) | UiPath.Word.Activities | Word COM + Portable, text/image/table operations |
+| [Presentations.md](Presentations.md) | UiPath.Presentations.Activities | PowerPoint COM + OpenXml |
+| [Database.md](Database.md) | UiPath.Database.Activities | ExecuteQuery, ExecuteNonQuery, InsertDataTable, BulkInsert |
+| [Credentials.md](Credentials.md) | UiPath.Credentials.Activities | Windows Credential Manager get/add/delete |
+| [FTP.md](FTP.md) | UiPath.FTP.Activities | FTP/FTPS/SFTP file transfer |
+| [Cryptography.md](Cryptography.md) | UiPath.Cryptography.Activities | AES encryption, HMAC hashing, PGP sign/verify |
+| [Python.md](Python.md) | UiPath.Python.Activities | Python script execution and object interaction |
+| [Java.md](Java.md) | UiPath.Java.Activities | Java method invocation and object interaction |
+
+## Specialized Packages
+
+| File | Package | Key Activities |
+|------|---------|----------------|
+| [Terminal.md](Terminal.md) | UiPath.Terminal.Activities | 3270/5250/VT terminal emulation |
+| [GSuite.md](GSuite.md) | UiPath.GSuite.Activities | Gmail, Drive, Sheets, Docs, Calendar, Tasks |
+| [Cognitive.md](Cognitive.md) | UiPath.Cognitive.Activities | Google/Azure/Watson NLP, sentiment, translation |
+| [IntelligentOCR.md](IntelligentOCR.md) | UiPath.IntelligentOCR.Activities | Document Understanding: classify, extract, validate, train |
+| [Forms.md](Forms.md) | UiPath.Form.Activities | FormIo/HTML forms, async display, field binding |
+| [OmniPage.md](OmniPage.md) | UiPath.OmniPage.Activities | OmniPage OCR engine |
+| [ImageProcessing.md](ImageProcessing.md) | UiPath.ImageProcessing | Template matching, image comparison |
+| [MobileAutomation.md](MobileAutomation.md) | UiPath.MobileAutomation.Activities | iOS/Android via Appium |
+| [SAP-BAPI.md](SAP-BAPI.md) | UiPath.SAP.BAPI.Activities | SAP BAPI function calls |
+| [CommunicationsMining.md](CommunicationsMining.md) | UiPath.CommunicationsMining.Activities | CM validation with Action Center |
+| [Vision-OCR.md](Vision-OCR.md) | UiPath.Vision.Activities | Multi-engine OCR (Azure, Google, ABBYY, Tesseract) |
+| [WorkflowEvents.md](WorkflowEvents.md) | UiPath.WorkflowEvents.Activities | App-triggered workflows via SignalR |
+| [Google-Speech.md](Google-Speech.md) | UiPath.Google.Activities | Google Cloud Speech-to-Text, Text-to-Speech |
+| [ComplexScenarios.md](ComplexScenarios.md) | UiPath.ComplexScenarios.Activities | Pre-built StudioX scenario templates |
+| [ActiveDirectory.md](ActiveDirectory.md) | (Deprecated) | Moved to github.com/UiPath/it-automation |
+
+## Third-Party Packages
+
+| File | Package |
+|------|---------|
+| [ThirdParty-Microsoft-WF4.md](ThirdParty-Microsoft-WF4.md) | Microsoft.Activities + Extensions |
+| [ThirdParty-SharePoint.md](ThirdParty-SharePoint.md) | UiPathTeam.SharePoint.Activities |
+| [ThirdParty-BalaReva-Excel.md](ThirdParty-BalaReva-Excel.md) | BalaReva.Excel + EasyExcel |
+| [ThirdParty-Persistence.md](ThirdParty-Persistence.md) | UiPath.Persistence.Activities |
+
+## Cross-Cutting References
+
+| File | Purpose |
+|------|---------|
+| [_BUILT-IN-ACTIVITIES.md](_BUILT-IN-ACTIVITIES.md) | Top 20 built-in activities with complete XAML — no find-activities needed |
+| [AllActivities.md](AllActivities.md) | Master catalog: every legacy activity organized by package |
+| [_COMMON-PITFALLS.md](_COMMON-PITFALLS.md) | Real-world issues: zombie processes, selector failures, encoding traps |
+| [_PATTERNS.md](_PATTERNS.md) | VB.NET expressions, DataTable cheat sheet, error handling, required scopes |
+| [_XAML-GUIDE.md](_XAML-GUIDE.md) | XAML structure, VB vs C#, Sequence/Flowchart/StateMachine, ViewState layout |
+| [_INVOKE-CODE.md](_INVOKE-CODE.md) | InvokeCode: compilation pipeline, arguments, namespaces, examples |
+| [_REFRAMEWORK.md](_REFRAMEWORK.md) | REFramework: state machine, Config.xlsx, retry logic, Dispatcher/Performer |
+| [_DU-PROCESS.md](_DU-PROCESS.md) | Document Understanding Process: digitize/classify/extract/validate pipeline |

--- a/skills/uipath-rpa-legacy/references/activity-docs/_INVOKE-CODE.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_INVOKE-CODE.md
@@ -1,0 +1,367 @@
+# UiPath Invoke Code Activity - Deep Reference
+
+## Overview
+`Invoke Code` executes inline VB.NET or C# code at runtime. It compiles user code using **Roslyn** into a temporary assembly, caches it, and invokes it via reflection. Located in `UiPath.System.Activities` package.
+
+---
+
+## 1. Properties
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `Code` | String | YES | (empty) | The inline code to execute |
+| `Language` | NetLanguage enum | NO | `VBNet` | `VBNet` or `CSharp` |
+| `Arguments` | Dictionary\<String, Argument\> | NO | empty dict | Named arguments passed in/out of the code |
+| `ContinueOnError` | InArgument\<Boolean\> | NO | false | Suppress runtime exceptions (NOT compilation errors) |
+
+---
+
+## 2. How It Works Internally (Source Code Verified)
+
+### Compilation Pipeline
+1. User code is wrapped in a generated class/module
+2. Namespace imports inherited from the workflow's `TextExpression.NamespacesForImplementation`
+3. Assemblies from `AppDomain.CurrentDomain.GetAssemblies()` provided as references
+4. Code compiled by **Roslyn** (`Microsoft.CodeAnalysis`) into in-memory assembly
+5. Compiled assembly **cached** by code+arguments hash (reuse in loops)
+6. Executed via `Assembly.GetType().InvokeMember("Run", ...)`
+
+### VB.NET Generated Code Structure
+```vb
+Option Explicit
+Option Strict
+Imports System
+Imports System.Collections.Generic
+' ... (all workflow namespace imports)
+
+Module UiPathCodeRunner_<guid>
+  Sub Run(ByVal inputArg As System.String, ByRef outputArg As System.Int32)
+    ' === YOUR CODE HERE ===
+  End Sub
+End Module
+```
+
+### C# Generated Code Structure
+```csharp
+using System;
+using System.Collections.Generic;
+// ... (all workflow namespace imports)
+
+namespace UiPathCodeRunnerNamespace {
+  public class UiPathCodeRunner_<guid> {
+    public static void Run(global::System.String inputArg, ref global::System.Int32 outputArg) {
+      // === YOUR CODE HERE ===
+    }
+  }
+}
+```
+
+### Key Implementation Details
+- **VB.NET uses `Option Explicit` and `Option Strict`** — you must declare variables and types must match
+- **C# uses `global::` prefix** for all type names to avoid namespace conflicts
+- **In arguments** → `ByVal` (VB) / no modifier (C#) — passed by value
+- **Out/InOut arguments** → `ByRef` (VB) / `ref` (C#) — passed by reference, changes reflected back
+- **Compilation cached** in static `Dictionary<string, CompilerRunner>` (max 25 entries) — same code in a loop compiles only once
+- **AssemblyLoadContext** used on .NET 6+ to allow unloading compiled assemblies
+
+---
+
+## 3. Arguments — How They Map
+
+### Argument Directions
+| Direction | VB.NET Generated | C# Generated | Behavior |
+|-----------|-----------------|--------------|----------|
+| `In` | `ByVal name As Type` | `Type name` | Read-only; changes NOT reflected back |
+| `Out` | `ByRef name As Type` | `ref Type name` | Write-only; value set in code is returned to workflow |
+| `InOut` | `ByRef name As Type` | `ref Type name` | Read+Write; initial value passed in, modified value returned |
+
+### How Arguments Appear in Your Code
+Arguments become **method parameters**. Use them directly by name:
+
+**VB.NET:**
+```vb
+' Arguments: inputText (In, String), result (Out, String), counter (InOut, Int32)
+result = inputText.ToUpper()
+counter = counter + 1
+```
+
+**C#:**
+```csharp
+// Arguments: inputText (In, String), result (Out, String), counter (InOut, Int32)
+result = inputText.ToUpper();
+counter = counter + 1;
+```
+
+### Type Mapping for Arguments
+| Workflow Type | VB.NET Parameter | C# Parameter |
+|--------------|-----------------|--------------|
+| String | `ByVal x As System.String` | `global::System.String x` |
+| Int32 | `ByVal x As System.Int32` | `global::System.Int32 x` |
+| Boolean | `ByVal x As System.Boolean` | `global::System.Boolean x` |
+| DataTable | `ByVal x As System.Data.DataTable` | `global::System.Data.DataTable x` |
+| List\<String\> | `ByVal x As System.Collections.Generic.List(Of System.String)` | `global::System.Collections.Generic.List<global::System.String> x` |
+| Dictionary\<String,Object\> | `ByVal x As System.Collections.Generic.Dictionary(Of System.String, System.Object)` | `global::System.Collections.Generic.Dictionary<global::System.String, global::System.Object> x` |
+| Object | `ByVal x As System.Object` | `global::System.Object x` |
+| String[] | `ByVal x As System.String()` | `global::System.String[] x` |
+
+### XAML Representation of Arguments
+```xml
+<ui:InvokeCode Code="result = input.ToUpper()" Language="VBNet"
+  DisplayName="Invoke code" sap2010:WorkflowViewState.IdRef="InvokeCode_1">
+  <ui:InvokeCode.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <InArgument x:TypeArguments="x:String" x:Key="input">[myVariable]</InArgument>
+      <OutArgument x:TypeArguments="x:String" x:Key="result">[outputVariable]</OutArgument>
+      <InOutArgument x:TypeArguments="x:Int32" x:Key="counter">[counterVariable]</InOutArgument>
+    </scg:Dictionary>
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+```
+
+---
+
+## 4. Available Namespaces & Assemblies
+
+### Automatically Available (inherited from workflow)
+All namespaces imported in the workflow's `TextExpression.NamespacesForImplementation` are available. Standard legacy VB.NET workflow includes:
+
+```
+System, System.Collections, System.Collections.Generic, System.Data,
+System.Diagnostics, System.Drawing, System.IO, System.Linq,
+System.Net.Mail, System.Xml, System.Xml.Linq,
+UiPath.Core, UiPath.Core.Activities
+```
+
+### Also Available (from loaded assemblies)
+All assemblies in the AppDomain are referenced for compilation. This means:
+- **System.Data** (DataTable, DataSet, DataRow)
+- **System.Drawing** (Color, Image, Bitmap)
+- **System.IO** (File, Directory, Path, Stream)
+- **System.Linq** (LINQ extension methods)
+- **System.Text.RegularExpressions** (Regex)
+- **System.Net.Http** (HttpClient — use fully qualified name to avoid conflicts)
+- Any activity package assemblies loaded in the project
+
+### Adding Custom Namespaces
+To use additional namespaces, add them in Studio: Design tab → Imports panel. They will be passed to the compiler via `GetImports()`.
+
+---
+
+## 5. Code Examples
+
+### VB.NET Examples
+
+**Simple calculation:**
+```vb
+' Arguments: x (In, Int32), y (In, Int32), result (Out, Int32)
+result = x + y
+```
+
+**String manipulation:**
+```vb
+' Arguments: input (In, String), output (Out, String)
+output = input.Trim().ToUpper().Replace("OLD", "NEW")
+```
+
+**DataTable filtering:**
+```vb
+' Arguments: dt (InOut, DataTable)
+Dim rows = dt.Select("[Status] = 'Active'")
+Dim filtered = dt.Clone()
+For Each row As System.Data.DataRow In rows
+    filtered.ImportRow(row)
+Next
+dt = filtered
+```
+
+**File operations:**
+```vb
+' Arguments: filePath (In, String), content (Out, String)
+content = System.IO.File.ReadAllText(filePath)
+```
+
+**Regex:**
+```vb
+' Arguments: input (In, String), matches (Out, String[])
+Dim rx = New System.Text.RegularExpressions.Regex("\d+")
+Dim mc = rx.Matches(input)
+Dim result(mc.Count - 1) As String
+For i As Integer = 0 To mc.Count - 1
+    result(i) = mc(i).Value
+Next
+matches = result
+```
+
+**Multi-line with variables:**
+```vb
+' Arguments: items (In, List(Of String)), csv (Out, String)
+Dim sb As New System.Text.StringBuilder()
+For Each item As String In items
+    sb.AppendLine(item)
+Next
+csv = sb.ToString()
+```
+
+### C# Examples
+
+**Simple calculation:**
+```csharp
+// Arguments: x (In, Int32), y (In, Int32), result (Out, Int32)
+result = x + y;
+```
+
+**String manipulation:**
+```csharp
+// Arguments: input (In, String), output (Out, String)
+output = input.Trim().ToUpper().Replace("OLD", "NEW");
+```
+
+**LINQ on DataTable:**
+```csharp
+// Arguments: dt (In, DataTable), total (Out, Double)
+total = dt.AsEnumerable()
+    .Where(r => r["Status"].ToString() == "Active")
+    .Sum(r => Convert.ToDouble(r["Amount"]));
+```
+
+**JSON parsing:**
+```csharp
+// Arguments: json (In, String), value (Out, String)
+var obj = Newtonsoft.Json.Linq.JObject.Parse(json);
+value = obj["data"]["name"].ToString();
+```
+
+**Dictionary building:**
+```csharp
+// Arguments: keys (In, String[]), values (In, String[]), dict (Out, Dictionary<String,String>)
+dict = new Dictionary<string, string>();
+for (int i = 0; i < keys.Length; i++) {
+    dict[keys[i]] = values[i];
+}
+```
+
+---
+
+## 6. Error Handling
+
+### Compilation Errors
+- **Always thrown** as `ArgumentException` regardless of `ContinueOnError`
+- Error message format: `"Compiled Code exception: <ErrorId> <Message> at line <Line>"`
+- Line numbers offset-adjusted to match user code (not generated wrapper)
+- **Shown at design time** if code is edited in the Code Editor dialog
+
+### Runtime Errors
+- Thrown as the original exception type (IOException, NullReferenceException, etc.)
+- **Suppressed** if `ContinueOnError = true`
+- `ArgumentException` from compilation is **NEVER suppressed** (explicit check in source code)
+
+### Common Compilation Errors
+
+**VB.NET:**
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `BC30451: 'x' is not declared` | Variable not declared or not in Arguments | Add as Argument or declare with `Dim` |
+| `BC30311: Cannot convert 'String' to 'Int32'` | Type mismatch (Option Strict enforced!) | Use explicit conversion: `CInt(str)` |
+| `BC30205: End of statement expected` | Missing line break or syntax error | Check VB.NET syntax |
+| `BC30035: Syntax error` | Invalid VB.NET syntax | Review code structure |
+
+**C#:**
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `CS0103: The name 'x' does not exist` | Variable not in Arguments | Add as Argument or declare locally |
+| `CS0029: Cannot implicitly convert type` | Type mismatch | Use explicit cast |
+| `CS1002: ; expected` | Missing semicolon | Add `;` at end of statements |
+| `CS0246: The type or namespace could not be found` | Missing import/reference | Use fully qualified name: `global::System.Net.Http.HttpClient` |
+
+---
+
+## 7. Critical Gotchas
+
+### Language & Syntax
+1. **VB.NET uses `Option Strict`** — implicit conversions are NOT allowed. `Dim x As Integer = "5"` will fail. Use `CInt("5")`.
+2. **C# requires semicolons** and follows standard C# syntax
+3. **You are writing the METHOD BODY only** — do not write class/module/method declarations, just the code inside `Sub Run()` / `void Run()`
+4. **Do NOT use `Return` statements** — the method is `Sub`/`void`. Set Out arguments instead.
+5. **VB arrays use `()` not `[]`** — `Dim arr(5) As String` not `string[] arr`
+
+### Arguments
+6. **Argument names must be valid identifiers** — no spaces, no special chars, must start with letter
+7. **In arguments are COPIES** (ByVal) — modifying them does NOT change the workflow variable
+8. **Out/InOut arguments are REFERENCES** (ByRef) — changes ARE reflected back to the workflow
+9. **Generic types work** but the generated code uses fully-qualified names like `System.Collections.Generic.List(Of System.Int32)`
+10. **Argument type must match exactly** — passing a String to an Int32 argument fails at compile time
+
+### Performance
+11. **First execution is SLOW** — Roslyn compilation takes 100-500ms
+12. **Subsequent executions are FAST** — compiled assembly cached by code+arguments hash
+13. **Cache limit is 25 entries** — after that, oldest entries may be evicted
+14. **Avoid modifying code dynamically** in loops — each unique code string triggers new compilation
+
+### Namespace Conflicts
+15. **C# `System` namespace conflict** — using `HttpClient` may fail because `System` is both a namespace and a member. Use `global::System.Net.Http.HttpClient` instead. (Bug fix: STUD-77435)
+16. **Workflow imports filter** — only namespaces that exist in loaded assemblies are passed to compiler. If you need `System.Net.Http`, ensure the assembly is loaded.
+
+### Assemblies
+17. **All AppDomain assemblies available** — activity package DLLs, .NET framework, etc.
+18. **Cannot add custom DLL references** at runtime — only assemblies already loaded in the workflow
+19. **On .NET 6+** compiled assemblies use `AssemblyLoadContext` for proper unloading
+
+### ContinueOnError
+20. **Compilation errors ALWAYS throw** — `ContinueOnError` only suppresses RUNTIME exceptions
+21. **This is by design** — invalid code that can't compile should never be silently ignored
+
+---
+
+## 8. XAML Template
+
+### Minimal VB.NET Invoke Code
+```xml
+<ui:InvokeCode Code="result = &quot;Hello &quot; + name" Language="VBNet"
+  DisplayName="Invoke code" sap2010:WorkflowViewState.IdRef="InvokeCode_1">
+  <ui:InvokeCode.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <InArgument x:TypeArguments="x:String" x:Key="name">[inputName]</InArgument>
+      <OutArgument x:TypeArguments="x:String" x:Key="result">[outputResult]</OutArgument>
+    </scg:Dictionary>
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+```
+
+### Minimal C# Invoke Code
+```xml
+<ui:InvokeCode Code="result = &quot;Hello &quot; + name;" Language="CSharp"
+  DisplayName="Invoke code" sap2010:WorkflowViewState.IdRef="InvokeCode_1">
+  <ui:InvokeCode.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <InArgument x:TypeArguments="x:String" x:Key="name">[inputName]</InArgument>
+      <OutArgument x:TypeArguments="x:String" x:Key="result">[outputResult]</OutArgument>
+    </scg:Dictionary>
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+```
+
+### With No Arguments (side-effect code)
+```xml
+<ui:InvokeCode Code="System.IO.File.WriteAllText(&quot;C:\temp\log.txt&quot;, &quot;done&quot;)"
+  Language="VBNet" DisplayName="Write File">
+  <ui:InvokeCode.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument" />
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+```
+
+---
+
+## 9. When to Use Invoke Code vs. Alternatives
+
+| Scenario | Best Choice | Why |
+|----------|-------------|-----|
+| Simple assignment | `Assign` activity | Simpler, no compilation overhead |
+| DataTable LINQ query | `Invoke Code` | LINQ not available in Assign expressions |
+| Complex string parsing | `Invoke Code` | Multi-line logic with variables |
+| File I/O | Built-in activities (Read/Write Text File) | Error handling built-in |
+| HTTP requests | `HTTP Request` activity | Retry, auth, proxy built-in |
+| Regex matching | `Matches` activity or Invoke Code | Activity is simpler for basic patterns |
+| JSON parsing | `Deserialize JSON` + Invoke Code | Activity for deserialization, code for complex traversal |
+| Custom business logic | `Invoke Code` | When no activity exists for the operation |
+| Reusable logic | `Invoke Workflow File` | Invoke Code can't be reused across workflows |

--- a/skills/uipath-rpa-legacy/references/activity-docs/_PATTERNS.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_PATTERNS.md
@@ -1,0 +1,278 @@
+# UiPath Legacy Workflows - Practical Patterns & Cheat Sheet
+
+## Purpose
+Quick-reference patterns for writing legacy XAML workflows: VB.NET expressions, DataTable operations, error handling, required scopes, and common recipes.
+
+---
+
+## Required Parent Scopes
+
+See [common-pitfalls.md](../common-pitfalls.md) for the canonical Required Parent Scopes table and ActivityAction body patterns.
+
+---
+
+## VB.NET Expression Cheat Sheet
+
+### String Operations
+```vb
+' Concatenation
+"Hello " + variable + " World"
+String.Format("Order {0} has {1} items", orderId, count)
+$"Order {orderId} has {count} items"    ' String interpolation (2021.10+)
+
+' Null/empty check
+String.IsNullOrEmpty(myVar)
+String.IsNullOrWhiteSpace(myVar)
+If(myVar Is Nothing, "default", myVar.ToString())
+
+' Common operations
+myString.Trim()
+myString.ToUpper() / myString.ToLower()
+myString.Contains("search")
+myString.Replace("old", "new")
+myString.Split({";"c}, StringSplitOptions.RemoveEmptyEntries)
+myString.Substring(startIndex, length)
+System.Text.RegularExpressions.Regex.Match(input, pattern).Value
+```
+
+### Type Conversions
+```vb
+' String to number
+CInt(stringVar)           ' To Integer (throws on failure)
+CDbl(stringVar)           ' To Double
+CDec(stringVar)           ' To Decimal
+Convert.ToInt32(stringVar)
+Integer.Parse(stringVar)
+Int32.TryParse(stringVar, result)  ' Safe parse (returns bool)
+
+' String to date
+CDate(stringVar)
+DateTime.Parse(stringVar)
+DateTime.ParseExact(stringVar, "MM/dd/yyyy", CultureInfo.InvariantCulture)
+DateTime.Now / DateTime.Today / DateTime.UtcNow
+
+' Number to string
+intVar.ToString()
+doubleVar.ToString("F2")      ' 2 decimal places
+doubleVar.ToString("#,##0.00") ' With thousands separator
+
+' Object to specific type
+CType(objVar, String)
+DirectCast(objVar, DataTable)
+CStr(objVar)
+```
+
+### DateTime Operations
+```vb
+DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")
+DateTime.Now.AddDays(7)
+DateTime.Now.AddHours(-2)
+(endDate - startDate).TotalDays
+DateTime.Now.ToString("yyyyMMdd")  ' Compact date for filenames
+```
+
+### Array/Collection Creation
+```vb
+' Array
+New String() {"item1", "item2", "item3"}
+New Integer() {1, 2, 3}
+
+' List
+New List(Of String) From {"item1", "item2"}
+
+' Dictionary
+New Dictionary(Of String, Object) From {
+  {"key1", "value1"},
+  {"key2", 42}
+}
+```
+
+---
+
+## DataTable Operations Cheat Sheet
+
+### Creating
+```vb
+' Use Build Data Table activity (wizard) for design-time creation
+' Or in code:
+New DataTable()
+```
+
+### Accessing Data
+```vb
+' Get cell value by column name
+row("ColumnName").ToString()
+row.Item("ColumnName").ToString()
+
+' Get cell value by column index (0-based)
+row(0).ToString()
+
+' Get value with null safety
+If(row("Column") Is Nothing OrElse row("Column") Is DBNull.Value,
+   "default",
+   row("Column").ToString())
+
+' Get typed value
+Convert.ToInt32(row("Amount"))
+Convert.ToDateTime(row("Date"))
+```
+
+### Filtering & Querying
+```vb
+' DataTable.Select (returns DataRow array)
+dt.Select("[Status] = 'Active'")
+dt.Select("[Amount] > 100")
+dt.Select("[Name] LIKE 'John%'")
+dt.Select("[Date] >= #2024-01-01#")
+dt.Select("[Column] = 'Value'", "Date DESC")  ' With sort
+
+' LINQ (requires System.Linq import)
+dt.AsEnumerable().Where(Function(r) r("Status").ToString() = "Active").CopyToDataTable()
+dt.AsEnumerable().OrderBy(Function(r) r("Name")).CopyToDataTable()
+dt.AsEnumerable().Select(Function(r) r("Name").ToString()).ToArray()
+
+' Count rows matching condition
+dt.Select("[Status] = 'Active'").Count()
+dt.AsEnumerable().Count(Function(r) CInt(r("Amount")) > 100)
+```
+
+### Modifying
+```vb
+' Add row (in Assign)
+dt.Rows.Add({"col1value", "col2value", "col3value"})
+
+' Remove column
+dt.Columns.Remove("ColumnName")
+
+' Rename column
+dt.Columns("OldName").ColumnName = "NewName"
+
+' Clone structure without data
+dt.Clone()
+
+' Copy structure with data
+dt.Copy()
+
+' Trim column names (common fix for Read Range whitespace)
+For Each col As DataColumn In dt.Columns
+    col.ColumnName = col.ColumnName.Trim()
+Next
+```
+
+### Common Gotchas
+- `row("Column")` returns `Object` - always `.ToString()` or convert explicitly
+- Empty cells may be `DBNull.Value` (not Nothing/null) - check with `row("Col") Is DBNull.Value`
+- Column names are case-sensitive in `.Select()` expressions
+- Column names with spaces need brackets: `[Column Name]`
+- `CopyToDataTable()` throws if LINQ query returns empty - wrap in If check
+
+---
+
+## Error Handling Quick Reference
+
+For the full error handling guide (exception classification, TryCatch best practices, Retry Scope configuration, ContinueOnError decision matrix, Finally patterns), see [error-handling-guide.md](../error-handling-guide.md).
+
+### Throw Activity — Quote Escaping Gotcha (XAML Generation)
+
+In `Throw.Exception` bracket expressions, fully-qualified class names + complex string concatenation with `&quot;` can cause compiler errors. The VB.NET expression compiler rejects the combination.
+
+**Rules:**
+1. **Use short-form class names** — `BusinessRuleException` not `UiPath.Core.Activities.BusinessRuleException`
+2. **For complex messages, use a variable** — Assign the message string first, then `[New BusinessRuleException(errorMessage)]`
+3. **Simple inline is fine** — `[New BusinessRuleException(&quot;simple message&quot;)]`
+
+```xml
+<!-- GOOD: Short name + simple expression -->
+<Throw Exception="[New BusinessRuleException(&quot;Invalid data for &quot; &amp; txId)]" />
+
+<!-- BEST: Variable approach for complex messages -->
+<!-- Step 1: Assign errorMessage = "Invalid: " & amount.ToString("F2") & " for " & txId -->
+<!-- Step 2: Throw with variable reference -->
+<Throw Exception="[New BusinessRuleException(errorMessage)]" />
+```
+
+### REFramework Exception Types
+| Exception | Meaning | Action |
+|-----------|---------|--------|
+| `BusinessRuleException` | Data/logic problem (invalid input, missing field) | Skip item, set Failed status |
+| `System.Exception` | Technical problem (timeout, app crash, network) | Retry, then escalate |
+| `SelectorNotFoundException` | UI element not found | Check app state, retry |
+| `TimeoutException` | Activity exceeded timeout | Retry with longer timeout |
+
+---
+
+## Orchestrator Integration Patterns
+
+### Queue Processing (Dispatcher + Performer)
+```
+DISPATCHER workflow:
+1. Read input data (Excel, DB, email)
+2. For Each row: Add Queue Item (QueueName, ItemInformation dictionary)
+
+PERFORMER workflow (REFramework):
+1. Get Transaction Item (QueueName)
+2. If TransactionItem Is Nothing → no more items
+3. Process item (access data via TransactionItem.SpecificContent("FieldName"))
+4. Set Transaction Status (Success/Failed)
+```
+
+### Asset Access Patterns
+```vb
+' Get text asset
+assetValue = Get Asset("MyAssetName")  ' Returns String
+
+' Get credential asset
+Get Credential("MyCredential") → username (String), password (SecureString)
+
+' Convert SecureString to String (when needed)
+New System.Net.NetworkCredential("", securePassword).Password
+```
+
+### Storage Bucket File Patterns
+```
+Upload: Upload Storage File (BucketName, LocalPath, RemoteBlobPath)
+Download: Download Storage File (BucketName, RemoteBlobPath, LocalPath)
+List: List Storage Files (BucketName) → IEnumerable of file info
+```
+
+---
+
+## File Path Patterns
+```vb
+' Project-relative path
+Path.Combine(Environment.CurrentDirectory, "Data", "input.xlsx")
+
+' User folders
+Environment.GetFolderPath(Environment.SpecialFolder.Desktop)
+Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+
+' Temp file
+Path.Combine(Path.GetTempPath(), "output_" + DateTime.Now.ToString("yyyyMMdd") + ".xlsx")
+
+' Safe path joining (handles separators)
+Path.Combine(folderPath, fileName)
+
+' Extract parts
+Path.GetFileName(fullPath)          ' "file.xlsx"
+Path.GetFileNameWithoutExtension()  ' "file"
+Path.GetExtension()                 ' ".xlsx"
+Path.GetDirectoryName()             ' parent folder
+```
+
+---
+
+## Deprecated Activity → Replacement Mapping
+
+| Deprecated | Replacement | Package |
+|-----------|-------------|---------|
+| `OpenWorkbook` | `Excel Application Scope` | Excel |
+| `CloseWorkbook` | (scope handles cleanup) | Excel |
+| `WithWorkbook` | `Excel Application Scope` | Excel |
+| `ExcelForEachRow` (v1) | `For Each Row in Data Table` | Excel |
+| `CreatePivotTableX` (v1) | `CreatePivotTableXv2` | Excel |
+| `KeywordBasedClassifier` | `IntelligentKeywordClassifier` | IntelligentOCR |
+| `AddTestDataQueueItem` | `NewAddTestDataQueueItem` | Testing |
+| `OutlookForEachMail` | `For Each Email` | Mail |
+| `OverwriteExistingFile` (property) | `ConflictResolution` enum | GSuite Drive |
+| `SingleFileToUpload` (property) | `MultipleFilesToUpload` | GSuite Drive |
+| `UseISConnection` (property) | `ConnectionDetails` | Mail |

--- a/skills/uipath-rpa-legacy/references/activity-docs/_REFRAMEWORK.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_REFRAMEWORK.md
@@ -1,0 +1,598 @@
+# UiPath REFramework (Robotic Enterprise Framework) - Complete Reference
+
+## Overview
+The REFramework is UiPath's official **State Machine-based project template** for building production-grade automation. It provides built-in retry logic, exception handling, configuration management, and application lifecycle control. It's the standard for transactional, unattended automation.
+
+**Source**: [github.com/UiPath/ReFrameWork](https://github.com/UiPath/ReFrameWork)
+**Current Desktop Template**: Studio 25.10 (verified from `C:\Users\alexandru.roman\Documents\UiPath\legacy_tests\`)
+**Available in**: VB.NET (`RoboticEnterpriseFramework-VB`) and C# (`RoboticEnterpriseFramework-Csharp`)
+
+---
+
+## 1. File Structure
+
+```
+Project Root/
+├── Main.xaml                              # Entry point — State Machine (DO NOT rename)
+├── project.json                           # Project configuration
+├── project.uiproj                         # Studio project file
+├── README.md                              # Template readme
+├── LICENSE                                # License file
+│
+├── Data/
+│   ├── Config.xlsx                        # Configuration file (Settings/Constants/Assets)
+│   ├── Input/                             # Input data files
+│   ├── Output/                            # Output data files
+│   └── Temp/                              # Temporary files (cleared on init)
+│
+├── Framework/                             # Core framework workflows
+│   ├── InitAllSettings.xaml               # Reads Config.xlsx → Dictionary
+│   ├── InitAllApplications.xaml           # Opens/authenticates apps
+│   ├── GetTransactionData.xaml            # Gets next transaction item
+│   ├── Process.xaml                       # YOUR business logic (CUSTOMIZE THIS)
+│   ├── SetTransactionStatus.xaml          # Sets Success/Failed/BusinessException (Flowchart)
+│   ├── RetryCurrentTransaction.xaml       # Retry logic with MaxRetryNumber check (Flowchart)
+│   ├── CloseAllApplications.xaml          # Gracefully closes apps
+│   ├── KillAllProcesses.xaml              # Force-kills app processes
+│   └── TakeScreenshot.xaml                # Captures error screenshot
+│
+├── Exceptions_Screenshots/                # Error screenshots stored here
+│
+├── Documentation/
+│   └── REFramework Documentation-EN.pdf   # Official documentation
+│
+└── Tests/                                 # Built-in test cases
+    ├── GeneralTestCase.xaml               # General test case
+    ├── GetTransactionDataTestCase.xaml     # Test GetTransactionData
+    ├── InitAllApplicationsTestCase.xaml    # Test InitAllApplications
+    ├── InitAllSettingsTestCase.xaml        # Test InitAllSettings
+    ├── MainTestCase.xaml                   # Test Main workflow
+    ├── ProcessTestCase.xaml               # Test Process workflow
+    ├── WorkflowTestCaseTemplate.xaml       # Test template
+    └── Tests.xlsx                         # Test data
+```
+
+> **Note**: Current template (Studio 25.10) moved `Process.xaml` into `Framework/` folder and added `RetryCurrentTransaction.xaml` as a separate Flowchart workflow for retry logic. Older GitHub version had `Process.xaml` at root and `GetAppCredentials.xaml` (removed in current).
+
+### File Roles
+
+| File | Role | Modify? |
+|------|------|---------|
+| `Main.xaml` | State Machine orchestrating all states/transitions | RARELY — only to add custom transitions |
+| `Framework/Process.xaml` | **YOUR business logic** — called for each transaction | YES — this is where your automation goes |
+| `Config.xlsx` | Settings, constants, Orchestrator asset names | YES — add your configuration here |
+| `InitAllSettings.xaml` | Reads Config.xlsx into `in_Config` dictionary | RARELY — add custom init logic if needed |
+| `InitAllApplications.xaml` | Opens apps (credential retrieval built-in now) | YES — add your app open/login logic |
+| `GetTransactionData.xaml` | Gets next queue item or data row to process | YES — configure your transaction source |
+| `SetTransactionStatus.xaml` | Updates transaction status (Flowchart: Success/BRE/SE branches) | YES if not using Orchestrator queues |
+| `RetryCurrentTransaction.xaml` | Retry logic Flowchart: checks MaxRetryNumber, manages retry counter | RARELY — logic is self-contained |
+| `CloseAllApplications.xaml` | Gracefully closes applications | YES — add your app close/logout logic |
+| `KillAllProcesses.xaml` | Force-kills processes (fallback cleanup) | YES — list all app processes to kill |
+| `TakeScreenshot.xaml` | Captures screenshot on error | RARELY |
+
+---
+
+## 2. State Machine Architecture
+
+### States (4)
+
+```
+┌──────────┐     Success      ┌─────────────────────┐
+│          │ ──────────────── │                     │
+│   INIT   │                  │  GET TRANSACTION    │
+│          │ ←─── System ──── │       DATA          │
+└──────────┘   Exception      └─────────────────────┘
+     │                              │          │
+     │ System Exception             │          │ No Data
+     │ (max retries)                │          │
+     ▼                              ▼          ▼
+┌──────────┐                  ┌──────────────────────┐
+│   END    │ ←─────────────── │                      │
+│ PROCESS  │   No More Data   │  PROCESS TRANSACTION │
+│ (Final)  │                  │                      │
+└──────────┘ ←─── System ──── └──────────────────────┘
+              Exception             │         ▲
+              (max consecutive)     │         │
+                                    └─────────┘
+                                   Success / Business
+                                   Exception → next item
+```
+
+### Transitions (7)
+
+| # | From | To | Condition |
+|---|------|----|-----------|
+| 1 | Init | Get Transaction Data | Initialization successful |
+| 2 | Init | End Process | System exception during init (max retries exceeded) |
+| 3 | Get Transaction Data | Process Transaction | Transaction item retrieved |
+| 4 | Get Transaction Data | End Process | No more items (TransactionItem is Nothing) |
+| 5 | Process Transaction | Get Transaction Data | Transaction succeeded (get next item) |
+| 6 | Process Transaction | Init | System exception → reinitialize apps, retry |
+| 7 | Process Transaction | End Process | Max consecutive system exceptions reached |
+
+---
+
+## 3. Config.xlsx — Configuration File
+
+### Three Sheets
+
+#### Settings Sheet
+| Name | Value | Description |
+|------|-------|-------------|
+| `logF_BusinessProcessName` | "MyProcess" | Process name for logging |
+| `MaxRetryNumber` | 3 | Max retries per transaction on System Exception |
+| `MaxConsecutiveSystemExceptions` | 3 | Max consecutive system exceptions before abort |
+| `TransactionNumber` | 1 | Starting transaction number (for non-queue sources) |
+| `OrchestratorQueueName` | "MyQueue" | Orchestrator queue name (queue-based processing) |
+| `OrchestratorQueueFolder` | "" | Orchestrator folder for queue |
+| Custom settings | | Add your own rows: URLs, file paths, thresholds |
+
+#### Constants Sheet
+| Name | Value | Description |
+|------|-------|-------------|
+| Values that never change | | Timeouts, static URLs, format strings |
+
+#### Assets Sheet
+| Name | Value | Description |
+|------|-------|-------------|
+| Asset names from Orchestrator | | Values fetched via Get Asset at runtime |
+| Credential asset names | | Fetched via Get Credential |
+
+### How Config Is Loaded
+1. `InitAllSettings.xaml` reads all three sheets
+2. Settings and Constants stored directly in `in_Config` dictionary
+3. Assets sheet values fetched from Orchestrator via Get Asset
+4. Entire config accessible throughout workflow as `in_Config("KeyName")`
+
+---
+
+## 4. Exception Handling — The Core Principle
+
+### Two Exception Types
+
+| | Business Rule Exception | System Exception |
+|---|------------------------|------------------|
+| **Class** | `UiPath.Core.BusinessRuleException` | `System.Exception` (any other) |
+| **Cause** | Invalid data, business rule violation, missing input | App crash, timeout, element not found, network error |
+| **Retry?** | **NO** — data problem won't fix itself | **YES** — transient issue may resolve |
+| **Action** | Skip transaction, mark as Business Exception | Retry transaction, reinitialize apps |
+| **Queue Status** | Failed (reason: business rule message) | Retry (up to MaxRetryNumber) |
+| **Example** | "Invoice amount is negative", "Missing customer ID" | "Selector not found", "Application not responding" |
+
+### How to Throw Business Exceptions in Process.xaml
+```vb
+' In your Process.xaml, throw when business data is invalid:
+Throw New BusinessRuleException("Invoice amount cannot be negative")
+```
+
+### Exception Flow
+
+**Business Exception in Process.xaml:**
+1. Caught by SetTransactionStatus
+2. Transaction marked as **Failed** with business reason
+3. No retry — moves to Get Transaction Data for next item
+4. `ConsecutiveSystemExceptions` counter **reset to 0**
+
+**System Exception in Process.xaml:**
+1. Caught by SetTransactionStatus
+2. `RetryNumber` incremented
+3. If `RetryNumber < MaxRetryNumber`: transition to **Init** (reinitialize apps, retry same item)
+4. If `RetryNumber >= MaxRetryNumber`: transaction marked as **Failed**, move to next item
+5. `ConsecutiveSystemExceptions` incremented
+6. If `ConsecutiveSystemExceptions >= MaxConsecutiveSystemExceptions`: transition to **End Process** (abort)
+
+**System Exception in Init:**
+1. `ConsecutiveSystemExceptions` incremented
+2. If limit reached: transition to **End Process**
+3. Otherwise: retry Init
+
+---
+
+## 5. MaxRetryNumber vs MaxConsecutiveSystemExceptions
+
+This is the **most confusing aspect** of REFramework. Here's the definitive explanation:
+
+### MaxRetryNumber (per transaction)
+- **Controls**: How many times a SINGLE transaction is retried after System Exceptions
+- **Scope**: Resets for each new transaction
+- **Default**: 3
+- **Behavior**: After 3 system exceptions on the same transaction, it's marked Failed and the next transaction is fetched
+- **Works with Orchestrator**: Queue items have their own retry count — REFramework MaxRetryNumber is IN ADDITION to queue retry settings
+
+### MaxConsecutiveSystemExceptions (across transactions)
+- **Controls**: How many System Exceptions in a ROW (across ALL transactions) before the robot stops entirely
+- **Scope**: Global counter, reset to 0 on any successful transaction or business exception
+- **Default**: 3
+- **Behavior**: If 3 different transactions all fail with system exceptions consecutively (no successes in between), robot assumes environment is broken and goes to End Process
+- **Purpose**: Safety net — if the app is down, don't keep retrying forever
+
+### Example Scenario
+```
+Transaction 1: System Exception → Retry 1 (ConsecutiveSystemExceptions = 1)
+Transaction 1: System Exception → Retry 2 (ConsecutiveSystemExceptions = 2)
+Transaction 1: System Exception → Retry 3 → FAILED (MaxRetryNumber reached)
+Transaction 2: System Exception → Retry 1 (ConsecutiveSystemExceptions = 3) → END PROCESS
+                                              (MaxConsecutiveSystemExceptions reached!)
+```
+
+```
+Transaction 1: System Exception → Retry 1 (ConsecutiveSystemExceptions = 1)
+Transaction 1: SUCCESS → (ConsecutiveSystemExceptions = 0, reset!)
+Transaction 2: System Exception → Retry 1 (ConsecutiveSystemExceptions = 1)
+Transaction 2: System Exception → Retry 2 (ConsecutiveSystemExceptions = 2)
+Transaction 2: SUCCESS → (ConsecutiveSystemExceptions = 0, reset!)
+  ← Robot continues processing normally
+```
+
+---
+
+## 6. Processing Lifecycle (Step by Step)
+
+### 1. INIT State
+```
+1. InitAllSettings.xaml
+   ├── Read Config.xlsx → in_Config dictionary
+   ├── Read Settings sheet (key-value pairs)
+   ├── Read Constants sheet (key-value pairs)
+   └── Read Assets sheet → Get Asset from Orchestrator for each row
+
+2. KillAllProcesses.xaml
+   └── Force-kill any lingering app processes (clean slate)
+
+3. InitAllApplications.xaml
+   ├── GetAppCredentials.xaml → Get credentials from Orchestrator/CredentialManager
+   └── Open and authenticate all required applications
+
+4. On Success → Transition to "Get Transaction Data"
+5. On System Exception → Increment ConsecutiveSystemExceptions
+   ├── If under limit → Retry Init
+   └── If limit reached → Transition to "End Process"
+```
+
+### 2. GET TRANSACTION DATA State
+```
+1. Check ShouldStop signal from Orchestrator
+   ├── If ShouldStop = True → Set TransactionItem = Nothing → End Process
+   └── If ShouldStop = False → Continue
+
+2. Try GetTransactionData.xaml
+   ├── Queue mode: Get Transaction Item from Orchestrator queue
+   │   └── Returns QueueItem or Nothing
+   ├── DataTable mode: Get row at TransactionNumber index
+   │   └── Returns DataRow or Nothing
+   └── Other: Custom data source
+
+3. Catch Exception → Log Fatal, Set TransactionItem = Nothing → End Process
+
+4. If TransactionItem is Nothing → Transition to "End Process" (no more data)
+5. If TransactionItem has value → Transition to "Process Transaction"
+```
+
+> **Current template detail**: Get Transaction Data state first calls `ShouldStop` activity to check if Orchestrator requested a graceful stop. This allows the robot to finish cleanly between transactions instead of being force-killed.
+
+### 3. PROCESS TRANSACTION State
+```
+1. Process.xaml (YOUR code)
+   └── Process the current TransactionItem
+
+2. SetTransactionStatus.xaml
+   ├── On Success:
+   │   ├── Set Transaction Status = Successful
+   │   ├── Reset RetryNumber = 0
+   │   ├── Reset ConsecutiveSystemExceptions = 0
+   │   └── Transition to "Get Transaction Data" (next item)
+   │
+   ├── On BusinessRuleException:
+   │   ├── Set Transaction Status = Failed (business reason)
+   │   ├── Reset ConsecutiveSystemExceptions = 0  ← important!
+   │   ├── DO NOT retry
+   │   └── Transition to "Get Transaction Data" (next item)
+   │
+   └── On System Exception:
+       ├── Take Screenshot → Exceptions_Screenshots/
+       ├── Increment RetryNumber
+       ├── Increment ConsecutiveSystemExceptions
+       ├── If RetryNumber < MaxRetryNumber:
+       │   └── Transition to "Init" (reinitialize, retry same item)
+       ├── If RetryNumber >= MaxRetryNumber:
+       │   ├── Set Transaction Status = Failed
+       │   └── Transition to "Get Transaction Data" (next item)
+       └── If ConsecutiveSystemExceptions >= Max:
+           └── Transition to "End Process" (abort)
+```
+
+### 4. END PROCESS State (Final)
+```
+1. CloseAllApplications.xaml
+   └── Gracefully close all applications
+
+2. Workflow ends
+```
+
+---
+
+## 7. Key Variables in Main.xaml
+
+### Main.xaml Arguments (new in current template)
+| Argument | Direction | Type | Purpose |
+|----------|-----------|------|---------|
+| `in_OrchestratorQueueName` | In | String | Allows queue name to be passed as argument (overrides Config) |
+| `in_OrchestratorQueueFolder` | In | String | Allows queue folder to be passed as argument (overrides Config) |
+
+### State Machine Variables
+| Variable | Type | Purpose |
+|----------|------|---------|
+| `Config` | Dictionary\<String, Object\> | All configuration from Config.xlsx |
+| `TransactionItem` | QueueItem | Current transaction being processed |
+| `TransactionNumber` | Int32 | Current transaction index |
+| `RetryNumber` | Int32 | Current retry count for this transaction |
+| `ConsecutiveSystemExceptions` | Int32 | Consecutive system exception counter |
+| `dt_TransactionData` | DataTable | Transaction data source (non-queue mode) |
+| `SystemException` | Exception | Last caught system exception |
+| `BusinessException` | BusinessRuleException | Last caught business exception |
+| `TransactionField1` | String | Optional transaction info for logging |
+| `TransactionField2` | String | Optional transaction info for logging |
+| `TransactionID` | String | Unique transaction identifier for logging |
+
+### GetTransactionData.xaml Arguments
+| Argument | Direction | Type | Purpose |
+|----------|-----------|------|---------|
+| `in_TransactionNumber` | In | Int32 | Sequential counter of transactions |
+| `in_Config` | In | Dictionary\<String, Object\> | Config dictionary |
+| `out_TransactionItem` | Out | QueueItem | Transaction item to process |
+| `out_TransactionField1` | Out | String | Optional transaction info |
+| `out_TransactionField2` | Out | String | Optional transaction info |
+| `out_TransactionID` | Out | String | Unique transaction ID for logging |
+| `io_dt_TransactionData` | InOut | DataTable | DataTable source for non-queue mode |
+
+### SetTransactionStatus.xaml Arguments
+| Argument | Direction | Type | Purpose |
+|----------|-----------|------|---------|
+| `in_BusinessException` | In | BusinessRuleException | Business exception (Nothing if success/system error) |
+| `in_SystemException` | In | Exception | System exception (Nothing if success/business error) |
+| `in_TransactionItem` | In | QueueItem | Current transaction item |
+| `in_TransactionField1` | In | String | Additional transaction info |
+| `in_TransactionField2` | In | String | Additional transaction info |
+| `in_TransactionID` | In | String | Transaction ID for logging |
+| `in_Config` | In | Dictionary\<String, Object\> | Config dictionary |
+| `io_RetryNumber` | InOut | Int32 | Retry counter |
+| `io_TransactionNumber` | InOut | Int32 | Transaction counter |
+| `io_ConsecutiveSystemExceptions` | InOut | Int32 | Consecutive system exception counter |
+
+### RetryCurrentTransaction.xaml Arguments (NEW in current template)
+| Argument | Direction | Type | Purpose |
+|----------|-----------|------|---------|
+| `in_Config` | In | Dictionary\<String, Object\> | Config dictionary |
+| `io_RetryNumber` | InOut | Int32 | Retry counter |
+| `io_TransactionNumber` | InOut | Int32 | Transaction counter |
+| `in_SystemException` | In | Exception | The system exception that occurred |
+| `in_QueueRetry` | In | Boolean | Whether retry is managed by Orchestrator queue |
+
+---
+
+## 8. Queue-Based vs Non-Queue Processing
+
+### Queue-Based (Default/Recommended)
+- `GetTransactionData.xaml` calls `Get Transaction Item` from Orchestrator
+- `SetTransactionStatus.xaml` calls `Set Transaction Status`
+- Orchestrator manages: retry count, defer dates, deadlines, progress
+- Supports Dispatcher/Performer pattern
+
+### Non-Queue (DataTable/File/Custom)
+- `GetTransactionData.xaml` reads from DataTable, file, database, etc.
+- `TransactionNumber` tracks current position (incremented manually)
+- No Orchestrator queue integration
+- Must implement your own retry tracking
+- `SetTransactionStatus.xaml` may write to Excel, database, or log
+
+### Non-Queue Mode: Tabular Data (Detailed)
+
+When processing data from Excel/CSV/DataTable without Orchestrator queues, modify the REFramework as follows:
+
+**Config.xlsx Modifications:**
+
+| Setting | Value | Action |
+|---|---|---|
+| `OrchestratorQueueName` | (empty or remove) | Not used in tabular mode |
+| `DataSourcePath` | Path to Excel/CSV file | **Add this row** — or use an Orchestrator Text asset |
+| `DataSourceSheet` | Sheet name (Excel only) | **Add this row** — e.g., `"Sheet1"` |
+
+**GetTransactionData.xaml Modifications:**
+
+1. In the **Init** state, load the data source ONCE into `io_dt_TransactionData`:
+   ```vb
+   ' Read Excel in InitAllSettings or a custom Init step:
+   ' Read Range: in_Config("DataSourcePath"), Sheet: in_Config("DataSourceSheet") → io_dt_TransactionData
+   ```
+
+2. In `GetTransactionData.xaml`, use `in_TransactionNumber` as a row counter:
+   ```vb
+   ' Check if more rows exist:
+   If in_TransactionNumber >= io_dt_TransactionData.Rows.Count Then
+       out_TransactionItem = Nothing   ' Signals "no more data" → End Process
+   Else
+       ' Return current row as the transaction item:
+       out_TransactionItem = io_dt_TransactionData.Rows(in_TransactionNumber)
+   End If
+   ```
+
+   > **Note:** `out_TransactionItem` type changes from `QueueItem` to `DataRow`. Update the variable type in Main.xaml accordingly, or use a separate `out_TransactionRow` argument.
+
+3. **Access data in Process.xaml** — use DataRow syntax instead of QueueItem:
+   ```vb
+   ' Queue mode:    transactionItem.SpecificContent("FieldName").ToString()
+   ' Tabular mode:  in_TransactionItem("ColumnName").ToString()
+   ```
+
+**SetTransactionStatus.xaml Modifications:**
+
+Without Orchestrator queues, status tracking is manual:
+
+| Approach | Implementation |
+|---|---|
+| **Status column in source DataTable** | Add "Status" column, set to "Success"/"Failed"/"Business Exception" per row |
+| **Output file** | Write processed rows + status to a separate output Excel/CSV |
+| **Log only** | Log Message with transaction ID and result (simplest) |
+
+**Load Data Once Principle:**
+- Read the Excel/CSV file **once** during Init, store in `io_dt_TransactionData`
+- Do NOT re-read the file for each transaction — this is wasteful and can cause file lock issues
+- The `io_` prefix on `dt_TransactionData` means it is InOut — loaded in Init, read in GetTransactionData
+
+**When to Use Tabular vs Queue Mode:**
+
+| Factor | Tabular Data | Orchestrator Queue |
+|---|---|---|
+| Robot count | Single robot | Multiple robots in parallel |
+| Orchestrator available | Not required | Required |
+| Auto-retry | Manual (REFramework handles via RetryNumber) | Built-in (Orchestrator + REFramework) |
+| Progress monitoring | Manual (log/file-based) | Dashboard, SLA tracking |
+| Data volume | Small to medium (fits in memory) | Any size (streamed one at a time) |
+| Best for | Offline processing, standalone robots, small datasets | Production enterprise processing |
+
+---
+
+## 9. Dispatcher/Performer Pattern
+
+### Dispatcher (separate workflow)
+1. Read input data (Excel, email, database, API)
+2. For each item: `Add Queue Item` to Orchestrator queue
+3. Done — dispatcher is typically simple and linear (no REFramework needed)
+
+### Performer (REFramework)
+1. `GetTransactionData` → `Get Transaction Item` from queue
+2. `Process.xaml` → Process the item using `TransactionItem.SpecificContent("FieldName")`
+3. `SetTransactionStatus` → Mark Success/Failed
+4. Repeat until queue empty
+
+### Benefits
+- Multiple robots can process the same queue in parallel
+- Failed items automatically retried by Orchestrator
+- Progress visible in Orchestrator dashboard
+- Audit trail for every item
+
+---
+
+## 10. Common Gotchas & Mistakes
+
+### Configuration
+1. **Config.xlsx must be closed** before running — Excel file lock causes "file in use" error
+2. **Asset names in Assets sheet must match Orchestrator exactly** (case-sensitive)
+3. **Config values are all Strings** in the dictionary — must convert: `CInt(in_Config("MaxRetryNumber"))`
+4. **Missing config keys** throw KeyNotFoundException — always check `in_Config.ContainsKey()` or add defaults
+
+### Exception Handling
+5. **Business exceptions should NOT be caught in Process.xaml** — let them propagate to SetTransactionStatus
+6. **System exceptions in Process.xaml should NOT be caught** either — the framework handles them
+7. **Wrapping everything in Try-Catch in Process.xaml defeats the purpose** — only catch exceptions you explicitly want to handle differently
+8. **MaxRetryNumber in Config.xlsx is SEPARATE from Orchestrator queue retry** — both apply; total retries = REF retries × queue retries
+9. **ConsecutiveSystemExceptions counter reset on BusinessRuleException** — a business exception proves the environment works, just the data was bad
+
+### State Machine
+10. **Init runs KillAllProcesses then InitAllApplications** — your apps WILL be killed and reopened on every system exception retry
+11. **Init is NOT just for first run** — it's called again on every system exception to reinitialize apps
+12. **End Process always runs** — even on successful completion (it closes apps)
+13. **Don't add activities directly to Main.xaml** — put business logic in Process.xaml and sub-workflows
+
+### Queue Processing
+14. **Get Transaction Item returns Nothing when queue empty** — this is the normal exit signal, not an error
+15. **QueueItem.SpecificContent returns Object** — always .ToString() or convert explicitly
+16. **Queue item retry count in Orchestrator is independent** — an item failing in REF gets requeued by Orchestrator with its own retry logic
+
+### Common Mistakes
+17. **Not throwing BusinessRuleException for data issues** — using generic Exception causes unnecessary retries
+18. **Leaving Process.xaml empty** — it must contain your actual automation logic
+19. **Not implementing CloseAllApplications** — apps remain open between runs, causing resource leaks
+20. **Not implementing KillAllProcesses** — stale app instances interfere with reinitializationF
+21. **Using REFramework for simple linear processes** — overkill for non-transactional workflows; use a simple Sequence instead
+
+### Debugging
+22. **Hard to debug in Studio** — state machine jumps are confusing; use Log Message extensively
+23. **Set MaxRetryNumber to 0 during development** — prevents infinite retry loops while testing
+24. **Screenshots land in Exceptions_Screenshots/ folder** — check there for error context
+25. **Orchestrator logs show state transitions** — filter by Log Level to trace framework behavior
+
+---
+
+## 11. When to Use REFramework
+
+### Use REFramework When:
+- Processing multiple similar items (transactions)
+- Items are independent (failure of one doesn't affect others)
+- Need retry logic for transient errors
+- Running unattended on Orchestrator
+- Need audit trail and error reporting
+- Multiple robots should process same workload
+
+### DON'T Use REFramework When:
+- Simple linear process (read file → do one thing → done)
+- Attended automation (user interaction throughout)
+- No transaction concept (single operation, not batch)
+- Quick proof-of-concept or prototype
+- Process takes <30 seconds total
+
+---
+
+## 12. Current Template Dependencies (Studio 25.10)
+
+```json
+{
+  "UiPath.Excel.Activities": "[2.24.4]",
+  "UiPath.System.Activities": "[24.10.8]",
+  "UiPath.Testing.Activities": "[25.10.1]",
+  "UiPath.UIAutomation.Activities": "[25.10.26]"
+}
+```
+
+- **targetFramework**: `"Legacy"` (.NET Framework 4.6.1)
+- **expressionLanguage**: `"VisualBasic"` (VB template) or `"CSharp"` (C# template)
+- **studioVersion**: `"25.10.7.0"`
+- Both VB and C# templates have identical structure and logic
+
+---
+
+## 13. Built-In Test Cases (NEW in current template)
+
+The template includes pre-built test case workflows:
+
+| Test Case | Purpose |
+|-----------|---------|
+| `GeneralTestCase.xaml` | General test template |
+| `InitAllSettingsTestCase.xaml` | Tests Config.xlsx loading |
+| `InitAllApplicationsTestCase.xaml` | Tests app initialization |
+| `GetTransactionDataTestCase.xaml` | Tests transaction data retrieval |
+| `ProcessTestCase.xaml` | Tests Process.xaml business logic |
+| `MainTestCase.xaml` | End-to-end test of Main workflow |
+| `WorkflowTestCaseTemplate.xaml` | Template for creating new tests |
+| `Tests.xlsx` | Test data file |
+
+---
+
+## 14. Customization Checklist
+
+When starting a new REFramework project:
+
+- [ ] **Config.xlsx**: Add your settings (URLs, paths, thresholds, queue name)
+- [ ] **Config.xlsx Assets**: Add Orchestrator asset names for credentials
+- [ ] **InitAllApplications.xaml**: Add logic to open/login to your apps
+- [ ] **CloseAllApplications.xaml**: Add logic to logout/close your apps
+- [ ] **KillAllProcesses.xaml**: List all app process names to force-kill
+- [ ] **GetTransactionData.xaml**: Configure your data source (queue, DataTable, etc.)
+- [ ] **Framework/Process.xaml**: Implement your business logic
+- [ ] **SetTransactionStatus.xaml**: Configure status reporting (if not using queues)
+- [ ] Test with MaxRetryNumber=0 first, then increase
+- [ ] Test Business Exception path (throw BusinessRuleException)
+- [ ] Test System Exception path (simulate app crash)
+- [ ] Test empty queue/data path (verify clean exit)
+- [ ] Run built-in test cases (Tests/ folder) to verify framework integrity
+
+---
+
+## Sources
+- [UiPath REFramework GitHub Repository](https://github.com/UiPath/ReFrameWork)
+- [UiPath Studio Documentation - Robotic Enterprise Framework](https://docs.uipath.com/studio/standalone/2024.10/user-guide/robotic-enterprise-framework)
+- [UiPath Forum - MaxRetryNumber vs MaxConsecutiveSystemExceptions](https://forum.uipath.com/t/re-framwork-maxretrynumber-vs-maxconsecutivesystemexceptions/453279)
+- [UiPath Forum - How would you improve ReFramework?](https://forum.uipath.com/t/how-would-you-improve-reframework/770451)
+- [UiPath Forum - REFramework Best Practices](https://forum.uipath.com/t/reframework-best-practices/182867)
+- [UiPath Forum - REFramework in 2026: Still Best Practice?](https://forum.uipath.com/t/reframework-in-2026-still-best-practice-or-due-for-modernization/5730782)
+- [UiPath Academy - Introduction to REFramework](https://academy.uipath.com/courses/introduction-to-robotic-enterprise-framework)

--- a/skills/uipath-rpa-legacy/references/activity-docs/_XAML-GUIDE.md
+++ b/skills/uipath-rpa-legacy/references/activity-docs/_XAML-GUIDE.md
@@ -1,0 +1,692 @@
+# UiPath Legacy XAML Workflow Guide
+
+## Purpose
+How XAML workflows work internally: structure, VB.NET vs C#, arguments, variables, Sequence vs Flowchart vs State Machine, visual layout, and templates for generating valid workflow files.
+
+---
+
+## 1. XAML File Structure
+
+Every UiPath .xaml workflow file is a **WF4 (Windows Workflow Foundation 4) Activity** serialized as XAML. The root structure is:
+
+```xml
+<Activity
+  mc:Ignorable="sap sap2010"
+  x:Class="WorkflowName"
+  xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+  xmlns:ui="http://schemas.uipath.com/workflow/activities"
+  xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation"
+  ...>
+
+  <!-- 1. Arguments (x:Members) -->
+  <!-- 2. Namespace imports -->
+  <!-- 3. Assembly references -->
+  <!-- 4. Root container (Sequence/Flowchart/StateMachine) -->
+
+</Activity>
+```
+
+### Key Attributes on Root `<Activity>`
+| Attribute | Purpose |
+|-----------|---------|
+| `x:Class="Main"` | Workflow class name (matches filename without .xaml) |
+| `mva:VisualBasic.Settings="{x:Null}"` | **VB.NET project** marker |
+| `sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#"` | **C# project** marker |
+| `sap:VirtualizedContainerService.HintSize="1224.8,523.2"` | Designer canvas size |
+
+---
+
+## 2. VB.NET vs C# — Key Differences
+
+### How to Tell
+| | VB.NET | C# |
+|---|--------|-----|
+| **Root attribute** | `mva:VisualBasic.Settings="{x:Null}"` | `sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#"` |
+| **Expression type** | `mva:VisualBasicValue<T>` / `mva:VisualBasicReference<T>` | `mca:CSharpValue<T>` / `mca:CSharpReference<T>` |
+| **Namespace xmlns** | `xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities"` | `xmlns:mca="clr-namespace:Microsoft.CSharp.Activities;assembly=System.Activities"` |
+| **project.json** | `"expressionLanguage": "VisualBasic"` | `"expressionLanguage": "CSharp"` |
+| **Assembly ref** | `Microsoft.VisualBasic` | `Microsoft.CSharp` |
+
+### Expression Syntax in XAML
+
+**VB.NET expressions** (inline in attributes):
+```xml
+<!-- Simple value in brackets -->
+<ui:LogMessage Message="[&quot;Hello &quot; + userName]" />
+
+<!-- Typed expression -->
+<Assign.Value>
+  <InArgument x:TypeArguments="x:Int32">[variable1 + 1]</InArgument>
+</Assign.Value>
+
+<!-- Condition (FlowDecision) -->
+<FlowDecision.Condition>
+  <mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="variable1 &lt; 5" />
+</FlowDecision.Condition>
+```
+
+**C# expressions** (wrapped in CSharpValue/CSharpReference):
+```xml
+<!-- String value -->
+<ui:LogMessage.Message>
+  <InArgument x:TypeArguments="x:Object">
+    <mca:CSharpValue x:TypeArguments="x:Object">"LegacyC#"</mca:CSharpValue>
+  </InArgument>
+</ui:LogMessage.Message>
+
+<!-- Condition -->
+<FlowDecision.Condition>
+  <mca:CSharpValue x:TypeArguments="x:Boolean">variable1 &lt; 5</mca:CSharpValue>
+</FlowDecision.Condition>
+```
+
+### Key Difference: VB uses `[expression]` bracket notation; C# uses `<mca:CSharpValue>` wrapper elements
+
+---
+
+## 3. Arguments (In/Out/InOut)
+
+Arguments are the workflow's public interface — how data flows between workflows via `Invoke Workflow File`.
+
+### XAML Declaration
+```xml
+<x:Members>
+  <x:Property Name="inputName"    Type="InArgument(x:String)" />
+  <x:Property Name="inputAge"     Type="InArgument(x:Int32)" />
+  <x:Property Name="inputData"    Type="InArgument(sd:DataTable)" />
+  <x:Property Name="outputResult" Type="OutArgument(x:String)" />
+  <x:Property Name="ioCounter"    Type="InOutArgument(x:Int32)" />
+</x:Members>
+```
+
+### Argument Directions
+| Direction | XAML Type | Description | Caller Side |
+|-----------|-----------|-------------|-------------|
+| `In` | `InArgument(TypeName)` | Input only — caller provides value | Set before invoke |
+| `Out` | `OutArgument(TypeName)` | Output only — workflow sets value | Read after invoke |
+| `InOut` | `InOutArgument(TypeName)` | Both directions — caller provides, workflow may modify | Set before, read after |
+
+### Common Type Mappings in XAML
+| XAML Type | .NET Type |
+|-----------|-----------|
+| `x:String` | System.String |
+| `x:Int32` | System.Int32 |
+| `x:Int64` | System.Int64 |
+| `x:Boolean` | System.Boolean |
+| `x:Double` | System.Double |
+| `x:Object` | System.Object |
+| `x:Decimal` | System.Decimal |
+| `sd:DataTable` | System.Data.DataTable (requires `xmlns:sd` namespace) |
+| `scg:Dictionary(x:String, x:Object)` | Dictionary\<String, Object\> |
+| `scg:List(x:String)` | List\<String\> |
+| `s:DateTime` | System.DateTime |
+| `s:SecureString` | System.Security.SecureString |
+
+### Referencing Arguments in Expressions
+```xml
+<!-- VB.NET: use [argumentName] brackets -->
+<InArgument x:TypeArguments="x:String">[inputName]</InArgument>
+
+<!-- Setting output argument -->
+<Assign.To>
+  <OutArgument x:TypeArguments="x:String">[outputResult]</OutArgument>
+</Assign.To>
+<Assign.Value>
+  <InArgument x:TypeArguments="x:String">[inputName + " processed"]</InArgument>
+</Assign.Value>
+```
+
+---
+
+## 4. Variables
+
+Variables are local to a container (Sequence, Flowchart, StateMachine, etc.). They are declared inside the container element.
+
+### XAML Declaration
+```xml
+<Sequence.Variables>
+  <Variable x:TypeArguments="x:String" Name="myText" Default="Hello" />
+  <Variable x:TypeArguments="x:Int32" Name="counter" Default="0" />
+  <Variable x:TypeArguments="sd:DataTable" Name="dtResult" />
+  <Variable x:TypeArguments="x:Boolean" Name="isValid" />
+</Sequence.Variables>
+```
+
+### Scope Rules
+- Variables are **scoped to their parent container** (Sequence, Flowchart, State, etc.)
+- Variables declared in an outer Sequence are accessible in inner Sequences
+- Variables are NOT accessible across invoked workflows (use Arguments for that)
+- Variables in a Flowchart are accessible from all FlowSteps in that Flowchart
+
+---
+
+## 5. Sequence
+
+**Purpose**: Executes activities in top-to-bottom order. The most common container.
+
+**When to use**: Linear processes, step-by-step operations, most workflows.
+
+### XAML Structure
+```xml
+<Sequence DisplayName="Main Sequence" sap2010:WorkflowViewState.IdRef="Sequence_1">
+  <Sequence.Variables>
+    <Variable x:TypeArguments="x:String" Name="result" />
+  </Sequence.Variables>
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+
+  <!-- Activities execute top-to-bottom -->
+  <Assign DisplayName="Set Result" sap2010:WorkflowViewState.IdRef="Assign_1">
+    <Assign.To>
+      <OutArgument x:TypeArguments="x:String">[result]</OutArgument>
+    </Assign.To>
+    <Assign.Value>
+      <InArgument x:TypeArguments="x:String">["Hello World"]</InArgument>
+    </Assign.Value>
+  </Assign>
+
+  <ui:LogMessage DisplayName="Log Result" sap2010:WorkflowViewState.IdRef="LogMessage_1"
+    Message="[result]" />
+
+</Sequence>
+```
+
+### Visual Layout
+- Activities stack vertically in order
+- `IsExpanded` controls whether the Sequence shows its children or is collapsed
+- `HintSize` controls the visual width/height in the designer
+
+---
+
+## 6. Flowchart
+
+**Purpose**: Visual flow with decisions, branches, and loops via connectors. Activities connect via arrows.
+
+**When to use**: Decision-heavy logic, loops with conditions, when you need visual flow representation.
+
+### XAML Structure
+```xml
+<Flowchart DisplayName="Main Flowchart" sap2010:WorkflowViewState.IdRef="Flowchart_1">
+  <Flowchart.Variables>
+    <Variable x:TypeArguments="x:Int32" Name="counter" />
+  </Flowchart.Variables>
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+      <!-- Start node position -->
+      <av:Point x:Key="ShapeLocation">270,2.5</av:Point>
+      <av:Size x:Key="ShapeSize">60,74.66</av:Size>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+
+  <!-- Start node points to first FlowStep -->
+  <Flowchart.StartNode>
+    <x:Reference>__ReferenceID0</x:Reference>
+  </Flowchart.StartNode>
+
+  <!-- FlowStep: wraps an activity + points to next -->
+  <FlowStep x:Name="__ReferenceID0">
+    <sap:WorkflowViewStateService.ViewState>
+      <scg:Dictionary x:TypeArguments="x:String, x:Object">
+        <av:Point x:Key="ShapeLocation">185,127</av:Point>
+        <av:Size x:Key="ShapeSize">229,62</av:Size>
+        <!-- Connector line coordinates -->
+        <av:PointCollection x:Key="ConnectorLocation">300,189 300,239</av:PointCollection>
+      </scg:Dictionary>
+    </sap:WorkflowViewStateService.ViewState>
+    <Assign DisplayName="Increment" .../>
+    <FlowStep.Next>
+      <x:Reference>__ReferenceID1</x:Reference>
+    </FlowStep.Next>
+  </FlowStep>
+
+  <!-- FlowDecision: True/False branching -->
+  <FlowDecision x:Name="__ReferenceID1" DisplayName="Check Condition">
+    <FlowDecision.Condition>
+      <mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="counter &lt; 10" />
+    </FlowDecision.Condition>
+    <FlowDecision.True>
+      <x:Reference>__ReferenceID0</x:Reference>  <!-- Loop back -->
+    </FlowDecision.True>
+    <FlowDecision.False>
+      <!-- null = end of flow -->
+    </FlowDecision.False>
+  </FlowDecision>
+
+  <!-- Do NOT add trailing <x:Reference> for child nodes here — they are already direct children -->
+</Flowchart>
+```
+
+### Key Elements
+| Element | Purpose |
+|---------|---------|
+| `Flowchart.StartNode` | Points to the first FlowStep (entry point) |
+| `FlowStep` | Wraps one activity + `FlowStep.Next` (pointer to next) |
+| `FlowDecision` | Boolean branch: `True` path and `False` path |
+| `FlowSwitch<T>` | Multi-branch switch (like Switch activity) |
+| `x:Reference` | Cross-references between nodes (used inside `Flowchart.StartNode`, `FlowStep.Next`, `FlowDecision.True/False` — never as trailing children of `<Flowchart>`) |
+
+### Flowchart ViewState Layout Guide
+
+**MANDATORY for generated/edited Flowcharts.** Without ViewState, Studio stacks all nodes at (0,0) — unusable.
+
+**Required xmlns** on root `<Activity>`:
+```xml
+xmlns:av="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+```
+
+**Coordinate system:** Origin top-left (0,0), X increases right, Y increases down, units in pixels.
+
+**Standard node sizes:**
+
+| Node Type | ShapeSize (W×H) | Notes |
+|-----------|----------------|-------|
+| Start Node (Flowchart entry) | 60×75 | Positioned by Flowchart container ViewState |
+| FlowStep (activity box) | 230×65 | Width varies with activity content |
+| FlowDecision (diamond) | 60×75 | Same as start node |
+
+**Layout algorithm (grid-based):**
+1. Main path center X: **270**
+2. Start node at **(270, 2.5)** — set in the Flowchart container's ViewState
+3. First FlowStep at **(155, 120)** — centered below start (270 - 230/2 = 155)
+4. Vertical step: **~110px** (node height + ~45px gap)
+5. True branch: offset left — center X at **~120** (150px left of main center)
+6. False branch: offset right — center X at **~420** (150px right of main center)
+7. Merge node: back to center X **~155**
+
+**ConnectorLocation formula:**
+- `center_x = ShapeLocation.X + ShapeSize.Width / 2`
+- `bottom_y = ShapeLocation.Y + ShapeSize.Height`
+- `top_y = ShapeLocation.Y`
+- **Straight down:** `center_x,bottom_y center_x,next_top_y`
+- **Decision True (left):** `decision_left_x,decision_center_y target_center_x,decision_center_y target_center_x,target_top_y`
+- **Decision False (right):** `decision_right_x,decision_center_y target_center_x,decision_center_y target_center_x,target_top_y`
+  - Where `decision_left_x = ShapeLocation.X`, `decision_right_x = ShapeLocation.X + ShapeSize.Width`
+  - Where `decision_center_y = ShapeLocation.Y + ShapeSize.Height / 2`
+
+**ViewState placement per node:**
+```xml
+<FlowStep x:Name="__ReferenceID0">
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <av:Point x:Key="ShapeLocation">155,120</av:Point>
+      <av:Size x:Key="ShapeSize">230,65</av:Size>
+      <av:PointCollection x:Key="ConnectorLocation">270,185 270,240</av:PointCollection>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+  <!-- activity here -->
+  <FlowStep.Next>...</FlowStep.Next>
+</FlowStep>
+```
+
+**Flowchart container ViewState (start node position):**
+```xml
+<Flowchart DisplayName="Main Flowchart" sap2010:WorkflowViewState.IdRef="Flowchart_1">
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+      <av:Point x:Key="ShapeLocation">270,2.5</av:Point>
+      <av:Size x:Key="ShapeSize">60,75</av:Size>
+      <av:PointCollection x:Key="ConnectorLocation">300,77.5 300,120</av:PointCollection>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+  ...
+</Flowchart>
+```
+
+**FlowDecision ViewState (True/False connectors):**
+```xml
+<FlowDecision x:Name="__ReferenceID1" DisplayName="Has Data?">
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <av:Point x:Key="ShapeLocation">240,240</av:Point>
+      <av:Size x:Key="ShapeSize">60,75</av:Size>
+      <!-- True exits left -->
+      <av:PointCollection x:Key="TrueConnector">240,277.5 120,277.5 120,340</av:PointCollection>
+      <!-- False exits right -->
+      <av:PointCollection x:Key="FalseConnector">300,277.5 450,277.5 450,340</av:PointCollection>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+  ...
+</FlowDecision>
+```
+
+**Complete example layout map:**
+```
+              [Start]             (270, 2.5)     60×75
+                 │
+          [Read Data]             (155, 120)    230×65
+                 │
+            <Has Data?>           (240, 240)     60×75
+           /           \
+    [Calculate]     [Log None]    (5, 340)      (335, 340)   230×65
+         │
+    <Direction?>                  (240, 460)     60×75
+       /       \
+ [Bullish]  [Bearish]            (5, 560)       (335, 560)   230×65
+       \       /
+    [Write Output]                (155, 680)    230×65
+```
+
+**When adding nodes to an existing Flowchart:** Read existing ShapeLocation values first. Place new nodes below or beside existing ones with ≥110px vertical / ≥200px horizontal clearance.
+
+---
+
+## 7. State Machine
+
+**Purpose**: State-based workflow with explicit states, transitions, and conditions. Used for complex business processes like the REFramework.
+
+**When to use**: Processes with distinct states (Init, Process, End), approval workflows, retry patterns.
+
+### XAML Structure
+```xml
+<StateMachine InitialState="{x:Reference __ReferenceID_InitState}"
+  DisplayName="Process State Machine" sap2010:WorkflowViewState.IdRef="StateMachine_1">
+
+  <StateMachine.Variables>
+    <Variable x:TypeArguments="x:Int32" Name="transactionCounter" />
+  </StateMachine.Variables>
+
+  <!-- State with Entry activities and Transitions -->
+  <State x:Name="__ReferenceID_InitState" DisplayName="Init">
+    <State.Entry>
+      <Sequence DisplayName="Initialize">
+        <!-- Activities that run when entering this state -->
+        <Assign .../>
+      </Sequence>
+    </State.Entry>
+    <State.Transitions>
+      <Transition DisplayName="Success" sap2010:WorkflowViewState.IdRef="Transition_1">
+        <Transition.Condition>[initSuccess]</Transition.Condition>
+        <Transition.To>
+          <x:Reference>__ReferenceID_ProcessState</x:Reference>
+        </Transition.To>
+      </Transition>
+      <Transition DisplayName="SystemError">
+        <Transition.Condition>[Not initSuccess]</Transition.Condition>
+        <Transition.To>
+          <x:Reference>__ReferenceID_EndState</x:Reference>
+        </Transition.To>
+      </Transition>
+    </State.Transitions>
+  </State>
+
+  <!-- Processing State -->
+  <State x:Name="__ReferenceID_ProcessState" DisplayName="Process Transaction">
+    <State.Entry>
+      <Sequence DisplayName="Process">...</Sequence>
+    </State.Entry>
+    <State.Transitions>
+      <Transition DisplayName="More Items">
+        <Transition.Condition>[hasMoreItems]</Transition.Condition>
+        <Transition.To>
+          <x:Reference>__ReferenceID_ProcessState</x:Reference> <!-- Loop to self -->
+        </Transition.To>
+      </Transition>
+      <Transition DisplayName="Done">
+        <Transition.To>
+          <x:Reference>__ReferenceID_EndState</x:Reference>
+        </Transition.To>
+      </Transition>
+    </State.Transitions>
+  </State>
+
+  <!-- Final State (IsFinal=True means workflow ends here) -->
+  <State x:Name="__ReferenceID_EndState" DisplayName="End Process" IsFinal="True">
+    <State.Entry>
+      <Sequence DisplayName="Cleanup">...</Sequence>
+    </State.Entry>
+  </State>
+
+</StateMachine>
+```
+
+### Key Elements
+| Element | Purpose |
+|---------|---------|
+| `StateMachine.InitialState` | Reference to first state |
+| `State` | A state with Entry activities, Exit activities, and Transitions |
+| `State.Entry` | Activities executed when entering the state |
+| `State.Exit` | Activities executed when leaving the state |
+| `State.Transitions` | List of possible transitions to other states |
+| `Transition.Condition` | Boolean expression that must be true to take this transition |
+| `Transition.To` | Reference to destination state |
+| `Transition.Action` | Activities to execute during the transition |
+| `State IsFinal="True"` | Final state — workflow ends when this state is reached |
+
+### StateMachine ViewState Layout Guide
+
+**MANDATORY for generated/edited StateMachines.** Without ViewState, Studio stacks all states at (0,0) — unusable.
+
+**Required xmlns** on root `<Activity>`:
+```xml
+xmlns:av="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+```
+
+**Coordinate system:** Same as Flowchart — origin top-left (0,0), X right, Y down, pixels. StateMachine uses a 600×600 container.
+
+**Standard sizes:**
+
+| Node Type | ShapeSize (W×H) | Notes |
+|-----------|----------------|-------|
+| State | 134×61.6 | Universal — all states same size |
+| Final State (IsFinal="True") | 134×61.6 | Same size as regular states |
+
+**StateMachine container ViewState:**
+```xml
+<StateMachine DisplayName="Process" sap2010:WorkflowViewState.IdRef="StateMachine_1">
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <x:Boolean x:Key="IsExpanded">True</x:Boolean>
+      <x:Double x:Key="StateContainerWidth">600</x:Double>
+      <x:Double x:Key="StateContainerHeight">600</x:Double>
+      <av:Point x:Key="ShapeLocation">270,2.5</av:Point>
+      <av:Size x:Key="ShapeSize">60,75</av:Size>
+      <av:PointCollection x:Key="ConnectorLocation">270,77.5 270,107 110,107 110,109</av:PointCollection>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+  ...
+</StateMachine>
+```
+
+**Layout algorithm:**
+1. Container: **600×600** pixels
+2. Start connector at **(270, 2.5)** — centered top
+3. Initial state: **(43, 109)** — top-left area
+4. Horizontal spacing: **~200px** between state centers
+5. Vertical spacing: **~130px** between state centers
+6. Final state: below the last processing state
+
+**State ViewState:**
+```xml
+<State x:Name="__ReferenceID_Init" DisplayName="Init">
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <av:Point x:Key="ShapeLocation">43,109</av:Point>
+      <av:Size x:Key="ShapeSize">134,61.6</av:Size>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+  ...
+</State>
+```
+
+**Transition connector ViewState:**
+```xml
+<Transition DisplayName="Success">
+  <sap:WorkflowViewStateService.ViewState>
+    <scg:Dictionary x:TypeArguments="x:String, x:Object">
+      <av:PointCollection x:Key="ConnectorLocation">177,139 300,139 300,149</av:PointCollection>
+      <x:Int32 x:Key="SrcConnectionPointIndex">8</x:Int32>
+      <x:Int32 x:Key="DestConnectionPointIndex">12</x:Int32>
+    </scg:Dictionary>
+  </sap:WorkflowViewStateService.ViewState>
+  ...
+</Transition>
+```
+
+Connector formula: exit right edge of source state → route horizontally → enter top edge of target state. `SrcConnectionPointIndex` and `DestConnectionPointIndex` are internal Studio indices — use values from existing workflows or let Studio adjust them on first open.
+
+**Complete REFramework-style layout map:**
+```
+         [Start]              (270, 2.5)     60×75
+            │
+       [Init]                 (43, 109)     134×61.6
+       /         \
+  [Process]    [End]          (233, 149)    (233, 279)    134×61.6
+    ↺ (self-loop)             Final state
+```
+
+**Self-loop transition** (Process → Process for retry):
+```xml
+<av:PointCollection x:Key="ConnectorLocation">367,158 397,158 397,162 367,162</av:PointCollection>
+```
+Forms a small rectangle extending ~30px right of the state's right edge.
+
+**When adding states to an existing StateMachine:** Read existing ShapeLocation values. Place new states with ≥130px vertical / ≥200px horizontal clearance. Update `StateContainerWidth`/`StateContainerHeight` if new states exceed the 600×600 canvas.
+
+---
+
+## 8. project.json Structure
+
+Every UiPath project has a `project.json` at the root defining metadata and configuration.
+
+### Key Fields
+```json
+{
+  "name": "MyProject",
+  "description": "Project description",
+  "main": "Main.xaml",
+  "dependencies": {
+    "UiPath.System.Activities": "[22.10.4]",
+    "UiPath.UIAutomation.Activities": "[22.10.4]",
+    "UiPath.Excel.Activities": "[2.11.3]",
+    "UiPath.Mail.Activities": "[1.12.1]",
+    "UiPath.Testing.Activities": "[22.10.3]"
+  },
+  "schemaVersion": "4.0",
+  "studioVersion": "23.4.0.0",
+  "projectVersion": "1.0.0",
+  "expressionLanguage": "VisualBasic",   // or "CSharp"
+  "targetFramework": "Legacy",           // "Legacy", "Windows", "Portable"
+  "runtimeOptions": {
+    "autoDispose": false,
+    "isPausable": true,
+    "isAttended": false,
+    "requiresUserInteraction": true,
+    "supportsPersistence": false,
+    "workflowSerialization": "DataContract",
+    "excludedLoggedData": ["Private:*", "*password*"],
+    "executionType": "Workflow"
+  },
+  "designOptions": {
+    "projectProfile": "Developement",
+    "outputType": "Process",             // "Process" or "Library"
+    "modernBehavior": true
+  },
+  "entryPoints": [
+    {
+      "filePath": "Main.xaml",
+      "uniqueId": "...",
+      "input": [],
+      "output": []
+    }
+  ]
+}
+```
+
+### Target Framework Values
+| Value | Description |
+|-------|-------------|
+| `"Legacy"` | .NET Framework 4.6.1 (Windows-Legacy compatibility) |
+| `"Windows"` | .NET 6+ Windows (modern) |
+| `"Portable"` | .NET 6+ cross-platform |
+
+### Output Types
+| Value | Description |
+|-------|-------------|
+| `"Process"` | Standalone process (has Main.xaml entry point) |
+| `"Library"` | Reusable library (workflows invokable from other projects) |
+| `"TestAutomation"` | Test automation project |
+
+---
+
+## 9. Namespace Imports
+
+### Standard VB.NET Legacy Namespaces
+```xml
+<TextExpression.NamespacesForImplementation>
+  <sco:Collection x:TypeArguments="x:String">
+    <x:String>System.Activities</x:String>
+    <x:String>System.Activities.Statements</x:String>
+    <x:String>System.Activities.Expressions</x:String>
+    <x:String>System.Activities.Validation</x:String>
+    <x:String>System.Activities.XamlIntegration</x:String>
+    <x:String>Microsoft.VisualBasic</x:String>
+    <x:String>Microsoft.VisualBasic.Activities</x:String>
+    <x:String>System</x:String>
+    <x:String>System.Collections</x:String>
+    <x:String>System.Collections.Generic</x:String>
+    <x:String>System.Data</x:String>
+    <x:String>System.Diagnostics</x:String>
+    <x:String>System.Drawing</x:String>
+    <x:String>System.IO</x:String>
+    <x:String>System.Linq</x:String>
+    <x:String>System.Net.Mail</x:String>
+    <x:String>System.Xml</x:String>
+    <x:String>System.Xml.Linq</x:String>
+    <x:String>UiPath.Core</x:String>
+    <x:String>UiPath.Core.Activities</x:String>
+    <x:String>System.Windows.Markup</x:String>
+  </sco:Collection>
+</TextExpression.NamespacesForImplementation>
+```
+
+### Additional C# Namespaces
+```xml
+<x:String>System.Text</x:String>
+<x:String>System.Linq.Expressions</x:String>
+```
+
+---
+
+## 10. ViewState — Visual Layout System
+
+The `sap:WorkflowViewStateService.ViewState` dictionary controls how activities appear in the designer.
+
+### Common ViewState Keys
+| Key | Type | Purpose |
+|-----|------|---------|
+| `IsExpanded` | Boolean | Whether container is expanded/collapsed |
+| `ShapeLocation` | Point | Position of node in Flowchart/StateMachine (x,y) |
+| `ShapeSize` | Size | Width/height of node |
+| `ConnectorLocation` | PointCollection | Arrow path coordinates between nodes |
+| `StateContainerWidth` | Double | Canvas width for StateMachine |
+| `StateContainerHeight` | Double | Canvas height for StateMachine |
+| `IsPinned` | Boolean | Whether state is pinned in StateMachine |
+
+### HintSize
+Every activity has `sap:VirtualizedContainerService.HintSize="width,height"` controlling its rendered size in the designer. The designer adjusts these automatically, but they must be present for proper rendering.
+
+### IdRef
+Every activity has `sap2010:WorkflowViewState.IdRef="UniqueId_N"` which is a unique identifier within the XAML file. Format is typically `ActivityType_N` (e.g., `Sequence_1`, `Assign_3`, `FlowDecision_1`).
+
+---
+
+## 11. Gotchas When Generating XAML
+
+1. **Every `x:Name` must be unique** within the file — FlowSteps use `__ReferenceID0`, `__ReferenceID1`, etc.
+2. **`x:Reference` must match an `x:Name`** — broken references crash the designer
+3. **IdRef must be unique** — duplicate IdRef values cause designer rendering errors
+4. **Bracket expressions `[expr]`** are VB.NET only — C# must use `<mca:CSharpValue>` elements
+5. **XML escaping required**: `<` becomes `&lt;`, `>` becomes `&gt;`, `"` becomes `&quot;`, `&` becomes `&amp;`
+6. **Assembly references must include all dependencies** — missing references cause design-time compilation errors
+7. **HintSize must be present** on every activity for proper designer rendering
+8. **`expressionLanguage` in project.json must match XAML expression style** — VB project with C# expressions crashes
+9. **Never add trailing `<x:Reference>` for Flowchart child nodes** — nodes defined inline as direct children must NOT be re-listed at the end. Only use `<x:Reference>` inside property elements (`Flowchart.StartNode`, `FlowStep.Next`, `FlowDecision.True/False`, etc.) to create cross-references
+10. **Variables declared inside a container** are only accessible within that container and its children
+11. **Arguments declared at top level** (`x:Members`) are the public API of the workflow
+12. **State Machine needs exactly one `IsFinal="True"` state** for proper termination

--- a/skills/uipath-rpa-legacy/references/cli-reference.md
+++ b/skills/uipath-rpa-legacy/references/cli-reference.md
@@ -1,0 +1,363 @@
+# CLI Tool Reference
+
+Complete reference for all `uip rpa-legacy` CLI commands and error recovery patterns.
+
+**The CLI is fully self-documenting.** Append `--help` at any level to discover commands, subcommands, and parameters:
+```bash
+uip rpa-legacy --help                      # all rpa-legacy subcommands
+uip rpa-legacy find-activities --help      # parameters for a specific command
+uip rpa-legacy validate --help             # parameters for validate
+```
+
+**Key difference from `uip rpa`:** The `rpa-legacy` CLI is standalone — it does **not** require Studio Desktop IPC. It uses UiRobot directly for execution and resolves project dependencies independently.
+
+---
+
+## Path and Output Rules
+
+- **Always use absolute paths** — store `{projectRoot}` at Phase 0, pass it to every command. **Never use `cd`.**
+- **Always use `--output json`** for programmatic parsing (global option on all `uip` subcommands).
+- **NEVER suppress stderr** (`2>/dev/null`) — error details are in the JSON output on stderr when exit code is non-zero.
+- Check the `Result` field in output: `"Success"` or `"Failure"`.
+- On failure, read `Message` and `Instructions` for diagnostics.
+
+```
+WRONG:  cd "C:/Projects/MyProject" && uip rpa-legacy validate . --output json
+RIGHT:  uip rpa-legacy validate "C:/Projects/MyProject" --output json
+RIGHT:  uip rpa-legacy validate "C:/Projects/MyProject/Main.xaml" --output json
+```
+
+---
+
+## File Operations (Built-in Tools)
+
+| Action | How | Key Parameters |
+|--------|-----|----------------|
+| **Explore project files** | `Glob` with `**/*.xaml` pattern | Project root directory |
+| **Find files by pattern** | `Glob` with pattern (e.g., `**/*Mail*.xaml`) | Glob pattern, path |
+| **Search XAML content** | `Grep` with regex pattern across `.xaml` files | Pattern, file/directory path |
+| **Read file contents** | `Read` tool | File path, offset, limit |
+| **Read project definition** | `Read` tool on `{projectRoot}/project.json` | File path |
+| **Create new workflow file** | `Write` tool — create a new `.xaml` file | File path, XAML content |
+| **Edit existing workflow** | `Edit` tool — exact string replacement in `.xaml` files | File path, old_string, new_string |
+
+---
+
+## Activity Discovery Tools
+
+| Action | How | Key Parameters |
+|--------|-----|----------------|
+| **Search for activities** | `Bash`: `uip rpa-legacy find-activities <project-path> --query "..." --output json` | `<project-path>` (required), `--query`, `--tags`, `--limit` (default 50) |
+| **Search with type info** | `Bash`: `uip rpa-legacy find-activities <project-path> --query "..." --include-type-definitions --output json` | Adds full type definitions for argument types |
+| **Inspect a .NET type** | `Bash`: `uip rpa-legacy type-definition <project-path> --type "FullyQualifiedTypeName" --output json` | `<project-path>` (required), `--type` (full or simple name) |
+| **Search NuGet for packages** | `Bash`: `uip rpa-legacy find-package --query "..." --output json` | `--query` (required), `--limit` (default: 50) |
+
+### find-activities
+
+Searches for available activities in the project's installed NuGet dependencies. Returns activity names, arguments (in/out with types), **ready-to-use XAML snippet**, **xmlns declaration**, and optionally full type definitions.
+
+**Always use the returned `XamlSnippet` as your starting point** for activity XAML instead of constructing from scratch. The snippet has correct element names, namespaces, and property names for the installed package version.
+
+```bash
+# Multi-word search (ranked by relevance)
+uip rpa-legacy find-activities "C:/Projects/MyLegacyProject" --query "Excel Read Range" --output json
+
+# Exact match when you know the name
+uip rpa-legacy find-activities "C:/Projects/MyLegacyProject" --query "ReadRange" --exact --output json
+
+# Find with type definitions (enums, classes)
+uip rpa-legacy find-activities "C:/Projects/MyLegacyProject" --query "invoke code" --include-type-definitions --output json
+```
+
+**Output per activity:**
+```json
+{
+  "DisplayName": "SendMail",
+  "ClassName": "SendMail",
+  "Namespace": "UiPath.Mail.SMTP.Activities",
+  "TypeFullName": "UiPath.Mail.SMTP.Activities.SendMail",
+  "Arguments": [
+    { "Name": "To", "Direction": "In", "Type": "String" },
+    { "Name": "Result", "Direction": "Out", "Type": "String" }
+  ],
+  "XmlnsPrefix": "umsa",
+  "XmlnsDeclaration": "xmlns:umsa=\"clr-namespace:UiPath.Mail.SMTP.Activities;assembly=UiPath.Mail.Activities\"",
+  "XamlSnippet": "<umsa:SendMail\n    To=\"[toValue]\"\n    Result=\"[result]\" />"
+}
+```
+
+With `--include-type-definitions`, output includes `TypeDefinitions` array with enum values, class properties, etc.
+
+| Parameter | Description |
+|-----------|-------------|
+| `<project-path>` | Path to project.json or folder containing it (required, positional) |
+| `--query <search>` | Filter activities by name, description, or category |
+| `--tags <tags>` | Comma-separated category tags to filter by |
+| `-l, --limit <count>` | Maximum results to return (default: 50) |
+| `--include-type-definitions` | Include full type definitions for argument types (enums, classes, interfaces) |
+| `--exact` | Only return activities whose ClassName or DisplayName exactly matches the query (case-insensitive) |
+
+**Query tips:**
+- **Multi-word queries work** with relevance scoring: `"Excel Read Range"` splits into words, scores matches independently, with bonuses when all words match
+- **CamelCase boundaries detected**: `"SendHotkey"`, `"ExcelReadRange"` match correctly
+- **Use `--exact`** when you know the exact activity name — avoids irrelevant results (e.g., `--query "If" --exact` returns only the WF4 If activity, not 17 unrelated matches)
+
+### type-definition
+
+Inspects any .NET type from the project's NuGet dependencies — enum values, properties, methods, constructors, and base types.
+
+```bash
+# Inspect an enum type
+uip rpa-legacy type-definition "C:/Projects/MyLegacyProject" --type "UiPath.Mail.Activities.MailFolder" --output json
+
+# Inspect a class
+uip rpa-legacy type-definition "C:/Projects/MyLegacyProject" --type "System.Net.Mail.MailMessage" --output json
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `<project-path>` | Path to project.json or folder containing it (required, positional) |
+| `--type <name>` | Full or simple name of the type to inspect |
+| `--timeout <seconds>` | Timeout in seconds |
+
+### find-package
+
+Searches all configured NuGet feeds for packages by name or description. Use when known packages don't cover a capability.
+
+```bash
+uip rpa-legacy find-package --query "UiPath.Excel" --limit 10 --output json
+uip rpa-legacy find-package --query "barcode" --output json
+```
+
+**Output per package:**
+```json
+{
+  "Id": "UiPath.Excel.Activities",
+  "Version": "2.24.4",
+  "Description": "Excel automation activities",
+  "Authors": "UiPath",
+  "Source": "Official"
+}
+```
+
+Activity packages (tagged `UiPathActivities`) are returned first. Searches all enabled v3 feeds in parallel.
+
+| Parameter | Description |
+|-----------|-------------|
+| `--query <search>` | Search term to match against package name and description (required) |
+| `-l, --limit <count>` | Maximum results (default: 50) |
+
+After finding a package, add it to `dependencies` in project.json. Then `find-activities` will index its activities.
+
+---
+
+## Validation Tools
+
+| Action | How | Key Parameters |
+|--------|-----|----------------|
+| **Validate file** | `Bash`: `uip rpa-legacy validate <xaml-path> --output json` | Single file validation |
+| **Validate project** | `Bash`: `uip rpa-legacy validate <project-path> --output json` | Whole-project validation |
+
+### validate
+
+Checks a XAML workflow file or entire project for compilation errors — missing arguments, broken references, type mismatches.
+
+Accepts: XAML file path, project.json path, or project folder path.
+
+```bash
+# Validate a specific file (use during iteration — one activity at a time)
+uip rpa-legacy validate "C:/Projects/MyLegacyProject/Main.xaml" --output json
+
+# Validate entire project (use before completing — final check)
+uip rpa-legacy validate "C:/Projects/MyLegacyProject" --output json
+
+# Save results to file
+uip rpa-legacy validate "C:/Projects/MyLegacyProject" --result-path "C:/output/errors.json"
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `<path>` | XAML file, project.json, or project folder (required, positional) |
+| `--result-path <path>` | Write validation results to a JSON file instead of stdout |
+
+**Workflow:** Use per-file validation during development (faster, focused). Use project-level validation as a final step before completing the task.
+
+---
+
+## Package & Debug Tools
+
+| Action | How | Key Parameters |
+|--------|-----|----------------|
+| **Package project (optional)** | `Bash`: `uip rpa-legacy package <project-path> -o <output-dir>` | `<project-path>` (required), `-o` output dir |
+| **Debug workflow** | `Bash`: `uip rpa-legacy debug <xaml-path>` | `<xaml-path>` (required), `-i` input args |
+
+### package
+
+Packages an RPA project into a deployable `.nupkg` file. **Optional** — not required for debugging (legacy RPA can be debugged directly).
+
+```bash
+# Basic package
+uip rpa-legacy package "C:/Projects/MyLegacyProject" -o "C:/output"
+
+# Package with version
+uip rpa-legacy package "C:/Projects/MyLegacyProject" -o "C:/output" --version "1.2.0"
+
+# Auto-version
+uip rpa-legacy package "C:/Projects/MyLegacyProject" -o "C:/output" --auto-version
+
+# With release notes
+uip rpa-legacy package "C:/Projects/MyLegacyProject" -o "C:/output" --version "1.2.0" --release-notes "Bug fixes and improvements"
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `<project-path>` | Path to the RPA project or project.json (required, positional) |
+| `-o, --output <path>` | Output directory for the generated .nupkg |
+| `-v, --version <version>` | Package version |
+| `--auto-version` | Auto-generate package version |
+| `--output-type <type>` | Force output type (Process\|Library\|Tests\|Objects) |
+| `--split-output` | Split output into runtime and design libraries |
+| `--repository-url <url>` | Source repository URL |
+| `--repository-commit <sha>` | Source repository commit SHA |
+| `--repository-branch <branch>` | Source repository branch |
+| `--repository-type <type>` | Source repository type |
+| `--project-url <url>` | Automation Hub project URL |
+| `--release-notes <text>` | Release notes for the package |
+| `--timeout <seconds>` | Timeout in seconds |
+
+### debug
+
+Executes a XAML workflow locally via UiRobot. Logs stream to console in real time. Returns structured JSON result with output arguments (success) or error diagnostics (failure).
+
+**Always validate before debugging** — don't debug a file with compilation errors.
+
+```bash
+# Basic execution
+uip rpa-legacy debug "C:/Projects/MyLegacyProject/Main.xaml"
+
+# With input arguments
+uip rpa-legacy debug "C:/Projects/MyLegacyProject/Main.xaml" -i '{"in_FilePath": "C:\\data.xlsx", "in_Count": 5}'
+
+# Programmatic: suppress streaming logs, capture result to file
+uip rpa-legacy debug "C:/Projects/MyLegacyProject/Main.xaml" \
+  -i '{"in_FilePath": "C:\\data.xlsx"}' \
+  --result-path /tmp/result.json \
+  --log-level error
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `<xaml-path>` | Full path to the XAML workflow file to execute (required, positional) |
+| `-i, --input <json>` | Input arguments as a JSON string |
+| `--result-path <path>` | Write full result JSON to file (persists after command exits) |
+| `--timeout <seconds>` | Execution timeout in seconds (0 = no timeout); kills robot process if exceeded |
+| `--robot-path <path>` | Path to UiRobot.exe (auto-detected if not provided) |
+| `--log-level <level>` | Global log level: `debug\|info\|warn\|error` (default: info) |
+
+**Exit codes:** 0 = success, 1 = failure.
+
+**Success output:**
+```json
+{
+  "Result": "Success",
+  "Code": "RpaLegacyDebug",
+  "Data": {
+    "XamlPath": "C:\\MyProject\\Main.xaml",
+    "Status": "Execution completed",
+    "Output": { "out_Result": "Done", "out_RowCount": 42 }
+  }
+}
+```
+`Output` is only present when the workflow has Out arguments with values.
+
+**Failure output:**
+```json
+{
+  "Result": "Failure",
+  "Message": "System.IO.FileFormatException: File contains corrupted data.",
+  "Data": {
+    "Error": {
+      "ExceptionType": "System.IO.FileFormatException",
+      "Message": "File contains corrupted data.",
+      "ActivityDisplayName": "Read Stock Data",
+      "ActivityType": "ReadRange",
+      "XamlFile": "Main.xaml",
+      "StackTrace": [
+        "at ReadRange \"Read Stock Data\"",
+        "at Sequence \"Initialize and Read Data\""
+      ]
+    },
+    "ErrorLog": [
+      {
+        "Timestamp": "2026-03-21T16:30:37",
+        "Level": "Error",
+        "Message": "Read Stock Data: File contains corrupted data."
+      }
+    ]
+  }
+}
+```
+
+**Reading failure diagnostics:**
+- `Error.ActivityDisplayName` + `Error.XamlFile` → locate the problem
+- `Error.ExceptionType` + `Error.Message` → understand it
+- `Error.StackTrace` → full call chain
+- `ErrorLog` → all error-level robot log entries (useful when multiple things failed)
+
+**Fix-and-retry loop:** edit XAML → validate → debug again.
+
+**Caution:** `debug` executes the workflow — it performs real actions (clicks, emails, file writes). Only use when safe to run, or with mock input data.
+
+---
+
+## Documentation Search
+
+| Action | How | Key Parameters |
+|--------|-----|----------------|
+| **Search UiPath docs** | `Bash`: `uip docsai ask "your question" --output json` | `<query>` (required) |
+
+### docsai ask
+
+Searches official UiPath documentation and returns relevant answers including best practices, guidelines, troubleshooting steps, and configuration details. Use as a fallback when bundled activity reference docs and CLI discovery tools are insufficient.
+
+```bash
+# Best practices and guidelines
+uip docsai ask "best practices for error handling in legacy UiPath workflows" --output json
+
+# Troubleshooting
+uip docsai ask "ExcelApplicationScope validation error ActivityAction body" --output json
+
+# Platform concepts
+uip docsai ask "Orchestrator queue item priority and deadline" --output json
+
+# Configuration details
+uip docsai ask "REFramework MaxRetryNumber and retry logic" --output json
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `<query>` | The question to ask (required, positional) |
+| `-t, --tenant <tenant-name>` | Tenant (optional, defaults to auth value) |
+
+**When to use:** Bundled activity docs and `find-activities`/`type-definition` don't cover the topic; you need best practices, guidelines, or troubleshooting from official UiPath documentation; you encounter an unfamiliar error.
+
+**If docsai is also insufficient**, use `WebSearch` to search the broader community: UiPath Forum (`forum.uipath.com`), Stack Overflow, GitHub public repos, Reddit (`r/UiPath`). Always verify web-sourced information against the project's actual configuration before applying.
+
+---
+
+## CLI Error Recovery
+
+When `uip rpa-legacy` commands fail, diagnose by error category:
+
+| Error Pattern | Cause | Recovery |
+|---------------|-------|----------|
+| `"project not found"`, `"project.json not found"` | Wrong project path | Verify `<project-path>` points to the folder containing `project.json` |
+| `"file not found"` | Wrong XAML path | Verify `<xaml-path>` is a full path to an existing `.xaml` file |
+| `"package not found"`, `"version not available"` | Missing NuGet dependency | Ask the user to install the package in Studio, or check the NuGet feeds |
+| `"not authenticated"`, 401, 403 | Auth required for cloud features | Run `uip login` and re-try |
+| `"UiRobot not found"` | UiRobot.exe not installed or not in PATH | Pass `--robot-path` explicitly, or ask user to install UiPath Robot |
+| `"timeout"`, `"ETIMEDOUT"` | Command took too long | Increase `--timeout` value |
+| `"compilation error"` in validate | XAML has errors | Parse the error details, fix the XAML, re-validate |
+| Any unrecognized error | Unknown | Use `--log-level debug` for debug details, inform the user |
+
+**General strategy:** Do NOT retry the same failing command in a loop. Diagnose the root cause, apply the recovery action, then retry once. If it fails again, inform the user.

--- a/skills/uipath-rpa-legacy/references/common-pitfalls.md
+++ b/skills/uipath-rpa-legacy/references/common-pitfalls.md
@@ -1,0 +1,317 @@
+# Common Pitfalls & Quick Reference
+
+Essential gotchas, required scopes, and VB.NET patterns for legacy UiPath RPA workflows.
+
+For the complete gotchas list, see [activity-docs/_COMMON-PITFALLS.md](./activity-docs/_COMMON-PITFALLS.md).
+For the complete VB.NET cheat sheet, see [activity-docs/_PATTERNS.md](./activity-docs/_PATTERNS.md).
+
+---
+
+## Flowcharts/StateMachines Without ViewState
+
+**Severity: HIGH.** Missing ViewState causes Studio to stack all nodes at (0,0) — unusable. Every Flowchart/StateMachine node needs `ShapeLocation` + `ShapeSize`. **Required xmlns:** `xmlns:av="http://schemas.microsoft.com/winfx/2006/xaml/presentation"`
+
+See [activity-docs/_XAML-GUIDE.md](./activity-docs/_XAML-GUIDE.md) for coordinate systems, standard sizes, layout algorithms, connector formulas, and complete examples.
+
+---
+
+## Required Parent Scopes
+
+These classic activities **must** be placed inside a specific parent scope:
+
+| Activities | Required Parent Scope |
+|-----------|----------------------|
+| Excel Interop (ExcelReadRange, ExcelWriteCell, etc.) | `Excel Application Scope` |
+| Excel Modern (ReadRangeX, WriteRangeX, etc.) | `ExcelApplicationCard` inside `ExcelProcessScopeX` |
+| PowerPoint Interop (InsertSlide, InsertText, etc.) | `PowerPoint Application Scope` |
+| Word Interop (AppendText, ReplaceText, etc.) | `Word Application Scope` |
+| FTP activities (Download, Upload, Delete, etc.) | `FTP Session` (WithFtpSession) |
+| Java activities (InvokeJavaMethod, LoadJar, etc.) | `Java Scope` |
+| Python activities (RunScript, InvokeMethod, etc.) | `Python Scope` |
+| Terminal activities (GetField, SetField, SendKeys, etc.) | `Terminal Session` |
+| Office 365 activities (SendMail, CreateEvent, etc.) | `Microsoft Office 365 Scope` |
+| SAP BAPI activities (InvokeSapBapi) | `SAP Application Scope` |
+| SharePoint activities (GetListItems, UploadFile, etc.) | `SharePoint Application Scope` |
+
+---
+
+## Scope Activities Require ActivityAction Body (CRITICAL for XAML Generation)
+
+Scope activities (Excel Application Scope, ExcelProcessScopeX, ExcelApplicationCard, Word Application Scope, etc.) do **NOT** accept direct children. They require an `ActivityAction<T>` body wrapper with a `DelegateInArgument`. Placing activities directly inside the scope element will fail validation.
+
+**Wrong — direct children (fails validation):**
+```xml
+<ueab:ExcelApplicationCard WorkbookPath="file.xlsx">
+  <ueab:ReadRangeX ... />  <!-- WRONG -->
+</ueab:ExcelApplicationCard>
+```
+
+**Correct — ActivityAction body wrapper:**
+```xml
+<ueab:ExcelApplicationCard WorkbookPath="file.xlsx" DisplayName="Use Excel File">
+  <ueab:ExcelApplicationCard.Body>
+    <ActivityAction x:TypeArguments="ue:IWorkbookQuickHandle">
+      <ActivityAction.Argument>
+        <DelegateInArgument x:TypeArguments="ue:IWorkbookQuickHandle" Name="Excel" />
+      </ActivityAction.Argument>
+      <Sequence DisplayName="Do">
+        <!-- Child activities go here, using Excel handle -->
+        <ueab:ReadRangeX Range="[Excel.Sheet(&quot;Sheet1&quot;).Range(&quot;A1:A20&quot;)]" />
+      </Sequence>
+    </ActivityAction>
+  </ueab:ExcelApplicationCard.Body>
+</ueab:ExcelApplicationCard>
+```
+
+### Common Scope Body Patterns
+
+| Activity | Body TypeArgument | DelegateInArgument Name | Notes |
+|----------|-------------------|------------------------|-------|
+| `ExcelProcessScopeX` | `ui:IExcelProcess` | `ExcelProcessScopeTag` | Outer Excel scope |
+| `ExcelApplicationCard` | `ue:IWorkbookQuickHandle` | `Excel` | Inner Excel scope (inside ExcelProcessScopeX) |
+| `ExcelApplicationScope` | `ue:WorkbookApplication` | `ExcelWorkbookScope` | Classic Interop scope |
+| `ForEachRow` | `ActivityAction(sd:DataRow)` | `row` | Iterates DataTable rows |
+| `WordApplicationScope` | (Word handle type) | `WordApplicationScope` | Word COM scope |
+| `PowerPointApplicationScope` | (PowerPoint handle type) | `PowerPointApplication` | PowerPoint COM scope |
+| `TryCatch` | (special — `Catches` collection) | — | Not ActivityAction, but has nested body structure |
+| `Parallel` | (multiple `Branches`) | — | Each branch is a separate Sequence |
+
+**`find-activities` now returns `Body` info** when an activity requires an `ActivityAction<T>` body — check the output before writing XAML for scope activities.
+
+**Key xmlns required:**
+- `xmlns:ue="clr-namespace:UiPath.Excel;assembly=UiPath.Excel.Activities"`
+- `xmlns:ueab="clr-namespace:UiPath.Excel.Activities.Business;assembly=UiPath.Excel.Activities"`
+- `xmlns:ui="http://schemas.uipath.com/workflow/activities"`
+- `xmlns:sd="clr-namespace:System.Data;assembly=System.Data"` (for ForEachRow DataRow type)
+
+**Nested scopes:** Modern Excel requires TWO levels: `ExcelProcessScopeX` → `ExcelApplicationCard` → activities. Each level has its own `ActivityAction` body.
+
+**Always check `find-activities` output** for body pattern info before using scope activities.
+
+---
+
+## Dangerous Defaults (Source Code Verified)
+
+### ContinueOnError Defaults to TRUE
+These activities **silently swallow all errors** by default:
+
+| Activity | Package | Impact |
+|----------|---------|--------|
+| `NetHttpRequest` / `HttpClient` (HTTP Request) | Web | HTTP 500/timeout → empty response, no error |
+| `Data Scraping` wizard output | UIAutomation | Extraction failure → empty DataTable |
+
+**Always** set `ContinueOnError=False` on HTTP Request activities.
+
+### ContinueOnError in Library Workflows
+**NEVER** use `ContinueOnError=True` in Library workflows. Library consumers cannot know which errors are silently swallowed. Always let exceptions propagate from libraries — the consuming process decides how to handle them.
+
+### Excel AutoSave Causes Performance Disasters
+`AutoSave=true` (default) on `ExcelApplicationScope` means every Write Cell triggers a disk write. In loops with 1000 operations, that's 1000 saves.
+
+**Fix:** Set `AutoSave=false`, add a single `Save Workbook` at the end.
+
+### OpenBrowser Defaults to Internet Explorer
+`BrowserType` defaults to `IE` in source code. **Always explicitly set** BrowserType to Chrome, Firefox, or Edge.
+
+### HTTP Request Very Short Timeout
+Legacy `HttpClient` (also called `NetHttpRequest` internally) timeout is only 6,000-10,000ms. Both are often too low for production APIs.
+
+**Fix:** Set `TimeoutMS` to 30,000-60,000ms.
+
+---
+
+## VB.NET Quote Escaping in Throw.Exception (CRITICAL for XAML Generation)
+
+The `Throw.Exception` attribute wraps the bracket expression in `VisualBasicValue<Exception>`. When fully-qualified class names are combined with complex string expressions containing multiple `&quot;`, the VB.NET compiler can reject the expression — even though the same `&quot;` escaping works fine in simpler attributes like `LogMessage.Message`.
+
+### What fails
+
+```xml
+<!-- FAILS: Fully-qualified name + complex string concatenation -->
+<Throw Exception="[New UiPath.Core.Activities.BusinessRuleException(&quot;Invalid amount: &quot; &amp; amount.ToString(&quot;F2&quot;) &amp; &quot; for &quot; &amp; txId)]" />
+
+<!-- FAILS: String.Format with multiple &quot; inside brackets -->
+<Throw Exception="[New UiPath.Core.Activities.BusinessRuleException(String.Format(&quot;Invalid amount: {0} for {1}&quot;, amount, txId))]" />
+```
+
+### What works
+
+**Approach 1: Short-form class name + simple expression (recommended for simple messages)**
+```xml
+<!-- Works: Short name (namespace already imported) + simple concatenation -->
+<Throw Exception="[New BusinessRuleException(&quot;Invalid amount for &quot; &amp; txId)]" />
+```
+
+**Approach 2: Variable for message, then Throw (recommended for complex messages)**
+```xml
+<!-- Best practice from codebase: construct message in a variable, then throw -->
+<Assign DisplayName="Build Error Message">
+  <Assign.To>
+    <OutArgument x:TypeArguments="x:String">[errorMessage]</OutArgument>
+  </Assign.To>
+  <Assign.Value>
+    <InArgument x:TypeArguments="x:String">["Invalid amount: " &amp; amount.ToString("F2") &amp; " for transaction " &amp; txId]</InArgument>
+  </Assign.Value>
+</Assign>
+<Throw Exception="[New BusinessRuleException(errorMessage)]" />
+```
+
+### Rules
+
+1. **Always use short-form class names** in `Throw.Exception` — `BusinessRuleException` not `UiPath.Core.Activities.BusinessRuleException`. Ensure `UiPath.Core.Activities` is in the namespace imports.
+2. **For complex messages, use the variable approach** — Assign the message string to a variable first, then pass the variable to the exception constructor.
+3. **For simple messages, inline is fine** — `[New BusinessRuleException(&quot;simple message&quot;)]` works.
+4. **Same rules apply to all exception types** — `Exception`, `BusinessRuleException`, `ArgumentException`, etc.
+
+### Why this happens
+
+`Throw.Exception` compiles the bracket expression via `VisualBasicValue<Exception>`. The combination of a long fully-qualified type path + embedded `&quot;` string literals with concatenation operators creates ambiguity for the VB.NET expression compiler. Shorter expressions or variable references avoid this.
+
+---
+
+## Top Gotchas by Package
+
+### Excel
+- **Zombie EXCEL.EXE processes** after workflow crashes — use Kill Process in Finally block
+- **Dates read as serial numbers** — set `PreserveFormat=true` or convert with `DateTime.FromOADate()`
+- **Empty DataTable from Read Range** — verify sheet name, use `""` for entire used range
+- **Write Range strips formatting** — use Write Cell in loops for small updates
+
+### UIAutomation
+- **TypeInto missing/wrong characters** — escape `{`, `}`, `[`, `]`, `+`, `^`, `%`, `~` with `{{}`, `{+}` etc.
+- **EmptyField ignored with SimulateType** — only works with hardware events or SendWindowMessages
+- **Selectors work in Studio, fail on Robot** — use SimulateClick/SimulateType, avoid `idx` attribute
+- **Dynamic selectors break** — use wildcards `*` for dynamic parts, prefer `AutomationId`
+
+### Mail
+- **SMTP auth fails with Gmail/M365** — use App Passwords or OAuth2, not "Less Secure Apps"
+- **SSL/TLS port mismatch** — Port 587 = STARTTLS, Port 465 = implicit SSL, Port 25 = unencrypted
+- **Multiple recipients** — use semicolons `;` not commas
+
+### Web
+- **HTTP Request ContinueOnError=TRUE by default** — errors silently swallowed
+- **Legacy HttpClient 6-second timeout** — increase to 30-60 seconds
+
+### PDF
+- **ReadPDFText returns empty** — PDF is scanned images, use Read PDF With OCR instead
+- **Text out of order** — set `PreserveFormatting=true`
+
+### GenericValue
+- **String comparison instead of numeric** — `"10" > "9"` returns False. Use `CInt()` explicitly.
+- **Boolean conversion trap** — ANY non-null, non-empty string converts to `True`
+- **Null converts to 0** — `GenericValue(null)` → int returns `0`, → DateTime returns `DateTime.MinValue`
+
+**Recommendation:** Avoid GenericValue entirely. Use strongly-typed variables.
+
+---
+
+## VB.NET Quick Reference
+
+### String Operations
+```vb
+"Hello " + variable + " World"              ' Concatenation
+String.IsNullOrEmpty(myVar)                  ' Null/empty check
+If(myVar Is Nothing, "default", myVar.ToString())  ' Null coalesce
+myString.Contains("search")                  ' Contains
+myString.Replace("old", "new")               ' Replace
+myString.Split({";"c}, StringSplitOptions.RemoveEmptyEntries)  ' Split
+```
+
+### Type Conversions
+```vb
+CInt(stringVar)                ' String to Integer
+CDbl(stringVar)                ' String to Double
+CDate(stringVar)               ' String to Date
+CType(objVar, String)          ' Object to specific type
+DirectCast(objVar, DataTable)  ' Object to DataTable
+```
+
+### DateTime
+```vb
+DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss")
+DateTime.Now.AddDays(7)
+(endDate - startDate).TotalDays
+```
+
+### Collections
+```vb
+New String() {"item1", "item2"}              ' Array
+New List(Of String) From {"a", "b"}          ' List
+New Dictionary(Of String, Object) From {{"key", "value"}}  ' Dictionary
+```
+
+### DataTable Access
+```vb
+row("ColumnName").ToString()                 ' Cell by name
+row(0).ToString()                            ' Cell by index
+Convert.ToInt32(row("Amount"))               ' Typed value
+dt.Select("[Status] = 'Active'")             ' Filter (returns DataRow[])
+dt.AsEnumerable().Where(Function(r) r("Col").ToString() = "Val").CopyToDataTable()  ' LINQ
+```
+
+### Error Handling
+```vb
+' Use Try-Catch activity (not code)
+' BusinessRuleException → skip item
+' System.Exception → retry/escalate
+' Always set ContinueOnError=False on HTTP Request
+```
+
+For the complete reference with DataTable operations, file paths, Orchestrator patterns, and deprecated activity mappings, see [activity-docs/_PATTERNS.md](./activity-docs/_PATTERNS.md).
+
+---
+
+## Common XAML Generation Mistakes
+
+These are patterns the agent is likely to produce incorrectly. Check for them after generating XAML.
+
+### Hallucination-Prone Activity Names
+
+| Wrong (invented) | Correct | Package |
+|---|---|---|
+| `ReadExcel`, `WriteExcel` | `ExcelReadRange`, `ExcelWriteRange` | Excel |
+| `SendEmail` | `SendSmtpMailMessage`, `SendOutlookMailMessage` | Mail |
+| `OpenBrowserActivity` | `OpenBrowser` | UIAutomation |
+| `ReadPdf` | `ReadPDFText`, `ReadPDFWithOCR` | PDF |
+| `HttpRequest` | `HttpClient` (also known as `NetHttpRequest`) | Web |
+
+**Rule:** NEVER guess activity names. Run `find-activities` to get the exact class name.
+
+### Nesting Errors
+
+| Mistake | Fix |
+|---|---|
+| Multiple children directly inside `If.Then` or `If.Else` | Wrap in a single `Sequence` |
+| Activities directly inside `ForEach` body | Use `ActivityAction` wrapper (see Scope Activities section above) |
+| Activities directly inside scope activities (Excel, Word, etc.) | Use `ActivityAction<T>` body pattern |
+| ViewState referencing nodes that don't exist in the workflow | Remove orphaned ViewState entries, or add the missing nodes |
+
+### Expression Language Mismatches
+
+| Mistake | Symptom | Fix |
+|---|---|---|
+| C# operators (`!=`, `&&`, `\|\|`) in VB.NET project | Compilation error | Use `<>`, `AndAlso`, `OrElse` |
+| C# string interpolation `$"..."` in VB.NET project | Compilation error | Use `String.Format` or `&` concatenation |
+| VB.NET `[bracket]` expressions in C# project | Compilation error | Use `<mca:CSharpValue>` or `<mca:CSharpReference>` |
+
+### Security Anti-Patterns
+
+| Anti-Pattern | Risk | Fix |
+|---|---|---|
+| Password stored in `String` variable | Visible in logs and memory dumps | Use `SecureString` type |
+| Hardcoded API keys or JWT tokens in XAML | Credentials in source control | Use Orchestrator Credential assets |
+| Hardcoded URLs in activity properties | Breaks across environments | Use Config.xlsx Settings or Orchestrator Text assets |
+| Empty Catch blocks (`Catch ex As Exception` with no body) | Silent failures, impossible to debug | At minimum, add `Log Message` with `ex.Message` |
+| Timeout values as magic numbers (`30000`) | Unclear intent, hard to tune | Use Config.xlsx Constants with descriptive names |
+
+---
+
+## Deprecated Activity → Replacement
+
+| Deprecated | Replacement |
+|-----------|-------------|
+| `OpenWorkbook` | `Excel Application Scope` |
+| `CloseWorkbook` | (scope handles cleanup) |
+| `ExcelForEachRow` (v1) | `For Each Row in Data Table` |
+| `KeywordBasedClassifier` | `IntelligentKeywordClassifier` |
+| `OutlookForEachMail` | `For Each Email` |

--- a/skills/uipath-rpa-legacy/references/data-manipulation-guide.md
+++ b/skills/uipath-rpa-legacy/references/data-manipulation-guide.md
@@ -1,0 +1,390 @@
+# Data Manipulation Guide
+
+Advanced data manipulation patterns for legacy UiPath workflows: RegEx, LINQ, JObject, StringBuilder, and type conversion edge cases.
+
+For basic VB.NET expressions (strings, DataTable access, DateTime, collections), see [activity-docs/_PATTERNS.md](./activity-docs/_PATTERNS.md).
+
+---
+
+## 1. Regular Expressions (RegEx)
+
+Use `System.Text.RegularExpressions.Regex` for pattern matching and extraction. Available by default in legacy projects.
+
+### Common Patterns
+
+| Pattern | RegEx | Match Examples |
+|---|---|---|
+| Email | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` | `user@example.com` |
+| Phone (US) | `\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}` | `(555) 123-4567`, `555.123.4567` |
+| Date (MM/DD/YYYY) | `\d{2}/\d{2}/\d{4}` | `01/15/2025` |
+| Date (YYYY-MM-DD) | `\d{4}-\d{2}-\d{2}` | `2025-01-15` |
+| Currency (USD) | `\$[\d,]+\.?\d{0,2}` | `$1,234.56`, `$50` |
+| Invoice Number | `INV-\d{4,10}` | `INV-12345`, `INV-0001234567` |
+| ZIP Code (US) | `\d{5}(-\d{4})?` | `90210`, `90210-1234` |
+| SSN | `\d{3}-\d{2}-\d{4}` | `123-45-6789` |
+| IP Address | `\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}` | `192.168.1.1` |
+| Decimal Number | `-?\d+\.?\d*` | `123.45`, `-67`, `0.5` |
+
+### VB.NET Usage
+
+```vb
+' Check if string matches pattern
+System.Text.RegularExpressions.Regex.IsMatch(inputText, "\d{3}-\d{2}-\d{4}")
+
+' Extract first match
+System.Text.RegularExpressions.Regex.Match(inputText, "INV-\d+").Value
+
+' Extract all matches (returns MatchCollection — iterate in ForEach)
+System.Text.RegularExpressions.Regex.Matches(inputText, "\$[\d,]+\.?\d{0,2}")
+
+' Replace matched text
+System.Text.RegularExpressions.Regex.Replace(inputText, "\s+", " ")
+
+' Extract with named groups
+System.Text.RegularExpressions.Regex.Match(inputText, "(?<amount>\$[\d,.]+)\s+(?<date>\d{2}/\d{2}/\d{4})")
+' Access: match.Groups("amount").Value, match.Groups("date").Value
+```
+
+### Rules
+
+1. **Use `Regex.IsMatch` before `Regex.Match`** when you only need a boolean check
+2. **Use named groups `(?<name>...)` for multi-value extraction** — clearer than positional groups
+3. **Escape special characters** — `.` matches any character; use `\.` for literal dot
+4. **Test patterns on sample data first** — regex bugs silently return empty matches
+5. **Set a timeout for complex patterns** — `New Regex(pattern, RegexOptions.None, TimeSpan.FromSeconds(5))` prevents catastrophic backtracking
+
+---
+
+## 2. StringBuilder
+
+Use `System.Text.StringBuilder` when concatenating strings in a loop. Regular `+` concatenation creates a new string object each iteration, wasting memory for large loops.
+
+### When to Use
+
+| Scenario | Use |
+|---|---|
+| Concatenating < 10 strings | Regular `+` or `String.Format` |
+| Building a string in a loop (10+ iterations) | `StringBuilder` |
+| Building large HTML/XML content | `StringBuilder` |
+| Simple single-line concatenation | Regular `+` |
+
+### VB.NET Pattern (InvokeCode)
+
+```vb
+Dim sb As New System.Text.StringBuilder()
+For Each row As DataRow In dt.Rows
+    sb.AppendLine(row("Name").ToString() & "," & row("Amount").ToString())
+Next
+Dim result As String = sb.ToString()
+```
+
+### In Workflow (without InvokeCode)
+
+1. Assign: `sb = New System.Text.StringBuilder()` (variable type: `System.Text.StringBuilder`)
+2. Inside For Each: Assign: `sb.AppendLine(row("Name").ToString())`
+3. After loop: Assign: `result = sb.ToString()`
+
+---
+
+## 3. Advanced LINQ for DataTables
+
+All LINQ operations require `System.Linq` in namespace imports (included by default in legacy projects). DataTable LINQ requires `.AsEnumerable()` first.
+
+### GroupBy
+
+```vb
+' Group rows by department, returns IEnumerable(Of IGrouping)
+dt.AsEnumerable().GroupBy(Function(r) r("Department").ToString())
+
+' Get grouped counts
+dt.AsEnumerable() _
+    .GroupBy(Function(r) r("Department").ToString()) _
+    .Select(Function(g) New Object() {g.Key, g.Count()})
+```
+
+### OrderBy / ThenBy
+
+```vb
+' Single sort
+dt.AsEnumerable() _
+    .OrderBy(Function(r) r("Name").ToString()) _
+    .CopyToDataTable()
+
+' Descending
+dt.AsEnumerable() _
+    .OrderByDescending(Function(r) Convert.ToDouble(r("Amount"))) _
+    .CopyToDataTable()
+
+' Multi-column sort
+dt.AsEnumerable() _
+    .OrderBy(Function(r) r("Department").ToString()) _
+    .ThenByDescending(Function(r) Convert.ToDouble(r("Amount"))) _
+    .CopyToDataTable()
+```
+
+### Aggregations
+
+```vb
+' Sum
+dt.AsEnumerable().Sum(Function(r) Convert.ToDouble(r("Amount")))
+
+' Average
+dt.AsEnumerable().Average(Function(r) Convert.ToDouble(r("Amount")))
+
+' Count with condition
+dt.AsEnumerable().Count(Function(r) r("Status").ToString() = "Active")
+
+' Min / Max
+dt.AsEnumerable().Min(Function(r) Convert.ToDateTime(r("Date")))
+dt.AsEnumerable().Max(Function(r) Convert.ToDouble(r("Amount")))
+```
+
+### Any / All
+
+```vb
+' Check if any row matches
+dt.AsEnumerable().Any(Function(r) Convert.ToDouble(r("Amount")) > 10000)
+
+' Check if all rows match
+dt.AsEnumerable().All(Function(r) Not String.IsNullOrEmpty(r("Email").ToString()))
+```
+
+### Distinct
+
+```vb
+' Distinct values from one column
+dt.AsEnumerable().Select(Function(r) r("Department").ToString()).Distinct().ToArray()
+
+' Distinct rows (by all columns) — use DataRowComparer
+dt.AsEnumerable().Distinct(DataRowComparer.Default).CopyToDataTable()
+```
+
+### Take / Skip (Pagination)
+
+```vb
+' First 10 rows
+dt.AsEnumerable().Take(10).CopyToDataTable()
+
+' Skip first 10, take next 10
+dt.AsEnumerable().Skip(10).Take(10).CopyToDataTable()
+```
+
+### CopyToDataTable Gotcha
+
+`CopyToDataTable()` throws `InvalidOperationException` when the LINQ result is empty. ALWAYS check first:
+
+```vb
+Dim filtered = dt.AsEnumerable().Where(Function(r) r("Status").ToString() = "Active")
+If filtered.Any() Then
+    resultDt = filtered.CopyToDataTable()
+Else
+    resultDt = dt.Clone()  ' Empty DataTable with same structure
+End If
+```
+
+---
+
+## 4. Dictionary Operations
+
+### Common Operations
+
+```vb
+' Check if key exists
+myDict.ContainsKey("KeyName")
+
+' Safe get (avoids KeyNotFoundException)
+Dim value As String = Nothing
+If myDict.TryGetValue("KeyName", value) Then
+    ' Use value
+End If
+
+' Iterate key-value pairs (ForEach with TypeArgument KeyValuePair(Of String, Object))
+For Each kvp As KeyValuePair(Of String, Object) In myDict
+    ' kvp.Key, kvp.Value
+Next
+
+' Get all keys or values
+myDict.Keys.ToList()
+myDict.Values.ToList()
+
+' Merge two dictionaries (second overwrites first on key conflicts)
+For Each kvp In dict2
+    dict1(kvp.Key) = kvp.Value
+Next
+
+' Count
+myDict.Count
+```
+
+### Nested Dictionaries
+
+For Config.xlsx-style hierarchical data:
+
+```vb
+' Dictionary(Of String, Dictionary(Of String, String))
+Dim settings = DirectCast(configDict("DatabaseSettings"), Dictionary(Of String, String))
+Dim connString = settings("ConnectionString")
+```
+
+---
+
+## 5. JObject / JArray (Newtonsoft.Json)
+
+`Newtonsoft.Json` is bundled with UiPath legacy projects. Use `Newtonsoft.Json.Linq` for JSON parsing and manipulation.
+
+### Parsing
+
+```vb
+' Parse JSON string to JObject
+Dim jObj = Newtonsoft.Json.Linq.JObject.Parse(jsonString)
+
+' Parse JSON array
+Dim jArr = Newtonsoft.Json.Linq.JArray.Parse(jsonArrayString)
+```
+
+### Accessing Values
+
+```vb
+' Top-level property
+jObj("name").ToString()
+
+' Nested property
+jObj("address")("city").ToString()
+
+' Array element
+jArr(0)("name").ToString()
+
+' Safe access (returns Nothing if path doesn't exist)
+jObj("optional")?("nested")?.ToString()
+
+' Typed value
+jObj("count").Value(Of Integer)()
+jObj("isActive").Value(Of Boolean)()
+```
+
+### Querying with LINQ to JSON
+
+```vb
+' Select all items matching condition
+jArr.Where(Function(item) item("status").ToString() = "active")
+
+' Select specific field from array
+jArr.Select(Function(item) item("name").ToString()).ToList()
+```
+
+### Creating/Modifying
+
+```vb
+' Create JObject
+Dim jObj = New Newtonsoft.Json.Linq.JObject()
+jObj("name") = "John"
+jObj("age") = 30
+
+' Serialize back to string
+Dim jsonString = jObj.ToString()
+' Or compact: Newtonsoft.Json.JsonConvert.SerializeObject(jObj)
+```
+
+### API Response Pattern
+
+```vb
+' HTTP Request → responseBody (String)
+' Parse response
+Dim response = Newtonsoft.Json.Linq.JObject.Parse(responseBody)
+
+' Check for errors
+If response("error") IsNot Nothing Then
+    Throw New BusinessRuleException("API error: " & response("error")("message").ToString())
+End If
+
+' Extract data
+Dim items = DirectCast(response("data")("items"), Newtonsoft.Json.Linq.JArray)
+For Each item In items
+    ' Process item("id").ToString(), item("name").ToString()
+Next
+```
+
+---
+
+## 6. Null Safety Patterns
+
+### String Null Checks
+
+```vb
+' Check for null or empty
+String.IsNullOrEmpty(myVar)
+
+' Check for null, empty, or whitespace-only
+String.IsNullOrWhiteSpace(myVar)
+
+' Null coalesce (return default if null)
+If(myVar Is Nothing, "default", myVar.ToString())
+If(String.IsNullOrEmpty(myVar), "default", myVar)
+```
+
+### DataRow Null Checks
+
+```vb
+' Cell may be DBNull (not Nothing)
+If row("Column") Is DBNull.Value OrElse row("Column") Is Nothing Then
+    ' Handle missing value
+Else
+    Dim value = row("Column").ToString()
+End If
+
+' Compact check
+If(IsDBNull(row("Column")), "default", row("Column").ToString())
+```
+
+### Object/Generic Null Checks
+
+```vb
+' Check Nothing
+If myObject Is Nothing Then ...
+
+' Safe ToString
+If(myObject Is Nothing, "", myObject.ToString())
+
+' Type check before cast
+If TypeOf myObject Is DataTable Then
+    Dim dt = DirectCast(myObject, DataTable)
+End If
+```
+
+---
+
+## 7. Type Conversion Edge Cases
+
+### Integer Parsing
+
+| Method | Behavior on Failure | Use When |
+|---|---|---|
+| `CInt(value)` | Throws `InvalidCastException` | VB.NET shorthand, known-good data |
+| `Convert.ToInt32(value)` | Throws `FormatException` | .NET standard, handles null (returns 0) |
+| `Integer.Parse(value)` | Throws `FormatException` | Explicit intent, known-good data |
+| `Int32.TryParse(value, result)` | Returns `False`, sets result to 0 | **SAFEST** — use for external/user input |
+
+### Culture-Dependent Parsing
+
+Number and date formats differ by culture. **ALWAYS specify culture for external data:**
+
+```vb
+' DANGEROUS: depends on system locale
+CDbl("1,234.56")   ' Works on US locale, fails on German locale (1.234,56)
+
+' SAFE: explicit culture
+Double.Parse("1,234.56", System.Globalization.CultureInfo.InvariantCulture)
+
+' SAFE: explicit date format
+DateTime.ParseExact("01/15/2025", "MM/dd/yyyy", System.Globalization.CultureInfo.InvariantCulture)
+```
+
+### Common Conversion Traps
+
+| Trap | Issue | Fix |
+|---|---|---|
+| `CInt("12.5")` | Rounds to 12 (not truncates) | Use `CInt(Math.Floor(CDbl("12.5")))` for truncation |
+| `CDate("01/02/2025")` | Jan 2 or Feb 1? Depends on locale | Use `DateTime.ParseExact` with explicit format |
+| `CBool("yes")` | Throws — only `"True"`/`"False"` work | Use `If(value.ToLower() = "yes", True, False)` |
+| `GenericValue("10") > GenericValue("9")` | Returns `False` — string comparison | Cast to `Int32` first: `CInt(gv1) > CInt(gv2)` |
+| `Convert.ToInt32(Nothing)` | Returns 0 (not exception) | Check for Nothing first if 0 is a valid value |

--- a/skills/uipath-rpa-legacy/references/discovery-workflow.md
+++ b/skills/uipath-rpa-legacy/references/discovery-workflow.md
@@ -1,0 +1,147 @@
+# Discovery Workflow — Detailed Steps
+
+Complete discovery procedure before writing or editing any XAML. Referenced from the main skill when detailed guidance is needed.
+
+---
+
+## Step 1: Project Structure
+
+```
+Glob: pattern="**/*.xaml" path="{projectRoot}"       → list all XAML workflow files
+Read: file_path="{projectRoot}/project.json"          → read the project definition
+```
+
+Analyze: folder conventions, naming patterns, existing workflows, `expressionLanguage` (VB.NET or C#), installed packages (`dependencies`).
+
+---
+
+## Step 2: Consult Activity Reference Docs
+
+Read `references/activity-docs/` for behavioral context (what activities do, gotchas, patterns).
+
+| Situation | Action |
+|-----------|--------|
+| Know the package | Read `activity-docs/{PackageName}.md` directly |
+| Don't know the package | Read `activity-docs/_INDEX.md` to find it |
+| Need VB.NET expressions | Read `activity-docs/_PATTERNS.md` |
+| Need XAML structure | Read `references/xaml-basics-and-rules.md` |
+| Need gotchas | Read `activity-docs/_COMMON-PITFALLS.md` |
+| Need InvokeCode patterns | Read `activity-docs/_INVOKE-CODE.md` |
+| Working with REFramework | Read `activity-docs/_REFRAMEWORK.md` |
+| Working with Document Understanding | Read `activity-docs/_DU-PROCESS.md` |
+| Need all activities | Read `activity-docs/AllActivities.md` |
+
+**These docs tell you what and how — NOT exact CLR property names/enum values for XAML. Steps 4 and 5 are mandatory for that.**
+
+---
+
+## Step 3: Search Current Project
+
+```
+Glob: pattern="**/*pattern*.xaml" path="{projectRoot}"
+Grep: pattern="ActivityName|pattern" path="{projectRoot}"
+Read: file_path="{projectRoot}/ExistingWorkflow.xaml"
+```
+
+Mature project: prioritize local patterns. Greenfield: skip.
+
+---
+
+## Step 4: Discover Activities (MANDATORY for non-built-in activities)
+
+**Skip find-activities for built-in activities** listed in [_BUILT-IN-ACTIVITIES.md](./activity-docs/_BUILT-IN-ACTIVITIES.md): If, Assign, Sequence, TryCatch, Flowchart, ForEach, While, Switch, Throw, Delay, Parallel, LogMessage, InvokeCode, InvokeWorkflowFile, ForEachRow, AddDataRow. Use the provided XAML snippets directly.
+
+**For all other activities**, run find-activities. Returns exact class names, argument signatures, types, **ready-to-use XAML snippet**, and **xmlns declaration**.
+
+```bash
+uip rpa-legacy find-activities "{projectRoot}" --query "send mail" --output json
+uip rpa-legacy find-activities "{projectRoot}" --query "invoke code" --include-type-definitions --output json
+```
+
+**Use the returned `XamlSnippet` as your starting point** for activity XAML — it has correct element names, namespaces, and property names for the installed package version. Also add the returned `XmlnsDeclaration` to the root `<Activity>` element.
+
+**Query syntax tips:**
+- **Multi-word queries work** with relevance scoring: `"Excel Read Range"` splits into words, scores matches, bonuses when all words match
+- **CamelCase boundaries detected**: `"SendHotkey"`, `"ExcelReadRange"` match correctly
+- **Use `--exact`** when you know the exact activity name: `--query "ReadRange" --exact` — avoids irrelevant results
+- Each call takes ~15-30 seconds — use `--exact` for known names to get precise results fast
+- If a query returns too many irrelevant results, add `--exact` or use more specific terms
+
+Activity reference docs describe behavior/gotchas but NOT exact CLR class names or argument types. Skipping this step → guessing → wasted validation cycles.
+
+---
+
+## Step 5: Inspect Types (MANDATORY for Enums/Complex Types)
+
+**Run for every enum or complex type.** Gets exact valid values.
+
+```bash
+# Example: InvokeCode Language accepts VBNet and CSharp (NOT "VisualBasic" or "VB")
+uip rpa-legacy type-definition "{projectRoot}" --type "NetLanguage" --output json
+
+uip rpa-legacy type-definition "{projectRoot}" --type "System.Net.Mail.MailMessage" --output json
+```
+
+When to run: any enum property, any complex type argument, any type without listed valid values in docs.
+
+---
+
+## Step 5.5: Search NuGet for Packages (When Needed)
+
+When the known packages in [project-structure.md](./project-structure.md) and `find-activities` don't cover a capability:
+
+```bash
+uip rpa-legacy find-package --query "barcode" --limit 10 --output json
+```
+
+Searches all configured NuGet feeds by name and description. After finding the right package, add it to `dependencies` in project.json, then `find-activities` will index its activities.
+
+Also works for arbitrary .NET packages (e.g., `CsvHelper`, `HtmlAgilityPack`). Avoid packages already bundled with Studio (e.g., `Newtonsoft.Json`) — version conflicts can cause issues.
+
+---
+
+## Step 6: Search UiPath Documentation (Fallback)
+
+```bash
+uip docsai ask "best practices for Excel automation in legacy projects" --output json
+uip docsai ask "ExcelApplicationScope ActivityAction body validation error" --output json
+```
+
+Use when: bundled docs + CLI tools don't cover the topic, need best practices/guidelines/troubleshooting, unfamiliar error, platform concepts (Orchestrator, queues, triggers).
+
+---
+
+## Step 7: Search the Web (Last Resort)
+
+Use `WebSearch` for UiPath Forum, Stack Overflow, GitHub, Reddit:
+
+```
+WebSearch: "UiPath forum ExcelApplicationScope ActivityAction body legacy"
+WebSearch: "site:stackoverflow.com UiPath legacy ExcelApplicationScope XAML"
+WebSearch: "site:github.com UiPath REFramework legacy XAML example"
+```
+
+Use when: all previous steps fail, obscure errors, community workarounds needed. Always verify web-sourced info against project config.
+
+---
+
+## Troubleshooting
+
+### Wrong enum value
+**Symptom:** "Cannot create unknown type" or "is not a member of"
+**Fix:** `uip rpa-legacy type-definition "{projectRoot}" --type "EnumTypeName" --output json`
+
+### Activity class name not found
+**Symptom:** Unknown activity type or missing namespace
+**Fix:** `uip rpa-legacy find-activities "{projectRoot}" --query "..." --output json`, add xmlns + assembly ref
+
+### Multiple errors after batch editing
+**Symptom:** Many errors at once
+**Fix:** Revert to last good state. Re-add one activity at a time, validating after each.
+
+### Activity docs don't match XAML property names
+**Symptom:** Properties from docs don't work
+**Fix:** `find-activities --include-type-definitions` for exact CLR property names
+
+### Stuck on unfamiliar problem
+**Escalation:** `docsai ask` → `WebSearch` → ask user

--- a/skills/uipath-rpa-legacy/references/environment-setup.md
+++ b/skills/uipath-rpa-legacy/references/environment-setup.md
@@ -1,0 +1,78 @@
+# Phase 0: Environment Readiness
+
+**Goal:** Establish the project root and verify the project is a legacy framework project before any other operations.
+
+**Key difference from modern (`uip rpa`):** The `uip rpa-legacy` CLI is standalone — it does **not** require Studio Desktop to be running. It resolves dependencies from NuGet directly and uses UiRobot for execution.
+
+---
+
+## Step 0.1: Establish Project Root
+
+All `uip rpa-legacy` commands require a `<project-path>` argument pointing to the folder containing `project.json` (or the `project.json` file itself).
+
+```bash
+# Check if project.json exists in the CWD
+ls {cwd}/project.json
+```
+
+If the CWD is not the project root:
+- Locate the project root by finding `project.json`: `Glob: pattern="**/project.json"`
+- Ask the user where their project is located if multiple `project.json` files are found
+
+Store the project root path and use it consistently as `{projectRoot}` throughout all subsequent operations.
+
+---
+
+## Step 0.2: Verify Legacy Project
+
+Read `project.json` and confirm this is a legacy framework project:
+
+```
+Read: file_path="{projectRoot}/project.json"
+```
+
+**Check these fields:**
+
+| Field | Legacy Value | Notes |
+|-------|-------------|-------|
+| `targetFramework` | `"Legacy"` | May be absent in very old projects (pre-2021), which implies Legacy |
+| `expressionLanguage` | `"VisualBasic"` (most common) or `"CSharp"` | Determines expression syntax in XAML |
+| `studioVersion` | Typically `< 23.x` | Older Studio versions |
+| `dependencies` | Classic package versions (no modern package IDs) | Very old projects (pre-2021) may have lower versions like ≤ 22.x |
+
+**If `targetFramework` is `"Windows"` or `"Portable"`**, this is a modern project — use the `uipath-rpa` skill instead.
+
+**If `targetFramework` is absent**, check the `studioVersion` and `dependencies` fields. Old projects without explicit `targetFramework` are Legacy by default.
+
+---
+
+## Step 0.3: Authentication (If Needed)
+
+Some operations (cloud-based NuGet feeds, Orchestrator assets) may require authentication:
+
+```bash
+uip login
+```
+
+This opens a browser-based login flow. Authentication is typically needed only for:
+- Projects that use private NuGet feeds requiring authentication
+- `build` commands that push packages to Orchestrator
+- Accessing Orchestrator resources (assets, queues) during `debug` execution
+
+For most local development tasks (validate, edit, find-activities), authentication is **not required**.
+
+---
+
+## Step 0.4: Package Restore
+
+After creating or modifying `project.json` dependencies, packages must be restored before `find-activities` or `type-definition` will work.
+
+**Trigger restore** by running validate on the project directory:
+
+```bash
+uip rpa-legacy validate "{projectRoot}" --output json
+```
+
+This resolves NuGet packages from configured feeds. After this completes, `find-activities` and `type-definition` will have access to the package assemblies.
+
+**If `find-activities` returns "No assemblies resolved from package dependencies"**, run validate first to trigger restore.

--- a/skills/uipath-rpa-legacy/references/error-handling-guide.md
+++ b/skills/uipath-rpa-legacy/references/error-handling-guide.md
@@ -1,0 +1,255 @@
+# Error Handling Guide
+
+Structured error handling patterns for legacy UiPath RPA workflows. Use this guide when designing exception handling strategy for any workflow.
+
+For TryCatch XAML syntax, see [activity-docs/_BUILT-IN-ACTIVITIES.md](./activity-docs/_BUILT-IN-ACTIVITIES.md).
+For REFramework exception flow, see [activity-docs/_REFRAMEWORK.md](./activity-docs/_REFRAMEWORK.md).
+For Throw expression escaping, see [common-pitfalls.md](./common-pitfalls.md).
+
+---
+
+## 1. Exception Classification
+
+Every exception in UiPath falls into one of two categories. Classify correctly — the wrong choice causes either wasted retries or skipped valid data.
+
+| | Business Rule Exception | System Exception |
+|---|---|---|
+| **Class** | `UiPath.Core.BusinessRuleException` | `System.Exception` (or any subclass) |
+| **Cause** | Invalid data, violated business rule, missing input | App crash, timeout, selector not found, network error |
+| **Will retry fix it?** | **NO** — the data is bad, retrying produces the same result | **MAYBE** — transient issue may resolve on retry |
+| **Action** | Skip transaction, log reason, mark Failed | Retry (up to limit), reinitialize apps, then escalate |
+| **REFramework** | Caught → Failed status, no retry, next item | Caught → retry counter incremented, reinitialize apps |
+
+### When to Throw BusinessRuleException
+
+Throw `BusinessRuleException` when the input data is invalid and no amount of retrying will fix it:
+
+1. Missing required fields: `If String.IsNullOrEmpty(invoiceNumber) Then Throw New BusinessRuleException("Invoice number is empty")`
+2. Data format violations: negative amounts, invalid dates, unrecognized codes
+3. Business rule failures: amount exceeds threshold, duplicate record, expired deadline
+4. Missing dependencies: referenced record not found in target system
+
+### When to Let System Exceptions Propagate
+
+Do NOT catch these as BusinessRuleException — they are transient and may resolve on retry:
+
+1. `SelectorNotFoundException` — UI element not found (app may not be ready)
+2. `TimeoutException` — activity exceeded timeout (network lag, slow app)
+3. `System.Net.WebException` — HTTP/network failure
+4. `System.IO.IOException` — file locked by another process
+5. `COMException` — Excel/Word COM automation failure
+
+---
+
+## 2. TryCatch Best Practices
+
+### Rule: Order Catch Clauses from Specific to General
+
+The first matching catch clause executes. If `System.Exception` is first, it catches everything — more specific clauses below it never execute.
+
+```
+Try
+  ├── [Business logic activities]
+Catch ex As BusinessRuleException          ← 1. Most specific
+  ├── Log Message (Warning): "Business error: " + ex.Message
+  ├── [Skip item, mark as business exception]
+Catch ex As System.TimeoutException        ← 2. Specific system error
+  ├── Log Message (Error): "Timeout: " + ex.Message
+  ├── [Retry with longer timeout or escalate]
+Catch ex As System.Exception               ← 3. Catch-all (ALWAYS last)
+  ├── Log Message (Error): "System error: " + ex.Message
+  ├── [Retry, reinitialize apps, or escalate]
+Finally
+  ├── [Cleanup: Kill Process for COM apps, close connections]
+```
+
+### Rules
+
+1. **ALWAYS put `System.Exception` last** — it catches everything, so specific clauses must come first
+2. **NEVER use empty catch blocks** — at minimum, log the exception. Silent failures are debugging nightmares.
+3. **Use Finally for cleanup** — Kill Process for Excel/Word COM objects, close database connections, delete temp files
+4. **Don't nest TryCatch more than 2 levels** — extract inner logic to sub-workflows with their own TryCatch
+
+---
+
+## 3. Retry Scope
+
+The Retry Scope activity retries a block of activities when a condition is not met or an exception occurs.
+
+### Configuration
+
+| Property | Description | Recommended Value |
+|---|---|---|
+| `NumberOfRetries` | Max retry attempts | 2-3 for UI actions, 3-5 for network calls |
+| `RetryInterval` | Wait between retries (TimeSpan) | `00:00:03` to `00:00:10` |
+
+### Structure
+
+```
+Retry Scope (NumberOfRetries=3, RetryInterval=00:00:05)
+  ├── Action: [Activities to retry]
+  │   └── Click "Submit" button
+  └── Condition: Element Exists "Success message"
+```
+
+### Rules
+
+1. **ALWAYS add a Condition activity** — without it, Retry Scope only retries on exception. The Condition checks whether the action actually succeeded (e.g., Element Exists, text appeared, file was created).
+2. **Keep actions idempotent** — the action block runs multiple times. Clicking "Submit" twice must not create duplicate records. If the action is not idempotent, check state before acting.
+3. **Set reasonable intervals** — too short (< 1 second) wastes CPU; too long (> 30 seconds) wastes time. Match the interval to how long the system typically needs to recover.
+
+### When to Use Which Retry Mechanism
+
+| Mechanism | Use When | Scope |
+|---|---|---|
+| **Retry Scope** | Single action needs retry with success check (e.g., click button, wait for result) | One activity or small block |
+| **REFramework retry** | Entire transaction needs retry after app reinitialization | Full transaction lifecycle |
+| **Manual retry loop** | Custom retry logic with backoff, conditional retry, different strategies per attempt | Complex scenarios |
+
+---
+
+## 4. ContinueOnError Decision Matrix
+
+`ContinueOnError` suppresses exceptions from an activity. When `True`, the activity fails silently and the workflow continues.
+
+### Activities That Default to TRUE (Dangerous)
+
+| Activity | Package | Risk |
+|---|---|---|
+| `HttpClient` (HTTP Request) | Web | HTTP 500/timeout → empty response, no error raised |
+| `Data Scraping` output | UIAutomation | Extraction failure → empty DataTable, no error raised |
+
+**ALWAYS set `ContinueOnError=False`** on these activities unless you explicitly handle empty results.
+
+### When ContinueOnError=True Is Acceptable
+
+| Scenario | Why It's OK |
+|---|---|
+| `Element Exists` / `Image Exists` | Activity returns Boolean — it never throws, ContinueOnError is irrelevant |
+| Non-critical Log Message | Logging failure should not stop the automation |
+| Optional cleanup in Finally block | Best-effort cleanup (e.g., close dialog that may not exist) |
+
+### When ContinueOnError=True Is NEVER Acceptable
+
+1. **HTTP Request** — you MUST know if the API call failed
+2. **Database operations** — silent SQL failures corrupt data
+3. **File write operations** — silent write failures mean data loss
+4. **Any activity whose output you use downstream** — silent failure → null/empty → downstream crash
+5. **Library workflows** — consumers cannot know which errors are swallowed. ALWAYS let exceptions propagate from libraries.
+
+---
+
+## 5. Throw and Rethrow Patterns
+
+### Throw — Create a New Exception
+
+Use `Throw` to signal a business rule violation or intentional failure:
+
+```xml
+<!-- Simple message -->
+<Throw Exception="[New BusinessRuleException(&quot;Invoice amount is negative&quot;)]" />
+
+<!-- With variable (recommended for complex messages) -->
+<!-- Step 1: Assign errorMsg = "Invalid: " & amount.ToString("F2") & " for " & txId -->
+<!-- Step 2: Throw with variable -->
+<Throw Exception="[New BusinessRuleException(errorMsg)]" />
+```
+
+**Rules:**
+1. **Use short-form class names** — `BusinessRuleException` not `UiPath.Core.Activities.BusinessRuleException`
+2. **Build complex messages in a variable first** — avoids VB.NET compiler issues with `&quot;` in `Throw.Exception`
+3. **Include context in the message** — "Invoice INV-12345 amount -500.00 is negative" not "Invalid amount"
+
+See [common-pitfalls.md](./common-pitfalls.md) for the full Throw expression escaping reference.
+
+### Rethrow — Preserve Original Stack Trace
+
+Use `Rethrow` inside a Catch block when you want to log/handle but still propagate the exception:
+
+```
+Catch ex As System.Exception
+  ├── Log Message: "Error in ProcessInvoice: " + ex.Message
+  ├── Take Screenshot
+  └── Rethrow   ← preserves original exception type and stack trace
+```
+
+**When to Rethrow:**
+- You need to log or screenshot before propagating
+- You're in a sub-workflow and the caller handles the exception
+- You want to add cleanup but still fail the transaction
+
+**When NOT to Rethrow:**
+- You've fully handled the exception (e.g., used a fallback value)
+- You're wrapping in a different exception type (use Throw instead)
+
+---
+
+## 6. Finally Block Patterns
+
+The Finally block runs regardless of whether an exception occurred. Use it for mandatory cleanup.
+
+### Common Cleanup Patterns
+
+| Scenario | Finally Action |
+|---|---|
+| Excel COM automation | Kill Process "EXCEL" — prevents zombie EXCEL.EXE processes after crashes |
+| Word COM automation | Kill Process "WINWORD" |
+| Database connection | Close connection activity or Dispose in InvokeCode |
+| Temp files created | Delete File for each temp file |
+| Browser opened | Close Tab / Close Browser |
+| Application opened | Close Application |
+
+### Rules
+
+1. **Kill Process in Finally for COM apps** — Excel Application Scope and Word Application Scope can leave zombie processes if the workflow crashes mid-execution
+2. **Don't put business logic in Finally** — Finally is for cleanup only
+3. **Use ContinueOnError=True in Finally cleanup** — if the process is already dead, Kill Process throws; this is acceptable to ignore
+
+---
+
+## 7. Fail-Fast Principle
+
+Validate inputs at the beginning of a workflow. Throw `BusinessRuleException` immediately when data is invalid — don't process halfway then fail.
+
+### Input Validation Pattern
+
+Place this at the START of `Process.xaml` (or any workflow that receives arguments):
+
+```
+Sequence "Validate Inputs"
+  ├── If String.IsNullOrWhiteSpace(in_InvoiceNumber)
+  │   └── Throw New BusinessRuleException("Invoice number is empty")
+  ├── If in_Amount <= 0
+  │   └── Throw New BusinessRuleException("Amount must be positive: " & in_Amount.ToString())
+  ├── If Not DateTime.TryParse(in_DateString, Nothing)
+  │   └── Throw New BusinessRuleException("Invalid date format: " & in_DateString)
+  └── [Continue with validated data]
+```
+
+### Rules
+
+1. **Validate ALL required inputs before processing** — catch all problems upfront, not one at a time
+2. **Include the invalid value in the error message** — "Amount -500.00 is negative" not "Invalid amount"
+3. **Use BusinessRuleException for validation failures** — the data is bad, retrying won't help
+4. **Don't validate inside loops** — validate once before the loop starts
+
+---
+
+## 8. State Machine Exit Conditions
+
+When building State Machine workflows (including REFramework customizations):
+
+1. **Every state machine MUST have a reachable Final State** — a state with no outgoing transitions that ends execution
+2. **Every state MUST have at least one outgoing transition** (except the Final State) — orphan states cause infinite hangs
+3. **Add a default/fallback transition** from every decision state — handles unexpected conditions
+4. **Limit transitions per state to 3-4** — more indicates the state is doing too much; split it
+5. **Set max-retry counters** — any retry loop must have a counter that eventually routes to the Final State
+6. **Test the "all failures" path** — verify that if every transaction fails, the robot reaches End Process (not infinite loop)
+
+### REFramework-Specific
+
+The REFramework already handles exit conditions via `MaxRetryNumber` and `MaxConsecutiveSystemExceptions`. When customizing:
+
+- **Do NOT remove the ConsecutiveSystemExceptions check** — it's the safety net that prevents infinite retries when the environment is broken
+- **Do NOT set MaxRetryNumber to 0** — this disables retry entirely; use 1 if you want minimal retry
+- **Do NOT add states without transitions to End Process** — every custom state needs a failure path that reaches the Final State

--- a/skills/uipath-rpa-legacy/references/orchestrator-guide.md
+++ b/skills/uipath-rpa-legacy/references/orchestrator-guide.md
@@ -1,0 +1,252 @@
+# Orchestrator Integration Guide
+
+Orchestrator concepts and integration patterns for legacy UiPath workflows: queues, assets, logging, triggers, and environment management.
+
+For Dispatcher/Performer REFramework pattern, see [activity-docs/_REFRAMEWORK.md](./activity-docs/_REFRAMEWORK.md) section 9.
+For Asset access VB.NET code, see [activity-docs/_PATTERNS.md](./activity-docs/_PATTERNS.md) Orchestrator Integration Patterns.
+
+---
+
+## 1. Queue Item Lifecycle
+
+Queue items progress through defined states. Understanding the lifecycle is critical for designing robust dispatcher/performer workflows.
+
+```
+                    ┌─────────────┐
+                    │    NEW       │  ← Add Queue Item creates this
+                    └──────┬──────┘
+                           │ Get Transaction Item
+                           ▼
+                    ┌─────────────┐
+         ┌────────│ IN PROGRESS  │────────┐
+         │         └─────────────┘         │
+         │                                 │
+         ▼                                 ▼
+┌─────────────┐                   ┌─────────────┐
+│ SUCCESSFUL  │                   │   FAILED    │
+└─────────────┘                   └──────┬──────┘
+                                         │ Auto-retry enabled?
+                                         ▼
+                                  ┌─────────────┐
+                                  │   RETRIED   │──→ Back to NEW
+                                  └─────────────┘
+                                         │ Max retries exceeded
+                                         ▼
+                                  ┌─────────────┐
+                                  │   FAILED    │ (final)
+                                  └─────────────┘
+
+Other states:
+  ABANDONED — item was In Progress but robot disconnected (timeout)
+  DELETED   — manually removed from queue
+```
+
+### State Transitions
+
+| From | To | Triggered By |
+|---|---|---|
+| (none) | New | `Add Queue Item` activity |
+| New | In Progress | `Get Transaction Item` activity |
+| In Progress | Successful | `Set Transaction Status` → Success |
+| In Progress | Failed | `Set Transaction Status` → Failed |
+| In Progress | Abandoned | Robot disconnected/crashed while processing |
+| Failed | New (Retried) | Auto-retry enabled, retry count < max |
+| New | Deleted | Manual deletion from Orchestrator UI |
+
+---
+
+## 2. Queue Item Properties
+
+### Add Queue Item — Configuration
+
+| Property | Type | Purpose | Required |
+|---|---|---|---|
+| **QueueName** | String | Target queue name | YES |
+| **Reference** | String | Unique business key for idempotency | Recommended |
+| **Priority** | Enum | High, Normal (default), Low | No |
+| **DeferDate** | DateTime | Earliest processing time (item is invisible until then) | No |
+| **Deadline** | DateTime | Must be processed by this time (SLA tracking) | No |
+| **SpecificContent** | Dictionary(Of String, Object) | Business data payload (key-value pairs) | YES (carries the data) |
+
+### Rules for Queue Item Creation (Dispatcher)
+
+1. **ALWAYS set a unique Reference** — enables deduplication and item lookup. Use a business key: invoice number, order ID, customer + date combination.
+2. **Set Priority based on business rules** — High for urgent items (approaching deadline), Normal for standard processing, Low for batch/background.
+3. **Set Deadline for SLA-tracked items** — Orchestrator reports overdue items in dashboards.
+4. **Use DeferDate for scheduled processing** — items with future DeferDate are invisible to performers until the date arrives.
+5. **Keep SpecificContent values as strings** — convert numbers and dates to strings in the dispatcher. Parse them in the performer. This avoids serialization issues.
+
+### Accessing Queue Item Data (Performer)
+
+```vb
+' Get Transaction Item returns a QueueItem object
+' Access SpecificContent fields:
+transactionItem.SpecificContent("InvoiceNumber").ToString()
+transactionItem.SpecificContent("Amount").ToString()
+transactionItem.SpecificContent("CustomerName").ToString()
+
+' Safe access with null check (for optional fields):
+If transactionItem.SpecificContent.ContainsKey("Notes") Then
+    Dim notes = transactionItem.SpecificContent("Notes").ToString()
+End If
+
+' Access queue item metadata:
+transactionItem.Reference            ' Unique reference string
+transactionItem.Priority             ' High, Normal, Low
+transactionItem.DeferDate            ' Nullable DateTime
+transactionItem.Deadline             ' Nullable DateTime
+transactionItem.RetryNo              ' Current retry count
+```
+
+### Setting Transaction Status (Performer)
+
+```vb
+' On success — pass output data for reporting:
+Set Transaction Status: Success
+  Output: New Dictionary(Of String, Object) From {
+    {"ProcessedAmount", totalAmount.ToString()},
+    {"ConfirmationNumber", confirmNo}
+  }
+
+' On business failure:
+Set Transaction Status: Failed
+  Reason: businessException.Message
+  ErrorType: Business
+
+' On system failure (REFramework handles this automatically):
+Set Transaction Status: Failed
+  Reason: systemException.Message
+  ErrorType: Application
+```
+
+---
+
+## 3. Asset Types
+
+Assets store configuration values in Orchestrator. Use assets for values that differ between environments or contain secrets.
+
+| Type | Value | Use Case | Access Pattern |
+|---|---|---|---|
+| **Text** | String | URLs, file paths, email addresses | `Get Asset "AssetName"` → String |
+| **Bool** | True/False | Feature flags, toggles | `Get Asset "AssetName"` → cast to Boolean |
+| **Integer** | Whole number | Thresholds, batch sizes, port numbers | `Get Asset "AssetName"` → cast to Int32 |
+| **Credential** | Username + Password | Login credentials, API tokens | `Get Credential "AssetName"` → String + SecureString |
+
+### Per-Robot vs Global Assets
+
+| Type | Behavior | Use When |
+|---|---|---|
+| **Global** | Same value for all robots | Shared URLs, thresholds, feature flags |
+| **Per-Robot** | Different value per robot | Machine-specific paths, per-machine credentials, environment-specific settings |
+
+### Rules
+
+1. **Get Asset returns Object** — ALWAYS cast to the expected type: `CStr(getAssetResult)`, `CInt(getAssetResult)`, `CBool(getAssetResult)`
+2. **Get Credential returns two values** — `username` (String) and `password` (SecureString). Use separate output variables.
+3. **NEVER log credential values** — not even in Verbose mode
+4. **Use Credential assets for ALL secrets** — API keys, tokens, passwords. Never use Text assets for sensitive data.
+5. **Name assets consistently** — `ProcessName_SettingName` pattern: `InvoiceBot_PortalURL`, `InvoiceBot_Credentials`
+
+---
+
+## 4. Logging Best Practices
+
+### Log Levels
+
+| Level | When to Use | Examples |
+|---|---|---|
+| **Verbose** | Detailed diagnostic data (variable values, loop counters) | "Processing row 42 of 100", "Variable X = 'abc'" |
+| **Trace** | Step-by-step execution flow | "Entering ProcessInvoice", "Opening browser" |
+| **Info** | Key business events and transaction lifecycle | "Transaction started: INV-12345", "Invoice submitted successfully" |
+| **Warn** | Recoverable issues that don't stop execution | "Retry 2 of 3 for INV-12345", "Fallback value used for missing field" |
+| **Error** | Failures that stop a transaction | "System exception in ProcessInvoice: Selector not found" |
+| **Fatal** | Failures that stop the entire process | "Max consecutive exceptions reached — aborting", "Init failed — cannot continue" |
+
+### Rules
+
+1. **Log at transaction boundaries** — Info level at transaction start and end, include transaction identifier
+2. **Include identifiers in log messages** — "Processing INV-12345" not "Processing invoice". This makes Orchestrator log search useful.
+3. **Log before and after key actions** — "Submitting invoice INV-12345" then "Invoice INV-12345 submitted, confirmation: CONF-789"
+4. **Use Warn for retries** — "Retry 2/3 for INV-12345: selector not found"
+5. **Use Error only for actual failures** — not for expected business exceptions
+6. **Don't log sensitive data** — no passwords, SSNs, credit card numbers, even at Verbose level
+7. **Use Log Fields for structured data** — key-value pairs that appear as structured data in Orchestrator, not just in the message string
+
+---
+
+## 5. Robot Types
+
+| Type | Triggered By | Interaction | Use Cases |
+|---|---|---|---|
+| **Attended** | User (from Assistant/tray) | CAN interact with user's desktop | User-triggered tasks, human-in-the-loop, data entry assistance |
+| **Unattended** | Orchestrator (triggers/schedules) | CANNOT interact with user desktop | Batch processing, scheduled tasks, queue processing |
+
+### Execution Modes
+
+| Mode | Behavior | Use When |
+|---|---|---|
+| **Foreground** | Takes control of the screen, interacts with UI | UI automation (Click, TypeInto, selectors) |
+| **Background** | Runs without UI interaction | API calls, data processing, file operations only |
+
+### Rules
+
+1. **Attended robots should NOT use long-running loops** — they block the user's desktop
+2. **Unattended robots MUST NOT show dialog boxes** — no one is watching to click OK. Use `InputDialog` only in attended mode.
+3. **Background processes CANNOT use UI activities** — no Click, TypeInto, or selector-based activities
+4. **Design workflows to work as both when possible** — use config flags to switch between interactive (InputDialog) and headless (Orchestrator asset) modes
+
+---
+
+## 6. Trigger Types
+
+Triggers start processes automatically in Orchestrator.
+
+| Trigger | Fires When | Best For |
+|---|---|---|
+| **Time Trigger** | Cron schedule (e.g., "0 8 * * MON-FRI" = 8 AM weekdays) | Daily/weekly batch processing, report generation |
+| **Queue Trigger** | New items appear in a queue | Dispatcher/Performer pattern, event-driven processing |
+| **Event Trigger** | External event (webhook, API call) | Integration-triggered automation |
+
+### Queue Trigger Configuration
+
+| Setting | Description |
+|---|---|
+| **Minimum items to trigger** | Don't start unless N+ items are waiting |
+| **Maximum jobs allowed** | Cap concurrent performers (prevents resource exhaustion) |
+| **Job priority** | Priority of the triggered job |
+
+### Rules
+
+1. **Use Queue Triggers for performer processes** — not Time Triggers. Queue Triggers scale with demand.
+2. **Use Time Triggers for dispatchers** — run the dispatcher on schedule to load items into the queue.
+3. **Set max concurrent jobs** based on infrastructure capacity — too many parallel robots can overwhelm target applications.
+
+---
+
+## 7. Environment Separation
+
+### Folder Strategy
+
+| Environment | Folder | Purpose |
+|---|---|---|
+| **Dev** | `/Development` | Active development, frequent deployments |
+| **Test/UAT** | `/Testing` | User acceptance testing, stable versions |
+| **Prod** | `/Production` | Live execution, change-controlled |
+
+### Per-Environment Configuration
+
+| Configuration Item | How to Separate |
+|---|---|
+| URLs (portal, API) | Per-environment Text assets: `InvoiceBot_PortalURL` with different values per folder |
+| Credentials | Per-environment Credential assets: `InvoiceBot_Credentials` |
+| File paths | Per-environment Text assets or per-robot assets |
+| Queue names | Same name in each folder (Orchestrator scopes queues to folders) |
+| Thresholds/batch sizes | Per-environment Text or Integer assets |
+
+### Rules
+
+1. **Same queue name across environments** — Orchestrator scopes queues to their folder automatically
+2. **Different asset values per environment** — same asset name, different value in each folder
+3. **Package versioning across environments** — deploy specific version to Test, promote exact same version to Prod after approval
+4. **Never deploy directly to Prod** — always go through Dev → Test → Prod pipeline
+5. **Use per-robot assets for machine-specific paths** — different robots may have different local folder structures

--- a/skills/uipath-rpa-legacy/references/project-organization-guide.md
+++ b/skills/uipath-rpa-legacy/references/project-organization-guide.md
@@ -1,0 +1,324 @@
+# Project Organization Guide
+
+Best practices for structuring, naming, and organizing legacy UiPath RPA projects.
+
+For project.json schema and package dependencies, see [project-structure.md](./project-structure.md).
+For REFramework file structure, see [activity-docs/_REFRAMEWORK.md](./activity-docs/_REFRAMEWORK.md).
+
+---
+
+## 1. Architecture Selection
+
+Before creating any files, decide the project architecture based on what the automation needs to accomplish:
+
+| Scenario | Architecture | Why |
+|---|---|---|
+| Simple linear task (read file, transform, write) | **Sequence** | No transaction concept, no retry needed, runs once |
+| Process multiple independent items with retry/logging | **REFramework** (Performer) | Transaction-based, built-in retry, Orchestrator monitoring |
+| Collect data from a source and load it into a queue | **Dispatcher** (simple Sequence) | Reads input, creates queue items — no REFramework needed |
+| Collect data AND process it with retry | **Dispatcher + Performer** (two separate projects) | Dispatcher loads the queue, Performer processes with REFramework |
+| Multi-step process with distinct phases | **StateMachine** (custom or REFramework) | Explicit states and transitions for complex flows |
+| Small utility (< 5 activities, no error handling) | **Single Sequence** | Flat structure, no folders needed |
+
+### Rules
+
+1. **Default to REFramework for production automations** — unless the process is genuinely linear with no retry needs
+2. **Dispatcher and Performer are SEPARATE projects** — never combine both in one project
+3. **Dispatcher does NOT need REFramework** — a simple Sequence that loops and calls Add Queue Item is sufficient
+4. **Ask the user if unclear** — "Will this process multiple items independently?" determines REFramework vs Sequence
+
+---
+
+## 2. Folder Structure
+
+Organize workflows into logical folders based on their purpose:
+
+```
+{projectRoot}/
+├── project.json
+├── Main.xaml                    # Entry point only — orchestrates, does not contain business logic
+├── Framework/                   # Framework/infrastructure workflows
+│   ├── InitAllSettings.xaml     # Configuration loading
+│   ├── InitAllApplications.xaml # App open/login
+│   ├── CloseAllApplications.xaml
+│   └── KillAllProcesses.xaml
+├── BusinessLogic/               # Core automation workflows
+│   ├── ProcessInvoice.xaml
+│   ├── ValidateInput.xaml
+│   └── GenerateReport.xaml
+├── Utilities/                   # Reusable helper workflows
+│   ├── SendNotificationEmail.xaml
+│   ├── LookupCustomer.xaml
+│   └── FormatCurrency.xaml
+├── Data/
+│   ├── Input/                   # Input files (Excel, CSV, config)
+│   ├── Output/                  # Generated output files
+│   └── Temp/                    # Temporary files (cleared each run)
+├── Tests/                       # Test case workflows
+│   └── Test_ProcessInvoice_ValidData.xaml
+└── Config.xlsx                  # Configuration file (REFramework pattern)
+```
+
+### Rules
+
+1. **Main.xaml is the orchestrator only** — it calls sub-workflows, it does NOT contain business logic
+2. **Framework/ for infrastructure** — initialization, cleanup, app management
+3. **BusinessLogic/ for automation** — the actual work the robot does
+4. **Utilities/ for reusable helpers** — email, lookups, formatting, logging wrappers
+5. **Data/ with Input/Output/Temp** — never write outputs to Input folder, clear Temp on each run
+6. **Tests/ for test cases** — see [testing-guide.md](./testing-guide.md)
+
+### Simple Projects
+
+For small automations (< 5 workflows), a flat structure is acceptable:
+
+```
+{projectRoot}/
+├── project.json
+├── Main.xaml
+├── ProcessData.xaml
+└── SendResults.xaml
+```
+
+Introduce folders when the project reaches 5+ workflows.
+
+---
+
+## 3. Naming Conventions
+
+### Workflow Files
+
+| Convention | Pattern | Examples |
+|---|---|---|
+| Case | **PascalCase** | `ProcessInvoice.xaml`, `ValidateInput.xaml` |
+| Pattern | **VerbNoun** | `SendEmail.xaml`, `ReadConfig.xaml`, `ExtractTableData.xaml` |
+| Avoid | Abbreviations, underscores | NOT `ProcInv.xaml`, NOT `process_invoice.xaml` |
+
+### Common Verb Prefixes
+
+| Verb | Meaning |
+|---|---|
+| `Process` | Execute business logic on an item |
+| `Validate` | Check data against rules |
+| `Extract` | Pull data from a source |
+| `Transform` | Convert data format |
+| `Send` | Transmit data (email, API, queue) |
+| `Get` | Retrieve a single value or record |
+| `Read` | Load data from file/database |
+| `Write` | Save data to file/database |
+| `Init` | Initialize resources |
+| `Close` | Gracefully close resources |
+| `Kill` | Force-terminate processes |
+
+### Activity DisplayNames
+
+1. **ALWAYS set meaningful DisplayNames** — `Click "Submit Invoice"` not `Click`
+2. **Describe the action and target** — `TypeInto "Invoice Number"`, `Read Range "Sales Data"`
+3. **Use quotes for UI element names** — `Click "OK"`, `TypeInto "Username"`
+4. **Prefix Assign with the variable** — `Assign totalAmount`, `Assign isValid`
+
+### Variables
+
+| Convention | Pattern | Examples |
+|---|---|---|
+| Case | **PascalCase** | `InvoiceNumber`, `TotalAmount`, `IsValid` |
+| Scope | **Minimize scope** | Declare at the innermost scope where the variable is used |
+| Type | **Use specific types** | `String`, `Int32`, `DataTable` — avoid `Object` and `GenericValue` |
+
+### Arguments
+
+| Direction | Prefix | Examples |
+|---|---|---|
+| In | `in_` | `in_FilePath`, `in_Config`, `in_TransactionItem` |
+| Out | `out_` | `out_Result`, `out_DataTable`, `out_ErrorMessage` |
+| In/Out | `io_` | `io_RetryCount`, `io_DataTable` |
+
+---
+
+## 4. Single Responsibility & Decomposition
+
+Each workflow should do ONE thing well. This makes workflows testable, reusable, and debuggable.
+
+### Guidelines
+
+1. **One workflow = one task** — `ProcessInvoice.xaml` processes an invoice, it does not also send emails and update databases
+2. **Keep workflows under ~30 activities** — if a workflow exceeds this, extract sub-sections into separate workflows
+3. **Extract via InvokeWorkflowFile** — call sub-workflows with clear argument interfaces
+4. **Each workflow has defined inputs and outputs** — use In/Out arguments, not global variables
+5. **One UI scope per workflow file** — if a workflow interacts with two different applications (e.g., SAP and a web portal), split it into two workflows. Mixing Attach Browser for App A and Attach Window for App B in one file makes error recovery and retries unreliable.
+6. **Application initialization stays together** — opening an application and logging in belong in the same workflow (e.g., `SAP_Launch.xaml`). Do not separate Open Application and Login into different files — if one fails, the other is useless.
+7. **Retrieve credentials where they are used** — call Get Credential inside the workflow that performs the login, not in a parent that passes the SecureString down through multiple InvokeWorkflowFile layers. This avoids exposing credentials across argument boundaries and simplifies the call chain.
+
+### Application-Based File Organization
+
+For automations that interact with multiple applications, organize workflows by application:
+
+```
+BusinessLogic/
+├── SAP/
+│   ├── SAP_Launch.xaml              # Open SAP + login
+│   ├── SAP_NavigateToTransaction.xaml
+│   ├── SAP_FillForm.xaml
+│   └── SAP_ExtractData.xaml
+├── WebPortal/
+│   ├── WebPortal_Launch.xaml        # Open browser + login
+│   ├── WebPortal_SearchInvoice.xaml
+│   └── WebPortal_SubmitApproval.xaml
+└── Excel/
+    ├── ReadInputData.xaml
+    └── WriteResults.xaml
+```
+
+The `AppName_Action.xaml` pattern makes it immediately clear which application a workflow targets and what it does.
+
+### Decomposition Example
+
+**Bad: One monolithic workflow**
+```
+Main.xaml (200 activities)
+  ├── Read Excel
+  ├── Loop rows
+  │   ├── Validate data
+  │   ├── Login to portal
+  │   ├── Enter invoice
+  │   ├── Submit
+  │   └── Log result
+  ├── Send summary email
+  └── Close applications
+```
+
+**Good: Decomposed into focused workflows**
+```
+Main.xaml (orchestrator — 10 activities)
+  ├── InvokeWorkflowFile: Framework/InitAllSettings.xaml
+  ├── InvokeWorkflowFile: Framework/InitAllApplications.xaml
+  ├── InvokeWorkflowFile: BusinessLogic/ReadInputData.xaml
+  ├── For Each Row:
+  │   ├── InvokeWorkflowFile: BusinessLogic/ValidateInput.xaml
+  │   └── InvokeWorkflowFile: BusinessLogic/ProcessInvoice.xaml
+  ├── InvokeWorkflowFile: Utilities/SendSummaryEmail.xaml
+  └── InvokeWorkflowFile: Framework/CloseAllApplications.xaml
+```
+
+---
+
+## 5. Config.xlsx Management
+
+The REFramework pattern uses `Config.xlsx` as a centralized configuration file. Apply this pattern to any production automation.
+
+### Three Sheets
+
+| Sheet | Purpose | Examples |
+|---|---|---|
+| **Settings** | Values that change between environments | URLs, file paths, queue names, thresholds |
+| **Constants** | Values that never change | Timeout values, format strings, static labels |
+| **Assets** | Names of Orchestrator assets to fetch at runtime | Credentials, API keys, environment-specific secrets |
+
+### Access Pattern
+
+After `InitAllSettings.xaml` loads the config:
+
+```vb
+' Read a setting
+in_Config("OrchestratorQueueName").ToString()
+
+' Read with default value
+If(in_Config.ContainsKey("MaxRetryNumber"), CInt(in_Config("MaxRetryNumber")), 3)
+```
+
+### No Hardcoded Values Rule
+
+**NEVER hardcode** these in workflows:
+
+| Value Type | Where It Goes |
+|---|---|
+| URLs (portal, API, web app) | Config.xlsx → Settings |
+| File paths (input, output, temp) | Config.xlsx → Settings |
+| Credentials (username, password) | Orchestrator Credential Asset → Config.xlsx Assets sheet |
+| API keys, tokens | Orchestrator Credential Asset → Config.xlsx Assets sheet |
+| Thresholds, limits | Config.xlsx → Settings or Constants |
+| Email recipients | Config.xlsx → Settings |
+| Queue names | Config.xlsx → Settings |
+| Application paths | Config.xlsx → Settings |
+
+**Exceptions:** Format strings (`"yyyy-MM-dd"`), literal constants that never change across any environment (`";"` as separator), and log messages.
+
+---
+
+## 6. Library Projects
+
+Libraries are reusable packages of workflows published as NuGet packages. Other projects consume them as activity packages.
+
+### When to Create a Library
+
+1. **Shared business logic** — the same validation/processing logic used across 2+ projects
+2. **Common integrations** — wrappers around specific applications (SAP, portal, database)
+3. **Standard practices** — email notification templates, logging wrappers, error handling utilities
+4. **UI automation wrappers** — Object Repository + workflows for a specific application
+
+### When NOT to Create a Library
+
+1. **Project-specific logic** — automation logic used by only one project
+2. **Rapidly changing interfaces** — unstable APIs or frequently redesigned UIs (versioning overhead too high)
+3. **Tightly coupled workflows** — logic that depends on specific project state or global variables
+
+### Library Project Configuration
+
+In `project.json`, set `outputType` to `"Library"`:
+
+```json
+{
+  "designOptions": {
+    "outputType": "Library"
+  }
+}
+```
+
+See [project-structure.md](./project-structure.md) for the full Library project.json template.
+
+### Key Differences from Process Projects
+
+| Aspect | Process | Library |
+|---|---|---|
+| `outputType` | `"Process"` | `"Library"` |
+| Entry point | `Main.xaml` required | No Main.xaml — all workflows are callable |
+| Workflow visibility | N/A | **Public** (exposed as activities) or **Private** (internal helpers) |
+| Arguments | Used for workflow communication | Become **activity properties** when consumed |
+| Publishing | Deployed to Orchestrator | Published to **NuGet feed** |
+
+### Semantic Versioning
+
+| Version Change | When | Example |
+|---|---|---|
+| **Major** (X.0.0) | Breaking changes — renamed arguments, removed workflows, changed behavior | 1.0.0 → 2.0.0 |
+| **Minor** (0.X.0) | New features — new workflows, new optional arguments | 1.0.0 → 1.1.0 |
+| **Patch** (0.0.X) | Bug fixes — selector fix, logic correction, no interface change | 1.0.0 → 1.0.1 |
+
+### Library Naming
+
+`[Company].[Domain].[Functionality]` — e.g., `Acme.Finance.InvoiceProcessing`, `Acme.Email.Notifications`
+
+### Library Rules
+
+1. **NEVER use ContinueOnError=True** — library consumers cannot know which errors you swallow. Always propagate exceptions.
+2. **Throw meaningful exceptions** — `BusinessRuleException("Invoice amount negative: " & amount)` not `Exception("Error")`
+3. **Don't swallow System Exceptions** — let them propagate so the consumer can retry/handle
+4. **Design arguments as the public API** — clear names, specific types (not Object), In/Out directions as needed
+5. **Test in isolation before publishing** — create a test harness project that invokes every public workflow
+6. **Pin versions in production** — consumers should use exact version constraints `[1.2.3]`, not ranges
+
+### Library Design Patterns
+
+| Pattern | Purpose | Example |
+|---|---|---|
+| **Wrapper** | Wrap an external service with retry/error handling | `SendEmailWithRetry.xaml` wrapping SMTP activities |
+| **Connector** | Encapsulate all interactions with one system | `SAPConnector` library with Login, GetOrder, CreateInvoice workflows |
+| **Data Access** | Centralize database/API queries | `CustomerDB` library with GetCustomer, UpdateStatus workflows |
+| **Framework** | Provide scaffolding for common patterns | Custom REFramework variant for the organization |
+
+### Feed Management
+
+1. **Publish to a shared NuGet feed** — Orchestrator tenant feed, host feed, or custom NuGet server
+2. **Test library upgrades in Dev first** — never upgrade directly in production
+3. **Keep older versions available** — consumers may need to roll back
+4. **Restrict publishing permissions** — only maintainers can publish new versions

--- a/skills/uipath-rpa-legacy/references/project-structure.md
+++ b/skills/uipath-rpa-legacy/references/project-structure.md
@@ -1,0 +1,206 @@
+# Legacy Project Structure
+
+Understanding the layout and configuration of a legacy UiPath RPA project.
+
+---
+
+## Directory Layout
+
+```
+{projectRoot}/
+├── project.json              # Project metadata and dependencies
+├── Main.xaml                 # Entry point workflow
+├── *.xaml                    # Additional workflows (flat or in folders)
+├── Workflows/                # (Optional) Sub-folder for organized workflows
+├── Data/                     # (Optional) Input/output data files
+├── .screenshots/             # (Optional) Studio screenshot captures
+├── .settings/                # (Optional) Studio settings profiles
+└── .tmh/                     # (Optional) Test Manager data
+```
+
+**Notable absences compared to modern projects:**
+- No `.local/docs/packages/` — no auto-generated activity documentation
+- No `.codedworkflows/` — no coded automation support
+- No `.objects/` — no Object Repository
+- No `.project/JitCustomTypesSchema.json` — no JIT custom types
+
+---
+
+## Creating a project.json from Scratch
+
+### Minimal Template
+
+Start with this — only `UiPath.System.Activities` is required. Add other packages as needed.
+
+```json
+{
+  "name": "MyProject",
+  "description": "",
+  "main": "Main.xaml",
+  "dependencies": {
+    "UiPath.System.Activities": "[24.10.8]"
+  },
+  "schemaVersion": "4.0",
+  "studioVersion": "25.10.0.0",
+  "projectVersion": "1.0.0",
+  "expressionLanguage": "VisualBasic",
+  "targetFramework": "Legacy",
+  "runtimeOptions": {
+    "autoDispose": false,
+    "isPausable": true,
+    "isAttended": false,
+    "requiresUserInteraction": true,
+    "supportsPersistence": false,
+    "workflowSerialization": "DataContract",
+    "excludedLoggedData": ["Private:*", "*password*"],
+    "executionType": "Workflow"
+  },
+  "designOptions": {
+    "projectProfile": "Developement",
+    "outputType": "Process"
+  },
+  "entryPoints": [
+    {
+      "filePath": "Main.xaml",
+      "uniqueId": "00000000-0000-0000-0000-000000000000",
+      "input": [],
+      "output": []
+    }
+  ]
+}
+```
+
+### Package Selection Guide
+
+**Add packages based on what the workflow needs.** Only `UiPath.System.Activities` is required — everything else is optional.
+
+| Need | Package | Latest Legacy Version |
+|------|---------|----------------------|
+| **Core (always include)** | `UiPath.System.Activities` | **24.10.8** |
+| UI automation (click, type, selectors) | `UiPath.UIAutomation.Activities` | **25.10.28** |
+| Excel (read/write, macros, CSV) | `UiPath.Excel.Activities` | **2.24.4** |
+| Email (SMTP, IMAP, POP3, Outlook) | `UiPath.Mail.Activities` | **1.24.18** |
+| HTTP/REST/SOAP/JSON/XML | `UiPath.WebAPI.Activities` | **1.21.1** |
+| Testing and assertions | `UiPath.Testing.Activities` | **25.10.1** |
+| PDF (read text, OCR, merge, split) | `UiPath.PDF.Activities` | **3.25.2** |
+| Office 365 (Graph API) | `UiPath.MicrosoftOffice365.Activities` | **2.9.13** |
+| Word documents | `UiPath.Word.Activities` | **1.20.3** |
+| PowerPoint presentations | `UiPath.Presentations.Activities` | **1.14.2** |
+| Database (SQL queries) | `UiPath.Database.Activities` | **1.10.1** |
+| Windows Credential Manager | `UiPath.Credentials.Activities` | **2.1.0** |
+| FTP/SFTP file transfer | `UiPath.FTP.Activities` | **2.4.0** |
+| Encryption/hashing (AES, HMAC, PGP) | `UiPath.Cryptography.Activities` | **1.6.1** |
+| Python script execution | `UiPath.Python.Activities` | **1.10.0** |
+| Java method invocation | `UiPath.Java.Activities` | **1.3.1** |
+| Document Understanding/OCR | `UiPath.IntelligentOCR.Activities` | **6.27.3** |
+| Forms (FormIo/HTML) | `UiPath.Form.Activities` | **2.0.8** |
+| Terminal emulation (3270/5250/VT) | `UiPath.Terminal.Activities` | **2.9.0** |
+| Google Suite (Gmail, Drive, Sheets) | `UiPath.GSuite.Activities` | **2.8.28** |
+| NLP (sentiment, translation) | `UiPath.Cognitive.Activities` | **2.2.4** |
+| StudioX scenario templates | `UiPath.ComplexScenarios.Activities` | **1.5.1** |
+| OmniPage OCR engine | `UiPath.OmniPage.Activities` | **1.22.2** |
+| Persistence (long-running workflows) | `UiPath.Persistence.Activities` | **1.8.1** |
+| Mobile automation (iOS/Android) | `UiPath.MobileAutomation.Activities` | **25.10.0** |
+| SAP BAPI function calls | `UiPath.SAP.BAPI.Activities` | **3.0.4** |
+
+**Example:** A workflow that reads Excel, sends email, and calls a REST API needs:
+```json
+"dependencies": {
+  "UiPath.System.Activities": "[24.10.8]",
+  "UiPath.Excel.Activities": "[2.24.4]",
+  "UiPath.Mail.Activities": "[1.24.18]",
+  "UiPath.WebAPI.Activities": "[1.21.1]"
+}
+```
+
+### Packages Can Be Added Later
+
+You don't need all packages upfront. Add them to `dependencies` as you discover what the workflow needs.
+
+**Important:** `find-activities` only searches packages listed in `dependencies`. If you add a package to project.json, re-run `find-activities` to discover its activities.
+
+### Searching for Packages
+
+When the known packages above don't cover a need, search configured NuGet feeds:
+
+```bash
+uip rpa-legacy find-package --query "barcode" --limit 10 --output json
+```
+
+This searches all configured feeds (UiPath official + any custom feeds) by name and description. Add the discovered package to `dependencies`, then `find-activities` will index it.
+
+### Arbitrary .NET Packages
+
+Any NuGet package can be added to `dependencies` for custom .NET classes, methods, and types. Examples:
+- `CsvHelper` — advanced CSV parsing
+- `ClosedXML` — .xlsx manipulation without COM
+- `HtmlAgilityPack` — HTML parsing
+
+Use these via `InvokeCode` with the appropriate namespace imports.
+
+**Avoid adding packages already bundled with Studio** (e.g., `Newtonsoft.Json`) — version conflicts can cause runtime issues.
+
+---
+
+## project.json Key Fields
+
+| Field | Description |
+|-------|-------------|
+| `name` | Project name (used as package ID when packaged) |
+| `main` | Entry point XAML file (relative path) |
+| `dependencies` | NuGet package dependencies with version constraints |
+| `expressionLanguage` | `"VisualBasic"` (most legacy) or `"CSharp"` |
+| `targetFramework` | `"Legacy"` for .NET Framework 4.6.1 projects |
+| `designOptions.outputType` | `"Process"` (standalone) or `"Library"` (reusable) |
+| `studioVersion` | Studio version that created the project |
+
+### Version Constraints
+
+| Syntax | Meaning |
+|--------|---------|
+| `[1.2.3]` | Exact version 1.2.3 |
+| `[1.2.3, )` | Minimum version 1.2.3 |
+| `[1.0, 2.0)` | Range: >= 1.0, < 2.0 |
+
+---
+
+## Library Project Template
+
+To create a **Library** project (reusable workflows published as a NuGet package), set `outputType` to `"Library"`:
+
+```json
+{
+  "name": "Acme.Finance.InvoiceUtilities",
+  "description": "Reusable invoice processing workflows",
+  "dependencies": {
+    "UiPath.System.Activities": "[24.10.8]"
+  },
+  "schemaVersion": "4.0",
+  "studioVersion": "25.10.0.0",
+  "projectVersion": "1.0.0",
+  "expressionLanguage": "VisualBasic",
+  "targetFramework": "Legacy",
+  "runtimeOptions": {
+    "autoDispose": false,
+    "isPausable": true,
+    "isAttended": false,
+    "requiresUserInteraction": false,
+    "supportsPersistence": false,
+    "workflowSerialization": "DataContract",
+    "excludedLoggedData": ["Private:*", "*password*"],
+    "executionType": "Workflow"
+  },
+  "designOptions": {
+    "projectProfile": "Developement",
+    "outputType": "Library"
+  }
+}
+```
+
+**Key differences from Process projects:**
+- **No `main` field** — libraries have no entry point
+- **No `entryPoints` array** — all workflows are callable individually
+- **`outputType: "Library"`** — published as activity package, not deployed as process
+- Workflows marked **Public** become activities when consumed; **Private** workflows are internal helpers
+
+For full library design guidance (naming, versioning, patterns), see [project-organization-guide.md](./project-organization-guide.md).

--- a/skills/uipath-rpa-legacy/references/selector-guide.md
+++ b/skills/uipath-rpa-legacy/references/selector-guide.md
@@ -1,0 +1,326 @@
+# Selector Guide
+
+Selector anatomy, strategy, and best practices for building reliable UI automation in legacy UiPath workflows.
+
+For UI automation activities (Click, TypeInto, etc.), see [activity-docs/UIAutomation.md](./activity-docs/UIAutomation.md).
+For input method gotchas (SimulateType, EmptyField), see [activity-docs/_COMMON-PITFALLS.md](./activity-docs/_COMMON-PITFALLS.md).
+
+---
+
+## 1. Selector XML Anatomy
+
+A selector is an XML string that identifies a UI element by its position in the application's control hierarchy. Each XML tag represents one level in the hierarchy.
+
+### Tag Types
+
+| Tag | Represents | Found In |
+|---|---|---|
+| `<wnd>` | Window (Win32/WPF/Java) | Desktop applications |
+| `<ctrl>` | Control inside a window | Desktop applications |
+| `<html>` | Browser window/document | Web applications |
+| `<webctrl>` | HTML element | Web applications |
+| `<java>` | Java component | Java applications |
+
+### Common Attributes
+
+| Attribute | Description | Stability |
+|---|---|---|
+| `automationid` | Developer-assigned unique ID (WPF/UWP) | **HIGH** — rarely changes |
+| `id` | HTML element ID | **HIGH** — if developer-assigned (not auto-generated) |
+| `name` | Control name | **MEDIUM** — stable for named controls |
+| `role` | ARIA role or control type (button, edit, combobox) | **MEDIUM** — describes function, not instance |
+| `aaname` | Accessible name (screen reader text) | **MEDIUM** — may change with UI text changes |
+| `cls` | Window class name | **MEDIUM** — stable within app version |
+| `tag` | HTML tag (input, div, span, a) | **LOW** — too generic for identification |
+| `parentid` | Parent element's ID | **MEDIUM** — depends on parent stability |
+| `idx` | Positional index among siblings | **VERY LOW** — breaks when UI order changes |
+| `title` | Window title | **LOW** — often contains dynamic data |
+
+### Selector Example (Web)
+
+```xml
+<html app='chrome.exe' title='Invoice Portal*' />
+<webctrl id='txtInvoiceNumber' tag='INPUT' />
+```
+
+### Selector Example (Desktop)
+
+```xml
+<wnd app='notepad.exe' cls='Notepad' title='Untitled*' />
+<ctrl name='Text Editor' role='edit' />
+```
+
+---
+
+## 2. Attribute Stability Ranking
+
+When multiple attributes are available, prefer the most stable ones:
+
+1. **automationid** — best for WPF/UWP apps; developer-assigned, rarely changes
+2. **id** — best for web apps with stable IDs (not auto-generated like `id='ember-1234'`)
+3. **name** — good for named controls in desktop apps
+4. **role** — good as supporting attribute (not unique alone)
+5. **aaname** — acceptable when other stable attributes unavailable
+6. **cls** — use for window-level identification
+7. **tag** — too generic alone; use only with other attributes
+8. **idx** — **AVOID** — breaks when siblings are added/removed/reordered
+
+### Rules
+
+1. **NEVER rely solely on `idx`** — positional indices break when the UI changes. If `idx` is the only distinguishing attribute, use Anchor Base instead.
+2. **Avoid auto-generated IDs** — IDs like `ember-1234`, `react-abc123`, or `__ID0` change between sessions
+3. **Prefer `automationid` over `name`** — both identify the control, but `automationid` is more stable across UI updates
+4. **Combine 2-3 attributes** for robust identification — e.g., `role='button' aaname='Submit'` is stronger than either alone
+
+---
+
+## 3. Full vs Partial Selectors
+
+### Full Selector
+
+Includes the top-level window tag. Used when the activity is NOT inside a container scope.
+
+```xml
+<wnd app='notepad.exe' cls='Notepad' title='*' />
+<ctrl name='Text Editor' role='edit' />
+```
+
+### Partial Selector
+
+Omits the top-level window tag. Used ONLY inside a container scope (Attach Window, Attach Browser, Open Browser, Open Application).
+
+```xml
+<!-- Inside Attach Browser for chrome.exe -->
+<webctrl id='txtInvoiceNumber' tag='INPUT' />
+```
+
+### When to Use Each
+
+| Context | Selector Type | Why |
+|---|---|---|
+| Activity is standalone (no container) | Full selector | Must identify the window + element |
+| Activity is inside Attach Browser | Partial selector | Container already identifies the browser window |
+| Activity is inside Attach Window | Partial selector | Container already identifies the app window |
+| Activity is inside Open Application | Partial selector | Container already identifies the app window |
+
+### Rule
+
+**ALWAYS use container scopes (Attach Browser/Window) with partial selectors inside** — this is more reliable than full selectors on every activity because:
+1. The window identification is done once (in the container)
+2. If the window title changes, you fix it in one place
+3. Partial selectors are shorter and less fragile
+
+---
+
+## 4. Dynamic Selector Strategies
+
+### Wildcards
+
+Use `*` to match any text in a dynamic attribute portion:
+
+```xml
+<!-- Window title changes with document name -->
+<wnd app='excel.exe' title='* - Excel' />
+
+<!-- Button text includes dynamic count -->
+<webctrl aaname='Show Results (*)' tag='BUTTON' />
+```
+
+### Variables in Selectors
+
+Inject VB.NET variables into selectors using `{{variableName}}` syntax:
+
+```xml
+<!-- Select a specific row by customer name -->
+<webctrl aaname='{{customerName}}' tag='TD' />
+
+<!-- Dynamic window title -->
+<wnd app='sap.exe' title='{{sapTransactionCode}} *' />
+```
+
+In XAML, this looks like:
+```xml
+<ui:Click Selector="&lt;html app='chrome.exe' /&gt;&lt;webctrl aaname='{{customerName}}' tag='TD' /&gt;" />
+```
+
+### Rules
+
+1. **Use wildcards for known-dynamic portions** — window titles with filenames, buttons with counts, timestamps
+2. **Use variables for data-driven selection** — customer names, invoice numbers, row identifiers
+3. **Don't wildcard everything** — `<webctrl aaname='*' tag='*' />` matches every element; keep enough specificity
+
+---
+
+## 5. Anchor Base Pattern
+
+When a target element has no stable selector, use a nearby stable element (the anchor) as reference.
+
+### Structure
+
+```
+Anchor Base
+  ├── Anchor: Find Element (stable label/header near the target)
+  │   └── Selector: <webctrl aaname='Invoice Amount' tag='LABEL' />
+  └── Action: Get Text / TypeInto / Click (target element)
+      └── Selector: <webctrl tag='INPUT' />
+```
+
+### When to Use
+
+1. Target element has only `idx` or auto-generated ID
+2. Multiple identical elements on the page (e.g., multiple "Edit" buttons)
+3. Element position changes relative to page but stays fixed relative to its label
+4. Data-driven forms where the field structure is consistent but selectors are not
+
+### Rules
+
+1. **The anchor must be unique and stable** — labels, headers, static text
+2. **Anchor and target must be visually close** — the Anchor Base finds the nearest matching target relative to the anchor
+3. **Set AnchorPosition** if needed — Top, Bottom, Left, Right, Auto (Auto works for most cases)
+
+---
+
+## 6. Container Scope Strategy
+
+Structure UI automation workflows with container scopes to reduce selector fragility and improve readability.
+
+### Recommended Pattern
+
+```
+Sequence "Process Invoice in Web Portal"
+  ├── Attach Browser (selector: <html app='chrome.exe' title='Invoice Portal*' />)
+  │   ├── TypeInto "Invoice Number" (partial: <webctrl id='txtInvoice' />)
+  │   ├── TypeInto "Amount" (partial: <webctrl id='txtAmount' />)
+  │   ├── Click "Submit" (partial: <webctrl id='btnSubmit' />)
+  │   └── Element Exists "Success" (partial: <webctrl id='lblSuccess' />)
+```
+
+### Rules
+
+1. **One container per application window** — don't nest Attach Browser inside Attach Browser
+2. **Use partial selectors inside containers** — shorter, less fragile, window identification handled by container
+3. **Check App State or Element Exists before acting** — verify the app is ready before clicking
+
+---
+
+## 7. Selector Validation Checklist
+
+When generating XAML with selectors, verify:
+
+1. [ ] No reliance on `idx` attribute alone — use stable attributes or Anchor Base
+2. [ ] Window title uses wildcard for dynamic portions — `title='Invoice*'` not `title='Invoice #12345'`
+3. [ ] No auto-generated IDs — avoid `id='ember-1234'`, `id='__ID0'`
+4. [ ] Container scope used for multiple actions on same window — Attach Browser/Window with partial selectors
+5. [ ] Variables used for data-driven selectors — `{{variableName}}` syntax
+6. [ ] Special characters escaped in XAML — `&lt;` for `<`, `&gt;` for `>`, `&amp;` for `&`, `&quot;` for `"`
+7. [ ] Web selectors start with `<html>` tag (full) or `<webctrl>` tag (partial)
+8. [ ] Desktop selectors start with `<wnd>` tag (full) or `<ctrl>` tag (partial)
+
+---
+
+## 8. Frames and iFrames
+
+Web pages with frames or iFrames have nested document contexts. Selectors must include the frame boundary.
+
+### Identifying Frame Selectors
+
+```xml
+<!-- Main page element -->
+<html app='chrome.exe' title='Portal' />
+<webctrl id='mainContent' tag='DIV' />
+
+<!-- Element INSIDE an iFrame -->
+<html app='chrome.exe' title='Portal' />
+<webctrl tag='IFRAME' id='contentFrame' />        <!-- frame boundary -->
+<webctrl id='txtField' tag='INPUT' />              <!-- element inside frame -->
+```
+
+### Rules
+
+1. **Each iFrame adds a `<webctrl>` tag level** in the selector pointing to the IFRAME element
+2. **Nested iFrames add multiple levels** — each frame boundary is a separate `<webctrl>` tag
+3. **Frame IDs may be dynamic** — use `name` attribute or wildcard if `id` changes
+
+---
+
+## 9. Common Selector Patterns by Platform
+
+### Desktop Application (Win32)
+
+```xml
+<wnd app='notepad.exe' cls='Notepad' title='*' />
+<ctrl name='Text Editor' role='edit' />
+```
+
+### Web — Chrome
+
+```xml
+<html app='chrome.exe' title='My Application*' />
+<webctrl id='submitBtn' tag='BUTTON' />
+```
+
+### Web — Edge
+
+```xml
+<html app='msedge.exe' title='My Application*' />
+<webctrl id='submitBtn' tag='BUTTON' />
+```
+
+### Java Application
+
+```xml
+<wnd app='java.exe' cls='SunAwtFrame' title='*' />
+<ctrl role='push button' name='OK' />
+```
+
+### SAP GUI
+
+```xml
+<wnd app='saplogon.exe' cls='SAP_FRONTEND_SESSION' title='SAP*' />
+<ctrl automationid='usr/txtRSYST-MESSION' />
+```
+
+### Citrix/RDP (Virtual Desktop)
+
+Standard selectors do NOT work inside Citrix/RDP sessions. Use:
+1. **Image-based automation** — Click Image, Find Image
+2. **OCR-based automation** — Get OCR Text, Click OCR Text
+3. **Citrix extension** (if available) — provides native selectors inside the virtual session
+
+---
+
+## 10. Object Repository Concepts
+
+For teams managing many UI automations against the same applications, the Object Repository centralizes selector management.
+
+### Hierarchy
+
+```
+Application (e.g., "InvoicePortal")
+  └── Screen (e.g., "LoginPage", "InvoiceListing")
+      └── UI Element (e.g., "UsernameField", "SubmitButton")
+          └── UI Descriptor (selector + fuzzy selector + image + anchor)
+```
+
+### Naming Convention
+
+`[ApplicationName].[ScreenName].[ElementName]` — e.g., `InvoicePortal.LoginPage.UsernameField`
+
+### UI Libraries
+
+Object Repository descriptors can be published as **UI Libraries** — NuGet packages that other projects consume. When a selector changes, update the UI Library once and all consuming projects get the fix.
+
+### Multiple Targeting Strategies
+
+A UI Descriptor can include multiple targeting methods for resilience:
+1. **Strict selector** — exact match (primary)
+2. **Fuzzy selector** — attribute-flexible match (fallback)
+3. **Image** — visual match (fallback when selectors fail)
+4. **Anchor** — relative to nearby stable element
+
+### When to Use Object Repository
+
+- Team maintains 5+ automations against the same application
+- Application undergoes frequent UI changes
+- Multiple developers work on automations for the same application
+- Organization wants centralized selector management

--- a/skills/uipath-rpa-legacy/references/test-data-guide.md
+++ b/skills/uipath-rpa-legacy/references/test-data-guide.md
@@ -1,0 +1,142 @@
+# Test Data Creation Guide
+
+How to create test data files and UiPath types for legacy workflow testing.
+
+---
+
+## Excel Test Data (COM-Compliant)
+
+### Using ExcelApplicationScope (Interop — .xls/.xlsx)
+
+Create a DataTable in code, then write it via Excel Interop:
+
+```xml
+<!-- Step 1: Build DataTable with InvokeCode -->
+<ui:InvokeCode Code="
+Dim dt As New DataTable()
+dt.Columns.Add(&quot;Name&quot;, GetType(String))
+dt.Columns.Add(&quot;Amount&quot;, GetType(Double))
+dt.Columns.Add(&quot;Date&quot;, GetType(String))
+dt.Columns.Add(&quot;Status&quot;, GetType(String))
+dt.Rows.Add(&quot;Invoice-001&quot;, 1500.50, &quot;2024-01-15&quot;, &quot;Active&quot;)
+dt.Rows.Add(&quot;Invoice-002&quot;, 2300.00, &quot;2024-02-20&quot;, &quot;Pending&quot;)
+dt.Rows.Add(&quot;Invoice-003&quot;, 890.25, &quot;2024-03-10&quot;, &quot;Closed&quot;)
+dt.Rows.Add(&quot;Invoice-004&quot;, 0, &quot;&quot;, &quot;Active&quot;)
+dt.Rows.Add(&quot;Invoice-005&quot;, -100.00, &quot;2024-12-31&quot;, &quot;Error&quot;)
+testData = dt" Language="VBNet">
+  <ui:InvokeCode.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <OutArgument x:TypeArguments="sd:DataTable" x:Key="testData">[dtTestData]</OutArgument>
+    </scg:Dictionary>
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+
+<!-- Step 2: Write to Excel via ExcelApplicationScope -->
+<!-- Use ExcelApplicationScope + ExcelWriteRange (Interop) for .xls/.xlsx -->
+```
+
+### Test data design principles
+- Include edge cases: empty strings, zero values, negative numbers, special characters
+- Include null/DBNull values to test null handling
+- Mix data types per column to test type coercion
+- Include dates in multiple formats to test parsing
+- Include at least 5-10 rows for meaningful iteration testing
+
+### Using WriteCsvFile (Portable — no Excel needed)
+
+```xml
+<!-- Write CSV then optionally convert to Excel -->
+<ui:WriteCsvFile FilePath="[Path.Combine(Environment.CurrentDirectory, &quot;Data&quot;, &quot;test.csv&quot;)]"
+  DataTable="[dtTestData]" />
+```
+
+---
+
+## Top 10 File Types
+
+| File Type | How to Create | Key Activity | Notes |
+|-----------|--------------|-------------|-------|
+| **Excel (.xls/.xlsx)** | `ExcelApplicationScope` + `ExcelWriteRange` | COM Interop | Use `.xls` for max legacy compat; `.xlsx` for modern |
+| **CSV (.csv)** | `WriteCsvFile` or `Write Text File` | Portable | Set `Delimitator` explicitly; specify `"UTF-8"` encoding |
+| **Text (.txt)** | `Write Text File` activity | System.IO | Use `Encoding="UTF-8"` for portability |
+| **JSON (.json)** | `Serialize JSON` + `Write Text File` | WebAPI package | Build JObject/JArray in InvokeCode, serialize, write |
+| **XML (.xml)** | Build XDocument in InvokeCode + `Write Text File` | System.Xml.Linq | Or use `Serialize XML` if available |
+| **PDF (.pdf)** | Export from Excel/Word scope, or HTML string + wkhtmltopdf | Requires source app | No native PDF creation activity in legacy |
+| **Word (.docx)** | `WordApplicationScope` + `Word Write Text` | COM Interop | Requires Word installed |
+| **HTML (.html)** | `Write Text File` with HTML string content | String building | Build HTML in InvokeCode or Assign |
+| **Email (.eml/.msg)** | `Save Mail Message` from mail activities | Mail package | Create MailMessage object first |
+| **Config (.xlsx)** | REFramework pattern: Config.xlsx with Settings/Constants/Assets sheets | Excel Interop | See `_REFRAMEWORK.md` for sheet structure |
+
+### Creating JSON test data
+
+```vb
+' InvokeCode — build JSON string
+Dim json As String = "{" & vbCrLf &
+  "  ""name"": ""Test User""," & vbCrLf &
+  "  ""amount"": 1500.50," & vbCrLf &
+  "  ""items"": [""A"", ""B"", ""C""]" & vbCrLf &
+  "}"
+output = json
+```
+
+### Creating XML test data
+
+```vb
+' InvokeCode — build XML string
+Dim xml As String = "<?xml version=""1.0"" encoding=""UTF-8""?>" & vbCrLf &
+  "<Invoices>" & vbCrLf &
+  "  <Invoice Id=""001"" Amount=""1500.50"" />" & vbCrLf &
+  "  <Invoice Id=""002"" Amount=""2300.00"" />" & vbCrLf &
+  "</Invoices>"
+output = xml
+```
+
+---
+
+## Top 10 UiPath Types
+
+| Type | How to Create | Common Test Values | VB.NET Expression |
+|------|--------------|-------------------|-------------------|
+| **DataTable** | `Build Data Table` activity or InvokeCode | Headers + 5-10 rows, mixed types, nulls | `New DataTable()` |
+| **String** | `Assign` / literal | `"test"`, `""`, `Nothing`, special chars `<>&"` | `"value"` |
+| **Int32** | `Assign` / `CInt()` | `0`, `-1`, `Integer.MaxValue`, `Integer.MinValue` | `CInt("42")` |
+| **Boolean** | `Assign` | `True`, `False` | `True` |
+| **DateTime** | `Assign` / `DateTime.Parse()` | Today, epoch, future, `DateTime.MinValue` | `DateTime.Now` |
+| **Dictionary(Of String, Object)** | InvokeCode or `Assign` | Config-style key-value pairs, nested objects | `New Dictionary(Of String, Object)` |
+| **String()** (array) | `Assign` / `Split()` | Empty `{}`, single item, many items | `New String() {"a","b","c"}` |
+| **SecureString** | `Get Credential` or InvokeCode | Test password strings | `New NetworkCredential("","pass").SecurePassword` |
+| **MailMessage** | `Get Outlook Mail Messages` or InvokeCode | Email with To/Subject/Body/Attachments | `New System.Net.Mail.MailMessage()` |
+| **QueueItem** | `Get Transaction Item` from Orchestrator | SpecificContent dictionary, Priority, Deadline | Requires Orchestrator queue |
+
+### Creating a test Dictionary (Config-style)
+
+```vb
+' InvokeCode
+Dim config As New Dictionary(Of String, Object)
+config("MaxRetryNumber") = 3
+config("logF_BusinessProcessName") = "TestProcess"
+config("OrchestratorQueueName") = "TestQueue"
+config("ExcelFilePath") = "Data\Input\test.xlsx"
+output = config
+```
+
+### Creating a test DataTable with edge cases
+
+```vb
+' InvokeCode
+Dim dt As New DataTable()
+dt.Columns.Add("Name", GetType(String))
+dt.Columns.Add("Amount", GetType(Double))
+dt.Columns.Add("IsActive", GetType(Boolean))
+
+' Normal rows
+dt.Rows.Add("Alice", 100.50, True)
+dt.Rows.Add("Bob", 0, False)
+
+' Edge cases
+dt.Rows.Add("", -999.99, True)           ' Empty name
+dt.Rows.Add(DBNull.Value, DBNull.Value, DBNull.Value)  ' All nulls
+dt.Rows.Add("Special <>&""chars", 1E+15, True)  ' Special chars, large number
+
+testData = dt
+```

--- a/skills/uipath-rpa-legacy/references/testing-guide.md
+++ b/skills/uipath-rpa-legacy/references/testing-guide.md
@@ -1,0 +1,309 @@
+# Testing & Debugging Guide
+
+Test design strategy, mock testing patterns, and debugging guidance for legacy UiPath workflows.
+
+For test assertion activity properties/XAML, see [activity-docs/Testing.md](./activity-docs/Testing.md).
+For test data file generation, see [test-data-guide.md](./test-data-guide.md).
+For CLI debug command, see [cli-reference.md](./cli-reference.md).
+
+---
+
+## 1. Test Case Structure
+
+Test cases are `.xaml` workflows that verify specific behaviors of your automation.
+
+### File Organization
+
+```
+{projectRoot}/
+├── Tests/
+│   ├── Test_ProcessInvoice_ValidData_Success.xaml
+│   ├── Test_ProcessInvoice_MissingVendor_ThrowsBusinessException.xaml
+│   ├── Test_ProcessInvoice_NegativeAmount_ThrowsBusinessException.xaml
+│   ├── Test_ValidateInput_EmptyString_ReturnsFalse.xaml
+│   └── Tests.xlsx                    # Test data for data-driven tests
+```
+
+### Naming Convention
+
+`Test_[Workflow]_[Scenario]_[Expected].xaml`
+
+| Part | Description | Examples |
+|---|---|---|
+| `Test_` | Prefix — identifies as test case | Always `Test_` |
+| `[Workflow]` | Workflow being tested | `ProcessInvoice`, `ValidateInput`, `SendEmail` |
+| `[Scenario]` | Input condition or scenario | `ValidData`, `MissingVendor`, `NegativeAmount`, `EmptyString` |
+| `[Expected]` | Expected outcome | `Success`, `ThrowsBusinessException`, `ReturnsFalse`, `CreatesOutput` |
+
+### Test Case Workflow Pattern
+
+```
+Sequence "Test_ProcessInvoice_ValidData_Success"
+  ├── [SETUP] Prepare test data
+  │   ├── Assign: testInvoiceNumber = "TEST-INV-001"
+  │   ├── Assign: testAmount = 1500.00
+  │   └── Assign: testVendor = "Acme Corp"
+  │
+  ├── [EXECUTE] Run the workflow under test
+  │   └── Invoke Workflow File: "BusinessLogic/ProcessInvoice.xaml"
+  │       Arguments: in_InvoiceNumber = testInvoiceNumber, in_Amount = testAmount, ...
+  │       Output: out_Result = actualResult
+  │
+  ├── [VERIFY] Assert expected outcomes
+  │   ├── Verify Expression: actualResult.Contains("Success")
+  │   └── Verify Expression: out_ConfirmationNumber IsNot Nothing
+  │
+  └── [TEARDOWN] Clean up test artifacts
+      └── Delete File: testOutputFile (if created)
+```
+
+---
+
+## 2. Verification Activities
+
+Use these activities from `UiPath.Testing.Activities` to assert expected outcomes.
+
+### When to Use Each
+
+| Activity | Use When | Example |
+|---|---|---|
+| **Verify Expression** | Boolean condition check | `actualResult = "Success"` |
+| **Verify Expression with Operator** | Comparison with specific operator | `amount` Greater Than `0` |
+| **Verify Control Attribute** | UI element attribute check | Button's `enabled` attribute = `True` |
+| **Verify Range** | Numeric bounds check | `amount` Between `0` and `10000` |
+
+### Rules
+
+1. **One verification per test case** — test one behavior at a time. Multiple assertions make it unclear which behavior failed.
+2. **Use descriptive assertion messages** — `"Invoice amount should be positive"` not `"Test failed"`
+3. **Verify the OUTCOME, not the process** — check that the result is correct, not that specific activities were called
+
+See [activity-docs/Testing.md](./activity-docs/Testing.md) for activity properties, XAML syntax, and gotchas.
+
+---
+
+## 3. Data-Driven Testing
+
+Run the same test with multiple data sets to verify behavior across different inputs.
+
+### Pattern: Excel-Driven Tests
+
+```
+Sequence "Test_ValidateInput_MultipleScenarios"
+  ├── Read Range: "Tests/TestData_ValidateInput.xlsx" → dt_TestData
+  │
+  └── For Each Row in dt_TestData
+      ├── Assign: testInput = row("Input").ToString()
+      ├── Assign: expectedResult = CBool(row("ExpectedValid"))
+      │
+      ├── Invoke Workflow File: "BusinessLogic/ValidateInput.xaml"
+      │   Arguments: in_Value = testInput
+      │   Output: out_IsValid = actualResult
+      │
+      └── Verify Expression: actualResult = expectedResult
+          OutputMessage: "Failed for input: " & testInput
+```
+
+### Test Data Excel Structure
+
+| Input | ExpectedValid | Description |
+|---|---|---|
+| `"INV-12345"` | True | Valid invoice number |
+| `""` | False | Empty string |
+| `"INV"` | False | Incomplete format |
+| `"INV-99999999999"` | False | Number too long |
+| `"inv-12345"` | True | Lowercase (should be case-insensitive) |
+
+### Data Sources
+
+| Source | Best For |
+|---|---|
+| Excel file in Tests/ folder | Small test data sets, easy to review |
+| CSV file | Portable, version-control friendly |
+| Orchestrator Test Data Queue | Cloud-hosted test data, shared across team |
+
+---
+
+## 4. Mock Testing
+
+Isolate the workflow under test by replacing external dependencies with controlled substitutes.
+
+### Strategy: Argument Injection
+
+Design workflows with arguments for external dependencies, then inject mock data during testing:
+
+**Production call:**
+```
+Invoke Workflow: ProcessInvoice.xaml
+  in_TransactionItem = orchestratorQueueItem
+  in_Config = productionConfig
+```
+
+**Test call:**
+```
+Invoke Workflow: ProcessInvoice.xaml
+  in_TransactionItem = mockQueueItem      ← controlled test data
+  in_Config = testConfig                  ← test-specific config
+```
+
+### What to Mock
+
+| Dependency | Mock Strategy |
+|---|---|
+| Orchestrator Queue Item | Create a mock Dictionary(Of String, Object) with SpecificContent fields |
+| API Response | Create a test JSON string matching the API response format |
+| Database Query Result | Build a test DataTable with expected columns and sample rows |
+| Email | Skip sending; verify that the email arguments are correct |
+| File System | Use temp directory; create test files in setup, delete in teardown |
+| Config.xlsx | Create a test Dictionary(Of String, Object) with test values |
+
+### Mock Queue Item Example
+
+```vb
+' In test setup:
+Dim mockSpecificContent As New Dictionary(Of String, Object) From {
+    {"InvoiceNumber", "TEST-INV-001"},
+    {"Amount", "1500.00"},
+    {"VendorName", "Test Vendor"}
+}
+```
+
+### Rules
+
+1. **Mock external systems, not internal workflows** — mock the database/API/email, not the sub-workflow that calls them
+2. **Verify mock inputs match production structure** — if the real API returns 20 fields, your mock should have the same 20 fields
+3. **Test failure paths with mocks** — inject invalid data, empty responses, exception conditions
+4. **Don't mock what you're testing** — if you're testing email sending, don't mock the email activity
+
+---
+
+## 5. Test Independence
+
+### Rules
+
+1. **Each test is self-contained** — creates its own test data, doesn't depend on other tests
+2. **No execution order dependencies** — tests can run in any order and produce the same results
+3. **Setup and teardown within each test** — create test files at start, delete them at end
+4. **Clean state between tests** — don't assume a previous test left the system in a specific state
+5. **No shared mutable state** — don't use global variables or shared files across tests
+
+### Test Isolation Pattern
+
+```
+Sequence "Test_WriteReport_CreatesFile"
+  ├── [SETUP]
+  │   ├── Assign: testOutputPath = Path.Combine(Path.GetTempPath(), "test_report_" & Guid.NewGuid().ToString() & ".xlsx")
+  │   └── Assign: testData = CreateTestDataTable()
+  │
+  ├── [EXECUTE]
+  │   └── Invoke Workflow: WriteReport.xaml
+  │       in_OutputPath = testOutputPath, in_Data = testData
+  │
+  ├── [VERIFY]
+  │   ├── Verify Expression: File.Exists(testOutputPath)
+  │   └── Read Range: testOutputPath → verify row count matches
+  │
+  └── [TEARDOWN]
+      └── Delete File: testOutputPath
+```
+
+---
+
+## 6. Debugging Guidance
+
+When the agent advises users on debugging, or when documenting troubleshooting steps.
+
+### Studio Debugging Tools
+
+| Tool | Shortcut | Purpose |
+|---|---|---|
+| **Step Into** | F11 | Execute next activity, entering sub-workflows |
+| **Step Over** | F10 | Execute next activity, skipping into sub-workflows |
+| **Step Out** | Shift+F11 | Execute remaining activities in current workflow, return to caller |
+| **Run to Activity** | Right-click → Run to This Activity | Execute until a specific activity |
+
+### Breakpoints
+
+| Feature | Usage |
+|---|---|
+| **Basic breakpoint** | Click line margin — pauses execution at that activity |
+| **Conditional breakpoint** | Right-click breakpoint → Condition: `amount > 10000` — only pauses when condition is true |
+| **Hit count** | Pause only after N executions — useful for debugging loop iteration 50 of 100 |
+| **Log When Hit** | Log a message instead of pausing — non-intrusive tracing |
+
+### Debug Panels
+
+| Panel | Shows | Use For |
+|---|---|---|
+| **Locals** | All variables and arguments in current scope with values | Inspecting variable state at breakpoint |
+| **Watch** | User-defined expressions evaluated at each step | Monitoring specific expressions across execution |
+| **Immediate** | Execute VB.NET/C# expressions during pause | Testing expressions, calling methods, checking conditions |
+| **Call Stack** | Workflow invocation chain (which workflow called which) | Understanding execution path, finding which caller triggered an error |
+| **Output** | Log messages, system messages | Reviewing execution history |
+
+### Binary Search Debugging Pattern
+
+When a long workflow fails and the error isn't obvious:
+
+1. Set a breakpoint at the **middle** of the workflow
+2. Run — did the breakpoint hit without errors? The bug is in the second half.
+3. Did it error before hitting the breakpoint? The bug is in the first half.
+4. Move the breakpoint to the middle of the problem half.
+5. Repeat until you isolate the failing activity.
+
+### Test Activity Feature
+
+Studio's **Test Activity** (right-click an activity → Test Activity) runs a single activity in isolation:
+- Prompts for input argument values
+- Executes only that activity
+- Shows output values and any exceptions
+- Useful for testing activities with complex configuration (HTTP Request, database queries)
+
+---
+
+## 7. Test Strategy
+
+### What to Test
+
+| Priority | Test Type | Examples |
+|---|---|---|
+| **1 (Critical)** | Happy path — normal successful execution | Valid invoice processes correctly |
+| **2 (High)** | Business exceptions — invalid data handling | Missing fields, invalid formats, rule violations |
+| **3 (High)** | Edge cases — boundary conditions | Zero amount, maximum length strings, empty DataTables |
+| **4 (Medium)** | Negative tests — error conditions | API timeout, file not found, invalid credentials |
+| **5 (Low)** | Regression tests — previously fixed bugs | Specific scenarios that caused past failures |
+
+### Rules
+
+1. **Test the automation, not the application** — verify that YOUR workflow handles data correctly, don't test that the web portal's Submit button works
+2. **Prioritize critical paths** — test the main transaction processing flow first, edge cases second
+3. **Include negative tests** — verify that invalid data throws `BusinessRuleException` (not silently processes)
+4. **Run regression suite after changes** — any modification to a workflow should re-run all tests for that workflow
+5. **Keep tests fast** — mock external systems to avoid network/UI delays in tests
+
+---
+
+## 8. CI/CD Integration
+
+### Test Execution Strategy
+
+| Stage | Tests | Purpose |
+|---|---|---|
+| **On commit** | Smoke tests (happy path only) | Fast feedback — catch breaking changes |
+| **On deployment to Test** | Full regression suite | Comprehensive validation before UAT |
+| **On deployment to Prod** | Smoke tests + critical path | Final validation in production environment |
+
+### Orchestrator Test Sets
+
+Tests can be organized into **Test Sets** in Orchestrator Test Manager:
+- Group related tests (all invoice processing tests)
+- Schedule test execution
+- Track test results over time
+- Integrate with CI/CD pipelines
+
+### Rules
+
+1. **Smoke tests should run in under 5 minutes** — fast feedback loop
+2. **Full regression can take longer** — but should complete within a release window
+3. **Test in an environment matching production** — same Orchestrator folder structure, same asset configuration
+4. **Version test data alongside workflows** — test Excel files and expected results in the same project

--- a/skills/uipath-rpa-legacy/references/validation-and-fixing.md
+++ b/skills/uipath-rpa-legacy/references/validation-and-fixing.md
@@ -1,0 +1,154 @@
+# Phase 3: Validate & Fix Loop
+
+Detailed procedures for validating legacy workflows, analyzing project quality, and fixing errors iteratively.
+
+---
+
+## Step 3.1: Validate
+
+Use `uip rpa-legacy validate` to check a XAML file or entire project for compilation errors. Accepts XAML file path, project.json path, or project folder.
+
+```bash
+# Validate a specific file (use during iteration — per activity)
+uip rpa-legacy validate "{projectRoot}/Main.xaml" --output json
+
+# Validate entire project (use as FINAL step before completing)
+uip rpa-legacy validate "{projectRoot}" --output json
+```
+
+**Workflow:**
+- **During iteration:** validate per-file after each activity edit (faster, focused feedback)
+- **Before completing:** validate the entire project to catch cross-file issues
+- Run after **every** XAML edit — do not batch multiple edits without validation
+
+---
+
+## Step 3.2: Categorize and Fix Errors
+
+**Fix order:** Package → Structure → Type → Activity Properties → Logic. Always fix in this order — higher-category fixes often resolve lower-category errors automatically.
+
+### 1. Package Errors — Missing namespace, unknown activity type, unresolved assembly
+
+**The legacy CLI does not have `install-or-update-packages`.** When a missing package is detected:
+1. Identify the missing package from the error message
+2. Check the [activity reference docs](./activity-docs/_INDEX.md) to confirm the correct package name
+3. **Ask the user** to install the package manually in Studio:
+   - Studio → Manage Packages → search for the package → Install
+   - Or edit `project.json` dependencies directly (advanced — must match NuGet version constraints)
+4. Re-validate after the package is installed
+
+### 2. Structural Errors — Invalid XML, malformed elements, missing closing tags
+
+- `Read` the XAML around the error location → `Edit` to fix XML structure
+- Cross-check against [xaml-basics-and-rules.md](./xaml-basics-and-rules.md) for correct element nesting and namespace declarations
+- Common issues: unclosed elements, mismatched namespace prefixes, duplicate `x:Name` attributes
+
+### 3. Type Errors — Wrong property type, invalid cast, type mismatch
+
+- **Always use `type-definition`** to discover exact enum values and type members — do not guess
+  ```bash
+  uip rpa-legacy type-definition "{projectRoot}" --type "EnumTypeName" --output json
+  ```
+- Example: InvokeCode `Language` property accepts `VBNet` (not `VisualBasic`, not `VB`)
+- Common fixes: wrong `x:TypeArguments`, missing namespace prefix (`sd:DataTable` vs `x:String`), VB vs C# expression syntax mismatch
+- Consult activity reference docs for behavioral context, but rely on `type-definition` for exact values
+
+### 4. Activity Properties Errors — Unknown properties, misconfigured settings
+
+- **Always use `find-activities --include-type-definitions`** to discover exact property names
+  ```bash
+  uip rpa-legacy find-activities "{projectRoot}" --query "activity name" --include-type-definitions --output json
+  ```
+- Activity reference docs describe behavior but may not list exact CLR property names — the CLI output is authoritative
+- Common issues: properties that exist in modern but not legacy versions, misspelled property names, wrong enum values
+
+### 5. Logic Errors — Wrong behavior, incorrect expressions, business logic issues
+
+- `Read` the XAML to understand current flow → `Edit` to correct
+- Verify expression syntax matches project language (VB.NET vs C#)
+- Consult [activity-docs/_PATTERNS.md](./activity-docs/_PATTERNS.md) for VB.NET expression patterns
+- Use `uip rpa-legacy debug` for runtime validation if static checks pass
+
+---
+
+## Step 3.3: Iteration Loop
+
+```
+REPEAT:
+  1. Run: uip rpa-legacy validate "{projectRoot}/{file}.xaml" --output json
+  2. IF 0 errors → EXIT loop (success)
+  3. IF errors exist:
+     a. Categorize by type (Package/Structure/Type/Properties/Logic)
+     b. Fix highest-category errors first
+     c. Apply fix using Read + Edit tools
+  4. IF error cannot be auto-resolved:
+     a. Document the error for the user
+     b. Suggest manual fix steps
+     c. Continue fixing other errors
+UNTIL: 0 errors OR all remaining errors require user action
+```
+
+**When stuck on one error:** Consider deferring to the user if it's a configuration detail (missing package, credential setup, connection string). Inform the user clearly about what needs to be done.
+
+---
+
+## Step 3.4: Package (Optional)
+
+If a deployable `.nupkg` artifact is needed, package the project after validation passes:
+
+```bash
+uip rpa-legacy package "{projectRoot}" -o "{outputDir}" --output json
+```
+
+Not required for debugging — legacy RPA can be debugged directly without packaging.
+
+---
+
+## Step 3.5: Smoke Test with Debug (Optional)
+
+**Always validate before debugging** — don't debug a file with compilation errors.
+
+```bash
+# Basic smoke test
+uip rpa-legacy debug "{projectRoot}/Main.xaml" -i '{"in_TestMode": true}' --timeout 60
+
+# Programmatic: capture result to file, suppress streaming logs
+uip rpa-legacy debug "{projectRoot}/Main.xaml" -i '{"in_TestMode": true}' --result-path /tmp/result.json --log-level error
+```
+
+**Reading results:**
+- Exit code 0 → success: check `Data.Output` for out-argument values
+- Exit code 1 → failure: check `Data.Error` for diagnostics:
+  - `Error.ActivityDisplayName` + `Error.XamlFile` → locate the problem
+  - `Error.ExceptionType` + `Error.Message` → understand it
+  - `Error.StackTrace` → full call chain
+  - `Data.ErrorLog` → all error-level log entries for context
+
+**Fix-and-retry:** edit XAML → validate → debug again.
+
+**Caution:** `debug` performs real actions (clicks, emails, file writes). Only use when safe.
+
+For test data creation (Excel files, CSV, JSON, common UiPath types), see **[test-data-guide.md](./test-data-guide.md)**.
+
+---
+
+## Common Error Scenarios
+
+### Wrong enum value
+**Symptom:** "Cannot create unknown type" or "is not a member of" for an enum property.
+**Fix:** `uip rpa-legacy type-definition "{projectRoot}" --type "EnumTypeName" --output json`. Example: InvokeCode `Language` accepts `VBNet` and `CSharp` — not `VisualBasic` or `VB`.
+
+### Activity class name not found
+**Symptom:** Unknown activity type or missing namespace.
+**Fix:** `uip rpa-legacy find-activities "{projectRoot}" --query "..." --output json`, add xmlns + assembly ref.
+
+### Multiple errors after batch editing
+**Symptom:** Many errors after writing multiple activities at once.
+**Fix:** Revert to last good state. Re-add one activity at a time, validating after each.
+
+### Activity docs don't match XAML property names
+**Symptom:** Properties from reference docs don't work in XAML.
+**Fix:** `find-activities --include-type-definitions` for exact CLR property names from compiled assemblies.
+
+### Stuck on unfamiliar problem
+**Escalation:** `uip docsai ask "..."` → `WebSearch` (UiPath Forum, Stack Overflow, GitHub) → ask user.

--- a/skills/uipath-rpa-legacy/references/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa-legacy/references/xaml-basics-and-rules.md
@@ -1,0 +1,457 @@
+# XAML Basics and Rules (Legacy)
+
+Core concepts for legacy UiPath workflow XAML files and rules for generating and editing XAML content. Legacy projects use .NET Framework 4.6.1 (WF4) and primarily VB.NET expressions.
+
+For the full XAML internals guide with detailed templates, see [activity-docs/_XAML-GUIDE.md](./activity-docs/_XAML-GUIDE.md).
+
+---
+
+## XAML File Anatomy
+
+Every legacy UiPath XAML workflow is a WF4 Activity serialized as XAML:
+
+```xml
+<Activity
+  mc:Ignorable="sap sap2010"
+  x:Class="WorkflowName"
+  mva:VisualBasic.Settings="{x:Null}"
+  xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities"
+  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+  xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities"
+  xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation"
+  xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation"
+  xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"
+  xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=mscorlib"
+  xmlns:ui="http://schemas.uipath.com/workflow/activities"
+  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+  <!-- BASELINE NAMESPACE IMPORTS (21 — include ALL of these in every new VB.NET XAML) -->
+  <TextExpression.NamespacesForImplementation>
+    <sco:Collection x:TypeArguments="x:String">
+      <x:String>System.Activities</x:String>
+      <x:String>System.Activities.Statements</x:String>
+      <x:String>System.Activities.Expressions</x:String>
+      <x:String>System.Activities.Validation</x:String>
+      <x:String>System.Activities.XamlIntegration</x:String>
+      <x:String>Microsoft.VisualBasic</x:String>
+      <x:String>Microsoft.VisualBasic.Activities</x:String>
+      <x:String>System</x:String>
+      <x:String>System.Collections</x:String>
+      <x:String>System.Collections.Generic</x:String>
+      <x:String>System.Data</x:String>
+      <x:String>System.Diagnostics</x:String>
+      <x:String>System.Drawing</x:String>
+      <x:String>System.IO</x:String>
+      <x:String>System.Linq</x:String>
+      <x:String>System.Net.Mail</x:String>
+      <x:String>System.Xml</x:String>
+      <x:String>System.Xml.Linq</x:String>
+      <x:String>UiPath.Core</x:String>
+      <x:String>UiPath.Core.Activities</x:String>
+      <x:String>System.Windows.Markup</x:String>
+      <!-- Add package-specific namespaces below when using additional packages -->
+    </sco:Collection>
+  </TextExpression.NamespacesForImplementation>
+
+  <!-- BASELINE ASSEMBLY REFERENCES (16 — include ALL of these in every new VB.NET XAML) -->
+  <TextExpression.ReferencesForImplementation>
+    <sco:Collection x:TypeArguments="AssemblyReference">
+      <AssemblyReference>System.Activities</AssemblyReference>
+      <AssemblyReference>Microsoft.VisualBasic</AssemblyReference>
+      <AssemblyReference>mscorlib</AssemblyReference>
+      <AssemblyReference>System.Data</AssemblyReference>
+      <AssemblyReference>System.Data.DataSetExtensions</AssemblyReference>
+      <AssemblyReference>System</AssemblyReference>
+      <AssemblyReference>System.Drawing</AssemblyReference>
+      <AssemblyReference>System.Core</AssemblyReference>
+      <AssemblyReference>System.Xml</AssemblyReference>
+      <AssemblyReference>System.Xml.Linq</AssemblyReference>
+      <AssemblyReference>PresentationFramework</AssemblyReference>
+      <AssemblyReference>WindowsBase</AssemblyReference>
+      <AssemblyReference>PresentationCore</AssemblyReference>
+      <AssemblyReference>System.Xaml</AssemblyReference>
+      <AssemblyReference>UiPath.System.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.UiAutomation.Activities</AssemblyReference>
+      <!-- Add package-specific assembly references below when using additional packages -->
+    </sco:Collection>
+  </TextExpression.ReferencesForImplementation>
+
+  <!-- x:Members (arguments) -->
+  <x:Members>
+    <x:Property Name="in_InputName" Type="InArgument(x:String)" />
+    <x:Property Name="out_Result" Type="OutArgument(x:String)" />
+  </x:Members>
+
+  <!-- Main workflow body -->
+  <Sequence DisplayName="Main Sequence" sap2010:WorkflowViewState.IdRef="Sequence_1">
+    <Sequence.Variables>
+      <Variable x:TypeArguments="x:String" Name="tempVar" Default="hello" />
+    </Sequence.Variables>
+    <!-- Activities go here -->
+  </Sequence>
+
+  <!-- ViewState (designer metadata - DO NOT EDIT) -->
+  <sap2010:WorkflowViewState.ViewStateManager>
+    <!-- ... -->
+  </sap2010:WorkflowViewState.ViewStateManager>
+</Activity>
+```
+
+### Key Differences from Modern XAML
+
+| Aspect | Legacy | Modern |
+|--------|--------|--------|
+| Root marker | `mva:VisualBasic.Settings="{x:Null}"` | No `mva:` marker; may have expression editor attribute |
+| Assembly xmlns | `assembly=mscorlib` | `assembly=System.Private.CoreLib` |
+| Expression types | `mva:VisualBasicValue` / `mva:VisualBasicReference` | Brackets `[expr]` or `CSharpValue` |
+| VB namespace | `xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities"` | Same or inferred |
+| Framework | .NET Framework 4.6.1 | .NET 6+ |
+
+---
+
+## VB.NET vs C# Expression Detection
+
+| Marker | VB.NET (Primary) | C# (Rare in Legacy) |
+|--------|-------------------|---------------------|
+| **Root attribute** | `mva:VisualBasic.Settings="{x:Null}"` | `sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#"` |
+| **Expression type** | `mva:VisualBasicValue<T>` / `mva:VisualBasicReference<T>` | `mca:CSharpValue<T>` / `mca:CSharpReference<T>` |
+| **Namespace xmlns** | `xmlns:mva="clr-namespace:Microsoft.VisualBasic.Activities;assembly=System.Activities"` | `xmlns:mca="clr-namespace:Microsoft.CSharp.Activities;assembly=System.Activities"` |
+| **project.json** | `"expressionLanguage": "VisualBasic"` | `"expressionLanguage": "CSharp"` |
+
+**Always check `project.json` `expressionLanguage` field before writing any expressions.**
+
+---
+
+## VB.NET Expression Syntax (Primary)
+
+VB.NET expressions use bracket notation `[expression]` inline in attributes:
+
+```xml
+<!-- Simple variable reference -->
+<ui:LogMessage Message="[myVariable]" />
+
+<!-- String concatenation -->
+<ui:LogMessage Message="[&quot;Hello &quot; + userName]" />
+
+<!-- Typed expression in InArgument -->
+<Assign.Value>
+  <InArgument x:TypeArguments="x:Int32">[counter + 1]</InArgument>
+</Assign.Value>
+
+<!-- Boolean condition -->
+<If Condition="[age >= 18]">
+
+<!-- FlowDecision with explicit VisualBasicValue -->
+<FlowDecision.Condition>
+  <mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="counter &lt; 10" />
+</FlowDecision.Condition>
+```
+
+**XML escaping required inside expressions:** `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`, `&` → `&amp;`
+
+**Throw.Exception quote escaping gotcha:** Fully-qualified class names + complex string expressions with multiple `&quot;` in `Throw.Exception` can cause compiler errors. Use short-form class names (`BusinessRuleException` not `UiPath.Core.Activities.BusinessRuleException`) and for complex messages, assign to a variable first then throw with the variable. See [common-pitfalls.md](./common-pitfalls.md#vbnet-quote-escaping-in-throwexception-critical-for-xaml-generation) for the full pattern.
+
+For comprehensive VB.NET expression patterns (strings, dates, collections, DataTables), see [activity-docs/_PATTERNS.md](./activity-docs/_PATTERNS.md).
+
+---
+
+## C# Expression Syntax (Secondary)
+
+C# expressions use `<mca:CSharpValue>` / `<mca:CSharpReference>` wrappers:
+
+```xml
+<!-- String value -->
+<ui:LogMessage.Message>
+  <InArgument x:TypeArguments="x:Object">
+    <mca:CSharpValue x:TypeArguments="x:Object">"Hello " + userName</mca:CSharpValue>
+  </InArgument>
+</ui:LogMessage.Message>
+
+<!-- Assign with CSharpReference (lvalue) and CSharpValue (rvalue) -->
+<Assign DisplayName="Set Name">
+  <Assign.To>
+    <OutArgument x:TypeArguments="x:String">
+      <mca:CSharpReference x:TypeArguments="x:String">fullName</mca:CSharpReference>
+    </OutArgument>
+  </Assign.To>
+  <Assign.Value>
+    <InArgument x:TypeArguments="x:String">
+      <mca:CSharpValue x:TypeArguments="x:String">firstName + " " + lastName</mca:CSharpValue>
+    </InArgument>
+  </Assign.Value>
+</Assign>
+```
+
+**Do NOT use `[bracket]` notation in C# projects** — brackets create `VisualBasicValue` nodes, causing validation failures for C#-only syntax.
+
+---
+
+## Workflow Types
+
+### Sequence
+Linear, top-to-bottom execution. **Most common** for legacy workflows.
+```xml
+<Sequence DisplayName="My Sequence" sap2010:WorkflowViewState.IdRef="Sequence_1">
+  <Sequence.Variables>
+    <Variable x:TypeArguments="x:String" Name="result" />
+  </Sequence.Variables>
+  <!-- Activities execute top to bottom -->
+</Sequence>
+```
+
+### Flowchart
+Visual branching with FlowStep, FlowDecision, and FlowSwitch nodes.
+```xml
+<Flowchart DisplayName="My Flowchart" sap2010:WorkflowViewState.IdRef="Flowchart_1">
+  <Flowchart.StartNode>
+    <x:Reference>__ReferenceID0</x:Reference>
+  </Flowchart.StartNode>
+  <FlowStep x:Name="__ReferenceID0">
+    <!-- Activity + FlowStep.Next -->
+  </FlowStep>
+  <FlowDecision x:Name="__ReferenceID1">
+    <FlowDecision.Condition>
+      <mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="condition" />
+    </FlowDecision.Condition>
+    <FlowDecision.True>
+      <x:Reference>__ReferenceID0</x:Reference>
+    </FlowDecision.True>
+  </FlowDecision>
+</Flowchart>
+```
+
+### State Machine
+State-based workflow with transitions. Used in REFramework pattern.
+```xml
+<StateMachine InitialState="{x:Reference __ReferenceID_Init}" DisplayName="Process">
+  <State x:Name="__ReferenceID_Init" DisplayName="Init">
+    <State.Entry>
+      <Sequence><!-- Init activities --></Sequence>
+    </State.Entry>
+    <State.Transitions>
+      <Transition DisplayName="Success">
+        <Transition.Condition>[initSuccess]</Transition.Condition>
+        <Transition.To>
+          <x:Reference>__ReferenceID_Process</x:Reference>
+        </Transition.To>
+      </Transition>
+    </State.Transitions>
+  </State>
+  <State x:Name="__ReferenceID_End" DisplayName="End" IsFinal="True" />
+</StateMachine>
+```
+
+For complete workflow type templates with ViewState, see [activity-docs/_XAML-GUIDE.md](./activity-docs/_XAML-GUIDE.md).
+
+---
+
+## Arguments (In/Out/InOut)
+
+Arguments are declared in `<x:Members>` and define the workflow's public interface:
+
+```xml
+<x:Members>
+  <x:Property Name="in_CustomerName" Type="InArgument(x:String)" />
+  <x:Property Name="out_ProcessedCount" Type="OutArgument(x:Int32)" />
+  <x:Property Name="io_DataTable" Type="InOutArgument(sd:DataTable)" />
+</x:Members>
+```
+
+### Common Type Mappings
+
+| XAML Type | .NET Type | Notes |
+|-----------|-----------|-------|
+| `x:String` | System.String | |
+| `x:Int32` | System.Int32 | |
+| `x:Int64` | System.Int64 | |
+| `x:Boolean` | System.Boolean | |
+| `x:Double` | System.Double | |
+| `x:Object` | System.Object | |
+| `x:Decimal` | System.Decimal | |
+| `sd:DataTable` | System.Data.DataTable | Requires `xmlns:sd="clr-namespace:System.Data;assembly=System.Data"` |
+| `s:DateTime` | System.DateTime | **Cannot** use `x:DateTime` — it's not in the XAML schema |
+| `ss:SecureString` | System.Security.SecureString | Requires `xmlns:ss="clr-namespace:System.Security;assembly=mscorlib"` (NOT `xmlns:s` — SecureString is in `System.Security`, not `System`) |
+| `scg:Dictionary(x:String, x:Object)` | Dictionary\<String, Object\> | |
+| `scg:List(x:String)` | List\<String\> | |
+
+**IMPORTANT:** The `x:` schema only supports: String, Int32, Int64, Double, Boolean, Byte, Single, Decimal, Char, Object, TimeSpan. Any other CLR type must use the appropriate namespace prefix (e.g., `s:DateTime`, `sd:DataTable`).
+
+---
+
+## Variables
+
+Variables are scoped to their containing activity:
+
+```xml
+<Sequence.Variables>
+  <Variable x:TypeArguments="x:String" Name="filePath" />
+  <Variable x:TypeArguments="x:Int32" Name="counter" Default="0" />
+  <Variable x:TypeArguments="x:Boolean" Name="isValid" Default="True" />
+  <Variable x:TypeArguments="sd:DataTable" Name="dtResults" />
+</Sequence.Variables>
+```
+
+Variables declared in an outer container are accessible in nested containers but not across invoked workflows (use Arguments for that).
+
+---
+
+## XAML Safety Rules
+
+### ViewState Rules (Editing vs Generating)
+
+ViewState controls how activities appear in the designer. The rules differ for editing vs generating:
+
+**Editing existing workflows:**
+- Do NOT modify the global `<sap2010:WorkflowViewState.ViewStateManager>` section
+- Do NOT modify existing ViewState on nodes you're not changing
+- When **adding new nodes** to an existing Flowchart/StateMachine, **DO generate ViewState** (ShapeLocation, ShapeSize, ConnectorLocation) for the new nodes — read existing node positions first to avoid overlap
+
+**Generating new workflows:**
+- **Sequence workflows:** ViewState is optional — Studio auto-manages `IsExpanded`
+- **Flowchart workflows:** ViewState is **MANDATORY** — generate ShapeLocation, ShapeSize, ConnectorLocation for every FlowStep and FlowDecision, plus the Flowchart container's start node position
+- **StateMachine workflows:** ViewState is **MANDATORY** — generate ShapeLocation, ShapeSize for every State, plus StateContainerWidth/Height on the container
+
+**Without ViewState on Flowchart/StateMachine nodes, Studio stacks everything at (0,0) — producing an unusable jumbled pile.**
+
+See the Flowchart and StateMachine ViewState Layout Guides in [activity-docs/_XAML-GUIDE.md](./activity-docs/_XAML-GUIDE.md) for coordinate systems, standard sizes, layout algorithms, and complete examples.
+
+### Preserve xmlns Declarations
+Never remove existing `xmlns` attributes from the root `<Activity>` element. Only add new ones as needed.
+
+### Respect Expression Language
+Always check `project.json` `expressionLanguage` before writing expressions. Mixing VB.NET and C# expression syntax causes build failures.
+
+### Preserve Existing Structure
+When editing XAML:
+- Do not reformat or re-indent the entire file
+- Only modify the specific section you need to change
+- Use the `Edit` tool for targeted replacements (match exact `old_string`, replace with `new_string`)
+
+### Validate After Every Change
+Run `uip rpa-legacy validate` after every XAML modification. Do not batch multiple edits without validation.
+
+### Unique Identifiers
+- Every `x:Name` must be unique within the file
+- Every `sap2010:WorkflowViewState.IdRef` must be unique
+- `x:Reference` must match an existing `x:Name`
+
+---
+
+## Property Binding: Attributes vs Child Elements
+
+### Attribute Syntax (Inline)
+```xml
+<ui:LogMessage Message="[myVar]" Level="Info" />
+```
+
+### Child Element Syntax (Property Element)
+```xml
+<Assign DisplayName="Set Result">
+  <Assign.To>
+    <OutArgument x:TypeArguments="x:String">[resultVar]</OutArgument>
+  </Assign.To>
+  <Assign.Value>
+    <InArgument x:TypeArguments="x:String">["processed"]</InArgument>
+  </Assign.Value>
+</Assign>
+```
+
+**Simple values** (strings, enums, booleans, VB expressions) work as attributes. **Output properties** and **complex objects** typically require child element syntax.
+
+---
+
+## Managing References When Adding Packages (CRITICAL)
+
+**Every package you use in a XAML file MUST have its assembly references and namespace imports added to that file.** Missing a single assembly reference causes all expressions using types from that assembly to fail validation.
+
+This replicates what Studio does automatically when you drag an activity onto the canvas or add an import via the Imports panel. When generating XAML programmatically, you must do this manually.
+
+### UiPath Activity Packages
+
+When you add a UiPath activity package to `dependencies` in project.json and use its activities in a XAML file:
+
+1. Add `xmlns` declaration to root `<Activity>` — use `XmlnsDeclaration` from `find-activities` output
+2. Add `<AssemblyReference>` — use `AssemblyName` from `find-activities` output
+3. Add `<x:String>` namespace imports — use the activity's `Namespace` from `find-activities` output
+
+```xml
+<!-- Example: after adding UiPath.Excel.Activities to dependencies -->
+<!-- 1. xmlns on root Activity: -->
+xmlns:ueab="clr-namespace:UiPath.Excel.Activities.Business;assembly=UiPath.Excel.Activities"
+
+<!-- 2. Assembly reference: -->
+<AssemblyReference>UiPath.Excel.Activities</AssemblyReference>
+
+<!-- 3. Namespace imports: -->
+<x:String>UiPath.Excel</x:String>
+<x:String>UiPath.Excel.Activities.Business</x:String>
+```
+
+### Arbitrary .NET Packages
+
+When you add a NuGet package (e.g., `CsvHelper`, `HtmlAgilityPack`) and use its classes in expressions or InvokeCode:
+
+1. Add `<AssemblyReference>` with the package's assembly name
+2. Add `<x:String>` namespace import for the namespace you use
+3. If using in xmlns attributes, add `xmlns` declaration too
+
+```xml
+<!-- Example: after adding HtmlAgilityPack to dependencies -->
+<AssemblyReference>HtmlAgilityPack</AssemblyReference>
+<x:String>HtmlAgilityPack</x:String>
+```
+
+### C# Projects — Additional Baseline References
+
+C# legacy projects need these **in addition** to the 16 VB.NET baseline refs:
+
+```xml
+<AssemblyReference>Microsoft.CSharp</AssemblyReference>
+<AssemblyReference>System.Runtime.Serialization</AssemblyReference>
+<AssemblyReference>System.ServiceModel</AssemblyReference>
+<AssemblyReference>System.ServiceModel.Activities</AssemblyReference>
+```
+
+And this additional namespace import:
+```xml
+<x:String>System.Text</x:String>
+```
+
+---
+
+## xmlns Prefix Deconfliction
+
+`find-activities` may suggest the **same xmlns prefix** for activities from different CLR namespaces (e.g., both `LogMessage` and `ReadCsvFile` return `uca`). Using the same prefix for two different namespace URIs breaks the XAML.
+
+**Before writing XAML:**
+1. Collect all `XmlnsDeclaration` values from all activities you plan to use
+2. Check for prefix collisions (same prefix, different `clr-namespace` URI)
+3. Rename conflicting prefixes with descriptive abbreviations
+
+**Example conflict:**
+```xml
+<!-- Both returned "uca" but point to different namespaces — CONFLICT -->
+xmlns:uca="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+xmlns:uca="clr-namespace:UiPath.CSV.Activities;assembly=UiPath.Excel.Activities"
+
+<!-- Fix: rename one prefix -->
+xmlns:uca="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+xmlns:ucsvact="clr-namespace:UiPath.CSV.Activities;assembly=UiPath.Excel.Activities"
+```
+
+**Tip:** The `ui` schema prefix (`xmlns:ui="http://schemas.uipath.com/workflow/activities"`) covers most `UiPath.Core.Activities` — prefer it over CLR-based prefixes for core activities like LogMessage, InvokeCode, etc.
+
+---
+
+## XAML Generation Gotchas
+
+1. **Every `x:Name` must be unique** — FlowSteps use `__ReferenceID0`, `__ReferenceID1`, etc.
+2. **`x:Reference` must match an `x:Name`** — broken references crash the designer
+3. **Bracket expressions `[expr]` are VB.NET only** — C# must use `<mca:CSharpValue>` elements
+4. **XML escaping required**: `<` → `&lt;`, `>` → `&gt;`, `"` → `&quot;`, `&` → `&amp;`
+5. **Assembly references must include all dependencies** — missing refs cause compilation errors
+6. **`expressionLanguage` must match XAML expression style** — VB project with C# expressions crashes
+7. **Never add trailing `<x:Reference>` for Flowchart child nodes** — FlowStep/FlowDecision/FlowSwitch nodes defined inline as direct children of `<Flowchart>` must NOT be re-listed with `<x:Reference>` at the end. Only use `<x:Reference>` inside property elements (`Flowchart.StartNode`, `FlowStep.Next`, `FlowDecision.True/False`, etc.) to create cross-references
+8. **State Machine needs exactly one `IsFinal="True"` state** for proper termination
+9. **Legacy uses `assembly=mscorlib`** — not `assembly=System.Private.CoreLib` (which is .NET 6+)
+10. **Scope activities require `ActivityAction<T>` body** — `ExcelApplicationScope`, `ExcelProcessScopeX`, `ExcelApplicationCard`, `WordApplicationScope`, etc. do NOT accept direct children. They require a `.Body` property with `ActivityAction<T>` and `DelegateInArgument`. See [common-pitfalls.md](./common-pitfalls.md#scope-activities-require-activityaction-body-critical-for-xaml-generation) for the complete template.

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-rpa
-description: "[PREVIEW] UiPath automations — coded workflows (C#), XAML workflows, and hybrid projects. Create, edit, build, run, debug. For Orchestrator/deploy→uipath-platform. For agents→uipath-agents."
+description: "[PREVIEW] UiPath automations — coded workflows (C#), XAML workflows, and hybrid projects. Create, edit, build, run, debug. For Orchestrator/deploy→uipath-platform. For agents→uipath-agents. For legacy (.NET 4.6.1)→uipath-rpa-legacy."
 ---
 
 # UiPath RPA Assistant

--- a/tests/tasks/uipath-rpa-legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa-legacy/create_and_validate.yaml
@@ -1,0 +1,110 @@
+task_id: skill-rpa-legacy-create-and-validate
+description: >
+  Skill-guided evaluation: agent uses the uipath-rpa-legacy skill to create
+  a new legacy UiPath RPA project (.NET Framework 4.6.1) with a simple
+  workflow. Tests whether the skill teaches the correct targetFramework
+  setting, XAML baseline (VB.NET, mscorlib), CLI flag conventions
+  (--output json), and discovery workflow.
+
+  Platform note: Legacy RPA targets .NET Framework 4.6.1 (Windows-only), so
+  `uip rpa-legacy validate` cannot successfully execute on Linux/Mac CI.
+  This smoke test verifies the skill guides the agent to produce correct
+  artifacts and invoke the right commands — it does not require the CLI
+  commands to succeed at runtime.
+tags: [uipath-rpa-legacy, smoke, create, validate]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a new legacy UiPath RPA project called "HelloLegacy" with a Main.xaml
+  that logs "Hello from legacy" using a LogMessage activity. Follow the skill's
+  full workflow: create the project, generate the XAML, and attempt validation.
+
+  Save a summary of what you did to report.json with at minimum:
+    {
+      "project_name": "HelloLegacy",
+      "target_framework": "Legacy",
+      "commands_used": ["<list of uip commands you ran>"]
+    }
+
+  Important:
+  - The `uip` CLI is already available in the environment.
+  - Do not run `uip rpa-legacy debug` — just attempt validation.
+  - The underlying CLI backend may not work on non-Windows hosts; that is
+    acceptable — what matters is that you produce correct files and invoke
+    the correct commands.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked uip rpa-legacy validate"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa-legacy\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json (not --format json) on uip rpa-legacy commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa-legacy\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json was created"
+    path: "HelloLegacy/project.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Main.xaml workflow was created"
+    path: "HelloLegacy/Main.xaml"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "project.json sets targetFramework to Legacy"
+    path: "HelloLegacy/project.json"
+    includes:
+      - '"targetFramework"'
+      - '"Legacy"'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Main.xaml uses legacy baseline (mscorlib, not System.Private.CoreLib)"
+    path: "HelloLegacy/Main.xaml"
+    includes:
+      - "assembly=mscorlib"
+    excludes:
+      - "System.Private.CoreLib"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Main.xaml contains a LogMessage activity with the expected text"
+    path: "HelloLegacy/Main.xaml"
+    includes:
+      - "LogMessage"
+      - "Hello from legacy"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure and values"
+    path: "report.json"
+    assertions:
+      - expression: "project_name"
+        operator: equals
+        expected: "HelloLegacy"
+      - expression: "target_framework"
+        operator: equals
+        expected: "Legacy"
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 1
+    weight: 1.5
+    pass_threshold: 0.75


### PR DESCRIPTION
## Summary

- Add complete legacy RPA skill for .NET Framework 4.6.1 XAML workflows with standalone CLI (`uip rpa-legacy`) — no Studio IPC required
- 59 files: SKILL.md, 14 reference guides, 48 activity docs covering 35+ packages
- 5-phase workflow (Environment → Discovery → Generate → Validate → Debug) with 10 critical rules
- 6 design guides for production best practices: error handling, selectors, project organization, data manipulation, Orchestrator integration, testing

## Test plan

- [ ] Verify `uip rpa-legacy validate` runs successfully against a legacy test project
- [ ] Verify all relative links in SKILL.md resolve to existing files
- [ ] Verify description is under 250 characters and includes `→` sibling redirect
- [ ] Spot-check 3-4 activity docs (Excel.md, Mail.md, UIAutomation.md, System.md) for accuracy
- [ ] Confirm no cross-skill references exist
- [ ] Test skill activation by opening a legacy project (`targetFramework: "Legacy"`) and verifying the skill triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)