### PR TITLE
chore: add E2E edit scenarios and multi-step pipeline tests

### DIFF
--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -18,6 +18,10 @@ For generic node/edge add, delete, and wiring procedures, see [flow-editing-oper
 
 ---
 
+## Critical: Connector Definition Must Include `form`
+
+> When writing a connector definition in the `definitions` array, you **must** include the `form` field from the `registry get` output. The `form` contains a `connectorDetail.configuration` JSON string that `uip flow node configure` reads to build the runtime configuration. Without it, `node configure` fails with `No instanceParameters found in definition`. Copy the full `form` object from `uip flow registry get <nodeType> --output json` → `Data.Node.form` into your definition.
+
 ## Configuration Workflow
 
 Follow these steps for every connector node.

--- a/skills/uipath-maestro-flow/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/impl.md
@@ -12,6 +12,10 @@ uip flow registry get core.action.http --output json
 
 Confirm: input port `input`, output ports `default` + dynamic `branch-{id}`, required inputs `method` and `url`.
 
+## Critical: `model` Field
+
+> **Never hardcode the `model` field.** The HTTP node requires a `model.expansion` block for the BPMN engine to capture outputs into flow variables at runtime. Without it, `$vars.{nodeId}.output` will be `null` after execution even though the node completes successfully. Always copy the full `model` object from `uip flow registry get core.action.http --output json` → `Data.Node.model`. The examples below use `"<COPY_FROM_REGISTRY>"` as a placeholder — replace it with the actual model from the registry.
+
 ## JSON Structure
 
 ### Basic GET
@@ -46,7 +50,7 @@ Confirm: input port `input`, output ports `default` + dynamic `branch-{id}`, req
       "var": "error"
     }
   },
-  "model": { "type": "bpmn:ServiceTask" }
+  "model": "<COPY_FROM_REGISTRY>"
 }
 ```
 
@@ -81,7 +85,7 @@ Confirm: input port `input`, output ports `default` + dynamic `branch-{id}`, req
       "var": "error"
     }
   },
-  "model": { "type": "bpmn:ServiceTask" }
+  "model": "<COPY_FROM_REGISTRY>"
 }
 ```
 
@@ -123,7 +127,7 @@ Confirm: input port `input`, output ports `default` + dynamic `branch-{id}`, req
       "var": "error"
     }
   },
