### PR TITLE
Loop node E2E test + skill changes

### DIFF
--- a/skills/uipath-maestro-flow/references/plugins/loop/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/loop/impl.md
@@ -14,62 +14,43 @@ Confirm: input ports `input` and `loopBack`, output ports `success` and `output`
 
 ## JSON Structure
 
-```json
-{
-  "id": "processItems",
-  "type": "core.logic.loop",
-  "typeVersion": "1.0.0",
-  "display": { "label": "Process Items" },
-  "inputs": {
-    "collection": "=js:$vars.fetchData.output.body.items"
-  },
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the loop",
-      "source": "=result.response",
-      "var": "output"
-    },
-    "error": {
-      "type": "object",
-      "description": "Error information if the loop fails",
-      "source": "=result.Error",
-      "var": "error"
-    }
-  },
-  "model": { "type": "bpmn:SubProcess" }
-}
-```
-
-### Parallel Execution
+### Loop node
 
 ```json
 {
-  "id": "processItemsParallel",
+  "id": "loop1",
   "type": "core.logic.loop",
   "typeVersion": "1.0.0",
-  "display": { "label": "Process Items (Parallel)" },
+  "display": { "label": "Loop over items" },
   "inputs": {
     "collection": "=js:$vars.fetchData.output.body.items",
-    "parallel": true
-  },
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the loop",
-      "source": "=result.response",
-      "var": "output"
-    },
-    "error": {
-      "type": "object",
-      "description": "Error information if the loop fails",
-      "source": "=result.Error",
-      "var": "error"
-    }
+    "parallel": false
   },
   "model": { "type": "bpmn:SubProcess" }
 }
 ```
+
+Set `"parallel": true` to execute all iterations concurrently.
+
+### Loop body nodes — `parentId` required
+
+Every node inside the loop body **must** have `"parentId"` set to the loop node's ID. Without this, the runtime does not know the node is part of the loop and variableUpdates will not fire per-iteration.
+
+```json
+{
+  "id": "processItem",
+  "type": "core.action.script",
+  "typeVersion": "1.0.0",
+  "display": { "label": "Process item" },
+  "inputs": {
+    "script": "return $vars.product * $vars.loop1.currentItem"
+  },
+  "model": { "type": "bpmn:ScriptTask" },
+  "parentId": "loop1"
+}
+```
+
+> **Critical:** If you omit `parentId`, the node executes outside the loop context. State variables will not update across iterations and loop outputs like `currentItem` will be inaccessible.
 
 ## Adding / Editing
 
@@ -88,20 +69,177 @@ See [flow-editing-operations.md](../../flow-editing-operations.md) for edge add 
 
 ## Accessing Loop Variables Inside Body
 
-Inside the loop body, use `iterator` to access the current item:
+Inside the loop body, access the current item via `$vars.<loopId>.currentItem`:
 
 ```javascript
-// In a Script node inside the loop body
-const item = iterator.currentItem;
-const index = iterator.currentIndex;
+// In a Script node inside the loop body (parentId must be set to the loop node)
+const item = $vars.loop1.currentItem;
+const index = $vars.loop1.currentIndex;
 return { processed: item.name.toUpperCase(), position: index };
 ```
