### PR TITLE
Document InvokeWorkflowFile argument and path pitfalls [PILOT-4743]

### DIFF
--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -220,7 +220,6 @@ Studio silently clears any Dictionary-wrapped argument entries on load — the a
 
 **Correct — direct child elements (what Studio actually serializes):**
 ```xml
-<!-- Literal string values -->
 <ui:InvokeWorkflowFile WorkflowFileName="ResetSpotify.xaml"
     DisplayName="ResetSpotify - Invoke Workflow File (ResetSpotify.xaml)" UnSafe="False">
   <ui:InvokeWorkflowFile.Arguments>
@@ -228,39 +227,16 @@ Studio silently clears any Dictionary-wrapped argument entries on load — the a
     <InArgument x:TypeArguments="x:String" x:Key="argument2">anotherValue</InArgument>
   </ui:InvokeWorkflowFile.Arguments>
 </ui:InvokeWorkflowFile>
-
-<!-- Variable bindings (VB project — brackets are VB expressions) -->
-<ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml"
-    DisplayName="Process Data" UnSafe="False">
-  <ui:InvokeWorkflowFile.Arguments>
-    <InArgument x:TypeArguments="x:String" x:Key="in_Name">[nameVar]</InArgument>
-    <OutArgument x:TypeArguments="x:String" x:Key="out_Result">[resultVar]</OutArgument>
-    <InOutArgument x:TypeArguments="x:Int32" x:Key="io_Count">[countVar]</InOutArgument>
-  </ui:InvokeWorkflowFile.Arguments>
-</ui:InvokeWorkflowFile>
-
-<!-- Variable bindings (C# project — use CSharpValue for expressions) -->
-<ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml"
-    DisplayName="Process Data" UnSafe="False">
-  <ui:InvokeWorkflowFile.Arguments>
-    <InArgument x:TypeArguments="x:String" x:Key="in_Name">
-      <CSharpValue x:TypeArguments="x:String">nameVar</CSharpValue>
-    </InArgument>
-    <OutArgument x:TypeArguments="x:String" x:Key="out_Result">
-      <CSharpReference x:TypeArguments="x:String">resultVar</CSharpReference>
-    </OutArgument>
-  </ui:InvokeWorkflowFile.Arguments>
-</ui:InvokeWorkflowFile>
 ```
 
 **Wrong — Dictionary wrapper (from `get-default-activity-xaml` empty state):**
 ```xml
-<ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml"
-    DisplayName="Process Data">
+<ui:InvokeWorkflowFile WorkflowFileName="ResetSpotify.xaml"
+    DisplayName="ResetSpotify - Invoke Workflow File (ResetSpotify.xaml)">
   <ui:InvokeWorkflowFile.Arguments>
     <scg:Dictionary x:TypeArguments="x:String, Argument">
-      <InArgument x:TypeArguments="x:String" x:Key="in_Name">[nameVar]</InArgument>
-      <OutArgument x:TypeArguments="x:String" x:Key="out_Result">[resultVar]</OutArgument>
+      <InArgument x:TypeArguments="x:String" x:Key="argument1">someValue</InArgument>
+      <InArgument x:TypeArguments="x:String" x:Key="argument2">anotherValue</InArgument>
     </scg:Dictionary>
   </ui:InvokeWorkflowFile.Arguments>
 </ui:InvokeWorkflowFile>
@@ -271,8 +247,7 @@ Studio silently clears any Dictionary-wrapped argument entries on load — the a
 2. Use the correct argument direction: `InArgument` for `in_*`, `OutArgument` for `out_*`, `InOutArgument` for `io_*`
 3. The `x:TypeArguments` must match the callee's argument type
 4. For literal string values, place the text directly in the element content (e.g., `<InArgument ...>someValue</InArgument>`)
-5. For variable bindings in **VB projects**, use bracket expressions: `[variableName]`
-6. For variable bindings in **C# projects**, use `<CSharpValue>` for In/InOut arguments and `<CSharpReference>` for Out/InOut arguments
+5. For variable bindings, follow the expression language rules in [xaml-basics-and-rules.md](xaml-basics-and-rules.md#expression-language): VB uses `[bracket]` shorthand, C# uses `<CSharpValue>`/`<CSharpReference>` elements
 
 ## InvokeCode Language Property
 

--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -194,6 +194,60 @@ This pattern applies to: `UploadFilesConnections`, `DownloadFileConnections`, `S
 - **TargetSession validation**: `TargetSession.Secondary` (or any non-Current value) requires `UnSafe=True`. Without it, validation fails.
 - **Persistence with isolation**: Using `ResumeInstanceId` with Safe mode (`UnSafe=false`) without persistence support throws `NotSupportedException`.
 
