### PR TITLE
feat: make planner always-on with upfront elicitation

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -66,7 +66,7 @@ jobs:
 
           if [ -z "$GLOBS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Changed skills have no test tasks — skipping smoke tests"
+            echo "::warning::Changed skills have no smoke tests: $SKILLS"
           else
             echo "task_globs=$GLOBS" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -13,7 +13,67 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect:
+    runs-on: ubuntu-latest
+    name: Detect changed skills
+    outputs:
+      task_globs: ${{ steps.detect.outputs.task_globs }}
+      skip: ${{ steps.detect.outputs.skip }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed skills and map to test tasks
+        id: detect
+        run: |
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          # If test infrastructure changed, run all smoke tests
+          if echo "$CHANGED" | grep -qE '^tests/(experiments|_shared)/|^tests/[^/]+\.(py|yaml|toml)$'; then
+            echo "task_globs=tasks/**/*.yaml" >> "$GITHUB_OUTPUT"
+            echo "Running all smoke tests (test infrastructure changed)"
+            exit 0
+          fi
+
+          # Extract unique skill names from changed paths
+          SKILLS=$(echo "$CHANGED" | grep '^skills/' | sed 's|skills/\([^/]*\)/.*|\1|' | sort -u)
+
+          # Also include skills whose test tasks changed
+          TEST_SKILLS=$(echo "$CHANGED" | grep '^tests/tasks/' | sed 's|tests/tasks/\([^/]*\)/.*|\1|' | sort -u)
+          SKILLS=$(printf '%s\n%s' "$SKILLS" "$TEST_SKILLS" | sort -u | grep -v '^$')
+
+          if [ -z "$SKILLS" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No skill changes detected — skipping smoke tests"
+            exit 0
+          fi
+
+          # Build task glob pattern for changed skills that have tests
+          GLOBS=""
+          for skill in $SKILLS; do
+            if [ -d "tests/tasks/$skill" ]; then
+              if [ -n "$GLOBS" ]; then
+                GLOBS="$GLOBS tasks/tasks/$skill/**/*.yaml"
+              else
+                GLOBS="tasks/tasks/$skill/**/*.yaml"
+              fi
+              echo "Will test: $skill"
+            else
+              echo "No tests for: $skill (skipping)"
+            fi
+          done
+
+          if [ -z "$GLOBS" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Changed skills have no test tasks — skipping smoke tests"
+          else
+            echo "task_globs=$GLOBS" >> "$GITHUB_OUTPUT"
+          fi
+
   e2e:
+    needs: detect
+    if: needs.detect.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     name: Run skill smoke tests
@@ -69,7 +129,8 @@ jobs:
         working-directory: tests
         id: smoke
         run: |
-          coder-eval run tasks/**/*.yaml \
+          echo "Running: coder-eval run ${{ needs.detect.outputs.task_globs }} --tags smoke"
+          coder-eval run ${{ needs.detect.outputs.task_globs }} \
             -e experiments/default.yaml --tags smoke -j 1 -v
         continue-on-error: true
 

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -19,6 +19,7 @@ jobs:
     outputs:
       task_globs: ${{ steps.detect.outputs.task_globs }}
       skip: ${{ steps.detect.outputs.skip }}
+      untested_skills: ${{ steps.detect.outputs.untested_skills }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -51,6 +52,7 @@ jobs:
 
           # Build task glob pattern for changed skills that have tests
           GLOBS=""
+          UNTESTED=""
           for skill in $SKILLS; do
             if [ -d "tests/tasks/$skill" ]; then
               if [ -n "$GLOBS" ]; then
@@ -60,16 +62,62 @@ jobs:
               fi
               echo "Will test: $skill"
             else
+              if [ -n "$UNTESTED" ]; then
+                UNTESTED="$UNTESTED, $skill"
+              else
+                UNTESTED="$skill"
+              fi
               echo "No tests for: $skill (skipping)"
             fi
           done
 
+          if [ -n "$UNTESTED" ]; then
+            echo "untested_skills=$UNTESTED" >> "$GITHUB_OUTPUT"
+          fi
+
           if [ -z "$GLOBS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Changed skills have no smoke tests: $SKILLS"
+            echo "::warning::Changed skills have no smoke tests: $UNTESTED"
           else
             echo "task_globs=$GLOBS" >> "$GITHUB_OUTPUT"
           fi
+
+  warn-untested:
+    needs: detect
+    if: needs.detect.outputs.untested_skills != ''
+    runs-on: ubuntu-latest
+    name: Warn about untested skills
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const skills = '${{ needs.detect.outputs.untested_skills }}';
+            const body = `⚠️ **Smoke test coverage gap** — the following changed skills have no tests under \`tests/tasks/\`:\n\n${skills.split(', ').map(s => '- `' + s + '`').join('\n')}\n\nConsider adding smoke tests before merging.`;
+
+            // Avoid duplicate comments on repeated pushes
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes('Smoke test coverage gap'));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
   e2e:
     needs: detect

--- a/README.md
+++ b/README.md
@@ -65,15 +65,11 @@ This repository works with **Claude Code**, **OpenAI Codex CLI**, and **Cursor I
 
 ### Claude Code
 
-This repository works as a **Claude Code plugin**. Install skills as a plugin marketplace for direct access to slash commands.
+This repository works as a **Claude Code plugin**. Install skills via `uip skills install` (the recommended method above) — this keeps skills updated automatically.
 
-```bash
-# Add the marketplace
-claude plugin marketplace add https://github.com/UiPath/skills
+> **Avoid manual plugin installation** (e.g., `claude plugin marketplace add` / `claude plugin install`). Manually installed plugins must be updated manually, and you may miss skill updates and fixes.
 
-# Install the plugin
-claude plugin install uipath@uipath-marketplace
-```
+If you've already installed manually, uninstall and re-install via `uip skills install` to switch to automatic updates.
 
 ### OpenAI Codex CLI
 

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -64,6 +64,16 @@ Skip if the user already specified a project type or if filesystem signals (Step
 
 **Do not ask the user to choose between XAML and C#.** Automation workflows default to XAML. Use C# coded workflows only as a fallback for parts that are too complex to build in XAML (e.g., advanced custom logic, complex data structures). The plan should note this strategy so the specialist skill applies it.
 
+### Question 3: PDD/SDD document (always ask for new automations)
+
+> Do you have a Process Definition Document (PDD) or Solution Design Document (SDD) for this automation? If so, provide the file path and I'll use it to guide the plan.
+>
+> Options: (1) Yes — provide the path, (2) No — proceed without one
+
+If the user provides a path, read the document and use it to inform the plan — it contains requirements, process steps, and design decisions that should drive skill selection and execution order.
+
+Skip this question if the user is modifying an existing automation or already referenced a document in their request.
+
 ### Default: Expression language
 
 Do not ask the user about expression language. Always use **VB.NET** for XAML workflows. Note this in the plan so the specialist skill applies it.

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -37,7 +37,7 @@ Understand what each skill can and cannot do before planning:
 
 Before any detection or planning, ask the user key questions using AskUserQuestion. Only ask questions that the user's request does not already answer. Ask questions **one at a time**, each with a recommended answer — wait for the response before asking the next.
 
-### Question 1: Generation approach (always ask for new automations)
+### Question 1: Generation approach (only for non-trivial automations)
 
 > How would you like me to work?
 >
@@ -46,7 +46,12 @@ Before any detection or planning, ask the user key questions using AskUserQuesti
 >
 > Recommended: Option 1 (explore first, then plan)
 
-Skip this question if the user is modifying an existing automation (the approach is implicitly "explore first").
+**When to ask:** Only for non-trivial automations — multi-step processes, UI automation, multi-skill workflows, or tasks with unclear scope.
+
+**Skip this question** and default to "explore & execute simultaneously" when:
+- The request is simple and well-defined (e.g., "create a workflow that reads an Excel file and logs the rows")
+- The user is modifying an existing automation (the approach is implicitly "explore first")
+- The task is a single-skill, single-step operation with clear requirements
 
 **If the user chose "explore first, then plan":**
 - You may run `uip` and `servo` commands to explore the project and live applications (e.g., `uip rpa analyze`, `servo snapshot`, `servo selector`, `servo click`, `servo type`)

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -12,7 +12,7 @@ Your job is to **elicit preferences, plan, and route** — never execute.
 2. **Always run first** — every UiPath request goes through this planner before specialist skills are loaded.
 3. Produce a plan, then stop. The main agent loads and executes the specialist skills.
 
-**Explore-first mode exception:** If the user chose "explore first, then plan" in Step 1, you MAY run read-only `uip` and `servo` commands (e.g., `uip rpa analyze`, `servo snapshot`, `servo selector`) to gather information before planning. You still must NOT write code, create files, or run commands that modify state. Enter plan mode (EnterPlanMode) to present the plan for user approval.
+**Explore-first mode exception:** If the user chose "explore first, then plan" in Step 1, you MAY run `uip` and `servo` commands to explore the project and live applications — including navigating through pages and screens. You may also save temporary notes and intermediate findings to files. You still must NOT write automation code (XAML, C#, Python) or modify the project. Enter plan mode (EnterPlanMode) to present the plan for user approval.
 
 ## When to Use This Skill
 
@@ -49,7 +49,9 @@ Before any detection or planning, ask the user key questions using AskUserQuesti
 Skip this question if the user is modifying an existing automation (the approach is implicitly "explore first").
 
 **If the user chose "explore first, then plan":**
-- You may run read-only `uip` and `servo` commands to gather project information (e.g., `uip rpa analyze`, `servo snapshot`, `servo selector`)
+- You may run `uip` and `servo` commands to explore the project and live applications (e.g., `uip rpa analyze`, `servo snapshot`, `servo selector`, `servo click`, `servo type`)
+- You may navigate through application pages and screens using `servo` to understand the full UI surface
+- You may save temporary notes and intermediate findings to files to build up context for the plan
 - After completing Steps 2–4, enter plan mode with EnterPlanMode to present the plan for user approval
 - The user reviews and approves the plan before any specialist skill executes
 
@@ -240,9 +242,9 @@ Include the user's preferences from Step 1 (generation approach, project type, e
 ## Anti-patterns — What NOT to Do
 
 1. **Do not skip Step 1 (upfront elicitation).** Always ask the generation approach question for new automations. Only skip questions the user's request already answers.
-2. **Do not write code, create files, or run state-modifying commands.** In explore-first mode you may run read-only `uip`/`servo` commands for discovery — but never write code or modify project state.
+2. **Do not write automation code or modify the project.** In explore-first mode you may run `uip`/`servo` for discovery (including UI navigation) and save temporary notes — but never write XAML, C#, Python, or modify project files.
 3. **Do not ask more than 4 questions total across all steps.** If you still cannot determine a project type after your questions, plan with the best available information.
 4. **Do not recommend a skill that doesn't match the filesystem signals.** If you see `.flow` files, don't route to `uipath-rpa`.
 5. **Do not skip Step 2.** Always check for multi-skill patterns before falling through to filesystem detection.
 6. **Do not ask the UIA question (Step 4) unless the plan actually involves `uipath-servo`.** This question is only relevant for UI automation tasks.
-7. **Do not run `uip` or `servo` commands in "explore & execute simultaneously" mode.** Only the explore-first path unlocks read-only discovery commands.
+7. **Do not run `uip` or `servo` commands in "explore & execute simultaneously" mode.** Only the explore-first path unlocks discovery commands.

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -1,24 +1,23 @@
 ---
 name: uipath-planner
-description: "UiPath task planner — plan multi-skill execution order, disambiguate overlapping skills, detect project type (.cs, .xaml, .flow, .py). Default entry for multi-step or ambiguous UiPath requests. Not needed when user names a specific domain."
+description: "UiPath task planner — ALWAYS invoke first for ANY UiPath request. Elicits preferences (C#/XAML, expression language, approach), plans multi-skill execution, detects project type (.cs, .xaml, .flow, .py), routes to specialist skills."
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
 ---
 
 # UiPath Task Planner
 
-Your job is to **plan and route** — never execute.
+Your job is to **elicit preferences, plan, and route** — never execute.
 
 1. **Do NOT** write code, XAML, JSON, or run `uip` commands.
-2. **Do NOT** use Bash for anything other than the filesystem probe in Step 2. Never run `uip`, `servo`, `npm`, or any command that modifies state.
-3. Produce a plan, then stop. The main agent loads and executes the specialist skills.
+2. **Do NOT** use Bash for anything other than the filesystem probe in Step 3. Never run `uip`, `servo`, `npm`, or any command that modifies state.
+3. **Always run first** — every UiPath request goes through this planner before specialist skills are loaded.
+4. Produce a plan, then stop. The main agent loads and executes the specialist skills.
 
 ## When to Use This Skill
 
-- The user's request is **ambiguous** — no specialist skill description matches clearly
-- The task **spans multiple skills** (e.g., build + deploy, UI discovery + automation)
-- The user asks "what can I build?" or needs help choosing a project type
-
-This planner is **not involved** for single-skill tasks with clear intent — the agent loads specialist skills directly.
+- **Always.** This planner is the mandatory entry point for every UiPath request.
+- Even when the user names a specific skill or domain (e.g., "create a coded workflow"), run the planner first to elicit preferences and emit a plan.
+- The planner ensures the right questions are asked and the right skills are loaded in the right order.
 
 ## Skill capability map
 
@@ -33,7 +32,49 @@ Understand what each skill can and cannot do before planning:
 | `uipath-platform` | Auth, Orchestrator resources, solution lifecycle (pack/publish/deploy), Integration Service, Test Manager | Yes (central auth hub) | **Yes** — the deploy destination for RPA and solutions |
 | `uipath-servo` | Interact with live desktop/browser UI — click, type, screenshot, inspect, verify. **Also the UI discovery tool**: `servo snapshot` captures UI trees, `servo selector` generates UiPath selectors for use in RPA workflows | No auth needed | **No** — local testing and discovery only, no deployment |
 
-## Step 1 — Detect multi-skill tasks
+## Step 1 — Upfront elicitation
+
+Before any detection or planning, ask the user key questions using AskUserQuestion. Only ask questions that the user's request does not already answer. Ask questions **one at a time**, each with a recommended answer — wait for the response before asking the next.
+
+### Question 1: Generation approach (always ask for new automations)
+
+> How would you like me to work?
+>
+> 1. **Explore first, then plan** — I'll analyze the project/requirements and present a plan for your approval before making any changes *(recommended)*
+> 2. **Explore, plan, and execute simultaneously** — I'll move faster by analyzing, planning, and building in one pass
+>
+> Recommended: Option 1 (explore first, then plan)
+
+Skip this question if the user is modifying an existing automation (the approach is implicitly "explore first").
+
+### Question 2: Project type (if ambiguous)
+
+Ask only if the user's request does not clearly indicate a project type (e.g., they said "automate invoices" but not whether they want C#, XAML, agent, etc.).
+
+> What type of project would you like to build?
+>
+> 1. **Automation workflow — C# coded** — best for complex logic, testability, version control *(recommended for new projects)*
+> 2. **Automation workflow — XAML low-code** — best for visual design in Studio Desktop
+> 3. **Python agent** — AI-powered with LangGraph/LlamaIndex/OpenAI Agents
+> 4. **Flow** — visual node-based orchestration connecting multiple automations
+> 5. **Coded web app** — React/Angular/Vue deployed to UiPath
+>
+> Recommended: Option 1 (C# coded workflow)
+
+Skip if the user already specified a project type or if filesystem signals (Step 3) unambiguously resolve it.
+
+### Question 3: Expression language (XAML only)
+
+Ask only if the user chose or is working with XAML workflows. C# coded workflows always use C# expressions — skip this question for them.
+
+> Which expression language for your XAML workflow?
+>
+> 1. **VB.NET** — traditional UiPath expression language *(recommended for compatibility)*
+> 2. **C#** — modern syntax, consistent with coded workflows
+>
+> Recommended: Option 1 (VB.NET)
+
+## Step 2 — Detect multi-skill tasks
 
 If the user's request clearly spans multiple skills, emit a multi-skill plan. These are the known multi-skill workflows:
 
@@ -126,9 +167,9 @@ Plan:
 
 Agents bind to published Orchestrator processes. The processes must exist and be published first.
 
-## Step 2 — Filesystem detection (for ambiguous single-skill requests)
+## Step 3 — Filesystem detection (for ambiguous single-skill requests)
 
-> **Check first:** If the request mentions deploy, publish, or Orchestrator alongside a clear domain, it likely needs a multi-skill plan from Step 1 — go back and check before proceeding here.
+> **Check first:** If the request mentions deploy, publish, or Orchestrator alongside a clear domain, it likely needs a multi-skill plan from Step 2 — go back and check before proceeding here.
 
 If the request does not clearly span multiple skills but no specialist description matched, probe the project context:
 
@@ -144,34 +185,28 @@ echo "=== CWD ===" && ls -1 project.json *.cs *.xaml *.py pyproject.toml flow_fi
 | `.venv/` AND `pyproject.toml` with uipath dependency | `uipath-agents` |
 | `project.json` exists but no `.cs` or `.xaml` files | `uipath-rpa` (the skill detects project type internally) |
 
-**Multiple signals match?** If the filesystem shows signals for more than one skill (e.g., `.cs` files AND `flow_files/*.flow`), treat it as a multi-skill scenario — go back to Step 1 and emit a multi-skill plan combining the relevant skills.
+**Multiple signals match?** If the filesystem shows signals for more than one skill (e.g., `.cs` files AND `flow_files/*.flow`), treat it as a multi-skill scenario — go back to Step 2 and emit a multi-skill plan combining the relevant skills.
 
 If a single project type is detected, emit a single-skill plan.
 
-## Step 3 — Lightweight discovery (max 2 questions)
+**No signals at all?** If the filesystem probe found nothing and Step 1 already resolved the project type, use that answer. If you still cannot determine the project type, plan with the best available information and note the assumption in the plan.
 
-Both the multi-skill patterns and filesystem produced no match. Ask the user to clarify:
+## Step 4 — UIA elicitation (only when the plan involves UI automation)
 
-1. **Ask one focused question** based on whatever weak signals exist. Include your best guess as a recommended answer.
-2. If still ambiguous, ask **one more question** to narrow down.
-3. After 2 questions, plan with the best available information.
+If the plan involves `uipath-servo` (UI discovery, UI interaction, or UI testing), ask this question before emitting the final plan:
 
-**Example — weak signal:**
-> You mentioned "automate invoices" but I don't see an existing UiPath project here. I'd recommend an **automation workflow** for this — it handles Excel and PDF extraction well. Would you prefer C# (coded) or XAML (low-code in Studio Desktop)?
+> Your plan involves UI automation. How would you like to handle UI element discovery?
 >
-> Options: (1) Automation workflow — C# coded or XAML low-code, (2) Python agent — AI-powered with LangGraph/LlamaIndex, (3) Flow — visual node-based orchestration, (4) Coded web app — React/Angular/Vue on UiPath
-
-**Example — zero signal:**
-> What would you like to build? Here are the UiPath project types:
+> 1. **Autonomous** — the agent uses Servo to automatically discover UI elements, capture selectors, and build the automation *(recommended)*
+> 2. **Guided** — you manually indicate which UI elements to target (provide screenshots, element names, or coordinates), and the agent builds selectors from your input
 >
-> 1. **Automation workflow** — C# coded or XAML low-code (best for: Excel, email, web, PDF, UI automation, API calls)
-> 2. **Python agent** — AI-powered with LangGraph/LlamaIndex/OpenAI Agents (best for: reasoning, document understanding, tool calling)
-> 3. **Flow** — Visual node-based orchestration (best for: connecting multiple automations and services)
-> 4. **Coded web app** — React/Angular/Vue deployed to UiPath (best for: internal tools, dashboards)
->
-> If you're unsure, tell me what you want to automate and I'll recommend one.
+> Recommended: Option 1 (autonomous)
 
-## Step 4 — Emit the plan
+Incorporate the answer into the plan. If guided, add a note to each Servo step that the user will provide element guidance.
+
+**Do not ask this question if the plan does not involve `uipath-servo`.** This elicitation is only relevant for UI automation tasks.
+
+## Step 5 — Emit the plan
 
 Once you have enough information, emit a numbered plan:
 
@@ -182,12 +217,14 @@ Plan:
 ```
 
 Include the user's original request as context so the specialist skill has full information.
+Include the user's preferences from Step 1 (generation approach, project type, expression language) so the specialist skill respects them.
 Do NOT execute the plan yourself. The main agent takes it from here.
 
 ## Anti-patterns — What NOT to Do
 
-1. **Do not load this planner when the user names a specific skill or domain.** If the user says "create a coded workflow" or "deploy to Orchestrator", the agent loads the specialist skill directly.
+1. **Do not skip Step 1 (upfront elicitation).** Always ask the generation approach question for new automations. Only skip questions the user's request already answers.
 2. **Do not execute any part of the plan.** No `uip` commands, no code generation, no file creation. Plan only.
-3. **Do not ask more than 2 clarifying questions.** After 2 questions, plan with the best available information. If you still cannot determine a project type, tell the user: "I couldn't determine the project type — please specify what you'd like to build (automation workflow, agent, flow, or web app)."
+3. **Do not ask more than 4 questions total across all steps.** If you still cannot determine a project type after your questions, plan with the best available information.
 4. **Do not recommend a skill that doesn't match the filesystem signals.** If you see `.flow` files, don't route to `uipath-rpa`.
-5. **Do not skip Step 1.** Always check for multi-skill patterns before falling through to filesystem detection.
+5. **Do not skip Step 2.** Always check for multi-skill patterns before falling through to filesystem detection.
+6. **Do not ask the UIA question (Step 4) unless the plan actually involves `uipath-servo`.** This question is only relevant for UI automation tasks.

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -64,16 +64,9 @@ Skip if the user already specified a project type or if filesystem signals (Step
 
 **Do not ask the user to choose between XAML and C#.** Automation workflows default to XAML. Use C# coded workflows only as a fallback for parts that are too complex to build in XAML (e.g., advanced custom logic, complex data structures). The plan should note this strategy so the specialist skill applies it.
 
-### Question 3: Expression language
+### Default: Expression language
 
-Ask only for new automation workflow projects. Skip if an existing project already has an expression language configured.
-
-> Which expression language for your workflow?
->
-> 1. **VB.NET** — traditional UiPath expression language *(recommended for compatibility)*
-> 2. **C#** — modern syntax
->
-> Recommended: Option 1 (VB.NET)
+Do not ask the user about expression language. Always use **VB.NET** for XAML workflows. Note this in the plan so the specialist skill applies it.
 
 ## Step 2 — Detect multi-skill tasks
 

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -49,28 +49,29 @@ Skip this question if the user is modifying an existing automation (the approach
 
 ### Question 2: Project type (if ambiguous)
 
-Ask only if the user's request does not clearly indicate a project type (e.g., they said "automate invoices" but not whether they want C#, XAML, agent, etc.).
+Ask only if the user's request does not clearly indicate a project type (e.g., they said "automate invoices" but not whether they want an automation, agent, flow, etc.).
 
 > What type of project would you like to build?
 >
-> 1. **Automation workflow — C# coded** — best for complex logic, testability, version control *(recommended for new projects)*
-> 2. **Automation workflow — XAML low-code** — best for visual design in Studio Desktop
-> 3. **Python agent** — AI-powered with LangGraph/LlamaIndex/OpenAI Agents
-> 4. **Flow** — visual node-based orchestration connecting multiple automations
-> 5. **Coded web app** — React/Angular/Vue deployed to UiPath
+> 1. **Automation workflow** — XAML low-code, with C# coded fallback for complex parts *(recommended)*
+> 2. **Python agent** — AI-powered with LangGraph/LlamaIndex/OpenAI Agents
+> 3. **Flow** — visual node-based orchestration connecting multiple automations
+> 4. **Coded web app** — React/Angular/Vue deployed to UiPath
 >
-> Recommended: Option 1 (C# coded workflow)
+> Recommended: Option 1 (automation workflow)
 
 Skip if the user already specified a project type or if filesystem signals (Step 3) unambiguously resolve it.
 
-### Question 3: Expression language (XAML only)
+**Do not ask the user to choose between XAML and C#.** Automation workflows default to XAML. Use C# coded workflows only as a fallback for parts that are too complex to build in XAML (e.g., advanced custom logic, complex data structures). The plan should note this strategy so the specialist skill applies it.
 
-Ask only if the user chose or is working with XAML workflows. C# coded workflows always use C# expressions — skip this question for them.
+### Question 3: Expression language
 
-> Which expression language for your XAML workflow?
+Ask only for new automation workflow projects. Skip if an existing project already has an expression language configured.
+
+> Which expression language for your workflow?
 >
 > 1. **VB.NET** — traditional UiPath expression language *(recommended for compatibility)*
-> 2. **C#** — modern syntax, consistent with coded workflows
+> 2. **C#** — modern syntax
 >
 > Recommended: Option 1 (VB.NET)
 

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: uipath-planner
 description: "UiPath task planner — ALWAYS invoke first for ANY UiPath request. Elicits preferences (C#/XAML, expression language, approach), plans multi-skill execution, detects project type (.cs, .xaml, .flow, .py), routes to specialist skills."
-allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion
+allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, EnterPlanMode, ExitPlanMode
 ---
 
 # UiPath Task Planner
 
 Your job is to **elicit preferences, plan, and route** — never execute.
 
-1. **Do NOT** write code, XAML, JSON, or run `uip` commands.
-2. **Do NOT** use Bash for anything other than the filesystem probe in Step 3. Never run `uip`, `servo`, `npm`, or any command that modifies state.
-3. **Always run first** — every UiPath request goes through this planner before specialist skills are loaded.
-4. Produce a plan, then stop. The main agent loads and executes the specialist skills.
+1. **Do NOT** write code, XAML, JSON, or create files.
+2. **Always run first** — every UiPath request goes through this planner before specialist skills are loaded.
+3. Produce a plan, then stop. The main agent loads and executes the specialist skills.
+
+**Explore-first mode exception:** If the user chose "explore first, then plan" in Step 1, you MAY run read-only `uip` and `servo` commands (e.g., `uip rpa analyze`, `servo snapshot`, `servo selector`) to gather information before planning. You still must NOT write code, create files, or run commands that modify state. Enter plan mode (EnterPlanMode) to present the plan for user approval.
 
 ## When to Use This Skill
 
@@ -40,12 +41,21 @@ Before any detection or planning, ask the user key questions using AskUserQuesti
 
 > How would you like me to work?
 >
-> 1. **Explore first, then plan** — I'll analyze the project/requirements and present a plan for your approval before making any changes *(recommended)*
+> 1. **Explore first, then plan** — I'll analyze the project/requirements, run discovery commands (`uip`, `servo`), and present a plan for your approval before making any changes *(recommended)*
 > 2. **Explore, plan, and execute simultaneously** — I'll move faster by analyzing, planning, and building in one pass
 >
 > Recommended: Option 1 (explore first, then plan)
 
 Skip this question if the user is modifying an existing automation (the approach is implicitly "explore first").
+
+**If the user chose "explore first, then plan":**
+- You may run read-only `uip` and `servo` commands to gather project information (e.g., `uip rpa analyze`, `servo snapshot`, `servo selector`)
+- After completing Steps 2–4, enter plan mode with EnterPlanMode to present the plan for user approval
+- The user reviews and approves the plan before any specialist skill executes
+
+**If the user chose "explore, plan, and execute simultaneously":**
+- Do not run `uip` or `servo` commands — stick to filesystem probing only
+- Emit the plan as text (Step 5) and the main agent starts executing immediately
 
 ### Question 2: Project type (if ambiguous)
 
@@ -222,13 +232,17 @@ Plan:
 
 Include the user's original request as context so the specialist skill has full information.
 Include the user's preferences from Step 1 (generation approach, project type, expression language) so the specialist skill respects them.
-Do NOT execute the plan yourself. The main agent takes it from here.
+
+**Explore first, then plan:** Call EnterPlanMode to present the plan. The user reviews and approves before execution begins. Use ExitPlanMode once the user approves.
+
+**Explore, plan, and execute simultaneously:** Emit the plan as text. The main agent starts executing immediately. Do NOT enter plan mode.
 
 ## Anti-patterns — What NOT to Do
 
 1. **Do not skip Step 1 (upfront elicitation).** Always ask the generation approach question for new automations. Only skip questions the user's request already answers.
-2. **Do not execute any part of the plan.** No `uip` commands, no code generation, no file creation. Plan only.
+2. **Do not write code, create files, or run state-modifying commands.** In explore-first mode you may run read-only `uip`/`servo` commands for discovery — but never write code or modify project state.
 3. **Do not ask more than 4 questions total across all steps.** If you still cannot determine a project type after your questions, plan with the best available information.
 4. **Do not recommend a skill that doesn't match the filesystem signals.** If you see `.flow` files, don't route to `uipath-rpa`.
 5. **Do not skip Step 2.** Always check for multi-skill patterns before falling through to filesystem detection.
 6. **Do not ask the UIA question (Step 4) unless the plan actually involves `uipath-servo`.** This question is only relevant for UI automation tasks.
+7. **Do not run `uip` or `servo` commands in "explore & execute simultaneously" mode.** Only the explore-first path unlocks read-only discovery commands.

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-planner
-description: "UiPath task planner — ALWAYS invoke first for ANY UiPath request. Elicits preferences (C#/XAML, expression language, approach), plans multi-skill execution, detects project type (.cs, .xaml, .flow, .py), routes to specialist skills."
+description: "UiPath task planner — elicits preferences, plans multi-skill execution, detects project type (.cs, .xaml, .flow, .py). Triggers for non-trivial or ambiguous UiPath requests. Simple single-skill tasks→specialist directly."
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, EnterPlanMode, ExitPlanMode
 ---
 
@@ -8,17 +8,17 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, EnterPlanMode, ExitPlanM
 
 Your job is to **elicit preferences, plan, and route** — never execute.
 
-1. **Do NOT** write code, XAML, JSON, or create files.
-2. **Always run first** — every UiPath request goes through this planner before specialist skills are loaded.
+1. **Do NOT** write automation code (XAML, C#, Python, JSON) or create project files.
+2. **Do NOT** use Bash for anything other than the filesystem probe in Step 3 — unless in explore-first mode (see Step 1).
 3. Produce a plan, then stop. The main agent loads and executes the specialist skills.
-
-**Explore-first mode exception:** If the user chose "explore first, then plan" in Step 1, you MAY run `uip` and `servo` commands to explore the project and live applications — including navigating through pages and screens. You may also save temporary notes and intermediate findings to files. You still must NOT write automation code (XAML, C#, Python) or modify the project. Enter plan mode (EnterPlanMode) to present the plan for user approval.
 
 ## When to Use This Skill
 
-- **Always.** This planner is the mandatory entry point for every UiPath request.
-- Even when the user names a specific skill or domain (e.g., "create a coded workflow"), run the planner first to elicit preferences and emit a plan.
-- The planner ensures the right questions are asked and the right skills are loaded in the right order.
+- The request is **non-trivial** — multi-step, multi-skill, UI automation, or unclear scope
+- The request is **ambiguous** — no single specialist skill clearly matches
+- The user asks "what can I build?" or needs help choosing a project type
+
+Skip this planner for simple, well-defined single-skill tasks (e.g., "create a workflow that sends an email") — the agent loads the specialist skill directly.
 
 ## Skill capability map
 
@@ -81,7 +81,7 @@ Skip if the user already specified a project type or if filesystem signals (Step
 
 **Do not ask the user to choose between XAML and C#.** Automation workflows default to XAML. Use C# coded workflows only as a fallback for parts that are too complex to build in XAML (e.g., advanced custom logic, complex data structures). The plan should note this strategy so the specialist skill applies it.
 
-### Question 3: PDD/SDD document (always ask for new automations)
+### Question 3: PDD/SDD document (ask for new automations)
 
 > Do you have a Process Definition Document (PDD) or Solution Design Document (SDD) for this automation? If so, provide the file path and I'll use it to guide the plan.
 >
@@ -246,9 +246,9 @@ Include the user's preferences from Step 1 (generation approach, project type, e
 
 ## Anti-patterns — What NOT to Do
 
-1. **Do not skip Step 1 (upfront elicitation).** Always ask the generation approach question for new automations. Only skip questions the user's request already answers.
+1. **Do not skip Step 1 (upfront elicitation).** Ask the generation approach question for non-trivial new automations. Only skip questions the user's request already answers.
 2. **Do not write automation code or modify the project.** In explore-first mode you may run `uip`/`servo` for discovery (including UI navigation) and save temporary notes — but never write XAML, C#, Python, or modify project files.
-3. **Do not ask more than 4 questions total across all steps.** If you still cannot determine a project type after your questions, plan with the best available information.
+3. **Do not ask more than 5 questions total across all steps.** If you still cannot determine a project type after your questions, plan with the best available information.
 4. **Do not recommend a skill that doesn't match the filesystem signals.** If you see `.flow` files, don't route to `uipath-rpa`.
 5. **Do not skip Step 2.** Always check for multi-skill patterns before falling through to filesystem detection.
 6. **Do not ask the UIA question (Step 4) unless the plan actually involves `uipath-servo`.** This question is only relevant for UI automation tasks.

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -238,9 +238,26 @@ Write the plan as a markdown file using this structure:
 # <Feature Name> Implementation Plan
 
 **Goal:** <one sentence summarizing what the automation does>
+**Source document:** <path to PDD/SDD if provided, or "None — planned from user request">
 **Project type:** <XAML / C# coded / agent / flow / app>
 **Expression language:** VB.NET
 **Approach:** <explore first / simultaneous>
+
+## Understanding
+
+<2-4 sentences explaining your interpretation of the request. What is the
+automation supposed to do end-to-end? What are the key inputs and outputs?
+Call out any assumptions you made or ambiguities you resolved during
+elicitation. If a PDD/SDD was provided, summarize the process steps and
+note which sections of the document informed each task below.>
+
+## Decisions & Trade-offs
+
+<Bullet list of key decisions made during planning and why:>
+- Why this project type was chosen
+- Why specific skills are loaded in this order
+- Any trade-offs (e.g., XAML default with C# fallback for specific parts)
+- Risks or open questions the user should be aware of
 
 ## Task 1: <skill-name> — <short description>
 

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, EnterPlanMode, ExitPlanM
 
 Your job is to **elicit preferences, plan, and route** — never execute.
 
-1. **Do NOT** write automation code (XAML, C#, Python, JSON) or create project files.
+1. **Do NOT** write automation code (XAML, C#, Python, JSON) or create project files. Plan documents are the only files you may create.
 2. **Do NOT** use Bash for anything other than the filesystem probe in Step 3 — unless in explore-first mode (see Step 1).
 3. Produce a plan, then stop. The main agent loads and executes the specialist skills.
 
@@ -61,7 +61,8 @@ Before any detection or planning, ask the user key questions using AskUserQuesti
 - The user reviews and approves the plan before any specialist skill executes
 
 **If the user chose "explore, plan, and execute simultaneously":**
-- Do not run `uip` or `servo` commands — stick to filesystem probing only
+- Create automations one at a time, processing each screen/step sequentially
+- For each automation: if UI automation is needed, use `uip` and `servo` commands to discover UI elements and capture selectors, then write the object repository and automation code, then validate before moving to the next screen/step
 - Emit the plan as text (Step 5) and the main agent starts executing immediately
 
 ### Question 2: Project type (if ambiguous)
@@ -227,18 +228,59 @@ Incorporate the answer into the plan. If guided, add a note to each Servo step t
 
 **Do not ask this question if the plan does not involve `uipath-servo`.** This elicitation is only relevant for UI automation tasks.
 
-## Step 5 — Emit the plan
+## Step 5 — Write and save the plan
 
-Once you have enough information, emit a numbered plan:
+### 5a. Plan format
 
+Write the plan as a markdown file using this structure:
+
+```markdown
+# <Feature Name> Implementation Plan
+
+**Goal:** <one sentence summarizing what the automation does>
+**Project type:** <XAML / C# coded / agent / flow / app>
+**Expression language:** VB.NET
+**Approach:** <explore first / simultaneous>
+
+## Task 1: <skill-name> — <short description>
+
+- [ ] <concrete sub-step — specific action with file paths, activity names, or commands>
+- [ ] <concrete sub-step — expected outcome or verification>
+- [ ] Validate: <what to check before moving on>
+
+## Task 2: <skill-name> — <short description>
+
+- [ ] ...
 ```
-Plan:
-1. Load <skill-name> → <what to do with it>
-2. Load <skill-name> → <what to do with it> (if multi-skill)
-```
 
-Include the user's original request as context so the specialist skill has full information.
-Include the user's preferences from Step 1 (generation approach, project type, expression language) so the specialist skill respects them.
+### 5b. Plan quality rules
+
+1. **No placeholders.** Every sub-step must include concrete details — activity names, package dependencies, file paths, CLI commands. Never write "TBD", "as needed", or "similar to Task 1".
+2. **Granular sub-steps.** Break each task into small, actionable steps. Each step should be one clear action (create file, add dependency, implement logic, validate). Aim for steps a specialist skill can execute without re-interpreting.
+3. **Checkbox syntax.** Use `- [ ]` for every sub-step so progress is trackable.
+4. **Include validation steps.** Each task must end with a validation step (build, run, test, or verify output).
+5. **Include user preferences.** The plan header must capture all preferences from Step 1 so specialist skills respect them.
+6. **Include the user's original request** as context in the Goal field.
+
+### 5c. Self-review before saving
+
+Before saving the plan, verify:
+
+1. **Coverage** — Does every requirement from the user's request appear in at least one task? If a PDD/SDD was provided, does the plan cover all process steps from the document?
+2. **Placeholder scan** — Search the plan for "TBD", "TODO", "as needed", "if appropriate", "similar to". Replace each with concrete details.
+3. **Skill consistency** — Does each task reference the correct specialist skill? Are skills loaded in the right order (e.g., RPA before platform deploy)?
+4. **Validation gaps** — Does every task end with a validation step?
+
+If the self-review finds issues, fix them before saving.
+
+### 5d. Save location
+
+Save the plan file as `YYYY-MM-DD-<feature-name>.md`:
+
+- **If a UiPath project directory exists** (detected via `project.json`, `flow_files/`, `.uipath/`, or `pyproject.toml`): save to `docs/plans/` within the project directory. Create the directory if it doesn't exist.
+- **If no project directory exists**: save to `~/Documents/UiPath/Plans/`. Create the directory if it doesn't exist.
+
+### 5e. Present the plan
 
 **Explore first, then plan:** Call EnterPlanMode to present the plan. The user reviews and approves before execution begins. Use ExitPlanMode once the user approves.
 
@@ -247,9 +289,10 @@ Include the user's preferences from Step 1 (generation approach, project type, e
 ## Anti-patterns — What NOT to Do
 
 1. **Do not skip Step 1 (upfront elicitation).** Ask the generation approach question for non-trivial new automations. Only skip questions the user's request already answers.
-2. **Do not write automation code or modify the project.** In explore-first mode you may run `uip`/`servo` for discovery (including UI navigation) and save temporary notes — but never write XAML, C#, Python, or modify project files.
+2. **Do not write automation code or modify the project.** You may create plan documents (Step 5) and temporary notes. In explore-first mode you may also run `uip`/`servo` for discovery (including UI navigation) — but never write XAML, C#, Python, or modify project files.
 3. **Do not ask more than 5 questions total across all steps.** If you still cannot determine a project type after your questions, plan with the best available information.
 4. **Do not recommend a skill that doesn't match the filesystem signals.** If you see `.flow` files, don't route to `uipath-rpa`.
 5. **Do not skip Step 2.** Always check for multi-skill patterns before falling through to filesystem detection.
 6. **Do not ask the UIA question (Step 4) unless the plan actually involves `uipath-servo`.** This question is only relevant for UI automation tasks.
-7. **Do not run `uip` or `servo` commands in "explore & execute simultaneously" mode.** Only the explore-first path unlocks discovery commands.
+7. **In "explore & execute simultaneously" mode, only run `uip` and `servo` commands for the automation currently being built.** Do not pre-discover the entire application — discover, build, and validate one screen/step at a time.
+8. **Do not save a plan with placeholders.** Run the self-review (Step 5c) before saving. Every sub-step must have concrete details — no "TBD", "TODO", "as needed", or "similar to Task N".


### PR DESCRIPTION
## Summary

- **Always-on planner**: The planner now triggers for every UiPath request, not just ambiguous/multi-skill ones. Removed "Not needed when user names a specific domain" from description and anti-patterns.
- **Upfront elicitation (new Step 1)**: Before any detection or planning, asks key questions via AskUserQuestion — one at a time with recommended answers:
  1. **Generation approach** — "explore first, then plan" vs "explore & execute simultaneously" (always asked for new automations)
  2. **Project type** — C#/XAML/agent/flow/app (only if ambiguous)
  3. **Expression language** — VB.NET vs C# (only if XAML)
- **UIA elicitation (new Step 4)**: When the plan involves `uipath-servo`, asks whether the user wants autonomous (default) or guided UI element discovery. Only triggered when UIA is actually needed, not upfront.
- **Max questions bumped** from 2 → 4 to accommodate the new elicitation steps
- **Steps renumbered**: old Steps 1-4 → Steps 2-5; old Step 3 (lightweight discovery) replaced by the upfront elicitation

## Test plan

- [ ] Trigger planner with a clear single-skill request (e.g., "create a coded workflow") — verify it still triggers and asks generation approach question
- [ ] Trigger planner with ambiguous request (e.g., "automate invoices") — verify it asks project type question
- [ ] Trigger planner with UI automation request — verify UIA elicitation appears in Step 4
- [ ] Trigger planner with existing project modification — verify generation approach question is skipped
- [ ] Verify description is under 250 chars (validated via hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)