+
+| Variable | Description |
+| --- | --- |
+| `$vars.<loopId>.currentItem` | The item being processed in this iteration |
+| `$vars.<loopId>.currentIndex` | 0-based iteration index |
+| `$vars.<loopId>.collection` | The full collection being iterated |
+
+> **Do not use `iterator.currentItem`.** The correct access pattern is `$vars.<loopId>.currentItem` where `<loopId>` is the loop node's `id` (e.g., `$vars.loop1.currentItem`).
+
+### Required node variables for loop outputs
+
+For `$vars.<loopId>.currentItem` etc. to resolve, you must add corresponding entries to `variables.nodes`:
+
+```json
+{
+  "variables": {
+    "nodes": [
+      {
+        "id": "loop1.currentItem",
+        "type": "any",
+        "description": "The current item being iterated in the loop",
+        "binding": { "nodeId": "loop1", "outputId": "currentItem" }
+      },
+      {
+        "id": "loop1.currentIndex",
+        "type": "number",
+        "description": "The current iteration index (0-based)",
+        "binding": { "nodeId": "loop1", "outputId": "currentIndex" }
+      },
+      {
+        "id": "loop1.collection",
+        "type": "array",
+        "description": "The collection being iterated over",
+        "binding": { "nodeId": "loop1", "outputId": "collection" }
+      },
+      {
+        "id": "loop1.output",
+        "type": "array",
+        "description": "Aggregated results from all loop iterations",
+        "binding": { "nodeId": "loop1", "outputId": "output" }
+      }
+    ]
+  }
+}
+```
+
+## State Accumulation with variableUpdates
+
+To accumulate state across loop iterations (counters, running totals), use an `inout` variable with a `variableUpdate` on the body node:
+
+```json
+{
+  "variables": {
+    "globals": [
+      {
+        "id": "runningTotal",
+        "direction": "inout",
+        "type": "number",
+        "defaultValue": 0
+      }
+    ],
+    "variableUpdates": {
+      "bodyNode": [
+        {
+          "variableId": "runningTotal",
+          "expression": "=js:$vars.bodyNode.output"
+        }
+      ]
+    }
+  }
+}
+```
+
+The variableUpdate fires after each iteration, so the `inout` variable carries the accumulated value into the next iteration.
+
+## Complete Example — Loop with State Accumulation
+
+A flow that iterates over a collection, accumulates a result in an `inout` variable via a Script body node, and outputs the final value.
+
+```json
+{
+  "nodes": [
+    {
+      "id": "start",
+      "type": "core.trigger.manual",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Manual trigger" },
+      "inputs": {},
+      "model": { "type": "bpmn:StartEvent", "entryPointId": "..." }
+    },
+    {
+      "id": "loop1",
+      "type": "core.logic.loop",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Loop" },
+      "inputs": { "collection": "=js:$vars.inputItems", "parallel": false },
+      "model": { "type": "bpmn:SubProcess" }
+    },
+    {
+      "id": "bodyScript",
+      "type": "core.action.script",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Process item" },
+      "inputs": {
+        "script": "return $vars.accumulator + $vars.loop1.currentItem"
+      },
+      "model": { "type": "bpmn:ScriptTask" },
+      "parentId": "loop1"
+    },
+    {
+      "id": "end1",
+      "type": "core.control.end",
+      "typeVersion": "1.0.0",
+      "display": { "label": "End" },
+      "inputs": {},
+      "outputs": {
+        "result": { "source": "=js:$vars.accumulator" }
+      },
+      "model": { "type": "bpmn:EndEvent" }
+    }
+  ],
+  "edges": [
+    { "id": "e1", "sourceNodeId": "start", "sourcePort": "output", "targetNodeId": "loop1", "targetPort": "input" },
+    { "id": "e2", "sourceNodeId": "loop1", "sourcePort": "output", "targetNodeId": "bodyScript", "targetPort": "input" },
+    { "id": "e3", "sourceNodeId": "bodyScript", "sourcePort": "success", "targetNodeId": "loop1", "targetPort": "loopBack" },
+    { "id": "e4", "sourceNodeId": "loop1", "sourcePort": "success", "targetNodeId": "end1", "targetPort": "input" }
+  ],
+  "variables": {
+    "globals": [
+      { "id": "inputItems", "direction": "in", "type": "array", "defaultValue": [] },
+      { "id": "accumulator", "direction": "inout", "type": "number", "defaultValue": 0 },
+      { "id": "result", "direction": "out", "type": "number" }
+    ],
+    "nodes": [
+      { "id": "loop1.currentItem", "type": "any", "binding": { "nodeId": "loop1", "outputId": "currentItem" } },
+      { "id": "loop1.currentIndex", "type": "number", "binding": { "nodeId": "loop1", "outputId": "currentIndex" } },
+      { "id": "loop1.collection", "type": "array", "binding": { "nodeId": "loop1", "outputId": "collection" } },
+      { "id": "loop1.output", "type": "array", "binding": { "nodeId": "loop1", "outputId": "output" } },
+      { "id": "bodyScript.output", "type": "object", "binding": { "nodeId": "bodyScript", "outputId": "output" } },
+      { "id": "bodyScript.error", "type": "object", "binding": { "nodeId": "bodyScript", "outputId": "error" } }
+    ],
+    "variableUpdates": {
+      "bodyScript": [
+        { "variableId": "accumulator", "expression": "=js:$vars.bodyScript.output" }
+      ]
+    }
+  }
+}
+```
+
+Key points in this pattern:
+- `bodyScript` has `"parentId": "loop1"` — places it inside the loop
+- Script accesses `$vars.loop1.currentItem` for the current iteration value
+- `variableUpdate` on `bodyScript` writes the script's return value back to `accumulator`
+- `accumulator` is `inout` so it persists across iterations
+- End node maps the final accumulated value to the `out` variable
 
 ## Debug
 
 | Error | Cause | Fix |
 | --- | --- | --- |
 | Collection is empty or null | Expression evaluates to null/undefined | Check `collection` expression and upstream output |