+### WorkflowFileName Must Be a Plain String Path
+
+`WorkflowFileName` accepts a **plain string literal**, not a VB/C# expression. Use the relative path directly — do NOT wrap it in expression brackets or string-literal quotes.
+
+**Correct:**
+```xml
+<ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml" />
+```
+
+**Wrong — VB expression string literal (common agent mistake):**
+```xml
+<!-- Studio silently accepts this but the path resolution may break -->
+<ui:InvokeWorkflowFile WorkflowFileName="[&quot;Workflows\ProcessData.xaml&quot;]" />
+```
+
+The path is relative to the project root directory. Use backslashes for subfolder paths (e.g., `Workflows\SendEmail.xaml`).
+
+### Arguments Must NOT Use a Dictionary Wrapper
+
+`uip rpa get-default-activity-xaml` returns an empty `scg:Dictionary` as the default container for `InvokeWorkflowFile.Arguments`. This is correct for the **empty state only**. When you populate arguments, drop the Dictionary wrapper and use direct `InArgument`/`OutArgument`/`InOutArgument` child elements instead.
+
+Studio silently clears any Dictionary-wrapped argument entries on load — the arguments appear mapped in the designer but are empty at runtime, with no validation error.
+
+**Correct — direct child elements (what Studio actually serializes):**
+```xml
+<ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml"
+    DisplayName="Process Data">
+  <ui:InvokeWorkflowFile.Arguments>
+    <InArgument x:TypeArguments="x:String" x:Key="in_Name">[nameVar]</InArgument>
+    <OutArgument x:TypeArguments="x:String" x:Key="out_Result">[resultVar]</OutArgument>
+    <InOutArgument x:TypeArguments="x:Int32" x:Key="io_Count">[countVar]</InOutArgument>
+  </ui:InvokeWorkflowFile.Arguments>
+</ui:InvokeWorkflowFile>
+```
+
+**Wrong — Dictionary wrapper (from `get-default-activity-xaml` empty state):**
+```xml
+<ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml"
+    DisplayName="Process Data">
+  <ui:InvokeWorkflowFile.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <InArgument x:TypeArguments="x:String" x:Key="in_Name">[nameVar]</InArgument>
+      <OutArgument x:TypeArguments="x:String" x:Key="out_Result">[resultVar]</OutArgument>
+    </scg:Dictionary>
+  </ui:InvokeWorkflowFile.Arguments>
+</ui:InvokeWorkflowFile>
+```
+
+**Rules for argument bindings:**
+1. Each argument key (`x:Key`) must match the argument name defined in the callee workflow's `x:Members` exactly (case-sensitive)
+2. Use the correct argument direction: `InArgument` for `in_*`, `OutArgument` for `out_*`, `InOutArgument` for `io_*`
+3. The `x:TypeArguments` must match the callee's argument type
+4. Values in brackets (e.g., `[nameVar]`) are expression bindings to variables in the caller workflow
+
 ## InvokeCode Language Property
 
 The `Language` property on `InvokeCode` uses the `UiPath.Core.Activities.NetLanguage` enum, which has **only two valid values**: `VBNet` and `CSharp`.

--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -200,6 +200,7 @@ This pattern applies to: `UploadFilesConnections`, `DownloadFileConnections`, `S
 
 **Correct:**
 ```xml
+<ui:InvokeWorkflowFile WorkflowFileName="ResetSpotify.xaml" />
 <ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml" />
 ```
 
@@ -209,7 +210,7 @@ This pattern applies to: `UploadFilesConnections`, `DownloadFileConnections`, `S
 <ui:InvokeWorkflowFile WorkflowFileName="[&quot;Workflows\ProcessData.xaml&quot;]" />
 ```
 
-The path is relative to the project root directory. Use backslashes for subfolder paths (e.g., `Workflows\SendEmail.xaml`).
+The path is relative to the project root directory. Use backslashes for subfolder paths (e.g., `Workflows\SendEmail.xaml`). If the file is at the project root, use just the filename (e.g., `ResetSpotify.xaml`).
 
 ### Arguments Must NOT Use a Dictionary Wrapper
 
@@ -219,12 +220,35 @@ Studio silently clears any Dictionary-wrapped argument entries on load — the a
 
 **Correct — direct child elements (what Studio actually serializes):**
 ```xml
