### PR TITLE
delete Studio Web solutions after flow e2e via post_run

### DIFF
--- a/tests/experiments/e2e.yaml
+++ b/tests/experiments/e2e.yaml
@@ -17,5 +17,11 @@ defaults:
         path: "$SKILLS_REPO_PATH"
     ignore_patterns: []
 
+  # Append default post_run to every e2e task: delete Studio Web solutions
+  # uploaded by `uip flow debug` (no-op for tasks that don't produce .uipx).
+  post_run:
+    - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+      timeout: 120
+
 variants:
   - variant_id: default

--- a/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
@@ -6,6 +6,12 @@ after evaluation completes; finds every ``.uipx`` file under it, reads
 ``SolutionId``, and best-effort deletes each via ``uip solution delete``.
 ``.uipx`` files without a ``SolutionId`` are skipped.
 
+Cleanup policy is controlled by the ``FLOW_E2E_CLEANUP`` env var:
+
+* ``always`` (default) — delete regardless of outcome. Use in CI.
+* ``never`` — delete nothing. Use when actively debugging locally so the
+  solution stays available in Studio Web for inspection.
+
 Best-effort: failures here never affect pass/fail (post_run results are
 informational only), so this script always exits 0.
 """
@@ -15,11 +21,23 @@ from __future__ import annotations
 import glob
 import json
 import logging
+import os
 import subprocess
 import sys
 
 logging.basicConfig(level=logging.INFO, format="cleanup_solutions: %(message)s")
 logger = logging.getLogger(__name__)
+
+
+def _resolve_policy() -> str:
+    policy = os.environ.get("FLOW_E2E_CLEANUP", "always").lower()
+    if policy not in ("always", "never"):
+        logger.warning(
+            "FLOW_E2E_CLEANUP=%r is invalid (expected always|never); treating as 'always'",
+            policy,
+        )
+        return "always"
+    return policy
 
 
 def main() -> int:
@@ -28,7 +46,9 @@ def main() -> int:
         logger.info("no .uipx files under cwd; nothing to do.")
         return 0
 
+    policy = _resolve_policy()
     deleted: list[str] = []
+    preserved: list[str] = []
     skipped: list[str] = []
     failed: list[str] = []
 
@@ -45,6 +65,15 @@ def main() -> int:
         if not sid:
             logger.info("no SolutionId in %s, skipping", path)
             skipped.append(path)
+            continue
+
+        if policy == "never":
+            logger.info(
+                "FLOW_E2E_CLEANUP=never; preserving %s (delete later with: uip solution delete %s)",
+                sid,
+                sid,
+            )
+            preserved.append(sid)
             continue
 
         r = subprocess.run(
@@ -66,8 +95,10 @@ def main() -> int:
             failed.append(sid)
 
     logger.info(
-        "summary deleted=%d skipped=%d failed=%d",
+        "summary policy=%s deleted=%d preserved=%d skipped=%d failed=%d",
+        policy,
         len(deleted),
+        len(preserved),
         len(skipped),
         len(failed),
     )

--- a/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Delete Studio Web solutions uploaded by ``uip flow debug`` during a task.
+
+Wired in via ``post_run`` in flow e2e task YAMLs. Runs from the sandbox CWD
+after evaluation completes; finds every ``.uipx`` file under it, reads
+``SolutionId``, and best-effort deletes each via ``uip solution delete``.
+``.uipx`` files without a ``SolutionId`` are skipped.
+
+Best-effort: failures here never affect pass/fail (post_run results are
+informational only), so this script always exits 0.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import subprocess
+import sys
+
+logging.basicConfig(level=logging.INFO, format="cleanup_solutions: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> int:
+    paths = glob.glob("**/*.uipx", recursive=True)
+    if not paths:
+        logger.info("no .uipx files under cwd; nothing to do.")
+        return 0
+
+    deleted: list[str] = []
+    skipped: list[str] = []
+    failed: list[str] = []
+
+    for path in paths:
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("could not read %s: %s", path, e)
+            skipped.append(path)
+            continue
+
+        sid = data.get("SolutionId")
+        if not sid:
+            logger.info("no SolutionId in %s, skipping", path)
+            skipped.append(path)
+            continue
+
+        r = subprocess.run(
+            ["uip", "solution", "delete", sid, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if r.returncode == 0:
+            logger.info("deleted %s (from %s)", sid, path)
+            deleted.append(sid)
+        else:
+            logger.warning(
+                "failed to delete %s (exit %d): %s",
+                sid,
+                r.returncode,
+                r.stderr.strip()[:300],
+            )
+            failed.append(sid)
+
+    logger.info(
+        "summary deleted=%d skipped=%d failed=%d",
+        len(deleted),
+        len(skipped),
+        len(failed),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -43,14 +43,14 @@ def run_debug(
         cmd.extend(["--inputs", json.dumps(inputs)])
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     if r.returncode != 0:
-        _fail(f"flow debug exit {r.returncode}\n{r.stderr[:500]}")
+        _fail(f"flow debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}")
     data = _parse_json(r.stdout)
     if data is None:
-        _fail(f"Could not parse JSON from flow debug\n{r.stdout[:500]}")
+        _fail(f"Could not parse JSON from flow debug\n{r.stdout}")
     payload = data.get("Data") or {}
     status = payload.get("finalStatus")
     if status != "Completed":
-        _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout[:1000]}")
+        _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}")
     return payload
 
 


### PR DESCRIPTION
## Summary

- Add `tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py` — globs every `.uipx` under the sandbox CWD, reads `SolutionId`, and best-effort deletes via `uip solution delete`. `.uipx` files without a `SolutionId` are skipped, so the script is a no-op for non-flow tests in the same e2e experiment.
- Wire it via `experiments/e2e.yaml` `defaults.post_run` so cleanup runs after every e2e task without per-task duplication. **Requires UiPath/coder_eval#152** for `ExperimentDefaults.post_run` support.
- Stop truncating stdout/stderr in `flow_check.py` failure messages so debug output is fully visible on CI.

## Cleanup policy

Controlled by the `FLOW_E2E_CLEANUP` env var:

- `always` (default) — delete regardless of outcome. Use in CI.
- `never` — delete nothing. Use when actively debugging locally so the solution stays available in Studio Web for inspection.

## Test plan

- [x] Ran `tests/tasks/uipath-maestro-flow/calculator/calculator.yaml` against `experiments/e2e.yaml` end-to-end — passed (2/2 criteria), cleanup inherited from defaults, output streamed to live log
- [x] Verified the deleted solution actually disappeared from the tenant (re-`uip solution delete` returned 404 Not Found)
- [x] Cleanup is a no-op when no `.uipx` is present (safe to leave wired across non-flow e2e tasks)
- [ ] Smoke-test `FLOW_E2E_CLEANUP=never` locally — expect no deletion and `preserved=N` in the summary log

🤖 Generated with [Claude Code](https://claude.com/claude-code)