### PR TITLE
feat(uipath-maestro-flow): add core.action.http.v2 managed HTTP support

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -275,6 +275,8 @@ Do not run any of these actions without an explicit user selection.
 - **Never forget output mapping on End nodes** — every `out` variable in `variables.globals` must have a `source` expression in every reachable End node's `outputs`. Missing mappings cause silent runtime failures.
 - **Never update `in` variables** — only `inout` variables can be modified via `variableUpdates`. Input variables are read-only after flow start.
 - **Never reference parent-scope `$vars` inside a subflow** — subflows have isolated scope. Pass values explicitly via subflow inputs.
+- **Never use `core.action.http` (v1) for connector-authenticated requests** — the v1 node's `authenticationType: "connection"` input does not pass IS credentials at runtime. Use `core.action.http.v2` (Managed HTTP Request) instead. See [http/planning.md](references/plugins/http/planning.md).
+- **Never hand-write `inputs.detail` for managed HTTP nodes** — run `uip flow node configure` to populate the `inputs.detail` structure, generate `bindings_v2.json`, and create the connection resource file. Hand-written configurations miss the `essentialConfiguration` block and fail at runtime.
 
 ## Task Navigation
 
@@ -353,7 +355,7 @@ When you finish building or editing a flow, report to the user:
 - **[Node Plugins](references/plugins/)** — Each node type has its own plugin folder with `planning.md` (selection heuristics, ports, key inputs) and `impl.md` (registry validation, JSON structure, configuration, debug):
   - [connector](references/plugins/connector/) — IS connector nodes: connection binding, enriched metadata, reference resolution, `bindings_v2.json`
   - [script](references/plugins/script/) — Custom JavaScript logic via Jint ES2020
-  - [http](references/plugins/http/) — REST API calls, response branching, connection auth
+  - [http](references/plugins/http/) — REST API calls: `core.action.http.v2` (managed HTTP with IS connector auth) and `core.action.http` (standalone with manual auth)
   - [decision](references/plugins/decision/) — Binary if/else branching
   - [switch](references/plugins/switch/) — Multi-way branching (3+ paths)
   - [loop](references/plugins/loop/) — Collection iteration (sequential/parallel)

--- a/skills/uipath-maestro-flow/references/flow-editing-operations-cli.md
+++ b/skills/uipath-maestro-flow/references/flow-editing-operations-cli.md
@@ -105,14 +105,39 @@ uip flow node configure <ProjectName>.flow <NODE_ID> \
 **What the CLI handles automatically:**
 - Populates `inputs.detail` (connectionId, method, endpoint, bodyParameters, etc.)
 - Creates connection binding entries in `bindings_v2.json`
+- Creates connection resource files under `resources/solution_folder/connection/`
 
-The `--detail` JSON schema differs between connector activity nodes and connector trigger nodes — see [connector/impl.md](plugins/connector/impl.md) and [connector-trigger/impl.md](plugins/connector-trigger/impl.md) for the exact fields.
+The `--detail` JSON schema differs between connector activity nodes, connector trigger nodes, and managed HTTP nodes — see [connector/impl.md](plugins/connector/impl.md), [connector-trigger/impl.md](plugins/connector-trigger/impl.md), and [http/impl.md](plugins/http/impl.md) for the exact fields.
 
 **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file:
 
 ```bash
 uip flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)"
 ```
+
+### Configure a managed HTTP node
+
+After adding a `core.action.http.v2` node, configure it with target connector and connection details:
+
+```bash
+uip flow node configure <ProjectName>.flow <NODE_ID> \
+  --detail '{
+    "authentication": "connector",
+    "targetConnector": "<TARGET_CONNECTOR_KEY>",
+    "connectionId": "<TARGET_CONNECTION_ID>",
+    "folderKey": "<FOLDER_KEY>",
+    "method": "GET",
+    "path": "/api/endpoint",
+    "query": {"param1": "value1"}
+  }'
+```
+
+**What the CLI handles automatically:**
+- Wraps your fields into the full `inputs.detail` structure (connector: `uipath-uipath-http`, bodyParameters, configuration)
+- Generates `bindings_v2.json` with the target connector's connection
+- Creates a connection resource file under `resources/solution_folder/connection/`
+
+See [http/impl.md](plugins/http/impl.md) for the full configuration workflow and JSON structure.
 
 ### Validate
 

--- a/skills/uipath-maestro-flow/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/planning-arch.md
@@ -86,7 +86,8 @@ Each plugin has a `planning.md` with full selection heuristics, ports, key input
 | Node Type | Plugin | When to Select |
 | --- | --- | --- |
 | `core.action.script` | [script](plugins/script/planning.md) | Custom logic, data transformation, computation, formatting |
-| `core.action.http` | [http](plugins/http/planning.md) | Call a REST API where no connector exists, or quick prototyping |
+| `core.action.http.v2` | [http](plugins/http/planning.md) | Call a REST API with IS connector-managed auth (connector exists but lacks the curated activity) |
+| `core.action.http` | [http](plugins/http/planning.md) | Call a REST API with manual auth or no auth — no connector exists, or quick prototyping |
 | `core.action.transform` | [transform](plugins/transform/planning.md) | Declarative map, filter, or group-by on a collection |
 | `core.logic.delay` | [delay](plugins/delay/planning.md) | Pause execution for a duration or until a specific date |
 | `core.action.queue.create` | [queue](plugins/queue/planning.md) | Distribute work to robots — fire-and-forget |