+<!-- Literal string values -->
+<ui:InvokeWorkflowFile WorkflowFileName="ResetSpotify.xaml"
+    DisplayName="ResetSpotify - Invoke Workflow File (ResetSpotify.xaml)" UnSafe="False">
+  <ui:InvokeWorkflowFile.Arguments>
+    <InArgument x:TypeArguments="x:String" x:Key="argument1">someValue</InArgument>
+    <InArgument x:TypeArguments="x:String" x:Key="argument2">anotherValue</InArgument>
+  </ui:InvokeWorkflowFile.Arguments>
+</ui:InvokeWorkflowFile>
+
+<!-- Variable bindings (VB project — brackets are VB expressions) -->
 <ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml"
-    DisplayName="Process Data">
+    DisplayName="Process Data" UnSafe="False">
   <ui:InvokeWorkflowFile.Arguments>
     <InArgument x:TypeArguments="x:String" x:Key="in_Name">[nameVar]</InArgument>
     <OutArgument x:TypeArguments="x:String" x:Key="out_Result">[resultVar]</OutArgument>
     <InOutArgument x:TypeArguments="x:Int32" x:Key="io_Count">[countVar]</InOutArgument>
+  </ui:InvokeWorkflowFile.Arguments>
+</ui:InvokeWorkflowFile>
+
+<!-- Variable bindings (C# project — use CSharpValue for expressions) -->
+<ui:InvokeWorkflowFile WorkflowFileName="Workflows\ProcessData.xaml"
+    DisplayName="Process Data" UnSafe="False">
+  <ui:InvokeWorkflowFile.Arguments>
+    <InArgument x:TypeArguments="x:String" x:Key="in_Name">
+      <CSharpValue x:TypeArguments="x:String">nameVar</CSharpValue>
+    </InArgument>
+    <OutArgument x:TypeArguments="x:String" x:Key="out_Result">
+      <CSharpReference x:TypeArguments="x:String">resultVar</CSharpReference>
+    </OutArgument>
   </ui:InvokeWorkflowFile.Arguments>
 </ui:InvokeWorkflowFile>
 ```
@@ -246,7 +270,9 @@ Studio silently clears any Dictionary-wrapped argument entries on load — the a
 1. Each argument key (`x:Key`) must match the argument name defined in the callee workflow's `x:Members` exactly (case-sensitive)
 2. Use the correct argument direction: `InArgument` for `in_*`, `OutArgument` for `out_*`, `InOutArgument` for `io_*`
 3. The `x:TypeArguments` must match the callee's argument type
-4. Values in brackets (e.g., `[nameVar]`) are expression bindings to variables in the caller workflow
+4. For literal string values, place the text directly in the element content (e.g., `<InArgument ...>someValue</InArgument>`)
+5. For variable bindings in **VB projects**, use bracket expressions: `[variableName]`
+6. For variable bindings in **C# projects**, use `<CSharpValue>` for In/InOut arguments and `<CSharpReference>` for Out/InOut arguments
 
 ## InvokeCode Language Property
 


### PR DESCRIPTION
**Jira:** [PILOT-4743](https://uipath.atlassian.net/browse/PILOT-4743)

## Summary
- Added pitfall entry for `WorkflowFileName` — must be a plain string path, not a VB expression string literal (e.g., `[\"path\"]`). Agents commonly wrap the path in expression brackets.
- Added pitfall entry for `InvokeWorkflowFile.Arguments` — populated arguments must use direct `InArgument`/`OutArgument` child elements, not a `scg:Dictionary` wrapper. `get-default-activity-xaml` returns an empty Dictionary as default, but Studio silently clears Dictionary-wrapped entries on load, causing empty arguments at runtime with no validation error.

## Test plan
- [ ] Verify the new pitfall entries are correctly placed in the InvokeWorkflow Gotchas section of `common-pitfalls.md`
- [ ] Verify XAML examples are valid and clearly show correct vs. wrong patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PILOT-4743]: https://uipath.atlassian.net/browse/PILOT-4743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