### PR TITLE
fix(bindings): scan all .py files and resolve module-level constants

### DIFF
--- a/skills/uipath-agents/references/coded/lifecycle/bindings-reference.md
+++ b/skills/uipath-agents/references/coded/lifecycle/bindings-reference.md
@@ -30,7 +30,15 @@ If `bindings.json` does not exist, create it with the empty skeleton:
 
 ### Step 2: Scan Code for Resource Calls
 
-Search all Python files for UiPath SDK resource calls that produce bindings. The eight bindable resource types are:
+Search **every** Python file found in Step 1 for UiPath SDK resource calls that produce bindings. Do NOT limit scanning to the main entry point (`main.py` / `graph.py`) — resource calls are frequently in helper modules, utility files, or store layers.
+
+**Scanning strategy:**
+1. Grep ALL `**/*.py` files (excluding `.venv/`, `__pycache__/`, `.uipath/`) for SDK service method patterns listed below.
+2. When a match is found, read the file to extract the argument values (resource name, folder path).
+3. If the argument is a **module-level constant** (e.g., `BUCKET = "my-bucket"`) rather than an inline string literal, **resolve it** — search the same file (and imports from sibling modules) for the constant definition and use its literal value. This is not dynamic; it is a resolvable constant.
+4. Only flag values as truly dynamic when they come from function calls, f-strings, environment variables, or runtime state that cannot be statically determined.
+
+The eight bindable resource types are:
 
 | SDK Service | Method Pattern | Resource Type | Identifier Param |
 |------------|---------------|---------------|-----------------|
@@ -43,9 +51,9 @@ Search all Python files for UiPath SDK resource calls that produce bindings. The
 | `.connections.retrieve` / `.retrieve_async` | `("connection_key")` | `connection` | `key` (positional) |
 | `.mcp.retrieve` / `.retrieve_async` | `(slug="slug", folder_path="folder")` | `mcpServer` | `slug` |
 
-Use Grep to find calls matching these patterns. Then read the surrounding code to extract the literal string values for resource name and folder path.
+Use Grep to find calls matching these patterns across all project Python files. Then read the surrounding code to extract the literal string values for resource name and folder path.
 
-**Important:** Only literal string arguments can be bound. If a value is dynamic (variable, f-string, function call), flag it to the user — it requires manual handling or refactoring.
+**Important:** Only literal or constant-resolvable string arguments can be bound. If a value is truly dynamic (computed at runtime from function calls, f-strings with variables, environment variables, or user input), flag it to the user — it requires manual handling or refactoring. Module-level constants (e.g., `BUCKET = "my-bucket"`) are NOT dynamic — resolve them to their literal values.
 
 ### Step 3: Compare with Existing Bindings
 
@@ -109,10 +117,10 @@ For detailed bindings.json schema, all eight resource type templates, SDK method
 
 ## Edge Cases
 
-- **Multiple entry points (code scanning)** — Scan all Python files, not just `main.py`. LangGraph agents may define tools in separate modules.
+- **Multiple entry points (code scanning)** — Scan ALL Python files in the project (`**/*.py`, excluding `.venv/`, `__pycache__/`, `.uipath/`), not just `main.py` or `graph.py`. Resource calls commonly live in helper modules (e.g., `storage.py`, `utils.py`, tool definition files). When arguments use module-level constants, resolve them to their literal values before creating bindings.
 - **Multiple entry points (entrypoint binding)** — When `entry-points.json` has multiple entrypoints, ask the user per-resource which entrypoint it belongs to. User can choose "None" to skip entrypoint binding for that resource.
 - **Duplicate resources** — If the same resource (same name + folder) is called multiple times, produce only one binding entry.
-- **No folder_path** — Some asset calls omit `folder_path`. In that case, use an empty string `""` for `folderPath.defaultValue` and construct the key as just `<name>.` (name followed by a dot and empty string).
+- **No folder_path** — Some calls omit `folder_path`. In that case, use an empty string `""` for `folderPath.defaultValue` and construct the key as just `<name>` (no trailing dot).
 - **LangGraph ContextGroundingVectorStore** — `ContextGroundingVectorStore(index_name="...", folder_path="...")` creates an `index` binding with the same structure as `context_grounding.retrieve_async`.
 - **Sync vs async** — Both `retrieve()` and `retrieve_async()` produce the same binding. Always use the `_async` method name in `ActivityName`.
 - **Jobs resume** — `sdk.jobs.resume(process_name="...")` creates a `process` binding (identifier param is `process_name`, not `name`).