@@ -151,8 +152,8 @@ Resource nodes invoke published UiPath automations. They are tenant-specific and
 When the flow needs to call an external service, use this decision order — prefer higher tiers:
 
 1. **Pre-built Integration Service connector** — Use when a connector exists and covers the use case. See [connector](plugins/connector/planning.md).
-2. **HTTP Request within a connector** — Use when a connector exists but lacks the specific endpoint. See [connector](plugins/connector/planning.md) HTTP Fallback section.
-3. **Standalone HTTP Request** (`core.action.http`) — Use for one-off API calls to services without connectors. See [http](plugins/http/planning.md).
+2. **Managed HTTP Request** (`core.action.http.v2`) — Use when a connector exists but lacks the specific curated activity. Uses the connector's IS connection for auth. See [http](plugins/http/planning.md).
+3. **Standalone HTTP Request** (`core.action.http`) — Use for one-off API calls to services without connectors, with manual auth or no auth. See [http](plugins/http/planning.md).
 4. **RPA workflow node** — Use only when the target system has no API (legacy desktop apps, terminals). See [rpa](plugins/rpa/planning.md).
 
 ---
@@ -167,6 +168,7 @@ Use this when defining edges. Every edge requires a `sourcePort` and `targetPort
 | `core.trigger.scheduled` | — | `output` |
 | `uipath.connector.trigger.*` | — | `output` |
 | `core.action.script` | `input` | `success` |
+| `core.action.http.v2` | `input` | `output` |
 | `core.action.http` | `input` | `default`, `branch-{id}` (dynamic per branch) |
 | `core.action.transform` | `input` | `output` |
 | `core.logic.delay` | `input` | `output` |
@@ -429,9 +431,10 @@ Quick decision guide. For full details, read the linked plugin's `planning.md`.
 
 ### "I need to call an external service"
 
-1. Is there a connector? -> [connector](plugins/connector/planning.md)
-2. No connector, but has a REST API? -> [http](plugins/http/planning.md)
-3. No API at all (desktop app, terminal)? -> [rpa](plugins/rpa/planning.md) or `core.logic.mock` if unpublished
+1. Is there a connector with a curated activity? -> [connector](plugins/connector/planning.md)
+2. Connector exists but lacks the specific activity? -> `core.action.http.v2` (managed HTTP with connector auth) — see [http](plugins/http/planning.md)
+3. No connector exists, but has a REST API? -> `core.action.http` (standalone HTTP with manual auth) — see [http](plugins/http/planning.md)
+4. No API at all (desktop app, terminal)? -> [rpa](plugins/rpa/planning.md) or `core.logic.mock` if unpublished
 
 ### "I need to branch"
 

--- a/skills/uipath-maestro-flow/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/planning-arch.md
@@ -428,8 +428,8 @@ Quick decision guide. For full details, read the linked plugin's `planning.md`.
 
 ### "I need to call an external service"
 
-1. Is there a connector with a curated activity? -> [connector](plugins/connector/planning.md)
-2. Connector exists but lacks the specific activity? -> `core.action.http.v2` connector mode — see [http](plugins/http/planning.md)
+1. Is there a connector with a curated activity? Run `uip flow registry list --output json` and check for typed nodes matching `uipath.connector.<key>.<operation>`. If the desired operation appears as a node type, it is a curated activity -> [connector](plugins/connector/planning.md)
+2. Connector exists but the operation is not listed as a curated node type? -> `core.action.http.v2` connector mode — see [http](plugins/http/planning.md)
 3. No connector exists, but has a REST API? -> `core.action.http.v2` manual mode — see [http](plugins/http/planning.md)
 4. No API at all (desktop app, terminal)? -> [rpa](plugins/rpa/planning.md) or `core.logic.mock` if unpublished
 

--- a/skills/uipath-maestro-flow/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/planning-arch.md
@@ -86,8 +86,7 @@ Each plugin has a `planning.md` with full selection heuristics, ports, key input
 | Node Type | Plugin | When to Select |
 | --- | --- | --- |
 | `core.action.script` | [script](plugins/script/planning.md) | Custom logic, data transformation, computation, formatting |
-| `core.action.http.v2` | [http](plugins/http/planning.md) | Call a REST API with IS connector-managed auth (connector exists but lacks the curated activity) |
-| `core.action.http` | [http](plugins/http/planning.md) | Call a REST API with manual auth or no auth — no connector exists, or quick prototyping |
+| `core.action.http.v2` | [http](plugins/http/planning.md) | Call a REST API — connector mode (IS auth) or manual mode (raw URL). Replaces deprecated `core.action.http` |
 | `core.action.transform` | [transform](plugins/transform/planning.md) | Declarative map, filter, or group-by on a collection |
 | `core.logic.delay` | [delay](plugins/delay/planning.md) | Pause execution for a duration or until a specific date |
 | `core.action.queue.create` | [queue](plugins/queue/planning.md) | Distribute work to robots — fire-and-forget |
@@ -152,9 +151,8 @@ Resource nodes invoke published UiPath automations. They are tenant-specific and
 When the flow needs to call an external service, use this decision order — prefer higher tiers:
 
 1. **Pre-built Integration Service connector** — Use when a connector exists and covers the use case. See [connector](plugins/connector/planning.md).
-2. **Managed HTTP Request** (`core.action.http.v2`) — Use when a connector exists but lacks the specific curated activity. Uses the connector's IS connection for auth. See [http](plugins/http/planning.md).
-3. **Standalone HTTP Request** (`core.action.http`) — Use for one-off API calls to services without connectors, with manual auth or no auth. See [http](plugins/http/planning.md).
-4. **RPA workflow node** — Use only when the target system has no API (legacy desktop apps, terminals). See [rpa](plugins/rpa/planning.md).
+2. **Managed HTTP Request** (`core.action.http.v2`) — connector mode: use when a connector exists but lacks the specific curated activity. Manual mode: use for one-off API calls to services without connectors. See [http](plugins/http/planning.md).
+3. **RPA workflow node** — Use only when the target system has no API (legacy desktop apps, terminals). See [rpa](plugins/rpa/planning.md).
 
 ---
 
@@ -169,7 +167,6 @@ Use this when defining edges. Every edge requires a `sourcePort` and `targetPort
 | `uipath.connector.trigger.*` | — | `output` |
 | `core.action.script` | `input` | `success` |
 | `core.action.http.v2` | `input` | `output` |