-  "model": { "type": "bpmn:ServiceTask" }
+  "model": "<COPY_FROM_REGISTRY>"
 }
 ```
 

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
@@ -1,0 +1,46 @@
+task_id: skill-flow-add-node
+description: >
+  Add a script node to an existing BellevueWeather flow that converts the
+  temperature from Fahrenheit to Celsius between the HTTP fetch and the
+  format-summary step. Exercises inserting a node into an existing edge.
+tags: [uipath-maestro-flow, e2e, edit, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: "../templates/initial_flow"
+
+initial_prompt: |
+  Add a script node called "convertToCelsius" between getWeather and formatSummary that converts the temp from F to C. Return both values. Also update formatSummary to include the Celsius value in its summary string.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow debug runs and output contains Celsius conversion"
+    command: "python3 $TASK_DIR/check_add_node.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/check_add_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/check_add_node.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Add-node check: convertToCelsius node exists and flow debug produces output with a Celsius value."""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    find_project_dir,
+    run_debug,
+)
+
+
+def _assert_node_exists(node_id: str) -> None:
+    """Verify a node with the given id exists in the .flow file."""
+    import glob as _glob
+
+    project_dir = find_project_dir()
+    for path in _glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+        with open(path) as f:
+            flow = json.load(f)
+        for node in flow.get("nodes") or []:
+            if node.get("id") == node_id:
+                return
+    sys.exit(f"FAIL: node '{node_id}' not found in flow")
+
+
+def _assert_edge_exists(source_id: str, target_id: str) -> None:
+    """Verify an edge from source to target exists."""
+    import glob as _glob
+
+    project_dir = find_project_dir()
+    for path in _glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+        with open(path) as f:
+            flow = json.load(f)
+        for edge in flow.get("edges") or []:
+            if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+                return
+    sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
+
+
+def main():
+    # Structural checks: the new node must exist and be wired correctly
+    _assert_node_exists("convertToCelsius")
+    _assert_edge_exists("getWeather", "convertToCelsius")
+    _assert_edge_exists("convertToCelsius", "formatSummary")
+
+    # Must still have the HTTP node
+    assert_flow_has_node_type(["core.action.http"])
+
+    # Runtime check: debug must complete and output should contain "C" (Celsius marker)
+    payload = run_debug(timeout=240)
+    assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
+    print("OK: convertToCelsius node present, wired correctly, debug output valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
@@ -1,0 +1,43 @@
+task_id: skill-flow-add-output
+description: >
+  Add a "location" field to the end node outputs in the BellevueWeather flow.
+  Exercises modifying node output mappings.
+tags: [uipath-maestro-flow, e2e, edit, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: "../templates/initial_flow"
+
+initial_prompt: |
+  Add a "location" field with value "Bellevue, WA" to the summary output of both end nodes.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow debug runs and output contains 'Bellevue, WA'"
+    command: "python3 $TASK_DIR/check_add_output.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/check_add_output.py
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/check_add_output.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Add-output check: end nodes must include 'Bellevue, WA' in their output."""
+
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    run_debug,
+)
+
+
+def main():
+    assert_flow_has_node_type(["core.action.http"])
+    payload = run_debug(timeout=240)
+    # Must still have a branch message
+    assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
+    # Must have the new location field
+    assert_outputs_contain(payload, ["Bellevue, WA"])
+    print("OK: output contains branch message and 'Bellevue, WA' location")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/check_group_to_subflow.py
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/check_group_to_subflow.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Group-to-subflow check: fetchAndFormat subflow exists and flow debug produces output."""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.flow_check import (  # noqa: E402
+    assert_outputs_contain,
+    find_project_dir,
+    run_debug,
+)
+
+
+def _load_flow() -> dict:
+    import glob as _glob
+
+    project_dir = find_project_dir()
+    for path in _glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+        with open(path) as f:
+            return json.load(f)
+    sys.exit("FAIL: no .flow file found")
+
+
+def _assert_subflow_node_exists(flow: dict) -> None:
+    """The main flow must have a node with id 'fetchAndFormat' and type 'core.subflow'."""
+    for node in flow.get("nodes") or []:
+        if node.get("id") == "fetchAndFormat" and node.get("type") == "core.subflow":
+            return
+    sys.exit("FAIL: no 'fetchAndFormat' node of type 'core.subflow' in main flow")
+
+
+def _assert_subflow_definition_exists(flow: dict) -> None:
+    """The top-level 'subflows' object must contain a 'fetchAndFormat' key."""
+    subflows = flow.get("subflows") or {}
+    if "fetchAndFormat" not in subflows:
+        sys.exit("FAIL: 'subflows.fetchAndFormat' definition missing from flow file")
+
+
+def _assert_main_flow_nodes_removed(flow: dict) -> None:
+    """getWeather and formatSummary must NOT be in the main flow's nodes."""
+    main_ids = {n.get("id") for n in flow.get("nodes") or []}
+    for removed in ("getWeather", "formatSummary"):
+        if removed in main_ids:
+            sys.exit(f"FAIL: '{removed}' should have been moved to subflow but is still in main flow nodes")
+
+
+def main():
+    flow = _load_flow()
+
+    # Structural checks
+    _assert_subflow_node_exists(flow)
+    _assert_subflow_definition_exists(flow)
+    _assert_main_flow_nodes_removed(flow)
+
+    # Runtime check
+    payload = run_debug(timeout=240)
+    assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
+    print("OK: fetchAndFormat subflow present, old nodes removed, debug output valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -1,0 +1,47 @@
+task_id: skill-flow-group-to-subflow
+description: >
+  Extract the getWeather HTTP node and formatSummary Script node into a subflow
+  named "fetchAndFormat". The subflow returns the formatted temperature data
+  and the main flow keeps the decision and end nodes. Exercises subflow creation
+  from existing nodes.
+tags: [uipath-maestro-flow, e2e, edit, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: "../templates/initial_flow"
+
+initial_prompt: |
+  Move getWeather and formatSummary into a subflow called "fetchAndFormat". The subflow should output the temperatureF value. The rest of the main flow (decision + end nodes) stays but reads from the subflow output.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow debug runs with subflow, output contains branch message"
+    command: "python3 $TASK_DIR/check_group_to_subflow.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/check_move_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/check_move_node.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Move-node check: decision before formatSummary, both branches merge into it, single end node."""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    find_project_dir,
+    run_debug,
+)
+
+
+def _load_flow() -> dict:
+    import glob as _glob
+
+    project_dir = find_project_dir()
+    for path in _glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+        with open(path) as f:
+            return json.load(f)
+    sys.exit("FAIL: no .flow file found")
+
+
+def _assert_edge_exists(flow: dict, source_id: str, target_id: str) -> None:
+    for edge in flow.get("edges") or []:
+        if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+            return
+    sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
+
+
+def _count_nodes_of_type(flow: dict, node_type: str) -> int:
+    return sum(1 for n in flow.get("nodes") or [] if n.get("type") == node_type)
+
+
+def main():
+    flow = _load_flow()
+
+    # Decision must come before formatSummary: getWeather → decision node
+    # Find the decision node id
+    decision_ids = [n["id"] for n in flow.get("nodes") or [] if n.get("type") == "core.logic.decision"]
+    if not decision_ids:
+        sys.exit("FAIL: no decision node found")
+    decision_id = decision_ids[0]
+
+    _assert_edge_exists(flow, "getWeather", decision_id)
+
+    # formatSummary must exist and be downstream of decision
+    fmt_ids = [n["id"] for n in flow.get("nodes") or [] if n.get("type") == "core.action.script"]
+    if not fmt_ids:
+        sys.exit("FAIL: no script node (formatSummary) found")
+
+    # Should have only one end node (merged)
+    end_count = _count_nodes_of_type(flow, "core.control.end")
+    if end_count != 1:
+        sys.exit(f"FAIL: expected 1 end node (merged), found {end_count}")
+
+    assert_flow_has_node_type(["core.action.http"])
+
+    # Runtime check
+    payload = run_debug(timeout=240)
+    assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
+    print("OK: decision before formatSummary, branches merged, single end node, debug valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
@@ -1,0 +1,43 @@
+task_id: skill-flow-move-node
+description: >
+  Move the decision node before formatSummary so both branches merge back into
+  formatSummary, then a single end node. Exercises reordering nodes and merging branches.
+tags: [uipath-maestro-flow, e2e, edit, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: "../templates/initial_flow"
+
+initial_prompt: |
+  Rearrange the flow so the decision happens right after the HTTP call. Both the true and false branches should merge back into formatSummary, which then goes to a single end node. formatSummary should pick the message ('nice day' or 'bring a jacket') based on which branch the decision took.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow debug runs with merged branches, output contains branch message"
+    command: "python3 $TASK_DIR/check_move_node.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/check_remove_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/check_remove_node.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Remove-node check: formatSummary node must be gone and flow must still run."""
+
+import json
+import os
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    find_project_dir,
+    run_debug,
+)
+
+
+def _assert_node_absent(node_id: str) -> None:
+    """Verify that no node with the given id exists in the .flow file."""
+    import glob as _glob
+
+    project_dir = find_project_dir()
+    for path in _glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+        with open(path) as f:
+            flow = json.load(f)
+        for node in flow.get("nodes") or []:
+            if node.get("id") == node_id:
+                sys.exit(f"FAIL: node '{node_id}' should have been removed but still exists")
+
+
+def _assert_edge_exists(source_id: str, target_id: str) -> None:
+    """Verify an edge from source to target exists."""
+    import glob as _glob
+
+    project_dir = find_project_dir()
+    for path in _glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+        with open(path) as f:
+            flow = json.load(f)
+        for edge in flow.get("edges") or []:
+            if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+                return
+    sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
+
+
+def main():
+    # Structural checks
+    _assert_node_absent("formatSummary")
+    _assert_edge_exists("getWeather", "checkTemperature")
+
+    # Must still have the HTTP node
+    assert_flow_has_node_type(["core.action.http"])
+
+    # Runtime check
+    payload = run_debug(timeout=240)
+    assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
+    print("OK: formatSummary removed, flow rewired correctly, debug output valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
@@ -1,0 +1,46 @@
+task_id: skill-flow-remove-node
+description: >
+  Remove the formatSummary script node from the BellevueWeather flow and rewire
+  the decision node to read temperature directly from the HTTP response.
+  Exercises deleting a node and reconnecting edges.
+tags: [uipath-maestro-flow, e2e, edit, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: "../templates/initial_flow"
+
+initial_prompt: |
+  Remove the formatSummary script node. The decision and end nodes should read temperature directly from the HTTP response instead.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow debug runs, formatSummary removed, output contains branch message"
+    command: "python3 $TASK_DIR/check_remove_node.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather.uipx
+++ b/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather.uipx
@@ -1,0 +1,12 @@
+{
+  "DocVersion": "1.0.0",
+  "StudioMinVersion": "2025.10.0",
+  "SolutionId": "d214b451-1bc8-420f-a0df-08de9b243934",
+  "Projects": [
+    {
+      "Type": "Flow",
+      "ProjectRelativePath": "BellevueWeather/project.uiproj",
+      "Id": "b4fd95d8-3129-40f2-a2d7-1e9bd45b234c"
+    }
+  ]
+}

--- a/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/BellevueWeather.flow
+++ b/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/BellevueWeather.flow
@@ -1,0 +1,843 @@
+{
+  "id": "51e93e69-8d7b-4543-b079-cec6c73673ff",
+  "version": "1.0.0",
+  "name": "BellevueWeather",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "core.trigger.manual",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Manual trigger" },
+      "inputs": {},
+      "outputs": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the trigger.",
+          "source": "=result.response",
+          "var": "output"
+        }
+      },
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": "916591de-a9b0-4145-9106-ac51175c293e"
+      }
+    },
+    {
+      "id": "getWeather",
+      "type": "core.action.http",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Get Bellevue Weather" },
+      "inputs": {
+        "mode": "manual",
+        "method": "GET",
+        "url": "https://api.open-meteo.com/v1/forecast?latitude=47.6101&longitude=-122.2015&current=temperature_2m&temperature_unit=fahrenheit",
+        "headers": {},
+        "queryParams": {},
+        "body": "",
+        "contentType": "application/json",
+        "timeout": "PT15M",
+        "retryCount": 0,
+        "branches": []
+      },
+      "outputs": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the HTTP request",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the HTTP request fails",
+          "source": "=result.Error",
+          "var": "error"
+        }
+      },
+      "model": { "type": "bpmn:ServiceTask" }
+    },
+    {
+      "id": "formatSummary",
+      "type": "core.action.script",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Format Weather Summary" },
+      "inputs": {
+        "script": "const tempF = $vars.getWeather.output.body.current.temperature_2m;\nconst time = $vars.getWeather.output.body.current.time;\nreturn {\n  temperatureF: tempF,\n  summary: 'Bellevue weather today: ' + tempF + 'F at ' + time\n};"
+      },
+      "outputs": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the script",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the script fails",
+          "source": "=result.Error",
+          "var": "error"
+        }
+      },
+      "model": { "type": "bpmn:ScriptTask" }
+    },
+    {
+      "id": "checkTemperature",
+      "type": "core.logic.decision",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Temp > 60F?" },
+      "inputs": {
+        "expression": "$vars.formatSummary.output.temperatureF > 60",
+        "trueLabel": "Nice Day",
+        "falseLabel": "Bring a Jacket"
+      },
+      "model": { "type": "bpmn:InclusiveGateway" }
+    },
+    {
+      "id": "endNiceDay",
+      "type": "core.control.end",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Nice Day" },
+      "inputs": {},
+      "outputs": {
+        "summary": {
+          "source": "=js:({ message: 'nice day', temperatureF: $vars.formatSummary.output.temperatureF, description: $vars.formatSummary.output.summary })"
+        }
+      },
+      "model": { "type": "bpmn:EndEvent" }
+    },
+    {
+      "id": "endBringJacket",
+      "type": "core.control.end",
+      "typeVersion": "1.0.0",
+      "display": { "label": "Bring a Jacket" },
+      "inputs": {},
+      "outputs": {
+        "summary": {
+          "source": "=js:({ message: 'bring a jacket', temperatureF: $vars.formatSummary.output.temperatureF, description: $vars.formatSummary.output.summary })"
+        }
+      },
+      "model": { "type": "bpmn:EndEvent" }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-start-getWeather",
+      "sourceNodeId": "start",
+      "sourcePort": "output",
+      "targetNodeId": "getWeather",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-getWeather-formatSummary",
+      "sourceNodeId": "getWeather",
+      "sourcePort": "default",
+      "targetNodeId": "formatSummary",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-formatSummary-checkTemperature",
+      "sourceNodeId": "formatSummary",
+      "sourcePort": "success",
+      "targetNodeId": "checkTemperature",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-checkTemperature-endNiceDay",
+      "sourceNodeId": "checkTemperature",
+      "sourcePort": "true",
+      "targetNodeId": "endNiceDay",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-checkTemperature-endBringJacket",
+      "sourceNodeId": "checkTemperature",
+      "sourcePort": "false",
+      "targetNodeId": "endBringJacket",
+      "targetPort": "input"
+    }
+  ],
+  "definitions": [
+    {
+      "nodeType": "core.trigger.manual",
+      "version": "1.0.0",
+      "category": "trigger",
+      "description": "Start workflow manually",
+      "tags": ["trigger", "start", "manual"],
+      "sortOrder": 40,
+      "display": {
+        "label": "Manual trigger",
+        "icon": "play",
+        "shape": "circle",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "output",
+              "type": "source",
+              "handleType": "output",
+              "showButton": true,
+              "constraints": {
+                "forbiddenTargetCategories": ["trigger"]
+              }
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": true
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "Data passed when manually triggering the workflow.",
+          "source": "null",
+          "var": "output"
+        }
+      },
+      "toolbarExtensions": {
+        "design": {
+          "actions": [
+            {
+              "id": "change-trigger-type",
+              "icon": "replace",
+              "label": "Change trigger type"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "core.action.http",
+      "version": "1.0.0",
+      "category": "data-operations",
+      "description": "Make API calls with branching and retry",
+      "tags": ["connector", "http", "api", "rest", "request"],
+      "sortOrder": 35,
+      "supportsErrorHandling": true,
+      "display": {
+        "label": "HTTP Request",
+        "icon": "app-window",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "branch-{item.id}",
+              "type": "source",
+              "handleType": "output",
+              "label": "{item.name}",
+              "repeat": "inputs.branches"
+            },
+            {
+              "id": "default",
+              "type": "source",
+              "handleType": "output",
+              "label": "Default"
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "debug": {
+        "runtime": "bpmnEngine"
+      },
+      "model": {
+        "type": "bpmn:ServiceTask",
+        "expansion": {
+          "processLevelVariables": [
+            {
+              "id": "{nodeId}.output",
+              "name": "output",
+              "type": "jsonSchema",
+              "elementId": "{nodeId}",
+              "custom": true
+            },
+            {
+              "condition": "hasEdgeFromHandle('error')",
+              "id": "{nodeId}.error",
+              "name": "error",
+              "type": "jsonSchema",
+              "elementId": "{nodeId}",
+              "custom": true
+            },
+            {
+              "condition": "!hasEdgeFromHandle('error')",
+              "id": "{nodeId}.boundaryError",
+              "name": "Error",
+              "type": "jsonSchema",
+              "elementId": "_Implicit_SubprocessBoundaryError_{nodeId}"
+            }
+          ],
+          "nodes": [
+            {
+              "id": "{nodeId}",
+              "type": "bpmn:SubProcess",
+              "replaceOriginal": true,
+              "data": {
+                "label": "{node.data.label}",
+                "isExpanded": true,
+                "model": {
+                  "serviceType": "BPMN.Variables",
+                  "subprocessVariables": {
+                    "inputOutputs": [
+                      {
+                        "id": "response",
+                        "name": "response",
+                        "type": "jsonSchema",
+                        "variableType": "inputOutput"
+                      },
+                      {
+                        "id": "error",
+                        "name": "error",
+                        "type": "jsonSchema",
+                        "variableType": "inputOutput"
+                      }
+                    ]
+                  },
+                  "outputs": [
+                    {
+                      "name": "output",
+                      "type": "jsonSchema",
+                      "source": "=vars.response",
+                      "var": "{nodeId}.output",
+                      "custom": true
+                    },
+                    {
+                      "name": "Error",
+                      "type": "jsonSchema",
+                      "source": "=vars.error",
+                      "var": "{nodeId}.error",
+                      "custom": true
+                    }
+                  ]
+                }
+              },
+              "nodes": [
+                {
+                  "id": "_Implicit_StartEvent_{nodeId}",
+                  "type": "bpmn:StartEvent",
+                  "parentId": "{nodeId}",
+                  "position": { "x": 0, "y": 0 },
+                  "data": { "label": "HTTP Request Start" }
+                },
+                {
+                  "id": "_Implicit_HttpTask_{nodeId}",
+                  "type": "bpmn:SendTask",
+                  "parentId": "{nodeId}",
+                  "position": { "x": 0, "y": 0 },
+                  "propagate": {
+                    "retry": {
+                      "condition": "node.data.inputs.retryCount > 0",
+                      "maxRetryCount": "node.data.inputs.retryCount",
+                      "retryBackoff": "node.data.inputs.timeout",
+                      "retryBackoffDefault": "PT1S",
+                      "retryAllErrors": "true",
+                      "retryBackoffType": "Static"
+                    }
+                  },
+                  "data": {
+                    "label": "{node.data.label}",
+                    "model": {
+                      "serviceType": "Intsvc.HttpExecution",
+                      "version": "v1",
+                      "context": [
+                        { "name": "mode", "type": "string", "source": "node.data.inputs.mode" },
+                        { "name": "method", "type": "string", "source": "node.data.inputs.method" },
+                        { "name": "url", "type": "string", "source": "node.data.inputs.url" },
+                        { "name": "headers", "type": "json", "source": "node.data.inputs.headers", "format": "json" },
+                        { "name": "parameters", "type": "json", "source": "node.data.inputs.queryParams", "format": "json" },
+                        { "name": "body", "type": "json", "source": "node.data.inputs.body", "format": "json" }
+                      ],
+                      "outputs": [
+                        { "name": "response", "type": "json", "source": "=response", "var": "response", "internal": true }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "_Implicit_EndEvent_Default_{nodeId}",
+                  "type": "bpmn:EndEvent",
+                  "parentId": "{nodeId}",
+                  "position": { "x": 0, "y": 0 },
+                  "data": { "label": "Default" }
+                },
+                {
+                  "condition": "hasEdgeFromHandle('error')",
+                  "id": "_Implicit_EndEvent_Failure_{nodeId}",
+                  "type": "bpmn:EndEvent",
+                  "parentId": "{nodeId}",
+                  "position": { "x": 0, "y": 0 },
+                  "data": { "label": "Failure" }
+                },
+                {
+                  "condition": "hasEdgeFromHandle('error')",
+                  "id": "_Implicit_BoundaryError_{nodeId}",
+                  "type": "bpmn:BoundaryEvent",
+                  "parentId": "{nodeId}",
+                  "position": { "x": 0, "y": 0 },
+                  "data": {
+                    "label": "Error",
+                    "attachedToId": "_Implicit_HttpTask_{nodeId}",
+                    "eventDefinition": {
+                      "type": "bpmn:ErrorEventDefinition",
+                      "id": "_Implicit_BoundaryError_{nodeId}_Error"
+                    },
+                    "model": {
+                      "outputs": [
+                        { "name": "Error", "type": "jsonSchema", "source": "=Error", "var": "error", "internal": true }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "edges": [
+                {
+                  "id": "_Implicit_Edge__Implicit_StartEvent_{nodeId}__Implicit_HttpTask_{nodeId}",
+                  "source": "_Implicit_StartEvent_{nodeId}",
+                  "target": "_Implicit_HttpTask_{nodeId}",
+                  "type": "bpmn:SequenceFlow",
+                  "data": {}
+                },
+                {
+                  "id": "_Implicit_Edge__Implicit_HttpTask_{nodeId}__Implicit_EndEvent_Default_{nodeId}",
+                  "source": "_Implicit_HttpTask_{nodeId}",
+                  "target": "_Implicit_EndEvent_Default_{nodeId}",
+                  "type": "bpmn:SequenceFlow",
+                  "data": {}
+                },
+                {
+                  "condition": "hasEdgeFromHandle('error')",
+                  "id": "_Implicit_Edge__Implicit_BoundaryError_{nodeId}__Implicit_EndEvent_Failure_{nodeId}",
+                  "source": "_Implicit_BoundaryError_{nodeId}",
+                  "target": "_Implicit_EndEvent_Failure_{nodeId}",
+                  "type": "bpmn:SequenceFlow",
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "condition": "!hasEdgeFromHandle('error')",
+              "id": "_Implicit_SubprocessBoundaryError_{nodeId}",
+              "type": "bpmn:BoundaryEvent",
+              "parentId": null,
+              "position": { "x": 0, "y": 0 },
+              "data": {
+                "label": "",
+                "attachedToId": "{nodeId}",
+                "eventDefinition": {
+                  "type": "bpmn:ErrorEventDefinition",
+                  "id": "_Implicit_SubprocessBoundaryError_{nodeId}_Error"
+                },
+                "model": {
+                  "outputs": [
+                    { "name": "Error", "type": "jsonSchema", "source": "=Error", "var": "{nodeId}.boundaryError" }
+                  ]
+                }
+              }
+            },
+            {
+              "id": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:ExclusiveGateway",
+              "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
+              "parentId": null,
+              "position": { "x": 0, "y": 0 },
+              "data": { "label": "Post-Subprocess Branch" }
+            }
+          ],
+          "edges": [
+            {
+              "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
+              "id": "_Implicit_Edge_{nodeId}__Implicit_PostSubprocessGateway_{nodeId}",
+              "source": "{nodeId}",
+              "target": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": {}
+            },
+            {
+              "forEach": "node.data.inputs.branches",
+              "condition": "node.data.inputs.branches.length > 0",
+              "matchOriginalEdgeByHandle": "branch-{branch.id}",
+              "preserveEdgeId": true,
+              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": {
+                "conditionExpression": "{branch.conditionExpression}",
+                "label": "{branch.name}"
+              }
+            },
+            {
+              "condition": "node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')",
+              "matchOriginalEdgeByHandle": "default",
+              "preserveEdgeId": true,
+              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": { "label": "Default" }
+            },
+            {
+              "condition": "hasEdgeFromHandle('error')",
+              "matchOriginalEdgeByHandle": "error",
+              "preserveEdgeId": true,
+              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": {
+                "conditionExpression": "=js:vars.{nodeId}.error != null || (vars.{nodeId}.output != null && vars.{nodeId}.output.statusCode >= 400)",
+                "label": "Error"
+              }
+            },
+            {
+              "condition": "node.data.inputs.branches.length === 0 && !hasEdgeFromHandle('error')",
+              "matchOriginalEdgeByHandle": "default",
+              "preserveEdgeId": true,
+              "source": "{nodeId}",
+              "type": "bpmn:SequenceFlow"
+            }
+          ]
+        }
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "mode": { "type": "string" },
+          "method": { "type": "string", "minLength": 1, "errorMessage": "Method is required" },
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(.*\\.\\S.*|.*\\$vars.*)$",
+            "errorMessage": {
+              "minLength": "URL is required",
+              "pattern": "URL must be a valid URL or variable expression"
+            }
+          },
+          "swaggerDefinition": { "type": ["object", "null"] },
+          "authenticationType": { "type": "string" },
+          "application": { "type": "string" },
+          "connection": { "type": "string" },
+          "headers": { "type": "object" },
+          "queryParams": { "type": "object" },
+          "body": { "type": "string" },
+          "contentType": { "type": "string" },
+          "timeout": {
+            "type": "string",
+            "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$",
+            "errorMessage": { "pattern": "Timeout must be in ISO 8601 duration format (e.g., PT15M, PT1H, P1D)" }
+          },
+          "retryCount": { "type": "number" },
+          "branches": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "conditionExpression": { "type": "string" }
+              }
+            }
+          }
+        },
+        "required": ["method", "url"]
+      },
+      "inputDefaults": {
+        "mode": "manual",
+        "method": "GET",
+        "url": "",
+        "swaggerDefinition": null,
+        "authenticationType": "manual",
+        "application": "",
+        "connection": "",
+        "headers": {},
+        "queryParams": {},
+        "body": "",
+        "contentType": "application/json",
+        "timeout": "PT15M",
+        "retryCount": 0,
+        "branches": []
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "HTTP response object",
+          "source": "=response",
+          "var": "output",
+          "properties": {
+            "body": { "type": "object", "description": "Response body content", "additionalProperties": true },
+            "statusCode": { "type": "number", "description": "HTTP status code" },
+            "headers": { "type": "object", "description": "Response headers", "additionalProperties": { "type": "string" } }
+          }
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": ["code", "message", "detail", "category", "status"],
+            "properties": {
+              "code": { "type": "string", "description": "Error code as a string" },
+              "message": { "type": "string", "description": "High-level error message" },
+              "detail": { "type": "string", "description": "Detailed error description" },
+              "category": { "type": "string", "description": "Error category" },
+              "status": { "type": "integer", "description": "HTTP status code" }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "core.action.script",
+      "version": "1.0.0",
+      "category": "data-operations",
+      "description": "Run custom JavaScript code",
+      "tags": ["code", "javascript", "python"],
+      "sortOrder": 35,
+      "supportsErrorHandling": true,
+      "display": {
+        "label": "Script",
+        "icon": "code",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            { "id": "input", "type": "target", "handleType": "input" }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            { "id": "success", "type": "source", "handleType": "output" }
+          ]
+        }
+      ],
+      "debug": { "runtime": "clientScript" },
+      "model": { "type": "bpmn:ScriptTask" },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "A script function is required",
+            "validationSeverity": "warning"
+          }
+        },
+        "required": ["script"]
+      },
+      "inputDefaults": { "script": "" },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the script",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the script fails",
+          "source": "=result.Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": ["code", "message", "detail", "category", "status"],
+            "properties": {
+              "code": { "type": "string", "description": "Error code as a string" },
+              "message": { "type": "string", "description": "High-level error message" },
+              "detail": { "type": "string", "description": "Detailed error description" },
+              "category": { "type": "string", "description": "Error category" },
+              "status": { "type": "integer", "description": "HTTP status code" }
+            },
+            "additionalProperties": false
+          }
+        }
+      }
+    },
+    {
+      "nodeType": "core.logic.decision",
+      "version": "1.0.0",
+      "category": "control-flow",
+      "description": "Branch based on a true/false condition",
+      "tags": ["control-flow", "if", "loop", "switch"],
+      "sortOrder": 20,
+      "display": {
+        "label": "Decision",
+        "icon": "trending-up-down",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            { "id": "input", "type": "target", "handleType": "input" }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "true",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.trueLabel}",
+              "constraints": { "minConnections": 1 }
+            },
+            {
+              "id": "false",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.falseLabel}",
+              "constraints": { "minConnections": 1 }
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "debug": { "runtime": "clientScript" },
+      "model": { "type": "bpmn:InclusiveGateway" },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "expression": { "type": "string", "minLength": 1, "errorMessage": "A condition expression is required" },
+          "trueLabel": { "type": "string" },
+          "falseLabel": { "type": "string" }
+        },
+        "required": ["expression"]
+      },
+      "outputDefinition": {
+        "matchedCase": {
+          "type": "string",
+          "description": "The label of the matched branch (true/false label)",
+          "var": "matchedCase"
+        },
+        "matchedCaseId": {
+          "type": "string",
+          "description": "The branch that was taken (true or false)",
+          "var": "matchedCaseId"
+        }
+      },
+      "inputDefaults": { "trueLabel": "True", "falseLabel": "False" }
+    },
+    {
+      "nodeType": "core.control.end",
+      "version": "1.0.0",
+      "category": "control-flow",
+      "description": "Mark the end of a workflow path",
+      "tags": ["control-flow", "end", "finish", "complete"],
+      "sortOrder": 20,
+      "display": {
+        "label": "End",
+        "icon": "circle-check",
+        "shape": "circle"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            { "id": "input", "type": "target", "handleType": "input" }
+          ]
+        }
+      ],
+      "model": { "type": "bpmn:EndEvent" }
+    }
+  ],
+  "bindings": [],
+  "variables": {
+    "globals": [
+      {
+        "id": "summary",
+        "direction": "out",
+        "type": "object",
+        "description": "Weather summary with temperature and message"
+      }
+    ],
+    "nodes": [
+      {
+        "id": "getWeather.output",
+        "type": "object",
+        "description": "HTTP response from open-meteo API",
+        "binding": { "nodeId": "getWeather", "outputId": "output" }
+      },
+      {
+        "id": "getWeather.error",
+        "type": "object",
+        "description": "Error if weather fetch fails",
+        "binding": { "nodeId": "getWeather", "outputId": "error" }
+      },
+      {
+        "id": "formatSummary.output",
+        "type": "object",
+        "description": "Formatted weather summary with temperature and description",
+        "binding": { "nodeId": "formatSummary", "outputId": "output" }
+      },
+      {
+        "id": "formatSummary.error",
+        "type": "object",
+        "description": "Error if formatting script fails",
+        "binding": { "nodeId": "formatSummary", "outputId": "error" }
+      }
+    ]
+  },
+  "layout": {
+    "nodes": {
+      "start": {
+        "position": { "x": 200, "y": 144 },
+        "size": { "width": 96, "height": 96 },
+        "collapsed": false
+      },
+      "getWeather": {
+        "position": { "x": 450, "y": 144 },
+        "size": { "width": 96, "height": 96 },
+        "collapsed": false
+      },
+      "formatSummary": {
+        "position": { "x": 700, "y": 144 },
+        "size": { "width": 96, "height": 96 },
+        "collapsed": false
+      },
+      "checkTemperature": {
+        "position": { "x": 950, "y": 144 },
+        "size": { "width": 96, "height": 96 },
+        "collapsed": false
+      },
+      "endNiceDay": {
+        "position": { "x": 1200, "y": 44 },
+        "size": { "width": 96, "height": 96 },
+        "collapsed": false
+      },
+      "endBringJacket": {
+        "position": { "x": 1200, "y": 244 },
+        "size": { "width": 96, "height": 96 },
+        "collapsed": false
+      }
+    }
+  },
+  "metadata": {
+    "createdAt": "2026-04-15T19:41:18.514Z",
+    "updatedAt": "2026-04-15T19:41:18.514Z"
+  }
+}

--- a/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/project.uiproj
+++ b/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/project.uiproj
@@ -1,0 +1,4 @@
+{
+  "Name": "BellevueWeather",
+  "ProjectType": "Flow"
+}

--- a/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/resources/solution_folder/package/BellevueWeather.json
+++ b/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/resources/solution_folder/package/BellevueWeather.json
@@ -1,0 +1,22 @@
+{
+  "docVersion": "1.0.0",
+  "resource": {
+    "name": "BellevueWeather",
+    "kind": "package",
+    "apiVersion": "orchestrator.uipath.com/v1",
+    "projectKey": "b4fd95d8-3129-40f2-a2d7-1e9bd45b234c",
+    "dependencies": [],
+    "runtimeDependencies": [],
+    "folders": [
+      {
+        "fullyQualifiedName": "solution_folder"
+      }
+    ],
+    "spec": {
+      "name": "BellevueWeather"
+    },
+    "locks": [],
+    "key": "920bcc37-e398-420d-ac60-6ddb27799ede",
+    "files": []
+  }
+}

--- a/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/resources/solution_folder/process/flow/BellevueWeather.json
+++ b/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/resources/solution_folder/process/flow/BellevueWeather.json
@@ -1,0 +1,38 @@
+{
+  "docVersion": "1.0.0",
+  "resource": {
+    "name": "BellevueWeather",
+    "kind": "process",
+    "type": "flow",
+    "apiVersion": "orchestrator.uipath.com/v1",
+    "projectKey": "b4fd95d8-3129-40f2-a2d7-1e9bd45b234c",
+    "dependencies": [
+      {
+        "kind": "package",
+        "name": "BellevueWeather"
+      }
+    ],
+    "runtimeDependencies": [],
+    "folders": [
+      {
+        "fullyQualifiedName": "solution_folder"
+      }
+    ],
+    "spec": {
+      "type": "Flow",
+      "name": "BellevueWeather",
+      "package": {
+        "key": "920bcc37-e398-420d-ac60-6ddb27799ede"
+      },
+      "inputArguments": "{}",
+      "targetFrameworkValue": "Portable",
+      "retentionAction": "Delete",
+      "retentionPeriod": 30,
+      "staleRetentionAction": "Delete",
+      "staleRetentionPeriod": 180
+    },
+    "locks": [],
+    "key": "956c194b-a420-4a06-ad49-0a120370b58f",
+    "files": []
+  }
+}

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/check_update_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/check_update_node.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""BellevueWeather: HTTP node executes and output contains one branch message."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    run_debug,
+)
+
+
+def main():
+    # Require an HTTP node in the flow — blocks agents that hardcode a
+    # branch message in a Script node without calling the weather API.
+    assert_flow_has_node_type(["core.action.http"])
+    payload = run_debug(timeout=240)
+    assert_outputs_contain(
+        payload, ["amazing day", "go home"], require_all=False
+    )
+    print("OK: HTTP node present; output contains a weather branch message")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
@@ -1,0 +1,47 @@
+task_id: skill-flow-update-node
+description: >
+  Create a UiPath Flow that fetches today's weather in Bellevue from open-meteo,
+  formats a summary with a script, and branches on temperature: if > 60F output
+  'nice day', otherwise 'bring a jacket'. Exercises HTTP, script, and decision nodes.
+tags: [uipath-maestro-flow, e2e, edit, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: "../templates/initial_flow"
+
+initial_prompt: |
+  Update the flow to ensure if temperature is greater than 60F returns a summary with a message field 'amazing day',
+  otherwise the message field should be 'go home'.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow debug runs and output contains 'amazing day' or 'go home'"
+    command: "python3 $TASK_DIR/check_update_node.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/multi_city_weather/check_multi_city_weather.py
+++ b/tests/tasks/uipath-maestro-flow/multi_city_weather/check_multi_city_weather.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Multi-city weather: loop + HTTP + script all ran, output has all 3 cities with verdicts."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    run_debug,
+)
+
+
+def main():
+    # Must have a loop and HTTP node — proves iteration + API calls
+    assert_flow_has_node_type(["core.logic.loop", "core.action.http"])
+
+    payload = run_debug(timeout=240)
+
+    # All 3 city names must appear in output — proves the loop iterated 3 times
+    assert_outputs_contain(payload, ["Seattle", "Phoenix", "New York"])
+
+    # At least one verdict must appear — proves the script classified the temp
+    assert_outputs_contain(
+        payload, ["warm", "cold"], require_all=False
+    )
+    print("OK: loop + HTTP + script all executed, all 3 cities with verdicts present")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_city_weather/multi_city_weather.yaml
@@ -1,0 +1,41 @@
+task_id: skill-flow-multi-city-weather
+description: >
+  Loop over 3 cities, fetch weather from open-meteo for each, classify warm/cold
+  with a script, collect results. Exercises Loop → HTTP → Script chaining with
+  data flowing between nodes across iterations.
+tags: [uipath-maestro-flow, e2e, generate, ootb, multi-step]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a flow called "MultiCityWeather". Loop over Seattle, Phoenix, and New York — for each city, fetch the current temperature from open-meteo (fahrenheit) and classify it as 'warm' (> 60F) or 'cold'. Output an array with all 3 results, each having the city name, temperature, and verdict.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip flow validate MultiCityWeather/MultiCityWeather/MultiCityWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow debug runs: loop + HTTP + script all execute, output contains all 3 cities"
+    command: "python3 $TASK_DIR/check_multi_city_weather.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/slack_weather_pipeline/check_slack_weather_pipeline.py
+++ b/tests/tasks/uipath-maestro-flow/slack_weather_pipeline/check_slack_weather_pipeline.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Slack weather pipeline: Slack connector + HTTP + decision all ran, output has verdict."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    run_debug,
+)
+
+
+def main():
+    # Must have both a Slack connector and an HTTP node — proves the pipeline
+    # isn't shortcutting by hardcoding the city or skipping the Slack read
+    assert_flow_has_node_type(["uipath.connector", "core.action.http"])
+
+    payload = run_debug(timeout=240)
+
+    # Verdict proves the full chain executed: Slack → Script → HTTP → Decision → End
+    assert_outputs_contain(
+        payload, ["warm office today", "cold office today"], require_all=False
+    )
+    print("OK: Slack connector + HTTP + decision all executed, verdict present")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -1,0 +1,42 @@
+task_id: skill-flow-slack-weather-pipeline
+description: >
+  Multi-step pipeline: read Slack channel description, extract city with a script,
+  fetch weather for that city via HTTP, decide warm/cold. Exercises chaining
+  Slack connector → Script → HTTP → Decision → End with data flowing between nodes.
+tags: [uipath-maestro-flow, e2e, generate, connector, multi-step]
+max_iterations: 1
+task_timeout: 2400 # this is a harder test.
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a flow called "SlackWeatherPipeline". Read the #office-bellevue Slack channel description to find out which city the office is in, then fetch the current weather for that city from open-meteo. If it's above 60F output 'warm office today', otherwise 'cold office today'.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip flow validate SlackWeatherPipeline/SlackWeatherPipeline/SlackWeatherPipeline.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow debug runs end-to-end: Slack + HTTP + decision all execute, output contains verdict"
+    command: "python3 $TASK_DIR/check_slack_weather_pipeline.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Edit scenarios (using shared BellevueWeather template):
- update_node: change end node output values
- add_node: insert node between existing nodes
- remove_node: delete node and rewire edges
- add_output: add field to node output mappings
- move_node: reorder nodes, merge branches, reduce end nodes
- group_to_subflow: extract nodes into a subflow

Multi-step pipeline tests:
- multi_city_weather: Loop → HTTP → Script across 3 cities
- slack_weather_pipeline: Slack connector → Script → HTTP → Decision

Skill doc fixes:
- http/impl.md: replaced hardcoded model with registry placeholder, added
  critical warning about missing expansion causing null outputs at runtime
- connector/impl.md: documented that definitions must include the form field
  from registry get for node configure to work

<img width="681" height="71" alt="image" src="https://github.com/user-attachments/assets/f54dd812-f9c8-4964-be14-42cc70aa3991" />
