### PR TITLE
fix(maestro-flow): show Studio Web URL and instanceId at top of debug summary

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -221,12 +221,27 @@ Common error categories:
 After validation passes, the user may want to test the flow end-to-end. **Do not run this without explicit user consent** — debug executes the flow for real (sends emails, posts messages, calls APIs). See Critical Rule #9.
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip flow debug <path-to-project-dir>
+UIPCLI_LOG_LEVEL=info uip flow debug <path-to-project-dir> --output json
 ```
 
 The argument is the **project directory path** (the folder containing `project.uiproj`). Use `<ProjectName>/` from the solution dir, or `.` if already inside the project dir. This uploads the project to Studio Web, triggers a debug session in Orchestrator, and streams results.
 
 > **Note:** Requires `uip login`. Debug is for **testing that the flow runs correctly** — not for publishing or viewing. To publish, use Step 8 instead.
+
+#### Debug output — surface the Studio Web URL and instanceId first
+
+When reporting debug results back to the user, the **first two lines of the summary MUST be the Studio Web URL and the instanceId**, in that order, each on its own line and clearly labeled. Parse them from the `uip flow debug --output json` response (`Data.studioWebUrl` / `Data.instanceId`, or the equivalent fields in the streamed output — fall back to regex-scraping the stdout if the JSON shape differs). Only after those two lines should the rest of the run summary follow (status, duration, node traces, errors, etc.).
+
+Required format:
+
+```
+Studio Web URL: <url>
+Instance ID: <instanceId>
+
+<the rest of the summary — status, node traces, errors, etc.>
+```
+
+If either value is missing from the CLI output, say so explicitly on that line (e.g., `Studio Web URL: <not returned by CLI>`) rather than omitting the line — the user should never have to scroll for these.
 
 ### Step 8 — Publish to Studio Web
 

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -228,20 +228,7 @@ The argument is the **project directory path** (the folder containing `project.u
 
 > **Note:** Requires `uip login`. Debug is for **testing that the flow runs correctly** — not for publishing or viewing. To publish, use Step 8 instead.
 
-#### Debug output — surface the Studio Web URL and instanceId first
-
-When reporting debug results back to the user, the **first two lines of the summary MUST be the Studio Web URL and the instanceId**, in that order, each on its own line and clearly labeled. Parse them from the `uip flow debug --output json` response (`Data.studioWebUrl` / `Data.instanceId`, or the equivalent fields in the streamed output — fall back to regex-scraping the stdout if the JSON shape differs). Only after those two lines should the rest of the run summary follow (status, duration, node traces, errors, etc.).
-
-Required format:
-
-```
-Studio Web URL: <url>
-Instance ID: <instanceId>
-
-<the rest of the summary — status, node traces, errors, etc.>
-```
-
-If either value is missing from the CLI output, say so explicitly on that line (e.g., `Studio Web URL: <not returned by CLI>`) rather than omitting the line — the user should never have to scroll for these.
+**Debug summary format:** Start the report with `Studio Web URL: <url>` and `Instance ID: <instanceId>` on the first two lines (parse `Data.studioWebUrl` / `Data.instanceId` from the JSON output). Use `<not returned by CLI>` if missing — never omit the line. See [flow-commands.md — uip flow debug](references/flow-commands.md#uip-flow-debug).
 
 ### Step 8 — Publish to Studio Web
 

--- a/skills/uipath-maestro-flow/references/flow-commands.md
+++ b/skills/uipath-maestro-flow/references/flow-commands.md
@@ -74,10 +74,10 @@ uip solution upload <SolutionDir> --output json
 Debug a Flow in the cloud via Studio Web + Orchestrator. **Requires `uip login`.**
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip flow debug <path-to-project-dir>
+UIPCLI_LOG_LEVEL=info uip flow debug <path-to-project-dir> --output json
 
 # Pass input arguments to the flow
-UIPCLI_LOG_LEVEL=info uip flow debug <path-to-project-dir> \
+UIPCLI_LOG_LEVEL=info uip flow debug <path-to-project-dir> --output json \
   --inputs '{"numberA": 5, "numberB": 7}'
 ```
 
@@ -86,6 +86,19 @@ The argument is the **project directory path** (the folder containing `project.u
 Use `--inputs` to pass a JSON object of input arguments when the flow has input parameters (e.g. trigger inputs or workflow arguments).
 
 Run `uip flow debug --help` to discover additional options.
+
+### Reporting the run back to the user
+
+The CLI response includes a **Studio Web URL** (where the user can inspect the run) and an **instanceId** (for log/trace correlation). Parse both from the JSON output — typically `Data.studioWebUrl` and `Data.instanceId` — and **always show them as the first two lines of the summary** you report back to the user:
+
+```
+Studio Web URL: <url>
+Instance ID: <instanceId>
+
+<run status, node traces, errors, etc.>
+```
+
+If either value is not present in the response, emit the label with `<not returned by CLI>` rather than dropping the line. Do not bury these values below the run summary — the user should see them immediately without scrolling.
 
 ## uip flow process
 


### PR DESCRIPTION
## Summary

- When reporting results from `uip flow debug`, surface the **Studio Web URL** and **instanceId** as the first two lines of the summary so users can immediately click through to inspect the run or correlate logs — no scrolling past node traces.
- Updates Step 7 in `SKILL.md` with a required summary format and parsing guidance.
- Updates the `uip flow debug` section in `references/flow-commands.md` with a matching "Reporting the run back to the user" subsection.
- Adds `--output json` to the documented debug commands so the two fields can be parsed reliably from `Data.studioWebUrl` / `Data.instanceId`.

## Test plan

- [ ] Run `uip flow debug <ProjectDir> --output json` on a validated flow and confirm `Data.studioWebUrl` + `Data.instanceId` are present
- [ ] Trigger a debug via the skill and verify the reported summary starts with `Studio Web URL:` and `Instance ID:` on the first two lines
- [ ] Confirm fallback behavior — when a field is missing, the line still appears with `<not returned by CLI>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)