-| `core.action.http` | `input` | `default`, `branch-{id}` (dynamic per branch) |
 | `core.action.transform` | `input` | `output` |
 | `core.logic.delay` | `input` | `output` |
 | `core.logic.decision` | `input` | `true`, `false` |
@@ -432,8 +429,8 @@ Quick decision guide. For full details, read the linked plugin's `planning.md`.
 ### "I need to call an external service"
 
 1. Is there a connector with a curated activity? -> [connector](plugins/connector/planning.md)
-2. Connector exists but lacks the specific activity? -> `core.action.http.v2` (managed HTTP with connector auth) — see [http](plugins/http/planning.md)
-3. No connector exists, but has a REST API? -> `core.action.http` (standalone HTTP with manual auth) — see [http](plugins/http/planning.md)
+2. Connector exists but lacks the specific activity? -> `core.action.http.v2` connector mode — see [http](plugins/http/planning.md)
+3. No connector exists, but has a REST API? -> `core.action.http.v2` manual mode — see [http](plugins/http/planning.md)
 4. No API at all (desktop app, terminal)? -> [rpa](plugins/rpa/planning.md) or `core.logic.mock` if unpublished
 
 ### "I need to branch"

--- a/skills/uipath-maestro-flow/references/plugins/connector/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/planning.md
@@ -13,8 +13,8 @@ Prefer higher tiers when connecting to external services:
 | Tier | Approach | When to Use |
 | --- | --- | --- |
 | 1 | **IS connector activity** (this node type) | A connector exists and its activities cover the use case |
-| 2 | **HTTP Request within a connector** | A connector exists but lacks the specific endpoint — connector still handles auth |
-| 3 | **Standalone HTTP Request** (`core.action.http`) | No connector exists, or quick prototyping — you handle auth manually |
+| 2 | **Managed HTTP Request** (`core.action.http.v2`) | A connector exists but lacks the specific curated activity — uses the connector's IS connection for auth |
+| 3 | **Standalone HTTP Request** (`core.action.http`) | No connector exists, or quick prototyping — you handle auth manually via headers |
 | 4 | **RPA workflow** | Target system has no API at all (legacy desktop apps, terminals) |
 
 ### Prerequisites
@@ -74,9 +74,15 @@ uip is connections list "<connector-key>" --output json
 - `$vars.{nodeId}.output` — the connector response (structure depends on the operation)
 - `$vars.{nodeId}.error` — error details if the call fails
 
-## HTTP Fallback
+## HTTP Fallback (Managed HTTP Request)
 
-When a connector exists but lacks the specific endpoint, use the connector's HTTP Request activity. The connector still manages authentication; you supply the path and payload. Note as `connector: <service> (HTTP fallback)` during planning.
+When a connector exists but lacks the specific curated activity, use `core.action.http.v2` (Managed HTTP Request). This node proxies through the `uipath-uipath-http` connector and uses the **target connector's** IS connection for authentication — you supply the API path and payload.
+
+> **Do NOT use `core.action.http` (v1) with `authenticationType: "connection"` for this.** The v1 node does not pass IS credentials at runtime. Always use `core.action.http.v2`.
+
+See [http/planning.md](../http/planning.md) for full selection heuristics and [http/impl.md](../http/impl.md) for configuration via `uip flow node configure`.
+
+Note as `managed-http: <service> — <operation>` during planning.
 
 ## Planning Annotation
 

--- a/skills/uipath-maestro-flow/references/plugins/connector/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/planning.md
@@ -14,7 +14,7 @@ Prefer higher tiers when connecting to external services:
 | --- | --- | --- |
 | 1 | **IS connector activity** (this node type) | A connector exists and its activities cover the use case |
 | 2 | **Managed HTTP Request** (`core.action.http.v2`) | A connector exists but lacks the specific curated activity — uses the connector's IS connection for auth |
