### PR TITLE
Remove --use-studio flag from uipath-rpa skill [PILOT-4745]

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -87,8 +87,8 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 ### Common Rules (Both Modes)
 
 1. **NEVER create a project without confirming none exists.** Follow Step 0 resolution: check explicit path, project name, running Studio instances, then CWD. Only create when confirmed no project matches AND user explicitly requests creation.
-2. **ALWAYS use `uip rpa create-project --use-studio`** to create new projects — never write `project.json` or scaffolding manually.
-3. **ALWAYS validate after every file create or edit.** Run `uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio` until 0 errors. Cap at 5 fix attempts. See [references/validation-guide.md](references/validation-guide.md).
+2. **ALWAYS use `uip rpa create-project`** to create new projects — never write `project.json` or scaffolding manually.
+3. **ALWAYS validate after every file create or edit.** Run `uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json` until 0 errors. Cap at 5 fix attempts. See [references/validation-guide.md](references/validation-guide.md).
 4. **Prefer UiPath built-in activities** for Orchestrator integration, UI automation, and document handling. Prefer plain .NET / third-party packages for pure data transforms, HTTP calls, parsing.
 5. **ALWAYS ensure required package dependencies are in `project.json`** before using their activities or services.
 6. **For UI automation workflows**, MUST follow the target configuration workflow in [references/ui-automation-guide.md](references/ui-automation-guide.md). NEVER hand-write selectors — use `uia-configure-target` exclusively.
