### PR TITLE
feat(planner,rpa): add execution autonomy mode with stop conditions

### DIFF
--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -55,6 +55,17 @@ Ask the user key questions using AskUserQuestion. Only ask questions the request
 - Emit the plan as text in Step 5. The main agent loads the first specialist skill immediately and follows that skill's own workflow.
 - Do NOT call EnterPlanMode.
 
+### Question 2: Execution autonomy
+
+> Once execution starts, how should I handle ambiguity or scope concerns?
+>
+> 1. **Autonomous to completion** *(recommended)* — follow the plan end-to-end without stopping for confirmation. Only interrupt for the concrete hard blockers listed in the plan's `Stop conditions` section.
+> 2. **Interactive** — pause and confirm on structural decisions, scope concerns, or side-effect actions during execution.
+
+Record the answer in the plan header as `Execution autonomy`. Specialist skills read this field at runtime — in autonomous mode they do NOT re-ask decisions the plan already makes.
+
+**Skip this question** only in explore-first mode — the approval gate at plan time already scopes autonomy. Default to `autonomous` for simultaneous mode when the user does not specify.
+
 ### Project type: infer first, ask only if vague
 
 Resolve project type on your own. Stop at the first match:
@@ -78,7 +89,7 @@ Only ask if the request is genuinely vague ("I want to build something with UiPa
 
 If the user picks **RPA workflow**, record `Project type: XAML` and move on. **Never follow up with "XAML or C#?"** — that authoring-mode decision belongs to `uipath-rpa`, not the planner. Coded mode is set only when the user independently says "coded workflow" or ".cs file" (which rule 1 above already honors); never as a follow-up.
 
-### Question 2: PDD/SDD document (new automations)
+### Question 3: PDD/SDD document (new automations)
 
 > Do you have a Process Definition Document (PDD) or Solution Design Document (SDD)? If so, provide the file path and I'll use it to guide the plan.
 
@@ -223,6 +234,7 @@ Record the answers in the plan header. **The handoff is informational** — `uip
 **Project type:** <XAML (default for RPA workflows) / C# coded (only if user explicitly asked) / AI Agent / Flow / Application>
 **Expression language:** VB.NET (XAML only; N/A for coded / AI Agent / Flow / Application)
 **Approach:** <explore first / simultaneous>
+**Execution autonomy:** <autonomous / interactive>
 **App type:** <web / desktop / citrix / N/A>
 **App state:** <open-and-ready / user-will-open / skip-discovery / N/A>
 **UI targeting:** <agent-builds-you-review / user-indicates / N/A>
@@ -239,6 +251,19 @@ was provided and note which sections informed each task.>
 - Why specific skills are loaded in this order
 - Trade-offs (e.g., XAML default with C# fallback for specific parts)
 - Risks or open questions
+
+## Stop conditions
+
+<Only populate when `Execution autonomy` is `autonomous`. List the concrete hard blockers that MUST interrupt execution — everything else is handled without asking the user. Examples:
+- Authentication fails and cannot be recovered without user credentials
+- The target application is unresponsive after a reasonable retry window
+- A UI element cannot be captured reliably after 3 selector-improvement attempts
+- The plan references a file, package, or resource that does not exist and cannot be created
+- A pre-existing record would block idempotent execution and cleanup is ambiguous
+
+In `interactive` mode this section is optional — the user is available to resolve ambiguity as it arises.
+
+"Scope feels large", "many tool calls used", "natural pause point", and "partial result looks usable" are NOT stop conditions. If it is not in this list, the executor continues.>
 
 ## Task 1: <skill-name> — <short description>
 
@@ -258,6 +283,7 @@ was provided and note which sections informed each task.>
 3. **Checkbox syntax.** `- [ ]` on every sub-step.
 4. **End every task with a validation step** (build, run, test, or verify output).
 5. **Capture all Step 1 preferences in the plan header.**
+5a. **Autonomous plans MUST include a populated Stop conditions section.** Without concrete stop items, downstream specialists have no way to distinguish "keep going" from "ask the user" and will default to asking — defeating autonomous mode.
 6. **Route — do not redescribe.** The plan says WHICH skill to load and IN WHAT ORDER. It does NOT describe the skill's internal flow (e.g., target-configuration procedures, OR registration steps, XAML authoring pipelines, auth flows). Each specialist's own docs own those details.
 
 ### 5c. Self-review before saving
@@ -298,3 +324,4 @@ Save as `YYYY-MM-DD-<feature-name>.md`:
 12. **Do not add a third option to the UI-targeting question.** Only two options exist: "I build it, you review it" (default) and "You indicate each element". Never invent a third "build it manually", "I'll do it in Studio", or "skip targeting" option — a developer choosing manual authoring wouldn't be using a coding agent, and adding it creates analysis paralysis for no gain.
 13. **Do not leak internal jargon or implementation details into user-facing questions.** Never mention "Servo", "snapshot", "hand-wire", "AutomationId", "selector candidate", "autonomous capture", "target configuration", "wire up later", or other internal terms. Never expose the runtime / framework / language stack in option labels or descriptions: no "Python agent", "Coded web app", "React / Angular / Vue", "LangGraph / LlamaIndex". Use the product category instead — "AI Agent", "Application", "RPA workflow". Speak in plain developer language: "the live app", "Studio", "elements", "selectors", "inspect", "discover". Implementation details are the specialist skill's concern, not the user's.
 14. **Do not inject the user's domain or app name into the question text.** Ask "What kind of application are we automating?" — not "What kind of HR application…". "Is the app open on your machine?" — not "Is the HR app open…". The domain is captured in the plan header; keeping questions generic makes them reusable and prevents the agent from sounding like it's reading back a template.
+15. **Do not omit `Execution autonomy` from the plan header, and do not leave `Stop conditions` empty when autonomy is `autonomous`.** Downstream specialists rely on both to decide whether to interrupt. If the user did not answer the autonomy question, default to `autonomous` for simultaneous mode and note that choice in Decisions & Trade-offs. Populate Stop conditions with the hard blockers realistic for this specific plan (auth, app state, element-capture limits, missing resources) — do not leave a generic placeholder.

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -94,6 +94,16 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 6. **For UI automation workflows**, MUST follow the target configuration workflow in [references/ui-automation-guide.md](references/ui-automation-guide.md). NEVER hand-write selectors — use `uia-configure-target` exclusively.
 7. **Use `--output json`** on all CLI commands whose output is parsed programmatically.
 
+### Execution Discipline (Both Modes)
+
+**Run to completion — do not declare work done while plan tasks remain.** If a plan file exists at `docs/plans/*.md` referenced by this request (or discoverable there for this feature), read its header before acting and during every checkpoint.
+
+- If the header has `Execution autonomy: autonomous`: continue until ALL plan task checkboxes are `[x]` OR a concrete item from the plan's `Stop conditions` section is hit.
+- If the header has `Execution autonomy: interactive`, or no plan file exists: use judgment and confirm with the user on material decisions.
+- Before declaring the task done, re-read the plan and enumerate any unchecked boxes. If unchecked tasks remain and no Stop condition was hit, keep going — do not summarize partial work as "Done".
+- "Feels expensive", "many tool calls used", "natural pause point", "partial result looks usable", and "too complex to continue in one session" are **NOT** Stop conditions. Only the concrete hard blockers in the plan's `Stop conditions` section count.
+- Plan decisions already made are authoritative. Do not `AskUserQuestion` about structure, file count, selector strategy, or capture approach when the plan specifies them — those questions belonged to the planner.
+
 ### Coded-Specific Rules
 
 8. **[Coded] ALWAYS inherit from `CodedWorkflow`** base class for workflow and test case classes (NOT for Coded Source Files).
@@ -276,9 +286,18 @@ Additional UIA procedures and guides:
 
 ## Completion Output
 
+**Before reporting "done", verify the plan is complete.** If a plan file at `docs/plans/*.md` drove this work:
+1. Re-read the plan and scan its task checkboxes.
+2. If any `[ ]` boxes remain AND the plan's header says `Execution autonomy: autonomous` AND no `Stop conditions` item was hit — **do not report done**. Resume execution on the next unchecked task.
+3. If unchecked boxes remain because a Stop condition was hit, name the exact stop-condition item in the report.
+4. If the plan is fully checked off, or execution autonomy is `interactive`, proceed to the report format below.
+
 When you finish a task, report to the user:
 1. **What was done** — files created, edited, or deleted (list file paths)
 2. **Validation status** — whether all files passed validation (or remaining errors)
-3. **How to run** — the `uip rpa run-file --use-studio` command (if applicable)
-4. **Next steps** — follow-up actions (configure connections, add OR elements, fill placeholders)
-5. **Trouble?** — if the user hit issues during this session, mention: "If something didn't work as expected, use `/uipath-feedback` to send a report."
+3. **Plan completion** — which task checkboxes in `docs/plans/*.md` are now `[x]`; list any still `[ ]` and, for each, the Stop-condition item that interrupted it (or "not reached" if execution was cut short another way)
+4. **How to run** — the `uip rpa run-file --use-studio` command (if applicable)
+5. **Next steps** — follow-up actions (configure connections, add OR elements, fill placeholders)
+6. **Trouble?** — if the user hit issues during this session, mention: "If something didn't work as expected, use `/uipath-feedback` to send a report."
+
+Do NOT use framing like "complete", "done", "finished", or "the automation is built" unless every plan task is checked off. "Partial", "stopped at <task N>", or "blocked by <stop condition>" is the honest framing otherwise.


### PR DESCRIPTION
## Summary
- Adds a new **Execution autonomy** question to `uipath-planner` (autonomous vs. interactive) and a **Stop conditions** section to the plan template, so autonomous plans must declare concrete hard blockers up front.
- Adds an **Execution Discipline** block and **Completion Output** gating to `uipath-rpa` so the executor runs plans to completion, refuses to declare "done" while unchecked tasks remain, and only interrupts on plan-specified stop conditions.
- Prevents premature "partial result looks usable" handoffs by enumerating what is explicitly NOT a stop condition ("feels expensive", "many tool calls", "natural pause point").

## Test plan
- [ ] Run `/uipath-planner` on a simultaneous-mode RPA request and confirm the autonomy question fires and the generated plan header contains `Execution autonomy:` plus a populated `Stop conditions` section.
- [ ] Run `uipath-rpa` against an autonomous plan with multiple tasks and verify it does not stop mid-plan without hitting a declared stop condition.
- [ ] Run `uipath-rpa` against an interactive plan and verify prompting behavior is unchanged.
- [ ] `hooks/validate-skill-descriptions.sh` still passes for both skills.