### PR TITLE
feat(case): drop solution bundle step; sync commands reference

### DIFF
--- a/skills/uipath-case-management/references/case-commands.md
+++ b/skills/uipath-case-management/references/case-commands.md
@@ -42,6 +42,20 @@ uip case pack ./my-case-project ./dist --name MyCase --version 2.0.0
 
 ---
 
+> **Note:** `pack` + `uip solution publish` deploys directly to Orchestrator — the user cannot visualize or edit the case in Studio Web via this path. Only use this when the user explicitly asks to deploy to Orchestrator. The default publish path is `uip solution upload` (see below). See [uipath-platform](/uipath:uipath-platform) for `solution publish` commands.
+
+## uip solution upload
+
+Upload a solution directly to Studio Web. **Requires `uip login`.**
+
+```bash
+uip solution upload <SolutionDir> --output json
+```
+
+`uip solution upload` accepts the solution directory (the folder containing the `.uipx` file) directly — no intermediate bundling step is required. Uploads the solution to Studio Web where the user can visualize, inspect, edit, and publish the case from the browser.
+
+> **This is the default publish path.** When the user asks to "publish" without specifying where, run `uip solution upload <SolutionDir>` to push to Studio Web. Share the resulting URL with the user.
+
 ## uip case debug
 
 Debug a Case JSON file via a Studio Web debug session. **Requires `uip login`.**
@@ -591,7 +605,7 @@ Manage the local resource cache. Requires `uip login` for tenant-specific resour
 # Refresh cache from all resource types
 uip case registry pull
 uip case registry pull --force             # ignore 30-min TTL and force refresh
-uip case registry pull --solutionId <id>  # include a specific solution's resources
+uip case registry pull --solution-id <id>  # include a specific solution's resources
 
 # List all cached resources
 uip case registry list --output json
@@ -601,9 +615,20 @@ uip case registry search <keyword>
 uip case registry search <keyword> --type process
 uip case registry search --filter "name:contains=Apple,category=Pipelines"
 uip case registry search <keyword> --filter "name:contains=Foo" --type agent
+
+# Get a resource by identifier (entityKey, id, or uiPathActivityTypeId)
+uip case registry get <identifier>
+uip case registry get <identifier> --type agent
+uip case registry get <uiPathActivityTypeId> --type typecache-activities --connection-id <uuid>
 ```
 
-Resource types: `agent`, `process`, `api`, `processOrchestration`, `caseManagement`, `typecache`, `action-apps`, `solution`.
+Resource types: `agent`, `process`, `api`, `processOrchestration`, `caseManagement`, `typecache-activities`, `typecache-triggers`, `action-apps`, `solution`.
+
+Options for `pull`:
+| Flag | Description |
+|------|-------------|
+| `-f, --force` | Force refresh, ignore 30-min cache TTL |
+| `-s, --solution-id <id>` | Include the registry of the specified solution |
 
 Options for `search`:
 | Flag | Description |
@@ -614,11 +639,20 @@ Options for `search`:
 
 Filter format: `field=value` or `field:operator=value`. Supported fields: `name`, `description`, `category`, `tags`. Supported operators: `equals`, `contains`, `in`, `startsWith`, `endsWith`. At least one of keyword or `--filter` is required.
 
+Options for `get`:
+| Flag | Description |
+|------|-------------|
+| `<identifier>` | **(required)** The entityKey (process types), id (action-apps), or uiPathActivityTypeId (typecache) of the resource |
+| `-t, --type <type>` | Limit to a specific resource type: `agent`, `process`, `api`, `processOrchestration`, `caseManagement`, `typecache-activities`, `typecache-triggers`, `action-apps`, `solution` |
+| `--connection-id <id>` | Connection UUID for connector-specific IS field metadata. Only applies to `typecache-activities` / `typecache-triggers` results — enriches the resource with input/output definitions from Integration Service |
+
+Output: `{ MatchCount, Resources: [{ ResourceType, Resource }] }`.
+
 Cache lives at `~/.uipcli/case-resources/` and expires after 30 minutes.
 
 ### uip case registry get-connector
 
-Look up a connector activity or trigger from the local TypeCache index.
+Look up a connector activity or trigger from the local TypeCache index. Returns the raw cache entry and its connector config (connector key, connector type, operation name). Does NOT fetch connections — use `get-connection` for that.
 
 ```bash
 uip case registry get-connector --type typecache-activities --activity-type-id <uuid>
@@ -674,9 +708,8 @@ Options for `list`:
 | Flag | Description |
 |------|-------------|
 | `-t, --tenant <name>` | Tenant name (defaults to authenticated tenant) |
-| `-f, --folder-key <key>` | Filter by folder key (GUID) |
+| `-f, --folder-key <key>` | **(required)** Filter by folder key (GUID) |
 | `--filter <odata>` | Additional OData filter expression |
-| `--folder-id <id>` | Folder ID (`OrganizationUnitId`, required for client credentials auth) |
 | `--login-validity <minutes>` | Minimum minutes before token expiration triggers refresh (default: `10`) |
 
 Options for `get`:
@@ -685,8 +718,7 @@ Options for `get`:
 | `<process-key>` | **(required)** Process key (from `list`) |
 | `<feed-id>` | **(required)** Feed ID (from `list`) |
 | `-t, --tenant <name>` | Tenant name |