-| `iterator` is undefined | Referencing `iterator` outside loop body | `iterator` is only available inside the loop body |
+| `$vars.loop1.currentItem` is undefined | Missing node variable binding or missing `parentId` | Add `loop1.currentItem` to `variables.nodes` and set `parentId` on body nodes |
+| State variable not updating across iterations | Body node missing `parentId` | Add `"parentId": "<loopId>"` to every node inside the loop body |
 | Infinite loop | Edges wired incorrectly | Ensure only `loopBack` creates the cycle, not arbitrary edges |
 | No output after loop | Missing `success` edge | Wire the `success` port to the next downstream node |

--- a/skills/uipath-maestro-flow/references/plugins/loop/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/loop/impl.md
@@ -152,6 +152,8 @@ To accumulate state across loop iterations (counters, running totals), use an `i
 
 The variableUpdate fires after each iteration, so the `inout` variable carries the accumulated value into the next iteration.
 
+> **Critical:** The variableUpdate expression **cannot** access loop iteration variables like `$vars.<loopId>.currentItem`. These are only available inside the body node's script. The variableUpdate must reference the body node's output (e.g., `=js:$vars.bodyNode.output`). If you need to compute using `currentItem`, do the computation in the script and reference the script's output in the variableUpdate.
+
 ## Complete Example — Loop with State Accumulation
 
 A flow that iterates over a collection, accumulates a result in an `inout` variable via a Script body node, and outputs the final value.
@@ -181,7 +183,7 @@ A flow that iterates over a collection, accumulates a result in an `inout` varia
       "typeVersion": "1.0.0",
       "display": { "label": "Process item" },
       "inputs": {
-        "script": "return $vars.accumulator + $vars.loop1.currentItem"
+        "script": "return $vars.accumulator + $vars.loop1.currentItem;"
       },
       "model": { "type": "bpmn:ScriptTask" },
       "parentId": "loop1"
@@ -241,5 +243,6 @@ Key points in this pattern:
 | Collection is empty or null | Expression evaluates to null/undefined | Check `collection` expression and upstream output |
 | `$vars.loop1.currentItem` is undefined | Missing node variable binding or missing `parentId` | Add `loop1.currentItem` to `variables.nodes` and set `parentId` on body nodes |
 | State variable not updating across iterations | Body node missing `parentId` | Add `"parentId": "<loopId>"` to every node inside the loop body |
+| State variable becomes `NaN` | variableUpdate expression uses `$vars.<loopId>.currentItem` | Loop variables are not available in variableUpdate expressions. Do the computation in the script and reference `$vars.<bodyNodeId>.output` in the variableUpdate |
 | Infinite loop | Edges wired incorrectly | Ensure only `loopBack` creates the cycle, not arbitrary edges |
 | No output after loop | Missing `success` edge | Wire the `success` port to the next downstream node |

--- a/skills/uipath-maestro-flow/references/plugins/loop/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/loop/planning.md
@@ -34,11 +34,13 @@ Use a Loop node to iterate over a collection of items. Supports sequential and p
 | `collection` | Yes | Expression pointing to an array (e.g., `$vars.fetchData.output.body.items`) |
 | `parallel` | No | `true` to execute all iterations concurrently (default: sequential) |
 
-## Internal Variables (available inside loop body only)
+## Loop Variables (available inside loop body only)
 
-- `iterator.currentItem` — the item being processed in this iteration
-- `iterator.currentIndex` — 0-based iteration index
-- `iterator.collection` — the full collection
+- `$vars.<loopId>.currentItem` — the item being processed in this iteration
+- `$vars.<loopId>.currentIndex` — 0-based iteration index
+- `$vars.<loopId>.collection` — the full collection
+
+Where `<loopId>` is the loop node's `id` (e.g., `$vars.loop1.currentItem`).
 
 ## Wiring Rules
 
@@ -46,3 +48,4 @@ Use a Loop node to iterate over a collection of items. Supports sequential and p
 - The last node in the loop body connects back to the loop's `loopBack` port
 - After all iterations, execution continues from the `success` port
 - Do not create cycles except through the `loopBack` mechanism
+- **Every node inside the loop body must have `"parentId": "<loopId>"`** — without this, variableUpdates will not fire per-iteration and loop variables will be inaccessible

--- a/skills/uipath-maestro-flow/references/variables-and-expressions.md
+++ b/skills/uipath-maestro-flow/references/variables-and-expressions.md
@@ -334,7 +334,7 @@ These variables are available in all expression contexts:
 | `$vars` | All workflow and node variables | `$vars.{variableId}` or `$vars.{nodeId}.{outputId}` |
 | `$metadata` | Workflow metadata (instanceId, executionId) | `$metadata.instanceId` |
 | `$self` | Current node's output (HTTP branch conditions only) | `$self.output.statusCode` |
-| `iterator` | Loop iteration context (inside loops only) | `iterator.currentItem`, `iterator.currentIndex` |
+| `$vars.<loopId>.*` | Loop iteration context (inside loops only) | `$vars.loop1.currentItem`, `$vars.loop1.currentIndex` |
 
 ### `$vars` Access Patterns
 
@@ -367,18 +367,19 @@ Expressions behave differently depending on where they appear.
 
 ### Script Node Body
 
-The `inputs.script` field contains a function body that **must return an object**. Full JavaScript statements are allowed (variables, loops, conditionals). The returned object becomes `$vars.{nodeId}.output`.
+The `inputs.script` field contains a function body. Full JavaScript statements are allowed (variables, loops, conditionals). The returned value becomes `$vars.{nodeId}.output`.
+
+Scripts can return any value — objects, numbers, strings, arrays, or booleans:
 
 ```javascript