@@ -263,9 +263,7 @@ Check `project.json` → `dependencies` for the required package.
 - **If absent** → install:
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output json --use-studio
-uip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output jsonuip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json```
 
 ### Step 2 — Find activity docs (priority order)
 
@@ -296,7 +294,7 @@ When you finish a task, report to the user:
 1. **What was done** — files created, edited, or deleted (list file paths)
 2. **Validation status** — whether all files passed validation (or remaining errors)
 3. **Plan completion** — which task checkboxes in `docs/plans/*.md` are now `[x]`; list any still `[ ]` and, for each, the Stop-condition item that interrupted it (or "not reached" if execution was cut short another way)
-4. **How to run** — the `uip rpa run-file --use-studio` command (if applicable)
+4. **How to run** — the `uip rpa run-file` command (if applicable)
 5. **Next steps** — follow-up actions (configure connections, add OR elements, fill placeholders)
 6. **Trouble?** — if the user hit issues during this session, mention: "If something didn't work as expected, use `/uipath-feedback` to send a report."
 

--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -66,8 +66,7 @@ Located at `{projectRoot}/.local/docs/packages/{PackageId}/`.
 List running UiPath Studio instances and their IPC status.
 
 ```bash
-uip rpa list-instances --output json --use-studio
-```
+uip rpa list-instances --output json```
 
 No command-specific options.
 
@@ -81,8 +80,7 @@ Ensure a Studio instance is running. Resolution waterfall:
 3. Start a new instance via `--studio-dir` -- poll until available
 
 ```bash
-uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json```
 
 ---
 
@@ -93,8 +91,7 @@ uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json --use-studio
 Create a new UiPath project from a template. Also available as `uip rpa new`.
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json --use-studio
-```
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json```
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
@@ -112,8 +109,7 @@ uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json -
 Open an existing project in Studio. Only needed when explicitly loading a project that isn't already open (e.g. after `create-project`, or when switching projects). Most commands (`validate`, `run-file`) auto-resolve a Studio instance, so this is rarely required.
 
 ```bash
-uip rpa open-project --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+uip rpa open-project --project-dir "<PROJECT_DIR>" --output json```
 
 No command-specific options.
 
@@ -127,11 +123,9 @@ Run or debug a workflow file using Studio.
 
 ```bash
 # Run (default -- closes app on completion or error):
-uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-
+uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json
 # Debug (pauses on error -- keeps app open for inspection/repair):
-uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json --use-studio
-```
+uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -149,8 +143,7 @@ uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command St
 Return validation errors for a file or project. By default, forces Studio to re-validate before returning errors.
 
 ```bash
-uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json --use-studio
-```
+uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -166,8 +159,7 @@ uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json --us
 Install or update NuGet packages in the project.
 
 ```bash
-uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]' --output json --use-studio
-```
+uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]' --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -186,9 +178,7 @@ Omit `version` to automatically resolve the latest compatible version (preferred
 Get available versions for a NuGet package.
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --output json --use-studio
-uip rpa get-versions --package-id <PackageId> --include-prerelease --output json --use-studio
-```
+uip rpa get-versions --package-id <PackageId> --output jsonuip rpa get-versions --package-id <PackageId> --include-prerelease --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -204,8 +194,7 @@ uip rpa get-versions --package-id <PackageId> --include-prerelease --output json
 Get unautomated test case IDs from Test Manager.
 
 ```bash
-uip rpa get-manual-test-cases --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+uip rpa get-manual-test-cases --project-dir "<PROJECT_DIR>" --output json```
 
 No command-specific options.
 
@@ -216,8 +205,7 @@ No command-specific options.
 Get steps for specific test cases from Test Manager.
 
 ```bash
-uip rpa get-manual-test-steps --test-case-ids "id1,id2,id3" --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+uip rpa get-manual-test-steps --test-case-ids "id1,id2,id3" --project-dir "<PROJECT_DIR>" --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -409,9 +397,7 @@ When `uip` commands fail, diagnose by error category:
 Search for activities by keyword. Global search -- not limited to installed packages.
 
 ```bash
-uip rpa find-activities --query "<KEYWORD>" --output json --use-studio
-uip rpa find-activities --query "<KEYWORD>" --tags "<TAGS>" --limit 20 --output json --use-studio
-```
+uip rpa find-activities --query "<KEYWORD>" --output jsonuip rpa find-activities --query "<KEYWORD>" --tags "<TAGS>" --limit 20 --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -427,11 +413,9 @@ Get the default XAML template for an activity. Two modes depending on whether th
 
 ```bash
 # Non-dynamic activity:
-uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json --use-studio
-
+uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json
 # Dynamic activity (connector-backed):
-uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json --use-studio
-```
+uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -446,9 +430,7 @@ uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id
 Search example workflows by service tags.
 
 ```bash
-uip rpa list-workflow-examples --tags "service1,service2" --output json --use-studio
-uip rpa list-workflow-examples --tags "service1" --prefix "<PREFIX>" --limit 20 --output json --use-studio
-```
+uip rpa list-workflow-examples --tags "service1,service2" --output jsonuip rpa list-workflow-examples --tags "service1" --prefix "<PREFIX>" --limit 20 --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -463,8 +445,7 @@ uip rpa list-workflow-examples --tags "service1" --prefix "<PREFIX>" --limit 20 
 Retrieve the full XAML content of an example workflow.
 
 ```bash
-uip rpa get-workflow-example --key "<BLOB_PATH>" --output json --use-studio
-```
+uip rpa get-workflow-example --key "<BLOB_PATH>" --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -477,9 +458,7 @@ uip rpa get-workflow-example --key "<BLOB_PATH>" --output json --use-studio
 Focus an activity in the Studio designer view.
 
 ```bash
-uip rpa focus-activity --activity-id "<IDREF>" --output json --use-studio
-uip rpa focus-activity --output json --use-studio
-```
+uip rpa focus-activity --activity-id "<IDREF>" --output jsonuip rpa focus-activity --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -513,8 +492,7 @@ Use the `packageId` and `version` from results with `uip rpa new --template-pack
 Close the current project in Studio.
 
 ```bash
-uip rpa close-project --output json --use-studio
-```
+uip rpa close-project --output json```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|

--- a/skills/uipath-rpa/references/coded/coding-guidelines.md
+++ b/skills/uipath-rpa/references/coded/coding-guidelines.md
@@ -83,11 +83,11 @@ using System.Text.RegularExpressions;  // regex
 - Read at least 5 existing workflow files (or all if fewer) to understand project conventions
 - **When writing UI automation code** — follow the **Finding Descriptors** hierarchy (see [ui-automation-guide.md](../ui-automation-guide.md)) in strict order. Do NOT write any UI code until descriptors are resolved:
   1. Read `ObjectRepository.cs` — use existing descriptors if present
-  2. Inspect UILibrary/descriptor NuGet packages in `project.json` (e.g. `*.Descriptors`, `*.UILibrary`) using `uip rpa inspect-package --use-studio`. The tool checks the local NuGet cache automatically. If the package is still not found, read `.metadata` files manually at `~/.nuget/packages/<package-name>/<version>/contentFiles/any/any/.objects/` to discover App/Screen/Element hierarchy
+  2. Inspect UILibrary/descriptor NuGet packages in `project.json` (e.g. `*.Descriptors`, `*.UILibrary`) using `uip rpa inspect-package`. The tool checks the local NuGet cache automatically. If the package is still not found, read `.metadata` files manually at `~/.nuget/packages/<package-name>/<version>/contentFiles/any/any/.objects/` to discover App/Screen/Element hierarchy
   3. If descriptors are still missing — use the `uia-configure-target` skill flow (found in the UIA activity-docs) to create targets. This handles snapshot capture, element discovery, selector generation, selector improvement, and OR registration. Do NOT manually call low-level `uip rpa uia` CLI commands outside of the skill flow. Fallback: `indicate-application` / `indicate-element` if the skill docs are unavailable
   4. UITask (ScreenPlay) is ONLY for when selectors are genuinely brittle/unreliable — NEVER as a first approach
   5. NEVER bypass Object Repository by constructing `TargetAppModel` with raw URL/BrowserType
-- Use `uip rpa inspect-package --use-studio` for API discovery when documentation is unclear
+- Use `uip rpa inspect-package` for API discovery when documentation is unclear
 
 ### IResource / ILocalResource — Converting File Paths
 
@@ -120,8 +120,7 @@ if (system.PathExists(@"C:\Reports\report.pdf", PathType.File, out ILocalResourc
 - **Escape backslashes in paths** — Use `C:\\path\\file.txt` not `C:\path\file.txt` in input arguments
 
 ### Validation Loop (Critical Rule #14)
-uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>" --output json --use-studio
-
+uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>" --output json
 @../validation-guide.md
 
 ### Error Handling
@@ -152,13 +151,13 @@ C) <user-driven approach>
 
 ### Project & Code Structure
 
-- Never manually write `project.json` or `project.uiproj` when creating a new project — use `uip rpa create-project --use-studio` (Critical Rule #1)
+- Never manually write `project.json` or `project.uiproj` when creating a new project — use `uip rpa create-project` (Critical Rule #1)
 - Never generate C# code without first searching for existing .cs files (API Discovery)
 - Never edit files without reading them first
 - Never skip the `[Workflow]` or `[TestCase]` attribute on the Execute method (Critical Rule #4)
 - Never forget to inherit from `CodedWorkflow` (except Coded Source Files) (Critical Rule #3)
 - Never add `using` statements for packages not in `project.json` — causes CS errors
-- Never guess service method names — verify with existing code or `uip rpa inspect-package --use-studio`
+- Never guess service method names — verify with existing code or `uip rpa inspect-package`
 
 ### UI Automation
 
@@ -210,4 +209,4 @@ C) <user-driven approach>
 | **"Target name 'X' is not part of the current screen"** | Element descriptor used on wrong screen handle | Use the `UiTargetApp` handle from `Open`/`Attach` for the screen that owns the element |
 | **"Cannot select item. It was not found among existing items"** | `SelectItem` fails on web dropdowns | Use `TypeInto` instead of `SelectItem` for web `<select>` elements |
 | **inspect-package cannot find UILibrary package** | Package is on a private/local NuGet feed | Use `--nupkg-path` to inspect the local `.nupkg` directly, or read `.metadata` files manually from `~/.nuget/packages/<name>/<version>/contentFiles/any/any/.objects/` |
-| **Studio rejects manually created project** | Missing metadata dirs, wrong schema/version | Always use `uip rpa create-project --use-studio` instead of writing `project.json` manually |
+| **Studio rejects manually created project** | Missing metadata dirs, wrong schema/version | Always use `uip rpa create-project` instead of writing `project.json` manually |

--- a/skills/uipath-rpa/references/coded/inspect-package-guide.md
+++ b/skills/uipath-rpa/references/coded/inspect-package-guide.md
@@ -8,15 +8,13 @@ The inspect-package tool is built into the UiPath CLI. No separate build step is
 
 ### Inspect a package from a NuGet feed
 ```bash
-uip rpa inspect-package --package-name <PackageName> --package-version <Version> [--feed-url <NuGetV3FeedUrl>] --use-studio
-```
+uip rpa inspect-package --package-name <PackageName> --package-version <Version> [--feed-url <NuGetV3FeedUrl>]```
 
 When `--feed-url` is omitted, the tool downloads from the UiPath Official feed first and falls back to nuget.org.
 
 ### Inspect a local .nupkg file
 ```bash
-uip rpa inspect-package --nupkg-path <path/to/package.nupkg> --use-studio
-```
+uip rpa inspect-package --nupkg-path <path/to/package.nupkg>```
 
 Use this when the package is already cached locally (e.g. from a private feed) or when you have a `.nupkg` file on disk.
 
@@ -24,20 +22,15 @@ Use this when the package is already cached locally (e.g. from a private feed) o
 
 ```bash
 # Inspect Excel activities from UiPath feed
-uip rpa inspect-package --package-name UiPath.Excel.Activities --package-version 3.3.1 --use-studio
-
+uip rpa inspect-package --package-name UiPath.Excel.Activities --package-version 3.3.1
 # Inspect a specific version the user has
-uip rpa inspect-package --package-name UiPath.System.Activities --package-version 25.12.2 --use-studio
-
+uip rpa inspect-package --package-name UiPath.System.Activities --package-version 25.12.2
 # Inspect from a custom feed
-uip rpa inspect-package --package-name MyPackage --package-version 1.0.0 --feed-url https://my-feed/v3/index.json --use-studio
-
+uip rpa inspect-package --package-name MyPackage --package-version 1.0.0 --feed-url https://my-feed/v3/index.json
 # Inspect third-party package from nuget.org
-uip rpa inspect-package --package-name CsvHelper --package-version 33.0.1 --use-studio
-
+uip rpa inspect-package --package-name CsvHelper --package-version 33.0.1
 # Inspect a local .nupkg file directly
-uip rpa inspect-package --nupkg-path ~/.nuget/packages/csvhelper/33.0.1/csvhelper.33.0.1.nupkg --use-studio
-```
+uip rpa inspect-package --nupkg-path ~/.nuget/packages/csvhelper/33.0.1/csvhelper.33.0.1.nupkg```
 
 ## Finding the Latest Stable Version
 

--- a/skills/uipath-rpa/references/coded/integration-service-guide.md
+++ b/skills/uipath-rpa/references/coded/integration-service-guide.md
@@ -256,8 +256,7 @@ var response = await conn.ExecuteAsync(config, request);
 Run `uip rpa get-errors` on the written workflow file until 0 errors. Cap at 5 fix attempts.
 
 ```bash
-uip rpa get-errors --file-path "<WORKFLOW_FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+uip rpa get-errors --file-path "<WORKFLOW_FILE>" --project-dir "<PROJECT_DIR>" --output json```
 
 ---
 

--- a/skills/uipath-rpa/references/coded/operations-guide.md
+++ b/skills/uipath-rpa/references/coded/operations-guide.md
@@ -11,8 +11,7 @@ Creates a complete UiPath coded automation project from scratch. **ALWAYS use `u
 **1. Create the project with `uip rpa create-project`:**
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --studio-dir "<STUDIO_DIR>" --output json --use-studio
-```
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --studio-dir "<STUDIO_DIR>" --output json```
 
 **Template options:**
 - `--template-id BlankTemplate` (default) — standard process project

--- a/skills/uipath-rpa/references/coded/third-party-packages-guide.md
+++ b/skills/uipath-rpa/references/coded/third-party-packages-guide.md
@@ -64,4 +64,4 @@ With `project.json` dependency:
   - `RestSharp` (REST APIs)
   - `Polly` (retry/resilience patterns)
   - `Newtonsoft.Json` (JSON parsing - already included in most projects)
-- After identifying a package, run the `uip rpa inspect-package --use-studio` command to discover exact APIs before coding
+- After identifying a package, run the `uip rpa inspect-package` command to discover exact APIs before coding

--- a/skills/uipath-rpa/references/environment-setup.md
+++ b/skills/uipath-rpa/references/environment-setup.md
@@ -11,8 +11,7 @@ The `uip rpa` commands use `--project-dir` to target a specific project (default
 2. **Project name reference** — The user mentioned a project by name → search for a folder with that name containing `project.json`.
 3. **Detect from running Studio** — No path or name given → run:
    ```bash
-   uip rpa list-instances --output json --use-studio
-   ```
+   uip rpa list-instances --output json   ```
    Parse the JSON response. If `Data` is a non-empty array, each entry has a `ProjectDirectory` field. Use it:
    - **One instance** → use its `ProjectDirectory`.
    - **Multiple instances** → pick the best match or ask the user.
@@ -26,8 +25,7 @@ If the CWD is not the project root:
 ## Step 0.2: Verify Studio is Running
 
 ```bash
-uip rpa list-instances --output json --use-studio
-```
+uip rpa list-instances --output json```
 
 **If no instances are found or Studio is not running:**
 ```bash
@@ -36,8 +34,7 @@ uip rpa start-studio
 
 **If Studio is running but the project is not open:**
 ```bash
-uip rpa open-project --project-dir "{projectRoot}" --use-studio
-```
+uip rpa open-project --project-dir "{projectRoot}"```
 
 **If Studio IPC connection fails** (error messages about connection refused, timeout, or pipe not found):
 1. Check if Studio Desktop is actually installed on the machine
@@ -59,7 +56,7 @@ If you encounter auth errors (401, 403, "not authenticated") during any phase, p
 
 ## Step 0.4: Creating a New Project
 
-**ALWAYS use `uip rpa create-project --use-studio`** — never write `project.json`, `project.uiproj`, or other scaffolding files manually.
+**ALWAYS use `uip rpa create-project`** — never write `project.json`, `project.uiproj`, or other scaffolding files manually.
 
 ### For XAML Projects
 
@@ -71,16 +68,14 @@ uip rpa new \
   --expression-language "VisualBasic" \
   --target-framework "Windows" \
   --description "Automates invoice processing" \
-  --output json --use-studio
-```
+  --output json```
 
 **Expression language for XAML projects:** Prefer `VisualBasic` for Windows target framework projects.
 
 ### For Coded Projects
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json --use-studio
-```
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json```
 
 Use `--template-id TestAutomationProjectTemplate` for test projects, or `--template-id LibraryProcessTemplate` for libraries.
 
@@ -137,8 +132,7 @@ uip rpa new \
   --location "/path/to/parent/directory" \
   --template-package-id "<PACKAGE_ID>" \
   --template-package-version "<VERSION>" \
-  --output json --use-studio
-```
+  --output json```
 
 | Parameter | Type | Default | Notes |
 |-----------|------|---------|-------|
@@ -147,6 +141,6 @@ uip rpa new \
 
 ### After Creation
 
-1. Open the project in Studio: `uip rpa open-project --project-dir "/path/to/MyAutomation" --use-studio`
+1. Open the project in Studio: `uip rpa open-project --project-dir "/path/to/MyAutomation"`
 2. **Read the scaffolded files** — the command generates starter files. Read them before making changes so you build on valid defaults
 3. Proceed with the skill workflow using the new project root

--- a/skills/uipath-rpa/references/project-structure.md
+++ b/skills/uipath-rpa/references/project-structure.md
@@ -99,7 +99,7 @@ MyProject/
 
 ## Rules
 
-1. **Use CLI for dependencies**: Always use `uip rpa install-or-update-packages --use-studio` to add/update dependencies. Do not manually edit `dependencies` in `project.json`.
+1. **Use CLI for dependencies**: Always use `uip rpa install-or-update-packages` to add/update dependencies. Do not manually edit `dependencies` in `project.json`.
 2. **Do not edit `.local/` or `.objects/`**: These are cache directories managed by the build system.
 3. **`main` entry point**: The default entrypoint that gets run if not specified otherwise.
 4. **`--project-dir` awareness**: All `uip rpa` commands default to the current working directory. If the CWD is not the project root, pass `--project-dir "{projectRoot}"` explicitly.

--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -118,7 +118,7 @@ using <ProjectNamespace>.ObjectRepository;
 
 #### Step 2 — Check UILibrary NuGet packages
 
-Look in `project.json` → `dependencies` for packages matching `*.UILibrary`, `*.ObjectRepository`, `*.Descriptors`, or `*.UIAutomation`. Inspect with `uip rpa inspect-package --use-studio`.
+Look in `project.json` → `dependencies` for packages matching `*.UILibrary`, `*.ObjectRepository`, `*.Descriptors`, or `*.UIAutomation`. Inspect with `uip rpa inspect-package`.
 
 For UILibrary packages, use the **package** namespace, not the project namespace:
 ```csharp

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -48,11 +48,9 @@ The skill will search the Object Repository for existing matches before creating
 
 ```bash
 # 1. Indicate a screen (creates App automatically if none exists)
-uip rpa indicate-application --name "<ScreenName>" --description "<ScreenDescription>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-
+uip rpa indicate-application --name "<ScreenName>" --description "<ScreenDescription>" --project-dir "<PROJECT_DIR>" --output json
 # 2. Indicate elements on that screen (use --parent-id from step 1 result's Data.reference)
-uip rpa indicate-element --name "<ElementName>" --activity-class-name "<TypeInto|Click|GetText|...>" --parent-id "<screen-reference>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-
+uip rpa indicate-element --name "<ElementName>" --activity-class-name "<TypeInto|Click|GetText|...>" --parent-id "<screen-reference>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 Both commands return `{ "Data": { "reference": "..." } }` — use that reference ID to retrieve XAML snippets and for OR lookups. After indication, Studio regenerates Object Repository files. For coded workflows, re-read `ObjectRepository.cs` to get descriptor paths. For XAML workflows, use the reference IDs to retrieve XAML snippets and embed them into activities as the workflow is created — see **Embedding OR Entries in XAML Activities** below.

--- a/skills/uipath-rpa/references/uia-debug-workflow.md
+++ b/skills/uipath-rpa/references/uia-debug-workflow.md
@@ -11,13 +11,11 @@
    Note which windows (w-refs and titles) are already present.
 2. **Run the workflow:**
    ```bash
-   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json --use-studio
-   ```
+   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json   ```
    If the run fails, [`uia-selector-recovery.md`](uia-selector-recovery.md) spawns the `uia-improve-selector` subagent — this is the **only** correct recovery path. Do not hand-edit selectors in the XAML file.
 3. **When done** (success or failure) — **stop the debug session:**
    ```bash
-   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json --use-studio
-   ```
+   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json   ```
 4. **List windows again:**
    ```bash
    servo targets

--- a/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
+++ b/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
@@ -61,8 +61,7 @@
      --file-path "<XAML_FILE_PATH>" \
      --project-dir "<PROJECT_DIR>" \
      --output json \
-     --use-studio
-   ```
+       ```
 
 5. **Self-repair** (D-10): If `get-errors` returns errors, fix and re-run. Max 3 fix cycles. After 3 attempts, stop and report remaining errors to the main conversation. **If the CLI itself times out** (Studio unresponsive, validation hung), the agent must report `"Validation unavailable — Studio not responding; file written but unverified."` and exit — never hang.
 
@@ -90,8 +89,7 @@
      --file-path "<XAML_FILE_PATH>" \
      --project-dir "<PROJECT_DIR>" \
      --output json \
-     --use-studio
-   ```
+       ```
 
 5. **Self-repair** (D-10): Max 3 fix cycles, then report to main conversation. If the CLI times out, the agent reports the timeout explicitly — never hangs.
 
@@ -148,8 +146,7 @@ These three rules govern what the orchestrator may and may not do while a `Write
      --file-path "<XAML_FILE_PATH>" \
      --project-dir "<PROJECT_DIR>" \
      --output json \
-     --use-studio
-   ```
+       ```
    Do NOT run `run-file` as a validation step — the target application state is not guaranteed to be in the correct starting state after the pipeline.
 
 2. **Add entry point to `project.json`.** Add the new workflow to the `entryPoints[]` array:
@@ -251,8 +248,7 @@ Create a new UiPath XAML workflow file at `<OUTPUT_XAML_PATH>`.
    timeout 60000 uip rpa get-default-activity-xaml \
      --activity-class-name "UiPath.UIAutomationNext.Activities.NApplicationCard" \
      --project-dir "<PROJECT_DIR>" \
-     --output json --use-studio
-   ```
+     --output json   ```
    Use the returned XAML as-is for the NApplicationCard element.
 4. Fetch the TargetApp XAML for the registered screen:
    ```bash
@@ -274,8 +270,7 @@ Create a new UiPath XAML workflow file at `<OUTPUT_XAML_PATH>`.
 
 After writing the file:
 ```bash
-timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json```
 If it returns errors, fix and re-validate. Max 3 fix attempts. If the CLI times out (Studio unresponsive), report: "Validation unavailable — Studio not responding; file written but unverified." Do not hang.
 
 ## Placeholders
@@ -311,8 +306,7 @@ Activity class names you will use: `<ACTIVITY_CLASS_LIST>` (comma-separated, e.g
    timeout 60000 uip rpa get-default-activity-xaml \
      --activity-class-name "<class>" \
      --project-dir "<PROJECT_DIR>" \
-     --output json --use-studio
-   ```
+     --output json   ```
    Use the returned XAML as the structural base for every instance of that activity type.
 
 2. Fetch all OR element XAML snippets in a single call:
@@ -340,8 +334,7 @@ For Delay with VB: `<Delay Duration="[TimeSpan.FromSeconds(N)]" />`.
 
 After editing:
 ```bash
-timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-```
+timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json```
 Fix on error, max 3 attempts. If CLI times out, report the timeout explicitly — do NOT hang.
 
 ## Placeholders

--- a/skills/uipath-rpa/references/uia-prerequisites.md
+++ b/skills/uipath-rpa/references/uia-prerequisites.md
@@ -7,10 +7,8 @@ The `uip rpa uia` subcommands (snapshot, selector-intelligence, object-repositor
 If the installed version is below the minimum, ask the user whether to upgrade:
 
 ```bash
-uip rpa get-versions --package-id UiPath.UIAutomation.Activities --project-dir "$PROJECT_DIR" --output json --use-studio
-
+uip rpa get-versions --package-id UiPath.UIAutomation.Activities --project-dir "$PROJECT_DIR" --output json
 # If user approves the upgrade:
-uip rpa install-or-update-packages --packages '[{"id": "UiPath.UIAutomation.Activities", "version": "26.3.1-beta.11672284"}]' --project-dir "$PROJECT_DIR" --output json --use-studio
-```
+uip rpa install-or-update-packages --packages '[{"id": "UiPath.UIAutomation.Activities", "version": "26.3.1-beta.11672284"}]' --project-dir "$PROJECT_DIR" --output json```
 
 If the user declines, warn that `uip rpa uia` commands will fail and fall back to the indication tools (see [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for fallback commands).

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -16,8 +16,7 @@ After every file create or edit, validate the specific file until clean.
 
 ```
 REPEAT:
-  1. uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
-  2. IF 0 errors -> EXIT to Smoke Test
+  1. uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json  2. IF 0 errors -> EXIT to Smoke Test
   3. Identify the highest-priority error
   4. Fix one thing (see rule above)
   5. GOTO 1
@@ -45,14 +44,11 @@ After reaching 0 validation errors, run the workflow to catch runtime errors (wr
 
 ```bash
 # Run with default arguments:
-uip rpa run-file --file-path "<FILE>" --output json --use-studio
-
+uip rpa run-file --file-path "<FILE>" --output json
 # Run with input arguments:
-uip rpa run-file --file-path "<FILE>" --input-arguments '{"key": "value"}' --output json --use-studio
-
+uip rpa run-file --file-path "<FILE>" --input-arguments '{"key": "value"}' --output json
 # Run with verbose logging for debugging:
-uip rpa run-file --file-path "<FILE>" --log-level Verbose --output json --use-studio
-```
+uip rpa run-file --file-path "<FILE>" --log-level Verbose --output json```
 
 **When to run:**
 1. Workflow has no compilation errors but you want to verify runtime behavior
@@ -86,18 +82,17 @@ C) <user-driven approach>
 ```
 Read: file_path="{projectRoot}/project.json"     -> check current dependencies
 
-Bash: uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]' --use-studio
-```
+Bash: uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]'```
 
 Omit `version` to automatically resolve the latest compatible version (preferred — gets newest docs and features). Only pin a specific version when you have a reason to (e.g., known compatibility constraint).
 
 **If `install-or-update-packages` fails:**
-- **Package not found**: Verify the exact package ID — check spelling, use `uip rpa find-activities --use-studio` to discover the correct package name from an activity's assembly
+- **Package not found**: Verify the exact package ID — check spelling, use `uip rpa find-activities` to discover the correct package name from an activity's assembly
 - **Network/feed error**: The user may need to check their NuGet feed configuration in Studio settings
 
 ### Resolving Dynamic Activity Custom Types
 
-Dynamic activities (e.g., Integration Service connectors) retrieved via `uip rpa get-default-activity-xaml --use-studio` (with `--activity-type-id`) may use **JIT-compiled custom types** for their input/output properties. After the activity is added to the workflow, when you need to discover the property names and CLR types of these custom entities (e.g., to populate an `Assign` activity targeting a custom type property, or to create a variable of a custom type), read the JIT custom types schema:
+Dynamic activities (e.g., Integration Service connectors) retrieved via `uip rpa get-default-activity-xaml` (with `--activity-type-id`) may use **JIT-compiled custom types** for their input/output properties. After the activity is added to the workflow, when you need to discover the property names and CLR types of these custom entities (e.g., to populate an `Assign` activity targeting a custom type property, or to create a variable of a custom type), read the JIT custom types schema:
 
 ```
 Read: file_path="{projectRoot}/.project/JitCustomTypesSchema.json"
@@ -109,11 +104,9 @@ When `get-errors` returns an error referencing a specific activity (by IdRef or 
 
 ```bash
 # Focus a specific activity by its IdRef (from the error output):
-uip rpa focus-activity --activity-id "Assign_1" --use-studio
-
+uip rpa focus-activity --activity-id "Assign_1"
 # Focus all activities sequentially (useful for walkthrough):
-uip rpa focus-activity --use-studio
-```
+uip rpa focus-activity```
 
 This is especially useful when:
 - An error references an activity and you want the user to confirm the context

--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -273,7 +273,7 @@ The HTTP Request activity (`NetHttpRequest`) has extensive configuration:
 | `UiPath.UIAutomation.Activities` | `UiPath.UIAutomationNext.Activities` | Modern UI activities use "Next" namespace |
 | `UiPath.UIAutomation.Activities` (classic) | `UiPath.Core.Activities` | Classic UI activities are in Core |
 
-Use `uip rpa get-default-activity-xaml --use-studio` to get correct xmlns declarations — never guess namespace mappings.
+Use `uip rpa get-default-activity-xaml` to get correct xmlns declarations — never guess namespace mappings.
 
 ## Portable vs Windows Framework Limitations
 
@@ -314,9 +314,9 @@ Use `uip rpa get-default-activity-xaml --use-studio` to get correct xmlns declar
 2. Remove attributes that don't exist in the target version
 3. Cap `Version` attributes to the maximum supported by the target package
 4. Add `<AssemblyReference>netstandard</AssemblyReference>` if type resolution errors persist
-5. Use `uip rpa get-errors --use-studio` to validate after changes
+5. Use `uip rpa get-errors` to validate after changes
 
-**Prevention:** When using `uip rpa get-default-activity-xaml --use-studio`, the output matches the currently installed package version. Never copy XAML snippets from projects using different package versions.
+**Prevention:** When using `uip rpa get-default-activity-xaml`, the output matches the currently installed package version. Never copy XAML snippets from projects using different package versions.
 
 ## Expression Language Mismatch
 
@@ -354,7 +354,7 @@ Common validation error: `"The type 'Dictionary<,>' is defined in an assembly th
 <AssemblyReference>System.Collections</AssemblyReference>
 ```
 
-**Note:** If you're adding activities manually or the references are missing from an existing file, you may need to add them through `uip rpa install-or-update-packages --use-studio`.
+**Note:** If you're adding activities manually or the references are missing from an existing file, you may need to add them through `uip rpa install-or-update-packages`.
 
 ## Invalid Use of `x:` Prefix for Non-Builtin CLR Types
 
@@ -524,7 +524,7 @@ The same registration rules apply to `<upa:ProcessDiagram>` and its node types (
 - `PropertyName="{x:Null}"` explicitly sets a property to null — this is serialized and persisted
 - Omitting a property entirely means "use the default value" — which may or may not be null
 - Some activities behave differently when a property is explicitly null vs absent (e.g., `Filter="{x:Null}"` may disable filtering, while omitting `Filter` uses a default filter)
-- When `uip rpa get-default-activity-xaml --use-studio` outputs properties with `{x:Null}`, preserve them — removing them may change behavior
+- When `uip rpa get-default-activity-xaml` outputs properties with `{x:Null}`, preserve them — removing them may change behavior
 
 ## Literal Curly Braces in Attribute Values
 
@@ -574,7 +574,7 @@ The `.project/JitCustomTypesSchema.json` file can be missing or outdated.
 
 ### `get-errors --file-path` requires relative paths
 
-The `--file-path` parameter of `uip rpa get-errors --use-studio` must be a path **relative to the project directory**:
+The `--file-path` parameter of `uip rpa get-errors` must be a path **relative to the project directory**:
 - Correct: `--file-path "Workflows/SendEmail.xaml"`
 - Wrong: `--file-path "C:\Users\me\Projects\MyProject\Workflows\SendEmail.xaml"`
 
@@ -587,9 +587,9 @@ All `uip rpa` commands default to the current working directory as the project r
 ### Studio IPC connection failures
 
 `uip rpa` commands communicate with Studio Desktop via IPC. If Studio is not running, not responding, or has no project open, commands will fail with connection errors. Recovery steps:
-1. `uip rpa list-instances --output json --use-studio` — check if Studio is running
+1. `uip rpa list-instances --output json` — check if Studio is running
 2. `uip rpa start-studio` — start Studio if not running
-3. `uip rpa open-project --project-dir "..." --use-studio` — open the project if Studio has no project loaded
+3. `uip rpa open-project --project-dir "..."` — open the project if Studio has no project loaded
 4. If Studio is running but unresponsive, the user may need to restart it manually
 
 ### CLI output format for parsing

--- a/skills/uipath-rpa/references/xaml/workflow-guide.md
+++ b/skills/uipath-rpa/references/xaml/workflow-guide.md
@@ -7,7 +7,7 @@ Discovery-first approach with iterative error-driven refinement for generating a
 1. **Activity Docs Are the Source of Truth** — Installed packages may ship structured documentation at `{projectRoot}/.local/docs/packages/{PackageId}/`. When present, these docs contain source-accurate properties, types, defaults, enum values, conditional property groups, and working XAML examples. Always check for them first.
 2. **Know Before You Write** — **NEVER** generate XAML blind. Understand the project structure, packages, expression language, and existing patterns.
 3. **Use What You Know, Skip What You Don't Need** — If you already know the package ID and activity class name, go directly to its doc file. Be efficient: the discovery steps are a priority ladder, not a mandatory checklist.
-4. **Start Minimal, Iterate to Correct** — Start one workflow at a time and break out logic into multiple files if needed. Build one activity at a time within each workflow. Write the smallest working XAML, validate with `uip rpa get-errors --use-studio`, fix what breaks, repeat.
+4. **Start Minimal, Iterate to Correct** — Start one workflow at a time and break out logic into multiple files if needed. Build one activity at a time within each workflow. Write the smallest working XAML, validate with `uip rpa get-errors`, fix what breaks, repeat.
 5. **Validate After Every Change** — **MUST** validate with `get-errors` after every change. **NEVER** assume an edit succeeded.
 6. **Fix Errors by Category** — Triage in order: Package → Structure → Type → Activity Properties → Logic.
 
@@ -94,8 +94,7 @@ Read: file_path="{projectRoot}/ExistingWorkflow.xaml"
 Use when you need to find which activity implements a user-described action:
 
 ```bash
-uip rpa find-activities --query "send mail" --limit 10 --output json --use-studio
-```
+uip rpa find-activities --query "send mail" --limit 10 --output json```
 
 - Results are **global** — not limited to installed packages
 - If a useful activity is in an uninstalled package, install it immediately
@@ -117,15 +116,13 @@ uip rpa find-activities --query "send mail" --limit 10 --output json --use-studi
 
 ### Step 1.6: Resolve Activity Properties (Fallback)
 
-Use `uip rpa get-default-activity-xaml --use-studio` when activity docs are insufficient:
+Use `uip rpa get-default-activity-xaml` when activity docs are insufficient:
 
 ```bash
 # Non-dynamic activity:
-uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json --use-studio
-
+uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json
 # Dynamic activity (connector-backed):
-uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json --use-studio
-```
+uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json```
 
 For JIT custom types: `Read: file_path="{projectRoot}/.project/JitCustomTypesSchema.json"`. See [jit-custom-types-schema.md](jit-custom-types-schema.md).
 
@@ -134,9 +131,7 @@ For JIT custom types: `Read: file_path="{projectRoot}/.project/JitCustomTypesSch
 Use when activity docs, `find-activities`, and `get-default-activity-xaml` don't provide enough context:
 
 ```bash
-uip rpa list-workflow-examples --tags web --limit 10 --output json --use-studio
-uip rpa get-workflow-example --key "<BLOB_PATH>" --use-studio
-```
+uip rpa list-workflow-examples --tags web --limit 10 --output jsonuip rpa get-workflow-example --key "<BLOB_PATH>"```
 
 **Complete tag list:** `adobe-sign`, `asana`, `box`, `concur`, `confluence`, `database`, `document-understanding`, `docusign`, `dropbox`, `email-generic`, `excel`, `excel-online`, `freshbooks`, `freshdesk`, `github`, `gmail`, `google-calendar`, `google-docs`, `google-drive`, `google-sheets`, `gsuite`, `hubspot`, `intacct`, `jira`, `mailchimp`, `marketo`, `microsoft-365`, `onedrive`, `outlook`, `outlook-calendar`, `pdf`, `powerpoint`, `productivity`, `quickbooks`, `salesforce`, `servicenow`, `sharepoint`, `shopify`, `slack`, `smartsheet`, `stripe`, `teams`, `testing`, `trello`, `web`, `webex`, `word`, `workday`, `zendesk`, `zoom`
 
@@ -195,8 +190,7 @@ Edit: file_path=... old_string=<exact text> new_string=<modified text>
 ### Step 3.1: Check for Errors
 
 ```bash
-uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --output json --use-studio
-```
+uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --output json```
 
 `--file-path` must be **relative to the project directory**. Use `--skip-validation` only for quick cached-error checks.
 

--- a/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
@@ -224,16 +224,16 @@ Always check the project's expression language before writing expressions:
 
 Mixing expression languages causes build failures.
 
-### Use `uip rpa get-default-activity-xaml --use-studio` Output
-Never construct activity XAML from memory. The `uip rpa get-default-activity-xaml --use-studio` command returns the exact XAML needed for the installed package version, including:
+### Use `uip rpa get-default-activity-xaml` Output
+Never construct activity XAML from memory. The `uip rpa get-default-activity-xaml` command returns the exact XAML needed for the installed package version, including:
 - Correct element names and namespaces
 - Required properties and their types
 - Default values
 - Assembly references to add
 
-Use `uip rpa find-activities --use-studio` to find the activity's fully qualified class name, type ID, and `isDynamicActivity` flag. Then use `uip rpa get-default-activity-xaml --use-studio` with the appropriate parameters.
+Use `uip rpa find-activities` to find the activity's fully qualified class name, type ID, and `isDynamicActivity` flag. Then use `uip rpa get-default-activity-xaml` with the appropriate parameters.
 
-Use `uip rpa list-workflow-examples --use-studio` and `uip rpa get-workflow-example --use-studio` to see example usages of the given activity, in addition to searching existing local `.xaml` files.
+Use `uip rpa list-workflow-examples` and `uip rpa get-workflow-example` to see example usages of the given activity, in addition to searching existing local `.xaml` files.
 
 ### Preserve Existing Structure
 When editing XAML:
@@ -242,7 +242,7 @@ When editing XAML:
 - Use the `Edit` tool for targeted replacements (match exact `old_string`, replace with `new_string`)
 
 ### Validate After Every Change
-Run `uip rpa get-errors --use-studio` after every XAML modification. Do not batch multiple edits without validation — catching errors early is much easier than debugging compound issues.
+Run `uip rpa get-errors` after every XAML modification. Do not batch multiple edits without validation — catching errors early is much easier than debugging compound issues.
 
 ## Common Editing Operations
 
@@ -614,12 +614,12 @@ Shows the generic `ConnectorActivity` pattern used for Integration Service conne
 
 **Key patterns:**
 - `isactr:ConnectorActivity` is the generic IS activity type (`xmlns:isactr="http://schemas.uipath.com/workflow/integration-service-activities/isactr"`)
-- `Configuration` holds a base64-encoded GZip-compressed blob — **never construct this manually**, it comes from `uip rpa get-default-activity-xaml --use-studio`
+- `Configuration` holds a base64-encoded GZip-compressed blob — **never construct this manually**, it comes from `uip rpa get-default-activity-xaml`
 - `ConnectionId` is the Integration Service connection GUID
 - `UiPathActivityTypeId` identifies the specific connector operation
 - `FieldObjects` define input/output fields with `isactr:FieldObject` elements
 - Output types reference a JIT-generated assembly (e.g., `CDF573A04A6_search_r.VeKd1XI2qK1X56UO2Br3Ui3`)
-- The generated assembly name and namespace imports are connector-specific — always use `uip rpa get-default-activity-xaml --use-studio` output
+- The generated assembly name and namespace imports are connector-specific — always use `uip rpa get-default-activity-xaml` output
 
 ## Property Binding: Attributes vs Child Elements
 
@@ -655,7 +655,7 @@ DisplayName="My Activity" Message="[variable]" Level="Info"
 Properties may exist in one package version but not another. If `get-errors` reports "Could not find member 'PropertyName'":
 1. The property may not exist in the installed package version — remove it
 2. The property may have been renamed between versions — check examples from the same package version
-3. Use `uip rpa get-default-activity-xaml --use-studio` output as the authoritative set of properties for the installed version
+3. Use `uip rpa get-default-activity-xaml` output as the authoritative set of properties for the installed version
 
 ## ConnectorActivity Internals
 
@@ -665,9 +665,9 @@ Understanding the structure of `isactr:ConnectorActivity` so you know what you c
 
 | Property | Editable? | Description |
 |----------|-----------|-------------|
-| `Configuration` | **NEVER** | ZIP-compressed, Base64-encoded JSON blob containing the full activity schema (fields, types, connector metadata). This is obtained and computed for you using the `uip rpa get-default-activity-xaml --use-studio` command. Do not parse, modify, or construct manually. |
+| `Configuration` | **NEVER** | ZIP-compressed, Base64-encoded JSON blob containing the full activity schema (fields, types, connector metadata). This is obtained and computed for you using the `uip rpa get-default-activity-xaml` command. Do not parse, modify, or construct manually. |
 | `ConnectionId` | Yes (replace GUID) | Integration Service connection GUID. Use `uip is connections list [connector-key]` to discover available connections and their IDs. |
-| `UiPathActivityTypeId` | **NEVER** | Identifies the specific connector operation. Obtain using `uip rpa get-default-activity-xaml --use-studio` or `uip rpa find-activities --use-studio`. |
+| `UiPathActivityTypeId` | **NEVER** | Identifies the specific connector operation. Obtain using `uip rpa get-default-activity-xaml` or `uip rpa find-activities`. |
 | `DisplayName` | Yes | Human-readable activity name for the designer. |
 
 ### FieldObjects (Input/Output Interface)
@@ -676,7 +676,7 @@ Understanding the structure of `isactr:ConnectorActivity` so you know what you c
 
 | Attribute | Description |
 |-----------|-------------|
-| `Name` | Field identifier (maps to the connector API parameter). Must match exactly what `uip rpa get-default-activity-xaml --use-studio` returns. |
+| `Name` | Field identifier (maps to the connector API parameter). Must match exactly what `uip rpa get-default-activity-xaml` returns. |
 | `Type` | One of: `FieldArgument` (contains an Activity Argument), `FieldLiteral` (contains a literal value), `FilterTreeValue` (filter builder criteria), `None` (empty). |
 
 **What you CAN edit in FieldObjects:**
@@ -687,7 +687,7 @@ Understanding the structure of `isactr:ConnectorActivity` so you know what you c
 - Field `Name` values — these must match the connector API schema exactly.
 - Field `Type` values — these are determined by the connector metadata.
 - Output field structure — the `OutArgument` types reference JIT-generated assemblies.
-- Adding/removing FieldObjects — the set of fields comes from `uip rpa get-default-activity-xaml --use-studio`.
+- Adding/removing FieldObjects — the set of fields comes from `uip rpa get-default-activity-xaml`.
 
 ### JIT-Generated Assemblies
 
@@ -700,13 +700,13 @@ CDF573A04A6_search_r.VeKd1XI2qK1X56UO2Br3Ui3
 These assembly names are:
 - **Unpredictable** — derived from SHA-512 hashes of the type schema
 - **Connection-specific** — different connections produce different hashes
-- **Generated by the runtime** — you cannot create or reference them without `uip rpa get-default-activity-xaml --use-studio`
+- **Generated by the runtime** — you cannot create or reference them without `uip rpa get-default-activity-xaml`
 
-The corresponding namespace imports and assembly references MUST come from `uip rpa get-default-activity-xaml --use-studio` output. Never construct them.
+The corresponding namespace imports and assembly references MUST come from `uip rpa get-default-activity-xaml` output. Never construct them.
 
-### What `uip rpa get-default-activity-xaml --use-studio` Returns for Dynamic Activities
+### What `uip rpa get-default-activity-xaml` Returns for Dynamic Activities
 
-When you call `uip rpa get-default-activity-xaml --use-studio` with `isDynamicActivity: true`, it returns everything needed:
+When you call `uip rpa get-default-activity-xaml` with `isDynamicActivity: true`, it returns everything needed:
 1. The complete `<isactr:ConnectorActivity>` XAML element with `Configuration` blob, `UiPathActivityTypeId`, and `FieldObjects`
 2. All required `xmlns` declarations for the root `<Activity>` element
 3. All required namespace imports and references


### PR DESCRIPTION
**Jira:** [PILOT-4745](https://uipath.atlassian.net/browse/PILOT-4745)

## Summary
- Removed the `--use-studio` flag from every CLI command across 18 files in the `uipath-rpa` skill
- The flag is no longer needed and was stripped from SKILL.md, cli-reference.md, and all reference guides

## Test plan
- [ ] Verify no `--use-studio` occurrences remain in `skills/uipath-rpa/`
- [ ] Verify CLI commands are still syntactically correct after flag removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PILOT-4745]: https://uipath.atlassian.net/browse/PILOT-4745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