-| `-f, --folder-key <key>` | Folder key (GUID) |
-| `--folder-id <id>` | Folder ID |
+| `-f, --folder-key <key>` | **(required)** Folder key (GUID) |
 | `--login-validity <minutes>` | Min minutes before token refresh |
 
 Options for `run`:
@@ -697,7 +729,6 @@ Options for `run`:
 | `-i, --inputs <json>` | Input parameters as JSON string or `@file.json` (also reads from stdin) |
 | `-t, --tenant <name>` | Tenant name |
 | `--release-key <key>` | Release key (GUID, from `list`) |
-| `--folder-id <id>` | Folder ID |
 | `--feed-id <id>` | Feed ID for package lookup |
 | `--robot-ids <ids>` | Comma-separated robot IDs |
 | `--validate` | Validate inputs against process schema before running |
@@ -737,7 +768,7 @@ Options for `status`:
 |------|-------------|
 | `<job-key>` | **(required)** Job key (GUID from `process run`) |
 | `-t, --tenant <name>` | Tenant name |
-| `--folder-id <id>` | Folder ID |
+| `--folder-key <key>` | Folder key (GUID, defaults to authenticated folder) |
 | `--detailed` | Show full response with all fields |
 | `--login-validity <minutes>` | Min minutes before token refresh |
 
@@ -800,13 +831,23 @@ uip case processes incidents <process-key> --folder-key <key>
 
 ---
 
-## uip case incidents
+## uip case incident
 
-View Case incident summaries across all processes. **Requires `uip login`.**
+View and retrieve Case incidents across all processes. **Requires `uip login`.**
 
 ```bash
-uip case incidents list
+# Get incident summaries across all processes
+uip case incident summary
+
+# Get a single incident by ID
+uip case incident get <incident-id> --folder-key <key>
 ```
+
+Options for `get`:
+| Flag | Description |
+|------|-------------|
+| `<incident-id>` | **(required)** Incident ID |
+| `--folder-key <key>` | **(required)** Folder key |
 
 ---
 

--- a/skills/uipath-case-management/references/implementation.md
+++ b/skills/uipath-case-management/references/implementation.md
@@ -212,7 +212,7 @@ Debug is for **testing that the case runs correctly** — not for publishing or 
 
 ## Step 14 — Publish to Studio Web
 
-**This is the default publish target.** When the user wants to publish, view, or share the case, upload it to Studio Web using `solution bundle` + `solution upload`:
+**This is the default publish target.** When the user wants to publish, view, or share the case, upload the solution directly to Studio Web:
 
 Always ask user:
 
@@ -222,15 +222,12 @@ Use `AskUserQuestion` with options: "Yes", "No"
 
 If the user says yes:
 ```bash
-# Bundle the solution directory into a .uis file
-uip solution bundle "<SolutionDir>" --output json
-
-# Upload the .uis to Studio Web
-uip solution upload "<SolutionName>.uis" --output json
+# Upload the solution folder (containing the .uipx) to Studio Web
+uip solution upload <SolutionDir> --output json
 ```
 
-The `bundle` command requires a solution directory containing a `.uipx` file. If the project was created with `uip case init`, it lives inside a solution directory already. The `upload` command pushes it to Studio Web where the user can visualize, inspect, edit, and publish from the browser. Share the Studio Web URL with the user.
+`uip solution upload` accepts the solution directory (the folder containing the `.uipx` file) directly — no intermediate bundling step is required. If the project was created with `uip case init`, it already lives inside a solution directory already. The `upload` command pushes it to Studio Web where the user can visualize, inspect, edit, and publish from the browser. Share the Studio Web URL with the user.
 
-**Do NOT run `uip case pack` + `uip solution publish` unless the user explicitly asks to deploy to Orchestrator.** That path puts the case directly into Orchestrator as a process, bypassing Studio Web — the user cannot visualize or edit it there. If the user asks to "publish" without specifying where, always default to the Studio Web path (`solution bundle` + `solution upload`).
+**Do NOT run `uip case pack` + `uip solution publish` unless the user explicitly asks to deploy to Orchestrator.** That path puts the case directly into Orchestrator as a process, bypassing Studio Web — the user cannot visualize or edit it there. If the user asks to "publish" without specifying where, always default to the Studio Web path (`uip solution upload <SolutionDir>`).
 
 For Orchestrator deployment when explicitly requested, see [case-commands.md](case-commands.md) for `uip case pack` and the [/uipath:uipath-platform](/uipath:uipath-platform) skill for `uip solution publish`.


### PR DESCRIPTION
- Simplifies the Step 14 publish workflow: uip solution upload now accepts the solution directory directly, removing the intermediate solution bundle step
- Adds uip solution upload section to case-commands.md with usage and clarifying note about the pack + solution publish alternative path
- Adds uip case registry get command with full options table, including --connection-id for IS field metadata enrichment
- Adds options table for uip case registry pull and expands resource types to include typecache-activities and typecache-triggers
- Fixes --solution-id flag casing (was --solutionId)
- Marks --folder-key as required for process list, process get, process status, and incident get
- Removes deprecated --folder-id flags from process list, process get, process run, and process status
- Renames uip case incidents → uip case incident and adds incident get <id> subcommand
- Clarifies get-connector description: does not fetch connections, use get-connection for that