### PR TITLE
fix(ci): correct smoke-tests glob path

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -56,9 +56,9 @@ jobs:
           for skill in $SKILLS; do
             if [ -d "tests/tasks/$skill" ]; then
               if [ -n "$GLOBS" ]; then
-                GLOBS="$GLOBS tasks/tasks/$skill/**/*.yaml"
+                GLOBS="$GLOBS tasks/$skill/**/*.yaml"
               else
-                GLOBS="tasks/tasks/$skill/**/*.yaml"
+                GLOBS="tasks/$skill/**/*.yaml"
               fi
               echo "Will test: $skill"
             else


### PR DESCRIPTION
## Summary

- Remove duplicated `tasks/` prefix in the smoke-skills workflow glob so tests are actually found

## The bug

The workflow builds the glob as `tasks/tasks/<skill>/**/*.yaml` and runs with `working-directory: tests`, which means it looks for `tests/tasks/tasks/<skill>/...` — a path that doesn't exist. Every smoke test run logs:

\`\`\`
Running: coder-eval run tasks/tasks/<skill>/**/*.yaml --tags smoke
...
No task files found!
##[error]Process completed with exit code 1.
\`\`\`

This affects every PR that has a smoke test (not just new ones). See UiPath/skills#219 job run for an example failure.

## Test plan

- [ ] Confirm the workflow runs on this PR (no smoke tests exist for the workflow file itself, but check that the syntax is valid)
- [ ] After merge, verify a downstream PR with a smoke test (e.g. #219) runs `Run skill smoke tests` successfully instead of failing at "No task files found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)