+// Returning an object (multiple fields)
 const items = $vars.fetchData.output.body.items;
 const filtered = items.filter(i => i.active);
-return {
-  count: filtered.length,
-  names: filtered.map(i => i.name)
-};
-```
+return { count: filtered.length, names: filtered.map(i => i.name) };
 
-> **Script nodes always return objects.** `return 42` or `return "hello"` will fail. Use `return { value: 42 }`.
+// Returning a bare value (useful for accumulators in loops)
+return $vars.total + $vars.loop1.currentItem;
+```
 
 ### Decision Node (`inputs.expression`)
 
@@ -432,7 +433,7 @@ The `inputs.collection` field on a Loop node resolves to an array to iterate ove
 =js:$vars.inputArray.filter(x => x.active)
 ```
 
-Inside the loop body, use `iterator.currentItem` and `iterator.currentIndex`.
+Inside the loop body, use `$vars.<loopId>.currentItem` and `$vars.<loopId>.currentIndex` (e.g., `$vars.loop1.currentItem`).
 
 ---
 
@@ -479,11 +480,15 @@ A node's output (`$vars.{nodeId}.output`) is available to **all downstream nodes
 
 Inside a loop body, you have access to:
 - All parent-scope `$vars` (read-only from loop's perspective)
-- `iterator.currentItem` — current array element
-- `iterator.currentIndex` — zero-based index
-- `iterator.collection` — the original array
+- `$vars.<loopId>.currentItem` — current array element
+- `$vars.<loopId>.currentIndex` — zero-based index
+- `$vars.<loopId>.collection` — the original array
 
-After loop completion, `$vars.{loopId}.output` contains aggregated results from all iterations.
+Where `<loopId>` is the loop node's `id` (e.g., `$vars.loop1.currentItem`).
+
+> **Important:** Loop body nodes must have `"parentId": "<loopId>"` set in their JSON. Without this, the runtime does not know the node is inside the loop and `$vars.<loopId>.currentItem` will be undefined.
+
+After loop completion, `$vars.<loopId>.output` contains aggregated results from all iterations.
 
 ### Subflow Scope
 

--- a/skills/uipath-maestro-flow/references/variables-and-expressions.md
+++ b/skills/uipath-maestro-flow/references/variables-and-expressions.md
@@ -264,6 +264,8 @@ Variable updates assign new values to `inout` (state) variables at specific node
 
 > **Only `inout` variables can be updated.** Updating an `in` or `out` variable is invalid.
 
+> **Inside loops:** variableUpdate expressions cannot access loop iteration variables like `$vars.<loopId>.currentItem`. Those are only available inside the body node's script. The variableUpdate must reference the body node's output (e.g., `=js:$vars.bodyNode.output`).
+
 ---
 
 ## Output Mapping on End Nodes

--- a/tests/tasks/uipath-maestro-flow/loop_multiply/check_loop_multiply.py
+++ b/tests/tasks/uipath-maestro-flow/loop_multiply/check_loop_multiply.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""LoopMultiply: a Loop node iterates over [13, 15, 17]; output is 3315."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_output_value,
+    run_debug,
+)
+
+EXPECTED = 13 * 15 * 17  # 3315
+
+
+def main():
+    assert_flow_has_node_type(["core.logic.loop"])
+    payload = run_debug(timeout=240)
+    assert_output_value(payload, EXPECTED)
+    print(f"OK: Loop node present; output contains {EXPECTED}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-flow/loop_multiply/loop_multiply.yaml
@@ -1,0 +1,44 @@
+task_id: skill-flow-loop-multiply
+description: >
+  Create a UiPath Flow that uses a Loop node to multiply the numbers
+  [13, 15, 17] together and return the product (3315). Exercises loop node
+  wiring, variable updates, and state accumulation.
+tags: [uipath-maestro-flow, e2e, generate, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "LoopMultiply" that multiplies the
+  numbers [13, 15, 17] together using a Loop node and returns the product.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate LoopMultiply/LoopMultiply/LoopMultiply.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow has a loop node and debug returns 3315 (13*15*17)"
+    command: "python3 $TASK_DIR/check_loop_multiply.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Loop nodes were completely broken when generated by the coding agent. Three critical issues in the skill documentation caused the agent to produce flows that validated but failed at runtime:

1. **Missing `parentId`**: Loop body nodes must have `"parentId": "<loopId>"` — without this, the runtime doesn't know the node is inside the loop, so variableUpdates don't fire per-iteration and loop variables are inaccessible.

2. **Wrong variable access pattern**: Docs said to use `iterator.currentItem` — the correct pattern is `$vars.<loopId>.currentItem` (e.g., `$vars.loop1.currentItem`).

3. **variableUpdate scope**: Loop iteration variables (`$vars.<loopId>.currentItem`) are not available in variableUpdate expressions. The computation must happen in the body script, and the variableUpdate must reference the script output (`=js:$vars.bodyNode.output`).

Additionally, the docs incorrectly stated that script nodes must always return objects — bare returns (numbers, strings, etc.) work fine and are the standard pattern for loop accumulators.

## Changes

- **`references/plugins/loop/impl.md`** — Major rewrite: added `parentId` requirement, fixed variable access syntax, added node variable bindings section, added state accumulation pattern, added complete working example, updated debug troubleshooting table
- **`references/plugins/loop/planning.md`** — Fixed "Internal Variables" to use `$vars.<loopId>.*`, added `parentId` to wiring rules
- **`references/variables-and-expressions.md`** — Fixed loop scope docs, fixed Available Globals table, added variableUpdate scoping warning for loops, fixed script return type docs
- **`tests/tasks/uipath-maestro-flow/loop_multiply/`** — New e2e test: multiply [13, 15, 17] using a loop node with state accumulation (expected output: 3315)

## Validation

The loop_multiply e2e test passes (2/2 criteria): `uip flow validate` succeeds and `uip flow debug` returns 3315.