@@ -657,15 +665,36 @@ Not every SDK service supports resource overrides. The following services have N
 
 ---
 
-## Dynamic Values
+## Dynamic Values vs Resolvable Constants
 
-If the resource name or folder path is constructed dynamically at runtime (e.g., from a variable, f-string, or function return), it cannot be statically bound. Flag these to the user as requiring manual bindings.json entries or refactoring to use literal string values.
+Not every non-literal argument is dynamic. **Resolve module-level constants before flagging a value as dynamic.**
 
-Example of a dynamic value that cannot be auto-bound:
+**Resolvable (DO bind):**
 ```python
+# Module-level constant — resolve to its literal value
+BUCKET = "one-alpha-signals"
+sdk.buckets.list_files(name=BUCKET, prefix="kiss/")  # → bind as "one-alpha-signals"
+
+# Constant imported from a sibling module in the same project
+from .config import QUEUE_NAME  # where QUEUE_NAME = "invoices"
+sdk.queues.create_item(item={"Name": QUEUE_NAME, ...})  # → bind as "invoices"
+```
+
+**Truly dynamic (flag to user):**
+```python
+# Runtime function call — cannot resolve statically
 asset_name = get_config("asset_name")
 asset = await sdk.assets.retrieve_async(asset_name, folder_path=folder)
+
+# f-string with runtime variable
+bucket = f"data-{environment}"
+sdk.buckets.upload(name=bucket, ...)
+
+# Environment variable
+queue = os.environ["QUEUE_NAME"]
 ```
+
+**Resolution strategy:** When a non-literal argument is found, search the same file for an assignment to that variable name at module scope (e.g., `BUCKET = "..."`). If not found in the same file, check imports from sibling modules within the project (not third-party packages). If the value traces back to a string literal through constants only, use that literal. Otherwise, flag as dynamic.
 
 ---
 

--- a/skills/uipath-agents/references/coded/lifecycle/bindings-reference.md
+++ b/skills/uipath-agents/references/coded/lifecycle/bindings-reference.md
@@ -94,7 +94,7 @@ For the exact JSON structure of each resource type, consult `bindings-reference.
 
 - `version` is always `"2.0"`
 - Each resource entry has `resource`, `key`, `value`, and `metadata` fields
-- The `key` is `<name>.<folder_path>` for most types, just `<connection_key>` for connections
+- The `key` is `<name>.<folder_path>` for most types, just `<connection_key>` for connections. When `folder_path` is empty, omit the dot separator — the key is just `<name>`
 - `ActivityName` in metadata always uses the `_async` variant name
 - Connection entries use `ConnectionId` instead of `name` and have no `folderPath`
 - The `app` resource type uses the app name as `DisplayLabel`; all others use `"FullName"`
@@ -211,7 +211,7 @@ credential = sdk.assets.retrieve_credential("cred_name", folder_path="folder_key
 }
 ```
 
-**Key construction:** `<name>.<folder_path>` — the first positional argument joined with the `folder_path` keyword argument by a dot.
+**Key construction:** `<name>.<folder_path>` — the first positional argument joined with the `folder_path` keyword argument by a dot. When `folder_path` is empty, omit the dot — use just `<name>`.
 
 **Parameter extraction:**
 - `name` — first positional argument to `retrieve_async()` / `retrieve()`

