### PR TITLE
feat: default uipath-maestro-flow to Direct JSON

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -50,21 +50,21 @@ Comprehensive guide for creating, editing, validating, and debugging UiPath Flow
 
 For targeted changes to an existing flow, use the recipes below instead of the full Quick Start pipeline. Each recipe links to the detailed step-by-step procedure in the [flow editing operations guide](references/flow-editing-operations.md). Run `uip flow validate` once after all edits are complete.
 
-**Read [references/flow-editing-operations.md](references/flow-editing-operations.md) first** to choose between CLI and direct JSON strategies for each operation.
+**Read [references/flow-editing-operations.md](references/flow-editing-operations.md) first** — Direct JSON is the default for all edits; CLI is used only for connector, connector-trigger, and inline-agent nodes, or when you explicitly request it.
 
 | Edit | Description | Guide |
 |------|-------------|-------|
 | **Change a script body or node inputs** | Edit the node's `inputs` in-place in the `.flow` JSON. Do not delete + re-add — that changes the node ID and breaks `$vars` expressions. Script nodes must return an object (`return { key: value }`). | [JSON: Update node inputs](references/flow-editing-operations-json.md#update-node-inputs) |
-| **Add a node between two existing nodes** | Remove the connecting edge, add the new node, wire upstream → new → downstream. | [CLI: Insert a node](references/flow-editing-operations-cli.md#insert-a-node-between-two-existing-nodes) / [JSON: Insert a node](references/flow-editing-operations-json.md#insert-a-node-between-two-existing-nodes) |
-| **Add a branch (decision node)** | Remove an edge, add a decision node, wire true/false branches. | [CLI: Insert a decision branch](references/flow-editing-operations-cli.md#insert-a-decision-branch) / [JSON: Insert a decision branch](references/flow-editing-operations-json.md#insert-a-decision-branch) |
-| **Remove a node** | Delete the node (edges cascade in CLI), reconnect upstream to downstream. | [CLI: Remove a node](references/flow-editing-operations-cli.md#remove-a-node-and-reconnect) / [JSON: Remove a node](references/flow-editing-operations-json.md#remove-a-node-and-reconnect) |
-| **Remove an edge** | Find the edge ID, delete it. | [CLI: Delete an edge](references/flow-editing-operations-cli.md#delete-an-edge) / [JSON: Delete an edge](references/flow-editing-operations-json.md#delete-an-edge) |
+| **Add a node between two existing nodes** | Remove the connecting edge, add the new node, wire upstream → new → downstream. | [JSON: Insert a node](references/flow-editing-operations-json.md#insert-a-node-between-two-existing-nodes) (default) or [CLI: Insert a node](references/flow-editing-operations-cli.md#insert-a-node-between-two-existing-nodes) (opt-in) |
+| **Add a branch (decision node)** | Remove an edge, add a decision node, wire true/false branches. | [JSON: Insert a decision branch](references/flow-editing-operations-json.md#insert-a-decision-branch) (default) or [CLI: Insert a decision branch](references/flow-editing-operations-cli.md#insert-a-decision-branch) (opt-in) |
+| **Remove a node** | Delete the node, sweep edges/definitions/variables, reconnect upstream to downstream. | [JSON: Remove a node](references/flow-editing-operations-json.md#remove-a-node-and-reconnect) (default) or [CLI: Remove a node](references/flow-editing-operations-cli.md#remove-a-node-and-reconnect) (opt-in, auto-cascades) |
+| **Remove an edge** | Find the edge ID, delete it. | [JSON: Delete an edge](references/flow-editing-operations-json.md#delete-an-edge) (default) or [CLI: Delete an edge](references/flow-editing-operations-cli.md#delete-an-edge) (opt-in) |
 | **Add a workflow variable** | Edit `variables.globals` in the `.flow` file (JSON only). For `out` variables, map on every End node. See [variables-and-expressions.md](references/variables-and-expressions.md). | [JSON: Add a workflow variable](references/flow-editing-operations-json.md#add-a-workflow-variable) |
 | **Update a state variable** | Add a `variableUpdates` entry for `inout` variables (JSON only). See [variables-and-expressions.md](references/variables-and-expressions.md). | [JSON: Add a variable update](references/flow-editing-operations-json.md#add-a-variable-update) |
 | **Create a subflow** | Add a `core.subflow` parent node + `subflows.{nodeId}` with nested nodes/edges/variables (JSON only). | [JSON: Create a subflow](references/flow-editing-operations-json.md#create-a-subflow) + [subflow/impl.md](references/plugins/subflow/impl.md) |
-| **Add a scheduled trigger** | Replace `core.trigger.manual` with `core.trigger.scheduled`. | [CLI: Replace trigger](references/flow-editing-operations-cli.md#replace-manual-trigger-with-scheduled-trigger) / [JSON: Replace trigger](references/flow-editing-operations-json.md#replace-manual-trigger-with-scheduled-trigger) + [scheduled-trigger/impl.md](references/plugins/scheduled-trigger/impl.md) |
+| **Add a scheduled trigger** | Replace `core.trigger.manual` with `core.trigger.scheduled`. | [JSON: Replace trigger](references/flow-editing-operations-json.md#replace-manual-trigger-with-scheduled-trigger) (default) or [CLI: Replace trigger](references/flow-editing-operations-cli.md#replace-manual-trigger-with-scheduled-trigger) (opt-in) + [scheduled-trigger/impl.md](references/plugins/scheduled-trigger/impl.md) |
 | **Add a connector trigger** | Delete manual trigger, add connector trigger, configure with connection. | [CLI: Replace trigger](references/flow-editing-operations-cli.md#replace-manual-trigger-with-connector-trigger) + [connector-trigger/impl.md](references/plugins/connector-trigger/impl.md) |
-| **Add a resource node** | Discover via registry, add with CLI or JSON, wire edges. Use `core.logic.mock` if unpublished. | [CLI: Replace a mock](references/flow-editing-operations-cli.md#replace-a-mock-with-a-real-resource-node) + relevant plugin's `impl.md` |
+| **Add a resource node** | Discover via registry, add via JSON (default) or CLI (opt-in), wire edges. Use `core.logic.mock` if unpublished. | [JSON: Replace a mock](references/flow-editing-operations-json.md#replace-a-mock-with-a-real-resource-node) (default) or [CLI: Replace a mock](references/flow-editing-operations-cli.md#replace-a-mock-with-a-real-resource-node) (opt-in) + relevant plugin's `impl.md` |
 | **Add an inline agent node** | Embed a `uipath.agent.autonomous` node with an inline agent definition living inside the flow project. | [inline-agent/planning.md](references/plugins/inline-agent/planning.md) for selection vs a published agent, [inline-agent/impl.md](references/plugins/inline-agent/impl.md) for scaffolding, CLI, JSON structure, and validation. |
 
 
@@ -192,7 +192,7 @@ Phase 2 takes the approved architectural plan and resolves all implementation de
 
 Edit `<ProjectName>.flow` directly in the project root. The `bindings_v2.json` file is also in the project root for resource bindings.
 
-**Read [references/flow-editing-operations.md](references/flow-editing-operations.md)** to choose between CLI and direct JSON strategies for each operation. Common approach: use CLI for node/edge CRUD, direct JSON for variables, variableUpdates, subflows, and output mapping.
+**Read [references/flow-editing-operations.md](references/flow-editing-operations.md).** Direct JSON is the default for all edits. CLI is used for connector, connector-trigger, and inline-agent nodes (see their plugin `impl.md`) or when the user explicitly opts in to CLI.
 
 For each node type, follow the relevant plugin's `impl.md` for node-specific inputs, JSON structure, and configuration. The operations guides cover the mechanics (how to add/delete/wire); the plugins cover the semantics (what inputs and model fields each node type needs).
 
@@ -342,9 +342,9 @@ When you finish building or editing a flow, report to the user:
 
 ## References
 
-- **[Flow Editing Operations](references/flow-editing-operations.md)** — Strategy selection matrix for CLI vs. direct JSON editing. Links to the two strategy guides below. **Read this before modifying any `.flow` file.**
-  - [CLI Strategy](references/flow-editing-operations-cli.md) — All node/edge operations via `uip flow node` and `uip flow edge` commands
-  - [Direct JSON Strategy](references/flow-editing-operations-json.md) — All operations via direct `.flow` file editing (variables, subflows, in-place updates)
+- **[Flow Editing Operations](references/flow-editing-operations.md)** — Strategy selection matrix; **Direct JSON is the default**. Links to the two strategy guides below. **Read this before modifying any `.flow` file.**
+  - [Direct JSON Strategy](references/flow-editing-operations-json.md) — Default for all `.flow` edits: node/edge CRUD, variables, subflows, output mapping, in-place input updates.
+  - [CLI Strategy](references/flow-editing-operations-cli.md) — Carve-outs (connector, connector-trigger, inline-agent) and explicit user opt-in for `uip flow node` and `uip flow edge` commands.
 - **[Planning Phase 1: Discovery & Architectural Design](references/planning-arch.md)** — Capability discovery (`registry search`/`list`), plugin index for node selection, topology design, mermaid diagram generation, wiring rules, and common patterns. **Read this first when planning a new flow.**
 - **[Planning Phase 2: Implementation Resolution](references/planning-impl.md)** — Implementation resolution process (registry lookups, connection binding, reference field resolution), wiring rules, and flow patterns. **Read this after the architectural plan is approved.**
 - **[.flow File Format](references/flow-file-format.md)** — JSON schema, node/edge structure, definition requirements, and minimal working example

--- a/skills/uipath-maestro-flow/references/flow-editing-operations-cli.md
+++ b/skills/uipath-maestro-flow/references/flow-editing-operations-cli.md
@@ -2,7 +2,7 @@
 
 All flow file modifications via `uip flow node` and `uip flow edge` CLI commands. The CLI automatically manages definitions, variables, edge cleanup, and `bindings_v2.json` — eliminating the most common build errors.
 
-> **When to use this strategy:** Prefer CLI for all node and edge operations. Fall back to the [JSON strategy](flow-editing-operations-json.md) only for operations the CLI does not support (variables, variableUpdates, subflows, output mapping on End nodes). See [flow-editing-operations.md](flow-editing-operations.md) for the strategy selection matrix.
+> **When to use this strategy:** Use this strategy for connector, connector-trigger, and inline-agent nodes, or when the user explicitly requests CLI. For all other edits, Direct JSON is the default (see [flow-editing-operations-json.md](flow-editing-operations-json.md)). See [flow-editing-operations.md](flow-editing-operations.md) for the strategy selection matrix.
 
 ---
 

--- a/skills/uipath-maestro-flow/references/flow-editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/flow-editing-operations-json.md
@@ -25,12 +25,16 @@ When editing the `.flow` file directly, **you** are responsible for everything t
 
 Before editing the `.flow` file, ensure each of the following is handled. These are the concerns the CLI used to manage automatically; under the Direct JSON default, **you** are responsible for them.
 
-1. **Definitions.** For every new node type, run `uip flow registry get <type> --output json`. Copy the `Data.Node` object **verbatim** into `definitions[]` — one entry per unique `type:typeVersion`. Never hand-write or paraphrase (Critical Rule #7).
-2. **Unique node ID.** Pick a camelCase ID that does not collide with existing node IDs. Prefer meaningful names (`fetchUsers`, `filterActive`) since they become part of every `$vars.<nodeId>.*` expression.
-3. **`targetPort` on every edge.** Omitting `targetPort` is the #1 validation error (Critical Rule #6). Look up ports in the relevant plugin's `planning.md` or in [flow-file-format.md — Standard ports](flow-file-format.md).
-4. **Node outputs block.** Every data-producing node needs an `outputs` block on the node instance (not just in `definitions`). Action nodes: `output` + `error`. Trigger nodes: `output`. End/terminate: none. (Critical Rule #18.)
-5. **`variables.nodes`.** Add an entry for the new node's outputs. Optional under today's runtime, but expected for completeness and diff clarity.
-6. **On delete — cascade manually.** Remove the node from `nodes`. Then sweep `edges[]` for any with matching `sourceNodeId`/`targetNodeId`. Then prune `definitions[]` if this was the last user of the type. Then check `bindings_v2.json` — but only remove a connector binding if no remaining node uses the same connector (bindings are shared at the connector level).
+1. **Locate the canonical `.flow` file.** Before any Write/Edit, find the flow project directory — it is the directory that contains `project.uiproj`. The canonical `.flow` lives **next to** that `project.uiproj`, not at the solution root. Commands like `uip solution new <Name>` + `uip flow init <Name>` create nested paths (`<Name>/<Name>/project.uiproj`); the `.flow` you must edit is `<Name>/<Name>/<Name>.flow`, not `<Name>/<Name>.flow`. Run `find . -name project.uiproj -type f` and pin every `.flow` Write/Edit to the sibling file. `uip flow validate <PATH>.flow` will accept a misplaced file, so validation alone does **not** confirm the right target — only the colocation with `project.uiproj` does.
+2. **Definitions.** For every new node type, run `uip flow registry get <type> --output json`. Copy the `Data.Node` object **verbatim** into `definitions[]` — one entry per unique `type:typeVersion`. Never hand-write or paraphrase (Critical Rule #7).
+3. **Unique node ID.** Pick a camelCase ID that does not collide with existing node IDs. Prefer meaningful names (`fetchUsers`, `filterActive`) since they become part of every `$vars.<nodeId>.*` expression.
+4. **`targetPort` on every edge.** Omitting `targetPort` is the #1 validation error (Critical Rule #6). Look up ports in the relevant plugin's `planning.md` or in [flow-file-format.md — Standard ports](flow-file-format.md).
+5. **Node outputs block.** Every data-producing node needs an `outputs` block on the node instance (not just in `definitions`). Action nodes: `output` + `error`. Trigger nodes: `output`. End/terminate: none. (Critical Rule #18.)
+6. **`variables.nodes`.** Add an entry for the new node's outputs. Optional under today's runtime, but expected for completeness and diff clarity.
+7. **On delete — cascade manually.** Remove the node from `nodes`. Then sweep `edges[]` for any with matching `sourceNodeId`/`targetNodeId`. Then prune `definitions[]` if this was the last user of the type. Then check `bindings_v2.json` — but only remove a connector binding if no remaining node uses the same connector (bindings are shared at the connector level).
+
+> **Anti-pattern: editing a `.flow` that is not colocated with `project.uiproj`.**
+> A `.flow` file outside the flow project directory is invisible to `uip flow debug`, to the Studio solution, and to any checker that discovers the project via `**/project.uiproj`. It will still pass `uip flow validate <PATH>.flow` because that command only checks JSON-schema correctness of the file you hand it — it does not verify the file is the project's canonical flow. Always edit the `.flow` that sits next to `project.uiproj`.
 
 ---
 

--- a/skills/uipath-maestro-flow/references/flow-editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/flow-editing-operations-json.md
@@ -2,7 +2,7 @@
 
 All flow file modifications via direct read-modify-write of the `.flow` JSON file. This strategy gives full control over every field but requires manual management of definitions, variables, and edge integrity.
 
-> **When to use this strategy:** Use for operations the CLI does not support (variables, variableUpdates, subflows, output mapping) or when you prefer direct file control. See [flow-editing-operations.md](flow-editing-operations.md) for the strategy selection matrix.
+> **When to use this strategy:** Direct JSON is the default for all `.flow` edits. Use CLI (see [flow-editing-operations-cli.md](flow-editing-operations-cli.md)) only for connector, connector-trigger, and inline-agent nodes, or when the user explicitly requests CLI. See [flow-editing-operations.md](flow-editing-operations.md) for the strategy selection matrix.
 
 ---
 
@@ -18,6 +18,19 @@ When editing the `.flow` file directly, **you** are responsible for everything t
 | Orphan cleanup | Auto-removes unused definitions and orphaned bindings | Remove definitions no longer referenced by any node; remove connector bindings only when no remaining node uses that connector |
 | `targetPort` | Auto-set | Set `targetPort` on every edge (validate rejects without it) |
 | `bindings_v2.json` | Auto-managed by `node configure` | Edit `bindings_v2.json` manually for connector nodes |
+
+---
+
+## Pre-flight Checklist
+
+Before editing the `.flow` file, ensure each of the following is handled. These are the concerns the CLI used to manage automatically; under the Direct JSON default, **you** are responsible for them.
+
+1. **Definitions.** For every new node type, run `uip flow registry get <type> --output json`. Copy the `Data.Node` object **verbatim** into `definitions[]` — one entry per unique `type:typeVersion`. Never hand-write or paraphrase (Critical Rule #7).
+2. **Unique node ID.** Pick a camelCase ID that does not collide with existing node IDs. Prefer meaningful names (`fetchUsers`, `filterActive`) since they become part of every `$vars.<nodeId>.*` expression.
+3. **`targetPort` on every edge.** Omitting `targetPort` is the #1 validation error (Critical Rule #6). Look up ports in the relevant plugin's `planning.md` or in [flow-file-format.md — Standard ports](flow-file-format.md).
+4. **Node outputs block.** Every data-producing node needs an `outputs` block on the node instance (not just in `definitions`). Action nodes: `output` + `error`. Trigger nodes: `output`. End/terminate: none. (Critical Rule #18.)
+5. **`variables.nodes`.** Add an entry for the new node's outputs. Optional under today's runtime, but expected for completeness and diff clarity.
+6. **On delete — cascade manually.** Remove the node from `nodes`. Then sweep `edges[]` for any with matching `sourceNodeId`/`targetNodeId`. Then prune `definitions[]` if this was the last user of the type. Then check `bindings_v2.json` — but only remove a connector binding if no remaining node uses the same connector (bindings are shared at the connector level).
 
 ---
 

--- a/skills/uipath-maestro-flow/references/flow-editing-operations.md
+++ b/skills/uipath-maestro-flow/references/flow-editing-operations.md
@@ -2,42 +2,44 @@
 
 Strategy selection and shared concepts for modifying `.flow` files. Two implementation strategies are available — choose one per operation and follow the corresponding guide.
 
-## Strategy Guides
+## Default Strategy
+
+> **Default to Direct JSON for all `.flow` edits.** Use CLI only when the user explicitly requests CLI, or for connector, connector-trigger, or inline-agent nodes (see carve-out rows in the matrix below).
 
 | Strategy | Guide | When to use |
 |----------|-------|-------------|
-| **CLI** | [flow-editing-operations-cli.md](flow-editing-operations-cli.md) | Node and edge CRUD. Automatic definition management, variable wiring, and cleanup. |
-| **Direct JSON** | [flow-editing-operations-json.md](flow-editing-operations-json.md) | Variable management, subflows, output mapping, in-place input updates. Full control. |
+| **Direct JSON** (default) | [flow-editing-operations-json.md](flow-editing-operations-json.md) | Default for all `.flow` edits — node/edge CRUD, variables, subflows, output mapping, in-place input updates. |
+| **CLI** (opt-in / carve-outs) | [flow-editing-operations-cli.md](flow-editing-operations-cli.md) | Connector, connector-trigger, and inline-agent nodes (carve-outs); or when the user explicitly requests CLI. |
 
 ---
 
 ## Strategy Selection Matrix
 
-Use this table to determine which strategy to follow for each operation.
+Use this table to determine which strategy to follow for each operation. **Direct JSON is the default**; use CLI only for the carve-out rows or when the user explicitly opts in.
 
-| Operation | CLI | Direct JSON | Notes |
-|-----------|-----|-------------|-------|
-| **Add a node** | Yes | Yes | CLI auto-manages definitions and variables |
-| **Delete a node** | Yes | Yes | CLI auto-cascades edge/definition/variable cleanup |
-| **Add an edge** | Yes | Yes | CLI auto-sets `targetPort` |
-| **Delete an edge** | Yes | Yes | Equivalent complexity |
-| **Update node inputs** | Not supported (delete + re-add changes node ID, breaking expressions) | In-place edit | Always use JSON — preserves node ID, edges, and `$vars` references |
-| **Configure connector node** | `node configure` | Manual `inputs.detail` + `bindings_v2.json` | CLI handles binding automatically |
-| **Add workflow variable** | Not supported | Yes | Edit `variables.globals` |
-| **Add variable update** | Not supported | Yes | Edit `variables.variableUpdates` |
-| **Map outputs on End node** | Not supported | Yes | Edit node `outputs` object |
-| **Create a subflow** | Not supported | Yes | Edit `subflows` object |
-| **Replace trigger type** | Delete + re-add | In-place edit | Both work; CLI handles definition/edge cleanup automatically |
-| **Replace mock with resource** | Delete + re-add | Delete + re-add | Both require registry lookup |
-| **Insert node between two** | 3 CLI commands | 3 JSON edits | Equivalent complexity |
-| **Insert a decision branch** | 4 CLI commands | 4 JSON edits | Equivalent complexity |
+| Operation | Default | Alternative | Notes |
+|-----------|---------|-------------|-------|
+| Add a node | **Direct JSON** | CLI (opt-in) | CLI still auto-manages definitions/variables when opted in. |
+| Delete a node | **Direct JSON** | CLI (opt-in) | |
+| Add an edge | **Direct JSON** | CLI (opt-in) | Remember `targetPort` (Rule #6). |
+| Delete an edge | **Direct JSON** | CLI (opt-in) | |
+| Update node inputs | **Direct JSON** | — | In-place edit; preserves node ID and `$vars`. |
+| Add/edit workflow variable | **Direct JSON** | — | JSON-only; CLI does not support. |
+| Add variable update | **Direct JSON** | — | JSON-only; CLI does not support. |
+| Map outputs on End node | **Direct JSON** | — | JSON-only. |
+| Create a subflow | **Direct JSON** | — | JSON-only. |
+| Replace trigger (non-connector) | **Direct JSON** | CLI (opt-in) | |
+| Replace mock with real resource (non-connector) | **Direct JSON** | CLI (opt-in) | |
+| Insert node between two existing nodes | **Direct JSON** | CLI (opt-in) | |
+| Insert a decision branch | **Direct JSON** | CLI (opt-in) | |
+| Remove a node and reconnect | **Direct JSON** | CLI (opt-in) | |
+| **Configure a connector node** | **CLI** (carve-out) | Direct JSON (fallback) | `uip flow node configure --detail` auto-populates `inputs.detail` + `bindings_v2.json`. |
+| **Configure a connector trigger** | **CLI** (carve-out) | Direct JSON (fallback) | Same as above. |
+| **Add an inline agent node** | **CLI** (carve-out) | — | Scaffolded via `uip agent init --inline-in-flow`. |
 
 ### Mixing strategies
 
-You can mix CLI and JSON strategies within the same flow build. Common pattern:
-
-1. Use **CLI** for adding/deleting nodes and edges (avoids manual definition management)
-2. Use **Direct JSON** for variables, variableUpdates, output mapping, and subflows
+The default strategy is Direct JSON. Mixing is still common: for connector, connector-trigger, or inline-agent nodes, use the CLI as documented in their respective plugin `impl.md`. For everything else, use Direct JSON unless the user explicitly asks for CLI.
 
 ---
 
@@ -85,14 +87,15 @@ See [variables-and-expressions.md](variables-and-expressions.md) for the full ex
 
 | I need to... | Go to |
 |---|---|
-| Add/delete nodes or edges | [CLI guide](flow-editing-operations-cli.md) or [JSON guide](flow-editing-operations-json.md) |
-| Change a node's inputs | [JSON guide — Update node inputs](flow-editing-operations-json.md#update-node-inputs) or [CLI guide — Update node inputs](flow-editing-operations-cli.md#update-node-inputs-expression-script-body-label-etc) |
-| Configure a connector node | [CLI guide — Configure a connector node](flow-editing-operations-cli.md#configure-a-connector-node) or [JSON guide — Connector Node Configuration](flow-editing-operations-json.md#connector-node-configuration-direct-json) |
+| Add/delete nodes or edges | [JSON guide](flow-editing-operations-json.md) (default) or [CLI guide](flow-editing-operations-cli.md) (opt-in) |
+| Change a node's inputs | [JSON guide — Update node inputs](flow-editing-operations-json.md#update-node-inputs) |
+| Configure a connector node | [CLI guide — Configure a connector node](flow-editing-operations-cli.md#configure-a-connector-node) (carve-out) or [JSON guide — Connector Node Configuration](flow-editing-operations-json.md#connector-node-configuration-direct-json) (fallback) |
 | Manage variables | [JSON guide — Variable Operations](flow-editing-operations-json.md#variable-operations) |
 | Map outputs on End nodes | [JSON guide — Add output mapping](flow-editing-operations-json.md#add-output-mapping-on-an-end-node) |
 | Create a subflow | [JSON guide — Create a subflow](flow-editing-operations-json.md#create-a-subflow) |
-| Replace a mock placeholder | [CLI guide — Replace a mock](flow-editing-operations-cli.md#replace-a-mock-with-a-real-resource-node) or [JSON guide — Replace a mock](flow-editing-operations-json.md#replace-a-mock-with-a-real-resource-node) |
-| Replace a trigger type | [CLI guide — Replace trigger](flow-editing-operations-cli.md#replace-manual-trigger-with-connector-trigger) or [JSON guide — Replace trigger](flow-editing-operations-json.md#replace-manual-trigger-with-scheduled-trigger) |
+| Replace a mock placeholder (non-connector) | [JSON guide — Replace a mock](flow-editing-operations-json.md#replace-a-mock-with-a-real-resource-node) (default) or [CLI guide — Replace a mock](flow-editing-operations-cli.md#replace-a-mock-with-a-real-resource-node) (opt-in) |
+| Replace a trigger type (non-connector) | [JSON guide — Replace trigger](flow-editing-operations-json.md#replace-manual-trigger-with-scheduled-trigger) (default) or [CLI guide — Replace trigger](flow-editing-operations-cli.md#replace-manual-trigger-with-scheduled-trigger) (opt-in) |
+| Replace a trigger type (connector trigger) | [CLI guide — Replace trigger](flow-editing-operations-cli.md#replace-manual-trigger-with-connector-trigger) (carve-out) |
 | Understand the `.flow` JSON schema | [flow-file-format.md](flow-file-format.md) |
 | Look up CLI flags and syntax | [flow-commands.md](flow-commands.md) |
 | Work with variables and expressions | [variables-and-expressions.md](variables-and-expressions.md) |


### PR DESCRIPTION
## Summary

- Flips the default `.flow` editing strategy in `uipath-maestro-flow` from CLI to **Direct JSON** for all operations except connector, connector-trigger, and inline-agent nodes (carve-outs that keep CLI as default).
- Adds a Pre-flight Checklist to the Direct JSON guide so agents re-arm the guardrails the CLI used to enforce automatically (definitions, IDs, targetPort, outputs, variables.nodes, delete cascade).
- Aligns `SKILL.md` Common Edits table and References section with the new default; CLI-first link orderings flipped to JSON-first for non-carve-out operations.
- Plan: `~/root/data/docs/skills/uipath-maestro-flow-json-default-plan.md`
- Validation report: `~/root/data/docs/skills/uipath-maestro-flow-json-default-validation-report.md`

**Why:** CLI covers only a subset of `.flow` operations; mixing strategies forced agents to context-switch on every edit. JSON-default gives one consistent path for the common case and keeps CLI where it materially helps (auto-binding for connectors, agent scaffolding).

## Files changed

- `skills/uipath-maestro-flow/SKILL.md` — wording tweaks at L53/L195; Common Edits table + References section reordered for JSON-default.
- `skills/uipath-maestro-flow/references/flow-editing-operations.md` — rewritten router (Default Strategy section, new Default/Alternative matrix, updated Mixing strategies, flipped Quick Reference).
- `skills/uipath-maestro-flow/references/flow-editing-operations-json.md` — updated callout + new Pre-flight Checklist.
- `skills/uipath-maestro-flow/references/flow-editing-operations-cli.md` — updated callout (carve-outs + opt-in).

## Test plan

- [x] `bash hooks/validate-skill-descriptions.sh` exits 0 (199 chars / 250 limit)
- [x] `bash hooks/ensure-uip.sh` exits 0
- [x] Full `coder_eval` suite (24 tasks) executed twice against this commit
  - 18/18 structurally-relevant suites pass cloud `flow debug` end-to-end (6 edit + 4 node + 6 OOTB generate + 2 smoke)
  - 6 cloud-debug failures all triaged from preserved sandboxes; root causes are tenant-side (Orchestrator `Shared` folder permissions) or test-tenant-availability (no Slack action connector). None caused by this PR.
- [x] Re-run `tests/tasks/uipath-maestro-flow/registry_discovery.yaml` with the local sandbox python symlink fix → 7/7 criteria pass
- [ ] Reviewer to spot-check the Direct JSON guide's new Pre-flight Checklist for completeness vs. the previously-CLI-managed concerns
- [ ] CI: `validate-skills` and `smoke-skills` workflows pass on the PR

## Follow-ups (separate PRs / tickets — outside this PR)

1. Fix Orchestrator `Shared` folder permissions in `popoc/flow_eval` (unblocks 4 resource tests).
2. Install Slack action connector in test tenant OR relax Slack test checkers (unblocks 2 connector tests + plan §6.2 carve-out coverage).
3. Improve `tests/tasks/uipath-maestro-flow/_shared/flow_check.py` to surface full `flow debug` stderr + the `globalVariables[].Error` payload on debug faults.
4. Add a JSON-first explicit `coder_eval` task to lock in the new default with dedicated coverage (plan §6.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>