### PR TITLE
fix(ci): prevent grep exit code 1 from aborting skill detection

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -42,7 +42,7 @@ jobs:
 
           # Also include skills whose test tasks changed
           TEST_SKILLS=$(echo "$CHANGED" | grep '^tests/tasks/' | sed 's|tests/tasks/\([^/]*\)/.*|\1|' | sort -u)
-          SKILLS=$(printf '%s\n%s' "$SKILLS" "$TEST_SKILLS" | sort -u | grep -v '^$')
+          SKILLS=$(printf '%s\n%s' "$SKILLS" "$TEST_SKILLS" | sort -u | grep -v '^$' || true)
 
           if [ -z "$SKILLS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
When no changed files match skills/ or tests/tasks/, grep -v '^$' returns exit code 1 (no matches), which kills the script under bash -e before reaching the graceful skip logic.