-| 3 | **Standalone HTTP Request** (`core.action.http`) | No connector exists, or quick prototyping — you handle auth manually via headers |
+| 3 | **Managed HTTP Request — manual mode** (`core.action.http.v2`) | No connector exists — you provide the full URL manually |
 | 4 | **RPA workflow** | Target system has no API at all (legacy desktop apps, terminals) |
 
 ### Prerequisites
@@ -25,7 +25,7 @@ Prefer higher tiers when connecting to external services:
 
 ### When NOT to Use
 
-- **No connector exists for the service** — use `core.action.http` instead
+- **No connector exists for the service** — use `core.action.http.v2` manual mode instead
 - **Simple GET request with no auth** — `core.action.http` is simpler and faster to configure
 - **The operation needs desktop/browser interaction** — use an RPA resource node
 - **The task requires reasoning or judgment** — use an agent node

--- a/skills/uipath-maestro-flow/references/plugins/connector/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/planning.md
@@ -76,7 +76,9 @@ uip is connections list "<connector-key>" --output json
 
 ## HTTP Fallback (Managed HTTP Request)
 
-When a connector exists but lacks the specific curated activity, use `core.action.http.v2` (Managed HTTP Request). This node proxies through the `uipath-uipath-http` connector and uses the **target connector's** IS connection for authentication — you supply the API path and payload.
+When a connector exists but lacks the specific curated activity, use `core.action.http.v2` (Managed HTTP Request). This node proxies through the `uipath-uipath-http` connector and uses the **target connector's** IS connection for authentication — you supply the API URL and payload.
+
+> **Do NOT use individual connector HTTP request nodes** (e.g., `uipath.connector.<key>.http-request`). Always use the unified `core.action.http.v2` Managed HTTP Request node for non-curated API calls.
 
 > **Do NOT use `core.action.http` (v1) with `authenticationType: "connection"` for this.** The v1 node does not pass IS credentials at runtime. Always use `core.action.http.v2`.
 

--- a/skills/uipath-maestro-flow/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/impl.md
@@ -2,164 +2,97 @@
 
 ## Node Type
 
-`core.action.http`
+`core.action.http.v2` (Managed HTTP Request)
+
+> **Always use `core.action.http.v2`** for all HTTP requests. The older `core.action.http` (v1) is deprecated.
 
 ## Registry Validation
 
 ```bash
-uip flow registry get core.action.http --output json
+uip flow registry get core.action.http.v2 --output json
 ```
 
-Confirm: input port `input`, output ports `default` + dynamic `branch-{id}`, required inputs `method` and `url`.
+Confirm: input port `input`, output port `output`, model serviceType `Intsvc.UnifiedHttpRequest`.
 
-## Critical: `model` Field
+## Critical: Use `node configure`
 
-> **Never hardcode the `model` field.** The HTTP node requires a `model.expansion` block for the BPMN engine to capture outputs into flow variables at runtime. Without it, `$vars.{nodeId}.output` will be `null` after execution even though the node completes successfully. Always copy the full `model` object from `uip flow registry get core.action.http --output json` → `Data.Node.model`. The examples below use `"<COPY_FROM_REGISTRY>"` as a placeholder — replace it with the actual model from the registry.
+> **Do not hand-write `inputs.detail`, `bindings_v2.json`, or connection resource files.** Run `uip flow node configure` — it builds everything from a simple `--detail` JSON. Hand-written configurations miss the `essentialConfiguration` block and fail at runtime.
 
-## JSON Structure
+## Configuration Workflow
 
-### Basic GET
+### Step 1 — Add the node
 
-```json
-{
-  "id": "fetchOrders",
-  "type": "core.action.http",
-  "typeVersion": "1.0.0",
-  "display": { "label": "Fetch Orders" },
-  "inputs": {
+```bash
+uip flow node add <ProjectName>.flow core.action.http.v2 \
+  --label "<Label>" --output json
+```
+
+### Step 2 — Identify target connector and connection (connector mode only)
+
+Skip this step for manual mode.
+
+```bash
+# List connections for the target connector (e.g., Slack)
+uip is connections list "<target-connector-key>" --output json
+
+# Verify the connection is healthy
+uip is connections ping "<connection-id>" --output json
+```
+
+Record the `Id` and `FolderKey` from the connection.
+
+### Step 3 — Configure the node
+
+**Connector mode** (IS connection auth):
+
+```bash
+uip flow node configure <ProjectName>.flow <nodeId> \
+  --detail '{
+    "authentication": "connector",
+    "targetConnector": "<target-connector-key>",
+    "connectionId": "<target-connection-id>",
+    "folderKey": "<folder-key>",
     "method": "GET",
