### PR TITLE
refactor(uipath-case-management): adopt plugin pattern (20 plugins)

### DIFF
--- a/skills/uipath-case-management/SKILL.md
+++ b/skills/uipath-case-management/SKILL.md
@@ -1,88 +1,141 @@
 ---
 name: uipath-case-management
-description: "[PREVIEW] Case Management authoring (sdd.md → tasks.md → caseplan.json). Resolves registry taskTypeIds, generates task plans, executes uip case CLI. For .xaml→uipath-rpa, for .flow→uipath-flow."
+description: "[PREVIEW] Case Management authoring from sdd.md. Produces tasks.md plan, executes uip case CLI to build caseplan.json. For .xaml→uipath-rpa, .flow→uipath-maestro-flow."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
 # UiPath Case Management Authoring Assistant
 
-End-to-end guide for creating UiPath Case Management definitions. Takes a design document (sdd.md), generates a reviewable task plan (tasks.md), and executes the plan via the `uip case` CLI.
+End-to-end guide for creating UiPath Case Management definitions. Takes a design document (`sdd.md`), generates a reviewable task plan (`tasks.md`), and executes the plan via the `uip case` CLI to produce `caseplan.json`.
+
+**Scope for this milestone:** creating a **new** case from `sdd.md`. Modifying an existing case is not supported — it requires remote fetch tooling that does not exist today.
 
 ## When to Use This Skill
 
-- User asks to create a case management project or definition
-- User asks to generate implementation tasks from an sdd.md
-- User asks to break down a case spec into tasks or plan case tasks from sdd
-- User asks to create a tasks.md from spec or interpret case spec
-- User asks to convert a spec to an implementation plan
-- User provides an sdd.md and wants a case built from it
-- User is editing an existing case JSON file — adding stages, tasks, edges, or properties
-- User wants to manage runtime case instances (list, pause, resume, cancel)
+- User provides an `sdd.md` and wants a Case Management project built from it
+- User asks to create a new case management project or definition
+- User asks to generate implementation tasks from an `sdd.md` or convert a spec into a plan
 - User asks about the case management JSON schema — nodes, edges, tasks, rules, SLA
+- User wants to manage runtime case instances (list, pause, resume, cancel) — see [references/case-commands.md](references/case-commands.md)
+
+**Do not use this skill for:**
+- `.xaml` workflows → use `uipath-rpa`
+- `.flow` files → use `uipath-maestro-flow`
+- Standalone agents, APIs, or processes outside a case context → use the corresponding UiPath skill
 
 ## Critical Rules
 
-1. **Always regenerate tasks.md from scratch** — never do incremental updates to an existing tasks.md. This avoids stale state from previous runs.
-2. **Run `uip case registry pull` before any interpretation** — pulling the registry cache upfront avoids network failures partway through.
-3. **tasks.md entries are declarative specifications** — no `uip` CLI commands in tasks.md. Each task entry contains parameters, IDs, and metadata only. The execution phase translates specs into CLI calls.
-4. **Follow every step as written — do not skip or shortcut** — the procedures exist because previous shortcuts caused failures. Do not skip registry lookups based on assumptions.
-5. **Best effort on registry failures** — if a lookup fails, mark it as `[REGISTRY LOOKUP FAILED: <keywords>]` and continue. Do not abort the entire run.
-6. **One task per T-number** — do not group multiple sdd.md tasks under a single T-number.
-7. **Max 2 registry refresh retries** — if `registry pull --force` still yields no match after 2 retries, mark the lookup as failed and move on.
-8. **Ask the user when login fails** — if `uip login status` shows not logged in, prompt the user to run `uip login` and stop until they confirm.
-9. **Every stage needs at least one edge** connecting it to the case or it will be orphaned.
-10. **Trigger node is created automatically** on `cases add` — don't add another unless it's a separate entry point (e.g. for a multi-trigger case).
-11. **Tasks are 2D arrays**: `tasks[lane][index]` — use `--lane` to put tasks in parallel lanes.
-12. **Edit `content/*.json` only** — `content/*.bpmn` is auto-generated and will be overwritten.
-13. **Execute all commands in sequence. No parallel execution.**
+1. **sdd.md is the sole input** — trust it as written. This skill does not validate or gap-fill `sdd.md`. If the file is ambiguous, use AskUserQuestion to clarify, do not infer silently.
+2. **Always run `uip case registry pull` before planning** — caches the registry at `~/.uipcli/case-resources/` so all subsequent discovery is local.
+3. **Registry discovery is direct cache-file inspection, not CLI search.** `uip case registry search` has known gaps (especially for action-apps). Read the `<type>-index.json` files directly. See [references/registry-discovery.md](references/registry-discovery.md).
+4. **Always use `--output json`** on every `uip case` read command whose output is parsed programmatically.
+5. **Follow the plugin for every node type.** Every task, trigger, and condition variant has its own plugin under `references/plugins/`. Open the matching `planning.md` during planning and `impl.md` during execution. Do not guess CLI flags or JSON shapes from memory.
+6. **`tasks.md` entries are declarative.** No `uip` CLI commands inside `tasks.md`. Each entry is parameters, IDs, and metadata only. The execution phase translates specs into CLI calls.
+7. **One T-entry per sdd.md declaration — no omissions.** Every stage, edge, task, trigger, condition, and SLA rule declared in `sdd.md` gets its own T-numbered entry, even when the declared value looks like a "default" (e.g., condition rule-type `current-stage-entered` / `case-entered`, stage-exit type `exit-only`, `is-interrupting: false`, `runOnlyOnce: true`). Never group multiple items under one T-number. Never skip a declaration on the grounds that "the default behavior would already cover it" — if `sdd.md` wrote it down, `tasks.md` must emit a T-task for it.
+8. **Always regenerate `tasks.md` from scratch** — never do incremental updates. Avoids stale state from previous runs.
+9. **HARD STOP before execution.** After generating `tasks.md`, present it to the user and require explicit approval via **AskUserQuestion** (`Approve and proceed` / `Request changes`). Do not execute until approved.
+10. **After approval, run `/compact` if supported by the runner**, then re-read `tasks.md`. `tasks.md` is the complete handoff artifact — all IDs, inputs, outputs, and references are captured there.
+11. **Unresolved task resources produce skeleton tasks — never mock, never fabricate.** Keep the `<UNRESOLVED: ...>` marker on the `taskTypeId` / `type-id` / `connection-id` slot in `tasks.md`, and omit `inputs:` / `outputs:` from that task entry. At execution time, the task is created in `caseplan.json` with `--type` + `--display-name` only (skeleton task) — no task-type-id, no connection-id, no variable bindings. Task-entry conditions and `selected-tasks-completed` rules still reference the skeleton's `TaskId`, so the workflow structure stays reviewable. The user attaches the real resource + bindings externally before runtime. See [references/skeleton-tasks.md](references/skeleton-tasks.md). Never fabricate a task-type-id or connection-id to "fill the gap".
+12. **Persist every registry resolution to `registry-resolved.json`** with full detail: search query, all matched results, selected result, rationale. This is the debug audit trail.
+13. **Cross-task references** use `"Stage Name"."Task Name".output_name` in planning and resolve to `--source-stage <id> --source-task <id> --source-output <name>` at execution time. Every ref must point to a task already in `tasks.md` order. Discover output names via `uip case tasks describe` — do not fabricate. See [references/bindings-and-expressions.md](references/bindings-and-expressions.md).
+14. **Expression prefixes are fixed:** `=metadata.`, `=js:`, `=vars.`, `=datafabric.`, `=bindings.`, `=orchestrator.JobAttachments`, `=response`, `=result`, `=Error`, `=jsonString:`. Plain strings without a prefix are literals, not expressions.
+15. **Connector integration uses the 3-step pipeline**: `get-connector` → `get-connection` → (optional) `tasks describe --connection-id`. One plugin (`connector-activity` / `connector-trigger` / event-`trigger`) per integration pattern — schema is data-driven. See [references/connector-integration.md](references/connector-integration.md).
+16. **Enrichable non-connector task types** (`process`, `agent`, `rpa`, `action`, `api-workflow`, `case-management`) pass `--task-type-id` on `tasks add` to auto-populate inputs/outputs. Connector variants use `tasks add-connector` with `--type-id` + `--connection-id` instead.
+17. **Every stage needs at least one inbound edge** or it will be orphaned. The Trigger node created automatically by `cases add` is the entry point for all single-trigger cases.
+18. **No lanes.** All tasks go into `tasks[0]` of the stage's `tasks` 2D array. Do not pass `--lane`.
+19. **User questions use AskUserQuestion with a "Something else" escape hatch.** Whenever a decision has finite enumerable choices (≤5), present a dropdown with those options AND "Something else" as the last option. For open-ended inputs (e.g., `--every 1h` vs `2h` vs `1d`), use a direct prompt. Never force a false choice.
+20. **Validate after build, not during.** Run `uip case validate` only after all stages, edges, tasks, conditions, and SLA are added. Intermediate states are expected to be invalid. Retry up to 3× on failure; on the 3rd failure, halt and ask the user with options: `Retry with fix` / `Pause for manual edit` / `Abort`.
+21. **Never run `uip case debug` automatically** — it executes the case for real (sends emails, posts messages, calls APIs). Only run on explicit user consent.
+22. **Edit `content/*.json` only** — `content/*.bpmn` is auto-generated and will be overwritten.
+23. **Execute CLI commands sequentially.** No parallel execution — each command may depend on IDs returned by the previous one.
 
 ## Workflow
 
-This skill has two phases: **Planning** generates a reviewable tasks.md from the sdd.md. **Implementation** translates tasks.md into CLI commands and builds the case definition. There is a hard stop between them — do not proceed to implementation without explicit user approval.
+Two phases with a hard stop between them: **Planning** generates a reviewable `tasks.md` from `sdd.md`. **Implementation** executes `tasks.md` via the `uip case` CLI.
 
----
+### Phase 1 — Planning (sdd.md → tasks.md)
 
-### Phase 1 — Planning
+**Read [references/planning.md](references/planning.md)** for the full procedure. Produces:
 
-**Read [references/planning.md](references/planning.md)** for the full planning process: resolve CLI, check login, pull registry, parse sdd.md, resolve task types, and generate tasks.md.
-
-Follow the process in that guide to produce:
 1. `tasks/tasks.md` — declarative task plan with T-numbered entries (stages → edges → tasks → conditions → SLA)
-2. `tasks/registry-resolved.json` — registry lookup audit trail
+2. `tasks/registry-resolved.json` — full audit trail of registry lookups
 
-Present tasks.md to the user for review.
+Present `tasks.md` to the user for approval. **Do NOT proceed until the user explicitly approves.**
 
-**Do NOT proceed to Phase 2 until the user explicitly approves tasks.md.**
+### Phase 2 — Implementation (tasks.md → caseplan.json)
 
-### Phase 2 — Implementation
+**Read [references/implementation.md](references/implementation.md)** for the full execution procedure. Steps:
 
-**Read [references/implementation.md](references/implementation.md)** for the full implementation process.
+1. Create the solution + project + case file (Step 6)
+2. Add stages (Step 7)
+3. Add edges (Step 8)
+4. Add tasks and bind inputs/outputs (Step 9) — per-task-type detail in `plugins/tasks/<type>/impl.md`
+5. Add conditions (Step 10) — per-scope detail in `plugins/conditions/<scope>/impl.md`
+6. Configure SLA and escalation (Step 11)
+7. Validate (Step 12)
+8. Post-build loop (Step 13) — AskUserQuestion dropdown for next steps; loop until user selects `Done`
 
-Phase 2 takes the approved tasks.md and executes it:
-1. Create case project structure (solution + project + case file)
-2. Add stages, edges, tasks, conditions, SLA
-3. Bind variables and wire cross-task references
-4. Validate the case file
-5. Optionally debug or publish to Studio Web
+After the user approves `tasks.md`: run `/compact` (if supported by your runner) to free planning-phase context, then re-read `tasks.md` before proceeding.
 
-Execute each task from tasks.md in order, translating declarative specifications into `uip case` CLI commands. Capture IDs returned by each command and use them in subsequent steps.
+## Quick Start
 
-**After the user approves tasks.md:** run `/compact` to free context, then re-read `tasks.md` before proceeding. The tasks.md file is the complete handoff artifact between the two phases.
+For a fresh case built from `sdd.md`, the 8 steps:
 
-## Anti-patterns — What NOT to Do
+### Step 0 — Resolve the `uip` binary
 