--- a/tests/tasks/uipath-agents/bindings_sync.yaml
+++ b/tests/tasks/uipath-agents/bindings_sync.yaml
@@ -1,0 +1,166 @@
+task_id: skill-agents-bindings-sync
+description: >
+  Skill-guided evaluation: agent uses the uipath-agents bindings skill to scan
+  all Python files in a project (including helper modules), resolve module-level
+  constants, and produce a correct bindings.json. Tests that the skill teaches
+  scanning beyond main.py and constant resolution.
+tags: [uipath-agents, smoke, bindings]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I have a UiPath coded agent project. Please set up these files, then sync
+  the bindings.json using the bindings skill.
+
+  Create the following project structure:
+
+  **pyproject.toml:**
+  ```toml
+  [project]
+  name = "invoice-processor"
+  version = "0.1.0"
+  requires-python = ">=3.11"
+  ```
+
+  **uipath.json:**
+  ```json
+  {"projectType": "CodedAgent"}
+  ```
+
+  **entry-points.json:**
+  ```json
+  {
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+      {
+        "filePath": "agent",
+        "uniqueId": "aaa11111-2222-3333-4444-555566667777",
+        "type": "agent",
+        "input": {"type": "object", "properties": {}, "required": []},
+        "output": {"type": "object", "properties": {"answer": {"type": "string"}}, "required": ["answer"]}
+      }
+    ]
+  }
+  ```
+
+  **graph.py** (main entry point):
+  ```python
+  from langgraph.graph import END, START, StateGraph
+  from langgraph.types import interrupt
+  from uipath.platform import UiPath
+  from uipath.platform.common import InvokeProcess
+  from storage import BUCKET_NAME
+
+  SCRAPER_PROCESS = "data-scraper"
+
+  def fetch_data(state):
+      response = interrupt(InvokeProcess(name=SCRAPER_PROCESS, input_arguments={}))
+      return {"data": response}
+
+  def save_results(state):
+      sdk = UiPath()
+      sdk.buckets.upload(name=BUCKET_NAME, blob_file_path="results.json", content="{}")
+      return state
+
+  def get_config(state):
+      sdk = UiPath()
+      api_key = sdk.assets.retrieve("api-key", folder_path="Shared")
+      return {"config": api_key}
+  ```
+
+  **storage.py** (helper module with constant):
+  ```python
+  from uipath.platform import UiPath
+
+  BUCKET_NAME = "invoice-data"
+
+  def download_template():
+      sdk = UiPath()
+      sdk.buckets.download(name=BUCKET_NAME, blob_file_path="template.xlsx", destination_path="/tmp/t.xlsx")
+  ```
+
+  **bindings.json** (start empty):
+  ```json
+  {"version": "2.0", "resources": []}
+  ```
+
+  After creating these files, sync the bindings.json so it reflects all resource
+  calls found across ALL Python files. The bindings skill should:
+  1. Scan graph.py AND storage.py (not just the main entry point)
+  2. Resolve the BUCKET_NAME constant from storage.py to "invoice-data"
+  3. Resolve the SCRAPER_PROCESS constant from graph.py to "data-scraper"
+  4. Produce bindings for: process (data-scraper), bucket (invoice-data), asset (api-key)
+  5. Bind all resources to the single entrypoint
+
+  Do NOT create any report file — just update bindings.json.
+
+success_criteria:
+  - type: file_exists
+    description: "bindings.json exists"
+    path: "bindings.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "bindings.json is valid JSON"
+    command: "python -c \"import json; json.load(open('bindings.json'))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "bindings.json contains all three resource types"
+    path: "bindings.json"
+    includes:
+      - '"process"'
+      - '"bucket"'
+      - '"asset"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Process binding has correct resolved name"
+    path: "bindings.json"
+    includes:
+      - "data-scraper"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Bucket binding has correct resolved constant value"
+    path: "bindings.json"
+    includes:
+      - "invoice-data"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Asset binding has correct name and folder"
+    path: "bindings.json"
+    includes:
+      - "api-key"
+      - "Shared"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Resources are bound to the entrypoint"
+    path: "bindings.json"
+    includes:
+      - "aaa11111-2222-3333-4444-555566667777"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "bindings.json has exactly 3 resources"
+    path: "bindings.json"
+    assertions:
+      - expression: "length(resources)"
+        operator: equals
+        expected: 3
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- **Step 2** now explicitly mandates scanning ALL project `.py` files (not just `main.py`/`graph.py`) with a 4-step strategy that includes resolving module-level constants to their literal values
- **Dynamic Values** section renamed to "Dynamic Values vs Resolvable Constants" with clear examples distinguishing resolvable constants (`BUCKET = "my-bucket"`) from truly dynamic values (function calls, f-strings, env vars)
- **Key construction** edge case fixed: empty `folder_path` produces `"name"` not `"name."` (trailing dot removed)

## Motivation
When agents define SDK resource calls in helper modules (e.g., `signals_store.py` using `BUCKET = "one-alpha-signals"` as a constant passed to `sdk.buckets.*`), the skill was either missing the call entirely (only scanning `main.py`) or flagging the constant as "dynamic" and skipping it.

## Test plan
- [x] Verify skill correctly identifies bucket calls in helper modules with constant names
- [x] Verify key construction without trailing dot for empty folder_path
- [x] Verify constant resolution follows imports across sibling modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)