-    "url": "=js:$vars.apiBaseUrl + '/orders'",
-    "headers": {
-      "Authorization": "=js:'Bearer ' + $vars.apiToken"
-    },
-    "contentType": "application/json",
-    "timeout": "PT15M",
-    "retryCount": 0
-  },
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the HTTP request",
-      "source": "=result.response",
-      "var": "output"
-    },
-    "error": {
-      "type": "object",
-      "description": "Error information if the HTTP request fails",
-      "source": "=result.Error",
-      "var": "error"
-    }
-  },
-  "model": "<COPY_FROM_REGISTRY>"
-}
+    "path": "/api/endpoint",
+    "query": {"param1": "value1"}
+  }'
 ```
 
-### POST with Body
+**Manual mode** (no connector auth):
 
-```json
-{
-  "id": "createRecord",
-  "type": "core.action.http",
-  "typeVersion": "1.0.0",
-  "display": { "label": "Create Record" },
-  "inputs": {
-    "method": "POST",
-    "url": "https://api.example.com/records",
-    "headers": {
-      "Authorization": "=js:'Bearer ' + $vars.apiToken"
-    },
-    "body": "=js:JSON.stringify({ name: $vars.recordName, type: $vars.recordType })",
-    "contentType": "application/json"
-  },
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the HTTP request",
-      "source": "=result.response",
-      "var": "output"
-    },
-    "error": {
-      "type": "object",
-      "description": "Error information if the HTTP request fails",
-      "source": "=result.Error",
-      "var": "error"
-    }
-  },
-  "model": "<COPY_FROM_REGISTRY>"
-}
-```
-
-### Response Branching
-
-```json
-{
-  "id": "callApi",
-  "type": "core.action.http",
-  "typeVersion": "1.0.0",
-  "display": { "label": "Call API" },
-  "inputs": {
+```bash
+uip flow node configure <ProjectName>.flow <nodeId> \
+  --detail '{
+    "authentication": "manual",
     "method": "GET",
-    "url": "https://api.example.com/status",
-    "branches": [
-      {
-        "id": "ok",
-        "name": "Success",
-        "conditionExpression": "$vars.callApi.output.statusCode === 200"
-      },
-      {
-        "id": "notFound",
-        "name": "Not Found",
-        "conditionExpression": "$vars.callApi.output.statusCode === 404"
-      }
-    ]
-  },
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the HTTP request",
-      "source": "=result.response",
-      "var": "output"
-    },
-    "error": {
-      "type": "object",
-      "description": "Error information if the HTTP request fails",
-      "source": "=result.Error",
-      "var": "error"
-    }
-  },
-  "model": "<COPY_FROM_REGISTRY>"
-}
+    "url": "https://api.example.com/endpoint",
+    "query": {"param1": "value1"}
+  }'
 ```
 
-Each branch creates a dynamic output port (`branch-ok`, `branch-notFound`). Wire edges from these ports. Unmatched responses go to `default`.
+**What the CLI handles automatically:**
+- Builds the full `inputs.detail` structure (connector, connectionId, bodyParameters, essentialConfiguration)
+- For connector mode: generates `bindings_v2.json` and creates a connection resource file under `resources/solution_folder/connection/`
+- For manual mode: uses `ImplicitConnection` (no bindings needed)
 
-### Connection-Authenticated Request
+### Step 4 — Wire edges
 
-When a connector exists but lacks the specific endpoint, use the connector's HTTP Request activity. The connector handles auth:
+The managed HTTP node uses port `output`:
 
-```json
-{
-  "inputs": {
-    "authenticationType": "connection",
-    "application": "<connector-key>",
-    "connection": "<connection-id>"
-  }
-}
+```bash
+uip flow edge add <ProjectName>.flow <upstreamNodeId> <nodeId> \
+  --source-port <port> --target-port input --output json
+
+uip flow edge add <ProjectName>.flow <nodeId> <downstreamNodeId> \
+  --source-port output --target-port input --output json
 ```
-
-## Adding / Editing
-
-For step-by-step add, delete, and wiring procedures, see [flow-editing-operations.md](../../flow-editing-operations.md). Use the JSON structure above for the node-specific `inputs` and `model` fields.
-
-When using response branching, each branch creates a dynamic output port (`branch-{id}`). Unmatched responses go to `default`. See [flow-editing-operations.md](../../flow-editing-operations.md) for edge add procedures.
 
 ## Debug
 
 | Error | Cause | Fix |
 | --- | --- | --- |
-| `url` is empty or invalid | Missing URL input | Provide a valid URL or `=js:` expression |
-| Timeout | Request took longer than `timeout` | Increase timeout or check target API |
-| Auth failure (401/403) | Wrong or missing auth header | Check `headers.Authorization` or use connection auth |
-| Branch not matched | No branch condition evaluated to true | Check `conditionExpression` values; unmatched goes to `default` |
-| Body not sent | `body` is null or empty string | Ensure `body` is set for POST/PUT/PATCH |
-| `$vars` reference in URL unresolvable | Upstream node not connected | Check edges and node IDs |
+| `not_authed` or 401/403 | Wrong node type (v1 instead of v2), missing bindings, or expired connection | Verify node type is `core.action.http.v2`, check `bindings_v2.json` exists, ping the connection |
+| `configuration` field missing | Node not configured via CLI | Run `uip flow node configure` — do not hand-write `inputs.detail` |
+| Connection not found | Wrong connection ID or connector key | Re-run `uip is connections list` for the target connector |
+| Wrong API response | Incorrect `path`, `url`, or `query` | Check the target service's API documentation |
+| `ImplicitConnection` errors | Manual mode misconfigured | Verify `authentication: "manual"` and `url` is a full URL |

--- a/skills/uipath-maestro-flow/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/impl.md
@@ -53,7 +53,7 @@ uip flow node configure <ProjectName>.flow <nodeId> \
     "connectionId": "<target-connection-id>",
     "folderKey": "<folder-key>",
     "method": "GET",
-    "path": "/api/endpoint",
+    "url": "/api/endpoint",
     "query": {"param1": "value1"}
   }'
 ```
@@ -94,5 +94,5 @@ uip flow edge add <ProjectName>.flow <nodeId> <downstreamNodeId> \
 | `not_authed` or 401/403 | Wrong node type (v1 instead of v2), missing bindings, or expired connection | Verify node type is `core.action.http.v2`, check `bindings_v2.json` exists, ping the connection |
 | `configuration` field missing | Node not configured via CLI | Run `uip flow node configure` — do not hand-write `inputs.detail` |
 | Connection not found | Wrong connection ID or connector key | Re-run `uip is connections list` for the target connector |
-| Wrong API response | Incorrect `path`, `url`, or `query` | Check the target service's API documentation |
+| Wrong API response | Incorrect `url` or `query` | Check the target service's API documentation |
 | `ImplicitConnection` errors | Manual mode misconfigured | Verify `authentication: "manual"` and `url` is a full URL |

--- a/skills/uipath-maestro-flow/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/planning.md
@@ -1,24 +1,99 @@
-# HTTP Request Node — Planning
+# HTTP Request Nodes — Planning
 
-## Node Type
+Two HTTP node types exist. Pick based on whether you need connector-managed authentication.
 
-`core.action.http`
+## Node Types
 
-## When to Use
+| Node Type | Version | When to Use |
+| --- | --- | --- |
+| `core.action.http.v2` | 2.0.0 | **Preferred.** Call a REST API with IS connector-managed auth (OAuth, API keys). Use this when a connector exists but lacks the specific curated activity. |
+| `core.action.http` | 1.0.0 | Call a REST API with **manual** auth (bearer token in headers) or no auth. Use for services with no IS connector, or quick prototyping. |
 
-Use an HTTP Request node to call a REST API where no pre-built connector exists, or for quick prototyping.
+> **Never use `core.action.http` (v1) for connector-authenticated requests.** The v1 node's `authenticationType: "connection"` input does not pass credentials at runtime — use `core.action.http.v2` instead.
+
+---
+
+## `core.action.http.v2` — Managed HTTP Request
+
+Use when a connector exists for the service but lacks the specific endpoint (curated activity). The managed HTTP node proxies through the `uipath-uipath-http` connector and uses the target connector's connection for auth.
 
 ### Selection Heuristics
 
-| Situation | Use HTTP? |
+| Situation | Use Managed HTTP? |
+| --- | --- |
+| Connector exists but lacks the specific curated activity | Yes — use target connector's connection for auth |
+| Connector exists and covers the use case | No — use [Connector Activity](../connector/planning.md) |
+| No connector exists for the service | No — use `core.action.http` (v1) with manual auth |
+| Simple GET with no auth | No — use `core.action.http` (v1) |
+
+### Ports
+
+| Input Port | Output Port(s) |
+| --- | --- |
+| `input` | `output` |
+
+### Output Variables
+
+- `$vars.{nodeId}.output` — `{ body, code, method, rawStringBody, request }`
+
+### Key Inputs (`--detail` for `node configure`)
+
+Run `uip flow node configure` with a `--detail` JSON. The CLI builds the full `inputs.detail` payload, `bindings_v2.json`, and connection resource files automatically. **Do not hand-write `inputs.detail`.**
+
+**Connector mode** (IS connection auth):
+
+| `--detail` Key | Required | Description |
+| --- | --- | --- |
+| `authentication` | Yes | `"connector"` |
+| `method` | Yes | HTTP method: GET, POST, PUT, PATCH, DELETE |
+| `targetConnector` | Yes | Target connector key (e.g., `"uipath-salesforce-slack"`) |
+| `connectionId` | Yes | Target connector's IS connection ID (from `uip is connections list`) |
+| `folderKey` | Yes | Orchestrator folder key (from `uip is connections list`) |
+| `path` | No | API endpoint path (e.g., `"/conversations.replies"`) |
+| `query` | No | Query parameters as key-value object |
+| `headers` | No | Additional headers as key-value object |
+| `body` | No | Request body (for POST/PUT/PATCH) |
+
+**Manual mode** (no connector auth):
+
+| `--detail` Key | Required | Description |
+| --- | --- | --- |
+| `authentication` | Yes | `"manual"` |
+| `method` | Yes | HTTP method: GET, POST, PUT, PATCH, DELETE |
+| `url` | Yes | Full target URL |
+| `query` | No | Query parameters as key-value object |
+| `headers` | No | Additional headers as key-value object |
+| `body` | No | Request body (for POST/PUT/PATCH) |
+
+### Prerequisites
+
+- `uip login` required
+- A healthy IS connection for the **target connector** (e.g., Slack, Jira)
+- `uip flow registry pull` to cache the `core.action.http.v2` definition
+
+### Planning Annotation
+
+In the architectural plan, annotate managed HTTP nodes as:
+- `managed-http: <service> — <operation>` (e.g., "managed-http: Slack — GET /conversations.replies")
+- Note the target connector key and intended API path. Phase 2 resolves the connection and configures the node.
+
+---
+
+## `core.action.http` — Standalone HTTP Request
+
+Use for one-off API calls to services **without** a connector, or when no auth is needed.
+
+### Selection Heuristics
+
+| Situation | Use Standalone HTTP? |
 | --- | --- |
 | No connector exists for the service | Yes |
 | Quick prototyping against any REST API | Yes |
+| Connector exists but lacks the specific endpoint | No — use `core.action.http.v2` (managed HTTP) |
 | Connector exists and covers the use case | No — use [Connector Activity](../connector/planning.md) |
-| Connector exists but lacks the specific endpoint | Maybe — use HTTP within the connector (handles auth) |
 | Target system has no API (desktop app) | No — use [RPA Workflow](../rpa/planning.md) |
 
-## Ports
+### Ports
 
 | Input Port | Output Port(s) |
 | --- | --- |
@@ -26,25 +101,24 @@ Use an HTTP Request node to call a REST API where no pre-built connector exists,
 
 **Dynamic ports:** Each entry in `branches` creates a `branch-{item.id}` output port. If no branch condition matches, flow goes to `default`.
 
-## Output Variables
+### Output Variables
 
 - `$vars.{nodeId}.output` — `{ body, statusCode, headers }`
 - `$vars.{nodeId}.error` — error details if the call fails
 
-## Key Inputs
+### Key Inputs
 
 | Input | Required | Description |
 | --- | --- | --- |
 | `method` | Yes | GET, POST, PUT, PATCH, DELETE |
 | `url` | Yes | Target URL or `=js:` expression |
-| `headers` | No | Key-value pairs |
+| `headers` | No | Key-value pairs (include `Authorization` header for manual auth) |
 | `body` | No | Request body string |
 | `contentType` | No | Default `application/json` |
 | `timeout` | No | ISO 8601 duration (default `PT15M`) |
 | `retryCount` | No | Retries on failure (default 0) |
 | `branches` | No | Response routing conditions |
-| `authenticationType` | No | `manual` or from a connector connection |
 
-## Planning Annotation
+### Planning Annotation
 
 In the architectural plan, note the HTTP method and URL pattern. Use `<PLACEHOLDER>` for values that Phase 2 must resolve.

--- a/skills/uipath-maestro-flow/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/planning.md
@@ -1,42 +1,43 @@
-# HTTP Request Nodes — Planning
+# HTTP Request Node — Planning
 
-Two HTTP node types exist. Pick based on whether you need connector-managed authentication.
+## Node Type
 
-## Node Types
+`core.action.http.v2` (Managed HTTP Request)
 
-| Node Type | Version | When to Use |
-| --- | --- | --- |
-| `core.action.http.v2` | 2.0.0 | **Preferred.** Call a REST API with IS connector-managed auth (OAuth, API keys). Use this when a connector exists but lacks the specific curated activity. |
-| `core.action.http` | 1.0.0 | Call a REST API with **manual** auth (bearer token in headers) or no auth. Use for services with no IS connector, or quick prototyping. |
+> **Always use `core.action.http.v2`** for all HTTP requests — both connector-authenticated and manual. The older `core.action.http` (v1) is deprecated and does not pass IS credentials at runtime.
 
-> **Never use `core.action.http` (v1) for connector-authenticated requests.** The v1 node's `authenticationType: "connection"` input does not pass credentials at runtime — use `core.action.http.v2` instead.
+## When to Use
 
----
-
-## `core.action.http.v2` — Managed HTTP Request
-
-Use when a connector exists for the service but lacks the specific endpoint (curated activity). The managed HTTP node proxies through the `uipath-uipath-http` connector and uses the target connector's connection for auth.
+Use a managed HTTP node to call a REST API — either with IS connector-managed authentication or with manual auth (raw URL).
 
 ### Selection Heuristics
 
 | Situation | Use Managed HTTP? |
 | --- | --- |
-| Connector exists but lacks the specific curated activity | Yes — use target connector's connection for auth |
+| Connector exists but lacks the specific curated activity | Yes — connector mode with target connector's connection |
+| No connector exists, but service has a REST API | Yes — manual mode with full URL |
+| Quick prototyping against any REST API | Yes — manual mode |
 | Connector exists and covers the use case | No — use [Connector Activity](../connector/planning.md) |
-| No connector exists for the service | No — use `core.action.http` (v1) with manual auth |
-| Simple GET with no auth | No — use `core.action.http` (v1) |
+| Target system has no API (desktop app) | No — use [RPA Workflow](../rpa/planning.md) |
 
-### Ports
+### Two Authentication Modes
+
+| Mode | When to use | Key `--detail` fields |
+| --- | --- | --- |
+| **Connector** | A connector exists for the service — uses IS connection for OAuth/API key auth | `authentication: "connector"`, `targetConnector`, `connectionId`, `folderKey`, `path` |
+| **Manual** | No connector, or public API with no auth needed | `authentication: "manual"`, `url` |
+
+## Ports
 
 | Input Port | Output Port(s) |
 | --- | --- |
 | `input` | `output` |
 
-### Output Variables
+## Output Variables
 
 - `$vars.{nodeId}.output` — `{ body, code, method, rawStringBody, request }`
 
-### Key Inputs (`--detail` for `node configure`)
+## Key Inputs (`--detail` for `node configure`)
 
 Run `uip flow node configure` with a `--detail` JSON. The CLI builds the full `inputs.detail` payload, `bindings_v2.json`, and connection resource files automatically. **Do not hand-write `inputs.detail`.**
 
@@ -65,60 +66,14 @@ Run `uip flow node configure` with a `--detail` JSON. The CLI builds the full `i
 | `headers` | No | Additional headers as key-value object |
 | `body` | No | Request body (for POST/PUT/PATCH) |
 
-### Prerequisites
+## Prerequisites
 
-- `uip login` required
-- A healthy IS connection for the **target connector** (e.g., Slack, Jira)
+- `uip login` required (for both modes — node type comes from registry)
+- For connector mode: a healthy IS connection for the **target connector**
 - `uip flow registry pull` to cache the `core.action.http.v2` definition
 
-### Planning Annotation
+## Planning Annotation
 
 In the architectural plan, annotate managed HTTP nodes as:
-- `managed-http: <service> — <operation>` (e.g., "managed-http: Slack — GET /conversations.replies")
-- Note the target connector key and intended API path. Phase 2 resolves the connection and configures the node.
-
----
-
-## `core.action.http` — Standalone HTTP Request
-
-Use for one-off API calls to services **without** a connector, or when no auth is needed.
-
-### Selection Heuristics
-
-| Situation | Use Standalone HTTP? |
-| --- | --- |
-| No connector exists for the service | Yes |
-| Quick prototyping against any REST API | Yes |
-| Connector exists but lacks the specific endpoint | No — use `core.action.http.v2` (managed HTTP) |
-| Connector exists and covers the use case | No — use [Connector Activity](../connector/planning.md) |
-| Target system has no API (desktop app) | No — use [RPA Workflow](../rpa/planning.md) |
-
-### Ports
-
-| Input Port | Output Port(s) |
-| --- | --- |
-| `input` | `default`, `branch-{id}` (dynamic per branch) |
-
-**Dynamic ports:** Each entry in `branches` creates a `branch-{item.id}` output port. If no branch condition matches, flow goes to `default`.
-
-### Output Variables
-
-- `$vars.{nodeId}.output` — `{ body, statusCode, headers }`
-- `$vars.{nodeId}.error` — error details if the call fails
-
-### Key Inputs
-
-| Input | Required | Description |
-| --- | --- | --- |
-| `method` | Yes | GET, POST, PUT, PATCH, DELETE |
-| `url` | Yes | Target URL or `=js:` expression |
-| `headers` | No | Key-value pairs (include `Authorization` header for manual auth) |
-| `body` | No | Request body string |
-| `contentType` | No | Default `application/json` |
-| `timeout` | No | ISO 8601 duration (default `PT15M`) |
-| `retryCount` | No | Retries on failure (default 0) |
-| `branches` | No | Response routing conditions |
-
-### Planning Annotation
-
-In the architectural plan, note the HTTP method and URL pattern. Use `<PLACEHOLDER>` for values that Phase 2 must resolve.
+- Connector mode: `managed-http: <service> — <operation>` (e.g., "managed-http: Slack — GET /conversations.replies")
+- Manual mode: `managed-http: manual — <method> <url>` (e.g., "managed-http: manual — GET https://api.example.com/data")

--- a/skills/uipath-maestro-flow/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/planning.md
@@ -24,7 +24,7 @@ Use a managed HTTP node to call a REST API — either with IS connector-managed 
 
 | Mode | When to use | Key `--detail` fields |
 | --- | --- | --- |
-| **Connector** | A connector exists for the service — uses IS connection for OAuth/API key auth | `authentication: "connector"`, `targetConnector`, `connectionId`, `folderKey`, `path` |
+| **Connector** | A connector exists for the service — uses IS connection for OAuth/API key auth | `authentication: "connector"`, `targetConnector`, `connectionId`, `folderKey`, `url` |
 | **Manual** | No connector, or public API with no auth needed | `authentication: "manual"`, `url` |
 
 ## Ports
@@ -50,7 +50,7 @@ Run `uip flow node configure` with a `--detail` JSON. The CLI builds the full `i
 | `targetConnector` | Yes | Target connector key (e.g., `"uipath-salesforce-slack"`) |
 | `connectionId` | Yes | Target connector's IS connection ID (from `uip is connections list`) |
 | `folderKey` | Yes | Orchestrator folder key (from `uip is connections list`) |
-| `path` | No | API endpoint path (e.g., `"/conversations.replies"`) |
+| `url` | No | API endpoint URL/path (e.g., `"/conversations.replies"`). Auto-fills both `bodyParameters.path` and `bodyParameters.url`. |
 | `query` | No | Query parameters as key-value object |
 | `headers` | No | Additional headers as key-value object |
 | `body` | No | Request body (for POST/PUT/PATCH) |


### PR DESCRIPTION
## Summary
- Adds `core.action.http.v2` (Managed HTTP Request) as the preferred node type for connector-authenticated HTTP calls
- Documents CLI-first workflow: `node add` → `node configure --detail` → `edge add` — the skill never builds `inputs.detail`, the CLI handles it
- Updates connector planning HTTP Fallback to reference managed HTTP v2 instead of the broken v1 `authenticationType: "connection"` pattern
- Adds anti-patterns: never use v1 for connector auth, never hand-write `inputs.detail`
- Updates Plugin Index, Standard Port Reference, and node selection heuristics in `planning-arch.md`

## Test plan
- [x] Verified flow creation with updated skill: `SlackThreadReplies-1` built successfully using `core.action.http.v2` + `node configure`
- [x] Flow validates and publishes to Studio Web
- [ ] Review all 6 changed files for accuracy against CLI `--detail` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)