-- Do NOT put `uip case ...` CLI commands in tasks.md — causes double-execution or mis-parsing. tasks.md is declarative only.
-- Do NOT incrementally update an existing tasks.md — always regenerate from scratch to avoid stale state.
-- Do NOT skip registry lookups based on assumptions like "this type is not discoverable." Always search the cache files first.
-- Do NOT group multiple sdd.md tasks under one T-number — each task in the sdd.md gets its own numbered entry.
-- Do NOT fabricate expression syntax for conditional SLA rules — describe the condition in natural language; the execution phase determines the correct expression format.
-- Do NOT add interactive checkpoints during tasks.md generation — run silently and let the user review the output after completion.
-- Do NOT include parameters the CLI does not support — only include what `uip case` can act on (see [CLI command reference](references/case-commands.md)).
-- Do NOT use lane assignments in tasks.md — the lane concept is no longer used for managing parallelism in the planning phase.
-- Do NOT edit `.bpmn` files — they are auto-generated and will be overwritten.
-- Do NOT run debug automatically — it has real side effects (sends emails, calls APIs, writes to databases).
-- Do NOT execute commands in parallel — run all CLI commands sequentially.
-- Do NOT fabricate input or output names in cross-task references — run `uip case tasks describe` to discover actual input/output names from the task's schema.
+```bash
+UIP=$(command -v uip 2>/dev/null || echo "$(npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip")
+$UIP --version
+```
+
+Use `$UIP` in place of `uip` if the plain command isn't on PATH.
+
+### Step 1 — Login and pull registry
+
+```bash
+uip login status --output json
+uip case registry pull
+```
+
+If not logged in, ask the user to run `uip login` and stop.
+
+### Step 2 — Locate the sdd.md
+
+Accept the path from the user. If multiple `.md` files exist in the directory, use **AskUserQuestion** with candidates + "Something else".
+
+### Step 3 — Resolve resources
+
+For each task, trigger, and condition in `sdd.md`:
+
+1. Identify the plugin from the sdd.md component type (see [references/planning.md §3](references/planning.md)).
+2. Load the plugin's `planning.md`.
+3. Apply registry discovery per [references/registry-discovery.md](references/registry-discovery.md).
+4. Record resolutions in `registry-resolved.json` (full detail).
+5. Mark unresolved resources with `<UNRESOLVED: ...>`.
+
+### Step 4 — Generate tasks.md
+
+Order: stages → edges → tasks → conditions → SLA. One T-numbered entry per item. See [references/planning.md §4](references/planning.md) for structure.
+
+### Step 5 — HARD STOP: user approval
+
+**AskUserQuestion**: `Approve and proceed` / `Request changes`. Loop on `Request changes`. Do not execute without explicit approval.
+
+### Step 6 — /compact and execute
+
+Run `/compact` (if runner supports), re-read `tasks.md`, then open [references/implementation.md](references/implementation.md) and execute each T-entry in order. Open the matching plugin's `impl.md` for each task/trigger/condition.
+
+### Step 7 — Validate
+
+```bash
+uip case validate <file>
+```
+
+Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fix` / `Pause for manual edit` / `Abort`.
+
+### Step 8 — Post-build prompt
+
+**AskUserQuestion** with options: `Run debug session` / `Publish to Studio Web` / `Done` / `Something else`. Loop until the user selects `Done`.
 
 ## Reference Navigation
 
@@ -91,27 +144,113 @@ Execute each task from tasks.md in order, translating declarative specifications
 | **Plan tasks from sdd.md** | [references/planning.md](references/planning.md) |
 | **Execute tasks.md into a case** | [references/implementation.md](references/implementation.md) |
 | **Understand the case JSON schema** | [references/case-schema.md](references/case-schema.md) |
-| **Know all CLI commands** | [references/case-commands.md](references/case-commands.md) |
+| **Know all CLI flags** | [references/case-commands.md](references/case-commands.md) |
 | **Resolve task types from registry** | [references/registry-discovery.md](references/registry-discovery.md) |
-| **Connect stages** | [references/implementation.md](references/implementation.md) Step 8 + [references/case-schema.md — Edges](references/case-schema.md) |
-| **Add a task to a stage** | [references/implementation.md](references/implementation.md) Step 9 + [references/case-commands.md](references/case-commands.md) |
-| **Find available processes/agents** | Run `uip case registry pull` then `uip case registry list` |
+| **Wire inputs/outputs and cross-task refs** | [references/bindings-and-expressions.md](references/bindings-and-expressions.md) |
+| **Configure a connector activity / trigger / event** | [references/connector-integration.md](references/connector-integration.md) |
+| **Handle unresolved resources (skeleton tasks)** | [references/skeleton-tasks.md](references/skeleton-tasks.md) |
+| **Create the root case (T01)** | [references/plugins/case/planning.md](references/plugins/case/planning.md) + `impl.md` |
+| **Create a stage (regular or exception)** | [references/plugins/stages/planning.md](references/plugins/stages/planning.md) + `impl.md` |
+| **Connect nodes with edges** | [references/plugins/edges/planning.md](references/plugins/edges/planning.md) + `impl.md` |
+| **Configure SLA (default, conditional, escalation)** | [references/plugins/sla/planning.md](references/plugins/sla/planning.md) + `impl.md` |
+| **Add a specific task type** | `references/plugins/tasks/<type>/planning.md` + `impl.md` |
+| **Add a specific trigger type** | `references/plugins/triggers/<type>/planning.md` + `impl.md` |
+| **Add a specific condition scope** | `references/plugins/conditions/<scope>/planning.md` + `impl.md` |
+
+### Plugin Index
+
+**Structural plugins**:
+
+| Plugin | Scope |
+|--------|-------|
+| [case](references/plugins/case/planning.md) | Root case (created once, T01) |
+| [stages](references/plugins/stages/planning.md) | Regular and exception (a.k.a. secondary) stages |
+| [edges](references/plugins/edges/planning.md) | Edges between Trigger/Stage nodes (type inferred) |
+| [sla](references/plugins/sla/planning.md) | Default SLA, conditional SLA rules, escalation rules |
+
+**Task plugins** (`references/plugins/tasks/`):
+
+| Plugin | sdd.md component type |
+|--------|-----------------------|
+| [process](references/plugins/tasks/process/planning.md) | PROCESS, AGENTIC_PROCESS |
+| [agent](references/plugins/tasks/agent/planning.md) | AGENT |
+| [rpa](references/plugins/tasks/rpa/planning.md) | RPA |
+| [action](references/plugins/tasks/action/planning.md) | HITL |
+| [api-workflow](references/plugins/tasks/api-workflow/planning.md) | API_WORKFLOW |
+| [case-management](references/plugins/tasks/case-management/planning.md) | CASE_MANAGEMENT |
+| [connector-activity](references/plugins/tasks/connector-activity/planning.md) | CONNECTOR_ACTIVITY |
+| [connector-trigger](references/plugins/tasks/connector-trigger/planning.md) | CONNECTOR_TRIGGER |
+| [wait-for-timer](references/plugins/tasks/wait-for-timer/planning.md) | TIMER (in-stage) |
+
+**Trigger plugins** (`references/plugins/triggers/`):
+
+| Plugin | When |
+|--------|------|
+| [manual](references/plugins/triggers/manual/planning.md) | User-initiated start |
+| [timer](references/plugins/triggers/timer/planning.md) | Scheduled start |
+| [event](references/plugins/triggers/event/planning.md) | External connector event |
+
+**Condition plugins** (`references/plugins/conditions/`):
+
+| Plugin | Scope |
+|--------|-------|
+| [stage-entry-conditions](references/plugins/conditions/stage-entry-conditions/planning.md) | When a stage is entered |
+| [stage-exit-conditions](references/plugins/conditions/stage-exit-conditions/planning.md) | When/how a stage exits |
+| [task-entry-conditions](references/plugins/conditions/task-entry-conditions/planning.md) | When a task starts |
+| [case-exit-conditions](references/plugins/conditions/case-exit-conditions/planning.md) | When the whole case completes or exits |
+
+## Anti-patterns — What NOT to Do
+
+- **Do NOT put `uip case ...` CLI commands inside `tasks.md`.** `tasks.md` is declarative only — causes double-execution or mis-parsing.
+- **Do NOT incrementally update an existing `tasks.md`.** Always regenerate from scratch.
+- **Do NOT skip registry lookups** based on assumptions like "this type is not discoverable." Always search the cache files first.
+- **Do NOT group multiple sdd.md tasks under one T-number.** Each task, trigger, edge, or condition gets its own numbered entry.
+- **Do NOT fabricate input or output names in cross-task references.** Run `uip case tasks describe` to discover actual names. A fabricated name becomes a silent runtime null.
+- **Do NOT fabricate expression syntax for conditional SLA rules.** Describe the condition in natural language; the execution phase determines the exact expression form.
+- **Do NOT fabricate task-type-ids or connection-ids.** When a resource is unresolved, use skeleton-task creation: `tasks add --type <t> --display-name <n>` with no `--task-type-id`, and for connectors `tasks add-connector --type <t> --display-name <n>` with no `--type-id` / `--connection-id`. Skip input/output bindings entirely — `var bind` needs a resolved schema. See [references/skeleton-tasks.md](references/skeleton-tasks.md).
+- **Do NOT invoke other skills automatically.** If the case needs a process, agent, or action that doesn't exist, emit a skeleton task (per Rule #11) and list the missing resources in the completion report so the user can register them externally. On-demand resource creation is a future milestone, not today.
+- **Do NOT pass `--lane` to `tasks add`.** Lane concept is not used.
+- **Do NOT edit `content/*.bpmn` files.** They are auto-generated and will be overwritten.
+- **Do NOT run `uip case debug` automatically.** It executes the case for real — sends emails, posts messages, calls APIs. Only run on explicit user consent.
+- **Do NOT execute CLI commands in parallel.** Each command may depend on IDs returned by the previous one — run them sequentially.
+- **Do NOT validate after each individual command.** Intermediate states are expected to be invalid. Run `uip case validate` once after the full build.
 
 ## Key Concepts
 
 ### Local vs cloud commands
 
 | Commands | What they do | Auth needed |
-|---------|-------------|-------------|
-| `uip case cases`, `stages`, `tasks`, `edges` | Edit local JSON definition files | No |
-| `uip case instance`, `processes`, `incidents` | Query/manage live Orchestrator data | Yes |
+|----------|--------------|-------------|
+| `uip case cases`, `stages`, `tasks`, `edges`, `var`, `sla` | Edit local `caseplan.json` | No |
+| `uip case registry pull/list/search`, `get-connector`, `get-connection` | Registry discovery (uses cached data after pull) | Yes (for `pull`) |
+| `uip case instance`, `processes`, `incidents`, `process run`, `job traces`, `debug` | Query/manage live Orchestrator state | Yes |
 
 ### CLI output format
 
-All `uip case` commands return structured JSON:
+All `uip case` commands return:
+
 ```json
-{ "Result": "Success", "Code": "StageAdded", "Data": { ... } }
+{ "Result": "Success", "Code": "...", "Data": { ... } }
 { "Result": "Failure", "Message": "...", "Instructions": "..." }
 ```
 
-Use `--output json` for programmatic use.
+Always pass `--output json` when the output is parsed.
+
+## Completion Output
+
+When the build completes, report to the user:
+
+1. **File path** of `caseplan.json`
+2. **What was built** — summary of stages, edges, tasks, conditions, SLA
+3. **Validation status** — whether `uip case validate` passes (or remaining errors)
+4. **Skeleton tasks + unresolved resources** — list every skeleton task created (TaskId, type, display-name, stage) alongside the external resource the user must register to upgrade it (task-type-id / connection-id). Include the wiring-notes from `tasks.md` so the user knows which inputs/outputs to attach. See [references/skeleton-tasks.md](references/skeleton-tasks.md) for the upgrade procedure.
+5. **Missing connections** — any connector tasks needing IS connections that don't exist yet
+6. **Next step** — **AskUserQuestion** dropdown (per Rule #19):
+   - `Run debug session` → ask for explicit consent, then run `uip case debug`
+   - `Publish to Studio Web` → `uip solution upload <SolutionDir>`
+   - `Done`
+   - `Something else`
+
+Do not take any of these actions automatically — wait for explicit selection.
+
+> **Trouble?** If something didn't work as expected, use `/uipath-feedback` to send a report.

--- a/skills/uipath-case-management/references/bindings-and-expressions.md
+++ b/skills/uipath-case-management/references/bindings-and-expressions.md
@@ -1,0 +1,126 @@
+# Bindings & Expressions Reference
+
+How to wire values into task inputs — expression prefixes, cross-task output references, and the `uip case var bind` CLI.
+
+## Two Binding Modes
+
+Every task input is wired using one of two modes. Pick based on the source of the value.
+
+| Mode | Tasks.md syntax | CLI form |
+|------|-----------------|---------|
+| **Literal or expression** | `input = "<value>"` | `uip case var bind <file> <stage-id> <task-id> <input-name> --value "<value>"` |
+| **Cross-task reference** | `input <- "Stage"."Task".output` | `uip case var bind <file> <stage-id> <task-id> <input-name> --source-stage <id> --source-task <id> --source-output <name>` |
+
+Exactly one of `--value` or all three `--source-*` options must be provided — not both.
+
+## Expression Prefixes
+
+When using the literal/expression mode, the `--value` string can start with one of these prefixes to resolve dynamically at runtime. Plain strings without a prefix are treated as literals.
+
+| Prefix | Meaning | Example |
+|--------|---------|---------|
+| `=metadata.` | Case metadata field | `=metadata.amount` |
+| `=js:` | Inline JavaScript expression | `=js:new Date().toISOString()` |
+| `=vars.` | Case-level variable | `=vars.inbox_config` |
+| `=bindings.` | Resource binding (connection, queue, trigger) | `=bindings.slackConnection` |
+| `=datafabric.` | Data Fabric entity field | `=datafabric.Customer.id` |
+| `=orchestrator.JobAttachments` | Orchestrator job attachments | `=orchestrator.JobAttachments[0]` |
+| `=response` | The response object from a previous HTTP step | `=response.body` |
+| `=result` | The result of the previous task | `=result.status` |
+| `=Error` | Error object from a failed step | `=Error.message` |
+| `=jsonString:` | Serialize the following expression to a JSON string | `=jsonString:vars.config` |
+
+> Plain strings (no prefix) are literal values. `"hello"` is literally the string `hello`, not an expression.
+
+## Cross-Task References
+
+Cross-task references wire the output of an earlier task into an input of a later task. The planning syntax uses **names** (human-readable), which the implementation phase translates to **IDs** when executing `uip case var bind`.
+
+### Planning syntax (in `tasks.md`)
+
+```
+input_name <- "Stage Name"."Task Name".output_name
+```
+
+- `Stage Name` — the `display-name` of the containing stage (exactly as written in a `Create stage "<name>"` task)
+- `Task Name` — the `display-name` of the source task (exactly as written in an `Add <type> task "<name>"` task)
+- `output_name` — a named output field from the source task
+
+### Discovering output names
+
+Run `tasks describe` during planning to list available outputs for a given task type:
+
+```bash
+uip case tasks describe --type <type> --id "<taskTypeId>" --output json
+# for connectors: also pass --connection-id
+```
+
+Output names appear in the response under the output schema. Record them in the source task's `outputs:` field in `tasks.md` so downstream references can be validated.
+
+### Validation rule
+
+Every cross-task reference in `tasks.md` MUST point to:
+1. A stage that exists (created by an earlier `Create stage "..."` task).
+2. A task inside that stage that exists (created by an earlier `Add ... task "..." to "<stage>"` task).
+3. An output name listed in that task's `outputs:` field.
+
+Missing any of the three → halt planning and ask the user; do not fabricate.
+
+### Implementation translation
+
+The execution phase resolves names to IDs using the case JSON:
+
+```bash
+# Pseudo-code the skill follows:
+src_stage_id = find_stage_id_by_display_name(case.json, "Stage Name")
+src_task_id  = find_task_id_by_display_name(case.json, src_stage_id, "Task Name")
+
+uip case var bind <file> <target-stage-id> <target-task-id> <input-name> \
+  --source-stage "$src_stage_id" \
+  --source-task  "$src_task_id" \
+  --source-output "output_name"
+```
+
+## Examples
+
+### Literal and expression inputs
+
+```markdown
+## T10: Add api-workflow task "Fetch Inbox" to "Triage"
+- inputs:
+  - inbox_config = "=vars.inbox_config"
+  - po_patterns  = "=vars.po_patterns"
+  - max_results  = "50"
+  - requested_at = "=js:new Date().toISOString()"
+```
+
+### Cross-task reference
+
+```markdown
+## T11: Add agent task "Classify Emails" to "Triage"
+- inputs:
+  - emails <- "Triage"."Fetch Inbox".emails
+  - customer_id <- "Triage"."Fetch Inbox".customer_id
+- outputs: category, priority_score
+```
+
+### Mixed inputs (HITL/action)
+
+```markdown
+## T12: Add action task "Review Classification" to "Triage"
+- recipient: approver@corp.com
+- priority: High
+- inputs:
+  - classification <- "Triage"."Classify Emails".category
+  - priority       <- "Triage"."Classify Emails".priority_score
+  - deadline       = "=js:new Date(Date.now() + 86400000).toISOString()"
+- outputs: decision, comments
+```
+
+## Anti-Patterns
+
+- **Mixing `--value` and `--source-*` in the same bind.** The CLI rejects this. Pick one mode per input.
+- **Referencing a future task's output.** Cross-task references must target an earlier task in execution order.
+- **Fabricating output names.** Always discover via `tasks describe`. A typo becomes a runtime null, not a validation error.
+- **Plain-string where expression was intended.** `"metadata.amount"` (no `=`) is the literal string `metadata.amount`, not a reference. Always include the `=` prefix for dynamic values.
+- **Nesting expressions inside literals.** `"$metadata.amount"` or `"{{ amount }}"` do not work. Use `=metadata.amount` directly as the full value.

--- a/skills/uipath-case-management/references/case-schema.md
+++ b/skills/uipath-case-management/references/case-schema.md
@@ -1,6 +1,6 @@
-# Case Management JSON Schema Reference
+# Case Management JSON Schema — Cross-Cutting Reference
 
-A case definition JSON file is the **source of truth** for a Case Management workflow. It is edited locally using `uip case` commands and then deployed to Orchestrator.
+Structural reference for the case definition JSON. Shared across all node types. Per-task-type and per-condition-type field shapes live in each plugin's `impl.md`.
 
 ## Top-level structure
 
@@ -49,8 +49,8 @@ Metadata and configuration for the case definition.
 | `caseIdentifierType` | `"constant"` \| `"external"` | How the identifier is resolved |
 | `caseAppEnabled` | boolean | Whether the Case App UI is enabled |
 | `version` | string | Schema version — `"v12"` for current schema |
-| `data.sla` | SlaSchema? | Default SLA for the case |
-| `data.slaRules` | SlaRuleEntry[]? | Expression-driven SLA rules |
+| `data.sla` | SlaSchema? | Default SLA for the case (see §5) |
+| `data.slaRules` | SlaRuleEntry[]? | Expression-driven SLA rules (see §5) |
 | `data.uipath` | object? | Variable and binding declarations |
 | `caseExitConditions` | CaseExitCondition[]? | Conditions that mark the case as complete |
 | `description` | string? | Case description |
@@ -66,22 +66,15 @@ Metadata and configuration for the case definition.
 }
 ```
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string? | Unique ID |
-| `displayName` | string? | Human-readable label |
-| `rules` | Rules? | DNF rule set (see §5) |
-| `marksCaseComplete` | boolean? | Whether this condition closes the case |
+Rule structure uses DNF — see §4.
 
 ---
 
-## 2. nodes
-
-Discriminated union on `type`. Three node types exist.
+## 2. nodes (three types, discriminated on `type`)
 
 ### a) Trigger Node — `"case-management:Trigger"`
 
-Entry point. Created automatically by `uip case cases add`. There should be exactly one.
+Entry point. Created automatically by `uip case cases add`. Exactly one per case.
 
 ```json
 {
@@ -90,18 +83,16 @@ Entry point. Created automatically by `uip case cases add`. There should be exac
   "position": { "x": 200, "y": 0 },
   "data": {
     "label": "Start",
-    "uipath": {
-      "serviceType": "None"
-    }
+    "uipath": { "serviceType": "None" }
   }
 }
 ```
 
-`serviceType` options: `"None"`, `"Intsvc.EventTrigger"`, `"Intsvc.TimerTrigger"`.
+`serviceType` values: `"None"`, `"Intsvc.EventTrigger"`, `"Intsvc.TimerTrigger"`. The specific binding/config shape for each trigger kind lives in the corresponding trigger plugin's `impl.md`.
 
 ### b) Stage Node — `"case-management:Stage"`
 
-Standard workflow stage. Contains tasks organized in parallel lanes.
+Standard workflow stage. Contains tasks.
 
 ```json
 {
@@ -110,30 +101,24 @@ Standard workflow stage. Contains tasks organized in parallel lanes.
   "position": { "x": 600, "y": 200 },
   "data": {
     "label": "Review Application",
-    "tasks": [
-      [
-        { "id": "<taskId>", "type": "process", "displayName": "Run KYC", "data": { "name": "KYC", "folderPath": "Shared" } }
-      ]
-    ],
+    "tasks": [ [ { ... task ... } ] ],
     "sla": { "count": 2, "unit": "d" },
     "entryConditions": [],
     "exitConditions": [],
-    "description": "some desc"
+    "description": "..."
   }
 }
 ```
-
-`tasks` is a 2D array: `tasks[lane][index]`. Outer = parallel lanes, inner = sequential tasks per lane.
 
 **StageNodeData fields:**
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `label` | string? | Display label |
-| `tasks` | Task[][]? | 2D array of tasks (lanes × sequential) |
+| `tasks` | Task[][]? | 2D array: `tasks[lane][index]`. The skill writes all tasks into `tasks[0]` — lane concept is not used. |
 | `sla` | SlaSchema? | SLA for this stage |
-| `entryConditions` | EntryCondition[]? | Conditions for entering the stage |
-| `exitConditions` | ExitCondition[]? | Conditions for exiting the stage |
+| `entryConditions` | EntryCondition[]? | See §3 |
+| `exitConditions` | ExitCondition[]? | See §3 |
 | `instanceIdPrefix` | string? | Prefix for instance IDs |
 | `description` | string? | Stage description |
 
@@ -141,61 +126,53 @@ Standard workflow stage. Contains tasks organized in parallel lanes.
 
 Like a Stage but also supports expression-driven SLA rules.
 
-```json
-{
-  "id": "<shortId>",
-  "type": "case-management:ExceptionStage",
-  "position": { "x": 1100, "y": 200 },
-  "data": {
-    "label": "Handle Rejection",
-    "tasks": [],
-    "entryConditions": [
-      { "id": "<id>", "displayName": "Fraud detected", "rules": [], "isInterrupting": true }
-    ],
-    "exitConditions": [
-      {
-        "id": "<id>",
-        "displayName": "Return to review",
-        "type": "return-to-origin",
-        "rules": []
-      }
-    ],
-    "slaRules": []
-  }
-}
-```
-
-ExceptionStage `data` extends StageNodeData with:
+Extends StageNodeData with:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `slaRules` | SlaRuleEntry[]? | Expression-driven SLA rules for this exception stage |
 
-### EntryCondition
+---
+
+## 3. Conditions (cross-cutting)
+
+All conditions share the same shape but attach at different levels. Per-level field tables and `--rule-type` semantics live in the corresponding condition plugin's `impl.md`.
+
+### EntryCondition (stage-level)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string? | Unique ID |
 | `displayName` | string? | Human-readable label |
-| `rules` | Rules? | DNF rule set (see §5) |
-| `isInterrupting` | boolean? | Whether this condition interrupts the current stage |
+| `rules` | Rules | DNF rule set — see §4 |
+| `isInterrupting` | boolean? | Whether the condition interrupts the current stage |
 
-### ExitCondition
+### ExitCondition (stage-level)
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `id` | string? | Unique ID |
 | `displayName` | string? | Human-readable label |
-| `rules` | Rules? | DNF rule set (see §5) |
+| `rules` | Rules | DNF rule set — see §4 |
 | `type` | string? | `"exit-only"` \| `"wait-for-user"` \| `"return-to-origin"` |
 | `exitToStageId` | string? | Target stage ID when routing to a specific stage |
 | `marksStageComplete` | boolean? | Whether this exit marks the stage complete |
 
+### TaskEntryCondition (task-level)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string? | Unique ID |
+| `displayName` | string? | Human-readable label |
+| `rules` | Rules | DNF rule set — see §4 |
+
+### CaseExitCondition (case-level)
+
+See `root.caseExitConditions` in §1.
+
 ---
 
-## 3. edges
-
-Discriminated union on `type`. Two edge types exist.
+## 4. edges (two types, discriminated on `type`)
 
 ### a) TriggerEdge — `"case-management:TriggerEdge"`
 
@@ -205,8 +182,8 @@ Connects Trigger → Stage. No rules.
 {
   "id": "<shortId>",
   "type": "case-management:TriggerEdge",
-  "source": "<trigger-node-id>",
-  "target": "<stage-node-id>",
+  "source": "<trigger-id>",
+  "target": "<stage-id>",
   "sourceHandle": "<trigger-id>____source____right",
   "targetHandle": "<stage-id>____target____left",
   "data": { "label": "Start" }
@@ -215,7 +192,7 @@ Connects Trigger → Stage. No rules.
 
 ### b) Edge — `"case-management:Edge"`
 
-Connects Stage → Stage. Transition conditions are defined via ExitConditions on the source stage node, not on the edge itself.
+Connects Stage → Stage. Transition conditions live on the source stage's `exitConditions`, not on the edge.
 
 ```json
 {
@@ -229,82 +206,13 @@ Connects Stage → Stage. Transition conditions are defined via ExitConditions o
 }
 ```
 
-**EdgeData fields:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `label` | string? | Display label on the edge |
-| `waypoints` | unknown? | Visual routing waypoints |
-
-Handle format: `<nodeId>____source____<direction>` or `<nodeId>____target____<direction>`.
-Directions: `right`, `left`, `top`, `bottom`.
+Handle format: `<nodeId>____source____<direction>` or `<nodeId>____target____<direction>`. Directions: `right`, `left`, `top`, `bottom`.
 
 ---
 
-## 4. Tasks
+## 5. Rules (DNF — OR of AND-clauses)
 
-All tasks share a `BaseTask`:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string? | Unique task ID (auto-generated) |
-| `elementId` | string? | Element ID |
-| `displayName` | string? | Human-readable label shown in the UI |
-| `type` | string | Task type (see below) |
-| `data` | object | Type-specific configuration |
-| `skipCondition` | string? | Expression — skip the task when truthy |
-| `entryConditions` | TaskEntryCondition[]? | Conditions controlling task entry |
-| `conditions` | TaskCondition[]? | **Deprecated** — use `entryConditions` instead |
-| `shouldRunOnReEntry` | boolean? | Re-run when stage is re-entered |
-| `description` | string? | Task description |
-
-### Task types
-
-| Type | `data` fields |
-|------|---------------|
-| `process` | `name?`, `folderPath?`, `inputs?`, `outputs?`, `context?` |
-| `action` | `name?`, `folderPath?`, `taskTitle?`, `labels?`, `priority?`, `actionCatalogName?`, `recipient?` |
-| `agent` | `name?`, `folderPath?`, `inputs?`, `outputs?`, `context?` |
-| `api-workflow` | `name?`, `folderPath?`, `inputs?`, `outputs?`, `context?` |
-| `rpa` | `name?`, `folderPath?`, `inputs?`, `outputs?`, `context?` |
-| `external-agent` | `name?`, `folderPath?`, `serviceType?`, `bindings?` |
-| `wait-for-timer` | `timer?`, `timeDuration?`, `timeDate?`, `timeCycle?` |
-| `wait-for-connector` | `name?`, `folderPath?`, `serviceType?`, `bindings?` |
-| `execute-connector-activity` | `name?`, `folderPath?`, `serviceType?`, `bindings?` |
-| `case-management` | `name?`, `folderPath?`, `inputs?`, `outputs?`, `context?` |
-
-### TaskEntryCondition
-
-```json
-{
-  "id": "<id>",
-  "displayName": "Run only if not verified",
-  "rules": [[{ "rule": "current-stage-entered" }]]
-}
-```
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `id` | string? | Unique ID |
-| `displayName` | string? | Human-readable label |
-| `rules` | Rules? | DNF rule set (see §5) |
-
-### TaskCondition (deprecated)
-
-```json
-{
-  "id": "<id>",
-  "displayName": "Skip if already verified",
-  "actionType": "skip",
-  "rules": [[{ "rule": "current-stage-entered" }]]
-}
-```
-
----
-
-## 5. Rules (DNF: OR of AND-clauses)
-
-Rules are used in entry/exit conditions and task conditions.
+Used by every condition type (entry, exit, task-entry, case-exit).
 
 ```
 Rules = Rule[][]
@@ -312,7 +220,7 @@ Rules = Rule[][]
   Inner array = AND conditions within a group
 ```
 
-### Rule types
+### Rule types (cross-cutting catalog)
 
 | `rule` | Additional fields | Description |
 |--------|-------------------|-------------|
@@ -321,27 +229,18 @@ Rules = Rule[][]
 | `selected-stage-completed` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has completed |
 | `selected-stage-exited` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has been exited |
 | `selected-tasks-completed` | `id?`, `selectedTasksIds?`, `conditionExpression?` | Specific tasks have all completed |
+| `required-tasks-completed` | `id?`, `conditionExpression?` | All required tasks in the stage have completed |
+| `required-stages-completed` | `id?`, `conditionExpression?` | All required stages have completed |
 | `current-stage-entered` | `id?`, `conditionExpression?` | The current stage was just entered |
 | `adhoc` | `id?`, `conditionExpression?` | Ad-hoc expression-based condition |
 
+Not every rule type is valid at every level — see each condition plugin's `impl.md` for the allowed subset per location.
+
 ```json
 { "rule": "case-entered", "id": "<id>" }
-
 { "rule": "selected-stage-completed", "id": "<id>", "selectedStageId": "<stageId>" }
-
 { "rule": "selected-tasks-completed", "id": "<id>", "selectedTasksIds": ["<taskId1>", "<taskId2>"] }
-
 { "rule": "adhoc", "id": "<id>", "conditionExpression": "in.Score > 700" }
-
-{
-  "rule": "wait-for-connector",
-  "id": "<id>",
-  "uipath": {
-    "serviceType": "Intsvc.EventTrigger",
-    "outputs": [],
-    "bindings": []
-  }
-}
 ```
 
 ---
@@ -367,14 +266,10 @@ Rules = Rule[][]
 ```
 
 Time units: `"h"` (hours), `"d"` (days), `"w"` (weeks), `"m"` (months).
-
 Escalation `triggerInfo.type`: `"at-risk"` or `"sla-breached"`.
-
 Escalation `action.recipients[].scope`: `"User"` or `"UserGroup"`.
 
-### SlaRuleEntry
-
-Expression-driven SLAs allow per-case-instance SLA overrides:
+### SlaRuleEntry (expression-driven overrides)
 
 ```json
 {
@@ -384,9 +279,44 @@ Expression-driven SLAs allow per-case-instance SLA overrides:
 }
 ```
 
+Evaluated in array order; the first truthy expression wins. The trailing entry with `expression: "=js:true"` (or equivalent) acts as the default.
+
 ---
 
-## Minimal example
+## 7. Tasks — BaseTask shape (shared)
+
+All tasks inside a stage share this envelope. Per-type `data` fields live in each task plugin's `impl.md`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string? | Unique task ID (auto-generated) |
+| `elementId` | string? | Element ID |
+| `displayName` | string? | Human-readable label shown in the UI |
+| `type` | string | Task type — see task plugins under `plugins/tasks/` |
+| `data` | object | Type-specific configuration — see corresponding plugin's `impl.md` |
+| `skipCondition` | string? | Expression — skip the task when truthy |
+| `entryConditions` | TaskEntryCondition[]? | See §3 |
+| `shouldRunOnReEntry` | boolean? | Re-run when stage is re-entered |
+| `description` | string? | Task description |
+
+**Task type catalog** (full shape in each plugin's `impl.md`):
+
+| Task `type` | Plugin |
+|-------------|--------|
+| `process` | `plugins/tasks/process/` |
+| `action` | `plugins/tasks/action/` |
+| `agent` | `plugins/tasks/agent/` |
+| `rpa` | `plugins/tasks/rpa/` |
+| `api-workflow` | `plugins/tasks/api-workflow/` |
+| `case-management` | `plugins/tasks/case-management/` |
+| `execute-connector-activity` | `plugins/tasks/connector-activity/` |
+| `wait-for-connector` | `plugins/tasks/connector-trigger/` |
+| `wait-for-timer` | `plugins/tasks/wait-for-timer/` |
+| `external-agent` | *(reserved — not covered in current milestone)* |
+
+---
+
+## 8. Minimal example
 
 ```json
 {

--- a/skills/uipath-case-management/references/connector-integration.md
+++ b/skills/uipath-case-management/references/connector-integration.md
@@ -1,0 +1,145 @@
+# Connector Integration Reference
+
+Procedure for resolving connector activity and connector trigger tasks against UiPath Integration Service. Shared between the `connector-activity` and `connector-trigger` task plugins and the `event` trigger plugin.
+
+## When to Use
+
+Consult this reference when planning or implementing any of:
+
+- `connector-activity` task (added via `uip case tasks add-connector --type activity`)
+- `connector-trigger` task (added via `uip case tasks add-connector --type trigger`)
+- `event` case-level trigger (added via `uip case triggers add-event`)
+
+## Prerequisites
+
+1. `uip login` — tenant-scoped connectors are only visible after authentication.
+2. `uip case registry pull` — populates `typecache-activities-index.json` and `typecache-triggers-index.json` at `~/.uipcli/case-resources/`.
+3. A healthy Integration Service connection must exist for the connector. If `Connections` is empty after `get-connection`, the user must create one in IS before proceeding.
+
+## Three-Step Resolution Pipeline
+
+For every connector task or event trigger, run these three CLI calls in order. Each call feeds required inputs into the next.
+
+### Step 1 — Find the activity-type-id
+
+Read the relevant TypeCache index file directly (CLI `registry search` has known gaps — see [registry-discovery.md](registry-discovery.md)).
+
+| Target | Cache file | Identifier field |
+|--------|-----------|------------------|
+| Connector activity | `typecache-activities-index.json` | `uiPathActivityTypeId` |
+| Connector trigger | `typecache-triggers-index.json` | `uiPathActivityTypeId` |
+
+Match on `displayName` from the sdd.md. **Skip entries without a `uiPathActivityTypeId`** — non-connector activities are not supported as case tasks.
+
+### Step 2 — Get connector metadata
+
+```bash
+uip case registry get-connector --type <typecache-activities|typecache-triggers> \
+  --activity-type-id "<uiPathActivityTypeId>" --output json
+```
+
+Output: `{ Entry, Config }`.
+
+- `Entry` — the raw TypeCache entry, including `displayName`, `configuration`.
+- `Config.connectorKey` — the Integration Service connector identifier (e.g., `gmail`, `uipath-atlassian-jira`).
+- `Config.objectName` — the specific operation (e.g., `message`, `issue`).
+
+### Step 3 — Get connections and pick one
+
+```bash
+uip case registry get-connection --type <typecache-activities|typecache-triggers> \
+  --activity-type-id "<uiPathActivityTypeId>" --output json
+```
+
+Output: `{ Entry, Config, Connections }` where `Connections` is an array of `{ id, name }` objects.
+
+**Selection rules (in priority order):**
+
+1. If the sdd.md names a specific connection, match by `name`. Use that `id`.
+2. If the sdd.md is silent and exactly one connection exists, use it.
+3. If multiple connections exist and sdd.md is silent, use **AskUserQuestion** with a bounded list of connection names + "Something else".
+4. If `Connections` is empty, mark the task `<UNRESOLVED: no IS connection for <connectorKey>>` in `tasks.md` and omit `input-values:`. Execution creates a skeleton connector task (bare `tasks add-connector --type <activity|trigger> --display-name …`). Tell the user in the completion report to create the connection in the IS portal before the task can run. See [skeleton-tasks.md](skeleton-tasks.md).
+
+### Step 4 — (Optional) Describe inputs/outputs
+
+For connector activities or triggers where the sdd.md requires wiring inputs to specific fields, run `tasks describe` to fetch the schema:
+
+```bash
+uip case tasks describe --type connector-activity --id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" --output json
+uip case tasks describe --type connector-trigger --id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" --output json
+```
+
+The `--connection-id` is required — without it, custom fields and dynamic enums are missing from the response.
+
+---
+
+## Applying Results to CLI Commands
+
+### Connector activity task
+
+```bash
+uip case tasks add-connector <file> <stage-id> \
+  --type activity \
+  --type-id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" \
+  --input-values '{"body":{"field":"value"},"queryParameters":{"key":"val"}}'
+```
+
+`--input-values` is a JSON object. Keys come from the `describe` response (Step 4). Use `body`, `queryParameters`, `pathParameters` as top-level keys depending on what the operation expects.
+
+### Connector trigger task (inside a stage)
+
+```bash
+uip case tasks add-connector <file> <stage-id> \
+  --type trigger \
+  --type-id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" \
+  --input-values '{"body":{"project":"PROJ"}}' \
+  --filter '((fields.status=`Open`))'
+```
+
+### Event trigger (case-level, outside any stage)
+
+```bash
+uip case triggers add-event <file> \
+  --type-id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" \
+  --event-params '{"project":"PROJ"}' \
+  --filter '((fields.status=`Open`))'
+```
+
+---
+
+## Filter Expression Syntax
+
+Trigger `--filter` expressions use the connector's filter DSL. Common patterns:
+
+| Pattern | Example |
+|---------|---------|
+| Equality | `` ((fields.status=`Open`)) `` |
+| Comparison | `` ((fields.priority>`3`)) `` |
+| String contains | `` ((fields.summary contains `urgent`)) `` |
+| Boolean AND | `` ((fields.status=`Open`) AND (fields.priority>`3`)) `` |
+
+Backticks wrap literal values. Double parentheses are required at the outermost level.
+
+If the sdd.md describes the filter in natural language, translate to the DSL. If unsure of the field name, consult the `describe` response (Step 4) for available fields.
+
+---
+
+## Output Contract to Tasks.md
+
+Record the resolved values in `tasks.md` under the task entry:
+
+```markdown
+## T25: Add connector-activity task "Create Jira Issue" to "Triage"
+- type-id: 718fdc36-73a8-3607-8604-ddef95bb9967
+- connection-id: 7622a703-5d85-4b55-849b-6c02315b9e6e
+- connector-key: uipath-atlassian-jira
+- object-name: issue
+- input-values: {"body":{"fields.project.key":"PROJ","fields.issuetype.id":"10004"}}
+```
+
+Also record in `registry-resolved.json`: search query, matched entry, selected connection, connector metadata.

--- a/skills/uipath-case-management/references/implementation.md
+++ b/skills/uipath-case-management/references/implementation.md
@@ -1,118 +1,54 @@
-# Implementation Phase: tasks.md → Case Definition
+# Implementation Phase: tasks.md → caseplan.json
 
-Execute the approved `tasks.md` plan by translating each declarative task specification into `uip case` CLI commands. This phase creates the case project, builds the case definition, validates it, and optionally debugs or publishes.
+Execute the approved `tasks.md` plan by translating each declarative task specification into `uip case` CLI commands. Build `caseplan.json`, validate, and optionally debug or publish.
 
 > **Prerequisite:** The user must have explicitly approved `tasks.md` from the [Planning Phase](planning.md) before starting.
 >
-> **Input:** `tasks/tasks.md` — the complete handoff artifact from the Planning Phase.
+> **Input:** `tasks/tasks.md` — the complete handoff artifact.
+
+> **Per-node-type CLI detail lives in plugins.** This document covers the cross-cutting execution workflow. For how to run the exact CLI for a specific node, consult the matching plugin's `impl.md`:
+> - Root case → `plugins/case/impl.md`
+> - Stages → `plugins/stages/impl.md`
+> - Edges → `plugins/edges/impl.md`
+> - Tasks → `plugins/tasks/<type>/impl.md`
+> - Triggers → `plugins/triggers/<type>/impl.md`
+> - Conditions → `plugins/conditions/<scope>/impl.md`
+> - SLA → `plugins/sla/impl.md`
 
 ---
 
-## Step 6 — Create Case project structure
+## Step 6 — Create the Case project structure
 
-The case file must be inside a proper solution/project structure:
-```bash
-mkdir -p <directory>
-
-# Create the solution
-cd <directory> && uip solution new <solutionName>
-
-# Create the case project inside the solution
-cd <solutionName> && uip case init <projectName>
-
-# Add the project to the solution
-uip solution project add \
-  <projectName> \
-  <solutionName>.uipx
-```
-
-This scaffolds a complete project. See [case-schema.md](case-schema.md) for the full project structure.
-
-```bash
-uip case cases add --name <CaseName> --file <directory>/<solutionName>/<projectName>/caseplan.json
-```
-
-> **`caseplan.json` is the literal filename — do not substitute the case name or project name here.**
-
-This scaffolds a minimal case JSON file with a root node and a default Trigger node.
-
-Optional flags:
-- `--case-identifier <string>` — defaults to the name
-- `--identifier-type constant|external` — default: `constant`
-- `--case-app-enabled` — enable the Case App UI
+The case file must live inside a solution + project. Scaffolding commands (solution new → case init → project add) plus the `cases add` invocation that creates `caseplan.json` live in [`plugins/case/impl.md`](plugins/case/impl.md). Run them in order, then capture the initial Trigger node ID returned by `cases add` for use in Step 8.
 
 ## Step 7 — Add stages
 
-```bash
-uip case stages add <file> --label "Review Application" --output json --is-required
-uip case stages add <file> --label "Exception Handler" --type exception --output json
-```
+For each stage in `tasks.md §4.4`, run the CLI per [`plugins/stages/impl.md`](plugins/stages/impl.md). **Capture the `StageId` for every stage** into the name → ID map — downstream edges, tasks, conditions, and SLA all reference it.
 
-Stage types: `stage` (default), `exception`, `trigger`.
-
-Stages are auto-positioned. Each stage gets a unique ID in the output — save it for adding tasks and edges.
+`isRequired` from `tasks.md` is planning-only metadata; it is not passed on `stages add`. It is consumed later by case-exit-conditions with `rule-type: required-stages-completed` (Step 10).
 
 ## Step 8 — Connect stages with edges
 
-The default trigger ID is `trigger_1`. Connect it to the first stage, then connect stages in sequence. Add edge labels for conditions if needed.
+For each edge in `tasks.md §4.5`, run the CLI per [`plugins/edges/impl.md`](plugins/edges/impl.md). Edge type is inferred automatically from the `--source` node.
 
-```bash
-uip case edges add <file> --source <trigger-id> --target <first-stage-id> --output json
-uip case edges add <file> --source <stage-id> --target <next-stage-id> --label "Approved" --output json
-```
+For multi-trigger cases, add the additional triggers first via the appropriate trigger plugin, then wire their IDs as edge sources.
 
-Edge type is inferred automatically: Trigger → `TriggerEdge`, Stage → `Edge`.
+## Step 9 — Add tasks and bind inputs/outputs
 
-Source/target handle directions default to `right`/`left` for stage edges and trigger edges.
+For each task entry in `tasks.md §4.6`, open the matching plugin's `impl.md` (`plugins/tasks/<type>/impl.md`) and run its command. **Capture the `TaskId` returned in `--output json`** — cross-task references and conditions need it.
 
-For multi-trigger cases, add extra triggers:
+After adding a task, bind its inputs per the two modes documented in [bindings-and-expressions.md](bindings-and-expressions.md):
 
-```bash
-uip case triggers add-timer <file> --every 1h --output json
-uip case triggers add-timer <file> --every 2d --at 2026-04-26T10:00:00.000Z --output json
-uip case triggers add-timer <file> --time-cycle "R/PT1H" --output json
-```
-
-Capture the returned trigger ID, then connect it to its target stage with an edge.
-
-## Step 9 — Add tasks to stages and bind variables
-
-```bash
-uip case tasks add <file> <stage-id> --type process --display-name "Run Background Check" --name "BackgroundCheck" --folder-path "Shared" --task-type-id <taskTypeId> --output json
-uip case tasks add <file> <stage-id> --type agent --display-name "AI Analysis" --task-type-id <taskTypeId> --output json
-uip case tasks add <file> <stage-id> --type action --display-name "Human Review" \
-  --task-title "Please review this application" \
-  --priority Medium \
-  --recipient reviewer@example.com \
-  --task-type-id <taskTypeId> --output json
-```
-
-Valid task types: `process`, `agent`, `api-workflow`, `rpa`, `external-agent`, `case-management`.
-
-Use `--lane <index>` for parallel execution (lane 0, 1, 2, etc.).
-
-**Bind task inputs and wire outputs** after adding each task. For each task in tasks.md, translate its `inputs` specification into `uip case var bind` commands.
-
-**Discover available inputs and outputs** — after adding a task with `--task-type-id`, the task is auto-enriched with input/output schemas. To inspect what inputs and outputs are available:
-
-```bash
-uip case tasks describe --type <type> --id <taskTypeId> --output json
-```
-
-Use the output to confirm that the input and output names in tasks.md match the actual schema.
-
-**Bind literal or expression values** — for each input specified as `input_name = "<value>"` in tasks.md:
+**Literal / expression mode** (for `input_name = "<value>"`):
 
 ```bash
 uip case var bind <file> <stage-id> <task-id> <input-name> --value "<value>" --output json
 ```
 
-Valid expression prefixes: `=metadata.<field>`, `=js:<expression>`, `=vars.<varId>`, `=datafabric.<entity>`, `=bindings.<name>`, `=orchestrator.JobAttachments`.
+**Cross-task reference mode** (for `input_name <- "Stage Name"."Task Name".output_name`):
 
-**Wire cross-task references** — for each input specified as `input_name <- "Stage Name"."Task Name".output_name` in tasks.md:
-
-1. Look up the source stage ID and source task ID from the IDs captured when those tasks were added in earlier steps.
-2. Run the bind command:
+1. Look up the source stage ID and source task ID from the capture map built in Steps 7 and 9.
+2. Run:
 
 ```bash
 uip case var bind <file> <target-stage-id> <target-task-id> <input-name> \
@@ -122,65 +58,53 @@ uip case var bind <file> <target-stage-id> <target-task-id> <input-name> \
   --output json
 ```
 
-**Binding order** — process bindings in task order as listed in tasks.md. Since tasks are ordered by dependency (`order: after T24`), binding each task's inputs immediately after adding it ensures all source tasks already exist. If a cross-task reference points to a task not yet added, defer that binding until the source task is created.
+**Binding order.** Process tasks in the order listed in `tasks.md` (already dependency-sorted by `order: after T<n>`). Bind each task's inputs immediately after adding it. If a cross-task reference points to a task not yet added, halt — `tasks.md` ordering is wrong; report to the user.
 
-## Step 10 — Add entry and exit conditions
+**Lane concept is not used.** Do not pass `--lane`. All tasks go into lane 0 by default.
 
-Only add conditions specified in tasks.md.
+### Step 9.1 — Skeleton tasks for unresolved resources
 
-**Stage entry conditions:**
+When a task entry's `taskTypeId` (or `type-id` / `connection-id` for connector tasks) is `<UNRESOLVED: …>`, create a **skeleton task** instead of halting. See [skeleton-tasks.md](skeleton-tasks.md) for the canonical reference.
+
+**Process / agent / rpa / action / api-workflow / case-management:**
+
 ```bash
-uip case stage-entry-conditions add <file> <stage-id> --display-name "<name>" \
-  --rule-type selected-stage-completed --selected-stage-id <id>
-```
-
-**Stage exit conditions:**
-```bash
-uip case stage-exit-conditions add <file> <stage-id> --display-name "<name>" \
-  --rule-type selected-tasks-completed --selected-tasks-ids "<task-id1>,<task-id2>" \
-  --marks-stage-complete true
-```
-
-**Case exit conditions:**
-```bash
-uip case case-exit-conditions add <file> --display-name "<name>" \
-  --rule-type required-stages-completed --marks-case-complete true
-```
-
-**Task entry conditions:**
-```bash
-uip case task-entry-conditions add <file> <stage-id> <task-id> \
+uip case tasks add <file> <stage-id> \
+  --type <process|agent|rpa|action|api-workflow|case-management> \
   --display-name "<name>" \
-  --rule-type selected-tasks-completed --selected-tasks-ids "<id>"
+  [--is-required] \
+  [--should-run-only-once] \
+  --output json
 ```
 
-Rule types:
-- Stage entry: `case-entered`, `selected-stage-exited`, `selected-stage-completed`, `wait-for-connector`, `adhoc`
-- Stage exit: `selected-tasks-completed`, `wait-for-connector`, `required-tasks-completed`
-- Case exit: `selected-stage-completed`, `selected-stage-exited`, `wait-for-connector`, `required-stages-completed`
-- Task entry: `current-stage-entered`, `selected-tasks-completed`, `wait-for-connector`, `adhoc`
-
-## Step 11 — Add SLA and escalation rules
-
-Set SLA duration on the root case or on individual stages. Only configure SLA if specified in tasks.md.
+**Connector activity / trigger:**
 
 ```bash
-# Root-level SLA
-uip case sla set <file> --count 5 --unit d
-
-# Per-stage SLA
-uip case sla set <file> --count 2 --unit w --stage-id <stage-id>
-
-# Escalation rule
-uip case sla escalation add <file> \
-  --trigger-type at-risk --at-risk-percentage 80 \
-  --recipient-scope User --recipient-target <target> --recipient-value <value>
-
-# Conditional SLA rule
-uip case sla rules add <file> --expression "=js:someCondition" --count 3 --unit d
+uip case tasks add-connector <file> <stage-id> \
+  --type <activity|trigger> \
+  --display-name "<name>" \
+  --output json
 ```
 
-SLA units: `h` (hours), `d` (days), `w` (weeks), `m` (months).
+**Skip `uip case var bind` entirely for skeleton tasks** — it rejects bindings without a resolved task-type schema. Capture the intended wiring from the `# wiring notes` block in `tasks.md` into the completion report so the user knows what to hook up after registering the resource.
+
+Skeleton tasks integrate with the rest of the graph:
+- **Task-entry conditions** use the captured skeleton `TaskId` normally.
+- **Stage-exit `selected-tasks-completed`** rules reference skeleton `TaskId`s normally.
+- **Cross-task variable bindings** are deferred — the user adds them via `uip case var bind` after attaching the real resource.
+
+## Step 10 — Add conditions
+
+For each condition in `tasks.md §4.7`, open the matching plugin:
+
+- Stage entry → [`plugins/conditions/stage-entry-conditions/impl.md`](plugins/conditions/stage-entry-conditions/impl.md)
+- Stage exit → [`plugins/conditions/stage-exit-conditions/impl.md`](plugins/conditions/stage-exit-conditions/impl.md)
+- Task entry → [`plugins/conditions/task-entry-conditions/impl.md`](plugins/conditions/task-entry-conditions/impl.md)
+- Case exit → [`plugins/conditions/case-exit-conditions/impl.md`](plugins/conditions/case-exit-conditions/impl.md)
+
+## Step 11 — SLA and escalation
+
+For each entry in `tasks.md §4.8`, run the matching sub-operation per [`plugins/sla/impl.md`](plugins/sla/impl.md): `sla set` for defaults, `sla rules add` for conditional overrides (root only), `sla escalation add` for notification rules.
 
 ## Step 12 — Validate
 
@@ -190,44 +114,43 @@ uip case validate <file>
 
 On success: `{ Result: "Success", Code: "CaseValidate", Data: { File, Status: "Valid" } }` — proceed to Step 13.
 
-On failure: the output lists each `[error]` or `[warning]` with its path and message. Fix the reported issues and re-run `validate` until it passes.
+On failure: output lists `[error]` and `[warning]` entries with path and message. Fix the reported issues (usually via a targeted re-run of the earlier step) and re-run `validate`.
 
-## Step 13 — Ask about debug
+**Retry policy.** Up to 3 validation retries per session. After the 3rd failure, halt and ask the user with **AskUserQuestion**: show the remaining errors and options — `Retry with fix`, `Pause for manual edit`, `Abort`.
 
-Once the case file passes validation, tell the user and ask:
+## Step 13 — Post-build prompt
 
-> "Case file created and validated. Do you want to debug it? This will upload it to Studio Web and run a debug session."
+Once validation passes, ask the user what to do next.
 
-Use `AskUserQuestion` with options: "Yes", "No"
+Use **AskUserQuestion** with options:
 
-If the user says yes:
+- `Run debug session` — proceed to Step 14.
+- `Publish to Studio Web` — proceed to Step 15.
+- `Done` — exit.
+- `Something else` — free-form prompt.
+
+After debug or publish completes, return to this prompt so the user can chain the other action (e.g., debug first, then publish). Exit when the user selects `Done`.
+
+For further authoring changes (add a task, tweak a condition, etc.), the user updates `sdd.md` and re-runs the skill from Phase 1 — this skill does not offer in-place incremental edits.
+
+## Step 14 — Optional: Debug session
+
+> Debug executes the case for real — it will send emails, post messages, call APIs, write to databases. Only run debug when the user explicitly asks. Never run it automatically.
+
 ```bash
 uip case debug "<directory>/<solutionName>/<projectName>" --log-level debug --output json
 ```
 
-Requires `uip login`. Uploads to Studio Web, triggers a debug session in Orchestrator, and streams results.
+Requires `uip login`. Uploads to Studio Web, runs in Orchestrator, streams results.
 
-**Do NOT run `case debug` automatically.** Debug executes the case for real — it will send emails, post Slack messages, call APIs, write to databases, etc. Only run debug when the user explicitly asks.
-Debug is for **testing that the case runs correctly** — not for publishing or viewing. To publish, use Step 14 instead.
+## Step 15 — Optional: Publish to Studio Web
 
-## Step 14 — Publish to Studio Web
+**Default publish target.** Uploads the case to Studio Web for visualization and editing.
 
-**This is the default publish target.** When the user wants to publish, view, or share the case, upload the solution directly to Studio Web:
-
-Always ask user:
-
-> "Do you want to publish it to Studio Web? This will upload it and make it available for visualization and editing."
-
-Use `AskUserQuestion` with options: "Yes", "No"
-
-If the user says yes:
 ```bash
-# Upload the solution folder (containing the .uipx) to Studio Web
-uip solution upload <SolutionDir> --output json
+uip solution upload "<SolutionDir>" --output json
 ```
 
-`uip solution upload` accepts the solution directory (the folder containing the `.uipx` file) directly — no intermediate bundling step is required. If the project was created with `uip case init`, it already lives inside a solution directory already. The `upload` command pushes it to Studio Web where the user can visualize, inspect, edit, and publish from the browser. Share the Studio Web URL with the user.
+Accepts the solution directory (the folder containing the `.uipx`) directly — no intermediate bundling step. `upload` pushes to Studio Web — share the returned URL with the user.
 
-**Do NOT run `uip case pack` + `uip solution publish` unless the user explicitly asks to deploy to Orchestrator.** That path puts the case directly into Orchestrator as a process, bypassing Studio Web — the user cannot visualize or edit it there. If the user asks to "publish" without specifying where, always default to the Studio Web path (`uip solution upload <SolutionDir>`).
-
-For Orchestrator deployment when explicitly requested, see [case-commands.md](case-commands.md) for `uip case pack` and the [/uipath:uipath-platform](/uipath:uipath-platform) skill for `uip solution publish`.
+> **Do NOT run `uip case pack` + `uip solution publish` unless the user explicitly asks for Orchestrator deployment.** That path puts the case directly into Orchestrator, bypassing Studio Web. Default is always Studio Web.

--- a/skills/uipath-case-management/references/planning.md
+++ b/skills/uipath-case-management/references/planning.md
@@ -1,16 +1,25 @@
 # Planning Phase: sdd.md → tasks.md
 
-Generate a reviewable task plan (`tasks.md`) from the design document (`sdd.md`). This phase discovers registry resources, resolves task type IDs, and produces a declarative specification that the [Implementation Phase](../references/implementation.md) executes via the `uip case` CLI.
+Generate a reviewable task plan (`tasks.md`) from the design document (`sdd.md`). This phase discovers registry resources, resolves task type IDs, and produces a declarative specification that the [Implementation Phase](implementation.md) executes via the `uip case` CLI.
 
 > **Output:** `tasks/tasks.md` + `tasks/registry-resolved.json` in the same directory as the sdd.md file.
 >
-> **Exit gate:** The user must explicitly approve tasks.md before the Implementation Phase begins.
+> **Exit gate:** The user must explicitly approve `tasks.md` before the Implementation Phase begins.
+
+> **Per-node-type detail lives in plugins.** This document covers the cross-cutting planning workflow. For how to fill fields for a specific node, consult the relevant plugin:
+> - Root case → `plugins/case/planning.md`
+> - Stages (regular / exception) → `plugins/stages/planning.md`
+> - Edges → `plugins/edges/planning.md`
+> - Tasks → `plugins/tasks/<type>/planning.md`
+> - Triggers → `plugins/triggers/<type>/planning.md`
+> - Conditions → `plugins/conditions/<scope>/planning.md`
+> - SLA → `plugins/sla/planning.md`
 
 ---
 
 ## Step 0 — Resolve the `uip` binary
 
-The `uip` CLI is installed via npm. If `uip` is not on PATH (common in nvm environments), resolve it first:
+`uip` is installed via npm. If it is not on PATH (common in nvm environments):
 
 ```bash
 UIP=$(command -v uip 2>/dev/null || echo "$(npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip")
@@ -21,320 +30,172 @@ Use `$UIP` in place of `uip` for all subsequent commands if the plain `uip` comm
 
 ## Step 1 — Check login and pull registry
 
-Registry discovery happens during interpretation, so login is required before starting.
+Registry discovery happens during planning, so login is required first.
 
 ```bash
 uip login status --output json
 uip case registry pull
 ```
 
-If not logged in, prompt the user to log in first. The registry pull caches all resources locally at `~/.uip/case-resources/` so that subsequent searches are local disk lookups with no network failures mid-interpretation.
+If not logged in, prompt the user to log in. The registry pull caches all resources locally at `~/.uipcli/case-resources/` so subsequent searches are local disk lookups.
 
 ## Step 2 — Locate and parse the design document
 
-Accept the sdd.md file path from the user, or ask if not provided.
+Accept the `sdd.md` file path from the user, or ask if not provided. When the directory contains multiple `.md` files, use **AskUserQuestion** with the candidates + "Something else" to disambiguate.
 
-- **sdd.md** — the semantic design document. This is the sole input: it describes stages, tasks, edges, rules, SLA, component types, persona information, and provides the search keywords for registry lookups.
+`sdd.md` is the **sole input**. It describes stages, tasks, edges, conditions, SLA, component types, persona information, and provides the search keywords for registry lookups. The skill does not validate or gap-fill sdd.md — trust it as written.
 
-Parse sdd.md as the single source of truth for the case design.
+## Step 3 — Resolve resources
 
-## Step 3 — Resolve task types via registry
+For every task, trigger, and condition in the sdd.md:
 
-For each task in the sdd.md, determine the correct `taskTypeId` by reading the local registry cache files directly. After `registry pull` (Step 1), all resources are cached at `~/.uip/case-resources/`. Search these files instead of using CLI search commands — it is more reliable and faster.
+1. **Identify the plugin** by matching the sdd.md component description to an entry in the catalogs below (§3.1–§3.3).
+2. **Load the plugin's `planning.md`** — it lists the exact fields to resolve from sdd.md, the cache file(s) to consult, and any discovery steps required.
+3. **Apply registry discovery** via [registry-discovery.md](registry-discovery.md) when a taskTypeId is needed.
+4. **Persist every resolution** to `registry-resolved.json` (search query, all matched results, selected result, rationale). Keep full detail for debugging.
 
-### Component type mapping
+### 3.1 Task Type catalog
 
-This table maps sdd.md component types to the primary cache file to search and the CLI `--type` flag:
+| sdd.md component type | Plugin |
+|-----------------------|--------|
+| PROCESS, AGENTIC_PROCESS | `plugins/tasks/process/` |
+| AGENT | `plugins/tasks/agent/` |
+| RPA | `plugins/tasks/rpa/` |
+| HITL | `plugins/tasks/action/` |
+| API_WORKFLOW | `plugins/tasks/api-workflow/` |
+| CASE_MANAGEMENT | `plugins/tasks/case-management/` |
+| CONNECTOR_ACTIVITY | `plugins/tasks/connector-activity/` |
+| CONNECTOR_TRIGGER | `plugins/tasks/connector-trigger/` |
+| TIMER (in-stage) | `plugins/tasks/wait-for-timer/` |
 
-| component_type | Primary cache file | CLI tasks add --type |
-|---|---|---|
-| API_WORKFLOW | `api-index.json` | api-workflow |
-| AGENTIC_PROCESS | `processOrchestration-index.json` | process |
-| HITL | `action-apps-index.json` | action |
-| RPA | `process-index.json` | rpa |
-| AGENT | `agent-index.json` | agent |
-| CASE_MANAGEMENT | `caseManagement-index.json` | case-management |
-| CONNECTOR_ACTIVITY | `typecache-activities-index.json` | execute-connector-activity |
-| CONNECTOR_TRIGGER | `typecache-triggers-index.json` | wait-for-connector |
-| EXTERNAL_AGENT | *(not in cache)* | external-agent |
-| TIMER | *(not in cache)* | wait-for-timer |
-| PROCESS | `process-index.json` | process |
+### 3.2 Trigger Type catalog (case-level)
 
-For types marked "not in cache" (`EXTERNAL_AGENT`, `TIMER`), use the `--type` value directly without searching.
+| sdd.md description | Plugin |
+|--------------------|--------|
+| "Start manually" / "User initiates" | `plugins/triggers/manual/` |
+| "Every N hours/days" / scheduled / cron-like | `plugins/triggers/timer/` |
+| Event from external system (connector-based) | `plugins/triggers/event/` |
 
-For all other types, follow the procedure in the [registry-discovery reference](registry-discovery.md):
+### 3.3 Condition Scope catalog
 
-1. **Search the primary cache file** by matching the task name and folder path from the sdd.md.
-2. **If no match in the primary file**, search all other cache files — the sdd.md component type label may not match the actual registry type (e.g., an "RPA" task may be registered as `process`).
-3. **Pick the best match** using exact name + folder path from sdd.md Process References.
-4. **Force-refresh and retry** (`uip case registry pull --force`) only if no match is found across all cache files.
-5. **Extract the correct identifier field** per cache file type (`entityKey`, `id`, or `uiPathActivityTypeId`).
-6. For **connector tasks** (typecache-activities, typecache-triggers), also run `get-connector` and `get-connection` CLI commands to collect full details.
+| Where the condition attaches | Plugin |
+|------------------------------|--------|
+| On stage entry | `plugins/conditions/stage-entry-conditions/` |
+| On stage exit | `plugins/conditions/stage-exit-conditions/` |
+| On task entry | `plugins/conditions/task-entry-conditions/` |
+| On case exit | `plugins/conditions/case-exit-conditions/` |
 
-Collect all registry results for the debug output in Step 4.
+### 3.4 Unresolved resources
+
+When a resource cannot be resolved (CLI gap and no cache match, or missing connection), **do not fabricate a placeholder or mock**. Instead:
+
+1. Mark the line in `tasks.md` with `<UNRESOLVED: <reason>>` in the `taskTypeId` / `type-id` / `connection-id` slot.
+2. **Omit `inputs:` and `outputs:` entirely** on that task entry — there is no schema to wire against. Any input mapping the sdd.md described becomes a `# wiring notes (user must attach):` comment block under the entry for later manual setup.
+3. Keep every other structural field (display-name, isRequired, runOnlyOnce, order). Task-entry conditions still emit normally.
+4. **Continue planning — do not halt.**
+
+At execution time, unresolved tasks become **skeleton tasks** in `caseplan.json` (display-name + type only, no task-type-id, no bindings). The workflow graph is still reviewable end-to-end, and the user attaches real resources + bindings externally before runtime. See [skeleton-tasks.md](skeleton-tasks.md).
 
 ## Step 4 — Generate tasks.md and registry-resolved.json
 
-Create a `tasks/` folder in the same directory as the sdd.md file. Generate `tasks.md` using the structure below. Each section is a numbered task (T01, T02, ...) that maps to one or more CLI commands.
+Create a `tasks/` folder adjacent to the sdd.md file. Generate `tasks.md` using the structure below. Each section is a numbered task (`T01`, `T02`, …) — declarative parameters only, no CLI commands. The implementation phase translates each entry into the matching plugin's CLI.
 
-Read the [CLI command reference](case-commands.md) and the [case JSON schema reference](case-schema.md) to understand the available flags and data structures as you generate each task.
+Cross-reference: [case-schema.md](case-schema.md) for JSON shape, [bindings-and-expressions.md](bindings-and-expressions.md) for inputs/outputs wiring.
 
-Also write a `registry-resolved.json` file in the `tasks/` folder containing all registry lookup results keyed by task ID. This serves as a debugging and audit trail. Include:
-- The search query used
-- All matched results
-- Which result was selected and why
+Also write `registry-resolved.json` — full detail per task: search query, all matches, selected entry, rationale.
 
-### Task structure
+### 4.0 Completeness principle (no omissions)
 
-The task ordering follows the execution phase steps: stages → edges → tasks → conditions → SLA. The task title IS the action description — do not add a redundant `what` or `type` field. Absorb type into the title (e.g., "Add api-workflow task" not "Add task" + "type: api-workflow").
+Every declaration in `sdd.md` must become a T-task in `tasks.md`. Mapping is 1-to-1:
 
-#### 1. Create case file (T01)
+- **Never filter** declarations on the grounds that the default rule-type, default field value, or "implicit behavior" would cover them. If `sdd.md` lists a task, stage, edge, trigger, condition, or SLA row, `tasks.md` emits a T-task for it — regardless of rule-type (`current-stage-entered`, `case-entered`, `exit-only`, `required-tasks-completed`, etc.).
+- **Never merge** two sdd.md items into one T-task "because they're similar."
+- **Never drop** defaults-looking items (e.g., `is-interrupting: false`, `runOnlyOnce: true`, `marks-stage-complete: true`). The explicit declaration is the signal — honor it.
+- **When in doubt, emit.** It is always correct to create a T-task that mirrors an sdd.md row. It is never correct to silently omit one.
+
+Before presenting `tasks.md` at Step 5, run a completeness cross-check: for every declared stage / edge / task / trigger / condition / SLA row in sdd.md, verify a corresponding T-task exists. Gaps are a defect — fix before approval.
+
+### 4.1 Task ordering
+
+Always in this order: stages → edges → tasks → conditions → SLA.
+
+The task **title IS the action description** — do not add a redundant `what` or `type` field. Absorb type into the title (e.g., `Add api-workflow task "..."` not `Add task` + `type: api-workflow`).
+
+### 4.2 Create case file (T01)
 
 Title format: `Create case file "<name>"`
 
-Set up the case definition with name, description, key prefix.
+Consult [`plugins/case/planning.md`](plugins/case/planning.md) for required fields (name, file path, case-identifier, identifier-type, case-app-enabled, description). Source all fields from sdd.md.
 
-#### 2. Configure trigger (T02)
+### 4.3 Configure trigger (T02)
 
-Title format: `Configure wait-for-connector trigger "<name>"`
+Title format: `Configure <trigger-type> trigger "<name>"`
 
-For connector triggers, resolve via registry using `typecache-triggers` and include connection details from `get-connection` if applicable.
+Consult the corresponding trigger plugin (`plugins/triggers/<type>/planning.md`) for required fields.
 
-#### 3. Create stages (one per stage)
+### 4.4 Create stages
 
 Title format: `Create stage "<name>"` or `Create exception stage "<name>"`
 
-Each stage is its own task. Basic properties only — SLA and escalation come later (section 7). Each stage specifies:
+One task per stage. Consult [`plugins/stages/planning.md`](plugins/stages/planning.md) for required fields and the `stage` vs `exception` (a.k.a. secondary) decision. Basic properties only — SLA and escalation come later (§4.7).
 
-- **isRequired** — whether this stage must complete for the case to be considered complete (true/false). Determines which stages are tracked by `required-stages-completed` case exit conditions. Determine from the sdd.md using these criteria:
-  - `true` — **Default for regular stages.** The stage is part of the main case flow and must complete before the case can close. Look for: stages on the happy path, stages described as mandatory, stages without "optional" or "exception" qualifiers.
-  - `false` — Use for exception stages, optional review stages, or rework loops that the case can complete without entering. Look for: stages labeled as "exception", "optional", "fallback", "on-error", or stages that are only reached via conditional/interrupting entry conditions.
-
-Example:
-```markdown
-## T05: Create stage "PO Receipt & Triage"
-- isRequired: true
-- order: after T04
-- verify: Confirm Result: Success, capture StageId
-
-## T06: Create exception stage "Exception Handling"
-- isRequired: false
-- order: after T05
-- verify: Confirm Result: Success, capture StageId
-```
-
-#### 4. Setup edges (one per edge)
+### 4.5 Setup edges
 
 Title format: `Add edge "<source>" → "<target>"`
 
-One task per edge with human-readable condition labels.
+One task per edge. Consult [`plugins/edges/planning.md`](plugins/edges/planning.md) for required fields (source, target, label, handles) and the orphan check.
 
-#### 5. Add tasks (one per task)
+### 4.6 Add tasks
 
 Title format: `Add <type> task "<name>" to "<stage>"`
 
-Each task from the sdd.md becomes its own numbered task. Do NOT group multiple tasks under a single T-number. Each task specifies:
+One task per task from the sdd.md — do NOT group multiple tasks under a single T-number. The plugin for the task's type (`plugins/tasks/<type>/planning.md`) lists exactly which fields to record.
 
-- **taskTypeId** — resolved from the registry in Step 3.
-- **inputs** — what data this task consumes. Each input uses one of two formats:
-  - **Literal or expression**: `input_name = "<value>"` — a static value or expression prefix (`=metadata.`, `=js:`, `=vars.`, `=datafabric.`, `=bindings.`).
-  - **Cross-task reference**: `input_name <- "Stage Name"."Task Name".output_name` — wires another task's output into this input. The execution phase translates this into a `uip case var bind --source-stage --source-task --source-output` command.
-- **outputs** — what data this task produces, listed as named output fields. Downstream tasks reference these via the cross-task input format above. To discover available output names, run `uip case tasks describe --type <type> --id <taskTypeId>` during planning.
-- **runOnlyOnce** — whether the task should execute only once per case instance (true/false). Sourced from the sdd.md. Maps to CLI flag `--should-run-only-once`. Defaults to true if not specified in sdd.md.
-- **isRequired** — whether the task is required for stage completion (true/false). Sourced from the sdd.md. Maps to CLI flag `--is-required`. Defaults to true if not specified in sdd.md.
-- **order** — which task(s) must complete before this one runs (expressed as a dependency, e.g., "after T05").
-- **verify** — what the execution phase should check after executing this task to confirm success.
-- **recipient** — for `action` tasks only: the email address of the assigned user, sourced from sdd.md. Omit if the sdd.md does not specify an assignee.
-- **priority** — for `action` tasks only: `Low`, `Medium`, `High`, or `Critical`, sourced from sdd.md (default: `Medium` if not specified).
+Every task entry includes at least:
 
-> **No uip commands in task entries.** Each task is a declarative specification — parameters, IDs, and metadata only. Never write `uip case tasks add ...` or any shell command inside a task body. The execution phase translates these specs into CLI commands.
+- **taskTypeId** — resolved from the registry in Step 3
+- **inputs** / **outputs** — see [bindings-and-expressions.md](bindings-and-expressions.md) for the two input modes (literal/expression and cross-task reference)
+- **runOnlyOnce** — from sdd.md (default `true` if not specified)
+- **isRequired** — from sdd.md (default `true` if not specified)
+- **order** — dependency on previous tasks (`after T05`, etc.)
+- **verify** — what the execution phase should check after running
 
-> Ignore lane concept in creating the task. It is no longer feasible for managing the parallelism.
+Additional fields are plugin-specific; read the plugin's `planning.md` before filling the entry.
 
-Example (task with outputs and literal inputs):
-```markdown
-## T25: Add api-workflow task "Monitor Order Inbox" to "PO Receipt & Triage"
-- taskTypeId: abc-123-def
-- inputs:
-  - inbox_config = "=vars.inbox_config"
-  - po_patterns = "=vars.po_patterns"
-- outputs: email_id, sender_email, po_document
-- runOnlyOnce: true
-- isRequired: true
-- order: after T24
-- verify: Confirm Result: Success, capture TaskId from output
-```
+> **No `uip` commands in task entries.** Each task is a declarative specification. Never write shell commands inside a task body — the execution phase translates specs into CLI calls.
 
-Example (task consuming another task's outputs via cross-task reference):
-```markdown
-## T26: Add agent task "Classify Purchase Order" to "PO Receipt & Triage"
-- taskTypeId: def-456-ghi
-- inputs:
-  - po_document <- "PO Receipt & Triage"."Monitor Order Inbox".po_document
-  - sender_email <- "PO Receipt & Triage"."Monitor Order Inbox".sender_email
-- outputs: po_category, urgency_score, extracted_line_items
-- runOnlyOnce: true
-- isRequired: true
-- order: after T25
-- verify: Confirm Result: Success, capture TaskId from output
-```
+> **Lane concept is not used.** All tasks go into `tasks[0]`. Do not set `--lane`.
 
-Example (HITL/action with mixed input types):
-```markdown
-## T30: Add action task "Review Purchase Order" to "PO Receipt & Triage"
-- taskTypeId: xyz-456-abc
-- recipient: approver@corp.com
-- priority: High
-- inputs:
-  - po_document <- "PO Receipt & Triage"."Monitor Order Inbox".po_document
-  - po_category <- "PO Receipt & Triage"."Classify Purchase Order".po_category
-  - review_deadline = "=js:new Date(Date.now() + 86400000).toISOString()"
-- outputs: review_decision, reviewer_comments
-- isRequired: true
-- order: after T26
-- verify: Confirm Result: Success, capture TaskId from output
-```
+> **Skeleton shape for unresolved resources.** If `taskTypeId` / `type-id` / `connection-id` is `<UNRESOLVED: …>`, omit `inputs:` and `outputs:` entirely and capture wiring intent in a trailing comment block. Execution creates a bare task node — structural only. See [skeleton-tasks.md](skeleton-tasks.md) for the full pattern and upgrade path.
 
-#### 6. Configure conditions (one per condition)
+### 4.7 Configure conditions
 
-Title format: `Add <scope> <event> condition for "<target>"` (e.g., `Add stage entry condition for "PO Receipt & Triage"`)
+One task per condition. Order within §4.7: stage entry → stage exit → case exit → task entry.
 
-Each condition is its own numbered task. Process conditions in this order: stage entry conditions, stage exit conditions, case exit conditions, then task entry conditions.
+Title format: `Add <scope> condition for "<target>"`
 
-**Stage entry conditions** — control when a stage is entered:
+For per-scope fields, consult the corresponding condition plugin:
+- `plugins/conditions/stage-entry-conditions/planning.md`
+- `plugins/conditions/stage-exit-conditions/planning.md`
+- `plugins/conditions/task-entry-conditions/planning.md`
+- `plugins/conditions/case-exit-conditions/planning.md`
 
-- **rule-type** — `case-entered`, `selected-stage-completed`, `selected-stage-exited`, or `wait-for-connector`
-- **selected-stage-id** — the stage this rule references (required when rule-type is `selected-stage-completed` or `selected-stage-exited`)
-- **order** — which task(s) must complete before this one
-- **verify** — what to check after execution
+### 4.8 Set SLA and escalation rules
 
-**Stage exit conditions** — control when/how a stage exits:
+SLA comes last. Consult [`plugins/sla/planning.md`](plugins/sla/planning.md) for the three sub-operations (`sla set`, `sla rules add`, `sla escalation add`), per-target ordering, and the constraint that conditional SLA rules are root-only.
 
-- **rule-type** — depends on the exit behavior:
-  - `required-tasks-completed` — use when `marks-stage-complete: true`. All tasks in the stage must complete; no task ID list needed.
-  - `selected-tasks-completed` — use when `marks-stage-complete: false` (exit-only conditions). Requires explicit task IDs.
-  - `wait-for-connector` — wait for an external connector event.
-- **selected-tasks-ids** — comma-separated task names that must complete (required only when rule-type is `selected-tasks-completed`)
-- **type** — exit routing type. Determine from the sdd.md using these criteria:
-  - `exit-only` — **Default.** Use when the stage exits normally and the case continues forward along the configured edges.
-  - `wait-for-user` — Use when the sdd.md indicates the exit requires a manual user decision or approval before proceeding.
-  - `return-to-origin` — Use when the sdd.md describes a rework or exception loop that sends the case back to the stage it came from.
-- **exit-to-stage-id** — the target stage name when the exit routes to a specific stage. Required when the sdd.md names an explicit destination stage for this exit. Omit when the routing follows the default edge configuration or uses `return-to-origin`.
-- **marks-stage-complete** — whether this exit counts as stage completion (true/false)
-- **order** — which task(s) must complete before this one
-- **verify** — what to check after execution
+### 4.9 Not Covered section
 
-**Case exit conditions** — control when the entire case completes:
-
-Use `required-stages-completed` as the primary rule-type. This mirrors how stage exit conditions use `required-tasks-completed` — the case completes when all stages marked `isRequired: true` (set in section 3) have completed.
-
-- **rule-type** — determines completion logic:
-  - `required-stages-completed` — **Preferred.** Use when `marks-case-complete: true`. The case completes when every stage with `isRequired: true` has completed. No stage ID list needed.
-  - `selected-stage-completed` — Use only when a non-completion exit depends on a specific stage. Requires `selected-stage-id`.
-  - `selected-stage-exited` — Use only when an exit depends on a stage being exited (not necessarily completed). Requires `selected-stage-id`.
-  - `wait-for-connector` — wait for an external connector event.
-- **selected-stage-id** — the stage this rule references (required only for `selected-stage-completed` or `selected-stage-exited`)
-- **marks-case-complete** — whether this exit counts as case completion (true/false)
-- **order** — which task(s) must complete before this one
-- **verify** — what to check after execution
-
-Example:
-```markdown
-## T100: Add case exit condition — case resolved
-- rule-type: required-stages-completed
-- marks-case-complete: true
-- order: after T99
-- verify: Confirm Result: Success
-```
-
-**Task entry conditions** — control when a task within a stage starts:
-
-- **rule-type** — `current-stage-entered`, `selected-tasks-completed`, `wait-for-connector`, or `adhoc`
-- **selected-tasks-ids** — comma-separated task names that must complete (required when rule-type is `selected-tasks-completed`)
-- **condition-expression** — expression for the rule (required when rule-type is `adhoc`)
-- **order** — which task(s) must complete before this one
-- **verify** — what to check after execution
-
-**Stage exit condition examples:**
-
-```markdown
-## T80: Add stage exit condition for "PO Receipt & Triage" — all tasks done
-- rule-type: required-tasks-completed
-- type: exit-only
-- marks-stage-complete: true
-- order: after T79
-- verify: Confirm Result: Success
-
-## T81: Add stage exit condition for "Manager Review" — user picks next step
-- rule-type: required-tasks-completed
-- type: wait-for-user
-- marks-stage-complete: true
-- order: after T80
-- verify: Confirm Result: Success
-
-## T82: Add stage exit condition for "Exception Handling" — return to origin
-- rule-type: required-tasks-completed
-- type: return-to-origin
-- marks-stage-complete: false
-- order: after T81
-- verify: Confirm Result: Success
-
-## T83: Add stage exit condition for "Initial Review" — route to Escalation
-- rule-type: selected-tasks-completed
-- selected-tasks-ids: "Flag for Escalation"
-- type: exit-only
-- exit-to-stage-id: "Escalation"
-- marks-stage-complete: false
-- order: after T82
-- verify: Confirm Result: Success
-```
-
-#### 7. Set SLA and escalation rules
-
-SLA and escalation come last. They are broken into individual tasks, ordered as follows for each target (root first, then each stage):
-
-1. **Set default SLA** — the time-based catch-all SLA. Always last in the slaRules array. Title format: `Set default SLA for "<target>" to <duration>`
-2. **Add conditional SLA rules** (if any) — condition-based SLA overrides evaluated before the default. Describe the condition in natural language from the sdd.md. Do NOT fabricate expression syntax. **Order matters:** rules are evaluated in the order they are added; the first rule whose expression evaluates to true becomes the active SLA. Title format: `Add conditional SLA rule for "<target>" — <condition summary>`
-3. **Add escalation rules** — one task per escalation rule. Each rule specifies a trigger type (`at-risk` with percentage threshold, or `sla-breached`) and one or more recipients. Each recipient has a scope (`User` or `UserGroup`), a target, and a display value. Title format: `Add escalation rule for "<target>" — <trigger summary>`
-
-Example:
-```markdown
-## T150: Set default SLA for "PO Receipt & Triage" to 15 minutes
-- count: 15
-- unit: m
-- order: after T149
-- verify: Confirm Result: Success
-
-## T151: Add conditional SLA rule for root case — when priority is Urgent
-- condition: Priority = Urgent
-- count: 30
-- unit: m
-- order: after T150
-- verify: Confirm Result: Success
-
-## T152: Add escalation rule for "PO Receipt & Triage" — At-Risk 80%
-- trigger-type: at-risk
-- at-risk-percentage: 80
-- recipients:
-  - User: manager@corp.com
-  - UserGroup: Order Management Team
-- order: after T151
-- verify: Confirm Result: Success and capture the EscalationRuleId
-```
-
-#### Not Covered section
-
-Add a brief section at the end of tasks.md listing things referenced in the sdd.md but outside the scope of the `uip case` CLI:
-- **Data Fabric entity schemas and global variables** — referenced in task mappings but must be configured separately in Data Fabric.
+Add a brief section at the end of `tasks.md` listing things referenced in sdd.md but outside the scope of the `uip case` CLI (e.g., Data Fabric entity schemas, global variables). These stay as notes for the user.
 
 ---
 
 ## Step 5 — HARD STOP: User reviews and approves tasks.md
 
-Present the generated tasks.md to the user and ask for explicit approval before proceeding to the Implementation Phase.
+Present the generated `tasks.md` to the user and ask for explicit approval before proceeding.
 
-Use `AskUserQuestion` with options: "Approve and proceed", "Request changes"
+Use **AskUserQuestion** with options: `Approve and proceed`, `Request changes`.
 
-If the user requests changes, update tasks.md and re-present for approval. Do NOT proceed to the Implementation Phase until the user explicitly approves.
+If the user requests changes, update `tasks.md` and re-present. Do NOT proceed to the Implementation Phase until the user explicitly approves.
 
-**After the user approves:** run `/compact` to free context, then re-read `tasks.md` before proceeding to the [Implementation Phase](implementation.md). The tasks.md file is the complete handoff artifact between the planning and implementation phases.
+**After approval:** run `/compact` (if supported by your runner) to free planning-phase context, then re-read `tasks.md` before proceeding to the [Implementation Phase](implementation.md). `tasks.md` is the complete handoff artifact — all resolved IDs, inputs, outputs, and references are captured there.

--- a/skills/uipath-case-management/references/plugins/case/impl.md
+++ b/skills/uipath-case-management/references/plugins/case/impl.md
@@ -1,0 +1,105 @@
+# case (root) — Implementation
+
+## Prerequisites
+
+The case file must live inside a solution + project structure. Run these **before** `cases add`:
+
+```bash
+mkdir -p <directory>
+cd <directory> && uip solution new <SolutionName>
+cd <SolutionName> && uip case init <ProjectName>
+uip solution project add <ProjectName> <SolutionName>.uipx
+```
+
+## CLI Command
+
+```bash
+uip case cases add \
+  --name "<name>" \
+  --file "<SolutionDir>/<ProjectName>/caseplan.json" \
+  --case-identifier "<identifier>" \
+  --identifier-type <constant|external> \
+  --case-app-enabled \
+  --description "<description>" \
+  --output json
+```
+
+### Required flags
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--name` | yes | Human-readable case name |
+| `--file` | yes | **Literal filename `caseplan.json`** — do not substitute |
+
+### Optional flags
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--case-identifier` | `<name>` | Runtime case identifier |
+| `--identifier-type` | `constant` | `constant` \| `external` |
+| `--case-app-enabled` | (flag not set = `false`) | Include the flag to enable |
+| `--description` | *(empty)* | |
+
+## Example
+
+```bash
+uip case cases add \
+  --name "Loan Approval" \
+  --file "loan-approval-solution/loan-approval-project/caseplan.json" \
+  --case-identifier "LOAN" \
+  --identifier-type constant \
+  --case-app-enabled \
+  --description "End-to-end loan application processing with credit check, risk scoring, and manual review" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+After the command runs, `caseplan.json` contains:
+
+```json
+{
+  "root": {
+    "id": "<shortId>",
+    "name": "Loan Approval",
+    "type": "case-management:root",
+    "caseIdentifier": "LOAN",
+    "caseIdentifierType": "constant",
+    "caseAppEnabled": true,
+    "version": "v12",
+    "data": {},
+    "description": "End-to-end loan application processing..."
+  },
+  "nodes": [
+    {
+      "id": "<trigger-id>",
+      "type": "case-management:Trigger",
+      "position": { "x": 200, "y": 0 },
+      "data": { "uipath": { "serviceType": "None" } }
+    }
+  ],
+  "edges": []
+}
+```
+
+> The implicit Trigger node is created automatically. Its ID is returned in the `--output json` response — capture it for use as an edge source in Step 8.
+
+## Post-Add Validation
+
+Capture from `--output json`:
+
+- **File path** — confirm the file exists on disk.
+- **Initial Trigger ID** — save it as the source for the first edge (Trigger → first stage).
+- Confirm `root.type == "case-management:root"` and `root.version == "v12"`.
+
+## Editing the Root Case
+
+```bash
+uip case cases edit <file> \
+  --name "<new-name>" \
+  --case-identifier "<new-identifier>" \
+  --identifier-type <constant|external> \
+  --case-app-enabled
+```
+
+At least one flag is required for `edit`. Use when the sdd.md is updated post-build and re-runs planning.

--- a/skills/uipath-case-management/references/plugins/case/planning.md
+++ b/skills/uipath-case-management/references/plugins/case/planning.md
@@ -1,0 +1,62 @@
+# case (root) — Planning
+
+The root case definition — the top-level container that every other node lives inside. Created exactly once per `caseplan.json` via `uip case cases add`.
+
+## When to Use
+
+Always. This plugin is invoked for the very first T-entry (`T01`) in every `tasks.md`. It creates the case file and the implicit Trigger node.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `name` | sdd.md case title | CLI flag `--name`. Human-readable. |
+| `file` | Derived: `<SolutionDir>/<ProjectName>/caseplan.json` | **Literal filename `caseplan.json`** — do not substitute project name. |
+| `case-identifier` | sdd.md (optional; defaults to `name`) | The runtime identifier. |
+| `identifier-type` | sdd.md (optional; default `constant`) | `constant` \| `external`. Use `external` when sdd.md says the identifier comes from an upstream system. |
+| `case-app-enabled` | sdd.md (default `false`) | `true` if the sdd.md says the case is exposed via the Case App UI. |
+| `description` | sdd.md case description | CLI flag `--description`. |
+
+## identifier-type Guidance
+
+- `constant` — **Default.** Use when sdd.md does not mention external identifier sources. The case identifier is fixed across instances (typically matches `name`).
+- `external` — Use when sdd.md says something like "the case is identified by the incoming PO number" or "the case uses the external ticket ID." Runtime will pull the identifier from case data.
+
+When ambiguous, use **AskUserQuestion** with both options + "Something else".
+
+## Registry Resolution
+
+**None.** The root case has no registry representation — no `taskTypeId`, no enrichment.
+
+## Trigger Node is Auto-Created
+
+`uip case cases add` creates an implicit `case-management:Trigger` node inside `caseplan.json.nodes`. Do not add another trigger unless the case has multiple entry points (multi-trigger — see [triggers plugins](../triggers/)).
+
+## tasks.md Entry Format
+
+```markdown
+## T01: Create case file "<name>"
+- file: "<SolutionDir>/<ProjectName>/caseplan.json"
+- case-identifier: "<identifier>"
+- identifier-type: constant
+- case-app-enabled: false
+- description: "<one-sentence description>"
+- order: first
+- verify: Confirm Result: Success, capture file path and initial Trigger node ID
+```
+
+## Project Structure Prerequisites
+
+The case file lives inside a solution + project structure. Before T01 runs, the execution phase creates:
+
+```
+<directory>/
+  <SolutionName>/
+    <SolutionName>.uipx
+    <ProjectName>/
+      project.uiproj
+      content/...
+      caseplan.json   ← this file
+```
+
+See [implementation.md Step 6](../../implementation.md) for the `uip solution new` / `uip case init` / `uip solution project add` sequence that must run before `cases add`.

--- a/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/impl.md
+++ b/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/impl.md
@@ -1,0 +1,104 @@
+# case-exit-conditions — Implementation
+
+## CLI Command
+
+```bash
+uip case case-exit-conditions add <file> \
+  --display-name "<name>" \
+  --marks-case-complete <true|false> \
+  --rule-type <rule-type> \
+  --selected-stage-id "<stage-id>" \
+  --condition-expression "<expr>" \
+  --output json
+```
+
+> Note: there is no `<stage-id>` positional argument — case-exit-conditions attach at the root, not to a stage. `--selected-stage-id` is a flag used only by `selected-stage-*` rule-types to name the referenced stage.
+
+## Rule-Type × Marks-Case-Complete Matrix
+
+| `marks-case-complete` | Valid `--rule-type` | Extra flag |
+|------------------------|---------------------|-----------|
+| `true` | `required-stages-completed` | — |
+| `true` | `wait-for-connector` | `--condition-expression` |
+| `false` | `selected-stage-completed` | `--selected-stage-id` |
+| `false` | `selected-stage-exited` | `--selected-stage-id` |
+| `false` | `wait-for-connector` | `--condition-expression` |
+
+## Translation from tasks.md
+
+- `selected-stage` → `--selected-stage-id <id>` via the stage capture map.
+
+## Example — Preferred completion pattern
+
+```bash
+uip case case-exit-conditions add caseplan.json \
+  --display-name "Case resolved" \
+  --marks-case-complete true \
+  --rule-type required-stages-completed \
+  --output json
+```
+
+Completes the case when every stage flagged `isRequired: true` (in the planning metadata for `stages add`) has completed.
+
+## Example — Non-completing exit when a specific stage completes
+
+```bash
+uip case case-exit-conditions add caseplan.json \
+  --display-name "Early exit via Escalation" \
+  --marks-case-complete false \
+  --rule-type selected-stage-completed \
+  --selected-stage-id stg_escalation_id \
+  --output json
+```
+
+## Example — Wait for connector event to close
+
+```bash
+uip case case-exit-conditions add caseplan.json \
+  --display-name "Closed by downstream system" \
+  --marks-case-complete true \
+  --rule-type wait-for-connector \
+  --condition-expression "event.type = 'case_closed'" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+The root's `caseExitConditions` array gains:
+
+```json
+{
+  "id": "cond00000004",
+  "displayName": "Case resolved",
+  "marksCaseComplete": true,
+  "rules": [
+    [ { "rule": "required-stages-completed", "id": "..." } ]
+  ]
+}
+```
+
+Rules use DNF — outer array is OR, inner array is AND.
+
+## Post-Add Validation
+
+Capture `ConditionId` from `--output json`. Confirm in `caseplan.json`:
+
+- Root's `caseExitConditions[].id` matches
+- `marksCaseComplete` matches what you passed
+- `rules` contains the expected rule-type
+- `selectedStageId` (if set) matches
+
+## Editing / Removing
+
+```bash
+uip case case-exit-conditions edit <file> <condition-id> \
+  --display-name "<new-name>" \
+  --marks-case-complete <bool> \
+  --rule-type <additional> \
+  --condition-expression "<expr>" \
+  --selected-stage-id "<id>"
+
+uip case case-exit-conditions remove <file> <condition-id>
+```
+
+`edit --rule-type` appends a new rule (OR group). Use `remove` + re-`add` to replace.

--- a/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/planning.md
@@ -1,0 +1,65 @@
+# case-exit-conditions — Planning
+
+Conditions that control **when the entire case completes (or exits non-completing)**. Attach at the case root level, not to any stage.
+
+## When to Use
+
+Pick this plugin when the sdd.md **literally uses the phrase "case exit condition"** (or close variants: "case exit conditions", "case completion condition", "case close condition").
+
+For stage-level conditions, use [stage-entry-conditions](../stage-entry-conditions/planning.md) / [stage-exit-conditions](../stage-exit-conditions/planning.md). For task-level, use [task-entry-conditions](../task-entry-conditions/planning.md).
+
+## No omission — one T-task per sdd.md case-exit row
+
+Every case-exit condition declared in sdd.md gets its own T-task — **including rule-type `required-stages-completed` with `marks-case-complete: true`** (the "preferred pattern"). Never skip a condition because it's the default completion shape. If sdd.md wrote the row, `tasks.md` emits the T-task.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | sdd.md (optional) | e.g., "Case resolved", "Closed — escalation path" |
+| `marks-case-complete` | sdd.md | `true` for normal completion, `false` for non-completing exits |
+| `rule-type` | From catalog below | See §Rule-type catalog |
+| `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
+| `condition-expression` | Required for `wait-for-connector` rule-type | |
+
+## Rule-Type Catalog (case-exit scope)
+
+Allowed `--rule-type` values depend on `marks-case-complete`:
+
+**When `marks-case-complete: true`** (the case completes):
+
+| Rule type | Meaning | Extra fields |
+|-----------|---------|--------------|
+| `required-stages-completed` | **Preferred.** Case completes when every stage with `isRequired: true` (set on `stages add` via planning metadata) has completed. No stage list needed. | — |
+| `wait-for-connector` | Wait for an external connector event to close the case. | `--condition-expression` |
+
+**When `marks-case-complete: false`** (the case exits without closing):
+
+| Rule type | Meaning | Extra fields |
+|-----------|---------|--------------|
+| `selected-stage-completed` | Exit triggered by a specific stage completing. | `--selected-stage-id` |
+| `selected-stage-exited` | Exit triggered by a specific stage being exited (even without completing). | `--selected-stage-id` |
+| `wait-for-connector` | Wait for an external connector event. | `--condition-expression` |
+
+## Preferred Pattern
+
+For most cases, define a single completion condition with `required-stages-completed` + `marks-case-complete: true`. The `isRequired` flag on each stage (from [`plugins/stages/`](../../stages/planning.md)) controls which stages count toward completion.
+
+Add non-completing exit conditions only when the sdd.md explicitly describes an exit path that does NOT close the case (rare).
+
+## Ordering
+
+Case exit conditions are created **after** all stages exist (so `--selected-stage-id` can resolve via the stage capture map). In `tasks.md`, place these between stage conditions and SLA.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add case-exit condition — <summary>
+- display-name: "<name>"
+- marks-case-complete: true
+- rule-type: required-stages-completed
+- selected-stage: "<stage-name>"        # only for selected-stage-* rule-types
+- condition-expression: "<expr>"         # only for wait-for-connector
+- order: after T<m>
+- verify: Confirm Result: Success, capture ConditionId
+```

--- a/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl.md
@@ -1,0 +1,87 @@
+# stage-entry-conditions — Implementation
+
+## CLI Command
+
+```bash
+uip case stage-entry-conditions add <file> <stage-id> \
+  --display-name "<name>" \
+  --is-interrupting <true|false> \
+  --rule-type <rule-type> \
+  --selected-stage-id "<upstream-stage-id>" \
+  --condition-expression "<expr>" \
+  --output json
+```
+
+### Flag matrix
+
+| `--rule-type` | Required extra flags |
+|---------------|-----------------------|
+| `case-entered` | — |
+| `selected-stage-completed` | `--selected-stage-id` |
+| `selected-stage-exited` | `--selected-stage-id` |
+| `wait-for-connector` | `--condition-expression` |
+
+`--is-interrupting` is optional (defaults to `false`).
+
+## Translation from tasks.md
+
+The planning phase records stage names; the implementation phase looks up the captured IDs from Step 7 (stages add) and passes them as `--selected-stage-id`.
+
+## Example — Enter "Resolution" after "Triage" exits
+
+```bash
+uip case stage-entry-conditions add caseplan.json stg_resolution_id \
+  --display-name "After Triage" \
+  --rule-type selected-stage-exited \
+  --selected-stage-id stg_triage_id \
+  --output json
+```
+
+## Example — Interrupt when a connector event arrives
+
+```bash
+uip case stage-entry-conditions add caseplan.json stg_exception_id \
+  --display-name "Fraud detected" \
+  --is-interrupting true \
+  --rule-type wait-for-connector \
+  --condition-expression "event.fraudScore > 0.8" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+The stage node's `data.entryConditions` array gains:
+
+```json
+{
+  "id": "cond00000001",
+  "displayName": "After Triage",
+  "isInterrupting": false,
+  "rules": [
+    [
+      { "rule": "selected-stage-exited", "id": "...", "selectedStageId": "stg_triage_id" }
+    ]
+  ]
+}
+```
+
+Rules use DNF — outer array is OR, inner array is AND. Adding rules via `edit --rule-type` appends new rules (see `case-commands.md`).
+
+## Post-Add Validation
+
+Capture `ConditionId`. Confirm in `caseplan.json`:
+
+- Target stage's `data.entryConditions[].id` matches
+- `rules` non-empty and contains the expected rule-type
+- `isInterrupting` matches what you passed
+
+## Editing Existing Conditions
+
+```bash
+uip case stage-entry-conditions edit <file> <stage-id> <condition-id> \
+  --display-name "<new-name>" \
+  --rule-type <additional-rule-type> \
+  --condition-expression "<expr>"
+```
+
+`edit --rule-type` **appends** a new rule (new AND-clause added as an OR group). Removing rules requires `remove` then re-`add`.

--- a/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -1,0 +1,54 @@
+# stage-entry-conditions — Planning
+
+Conditions that control **when a stage is entered**. Attach to a stage; fire when the inbound rule is satisfied.
+
+## When to Use
+
+Pick this plugin when the sdd.md **literally uses the phrase "stage entry condition"** (or close variants: "stage entry conditions", "entry rule on stage", "entry gate on <stage>").
+
+For when a stage **exits**, use [stage-exit-conditions](../stage-exit-conditions/planning.md). For when a specific **task** starts, use [task-entry-conditions](../task-entry-conditions/planning.md).
+
+## No omission — one T-task per sdd.md Entry Condition row
+
+Every stage with an **Entry Condition** declared in sdd.md gets its own stage-entry-condition T-task — **including rule-type `case-entered`** and stages with `is-interrupting: false`. Never skip a condition because the rule-type or field values look like defaults. If sdd.md wrote the row, `tasks.md` emits the T-task.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `<stage-id>` | Previously captured from `stages add` | Target stage |
+| `display-name` | sdd.md (optional) | e.g., "Pre-check", "Interrupt on Fraud" |
+| `is-interrupting` | sdd.md (default `false`) | `true` if the condition interrupts the current stage |
+| `rule-type` | Pick from the catalog below | See §Rule-type catalog |
+| `selected-stage-id` | Required for `selected-stage-*` rule-types | ID of the referenced stage |
+| `condition-expression` | Required for `wait-for-connector` rule-type (and optional for others) | |
+
+## Rule-Type Catalog (stage-entry scope)
+
+Allowed `--rule-type` values and when to pick each:
+
+| Rule type | Meaning | Extra fields |
+|-----------|---------|--------------|
+| `case-entered` | Fires the moment the case is entered (first stage pattern) | — |
+| `selected-stage-completed` | Fires when a specific upstream stage completes | `--selected-stage-id` |
+| `selected-stage-exited` | Fires when a specific upstream stage exits (even without completing) | `--selected-stage-id` |
+| `wait-for-connector` | Waits for a connector event | `--condition-expression` |
+
+`is-interrupting: true` means the condition can fire **while another stage is active** and will interrupt it. Use for exception/interrupt flows.
+
+## Ordering
+
+Stage entry conditions are created **after** all stages exist (Step 7 in implementation.md). Source/target stage IDs must both be captured by then.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add stage-entry condition for "<stage>" — <summary>
+- target-stage: "<stage-name>"
+- display-name: "<name>"
+- is-interrupting: false
+- rule-type: selected-stage-completed
+- selected-stage: "<upstream-stage-name>"
+- order: after T<m>
+- verify: Confirm Result: Success, capture ConditionId
+```

--- a/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl.md
@@ -1,0 +1,116 @@
+# stage-exit-conditions — Implementation
+
+## CLI Command
+
+```bash
+uip case stage-exit-conditions add <file> <stage-id> \
+  --display-name "<name>" \
+  --type <exit-only|wait-for-user|return-to-origin> \
+  --exit-to-stage-id "<target-stage-id>" \
+  --marks-stage-complete <true|false> \
+  --rule-type <rule-type> \
+  --selected-tasks-ids "<id1>,<id2>" \
+  --condition-expression "<expr>" \
+  --output json
+```
+
+## Rule-Type × Marks-Stage-Complete Matrix
+
+| `marks-stage-complete` | Valid `--rule-type` | Extra flag |
+|------------------------|---------------------|-----------|
+| `true` | `required-tasks-completed` | — |
+| `true` | `wait-for-connector` | `--condition-expression` |
+| `false` | `selected-tasks-completed` | `--selected-tasks-ids "<id1>,<id2>"` |
+| `false` | `wait-for-connector` | `--condition-expression` |
+
+## Translation from tasks.md
+
+- `target-stage` → `<stage-id>` (positional arg) via capture map.
+- `exit-to-stage` → `--exit-to-stage-id <id>` via capture map.
+- `selected-tasks` → `--selected-tasks-ids <comma-separated task IDs>` via capture map.
+
+## Example — Complete when all required tasks finish
+
+```bash
+uip case stage-exit-conditions add caseplan.json stg_triage_id \
+  --display-name "All tasks done" \
+  --type exit-only \
+  --marks-stage-complete true \
+  --rule-type required-tasks-completed \
+  --output json
+```
+
+## Example — Route to Escalation when specific tasks complete
+
+```bash
+uip case stage-exit-conditions add caseplan.json stg_review_id \
+  --display-name "Route to Escalation" \
+  --type exit-only \
+  --exit-to-stage-id stg_escalation_id \
+  --marks-stage-complete false \
+  --rule-type selected-tasks-completed \
+  --selected-tasks-ids "tsk_flag_1,tsk_flag_2" \
+  --output json
+```
+
+## Example — Wait for user decision
+
+```bash
+uip case stage-exit-conditions add caseplan.json stg_manager_review_id \
+  --display-name "User picks next step" \
+  --type wait-for-user \
+  --marks-stage-complete true \
+  --rule-type required-tasks-completed \
+  --output json
+```
+
+## Example — Return to origin on rework
+
+```bash
+uip case stage-exit-conditions add caseplan.json stg_exception_id \
+  --display-name "Rework — return to origin" \
+  --type return-to-origin \
+  --marks-stage-complete false \
+  --rule-type required-tasks-completed \
+  --output json
+```
+
+## Resulting JSON Shape
+
+The stage node's `data.exitConditions` array gains:
+
+```json
+{
+  "id": "cond00000002",
+  "displayName": "All tasks done",
+  "type": "exit-only",
+  "exitToStageId": null,
+  "marksStageComplete": true,
+  "rules": [
+    [ { "rule": "required-tasks-completed", "id": "..." } ]
+  ]
+}
+```
+
+## Post-Add Validation
+
+Capture `ConditionId`. Confirm:
+
+- `exitConditions[].type` matches
+- `exitConditions[].marksStageComplete` matches
+- `exitConditions[].exitToStageId` matches (if set)
+- `rules` contains the expected rule-type
+
+## Editing Existing Conditions
+
+```bash
+uip case stage-exit-conditions edit <file> <stage-id> <condition-id> \
+  --display-name "<new-name>" \
+  --type <new-type> \
+  --exit-to-stage-id <id> \
+  --marks-stage-complete <bool> \
+  --rule-type <additional> \
+  --condition-expression "<expr>"
+```
+
+`edit --rule-type` **appends** a new rule. Removing rules requires `remove` then re-`add`.

--- a/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -1,0 +1,69 @@
+# stage-exit-conditions — Planning
+
+Conditions that control **when and how a stage exits**. Attach to a stage; fire when the inbound rule is satisfied.
+
+## When to Use
+
+Pick this plugin when the sdd.md **literally uses the phrase "stage exit condition"** (or close variants: "stage exit conditions", "stage completion condition", "exit rule on <stage>").
+
+For when a stage **enters**, use [stage-entry-conditions](../stage-entry-conditions/planning.md).
+
+## No omission — one T-task per sdd.md Exit Condition row
+
+Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exit-condition T-task — **including type `exit-only`, rule-type `required-tasks-completed`, and `marks-stage-complete: true`**. Never skip a condition because it looks like "the obvious default completion." If sdd.md wrote the row, `tasks.md` emits the T-task.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `<stage-id>` | Captured from `stages add` | Target stage |
+| `display-name` | sdd.md (optional) | |
+| `type` | sdd.md exit style | `exit-only` / `wait-for-user` / `return-to-origin` |
+| `exit-to-stage-id` | sdd.md routing target (optional) | Required when routing to a specific stage |
+| `marks-stage-complete` | sdd.md (default depends on type) | `true` for completion exits, `false` for diverging routes |
+| `rule-type` | From catalog below | |
+| `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
+| `condition-expression` | Required for `wait-for-connector` | |
+
+## Exit Type Catalog
+
+| Exit `type` | When to pick |
+|-------------|--------------|
+| `exit-only` | **Default.** Stage exits normally along configured edges. |
+| `wait-for-user` | Exit requires manual user decision or approval. |
+| `return-to-origin` | Rework / exception loop — sends the case back to the previous stage. |
+
+## Rule-Type Catalog (stage-exit scope)
+
+Allowed `--rule-type` values depend on `marks-stage-complete`:
+
+**When `marks-stage-complete: true`:**
+| Rule type | Extra fields |
+|-----------|--------------|
+| `required-tasks-completed` | — |
+| `wait-for-connector` | `--condition-expression` |
+
+**When `marks-stage-complete: false` (exit-only, routing):**
+| Rule type | Extra fields |
+|-----------|--------------|
+| `selected-tasks-completed` | `--selected-tasks-ids` (comma-separated) |
+| `wait-for-connector` | `--condition-expression` |
+
+## Ordering
+
+Stage exit conditions are created **after** all tasks in the stage have been added (so `selected-tasks-ids` can resolve). Planning records task names; implementation looks up captured IDs.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add stage-exit condition for "<stage>" — <summary>
+- target-stage: "<stage-name>"
+- display-name: "<name>"
+- type: exit-only
+- exit-to-stage: "<target-stage-name>"          # optional
+- marks-stage-complete: true
+- rule-type: required-tasks-completed
+- selected-tasks: "<Task A>, <Task B>"          # only if rule-type requires
+- order: after T<m>
+- verify: Confirm Result: Success, capture ConditionId
+```

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl.md
@@ -1,0 +1,90 @@
+# task-entry-conditions — Implementation
+
+## CLI Command
+
+```bash
+uip case task-entry-conditions add <file> <stage-id> <task-id> \
+  --display-name "<name>" \
+  --rule-type <rule-type> \
+  --selected-tasks-ids "<id1>,<id2>" \
+  --condition-expression "<expr>" \
+  --output json
+```
+
+### Flag matrix
+
+| `--rule-type` | Required extra flag |
+|---------------|---------------------|
+| `current-stage-entered` | — |
+| `selected-tasks-completed` | `--selected-tasks-ids "<comma-separated task IDs>"` |
+| `wait-for-connector` | `--condition-expression` |
+| `adhoc` | `--condition-expression` |
+
+## Translation from tasks.md
+
+- `target-stage` / `target-task` → `<stage-id> <task-id>` via capture map.
+- `selected-tasks` → `--selected-tasks-ids <ids>` via capture map (names → IDs).
+
+## Example — Run only after a sibling task completes
+
+```bash
+uip case task-entry-conditions add caseplan.json stg_review_id tsk_notify_id \
+  --display-name "After Approval" \
+  --rule-type selected-tasks-completed \
+  --selected-tasks-ids "tsk_approval_id" \
+  --output json
+```
+
+## Example — Ad-hoc expression gate
+
+```bash
+uip case task-entry-conditions add caseplan.json stg_triage_id tsk_escalate_id \
+  --display-name "High-risk only" \
+  --rule-type adhoc \
+  --condition-expression "in.riskScore > 700" \
+  --output json
+```
+
+## Example — Wait for connector event before starting
+
+```bash
+uip case task-entry-conditions add caseplan.json stg_triage_id tsk_process_id \
+  --display-name "Wait for inbound" \
+  --rule-type wait-for-connector \
+  --condition-expression "event.type = 'order_received'" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+The task's `entryConditions` array gains:
+
+```json
+{
+  "id": "cond00000003",
+  "displayName": "After Approval",
+  "rules": [
+    [ { "rule": "selected-tasks-completed", "id": "...", "selectedTasksIds": ["tsk_approval_id"] } ]
+  ]
+}
+```
+
+## Post-Add Validation
+
+Capture `ConditionId`. Confirm:
+
+- The target task's `entryConditions[].id` matches
+- `rules` contains the expected rule-type
+- `selectedTasksIds` (if set) matches the comma-split list
+
+## Editing Existing Conditions
+
+```bash
+uip case task-entry-conditions edit <file> <stage-id> <task-id> <condition-id> \
+  --display-name "<new-name>" \
+  --rule-type <additional> \
+  --condition-expression "<expr>" \
+  --selected-tasks-ids "<ids>"
+```
+
+`edit --rule-type` appends a new rule. Use `remove` + re-`add` to replace a rule.

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/planning.md
@@ -1,0 +1,50 @@
+# task-entry-conditions — Planning
+
+Conditions that control **when a specific task within a stage starts**. Attach to a task.
+
+## When to Use
+
+Pick this plugin when the sdd.md **literally uses the phrase "task entry condition"** (or close variants: "task entry conditions", "entry rule on task", "task gate", "task precondition").
+
+For **stage-level** conditions (entire stage enters/exits), use [stage-entry-conditions](../stage-entry-conditions/planning.md) / [stage-exit-conditions](../stage-exit-conditions/planning.md).
+
+## No omission — one T-task per sdd.md Entry Condition row
+
+Every task in sdd.md that declares an **Entry Condition** row gets its own task-entry-condition T-task — **including rule-type `current-stage-entered`**. Do NOT skip, collapse, or omit a condition because the rule-type looks like a default. If sdd.md wrote the row, `tasks.md` emits the T-task. "The default behavior would already cover it" is not a valid reason to omit.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `<stage-id>`, `<task-id>` | Captured from prior steps | |
+| `display-name` | sdd.md (optional) | |
+| `rule-type` | From catalog below | |
+| `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
+| `condition-expression` | Required for `adhoc` and `wait-for-connector` | |
+
+## Rule-Type Catalog (task-entry scope)
+
+| Rule type | Meaning | Extra fields |
+|-----------|---------|--------------|
+| `current-stage-entered` | Fires when the containing stage is entered | — |
+| `selected-tasks-completed` | Fires when specific sibling tasks in the same stage complete | `--selected-tasks-ids` |
+| `wait-for-connector` | Waits for a connector event | `--condition-expression` |
+| `adhoc` | Fires when an arbitrary expression evaluates truthy | `--condition-expression` |
+
+## Ordering
+
+Task entry conditions are created **after** all tasks in the stage have been added (so `selected-tasks-ids` can resolve).
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add task-entry condition for "<task>" in "<stage>" — <summary>
+- target-stage: "<stage-name>"
+- target-task: "<task-name>"
+- display-name: "<name>"
+- rule-type: selected-tasks-completed
+- selected-tasks: "<Task A>, <Task B>"
+- condition-expression: "<expr>"          # for adhoc / wait-for-connector
+- order: after T<m>
+- verify: Confirm Result: Success, capture ConditionId
+```

--- a/skills/uipath-case-management/references/plugins/edges/impl.md
+++ b/skills/uipath-case-management/references/plugins/edges/impl.md
@@ -1,0 +1,127 @@
+# edges — Implementation
+
+## CLI Command
+
+```bash
+uip case edges add <file> \
+  --source "<source-id>" \
+  --target "<target-id>" \
+  --label "<label>" \
+  --source-handle <right|left|top|bottom> \
+  --target-handle <right|left|top|bottom> \
+  --z-index <n> \
+  --output json
+```
+
+### Required flags
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--source` | yes | Trigger ID or stage ID |
+| `--target` | yes | Stage ID |
+| `--label` | no | Display label. |
+| `--source-handle` | no | Default: `right` |
+| `--target-handle` | no | Default: `left` |
+| `--z-index` | no | Visual stacking order |
+
+Edge type is inferred — do not pass a `--type` flag.
+
+## Translation from tasks.md
+
+- `source` name → ID via trigger-ID (from T01 and any triggers plugin) or stage capture map.
+- `target` name → ID via stage capture map.
+
+## Example — Trigger → first stage
+
+```bash
+uip case edges add caseplan.json \
+  --source "trig0000001" \
+  --target "stg00000001" \
+  --label "Start" \
+  --output json
+```
+
+## Example — Stage → next stage with label
+
+```bash
+uip case edges add caseplan.json \
+  --source "stg00000001" \
+  --target "stg00000002" \
+  --label "Approved" \
+  --output json
+```
+
+## Example — Stage → exception stage with custom handles
+
+```bash
+uip case edges add caseplan.json \
+  --source "stg00000001" \
+  --target "stg_exception_id" \
+  --label "Rejected" \
+  --source-handle bottom \
+  --target-handle top \
+  --output json
+```
+
+## Resulting JSON Shape
+
+### TriggerEdge (Trigger → Stage)
+
+```json
+{
+  "id": "edg00000001",
+  "type": "case-management:TriggerEdge",
+  "source": "trig0000001",
+  "target": "stg00000001",
+  "sourceHandle": "trig0000001____source____right",
+  "targetHandle": "stg00000001____target____left",
+  "data": { "label": "Start" }
+}
+```
+
+### Edge (Stage → Stage)
+
+```json
+{
+  "id": "edg00000002",
+  "type": "case-management:Edge",
+  "source": "stg00000001",
+  "target": "stg00000002",
+  "sourceHandle": "stg00000001____source____right",
+  "targetHandle": "stg00000002____target____left",
+  "data": { "label": "Approved" }
+}
+```
+
+Handle values are formatted automatically as `<nodeId>____source____<direction>` (source) or `<nodeId>____target____<direction>` (target).
+
+## Post-Add Validation
+
+Capture `EdgeId` from `--output json`. Rarely needed downstream (nothing references edges by ID), but useful for the audit trail in `registry-resolved.json`.
+
+Confirm in `caseplan.json`:
+
+- `edges[].source` matches the source ID
+- `edges[].target` matches the target ID
+- `edges[].type` is `case-management:TriggerEdge` when source is a Trigger, else `case-management:Edge`
+- `edges[].data.label` matches what you passed
+
+## Editing Existing Edges
+
+```bash
+uip case edges edit <file> <edge-id> \
+  --label "<new-label>" \
+  --source-handle <direction> \
+  --target-handle <direction> \
+  --z-index <n>
+```
+
+At least one flag required. Source and target are immutable — to rewire, `remove` + re-`add`.
+
+## Removing Edges
+
+```bash
+uip case edges remove <file> <edge-id>
+```
+
+Note: removing a stage (via `stages remove`) automatically cascades to connected edges. Only `edges remove` directly when you need to change wiring without touching the stage.

--- a/skills/uipath-case-management/references/plugins/edges/planning.md
+++ b/skills/uipath-case-management/references/plugins/edges/planning.md
@@ -1,0 +1,78 @@
+# edges — Planning
+
+Edges connect nodes in the case graph — Trigger → Stage, Stage → Stage, Stage → ExceptionStage, etc. Every stage must have at least one inbound edge or it will be orphaned.
+
+## When to Use
+
+Always. Every `tasks.md` has one edge entry per transition in the sdd.md flow graph. One plugin covers both edge variants (`TriggerEdge` and `Edge`) — the CLI infers the type from the source node.
+
+## Edge Types (CLI-inferred)
+
+| Source node type | Target node type | JSON type |
+|-------------------|------------------|-----------|
+| Trigger | Stage | `case-management:TriggerEdge` |
+| Stage | Stage | `case-management:Edge` |
+
+You do not specify the edge type — `uip case edges add` figures it out from the `--source` node's type.
+
+## Wiring Constraints
+
+**Exception / secondary stages have no edges at all — neither inbound nor outbound.** Do not create any edge where `--source` or `--target` is an exception stage.
+
+- ❌ `--source <exception-stage-id>` — never.
+- ❌ `--target <exception-stage-id>` — never (applies to TriggerEdge and Edge alike).
+- ✅ Exception stages are **reached via an interrupting entry condition** on the exception stage itself, not via an edge. See [stage-entry-conditions plugin](../conditions/stage-entry-conditions/planning.md).
+- ✅ Exception stages **exit via a `return-to-origin` exit condition**, not via an outbound edge. See [stage-exit-conditions plugin](../conditions/stage-exit-conditions/planning.md).
+
+If the sdd.md describes an exception stage with edges, flag to the user: re-model as a regular stage, or use the conditions-only pattern above.
+
+### Orphan check scope
+
+The orphan check in the planning pipeline applies to **regular stages only** — every regular stage must be the target of at least one edge. Exception stages intentionally have no edges and are not orphans.
+
+This constraint is also documented in the [stages plugin](../stages/planning.md#wiring-constraints-for-exception--secondary-stages).
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `source` | sdd.md flow arrow origin | Trigger ID or stage name |
+| `target` | sdd.md flow arrow destination | Stage name |
+| `label` | sdd.md edge label | Optional. Human-readable label on the connector. |
+| `source-handle` | sdd.md (rarely specified) | `right` (default) \| `left` \| `top` \| `bottom` |
+| `target-handle` | sdd.md (rarely specified) | `left` (default) \| `right` \| `top` \| `bottom` |
+
+## Labels
+
+Edge labels are **display-only** — they do not control routing. Routing conditions live on the source stage's `exitConditions`, not on the edge. Use labels to annotate the intent ("Approved", "Rejected", "On timeout") so the diagram in Studio Web is readable.
+
+## Handles
+
+Handle directions control visual rendering (where the edge emerges from the source, where it enters the target). Defaults (`right` / `left`) match the horizontal left-to-right canvas layout. Only override when the sdd.md specifies a specific routing, e.g., an exception branch going down to a lower stage.
+
+## Ordering
+
+Edges are created **after** all stages exist so both endpoints can resolve. Each edge references the initial Trigger node (created by `cases add` in T01) or stage IDs captured in the stages capture map.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add edge "<source>" → "<target>"
+- source: "<trigger-id-or-stage-name>"
+- target: "<stage-name>"
+- label: "<optional label>"
+- source-handle: right      # optional
+- target-handle: left       # optional
+- order: after T<m>
+- verify: Confirm Result: Success, capture EdgeId
+```
+
+## Multi-Trigger Cases
+
+When the sdd.md has multiple entry points (manual + timer + event), each non-default trigger is added via its plugin ([`plugins/triggers/`](../triggers/)), returning a `TriggerId`. Each trigger needs its own outgoing edge to the relevant first stage. Record one edge entry per trigger.
+
+## Orphan Check
+
+After all edges are planned, cross-check: every **regular stage** (`--type stage`) in `tasks.md §4.4` must appear as a `target` in at least one edge entry. Missing → sdd.md has an orphan regular stage; flag to the user.
+
+Exception stages are **excluded** from this check — they intentionally have no edges. Any exception stage present in `tasks.md` that also appears in an edge entry is an error (see Wiring Constraints above).

--- a/skills/uipath-case-management/references/plugins/sla/impl.md
+++ b/skills/uipath-case-management/references/plugins/sla/impl.md
@@ -1,0 +1,175 @@
+# sla — Implementation
+
+Three CLI sub-operations cover SLA authoring: `set`, `escalation`, `rules`. Run each per the entries in `tasks.md §4.8`.
+
+## Units
+
+| Unit | Meaning |
+|------|---------|
+| `h` | hours |
+| `d` | days |
+| `w` | weeks |
+| `m` | months |
+
+## Default SLA — `sla set`
+
+### CLI
+
+```bash
+# Root-level
+uip case sla set <file> --count <n> --unit <h|d|w|m> --output json
+
+# Per-stage
+uip case sla set <file> --count <n> --unit <h|d|w|m> --stage-id <stage-id> --output json
+```
+
+### Example
+
+```bash
+uip case sla set caseplan.json --count 5 --unit d --output json
+uip case sla set caseplan.json --count 2 --unit w --stage-id stg00000001 --output json
+```
+
+### Resulting JSON
+
+Root: `root.data.sla = { count: 5, unit: "d" }`.
+Stage: `nodes[].data.sla = { count: 2, unit: "w" }` on the matching stage.
+
+## Conditional SLA Rule — `sla rules add` (root only)
+
+### CLI
+
+```bash
+uip case sla rules add <file> \
+  --expression "<expr>" \
+  --count <n> \
+  --unit <h|d|w|m> \
+  --output json
+```
+
+### Example
+
+```bash
+uip case sla rules add caseplan.json \
+  --expression "=js:vars.priority === 'Urgent'" \
+  --count 30 \
+  --unit m \
+  --output json
+```
+
+### Resulting JSON
+
+Root: `root.data.slaRules[]` gains an entry:
+
+```json
+{ "expression": "=js:vars.priority === 'Urgent'", "count": 30, "unit": "m" }
+```
+
+Rules are evaluated in array order — first truthy expression wins. The default SLA (from `sla set`) acts as the fallback.
+
+### Expression Translation
+
+The `tasks.md` entry has `condition: "<natural-language>"`. Translate at execution time:
+
+| sdd.md phrase | Expression |
+|---------------|-----------|
+| "when priority is Urgent" | `=js:vars.priority === 'Urgent'` |
+| "when amount exceeds 10000" | `=js:vars.amount > 10000` |
+| "when customer is a VIP" | `=js:vars.customerTier === 'VIP'` |
+
+If the translation is not obvious, ask the user with **AskUserQuestion** including 2–3 candidate expressions + "Something else".
+
+## Escalation Rule — `sla escalation add`
+
+### CLI
+
+```bash
+uip case sla escalation add <file> \
+  --trigger-type <at-risk|sla-breached> \
+  --at-risk-percentage <1-99> \
+  --recipient-scope <User|UserGroup> \
+  --recipient-target "<target>" \
+  --recipient-value "<value>" \
+  --display-name "<name>" \
+  --stage-id "<stage-id>" \
+  --output json
+```
+
+`--at-risk-percentage` is required only when `--trigger-type at-risk`. Omit `--stage-id` for root-level escalation.
+
+### Example — Notify manager at 80% SLA risk
+
+```bash
+uip case sla escalation add caseplan.json \
+  --trigger-type at-risk \
+  --at-risk-percentage 80 \
+  --recipient-scope User \
+  --recipient-target "manager@corp.com" \
+  --recipient-value "manager@corp.com" \
+  --display-name "Notify Manager" \
+  --output json
+```
+
+### Example — Notify group on breach, stage-scoped
+
+```bash
+uip case sla escalation add caseplan.json \
+  --trigger-type sla-breached \
+  --recipient-scope UserGroup \
+  --recipient-target "OrderMgmt" \
+  --recipient-value "Order Management Team" \
+  --stage-id stg00000001 \
+  --output json
+```
+
+### Resulting JSON
+
+Root (or stage) `sla.escalationRule[]` gains:
+
+```json
+{
+  "id": "<escalationId>",
+  "displayName": "Notify Manager",
+  "action": {
+    "type": "notification",
+    "recipients": [
+      { "scope": "User", "target": "manager@corp.com", "value": "manager@corp.com" }
+    ]
+  },
+  "triggerInfo": { "type": "at-risk", "atRiskPercentage": 80 }
+}
+```
+
+### Multiple Recipients
+
+If the `tasks.md` entry lists multiple recipients, run `sla escalation add` **once per recipient** (the CLI accepts one recipient per call). Each call returns an `EscalationRuleId` — capture all.
+
+## Listing and Removing
+
+```bash
+# List
+uip case sla get <file>
+uip case sla get <file> --stage-id <id>
+uip case sla escalation list <file> [--stage-id <id>]
+uip case sla rules list <file>
+
+# Remove
+uip case sla remove <file> [--stage-id <id>]
+uip case sla escalation remove <file> <escalation-id> [--stage-id <id>]
+uip case sla rules remove <file> <index>    # 0-based index
+```
+
+## Post-Add Validation
+
+After each `sla *` command, capture any returned IDs. Confirm in `caseplan.json`:
+
+- Root SLA: `root.data.sla` set
+- Stage SLA: target stage node's `data.sla` set
+- Conditional rules: `root.data.slaRules` array in the expected order
+- Escalation: `sla.escalationRule` array on the correct target (root or stage) contains the new rule
+
+## Anti-Patterns
+
+- **Do not attempt `sla rules add --stage-id`.** The CLI does not support conditional SLA rules at the stage level. Flag to the user when sdd.md describes one.
+- **Do not combine multiple recipients into one `--recipient-*` call.** One call per recipient.
+- **Do not set stage SLA before the stage is created.** `sla set --stage-id` requires the stage to exist.

--- a/skills/uipath-case-management/references/plugins/sla/planning.md
+++ b/skills/uipath-case-management/references/plugins/sla/planning.md
@@ -1,0 +1,113 @@
+# sla — Planning
+
+SLA duration settings, escalation rules, and conditional SLA overrides. Applied at either root (whole case) or stage level.
+
+## When to Use
+
+Pick this plugin whenever the sdd.md mentions deadlines, service-level agreements, time-to-complete expectations, or escalation notifications:
+
+- "This case must resolve within 5 days"
+- "Notify the manager when the SLA is at 80% risk"
+- "If the case is flagged Urgent, use a 30-minute SLA"
+- "Escalate to the group when the SLA breaches"
+
+## Three Sub-Operations (one plugin, three workflows)
+
+| Sub-op | CLI | Purpose |
+|--------|-----|---------|
+| **Default SLA** | `sla set` | The time-based catch-all SLA. One per target (root or stage). |
+| **Conditional SLA rules** | `sla rules add` | Expression-driven SLA overrides. Root-only. |
+| **Escalation rules** | `sla escalation add` | Notifications triggered at-risk or on breach. |
+
+## Applying SLA at Root vs Stage
+
+- **Root** — the default SLA for the whole case. Omit `--stage-id`.
+- **Stage** — stage-specific SLA. Pass `--stage-id <id>`. Overrides the root default while the stage is active.
+
+Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage > root.
+
+> **Conditional SLA rules are root-only.** `sla rules add` does not accept `--stage-id`. If the sdd.md describes a per-stage conditional SLA, that semantics is not supported by the CLI — flag to the user.
+
+## Required Fields from sdd.md
+
+### Default SLA (`sla set`)
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `count` | sdd.md duration number | Positive integer |
+| `unit` | sdd.md duration unit | `h` \| `d` \| `w` \| `m` |
+| `stage-id` | sdd.md target (root vs stage) | Omit for root |
+
+### Conditional SLA rule (`sla rules add`)
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `expression` | sdd.md condition | Natural-language in planning; the execution phase translates. **Do not fabricate syntax during planning.** |
+| `count`, `unit` | sdd.md duration for this condition | Same units as default |
+
+Rules are evaluated in insertion order — first truthy expression wins. The default SLA (set via `sla set`) acts as the fallback.
+
+### Escalation rule (`sla escalation add`)
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `trigger-type` | sdd.md | `at-risk` \| `sla-breached` |
+| `at-risk-percentage` | sdd.md | Required when `trigger-type: at-risk` (1–99) |
+| `recipient-scope` | sdd.md | `User` \| `UserGroup` |
+| `recipient-target` | sdd.md | Identifier for the recipient |
+| `recipient-value` | sdd.md | Display value for the recipient |
+| `display-name` | sdd.md (optional) | |
+| `stage-id` | sdd.md target (root vs stage) | Omit for root |
+
+## Ordering
+
+SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each target, order within the target:
+
+1. `sla set` — default SLA
+2. `sla rules add` — conditional rules (root only)
+3. `sla escalation add` — one call per escalation rule
+
+## tasks.md Entry Format
+
+### Default SLA
+
+```markdown
+## T<n>: Set default SLA for "<target>" to <duration>
+- target: "<root>" | "<stage-name>"
+- count: 5
+- unit: d
+- order: after T<m>
+- verify: Confirm Result: Success
+```
+
+### Conditional SLA rule
+
+```markdown
+## T<n>: Add conditional SLA rule for root case — <condition summary>
+- condition: "<natural-language condition from sdd.md>"
+- count: 30
+- unit: m
+- order: after T<m>
+- verify: Confirm Result: Success
+```
+
+### Escalation rule
+
+```markdown
+## T<n>: Add escalation rule for "<target>" — <trigger summary>
+- target: "<root>" | "<stage-name>"
+- trigger-type: at-risk
+- at-risk-percentage: 80
+- recipients:
+  - User: manager@corp.com
+  - UserGroup: "Order Management Team"
+- display-name: "Notify Manager"
+- order: after T<m>
+- verify: Confirm Result: Success, capture EscalationRuleId
+```
+
+## Anti-Patterns
+
+- **Do not fabricate expression syntax.** Describe conditional SLA rules in natural language during planning; the execution phase handles the exact syntax.
+- **Do not put conditional SLA rules on stages.** The CLI does not support `sla rules add --stage-id`. Flag to the user if the sdd.md describes one.
+- **Do not invert rule order.** Conditional rules are evaluated in insertion order — insert them in the priority order the sdd.md specifies.

--- a/skills/uipath-case-management/references/plugins/stages/impl.md
+++ b/skills/uipath-case-management/references/plugins/stages/impl.md
@@ -1,0 +1,115 @@
+# stages — Implementation
+
+## CLI Command
+
+```bash
+uip case stages add <file> \
+  --label "<label>" \
+  --type <stage|exception> \
+  --description "<description>" \
+  --output json
+```
+
+### Flags
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--label` | no (recommended) | Display label. If omitted, the CLI uses a default. |
+| `--type` | no | `stage` (default) \| `exception`. The `trigger` value exists in the schema but is reserved for the auto-created trigger node — do not pass it manually. |
+| `--description` | no | Free-form description. |
+
+There is **no `--is-required` flag**. `isRequired` from `tasks.md` is consumed by later case-exit-condition calls, not by `stages add` itself.
+
+## Example — Regular Stage
+
+```bash
+uip case stages add caseplan.json \
+  --label "PO Receipt & Triage" \
+  --type stage \
+  --description "Receive incoming POs and classify for downstream processing" \
+  --output json
+```
+
+## Example — Exception / Secondary Stage
+
+```bash
+uip case stages add caseplan.json \
+  --label "Exception Handling" \
+  --type exception \
+  --description "Fallback handler for POs that fail classification" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+### Regular stage
+
+```json
+{
+  "id": "stg00000001",
+  "type": "case-management:Stage",
+  "position": { "x": 600, "y": 200 },
+  "data": {
+    "label": "PO Receipt & Triage",
+    "description": "Receive incoming POs and classify for downstream processing",
+    "tasks": [],
+    "entryConditions": [],
+    "exitConditions": []
+  }
+}
+```
+
+### Exception stage
+
+```json
+{
+  "id": "stg00000002",
+  "type": "case-management:ExceptionStage",
+  "position": { "x": 1100, "y": 200 },
+  "data": {
+    "label": "Exception Handling",
+    "description": "Fallback handler for POs that fail classification",
+    "tasks": [],
+    "entryConditions": [],
+    "exitConditions": [],
+    "slaRules": []
+  }
+}
+```
+
+The only schema-level difference is the `type` literal (`Stage` vs `ExceptionStage`) and the presence of a `slaRules` array on exception stages (always empty after `stages add`; populated manually or by future CLI support).
+
+## Post-Add Validation
+
+Capture `StageId` from the `--output json` response. Store in the capture map:
+
+```
+stage_name → stage_id
+```
+
+Used by:
+- **Edges** — `--source`, `--target`, `--exit-to-stage-id`
+- **Tasks** — `<stage-id>` positional arg on `tasks add` and `tasks add-connector`
+- **Conditions** — `<stage-id>` on all `stage-*-conditions` and `task-entry-conditions` commands
+- **SLA** — `--stage-id` on `sla set`, `sla escalation add`
+
+Confirm in `caseplan.json`:
+- `nodes[].id` matches the returned `StageId`
+- `nodes[].type` is `case-management:Stage` or `case-management:ExceptionStage` per the intended type
+- `nodes[].data.label` matches what you passed
+
+## Editing Stage Labels
+
+```bash
+uip case stages edit <file> <stage-id> --label "<new-label>" --output json
+```
+
+Only the `--label` is editable via `stages edit`. For other changes, `remove` + re-`add` (note: removing a stage also removes its connected edges — downstream wiring must be redone).
+
+## Removing a Stage
+
+```bash
+uip case stages remove <file> <stage-id>
+```
+
+Removes the stage and all its connected edges. Does **not** remove tasks from other stages that referenced this one via cross-task refs — re-validate all cross-task references after a stage removal.

--- a/skills/uipath-case-management/references/plugins/stages/planning.md
+++ b/skills/uipath-case-management/references/plugins/stages/planning.md
@@ -1,0 +1,100 @@
+# stages — Planning
+
+A stage node inside the case. Stages contain tasks and connect via edges. Two CLI-level variants (`stage` and `exception`) share the same plugin.
+
+## Terminology
+
+| Term | Same as |
+|------|---------|
+| Regular stage | `--type stage` (default) |
+| Exception stage | `--type exception` |
+| Secondary stage | Alias for exception stage. Sometimes used in sdd.md. |
+
+At the CLI level the only difference between `stage` and `exception` is the `--type` flag. All other fields (label, description, entry/exit conditions, tasks, SLA) behave identically. Schema-wise, `ExceptionStage` can carry `slaRules` (expression-driven SLA), but `uip case sla rules add` is root-level only — this schema extension is not reachable via CLI at the stage level today.
+
+## When to Pick `exception` vs `stage`
+
+Use `--type exception` (also "secondary stage") when the sdd.md describes any of:
+
+- A handler for errors, escalations, or rejected items
+- A rework / retry loop
+- An on-error fallback
+- A stage only reached via **interrupting** entry conditions
+- Anything labeled "exception", "fallback", "on-error", or "secondary"
+
+Otherwise default to `--type stage`.
+
+When ambiguous, use **AskUserQuestion** with both options + "Something else".
+
+### Wiring constraints for exception / secondary stages
+
+Exception stages **have no edges** — neither inbound nor outbound. They are fully detached from the edge graph:
+
+- ❌ No edge into an exception stage (not from Triggers, not from regular stages, not from other exception stages).
+- ❌ No edge out of an exception stage to any stage.
+- ✅ **Reached via an interrupting entry condition** on the exception stage itself (fires based on case state, not by traversing an edge). See [stage-entry-conditions plugin](../conditions/stage-entry-conditions/planning.md).
+- ✅ **Exits via a `return-to-origin` exit condition** — routes the case back to the stage it came from, through the exit condition rule, not a new edge. See [stage-exit-conditions plugin](../conditions/stage-exit-conditions/planning.md).
+
+If the sdd.md describes an exception stage that is connected to other stages via edges, or that flows onward to another stage, flag this to the user. Options:
+
+- Re-model the node as a regular stage (so edges are allowed).
+- Use a `return-to-origin` exit and let the origin stage's existing edges handle the onward flow.
+
+This constraint is also documented in the [edges plugin](../edges/planning.md).
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `label` | sdd.md stage name | CLI flag `--label`. Shown in the UI. |
+| `type` | sdd.md intent | `stage` (default) or `exception` — see above |
+| `description` | sdd.md stage description | CLI flag `--description`. Optional. |
+| `isRequired` | sdd.md (default `true` for regular, `false` for exception) | **Planning-only metadata.** See note below. |
+
+### Note on `isRequired`
+
+`isRequired` is **not a CLI flag** on `uip case stages add`. It is a planning-phase attribute used downstream by case exit conditions with `rule-type: required-stages-completed` — the case completes when all stages flagged `isRequired: true` have completed.
+
+Record `isRequired` in `tasks.md` for each stage. Use:
+- `true` — **Default for regular stages.** Stage is on the main flow path and must complete for case completion.
+- `false` — **Default for exception stages.** Exception / optional / fallback / rework stages only reached via conditional/interrupting entry conditions.
+
+Implementation phase consumes this value when adding case-exit-conditions; the stage itself is created without it.
+
+## Registry Resolution
+
+**None.** Stages have no registry representation — no `taskTypeId`, no enrichment.
+
+## Auto-Positioning
+
+CLI auto-positions stages: `x = 100 + (existingStageCount * 500), y = 200`. Do not pass `--position` unless the sdd.md specifies explicit coordinates.
+
+## Ordering
+
+Stages are created **after** the root case (T01) and **before** any edges, tasks, or conditions reference them. Each `stages add` call returns a `StageId` — capture it in the planning/execution capture map. Downstream T-entries (edges, tasks, conditions, SLA) use the stage **name** in `tasks.md`; the implementation phase resolves the name to the captured `StageId`.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Create stage "<label>"
+- type: stage
+- description: "<optional description>"
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture StageId
+```
+
+Exception variant:
+
+```markdown
+## T<n>: Create exception stage "<label>"
+- type: exception
+- description: "<optional description>"
+- isRequired: false
+- order: after T<m>
+- verify: Confirm Result: Success, capture StageId
+```
+
+## Unresolved Fallback
+
+Stages have no registry lookup, so there is no "unresolved" path. If the sdd.md is missing stage names or descriptions, ask the user with **AskUserQuestion** rather than proceeding with placeholders.

--- a/skills/uipath-case-management/references/plugins/tasks/action/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/action/impl.md
@@ -1,0 +1,70 @@
+# action task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type action \
+  --display-name "<display-name>" \
+  --task-title "<title>" \
+  --priority <Low|Medium|High|Critical> \
+  --recipient "<email>" \
+  --task-type-id "<action-app-id>" \
+  --is-required \
+  --output json
+```
+
+### Required flags
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--type action` | yes | |
+| `--display-name` | yes | Card header |
+| `--task-title` | yes | Shown to the assignee inside the Action card |
+| `--task-type-id` | yes | Action-app ID from `action-apps-index.json` |
+| `--priority` | no | Default: `Medium` |
+| `--recipient` | no | Omit for group/role assignment |
+
+## Example
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type action \
+  --display-name "Review Purchase Order" \
+  --task-title "Please review this PO and approve or reject" \
+  --priority High \
+  --recipient "approver@corp.com" \
+  --task-type-id "act_app_9876543210" \
+  --is-required \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000004",
+  "elementId": "el_0004",
+  "type": "action",
+  "displayName": "Review Purchase Order",
+  "data": {
+    "taskTitle": "Please review this PO and approve or reject",
+    "priority": "High",
+    "recipient": "approver@corp.com",
+    "actionCatalogName": "<catalog-name-from-enrichment>",
+    "labels": [ /* enriched */ ],
+    "context": { "taskTypeId": "act_app_9876543210" }
+  },
+  "isRequired": true
+}
+```
+
+> The `data` shape for `action` differs from process/agent — no `inputs`/`outputs` arrays at the top of `data`. Form field bindings still use `uip case var bind` in the standard way.
+
+## Binding Inputs and Outputs
+
+Use `uip case var bind` per [bindings-and-expressions.md](../../../bindings-and-expressions.md). Input names for an action task map to fields on the Actions app form — discover them via `tasks describe --type action --id <action-app-id>`.
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm `type: "action"` and `data.taskTitle` non-empty. Verify `data.recipient` matches the sdd.md assignee if one was specified.

--- a/skills/uipath-case-management/references/plugins/tasks/action/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/action/planning.md
@@ -1,0 +1,67 @@
+# action task — Planning
+
+A human-in-the-loop (HITL) action task. Assigns a task to a user or group for manual review, approval, or data entry via the Actions app.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes a `HITL` task, or any task requiring manual user interaction: approval, review, sign-off, correction, classification by a person.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | sdd.md task name | CLI flag `--display-name` |
+| `task-type-id` | Registry resolution (below) | CLI flag `--task-type-id` — the action-app ID |
+| `task-title` | sdd.md task title or question | CLI flag `--task-title`. Required for `action` type. |
+| `priority` | sdd.md (default `Medium`) | `Low` / `Medium` / `High` / `Critical`. CLI flag `--priority`. |
+| `recipient` | sdd.md assignee email; **prompt the user if silent** | CLI flag `--recipient`. See Recipient Handling below. |
+| `inputs` | sdd.md task data mapping | See [bindings-and-expressions.md](../../../bindings-and-expressions.md) |
+| `outputs` | Discovered via `tasks describe` | Decision, comments, structured form fields |
+| `isRequired` | sdd.md (default `true`) | CLI flag `--is-required` |
+
+## Registry Resolution
+
+1. **Primary cache file:** `action-apps-index.json`.
+2. **Identifier field:** `id` (NOT `entityKey` — action-apps use a different field).
+3. **Name field:** `deploymentTitle` (not `name`).
+4. **Folder field:** `deploymentFolder.fullyQualifiedName`.
+5. **CLI search known to fail** for action-apps — always use direct cache-file inspection.
+6. Discover form fields / inputs / outputs via `tasks describe` — see [bindings-and-expressions.md § Discovering output names](../../../bindings-and-expressions.md).
+
+See [registry-discovery.md](../../../registry-discovery.md#cli-search-gaps) for the fallback rationale.
+
+## Unresolved Fallback
+
+Mark `<UNRESOLVED: action-app "<deploymentTitle>" in folder "<folder>" not found in action-apps-index.json>`. Omit `inputs:` and `outputs:` and the `task-title:` line; capture intended wiring in a `# wiring notes` comment block. Execution creates a skeleton action task (no `--task-type-id`, no `--task-title`) — see [skeleton-tasks.md](../../../skeleton-tasks.md).
+
+## Recipient Handling
+
+- If sdd.md **names a specific user email**, record it in `tasks.md`. Sets `assignmentCriteria: "user"` at execution time.
+- If sdd.md **names a group or role**, do **not** record a recipient — group assignment is configured separately via Actions app rules. Record a note in `tasks.md` so the user remembers to configure group assignment externally.
+- If sdd.md is **silent on assignee**, **prompt the user** using **AskUserQuestion** with a direct open-ended prompt:
+  > "The action task '<display-name>' has no assignee specified in sdd.md. Who should receive it? Enter an email, a group/role name, or 'Skip' to leave it unassigned for now."
+
+  Parse the user's response:
+  - Looks like an email → record as `recipient: <email>`.
+  - Group / role name → omit recipient; record a note in `tasks.md` reminding the user to configure group assignment externally.
+  - `Skip` or empty → omit recipient.
+
+This follows Critical Rule #19 — for open-ended inputs like an email address, use a direct prompt rather than AskUserQuestion with a finite option list.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add action task "<display-name>" to "<stage>"
+- taskTypeId: <action-app-id>
+- task-title: "<title-shown-to-user>"
+- priority: Medium
+- recipient: user@company.com   # omit when group-assigned or when user chose Skip
+- assignment-note: "<free-form note if group-assigned>"   # optional
+- inputs:
+  - <input_name> <- "<Stage>"."<Task>".<output>
+  - <input_name> = "<literal-or-expression>"
+- outputs: decision, comments
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/agent/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/agent/impl.md
@@ -1,0 +1,62 @@
+# agent task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type agent \
+  --display-name "<display-name>" \
+  --name "<agent-name>" \
+  --folder-path "<folder-path>" \
+  --task-type-id "<entityKey>" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+For agents with multiple element bindings, pre-enrich with the element-id:
+
+```bash
+uip case tasks enrich --type agent --id "<entityKey>" --element-id "<elementId>"
+```
+
+## Example
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type agent \
+  --display-name "Classify Purchase Order" \
+  --name "PO Classifier" \
+  --folder-path "Shared" \
+  --task-type-id "a1b2c3d4-5678-90ab-cdef-1234567890ab" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000002",
+  "elementId": "el_0002",
+  "type": "agent",
+  "displayName": "Classify Purchase Order",
+  "data": {
+    "name": "PO Classifier",
+    "folderPath": "Shared",
+    "inputs": [ /* enriched */ ],
+    "outputs": [ /* enriched */ ],
+    "context": { "taskTypeId": "a1b2c3d4-5678-90ab-cdef-1234567890ab" }
+  },
+  "isRequired": true
+}
+```
+
+## Binding Inputs
+
+Same as [process/impl.md](../process/impl.md#binding-inputs-and-outputs) — use `uip case var bind` with `--value` or `--source-*` per [bindings-and-expressions.md](../../../bindings-and-expressions.md).
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm `data.context.taskTypeId` is non-empty. Verify `data.inputs` and `data.outputs` are populated (if empty, enrichment failed — retry `uip case tasks enrich`).

--- a/skills/uipath-case-management/references/plugins/tasks/agent/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/agent/planning.md
@@ -1,0 +1,48 @@
+# agent task — Planning
+
+An AI agent task. Invokes a UiPath Agent by entityKey for reasoning, classification, extraction, or generative work.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes a task as `AGENT` — an AI agent that processes inputs and returns structured outputs. Use when the task requires reasoning or judgment rather than deterministic automation.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | Agent Reference "Name" | Shown in the UI |
+| `name` | Agent Reference "Name" | CLI flag `--name` |
+| `folder-path` | Agent Reference "Folder" | CLI flag `--folder-path` |
+| `task-type-id` | Registry resolution (below) | CLI flag `--task-type-id`, enables enrichment |
+| `element-id` | (optional) | Required only when the agent has multiple element bindings |
+| `inputs` | sdd.md task data mapping | See [bindings-and-expressions.md](../../../bindings-and-expressions.md) |
+| `outputs` | Discovered via `tasks describe` | For downstream cross-task references |
+| `runOnlyOnce` | sdd.md (default `true`) | CLI flag `--should-run-only-once` |
+| `isRequired` | sdd.md (default `true`) | CLI flag `--is-required` |
+
+## Registry Resolution
+
+1. **Primary cache file:** `agent-index.json`.
+2. **Identifier field:** `entityKey`.
+3. **Cross-type fallback.** Agents are occasionally registered in `processOrchestration-index.json` when wrapped in an agentic process — search both if the primary yields no match.
+4. **Match priority:** exact name + exact folder > exact name only.
+5. **Discover inputs/outputs** via `tasks describe` — see [bindings-and-expressions.md § Discovering output names](../../../bindings-and-expressions.md). For agents with multiple elements, also pass `--element-id` when invoking describe (see [case-commands.md § uip case tasks](../../../case-commands.md)).
+
+## Unresolved Fallback
+
+Mark `<UNRESOLVED: agent "<name>" in folder "<folder>" not found in registry>`. Omit `inputs:` and `outputs:`; capture intended wiring in a `# wiring notes` comment block. Execution creates a skeleton task — see [skeleton-tasks.md](../../../skeleton-tasks.md).
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add agent task "<display-name>" to "<stage>"
+- taskTypeId: <entityKey>
+- folder-path: "<folder>"
+- inputs:
+  - <input_name> <- "<Stage>"."<Task>".<output>
+- outputs: <out1>, <out2>
+- runOnlyOnce: true
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/api-workflow/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/api-workflow/impl.md
@@ -1,0 +1,58 @@
+# api-workflow task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type api-workflow \
+  --display-name "<display-name>" \
+  --name "<workflow-name>" \
+  --folder-path "<folder-path>" \
+  --task-type-id "<entityKey>" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+Passing `--task-type-id` auto-enriches inputs and outputs.
+
+## Example
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type api-workflow \
+  --display-name "Monitor Order Inbox" \
+  --name "OrderInboxWatcher" \
+  --folder-path "Shared" \
+  --task-type-id "c3d4e5f6-7890-1234-abcd-345678901234" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000005",
+  "elementId": "el_0005",
+  "type": "api-workflow",
+  "displayName": "Monitor Order Inbox",
+  "data": {
+    "name": "OrderInboxWatcher",
+    "folderPath": "Shared",
+    "inputs": [ /* enriched */ ],
+    "outputs": [ /* enriched */ ],
+    "context": { "taskTypeId": "c3d4e5f6-7890-1234-abcd-345678901234" }
+  },
+  "isRequired": true
+}
+```
+
+## Binding Inputs
+
+Use `uip case var bind` per [bindings-and-expressions.md](../../../bindings-and-expressions.md).
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm `type: "api-workflow"` and `data.context.taskTypeId` populated.

--- a/skills/uipath-case-management/references/plugins/tasks/api-workflow/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/api-workflow/planning.md
@@ -1,0 +1,46 @@
+# api-workflow task — Planning
+
+An API Workflow (formerly "Coded Workflow") task. Invokes a UiPath API workflow by entityKey.
+
+## When to Use
+
+Pick this plugin when the sdd.md labels a task as `API_WORKFLOW` — typically a TypeScript / C# coded workflow that exposes an API-style interface.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | API Workflow Reference "Name" | |
+| `name` | API Workflow Reference "Name" | CLI flag `--name` |
+| `folder-path` | API Workflow Reference "Folder" | CLI flag `--folder-path` |
+| `task-type-id` | Registry resolution (below) | `entityKey` in `api-index.json` |
+| `inputs` | sdd.md task data mapping | See [bindings-and-expressions.md](../../../bindings-and-expressions.md) |
+| `outputs` | Discovered via `tasks describe` | |
+| `runOnlyOnce` | sdd.md (default `true`) | |
+| `isRequired` | sdd.md (default `true`) | |
+
+## Registry Resolution
+
+1. **Primary cache file:** `api-index.json`.
+2. **Identifier field:** `entityKey`.
+3. Match by exact name + folder.
+4. Discover inputs/outputs via `tasks describe` — see [bindings-and-expressions.md § Discovering output names](../../../bindings-and-expressions.md).
+
+## Unresolved Fallback
+
+Mark `<UNRESOLVED: api-workflow "<name>" in folder "<folder>" not found in api-index.json>`. Omit `inputs:` and `outputs:`; capture intended wiring in a `# wiring notes` comment block. Execution creates a skeleton task — see [skeleton-tasks.md](../../../skeleton-tasks.md).
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add api-workflow task "<display-name>" to "<stage>"
+- taskTypeId: <entityKey>
+- folder-path: "<folder>"
+- inputs:
+  - <input_name> = "<value>"
+- outputs: <out1>, <out2>
+- runOnlyOnce: true
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/case-management/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/case-management/impl.md
@@ -1,0 +1,57 @@
+# case-management task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type case-management \
+  --display-name "<display-name>" \
+  --name "<case-name>" \
+  --folder-path "<folder-path>" \
+  --task-type-id "<entityKey>" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+## Example
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type case-management \
+  --display-name "Run Vendor Onboarding Sub-Case" \
+  --name "VendorOnboarding" \
+  --folder-path "Shared/Procurement" \
+  --task-type-id "d4e5f6g7-8901-2345-abcd-456789012345" \
+  --is-required \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000006",
+  "elementId": "el_0006",
+  "type": "case-management",
+  "displayName": "Run Vendor Onboarding Sub-Case",
+  "data": {
+    "name": "VendorOnboarding",
+    "folderPath": "Shared/Procurement",
+    "inputs": [ /* enriched */ ],
+    "outputs": [ /* enriched */ ],
+    "context": { "taskTypeId": "d4e5f6g7-8901-2345-abcd-456789012345" }
+  },
+  "isRequired": true
+}
+```
+
+## Binding Inputs
+
+Use `uip case var bind` per [bindings-and-expressions.md](../../../bindings-and-expressions.md).
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm `type: "case-management"` and `data.context.taskTypeId` populated.
+
+> Sub-case recursion is allowed by the schema but watch for circular references — a case cannot embed itself directly or transitively. If the sdd.md hints at recursion, flag for user review before binding.

--- a/skills/uipath-case-management/references/plugins/tasks/case-management/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/case-management/planning.md
@@ -1,0 +1,51 @@
+# case-management task — Planning
+
+A nested case task. Invokes another case definition as a sub-case within the current one. Enables hierarchical / recursive case structures.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes a task that spawns or delegates to another case definition. Typical patterns:
+
+- Parent case orchestrates multiple sub-cases
+- Long-running sub-workflow packaged as its own case
+
+If sdd.md describes a simple stage-to-stage flow within the same case, do not use this — use regular stages and edges.
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | Case Reference "Name" | |
+| `name` | Case Reference "Name" | |
+| `folder-path` | Case Reference "Folder" | |
+| `task-type-id` | Registry resolution (below) | `entityKey` in `caseManagement-index.json` |
+| `inputs` | sdd.md task data mapping | Passed as case-instance inputs to the sub-case |
+| `outputs` | Discovered via `tasks describe` | Returned when the sub-case completes |
+| `runOnlyOnce` | sdd.md (default `true`) | |
+| `isRequired` | sdd.md (default `true`) | |
+
+## Registry Resolution
+
+1. **Primary cache file:** `caseManagement-index.json`.
+2. **Identifier field:** `entityKey`.
+3. Match by exact name + folder.
+4. Discover inputs/outputs via `tasks describe` — see [bindings-and-expressions.md § Discovering output names](../../../bindings-and-expressions.md).
+
+## Unresolved Fallback
+
+Mark `<UNRESOLVED: case "<name>" in folder "<folder>" not found in caseManagement-index.json>`. Omit `inputs:` and `outputs:`; capture intended wiring in a `# wiring notes` comment block. Execution creates a skeleton task — see [skeleton-tasks.md](../../../skeleton-tasks.md). Note: if the referenced sub-case has not been deployed yet, it will not appear in the registry — the user must deploy it before the parent case can reference it.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add case-management task "<display-name>" to "<stage>"
+- taskTypeId: <entityKey>
+- folder-path: "<folder>"
+- inputs:
+  - <input_name> = "<value>"
+- outputs: <out1>, <out2>
+- runOnlyOnce: true
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/connector-activity/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/connector-activity/impl.md
@@ -1,0 +1,94 @@
+# connector-activity task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add-connector <file> <stage-id> \
+  --type activity \
+  --type-id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" \
+  --display-name "<display-name>" \
+  --input-values '<json>' \
+  --output json
+```
+
+### Required flags
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--type activity` | yes | Fixed for connector-activity tasks |
+| `--type-id` | yes | `uiPathActivityTypeId` from TypeCache |
+| `--connection-id` | yes | Connection UUID from `get-connection` |
+| `--display-name` | no | Overrides the default |
+| `--input-values` | no | JSON object with `body`, `queryParameters`, etc. |
+
+## Example
+
+```bash
+uip case tasks add-connector caseplan.json stg000abc123 \
+  --type activity \
+  --type-id "718fdc36-73a8-3607-8604-ddef95bb9967" \
+  --connection-id "7622a703-5d85-4b55-849b-6c02315b9e6e" \
+  --display-name "Create Jira Issue" \
+  --input-values '{"body":{"fields.project.key":"PROJ","fields.issuetype.id":"10004","fields.summary":"=result.summary"}}' \
+  --output json
+```
+
+> **Shell quoting tip** — for complex JSON, write to a temp file and read it back:
+> `uip case tasks add-connector caseplan.json <stage-id> --type activity ... --input-values "$(cat /tmp/inputs.json)" --output json`
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000007",
+  "elementId": "el_0007",
+  "type": "execute-connector-activity",
+  "displayName": "Create Jira Issue",
+  "data": {
+    "name": "Create Jira Issue",
+    "folderPath": null,
+    "serviceType": "Intsvc.Activity",
+    "bindings": [
+      {
+        "type": "connection",
+        "connectionId": "7622a703-5d85-4b55-849b-6c02315b9e6e",
+        "connectorKey": "uipath-atlassian-jira"
+      }
+    ],
+    "inputs": [ /* from --input-values */ ],
+    "outputs": [ /* from describe */ ],
+    "context": {
+      "uiPathActivityTypeId": "718fdc36-73a8-3607-8604-ddef95bb9967",
+      "objectName": "issue"
+    }
+  },
+  "isRequired": true
+}
+```
+
+> Note: the task `type` in `caseplan.json` is `execute-connector-activity` (the internal schema name), not `connector-activity` (the CLI / plugin name).
+
+## Binding Inputs via var bind
+
+Fields inside `--input-values` can reference cross-task outputs or expressions, but **the CLI does not accept `--source-*` in the `--input-values` JSON**. For cross-task wires, pass the literal expression inline:
+
+```json
+{"body":{"summary":"=result.some_field","description":"=metadata.description"}}
+```
+
+For complex cross-task references, after `tasks add-connector`, run `uip case var bind` on the individual input as with other task types. See [bindings-and-expressions.md](../../../bindings-and-expressions.md).
+
+## Filter Expression (if needed)
+
+Connector-activity does not use `--filter` — that flag is for triggers. If sdd.md describes filtering, apply it inside `input-values` or via an upstream task.
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm:
+
+- `type: "execute-connector-activity"`
+- `data.bindings[0].connectionId` matches the UUID you passed
+- `data.context.uiPathActivityTypeId` matches what you passed
+
+If `data.inputs` or `data.outputs` is empty, the `--connection-id` may have been missing or invalid — the schema enrichment depends on a live connection.

--- a/skills/uipath-case-management/references/plugins/tasks/connector-activity/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/connector-activity/planning.md
@@ -1,0 +1,61 @@
+# connector-activity task — Planning
+
+A connector activity task inside a stage. Calls an external service (Jira, Slack, Salesforce, Gmail, etc.) via UiPath Integration Service.
+
+This plugin is **schema-data-driven** — one plugin covers every connector. Connector-specific input shapes are discovered at runtime via `tasks describe --connection-id`, not baked into this plugin. See [connector-integration.md](../../../connector-integration.md) for the shared resolution pipeline.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes a task as `CONNECTOR_ACTIVITY` or names a specific external service action (e.g., "send a Slack message", "create a Jira issue", "update Salesforce opportunity").
+
+For **connector-based triggers** inside a stage (wait for an external event), use [connector-trigger](../connector-trigger/planning.md).
+
+For **case-level event triggers** (outside any stage), use [`plugins/triggers/event/`](../../triggers/event/planning.md).
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | sdd.md task name | |
+| `type-id` | `uiPathActivityTypeId` from TypeCache | See pipeline below |
+| `connection-id` | Connection UUID from `get-connection` | See pipeline below |
+| `connector-key` | `Config.connectorKey` | Recorded for debugging |
+| `object-name` | `Config.objectName` | Recorded for debugging |
+| `input-values` | sdd.md task data mapping | JSON object matching schema from `describe` |
+| `isRequired` | sdd.md (default `true`) | |
+
+## Resolution Pipeline
+
+Follow the full procedure in [connector-integration.md](../../../connector-integration.md). Summary of planning-time decisions:
+
+1. **Find `uiPathActivityTypeId`** by reading `~/.uipcli/case-resources/typecache-activities-index.json` directly. Match on `displayName`. Skip entries without `uiPathActivityTypeId`.
+2. **Resolve connector metadata** (`connectorKey`, `objectName`) via the `get-connector` call documented in [connector-integration.md § Step 2](../../../connector-integration.md).
+3. **Resolve the connection** via the `get-connection` call documented in [connector-integration.md § Step 3](../../../connector-integration.md):
+   - Single connection → use it.
+   - Multiple connections → **AskUserQuestion** with names + "Something else".
+   - Empty `Connections` → mark `<UNRESOLVED: no IS connection for <connectorKey>>` and omit `input-values:`. Execution creates a skeleton connector task — see [skeleton-tasks.md](../../../skeleton-tasks.md).
+4. **(Optional) Describe the input schema** when sdd.md requires specific field wiring — see [connector-integration.md § Step 4](../../../connector-integration.md).
+
+## Input-Values Shape
+
+The `--input-values` JSON is connector-specific. Common top-level keys:
+
+- `body` — request body fields
+- `queryParameters` — query string parameters
+- `pathParameters` — URL path parameters
+
+Discover exact keys from the `describe` response. Use resolved IDs (not display names) where the connector schema requires references — see [connector-integration.md](../../../connector-integration.md#step-4--optional-describe-inputsoutputs).
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add connector-activity task "<display-name>" to "<stage>"
+- type-id: <uiPathActivityTypeId>
+- connection-id: <connection-uuid>
+- connector-key: <connectorKey>
+- object-name: <objectName>
+- input-values: {"body":{"field":"value"},"queryParameters":{"key":"val"}}
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/connector-trigger/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/connector-trigger/impl.md
@@ -1,0 +1,87 @@
+# connector-trigger task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add-connector <file> <stage-id> \
+  --type trigger \
+  --type-id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" \
+  --display-name "<display-name>" \
+  --input-values '<json>' \
+  --filter '<filter-expression>' \
+  --output json
+```
+
+### Required flags
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--type trigger` | yes | Distinguishes from connector-activity |
+| `--type-id` | yes | From `typecache-triggers-index.json` |
+| `--connection-id` | yes | From `get-connection` |
+| `--input-values` | no | Event parameters as JSON |
+| `--filter` | no | Connector filter DSL string |
+
+## Example
+
+```bash
+uip case tasks add-connector caseplan.json stg000abc123 \
+  --type trigger \
+  --type-id "829ef147-84b9-4718-9715-eefa06cc0a78" \
+  --connection-id "7622a703-5d85-4b55-849b-6c02315b9e6e" \
+  --display-name "Wait for Jira Issue Update" \
+  --input-values '{"body":{"project":"PROJ"}}' \
+  --filter '((fields.status=`Resolved`))' \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000008",
+  "elementId": "el_0008",
+  "type": "wait-for-connector",
+  "displayName": "Wait for Jira Issue Update",
+  "data": {
+    "name": "Wait for Jira Issue Update",
+    "serviceType": "Intsvc.EventTrigger",
+    "bindings": [
+      {
+        "type": "connection",
+        "connectionId": "7622a703-5d85-4b55-849b-6c02315b9e6e",
+        "connectorKey": "uipath-atlassian-jira"
+      },
+      {
+        "type": "eventTrigger",
+        "filter": "((fields.status=`Resolved`))",
+        "eventParams": { "project": "PROJ" }
+      }
+    ],
+    "outputs": [ /* from describe */ ],
+    "context": {
+      "uiPathActivityTypeId": "829ef147-84b9-4718-9715-eefa06cc0a78",
+      "objectName": "issue"
+    }
+  },
+  "isRequired": true
+}
+```
+
+> The task `type` in `caseplan.json` is `wait-for-connector` (the internal schema name), not `connector-trigger` (the CLI / plugin name).
+
+## Binding Outputs
+
+Outputs of a connector-trigger are the fields of the fired event (e.g., `issueId`, `summary`). Downstream tasks reference them via cross-task refs per [bindings-and-expressions.md](../../../bindings-and-expressions.md).
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm:
+
+- `type: "wait-for-connector"`
+- `data.bindings` has **both** a `connection` entry and an `eventTrigger` entry
+- `data.bindings[].filter` matches what you passed
+- `data.context.uiPathActivityTypeId` matches
+
+If `data.outputs` is empty, the connection may be invalid — schema enrichment requires a live connection.

--- a/skills/uipath-case-management/references/plugins/tasks/connector-trigger/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/connector-trigger/planning.md
@@ -1,0 +1,61 @@
+# connector-trigger task — Planning
+
+A connector-based trigger **inside a stage** — waits for an external event (e.g., "issue created in Jira", "message posted to Slack channel") before continuing.
+
+This plugin is **schema-data-driven** — one plugin covers every connector trigger. Per-connector shapes are discovered via `tasks describe --connection-id`. See [connector-integration.md](../../../connector-integration.md) for the shared resolution pipeline.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes a task that **suspends the stage until an external event fires**. Typical patterns:
+
+- "Wait until a new row appears in Salesforce"
+- "Continue when a Slack reaction is added"
+- "Suspend until a Jira issue is transitioned"
+
+Distinguish from:
+
+- **Case-level event triggers** (start the case from outside) → [`plugins/triggers/event/`](../../triggers/event/planning.md)
+- **Connector activity** (call out, don't wait) → [connector-activity](../connector-activity/planning.md)
+- **Timer wait** (not connector-driven) → [wait-for-timer](../wait-for-timer/planning.md)
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | sdd.md task name | |
+| `type-id` | `uiPathActivityTypeId` from TypeCache triggers | |
+| `connection-id` | Connection UUID | |
+| `connector-key` | `Config.connectorKey` | Recorded for debugging |
+| `object-name` | `Config.objectName` | Recorded for debugging |
+| `input-values` | sdd.md task data mapping | Event params |
+| `filter` | sdd.md filter description | Translated to the connector's filter DSL |
+| `isRequired` | sdd.md (default `true`) | |
+
+## Resolution Pipeline
+
+Same as [connector-activity/planning.md](../connector-activity/planning.md), but using the **trigger** TypeCache (`typecache-triggers-index.json`). Follow the full procedure in [connector-integration.md](../../../connector-integration.md) — use `--type typecache-triggers` for each call.
+
+## Filter Translation
+
+Translate the sdd.md natural-language filter to the connector's filter DSL. See [connector-integration.md](../../../connector-integration.md#filter-expression-syntax).
+
+Example:
+- sdd.md: "wait for an issue where status is Open"
+- filter: `` ((fields.status=`Open`)) ``
+
+If the filter cannot be translated unambiguously, ask the user.
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add connector-trigger task "<display-name>" to "<stage>"
+- type-id: <uiPathActivityTypeId>
+- connection-id: <connection-uuid>
+- connector-key: <connectorKey>
+- object-name: <objectName>
+- input-values: {"body":{"project":"PROJ"}}
+- filter: "((fields.status=`Open`))"
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/process/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/process/impl.md
@@ -1,0 +1,93 @@
+# process task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type process \
+  --display-name "<display-name>" \
+  --name "<process-name>" \
+  --folder-path "<folder-path>" \
+  --task-type-id "<entityKey>" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+### Required flags
+
+| Flag | Source | Required |
+|------|--------|----------|
+| `--type process` | fixed | yes |
+| `--display-name` | tasks.md title | yes |
+| `--task-type-id` | tasks.md `taskTypeId` | yes (triggers enrichment) |
+
+### Optional flags
+
+| Flag | Purpose |
+|------|---------|
+| `--name` | Process name (display) |
+| `--folder-path` | Orchestrator folder path |
+| `--should-run-only-once` | Runs once per case instance |
+| `--is-required` | Stage completion depends on this task |
+| `--description` | Task description |
+
+Passing `--task-type-id` auto-enriches the task with inputs, outputs, and bindings. If enrichment fails, re-run `uip case tasks enrich --type process --id <entityKey>` separately.
+
+## Example
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type process \
+  --display-name "Run KYC" \
+  --name "KYC" \
+  --folder-path "Shared" \
+  --task-type-id "f1b2c3d4-1234-5678-abcd-ef1234567890" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+## Resulting JSON Shape in caseplan.json
+
+After the command runs, the stage's `data.tasks[0]` array gains an entry like:
+
+```json
+{
+  "id": "tsk00000001",
+  "elementId": "el_0001",
+  "type": "process",
+  "displayName": "Run KYC",
+  "data": {
+    "name": "KYC",
+    "folderPath": "Shared",
+    "inputs": [ /* enriched from taskTypeId */ ],
+    "outputs": [ /* enriched */ ],
+    "context": { "taskTypeId": "f1b2c3d4-1234-5678-abcd-ef1234567890" }
+  },
+  "shouldRunOnReEntry": false,
+  "isRequired": true
+}
+```
+
+## Binding Inputs and Outputs
+
+After `tasks add`, bind each input from tasks.md per [bindings-and-expressions.md](../../../bindings-and-expressions.md):
+
+```bash
+# Literal or expression input
+uip case var bind <file> <stage-id> <task-id> <input-name> --value "<value>" --output json
+
+# Cross-task reference input
+uip case var bind <file> <stage-id> <task-id> <input-name> \
+  --source-stage <src-stage-id> \
+  --source-task <src-task-id> \
+  --source-output <output-name> \
+  --output json
+```
+
+## Post-Add Validation
+
+Capture `TaskId` from the `--output json` response. Save it in the stage/task ID map for downstream cross-task references.
+
+Confirm the task appears in `caseplan.json` with the expected `type: "process"` and a non-empty `data.context.taskTypeId`.

--- a/skills/uipath-case-management/references/plugins/tasks/process/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/process/planning.md
@@ -1,0 +1,59 @@
+# process task — Planning
+
+An RPA-driven automated process task. Invokes a UiPath process (or agentic process) by name and folder.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes a task as any of:
+
+- `PROCESS` — a regular UiPath process
+- `AGENTIC_PROCESS` — an agentic process orchestrated by UiPath
+- Generic "run automation X" where X is a published process
+
+For RPA robot tasks specifically, prefer [rpa](../rpa/planning.md). For Coded workflows / API-workflows, use [api-workflow](../api-workflow/planning.md).
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | Process Reference "Name" | Shown in the UI |
+| `name` | Process Reference "Name" | CLI flag `--name` |
+| `folder-path` | Process Reference "Folder" | CLI flag `--folder-path`. Required for disambiguation. |
+| `task-type-id` | Registry resolution (see below) | CLI flag `--task-type-id`. Enables auto-enrichment. |
+| `inputs` | sdd.md task data mapping | See [bindings-and-expressions.md](../../../bindings-and-expressions.md) |
+| `outputs` | Discovered via `tasks describe` | Listed for downstream cross-task references |
+| `runOnlyOnce` | sdd.md (default `true`) | CLI flag `--should-run-only-once` |
+| `isRequired` | sdd.md (default `true`) | CLI flag `--is-required` |
+
+## Registry Resolution
+
+1. **Primary cache file:** `process-index.json` for `PROCESS`, `processOrchestration-index.json` for `AGENTIC_PROCESS`.
+2. **Identifier field:** `entityKey`.
+3. **Cross-type fallback.** If the primary cache file has no match, search both files — the sdd.md label is not authoritative. A process registered as `process` may be mislabeled `AGENTIC_PROCESS` in sdd.md and vice versa.
+4. **Match priority:** exact name + exact folder > exact name, multiple folders (pick matching) > exact name only > no match.
+5. **Discover inputs/outputs:** after resolving the `entityKey`, fetch the input/output schema via `tasks describe` — see [bindings-and-expressions.md § Discovering output names](../../../bindings-and-expressions.md). Record input names, types, and output names. Unrecognized inputs in sdd.md → ask the user (**AskUserQuestion** with matching field names + "Something else").
+
+## Unresolved Fallback
+
+If no match is found across both cache files after `uip case registry pull --force`:
+
+- Mark the task line: `<UNRESOLVED: process "<name>" in folder "<folder>" not found in registry>`
+- Omit `inputs:` and `outputs:`; capture intended wiring in a `# wiring notes` comment block.
+- Continue planning for remaining tasks.
+- Execution creates a skeleton task (no `--task-type-id`, no bindings). See [skeleton-tasks.md](../../../skeleton-tasks.md).
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add process task "<display-name>" to "<stage>"
+- taskTypeId: <entityKey>
+- folder-path: "<folder>"
+- inputs:
+  - <input_name> = "<literal-or-expression>"
+  - <input_name> <- "<Stage>"."<Task>".<output>
+- outputs: <out1>, <out2>, <out3>
+- runOnlyOnce: true
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/rpa/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/rpa/impl.md
@@ -1,0 +1,57 @@
+# rpa task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type rpa \
+  --display-name "<display-name>" \
+  --name "<process-name>" \
+  --folder-path "<folder-path>" \
+  --task-type-id "<entityKey>" \
+  --should-run-only-once \
+  --is-required \
+  --output json
+```
+
+Enrichment is the same as `process` — passing `--task-type-id` auto-populates inputs and outputs.
+
+## Example
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type rpa \
+  --display-name "Extract Invoice Data" \
+  --name "InvoiceExtractor" \
+  --folder-path "Finance" \
+  --task-type-id "b2c3d4e5-6789-01ab-cdef-234567890abc" \
+  --is-required \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000003",
+  "elementId": "el_0003",
+  "type": "rpa",
+  "displayName": "Extract Invoice Data",
+  "data": {
+    "name": "InvoiceExtractor",
+    "folderPath": "Finance",
+    "inputs": [ /* enriched */ ],
+    "outputs": [ /* enriched */ ],
+    "context": { "taskTypeId": "b2c3d4e5-6789-01ab-cdef-234567890abc" }
+  },
+  "isRequired": true
+}
+```
+
+## Binding Inputs
+
+Use `uip case var bind` — identical pattern to [process/impl.md](../process/impl.md#binding-inputs-and-outputs).
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm `type: "rpa"` in `caseplan.json` and `data.context.taskTypeId` populated.

--- a/skills/uipath-case-management/references/plugins/tasks/rpa/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/rpa/planning.md
@@ -1,0 +1,48 @@
+# rpa task — Planning
+
+An RPA robot task. The sdd.md component type is `RPA`. At the CLI level, RPA tasks use `--type rpa` but the cached entity typically lives in `process-index.json` — the registry does not separate "process" from "rpa" at storage time.
+
+## When to Use
+
+Pick this plugin when the sdd.md explicitly labels a task as `RPA` (e.g., "RPA robot does X"). The distinction from `process` is **semantic** (sdd.md intent) rather than structural (registry representation).
+
+If sdd.md is ambiguous between `PROCESS` and `RPA`, default to `process` unless the sdd.md mentions UI automation, desktop apps, or robot-specific concerns.
+
+## Required Fields from sdd.md
+
+Same shape as [process/planning.md](../process/planning.md):
+
+| Field | Notes |
+|-------|-------|
+| `display-name` | from Process Reference |
+| `name` | from Process Reference |
+| `folder-path` | from Process Reference |
+| `task-type-id` | from registry (`entityKey` in `process-index.json`) |
+| `inputs`, `outputs`, `runOnlyOnce`, `isRequired` | see [bindings-and-expressions.md](../../../bindings-and-expressions.md) |
+
+## Registry Resolution
+
+1. **Primary cache file:** `process-index.json` (yes — RPA tasks share this cache with `process`).
+2. **Identifier field:** `entityKey`.
+3. Use the sdd.md `RPA` label to set `--type rpa` on the CLI; use the cache `entityKey` for `--task-type-id`.
+4. If no match in `process-index.json`, search all other cache files as a fallback.
+5. Discover inputs/outputs via `tasks describe` — see [bindings-and-expressions.md § Discovering output names](../../../bindings-and-expressions.md).
+
+## Unresolved Fallback
+
+Mark `<UNRESOLVED: rpa "<name>" in folder "<folder>" not found in registry>`. Omit `inputs:` and `outputs:`; capture intended wiring in a `# wiring notes` comment block. Execution creates a skeleton task — see [skeleton-tasks.md](../../../skeleton-tasks.md).
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add rpa task "<display-name>" to "<stage>"
+- taskTypeId: <entityKey>
+- folder-path: "<folder>"
+- inputs:
+  - <input_name> = "<value>"
+- outputs: <out1>
+- runOnlyOnce: true
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/tasks/wait-for-timer/impl.md
+++ b/skills/uipath-case-management/references/plugins/tasks/wait-for-timer/impl.md
@@ -1,0 +1,67 @@
+# wait-for-timer task — Implementation
+
+## CLI Command
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type wait-for-timer \
+  --display-name "<display-name>" \
+  --is-required \
+  --output json
+```
+
+> **Note:** The `uip case tasks add` command itself does not accept `--every`, `--at`, `--repeat`, or `--time-cycle` — those flags exist on `triggers add-timer`, not on `tasks add`. For in-stage timer tasks, `tasks add --type wait-for-timer` creates the task with default timer data; configure the duration afterwards with direct JSON editing OR (preferred) by using `triggers add-timer` and wiring via an edge.
+
+## Two Patterns
+
+### Pattern A — Simple in-stage wait (fixed delay)
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type wait-for-timer \
+  --display-name "24-hour cooldown" \
+  --is-required \
+  --output json
+```
+
+After creation, the task's `data` is empty. If the sdd.md specifies a duration, edit `caseplan.json` directly or use a case-level timer trigger instead (Pattern B).
+
+### Pattern B — Case-level scheduled trigger (preferred for scheduled events)
+
+Use [`plugins/triggers/timer/`](../../triggers/timer/impl.md) — most "timer" behavior in sdd.md is better modeled as a case-level timer trigger than an in-stage wait.
+
+## Example
+
+```bash
+uip case tasks add caseplan.json stg000abc123 \
+  --type wait-for-timer \
+  --display-name "Wait 24 hours" \
+  --is-required \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "tsk00000009",
+  "elementId": "el_0009",
+  "type": "wait-for-timer",
+  "displayName": "Wait 24 hours",
+  "data": {
+    "timer": null,
+    "timeDuration": null,
+    "timeDate": null,
+    "timeCycle": null
+  },
+  "isRequired": true
+}
+```
+
+The `data` fields are populated by subsequent edits — the CLI does not yet support setting them on `tasks add`.
+
+## Post-Add Validation
+
+Capture `TaskId`. Confirm `type: "wait-for-timer"` in `caseplan.json`.
+
+If sdd.md specified a duration but the data fields remain null, flag to the user: "The CLI does not set timer duration on `tasks add`. Model this as a case-level timer trigger instead, or edit `caseplan.json.data` directly."

--- a/skills/uipath-case-management/references/plugins/tasks/wait-for-timer/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/wait-for-timer/planning.md
@@ -1,0 +1,69 @@
+# wait-for-timer task — Planning
+
+A timer task inside a stage. Suspends the stage for a duration, until a specific time, or on a repeating cycle.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes a task that **pauses or delays execution** within a stage. Typical patterns:
+
+- "Wait 24 hours before reminding"
+- "Delay until next business day at 9 AM"
+- "Poll every hour for up to 5 iterations"
+
+Distinguish from:
+
+- **Case-level timer triggers** (start the case on a schedule) → [`plugins/triggers/timer/`](../../triggers/timer/planning.md)
+- **Connector event wait** → [connector-trigger](../connector-trigger/planning.md)
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | sdd.md task name | |
+| Either `timeDuration` (`--every`) OR `timeCycle` OR `timeDate` (`--at`) | sdd.md timer semantics | At least one required |
+| `repeat` | sdd.md (optional) | Number of repetitions — omit for infinite |
+| `isRequired` | sdd.md (default `true`) | |
+
+## Registry Resolution
+
+**No cache lookup required.** Timer is a built-in task type with no registry representation — no `taskTypeId`, no `enrich`, no `describe`.
+
+## Duration Formats
+
+Accepted `--every` values:
+
+| Format | Example | Meaning |
+|--------|---------|---------|
+| Seconds | `10s` | 10 seconds |
+| Minutes | `5m` | 5 minutes |
+| Hours | `1h` | 1 hour |
+| Days | `2d` | 2 days |
+| Weeks | `1w` | 1 week |
+| Months | `3mo` | 3 months |
+| ISO 8601 | `PT10S` | 10 seconds (raw ISO) |
+
+Accepted `--at` values: ISO 8601 datetime (e.g., `2026-04-26T10:00:00.000Z`).
+
+Accepted `--time-cycle` values: raw ISO 8601 repeating interval (e.g., `R/PT1H` = repeat every hour, infinite). Overrides `--every`, `--at`, `--repeat` if set.
+
+## Translation Guidance
+
+- "Wait X hours" → `--every Xh`, no `--at`, no `--repeat`.
+- "Every day at 9 AM" → `--every 1d --at <ISO datetime with 09:00>`.
+- "Every hour, up to N times" → `--every 1h --repeat N`.
+- "Run repeatedly forever every N" → `--time-cycle R/PT<N>`.
+
+Ambiguous phrasing → **AskUserQuestion** with 2–3 candidate interpretations + "Something else".
+
+## tasks.md Entry Format
+
+```markdown
+## T<n>: Add wait-for-timer task "<display-name>" to "<stage>"
+- every: 1h
+- at: 2026-04-26T09:00:00.000Z   # optional
+- repeat: 5                       # optional
+- time-cycle: R/PT1H              # optional (overrides above)
+- isRequired: true
+- order: after T<m>
+- verify: Confirm Result: Success, capture TaskId
+```

--- a/skills/uipath-case-management/references/plugins/triggers/event/impl.md
+++ b/skills/uipath-case-management/references/plugins/triggers/event/impl.md
@@ -1,0 +1,77 @@
+# event trigger — Implementation
+
+## CLI Command
+
+```bash
+uip case triggers add-event <file> \
+  --type-id "<uiPathActivityTypeId>" \
+  --connection-id "<connection-id>" \
+  --event-params '<json>' \
+  --filter '<filter-expression>' \
+  --display-name "<display-name>" \
+  --output json
+```
+
+### Required flags
+
+| Flag | Required | Notes |
+|------|----------|-------|
+| `--type-id` | yes | `uiPathActivityTypeId` from `typecache-triggers-index.json` |
+| `--connection-id` | yes | Connection UUID |
+| `--event-params` | no | JSON object of event parameter key/values |
+| `--filter` | no | Connector filter DSL string |
+
+## Example
+
+```bash
+uip case triggers add-event caseplan.json \
+  --type-id "829ef147-84b9-4718-9715-eefa06cc0a78" \
+  --connection-id "7622a703-5d85-4b55-849b-6c02315b9e6e" \
+  --event-params '{"project":"PROJ"}' \
+  --filter '((fields.status=`Open`))' \
+  --display-name "New Jira Issue" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "trig0000003",
+  "type": "case-management:Trigger",
+  "position": { "x": -100, "y": 620 },
+  "data": {
+    "label": "New Jira Issue",
+    "uipath": {
+      "serviceType": "Intsvc.EventTrigger",
+      "bindings": [
+        {
+          "type": "connection",
+          "connectionId": "7622a703-5d85-4b55-849b-6c02315b9e6e",
+          "connectorKey": "uipath-atlassian-jira"
+        },
+        {
+          "type": "eventTrigger",
+          "uiPathActivityTypeId": "829ef147-84b9-4718-9715-eefa06cc0a78",
+          "eventParams": { "project": "PROJ" },
+          "filter": "((fields.status=`Open`))"
+        }
+      ]
+    }
+  }
+}
+```
+
+`serviceType: "Intsvc.EventTrigger"` marks this as an event-driven trigger.
+
+## Post-Add Validation
+
+Capture `TriggerId`. Use it as the `--source` when wiring an edge to the first stage.
+
+Confirm:
+- `data.uipath.serviceType == "Intsvc.EventTrigger"`
+- `data.uipath.bindings` has both `connection` and `eventTrigger` entries
+- `eventTrigger.filter` matches what you passed
+- `eventTrigger.uiPathActivityTypeId` matches
+
+If `data.uipath.bindings` is missing the `eventTrigger` entry, re-run with `--connection-id` — schema enrichment requires a live connection.

--- a/skills/uipath-case-management/references/plugins/triggers/event/planning.md
+++ b/skills/uipath-case-management/references/plugins/triggers/event/planning.md
@@ -1,0 +1,58 @@
+# event trigger — Planning
+
+A case-level trigger that fires on an external connector event (e.g., "new Salesforce opportunity created", "Jira issue transitioned"). Starts the case when the event matches a filter.
+
+This plugin is **schema-data-driven** — one plugin covers every connector. The resolution pipeline is shared with the `connector-trigger` task plugin. See [connector-integration.md](../../../connector-integration.md).
+
+## When to Use
+
+Pick this plugin when the sdd.md describes the case as starting in response to an external event:
+
+- "When a new row is added in Salesforce"
+- "On each new Jira issue with priority High"
+- "When a file is uploaded to SharePoint"
+
+Distinguish from:
+
+- **User-initiated start** → [manual](../manual/planning.md)
+- **Scheduled start** → [timer](../timer/planning.md)
+- **In-stage event wait** → [connector-trigger task](../../tasks/connector-trigger/planning.md)
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | sdd.md (optional) | Defaults to `Trigger N` |
+| `type-id` | `uiPathActivityTypeId` from TypeCache triggers | |
+| `connection-id` | Connection UUID from `get-connection` | |
+| `connector-key` | `Config.connectorKey` | Recorded for debugging |
+| `object-name` | `Config.objectName` | Recorded for debugging |
+| `event-params` | sdd.md event parameters | JSON object |
+| `filter` | sdd.md filter description | Translated to connector's filter DSL |
+
+## Resolution Pipeline
+
+Follow the full procedure in [connector-integration.md](../../../connector-integration.md) using the **trigger** TypeCache (`typecache-triggers-index.json`):
+
+1. **Find `uiPathActivityTypeId`** by reading the cache file directly.
+2. **Resolve connector metadata** (`connectorKey`, `objectName`).
+3. **Resolve the connection** — if `Connections` is empty, mark `<UNRESOLVED: no IS connection for <connectorKey>>` in `tasks.md`. **Event triggers do not support the skeleton pattern** — without a connector there is no trigger configuration, and a bare trigger node has no entry semantics. The implementation phase skips `triggers add-event` and falls back to the auto-created Trigger node (from `cases add` in T01) as the case entry point. Document the missing event trigger in the completion report so the user adds it after registering the connector + connection.
+4. **(Optional) Describe trigger schema** when the event needs specific field wiring.
+
+## Filter Translation
+
+Convert sdd.md natural language to the connector's filter DSL. See [connector-integration.md](../../../connector-integration.md#filter-expression-syntax) for syntax.
+
+## tasks.md Entry Format
+
+```markdown
+## T02: Configure event trigger "<display-name>"
+- type-id: <uiPathActivityTypeId>
+- connection-id: <connection-uuid>
+- connector-key: <connectorKey>
+- object-name: <objectName>
+- event-params: {"project":"PROJ"}
+- filter: "((fields.status=`Open`))"
+- order: after T01
+- verify: Confirm Result: Success, capture TriggerId
+```

--- a/skills/uipath-case-management/references/plugins/triggers/manual/impl.md
+++ b/skills/uipath-case-management/references/plugins/triggers/manual/impl.md
@@ -1,0 +1,48 @@
+# manual trigger — Implementation
+
+## CLI Command
+
+```bash
+uip case triggers add-manual <file> \
+  --display-name "<display-name>" \
+  --output json
+```
+
+### Optional flags
+
+| Flag | Notes |
+|------|-------|
+| `--display-name` | Auto-generated as `Trigger N` if omitted |
+| `--position "<x>,<y>"` | Auto-stacked to the left of stages if omitted |
+
+## Example
+
+```bash
+uip case triggers add-manual caseplan.json \
+  --display-name "Start Manually" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+The Trigger node in `caseplan.json.nodes`:
+
+```json
+{
+  "id": "trig0000001",
+  "type": "case-management:Trigger",
+  "position": { "x": -100, "y": 340 },
+  "data": {
+    "label": "Start Manually",
+    "uipath": { "serviceType": "None" }
+  }
+}
+```
+
+`serviceType: "None"` marks this as a manual trigger (no event, no schedule).
+
+## Post-Add Validation
+
+Capture `TriggerId` from `--output json`. Use it as the `--source` when adding an edge from the trigger to the first stage (via `uip case edges add`).
+
+Confirm `data.uipath.serviceType == "None"` in `caseplan.json`.

--- a/skills/uipath-case-management/references/plugins/triggers/manual/planning.md
+++ b/skills/uipath-case-management/references/plugins/triggers/manual/planning.md
@@ -1,0 +1,33 @@
+# manual trigger — Planning
+
+A case-level trigger that the user starts by hand (e.g., clicking "Start" in the Case App). No schedule, no event — it just waits for a human.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes the case as starting on user action:
+
+- "User initiates the case from the portal"
+- "Operator starts a new case manually"
+- "Start button in the Case App"
+
+If the sdd.md says the case runs on a schedule, use [timer](../timer/planning.md). If it starts from an external event, use [event](../event/planning.md).
+
+## Required Fields from sdd.md
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `display-name` | sdd.md (optional) | Defaults to auto-generated `Trigger N` |
+| `position` | rarely specified | CLI auto-positions to the left of stages |
+
+## Registry Resolution
+
+**None.** Manual triggers have no registry representation.
+
+## tasks.md Entry Format
+
+```markdown
+## T02: Configure manual trigger "<display-name>"
+- display-name: "Start Manually"
+- order: after T01
+- verify: Confirm Result: Success, capture TriggerId
+```

--- a/skills/uipath-case-management/references/plugins/triggers/timer/impl.md
+++ b/skills/uipath-case-management/references/plugins/triggers/timer/impl.md
@@ -1,0 +1,88 @@
+# timer trigger — Implementation
+
+## CLI Command
+
+```bash
+uip case triggers add-timer <file> \
+  --every "<duration>" \
+  --at "<iso-datetime>" \
+  --repeat <count> \
+  --display-name "<display-name>" \
+  --output json
+```
+
+Or use a raw ISO 8601 repeating interval:
+
+```bash
+uip case triggers add-timer <file> \
+  --time-cycle "<R/PT...>" \
+  --display-name "<display-name>" \
+  --output json
+```
+
+### Flag rules
+
+| Flag | Notes |
+|------|-------|
+| `--every <duration>` | Required unless `--time-cycle` is set |
+| `--at <iso>` | Optional start datetime |
+| `--repeat <n>` | Optional; omit for infinite |
+| `--time-cycle <expr>` | Overrides `--every`/`--at`/`--repeat` |
+
+## Example — Every hour, forever
+
+```bash
+uip case triggers add-timer caseplan.json \
+  --every 1h \
+  --display-name "Hourly Poll" \
+  --output json
+```
+
+## Example — Every day at 9 AM UTC, for 30 days
+
+```bash
+uip case triggers add-timer caseplan.json \
+  --every 1d \
+  --at 2026-04-26T09:00:00.000Z \
+  --repeat 30 \
+  --display-name "Daily 9 AM Check" \
+  --output json
+```
+
+## Example — Raw ISO 8601
+
+```bash
+uip case triggers add-timer caseplan.json \
+  --time-cycle "R/PT1H" \
+  --display-name "Raw Hourly" \
+  --output json
+```
+
+## Resulting JSON Shape
+
+```json
+{
+  "id": "trig0000002",
+  "type": "case-management:Trigger",
+  "position": { "x": -100, "y": 480 },
+  "data": {
+    "label": "Hourly Poll",
+    "uipath": {
+      "serviceType": "Intsvc.TimerTrigger",
+      "timeCycle": "R/PT1H"
+    }
+  }
+}
+```
+
+`serviceType: "Intsvc.TimerTrigger"` marks this as a timer trigger. Duration fields (`--every`, `--at`, `--repeat`) are composed into a `timeCycle` ISO 8601 string.
+
+## Post-Add Validation
+
+Capture `TriggerId`. Use it as the `--source` when wiring an edge to the first stage.
+
+Confirm:
+- `data.uipath.serviceType == "Intsvc.TimerTrigger"`
+- `data.uipath.timeCycle` non-empty and matches the intended schedule
+
+The response includes a `TimeCycle` field — cross-check it against the sdd.md phrasing to catch translation errors.

--- a/skills/uipath-case-management/references/plugins/triggers/timer/planning.md
+++ b/skills/uipath-case-management/references/plugins/triggers/timer/planning.md
@@ -1,0 +1,59 @@
+# timer trigger — Planning
+
+A case-level trigger that fires on a schedule — once at a specific time, on a repeating interval, with an optional repeat count.
+
+## When to Use
+
+Pick this plugin when the sdd.md describes the case as running on a schedule:
+
+- "Every hour"
+- "Daily at 9 AM"
+- "Every Monday for 5 weeks"
+- Cron-like phrasing
+
+For user-initiated starts, use [manual](../manual/planning.md). For external events, use [event](../event/planning.md).
+
+## Required Fields from sdd.md
+
+At least one of:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `every` | sdd.md interval phrasing | `10s`, `5m`, `1h`, `2d`, `1w`, `3mo`, or raw ISO 8601 like `PT10S` |
+| `at` | sdd.md start time | ISO 8601 datetime |
+| `time-cycle` | sdd.md repeating expression | Raw ISO 8601 (e.g., `R/PT1H`); overrides `every`/`at`/`repeat` |
+
+Plus optional:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `repeat` | sdd.md (optional) | Integer. Omit for infinite. |
+| `display-name` | sdd.md (optional) | Defaults to `Trigger N` |
+
+## Registry Resolution
+
+**None.** Timer triggers have no registry representation.
+
+## Translation Guidance
+
+| sdd.md phrase | CLI flags |
+|---------------|-----------|
+| "Every hour" | `--every 1h` |
+| "Every 30 minutes" | `--every 30m` |
+| "Daily at 9 AM UTC" | `--every 1d --at 2026-04-26T09:00:00.000Z` |
+| "Every hour, 10 times" | `--every 1h --repeat 10` |
+| "Infinite, every hour (raw ISO)" | `--time-cycle R/PT1H` |
+
+When the sdd.md phrasing is ambiguous, **AskUserQuestion** with 2–3 candidate interpretations + "Something else".
+
+## tasks.md Entry Format
+
+```markdown
+## T02: Configure timer trigger "<display-name>"
+- every: 1h
+- at: 2026-04-26T09:00:00.000Z   # optional
+- repeat: 5                        # optional
+- time-cycle: R/PT1H               # optional, overrides above
+- order: after T01
+- verify: Confirm Result: Success, capture TriggerId
+```

--- a/skills/uipath-case-management/references/registry-discovery.md
+++ b/skills/uipath-case-management/references/registry-discovery.md
@@ -10,11 +10,21 @@ During sdd.md → task.md interpretation, when you need to determine:
 
 ## Prerequisites
 
-Run `uip case registry pull` before any lookups. This populates the local cache at `~/.uip/case-resources/`. All subsequent discovery is done by reading these cache files directly — no CLI search commands needed.
+Run `uip case registry pull` before any lookups. This populates the local cache at `~/.uipcli/case-resources/`. All subsequent discovery is done by reading these cache files directly — **do not** rely on `uip case registry search` as the primary discovery method. See the "CLI Search Gaps" section below for the reason.
+
+## CLI Search Gaps
+
+The `uip case registry search` command has known gaps. In particular, it fails to return results for certain resource types even when the resource is present in the cache (most commonly affecting **action-apps** / HITL tasks). When search returns an empty or incomplete result for a resource you know exists:
+
+1. Do **not** retry the same search with different keywords.
+2. Fall back to reading the cache files directly using the procedure in this document.
+3. Record the gap in `registry-resolved.json` so the audit trail reflects the fallback.
+
+Direct cache-file inspection is the authoritative discovery method for this skill.
 
 ## Cache File Index
 
-Each resource type has a `<type>-index.json` file at `~/.uip/case-resources/`:
+Each resource type has a `<type>-index.json` file at `~/.uipcli/case-resources/`:
 
 | File | Identifier field | Name field | Folder field |
 |------|-----------------|------------|--------------|
@@ -58,7 +68,7 @@ For types marked "not in cache" (`EXTERNAL_AGENT`, `TIMER`), skip the cache look
 For each task in the sdd.md, extract the **name** and **folder path** from the Process References table, then filter the cache file:
 
 ```bash
-cat ~/.uip/case-resources/<type>-index.json | python3 -c "
+cat ~/.uipcli/case-resources/<type>-index.json | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 for item in data:
@@ -118,49 +128,9 @@ Additional `--type` values not discoverable through cache: `rpa`, `external-agen
 
 ## Connector Tasks
 
-For results from `typecache-activities-index.json` or `typecache-triggers-index.json`:
+For entries in `typecache-activities-index.json` or `typecache-triggers-index.json`, the full resolution pipeline (get-connector → get-connection → pick connection → describe) lives in [connector-integration.md](connector-integration.md). Registry discovery provides only the `uiPathActivityTypeId`; everything else is handled there.
 
 - **Only use entries that have a `uiPathActivityTypeId` field.** Skip entries without it — these are non-connector activities and are not supported as case tasks at this time.
-- The implementation agent can retrieve full connector details using:
-  ```bash
-  uip case registry get-connector --type <typecache-activities|typecache-triggers> --activity-type-id "<uiPathActivityTypeId>" --output json
-  ```
-- To check available connections for the connector:
-  ```bash
-  uip case registry get-connection --type <typecache-activities|typecache-triggers> --activity-type-id "<uiPathActivityTypeId>" --output json
-  ```
-
-### Handling Connection Results
-
-The `get-connection` response includes `Entry`, `Config`, and `Connections`:
-
-```json
-{
-  "Result": "Success",
-  "Code": "ConnectionGetSuccess",
-  "Data": {
-    "Entry": {
-      "uiPathActivityTypeId": "718fdc36-73a8-3607-8604-ddef95bb9967",
-      "displayName": "Send Email",
-      "configuration": "{}"
-    },
-    "Config": {
-      "connectorKey": "gmail",
-      "objectName": "message"
-    },
-    "Connections": [
-      { "id": "conn-1", "name": "My Gmail" },
-      { "id": "conn-2", "name": "Work Gmail" }
-    ]
-  }
-}
-```
-
-When processing connection results:
-- The sdd.md provides the necessary information to identify the correct connection. Match the connection name from the sdd.md against the `Connections` list.
-- If **`Connections` is empty**, no connection has been configured for this connector in Integration Service. Flag this to the user — they need to create a connection before the task can run.
-- The `Config.connectorKey` identifies the Integration Service connector (e.g., `gmail`, `uipath-drip-drip`).
-- The `Config.objectName` identifies the specific operation within the connector.
 
 ## Output Contract
 

--- a/skills/uipath-case-management/references/skeleton-tasks.md
+++ b/skills/uipath-case-management/references/skeleton-tasks.md
@@ -1,0 +1,208 @@
+# Skeleton Tasks Reference
+
+How the skill handles unresolved task resources — what a skeleton task is, when one is created, what it preserves, what it leaves out, and how the user upgrades it to a fully wired task later.
+
+## Why Skeletons Exist
+
+Registry pulls are often incomplete during early authoring:
+
+- The target tenant has not yet published the processes / agents / RPA / action-apps.
+- Custom Integration Service connectors have not been registered.
+- IS connections for registered connectors are not yet provisioned.
+
+If the skill halted on every unresolved resource, the generated `caseplan.json` would be a small fragment — not reviewable, not validatable, not useful. Skeletons solve that: the full **workflow structure** (stages, edges, conditions, SLA, ordering, task names + types) lands in `caseplan.json`, and only the parts that strictly require a registry lookup (task-type-id, connection-id, input/output schemas) are deferred.
+
+The user reviews structure first, then attaches real resources once they exist.
+
+## What a Skeleton Is (vs a Mock)
+
+| Field | Full task | Skeleton task | Mock (forbidden) |
+|-------|-----------|---------------|------------------|
+| `--type` | ✓ | ✓ | ✓ |
+| `--display-name` | ✓ | ✓ | ✓ |
+| `--is-required`, `--should-run-only-once` | ✓ | ✓ | ✓ |
+| `--task-type-id` / `--type-id` | real ID | **omitted** | fake ID |
+| `--connection-id` (connectors) | real UUID | **omitted** | fake UUID |
+| `--input-values` (connectors) | real JSON | **omitted** | `{}` |
+| Input / output variable bindings | real `var bind` calls | **skipped entirely** | `var bind` to nonexistent names |
+| Task-entry conditions | ✓ | ✓ | ✓ |
+| Referenced by stage-exit `selected-tasks-completed` | ✓ | ✓ | ✓ |
+
+**Mocks are forbidden** because Case's typed cross-task outputs reject references to non-existent output schemas at validation time. A fabricated task-type-id causes `uip case validate` to emit errors about unknown bindings. A skeleton sidesteps this by having no bindings at all — clean validation, clear `<UNRESOLVED>` markers in `tasks.md`, explicit upgrade path.
+
+## When a Skeleton Is Created
+
+During **execution** (Phase 2, Step 9), for any `tasks.md` entry whose `taskTypeId`, `type-id`, or `connection-id` is `<UNRESOLVED: …>`:
+
+1. Skip the enrichment command (`tasks add --task-type-id …`).
+2. Run the bare `tasks add` / `tasks add-connector` command with structural flags only.
+3. Skip every `uip case var bind` call for that task.
+4. Capture the returned `TaskId` normally — task-entry conditions and stage-exit rules still reference it.
+
+## CLI Shape
+
+### Non-connector tasks
+
+```bash
+uip case tasks add <file> <stage-id> \
+  --type <process|agent|rpa|action|api-workflow|case-management> \
+  --display-name "<name>" \
+  [--is-required] \
+  [--should-run-only-once] \
+  --output json
+```
+
+> **`action` skeletons** do not receive `--task-title`. Without a resolved action-app schema, the title field has no UI to render against. Add it when the user attaches the action-app.
+
+### Connector tasks
+
+```bash
+uip case tasks add-connector <file> <stage-id> \
+  --type <activity|trigger> \
+  --display-name "<name>" \
+  --output json
+```
+
+### In-stage timer
+
+Timers are a built-in type — they are never skeletons because they have no registry dependency. Use [`plugins/tasks/wait-for-timer/impl.md`](plugins/tasks/wait-for-timer/impl.md).
+
+## Resulting JSON Shape
+
+A skeleton task in `caseplan.json.nodes[<stage>].data.tasks[0][]`:
+
+```json
+{
+  "id": "t8GQTYo8O",
+  "displayName": "Validate Submission Completeness",
+  "isRequired": true,
+  "type": "process",
+  "data": {},
+  "entryConditions": [
+    {
+      "id": "Condition_xC1XyX",
+      "displayName": "After Fetch Submission",
+      "rules": [
+        [{ "rule": "selected-tasks-completed", "id": "Rule_jdBFrJ", "selectedTasksIds": ["…"] }]
+      ]
+    }
+  ]
+}
+```
+
+Note the empty `data: {}` — no `taskTypeId`, no folder path, no input/output wiring.
+
+## `tasks.md` Planning-Entry Shape
+
+A skeleton-bound entry keeps every structural field and moves the lost wiring into a comment block the user will act on later:
+
+```markdown
+## T20: Add process task "Validate Submission Completeness" to "Submission Review"
+- taskTypeId: <UNRESOLVED: process-index.json empty in tenant>
+- folder-path: <UNRESOLVED>
+- runOnlyOnce: false
+- isRequired: true
+- order: after T19
+- verify: Confirm Result: Success, capture TaskId (skeleton — user to attach process + bindings)
+# wiring notes (user must attach after publishing the process):
+#   lob = =metadata.lob
+#   sourceDocs <- "Submission Review"."Fetch Submission from U Submit".submissionData
+#   outputs expected: submissionComplete, missingItems, tier
+```
+
+Rules:
+- **Omit `inputs:` and `outputs:` lines** — no schema to wire against.
+- **Capture the intended wiring in a `# wiring notes` comment block** so the user sees the mapping when they upgrade.
+- **Keep every other field** — order, verify, is-required, run-only-once, display-name.
+
+## What Validation Catches
+
+`uip case validate` on a caseplan with skeletons emits warnings, not errors:
+
+- `Stage "<name>" has a task with no configuration` — one per skeleton.
+- `Stage "<name>" has no tasks` — if every task in a stage is absent (not even a skeleton).
+
+These are **expected** and do not block the build. Errors only appear when cross-task bindings reference non-existent outputs — which is exactly why the skill forbids mocks.
+
+## Upgrade Procedure — Skeleton → Full Task
+
+When the user has registered the real resource:
+
+### 1. Re-pull the registry
+
+```bash
+uip case registry pull --force
+```
+
+### 2. Resolve the task-type-id
+
+Read the relevant cache file directly per [registry-discovery.md](registry-discovery.md) — e.g., `process-index.json` for processes, `action-apps-index.json` for action apps.
+
+### 3. Attach the resource to the skeleton
+
+There is no single `tasks edit --task-type-id` flag today. The upgrade path depends on the task type:
+
+| Task type | Upgrade approach |
+|-----------|------------------|
+| `process`, `agent`, `rpa`, `api-workflow`, `case-management` | `uip case tasks remove <file> <stage-id> <task-id>` then re-add with `--task-type-id <entityKey>`. Conditions referencing the skeleton's TaskId will break — re-add them with the new TaskId. |
+| `action` | Same remove + re-add, passing `--task-type-id <actionAppId>` and `--task-title "<title>"`. |
+| `connector-activity`, `connector-trigger` | Remove + re-add via `tasks add-connector --type-id … --connection-id … --input-values '…'`. |
+
+> **Tip:** If the user has many skeletons to upgrade, a cleaner workflow is to update `sdd.md` with whatever context was missing (e.g., the now-registered process name) and re-invoke the skill from Phase 1. The regeneration path preserves the declarative intent; manual edits on `caseplan.json` are brittle.
+
+### 4. Bind inputs and outputs
+
+Use the `# wiring notes` block from `tasks.md` as the reference. For each input:
+
+```bash
+# Literal / expression
+uip case var bind <file> <stage-id> <task-id> <input-name> --value "=metadata.lob" --output json
+
+# Cross-task
+uip case var bind <file> <stage-id> <task-id> <input-name> \
+  --source-stage <source-stage-id> \
+  --source-task <source-task-id> \
+  --source-output <output-name> \
+  --output json
+```
+
+Run `uip case tasks describe --id <entityKey>` first to confirm the exact input/output names — do not guess.
+
+### 5. Re-validate
+
+```bash
+uip case validate <file>
+```
+
+The "task with no configuration" warning disappears once the task-type-id is attached.
+
+## Completion-Report Shape
+
+When the build finishes with skeletons, the skill's completion report must list them explicitly:
+
+```
+### Skeleton tasks (N)
+
+| Stage | Task | Type | TaskId | Attach |
+|-------|------|------|--------|--------|
+| Submission Review | Validate Submission Completeness | process | t8GQTYo8O | process-index.json — "Validate Submission Completeness" |
+| Submission Review | Review Submission | action | ty5UcykfU | action-apps-index.json — "Review Submission" |
+| … | … | … | … | … |
+
+### External resources to register before upgrading skeletons
+
+- **Processes** (N): Validate Submission Completeness, Route Submission Decision, Finalize Case Closure
+- **Agents** (N): Classify Documents, Generate Carrier Emails, …
+- **Action Apps** (N): Review Submission, Schedule Huddle Meeting, …
+- **Custom IS connectors** (N): U Submit (GetSubmission), U Place (SubmitPlannedMarkets), …
+```
+
+The user uses this list to drive external resource creation, then runs the upgrade procedure.
+
+## Anti-Patterns
+
+- **Do NOT fabricate a task-type-id to silence the warning.** Validation will pass but runtime will fail with binding errors.
+- **Do NOT partially bind inputs on a skeleton.** `var bind` either binds a full resolved input or nothing — half-bound skeletons are harder to upgrade than bare ones.
+- **Do NOT skip task-entry conditions on skeletons.** Conditions are structural; they work on the TaskId and must be created so the workflow order is visible in review.
+- **Do NOT manually edit `caseplan.json` to add task-type-ids.** Use `tasks remove` + re-`add` so the JSON shape matches what the CLI would produce (including `elementId` generation and other internals).
+- **Do NOT create skeletons for timer tasks.** Timers have no registry dependency — use the full `wait-for-timer` plugin.


### PR DESCRIPTION
## Summary

Reimplement the `uipath-case-management` skill to follow the plugin-per-node-type architecture from `uipath-maestro-flow`. Every build-time `uip case` CLI family now has its own plugin (`planning.md` + `impl.md`), so adding a new node type or changing an existing CLI means touching one folder, not several shared docs.

- **20 plugins** across 5 categories: 1 case, 1 stages, 1 edges, 1 sla, 9 tasks, 3 triggers, 4 conditions — see `skills/uipath-case-management/DESIGN.md` for the full inventory and the audit that grounded it in `case-commands.md`.
- **Two new shared refs** replace inline duplication: `connector-integration.md` (3-step `get-connector` → `get-connection` → `describe` pipeline) and `bindings-and-expressions.md` (expression prefixes + cross-task reference syntax).
- **Narrowed** `planning.md` and `implementation.md` to cross-cutting workflow only; per-node-type detail moved into plugins.
- **Fixed**: frontmatter description now has `[PREVIEW]` tag and the correct `→uipath-maestro-flow` redirect (was `→uipath-flow`); registry cache path corrected to `~/.uipcli/case-resources/`; dropped legacy 2D-lanes rule that contradicted existing guidance.
- **Captured real constraints**: exception/secondary stages have zero edges (reached via interrupting entry conditions, exit via `return-to-origin`); `action` tasks now prompt the user when sdd.md doesn't specify a recipient.

Scope for this milestone is creating a **new** case from sdd.md. Modifying an existing case requires remote case-fetch tooling that doesn't exist yet — deferred to a future milestone.

`DESIGN.md` is included as a review artifact; remove before final merge if you prefer not to ship it.

## Test plan

- [ ] Walk through planning phase end-to-end with an existing sdd.md; confirm the skill loads the right plugin for each node type
- [ ] Walk through execution phase end-to-end; confirm each plugin's `impl.md` CLI command works against a real tenant
- [ ] Confirm `connector-activity` + `connector-trigger` + `event` trigger all resolve connections via the shared `connector-integration.md` pipeline
- [ ] Confirm `action` task prompts for recipient when sdd.md is silent
- [ ] Confirm exception stages cannot be edge source or target (planning-phase orphan check + impl.md guardrail)
- [ ] Confirm `uip case validate` passes on a case built end-to-end
- [ ] Confirm post-build prompt offers only `Debug / Publish / Done / Something else`
- [ ] Verify `hooks/validate-skill-descriptions.sh` passes
- [ ] Verify all relative links across SKILL.md + references/ resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)