### PR TITLE
feat(flow-e2e): optionally delete solution after debug completes

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -49,13 +49,13 @@ def run_debug(
     if data is not None:
         _register_solution_cleanup((data.get("Data") or {}).get("solutionId"))
     if r.returncode != 0:
-        _fail(f"flow debug exit {r.returncode}\n{r.stderr[:500]}")
+        _fail(f"flow debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}")
     if data is None:
-        _fail(f"Could not parse JSON from flow debug\n{r.stdout[:500]}")
+        _fail(f"Could not parse JSON from flow debug\n{r.stdout}")
     payload = data.get("Data") or {}
     status = payload.get("finalStatus")
     if status != "Completed":
-        _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout[:1000]}")
+        _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}")
     return payload
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -17,6 +17,7 @@ Runs ``uip flow debug --output json`` and asserts:
 
 from __future__ import annotations
 
+import atexit
 import glob
 import json
 import os
@@ -48,6 +49,7 @@ def run_debug(
     if data is None:
         _fail(f"Could not parse JSON from flow debug\n{r.stdout[:500]}")
     payload = data.get("Data") or {}
+    _register_solution_cleanup(payload.get("solutionId"))
     status = payload.get("finalStatus")
     if status != "Completed":
         _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout[:1000]}")
@@ -196,6 +198,36 @@ def find_project_dir(pattern: str = "**/project.uiproj") -> str:
 
 
 # ── Internals ───────────────────────────────────────────────────────────────
+
+
+_solutions_to_cleanup: set[str] = set()
+_cleanup_registered = False
+
+
+def _register_solution_cleanup(solution_id: str | None) -> None:
+    """Queue a Studio Web solution for deletion at process exit.
+
+    ``flow debug`` creates/overwrites a solution on Studio Web each run. Tests
+    that invoke it accumulate solutions in the target tenant; best-effort
+    cleanup keeps the tenant tidy without failing the test if deletion fails.
+    """
+    global _cleanup_registered
+    if not solution_id:
+        return
+    _solutions_to_cleanup.add(solution_id)
+    if not _cleanup_registered:
+        atexit.register(_cleanup_solutions)
+        _cleanup_registered = True
+
+
+def _cleanup_solutions() -> None:
+    for sid in _solutions_to_cleanup:
+        subprocess.run(
+            ["uip", "solution", "delete", sid, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
 
 
 def _parse_json(stdout: str) -> dict | None:

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -205,6 +205,7 @@ def find_project_dir(pattern: str = "**/project.uiproj") -> str:
 
 _solutions_to_cleanup: set[str] = set()
 _cleanup_registered = False
+_any_failure = False
 
 
 def _register_solution_cleanup(solution_id: str | None) -> None:
@@ -224,6 +225,31 @@ def _register_solution_cleanup(solution_id: str | None) -> None:
 
 
 def _cleanup_solutions() -> None:
+    """Delete queued Studio Web solutions according to ``FLOW_E2E_CLEANUP``.
+
+    - ``auto`` (default): delete on pass, keep on fail so the failure can be
+      inspected in Studio Web.
+    - ``always``: delete regardless — keeps the test tenant tidy in CI.
+    - ``never``: keep everything — useful when actively debugging.
+    """
+    policy = os.environ.get("FLOW_E2E_CLEANUP", "auto").lower()
+    if policy not in ("auto", "always", "never"):
+        print(
+            f"warning: FLOW_E2E_CLEANUP={policy!r} is invalid "
+            "(expected auto|always|never); treating as 'auto'",
+            file=sys.stderr,
+        )
+        policy = "auto"
+    keep = policy == "never" or (policy == "auto" and _any_failure)
+    if keep:
+        for sid in _solutions_to_cleanup:
+            print(
+                f"Preserving Studio Web solution {sid} "
+                f"(FLOW_E2E_CLEANUP={policy}); delete with: "
+                f"uip solution delete {sid}",
+                file=sys.stderr,
+            )
+        return
     for sid in _solutions_to_cleanup:
         subprocess.run(
             ["uip", "solution", "delete", sid, "--output", "json"],
@@ -258,4 +284,6 @@ def _stringify(values: Iterable[Any]) -> str:
 
 
 def _fail(msg: str):
+    global _any_failure
+    _any_failure = True
     sys.exit(f"FAIL: {msg}")

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -43,13 +43,16 @@ def run_debug(
     if inputs is not None:
         cmd.extend(["--inputs", json.dumps(inputs)])
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    # Parse and register cleanup *before* any early exit: a faulted/errored
+    # debug run still uploads a solution to Studio Web that needs deleting.
+    data = _parse_json(r.stdout)
+    if data is not None:
+        _register_solution_cleanup((data.get("Data") or {}).get("solutionId"))
     if r.returncode != 0:
         _fail(f"flow debug exit {r.returncode}\n{r.stderr[:500]}")
-    data = _parse_json(r.stdout)
     if data is None:
         _fail(f"Could not parse JSON from flow debug\n{r.stdout[:500]}")
     payload = data.get("Data") or {}
-    _register_solution_cleanup(payload.get("solutionId"))
     status = payload.get("finalStatus")
     if status != "Completed":
         _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout[:1000]}")


### PR DESCRIPTION
- After each `uip flow debug` run, capture the returned `solutionId` and queue it for deletion at process exit via `uip solution delete`. Keeps the test tenant from accumulating abandoned Studio Web solutions across test runs.
- Cleanup policy is controlled by the `FLOW_E2E_CLEANUP` env var:
  - `auto` (default) — delete on pass, **keep on fail** so the faulted solution can be inspected in Studio Web.
  - `always` — delete regardless of outcome. Use in CI.
  - `never` — delete nothing. Use when actively debugging locally.
- Cleanup is registered *before* any early exit in `run_debug`, so a faulted/errored debug that still produced a solution on Studio Web will also be cleaned up.