### PR TITLE
docs(uipath-rpa): link-screen/link-element fast path with embed fallback

### DIFF
--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -154,9 +154,9 @@ Every UI automation workflow starts with an **Application Card** (`uix:NApplicat
 
 #### Target Configuration
 
-Follow [uia-configure-target-workflows.md](uia-configure-target-workflows.md) to register the Application Card's screen and each activity's elements in the Object Repository. Then retrieve the XAML snippets using `get-screen-xaml` and `get-elements-xaml`, and embed them directly in the workflow during creation — see the **Embedding OR Entries in XAML Activities** section in [uia-configure-target-workflows.md](uia-configure-target-workflows.md).
+Follow [uia-configure-target-workflows.md](uia-configure-target-workflows.md) to register the Application Card's screen and each activity's elements in the Object Repository. Then write plain activities (NApplicationCard, NClick, NTypeInto, ...) with unique `sap2010:WorkflowViewState.IdRef` attributes and no `.Target` children, and attach targets per [uia-target-attachment-guide.md](uia-target-attachment-guide.md).
 
-Do NOT hand-write `<uix:TargetApp>` or `<uix:TargetAnchorable>` XAML from scratch. Always use the CLI commands to retrieve the correct snippets from the Object Repository.
+Do NOT hand-write `<uix:TargetApp>` or `<uix:TargetAnchorable>` XAML from scratch. Attach targets per [uia-target-attachment-guide.md](uia-target-attachment-guide.md) — never fabricate them.
 
 ### Common Activities
 

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -7,7 +7,7 @@
 **Execute `uia-configure-target` steps inline in the main conversation.** Do NOT delegate the entire skill to a subagent. The skill's internal steps already spawn their own subagents.
 
 Why this matters:
-- **OR references** must be visible in the main conversation so they can be embedded into workflow activities as the workflow is created.
+- **OR references** must be visible in the main conversation so they can be attached to workflow activities as the workflow is created — either inline (for single-file workflows) or handed off to write agents (for multi-screen pipelines). See [uia-target-attachment-guide.md](uia-target-attachment-guide.md).
 - **Context continuity** — as the main conversation proceeds, it already knows which screens and elements are registered: the references were returned in earlier turns, and the OR itself is queryable via `object-repository get-screens` / `get-elements`. This is what "knowing what's registered" means here — the in-conversation state plus live OR queries — so duplicate captures are avoided and the workflow build stays coherent.
 
 Read the SKILL.md, then execute each TARGET step yourself. Only spawn `Agent` where the skill explicitly says to (create-selector, improve-selector).
@@ -53,7 +53,7 @@ uip rpa indicate-application --name "<ScreenName>" --description "<ScreenDescrip
 uip rpa indicate-element --name "<ElementName>" --activity-class-name "<TypeInto|Click|GetText|...>" --parent-id "<screen-reference>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
-Both commands return `{ "Data": { "reference": "..." } }` — use that reference ID to retrieve XAML snippets and for OR lookups. After indication, Studio regenerates Object Repository files. For coded workflows, re-read `ObjectRepository.cs` to get descriptor paths. For XAML workflows, use the reference IDs to retrieve XAML snippets and embed them into activities as the workflow is created — see **Embedding OR Entries in XAML Activities** below.
+Both commands return `{ "Data": { "reference": "..." } }` — use that reference ID for OR lookups and target attachment. After indication, Studio regenerates Object Repository files. For coded workflows, re-read `ObjectRepository.cs` to get descriptor paths. For XAML workflows, attach each reference to its activity per [uia-target-attachment-guide.md](uia-target-attachment-guide.md).
 
 <details>
 <summary>Full parameter reference</summary>
@@ -107,65 +107,12 @@ Alternate input forms:
 
 See [uia-multi-step-flows.md](uia-multi-step-flows.md) for when to use `uia interact` vs servo and the full capture loop.
 
-## Embedding OR Entries in XAML Activities
+## Attaching Targets to Workflow Activities
 
-After registering targets in the Object Repository (via `uia-configure-target` or indication fallback), retrieve the XAML snippets and embed them directly when creating the workflow. This is more reliable than post-creation linking because it works regardless of intermediate validation errors.
+Once targets are registered in the OR (via `uia-configure-target` or indication fallback), attach them to XAML activities per [uia-target-attachment-guide.md](uia-target-attachment-guide.md).
 
-### 1. Get the screen XAML for the ApplicationCard
+### Multi-Screen Workflows
 
-```bash
-uip rpa uia object-repository get-screen-xaml \
-  --reference-id "<SCREEN_REFERENCE_ID>" \
-  --project-dir "<PROJECT_DIR>"
-```
-
-Returns a `<TargetApp>` element. Embed it inside the ApplicationCard:
-
-```xml
-<uix:NApplicationCard.TargetApp>
-  <!-- paste the returned <TargetApp ... /> here (remove the xmlns attribute — it's inherited from the uix prefix) -->
-</uix:NApplicationCard.TargetApp>
-```
-
-### 2. Get element XAML for UI activities
-
-```bash
-uip rpa uia object-repository get-elements-xaml \
-  --reference-ids "<REF_1>,<REF_2>,<REF_3>" \
-  --project-dir "<PROJECT_DIR>"
-```
-
-Returns `<TargetAnchorable>` elements, one per reference ID, separated by `=== Element Name ===` headers. Embed each inside its activity's `.Target` property:
-
-```xml
-<uix:NClick ...>
-  <uix:NClick.Target>
-    <!-- paste the returned <TargetAnchorable ... /> here (remove the xmlns attribute) -->
-  </uix:NClick.Target>
-</uix:NClick>
-
-<uix:NTypeInto ...>
-  <uix:NTypeInto.Target>
-    <!-- paste the returned <TargetAnchorable ... /> here -->
-  </uix:NTypeInto.Target>
-</uix:NTypeInto>
-
-<uix:NGetText ...>
-  <uix:NGetText.Target>
-    <!-- paste the returned <TargetAnchorable ... /> here -->
-  </uix:NGetText.Target>
-</uix:NGetText>
-```
-
-| Parameter | Source |
-|-----------|--------|
-| `<SCREEN_REFERENCE_ID>` | OR screen reference returned by `uia-configure-target` or `indicate-application` |
-| `<REF_1>,<REF_2>,...` | Comma-separated OR element references returned by `uia-configure-target` or `indicate-element` |
-
-When an element is used by multiple activities (e.g., the same field clicked and then typed into), use the same `<TargetAnchorable>` snippet in each activity's `.Target` property.
-
-### Multi-Screen Workflows: Passing OR Data to Write Agents
-
-For multi-screen XAML workflows using the parallel authoring pipeline, retrieve OR XAML snippets (`get-screen-xaml`, `get-elements-xaml`) immediately after registration and pass them to a write agent's prompt. The write agent embeds `TargetApp` and `TargetAnchorable` snippets using the same patterns shown above. This decouples target configuration from XAML generation, allowing the main conversation to configure the next screen's targets while the write agent works.
+For XAML workflows spanning multiple screens, use the parallel authoring pipeline. The main conversation passes only OR reference IDs to each write agent — no XAML snippets. The agent handles attachment itself per the shared guide.
 
 See [uia-parallel-xaml-authoring-guide.md](uia-parallel-xaml-authoring-guide.md) for prompt templates and the chained dependency model.

--- a/skills/uipath-rpa/references/uia-multi-step-flows.md
+++ b/skills/uipath-rpa/references/uia-multi-step-flows.md
@@ -57,7 +57,7 @@ servo click <servo-element-ref>
 
 ## Spawning XAML Write Agents
 
-After completing all `uia-configure-target` calls for a screen (through TARGET-8 for all elements) and retrieving OR XAML snippets via `get-elements-xaml`, spawn a write agent to add that screen's activities to the workflow file. Each write agent depends on the previous one completing — they form a strict chain.
+After completing all `uia-configure-target` calls for a screen (through TARGET-8 for all elements), spawn a write agent to add that screen's activities to the workflow file. The orchestrator hands off only OR reference IDs — the agent inserts plain activities with unique `sap2010:WorkflowViewState.IdRef` attributes and attaches targets itself via `link-element`. Each write agent depends on the previous one completing — they form a strict chain.
 
 The screen boundary for write agents aligns with the Complete-then-advance rule above: everything configured before the next servo advance belongs to one write agent's scope.
 

--- a/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
+++ b/skills/uipath-rpa/references/uia-parallel-xaml-authoring-guide.md
@@ -8,7 +8,7 @@
 
 ## Phase 0: Plan the Workflow
 
-> **CRITICAL:** Complete Phase 0 before spawning any agent. The orchestrator's job in Phase 0 is to plan screens and actions, then determine the few values agents cannot derive themselves (expression language, x:Class). All other data (activity templates, xmlns, TextExpression, TargetApp XAML, OR element snippets) is retrieved inside the agent — see [Prompt Templates](#prompt-templates).
+> **CRITICAL:** Complete Phase 0 before spawning any agent. The orchestrator's job in Phase 0 is to plan screens and actions, then determine the few values agents cannot derive themselves (expression language, x:Class). All other data (activity templates, xmlns, TextExpression blocks) is retrieved inside the agent, and target attachment happens inside the agent per [uia-target-attachment-guide.md](uia-target-attachment-guide.md) — see [Prompt Templates](#prompt-templates).
 
 1. **Identify screens.** List each distinct application state the workflow will interact with. A "screen" is a stable UI state where one or more elements need to be targeted — a page, a modal dialog, an inline form, or a panel that appears after an action.
 
@@ -24,7 +24,7 @@
 
    b. **x:Class value** — derived from the output `.xaml` filename per the naming rule in [xaml-basics-and-rules.md](xaml/xaml-basics-and-rules.md): folder separators become underscores, not dots. Root-level `MyWorkflow.xaml` → `x:Class="MyWorkflow"`. Subfolder `Workflows/MyWorkflow.xaml` → `x:Class="Workflows_MyWorkflow"`. Passed to the scaffolding agent prompt.
 
-   All other data (activity templates, xmlns, TextExpression blocks, TargetApp XAML, OR element snippets) is retrieved by the agent itself — see the agent prompt templates in [Prompt Templates](#prompt-templates).
+   All other data (activity templates, xmlns, TextExpression blocks) is retrieved by the agent itself, and target attachment happens inside the agent per [uia-target-attachment-guide.md](uia-target-attachment-guide.md) — see the agent prompt templates in [Prompt Templates](#prompt-templates).
 
 6. **Create a split task list** before starting Phase 1. Each screen produces TWO tasks with distinct lifecycles — `Configure-<ScreenName>` (owned by the main conversation, completes when OR registration finishes) and `Write-<ScreenName>` (owned by a background agent, completes on `<task-notification>`). Splitting these prevents the ambiguous "configure done but write running" status that collapses the Task list progress view.
 
@@ -44,7 +44,7 @@
 
 ## Phase 1: Scaffolding Agent
 
-1. **When to spawn:** Immediately after the first screen is registered in the Object Repository (TARGET-8 screen creation), before element configuration for that screen begins. The scaffolding agent depends only on the TargetApp XAML from the first screen registration — not on any element targets.
+1. **When to spawn:** Immediately after the first screen is registered in the Object Repository (TARGET-8 screen creation), before element configuration for that screen begins. The scaffolding agent depends only on the first screen reference being registered — not on any element targets.
 
 2. **Run mode:** Spawn the scaffolding agent with `run_in_background: true`. Foreground mode blocks the main conversation and defeats the purpose of the parallel pipeline — while the scaffolding agent works, the main conversation must advance the application to the next screen and configure its targets. The scaffolding agent creates a new file with no concurrent access risk, so background mode is safe.
 
@@ -52,8 +52,8 @@
    - Reads `<PROJECT_DIR>/project.json` to obtain `expressionLanguage`.
    - Reads an existing `.xaml` in the project root (e.g., `Main.xaml`) to extract the root `<Activity>` xmlns declarations and both `<TextExpression.NamespacesForImplementation>` and `<TextExpression.ReferencesForImplementation>` blocks. Copied verbatim into the new file.
    - Runs `uip rpa get-default-activity-xaml --activity-class-name "UiPath.UIAutomationNext.Activities.NApplicationCard"` for the NApplicationCard template.
-   - Runs `uip rpa uia object-repository get-screen-xaml --reference-id "<SCREEN_REFERENCE_ID>"` for the TargetApp XAML.
-   - Writes the complete `.xaml` file: `<Activity>` root with `x:Class`, namespace declarations, TextExpression blocks, NApplicationCard with embedded TargetApp, and an empty `<Sequence DisplayName="Do">` (open/close form, not self-closing) inside the ApplicationCard body where screen agents will insert activities.
+   - Writes the complete `.xaml` file: `<Activity>` root with `x:Class`, namespace declarations, TextExpression blocks, an NApplicationCard carrying `sap2010:WorkflowViewState.IdRef="NApplicationCard_1"` (no `<uix:NApplicationCard.TargetApp>` child — attachment happens next), and an empty `<Sequence DisplayName="Do">` (open/close form, not self-closing) inside the ApplicationCard body where screen agents will insert activities.
+   - Attaches the registered screen to the NApplicationCard (activity ref ID `NApplicationCard_1`) per [uia-target-attachment-guide.md](uia-target-attachment-guide.md). Every CLI call is wrapped with `timeout 60000`.
 
 4. **Post-write verification** (D-09): The agent runs `get-errors` itself, wrapped with a `timeout`:
    ```bash
@@ -67,21 +67,20 @@
 
 6. **Prompt template:** See [Scaffolding Agent Template](#scaffolding-agent-template) for the complete Agent() call.
 
-> **CRITICAL:** The agent must strip the `xmlns` attribute from the `<TargetApp>` element returned by `get-screen-xaml` before embedding it. The root `<Activity>` element's namespace declarations already cover it. Duplicate xmlns causes namespace-related validation errors.
-
 ## Phase 2: Screen Activity Agents
 
 1. **Spawn precondition** — Do NOT spawn `Write-<N>` until ALL of the following hold (the orchestrator MUST verify each via `TaskGet` before calling `Agent()`):
-   - (a) `Configure-<N>` is `completed` (screen N's element targets are fully configured and registered in the OR — but the orchestrator does NOT pre-fetch the snippets; the agent fetches them itself via `get-elements-xaml`).
+   - (a) `Configure-<N>` is `completed` (screen N's element targets are fully configured and registered in the OR — the orchestrator hands off only reference IDs; the agent attaches them to activities itself via `link-element`).
    - (b) `Write-<N-1>` is `completed` (or `Write-Scaffold` for N=1). **If `Write-<N-1>` is `in_progress`, do NOT spawn — the chain is violated.** See [Waiting for Background Agents](#waiting-for-background-agents).
 
 2. **Run mode:** Spawn each screen activity agent with `run_in_background: true`. While the agent writes screen N, the main conversation must advance the application to screen N+1 and configure its targets (`Configure-<N+1>`) — but it must NOT spawn `Write-<N+1>` until `Write-<N>` is `completed`. The chain requires each agent to read the previous agent's finalized file state.
 
 3. **What the agent does** (the agent retrieves its own data — orchestrator does NOT pre-fetch):
    - Reads the file and locates the inner `<Sequence DisplayName="Do">`. Ordering safety is enforced upstream by the task queueing model (see [Waiting for Background Agents](#waiting-for-background-agents) — `Write-<N>` cannot spawn until `Write-<N-1>` is `completed`), so the agent treats the file as in a known good state.
+   - Assigns unique `sap2010:WorkflowViewState.IdRef` values to each new activity per the IdRef contract in [uia-target-attachment-guide.md](uia-target-attachment-guide.md#idref-contract).
    - Runs `uip rpa get-default-activity-xaml --activity-class-name "<class>"` (with `timeout`) for each activity class in its action list.
-   - Runs `uip rpa uia object-repository get-elements-xaml --reference-ids "<csv>"` (with `timeout`) for the ref IDs in its action list.
-   - Constructs and inserts activities immediately before the closing `</Sequence>` of the inner `<Sequence DisplayName="Do">`. Does NOT modify any content before the insertion point.
+   - Constructs and inserts activities immediately before the closing `</Sequence>` of the inner `<Sequence DisplayName="Do">`. Each activity carries its assigned IdRef and has NO `.Target` / `.SearchedElement.Target` child — attachment happens next. Does NOT modify any content before the insertion point.
+   - For each action with a `reference_id`, attaches it to the activity's assigned IdRef per [uia-target-attachment-guide.md](uia-target-attachment-guide.md), passing the action's `target_property` when set. Every CLI call is wrapped with `timeout 60000`.
 
 4. **Post-write verification** (D-09): Agent runs `get-errors` itself, wrapped with a `timeout`:
    ```bash
@@ -95,8 +94,6 @@
 
 6. **Prompt template:** See [Screen Activity Agent Template](#screen-activity-agent-template) for the complete Agent() call.
 
-> **CRITICAL:** The agent must strip `xmlns` attributes from all `<TargetAnchorable>` elements returned by `get-elements-xaml` before embedding them. The root `<Activity>` element's namespace declarations already cover them.
-
 ### Screen Boundaries
 
 A "screen" equals everything configured before advancing the application to the next workflow state via servo. This may include intermediate servo clicks within the same logical state (for example, navigating to a list view to reveal a "New" button before configuring it) — per the Complete-then-advance rule in [uia-multi-step-flows.md](uia-multi-step-flows.md).
@@ -104,7 +101,7 @@ A "screen" equals everything configured before advancing the application to the 
 All `uia-configure-target` calls for the current workflow state must complete before spawning the write agent for that screen AND before using servo to advance to the next state.
 
 See also: [uia-multi-step-flows.md](uia-multi-step-flows.md) for the Complete-then-advance rule.
-See also: [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for OR embedding patterns and passing OR data to write agents.
+See also: [uia-target-attachment-guide.md](uia-target-attachment-guide.md) and [uia-configure-target-workflows.md](uia-configure-target-workflows.md).
 
 ### Chained Dependency Model
 
@@ -164,8 +161,8 @@ These three rules govern what the orchestrator may and may not do while a `Write
 
 ## Prompt Construction Rules
 
-1. **Pass the ref-ID-keyed action list; the agent retrieves its own XAML.** Do NOT paste activity templates, xmlns blocks, TextExpression blocks, TargetApp XAML, or `<TargetAnchorable>` snippets into the agent prompt. The orchestrator constructs a structured action list (see [Action List Format](#action-list-format)); the agent runs `get-default-activity-xaml` and `get-elements-xaml` itself for everything it needs.
-2. Describe actions as a structured list with exact data values (`display_name`, `type`, `reference_id`, optional `text`/`duration_seconds`) — see [Action List Format](#action-list-format). Each action carries enough detail for the agent to construct the activity from the template + OR snippet it retrieves.
+1. **Pass the ref-ID-keyed action list; the agent retrieves its own XAML.** Do NOT paste activity templates, xmlns blocks, TextExpression blocks, TargetApp XAML, or `<TargetAnchorable>` snippets into the agent prompt. The orchestrator constructs a structured action list (see [Action List Format](#action-list-format)); the agent runs `get-default-activity-xaml` itself for activity templates, and uses `link-element` / `link-screen` to attach targets. Snippet fetches (`get-elements-xaml`, `get-screen-xaml`) run only on the fallback path — per ref whose link call failed.
+2. Describe actions as a structured list with exact data values (`display_name`, `type`, `reference_id`, optional `text`/`duration_seconds`/`target_property`) — see [Action List Format](#action-list-format). Each action carries enough detail for the agent to construct the activity from the template it retrieves and then attach the target via `link-element`.
 3. Specify interaction patterns **explicitly** for each non-trivial interaction: dropdown selection (Click then TypeInto with `[k(enter)]`), wait durations between actions, checkbox toggling, element reuse across repeated form instances. These go in a per-screen notes block in the prompt.
 4. Specify **expression-language-specific syntax** for inline expressions. CSharp: `<Delay>` uses an `<InArgument x:TypeArguments="x:TimeSpan">` with a `<CSharpValue>` containing `TimeSpan.FromSeconds(N)`. VB: `<Delay Duration="[TimeSpan.FromSeconds(N)]" />`. Always match the `expressionLanguage` value passed in the prompt.
 5. All context (action list, interaction patterns) goes **inline in the Agent() prompt parameter** as labeled blocks (D-06). Do not pass context via temp `.md` files or any other file-based method.
@@ -177,7 +174,7 @@ These three rules govern what the orchestrator may and may not do while a `Write
 
 ### Reused Forms (Same OR Targets, Different Data)
 
-When the same form appears more than once (for example, a "Save & New" pattern that reopens the same contact form), treat the repetitions as screens that share the same `<TargetAnchorable>` snippets but have different action sequences and data values.
+When the same form appears more than once (for example, a "Save & New" pattern that reopens the same contact form), treat the repetitions as screens that reuse the same OR element references but have different action sequences and data values. Each activity instance gets its own unique `sap2010:WorkflowViewState.IdRef` and its own `link-element` call — the same `--reference-id` linked to multiple `--activity-ref-id`s.
 
 **Prefer a single write agent when all of these hold:**
 - The repetitions are back-to-back in the workflow (no intervening pipeline work).
@@ -215,10 +212,10 @@ Write agents are typically fast — they perform pure text generation against a 
 2. Do NOT have a screen activity agent modify activities from earlier screens — insert before the closing `</Sequence>` tag only.
 3. Do NOT spawn `Write-<N>` while `Write-<N-1>` is `in_progress`. Check `TaskGet(Write-<N-1>)` first; only spawn if `completed`. Spawning early breaks the chain — the agents will race on the same insertion point.
 4. Do NOT poll for agent completion. No `sleep`, no `Monitor` + `until` loop, no `ScheduleWakeup`, no file-growth checks, no respawning the agent to "see if it's done". Either do non-conflicting work, or reply with a one-line status and stop. The runtime delivers `<task-notification>` asynchronously.
-5. Do NOT paste activity templates, xmlns blocks, TextExpression blocks, TargetApp XAML, or OR `<TargetAnchorable>` snippets into the agent prompt. Pass reference IDs, activity class names, and a structured action list — the agent retrieves its own XAML.
-6. Do NOT pass unstable selectors (auto-generated numeric IDs, `css-selector` attributes, hash-based class names) to write agents — identify and fix them during target configuration via selector improvement before the agent retrieves OR snippets.
+5. Do NOT paste activity templates, xmlns blocks, TextExpression blocks, TargetApp XAML, or OR `<TargetAnchorable>` snippets into the agent prompt. Pass reference IDs, activity class names, and a structured action list — the agent retrieves activity templates itself and links targets via `link-element` / `link-screen`.
+6. Do NOT pass unstable selectors (auto-generated numeric IDs, `css-selector` attributes, hash-based class names) to write agents — identify and fix them during target configuration via selector improvement before the agent attaches targets.
 7. Do NOT duplicate pipeline logic in SKILL.md or other reference files — those files route here; this file is the single source of truth for the pipeline.
-8. Do NOT skip the selector stability gate before the agent retrieves OR snippets. Syntactically valid XAML that uses runtime-broken selectors is harder to debug than a build error.
+8. Do NOT skip the selector stability gate before the agent attaches targets. Syntactically valid XAML that uses runtime-broken selectors is harder to debug than a build error.
 9. Do NOT modify the `.xaml` file from the main conversation while a write agent is running. The chained model depends on each agent reading the current valid file state; concurrent edits produce an unknown file state for the next agent.
 10. Do NOT spawn write agents in foreground mode — this blocks the main conversation and serializes the pipeline. Always use `run_in_background: true` so the main conversation can configure the next screen's targets in parallel.
 11. Do NOT call agent-side CLI commands without a `timeout` wrapper. A hung Studio causes `get-errors` to block indefinitely — agents must fail fast, not hang.
@@ -250,25 +247,27 @@ Create a new UiPath XAML workflow file at `<OUTPUT_XAML_PATH>`.
      --project-dir "<PROJECT_DIR>" \
      --output json   ```
    Use the returned XAML as-is for the NApplicationCard element.
-4. Fetch the TargetApp XAML for the registered screen:
-   ```bash
-   timeout 60000 uip rpa uia object-repository get-screen-xaml \
-     --reference-id "<SCREEN_REFERENCE_ID>" \
-     --project-dir "<PROJECT_DIR>"
-   ```
-   Strip the `xmlns` attribute from the returned `<TargetApp>` element before embedding it inside `<uix:NApplicationCard.TargetApp>`.
-
 ## File structure requirements
 
 - Root `<Activity>` with `x:Class="<X_CLASS_VALUE>"` (derived from `<OUTPUT_XAML_PATH>` per the naming rule in [xaml-basics-and-rules.md](xaml/xaml-basics-and-rules.md): folder separators become underscores).
 - `mc:Ignorable="sap sap2010"`, `sap2010:ExpressionActivityEditor.ExpressionActivityEditor="<CSharp|VB>"`, `sap2010:WorkflowViewState.IdRef="ActivityBuilder_1"`.
 - The `<TextExpression.*>` blocks from step 2.
-- A single NApplicationCard from step 3 with TargetApp from step 4 embedded.
+- A single NApplicationCard from step 3 with `sap2010:WorkflowViewState.IdRef="NApplicationCard_1"` and NO `<uix:NApplicationCard.TargetApp>` child (linking attaches it in the next step).
 - Inside `<uix:NApplicationCard.Body>` → `<ActivityAction>`, create an empty `<Sequence DisplayName="Do"></Sequence>`. Use open/close form (not self-closing).
+
+## Attachment guide
+
+<attachment-guide>
+<ATTACHMENT_GUIDE_CONTENT>
+</attachment-guide>
+
+## Attach the screen to the NApplicationCard
+
+Following the attachment guide above, attach screen `<SCREEN_REFERENCE_ID>` to activity `NApplicationCard_1`. Wrap every CLI call with `timeout 60000`.
 
 ## Validation
 
-After writing the file:
+After attachment:
 ```bash
 timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json```
 If it returns errors, fix and re-validate. Max 3 fix attempts. If the CLI times out (Studio unresponsive), report: "Validation unavailable — Studio not responding; file written but unverified." Do not hang.
@@ -278,9 +277,11 @@ If it returns errors, fix and re-validate. Max 3 fix attempts. If the CLI times 
 | Placeholder | Value |
 |---|---|
 | <OUTPUT_XAML_PATH> | <fill in> |
+| <RELATIVE_XAML_PATH> | <OUTPUT_XAML_PATH> relative to <PROJECT_DIR> |
 | <X_CLASS_VALUE> | <fill in> |
 | <PROJECT_DIR> | <fill in> |
 | <SCREEN_REFERENCE_ID> | <fill in> |
+| <ATTACHMENT_GUIDE_CONTENT> | Verbatim contents of `uia-target-attachment-guide.md` — orchestrator reads the file and pastes the body here |
 """
 )
 ```
@@ -309,30 +310,32 @@ Activity class names you will use: `<ACTIVITY_CLASS_LIST>` (comma-separated, e.g
      --output json   ```
    Use the returned XAML as the structural base for every instance of that activity type.
 
-2. Fetch all OR element XAML snippets in a single call:
-   ```bash
-   timeout 60000 uip rpa uia object-repository get-elements-xaml \
-     --reference-ids "<COMMA_SEPARATED_REF_IDS>" \
-     --project-dir "<PROJECT_DIR>"
-   ```
-   Parse the output (separated by `=== <Element Name> ===` headers). For each `<TargetAnchorable>` returned, strip the `xmlns` attribute and add the `uix:` prefix when embedding.
+## Attachment guide
+
+<attachment-guide>
+<ATTACHMENT_GUIDE_CONTENT>
+</attachment-guide>
 
 ## Action list — implement in this EXACT order
 
-Insert the following activities IMMEDIATELY BEFORE the closing `</Sequence>` tag of the inner `<Sequence DisplayName="Do">`. Do NOT modify any content before the insertion point.
+Insert the following activities IMMEDIATELY BEFORE the closing `</Sequence>` tag of the inner `<Sequence DisplayName="Do">`. Do NOT modify any content before the insertion point. Each new activity carries a unique `sap2010:WorkflowViewState.IdRef` assigned per the IdRef contract in the attachment guide above, and has NO `.Target` / `.SearchedElement.Target` child — attachment happens after insertion.
 
 <ACTION_LIST>
 
-Each action has fields: `display_name`, `type` (NClick | NTypeInto | Delay | ...), and either `reference_id` (for UI activities) with optional `text` (for NTypeInto) or `duration_seconds` (for Delay).
+Each action has fields: `display_name`, `type` (NClick | NTypeInto | Delay | ...), and either `reference_id` (for UI activities) with optional `text` (for NTypeInto) and optional `target_property` (for activities whose target is not at `.Target`, e.g., `SearchedElement.Target`), or `duration_seconds` (for Delay).
 
-For NClick: wrap the element's `<uix:TargetAnchorable>` inside `<uix:NClick.Target>...</uix:NClick.Target>`.
-For NTypeInto: set `Text` as an attribute on `<uix:NTypeInto>` and wrap the TargetAnchorable in `<uix:NTypeInto.Target>...</uix:NTypeInto.Target>`.
-For Delay with CSharp: `<Delay><Delay.Duration><InArgument x:TypeArguments="x:TimeSpan"><CSharpValue x:TypeArguments="x:TimeSpan">TimeSpan.FromSeconds(N)</CSharpValue></InArgument></Delay.Duration></Delay>` — duration as an InArgument, NOT an attribute.
-For Delay with VB: `<Delay Duration="[TimeSpan.FromSeconds(N)]" />`.
+For NClick: insert `<uix:NClick ... sap2010:WorkflowViewState.IdRef="NClick_<N>" />` with no `.Target` child.
+For NTypeInto: set `Text` as an attribute on `<uix:NTypeInto ... sap2010:WorkflowViewState.IdRef="NTypeInto_<N>" Text="...">` with no `.Target` child.
+For Delay with CSharp: `<Delay sap2010:WorkflowViewState.IdRef="Delay_<N>"><Delay.Duration><InArgument x:TypeArguments="x:TimeSpan"><CSharpValue x:TypeArguments="x:TimeSpan">TimeSpan.FromSeconds(N)</CSharpValue></InArgument></Delay.Duration></Delay>` — duration as an InArgument, NOT an attribute.
+For Delay with VB: `<Delay Duration="[TimeSpan.FromSeconds(N)]" sap2010:WorkflowViewState.IdRef="Delay_<N>" />`.
+
+## Attach targets
+
+For every action with a `reference_id`, follow the attachment guide above to attach the OR reference to the IdRef you assigned. Pass `target_property` when the action specifies one. Wrap every CLI call with `timeout 60000`.
 
 ## Validation
 
-After editing:
+After attachment (and any fallback embedding):
 ```bash
 timeout 60000 uip rpa get-errors --file-path "<OUTPUT_XAML_PATH>" --project-dir "<PROJECT_DIR>" --output json```
 Fix on error, max 3 attempts. If CLI times out, report the timeout explicitly — do NOT hang.
@@ -342,11 +345,12 @@ Fix on error, max 3 attempts. If CLI times out, report the timeout explicitly �
 | Placeholder | Value |
 |---|---|
 | <OUTPUT_XAML_PATH> | <fill in> |
+| <RELATIVE_XAML_PATH> | <OUTPUT_XAML_PATH> relative to <PROJECT_DIR> |
 | <PROJECT_DIR> | <fill in> |
 | <EXPRESSION_LANGUAGE> | CSharp or VB |
 | <ACTIVITY_CLASS_LIST> | comma-separated fully-qualified activity class names |
-| <COMMA_SEPARATED_REF_IDS> | ref IDs this agent needs snippets for |
 | <ACTION_LIST> | JSON or YAML list — see [Action List Format](#action-list-format) |
+| <ATTACHMENT_GUIDE_CONTENT> | Verbatim contents of `uia-target-attachment-guide.md` — orchestrator reads the file and pastes the body here |
 """
 )
 ```
@@ -366,9 +370,12 @@ The orchestrator composes the action list once per screen agent from the registe
 Minimum fields per entry:
 - `display_name` — string. Becomes the activity's `DisplayName`.
 - `type` — `NClick`, `NTypeInto`, `Delay`, `NSelectItem`, `NGoToUrl`, etc.
-- For UI activities: `reference_id` — the OR reference ID. The agent looks up the snippet from the `get-elements-xaml` output it fetches itself.
+- For UI activities: `reference_id` — the OR reference ID. The agent passes this to `link-element --reference-id` after inserting the activity.
+- For UI activities whose target is not at `.Target`: optional `target_property` — dot-separated property path (e.g., `"SearchedElement.Target"`). Passed to `link-element --target-property` and used by the fallback embed path. Omit when the default `.Target` applies.
 - For `NTypeInto`: optional `text` — the text to type.
 - For `Delay`: `duration_seconds` instead of `reference_id`.
+
+The agent assigns `sap2010:WorkflowViewState.IdRef` per the contract in the Screen Activity Agent Template — the orchestrator does NOT specify IdRefs in the action list.
 
 ## Task Structure
 

--- a/skills/uipath-rpa/references/uia-prerequisites.md
+++ b/skills/uipath-rpa/references/uia-prerequisites.md
@@ -1,14 +1,15 @@
 # UiAutomation Prerequisites
 
 **Required package:** `UiPath.UIAutomation.Activities`
+**Minimum version (`<MIN_VERSION>`):** `26.4.1-beta.11749457`
 
-The `uip rpa uia` subcommands (snapshot, selector-intelligence, object-repository) used by `uia-configure-target` require **`UiPath.UIAutomation.Activities` >= 26.3.1-beta.11672284**. Before configuring any target, check the installed version in `project.json` under `dependencies`.
+The `uip rpa uia` subcommands (snapshot, selector-intelligence, object-repository) used by `uia-configure-target` require `UiPath.UIAutomation.Activities` at `<MIN_VERSION>` or newer. Before configuring any target, check the installed version in `project.json` under `dependencies`.
 
 If the installed version is below the minimum, ask the user whether to upgrade:
 
 ```bash
 uip rpa get-versions --package-id UiPath.UIAutomation.Activities --project-dir "$PROJECT_DIR" --output json
-# If user approves the upgrade:
-uip rpa install-or-update-packages --packages '[{"id": "UiPath.UIAutomation.Activities", "version": "26.3.1-beta.11672284"}]' --project-dir "$PROJECT_DIR" --output json```
+# If user approves the upgrade (substitute <MIN_VERSION> with the value declared above):
+uip rpa install-or-update-packages --packages '[{"id": "UiPath.UIAutomation.Activities", "version": "<MIN_VERSION>"}]' --project-dir "$PROJECT_DIR" --output json```
 
 If the user declines, warn that `uip rpa uia` commands will fail and fall back to the indication tools (see [uia-configure-target-workflows.md](uia-configure-target-workflows.md) for fallback commands).

--- a/skills/uipath-rpa/references/uia-target-attachment-guide.md
+++ b/skills/uipath-rpa/references/uia-target-attachment-guide.md
@@ -1,0 +1,113 @@
+# OR Target Attachment
+
+How to attach Object Repository screens and elements to XAML workflow activities.
+
+## IdRef Contract
+
+The linker addresses activities by `sap2010:WorkflowViewState.IdRef`. Every activity that will be linked MUST carry a unique IdRef of the form `<ClassName>_<N>` — for example `NApplicationCard_1`, `NClick_1`, `NClick_2`, `NTypeInto_1`. Numbering is per class and unique across the whole file. When inserting activities into an existing file, scan for the highest existing `<ClassName>_<N>` and continue from `N+1`.
+
+This matches Studio's own naming convention, so files remain clean when re-opened in Studio.
+
+## Fast Path: Linking OR Entries to Activities
+
+Write plain activities (no `.Target` child element) with unique IdRefs, then attach targets post-write using `link-screen` and `link-element`.
+
+> **Do not run `link-screen` or `link-element` calls in parallel.** These commands mutate the same `.xaml` file and will corrupt each other when invoked as parallel Bash tool calls. Run them sequentially — either as separate Bash calls one after another, or batched in a single Bash call chained with `&&` (stop on first failure) or `;` (continue on failure). Link the screen first, then link each element.
+
+### 1. Link a screen to an ApplicationCard
+
+```bash
+uip rpa uia object-repository link-screen \
+  --workflow-relative-path "<RELATIVE_XAML_PATH>" \
+  --activity-ref-id "<ACTIVITY_REF_ID>" \
+  --reference-id "<SCREEN_REFERENCE_ID>" \
+  --project-dir "<PROJECT_DIR>" \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--workflow-relative-path` | Yes | Path to the `.xaml` file, relative to the project directory (e.g., `Workflows/Main.xaml`). |
+| `--activity-ref-id` | Yes | The `sap2010:WorkflowViewState.IdRef` on the target activity — typically `NApplicationCard_1`. |
+| `--reference-id` | Yes | OR screen reference returned by `uia-configure-target` or `indicate-application`. |
+
+### 2. Link elements to UI activities
+
+One call per (activity, element) pair. The CLI does not batch.
+
+```bash
+uip rpa uia object-repository link-element \
+  --workflow-relative-path "<RELATIVE_XAML_PATH>" \
+  --activity-ref-id "<ACTIVITY_REF_ID>" \
+  --reference-id "<ELEMENT_REFERENCE_ID>" \
+  --project-dir "<PROJECT_DIR>" \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--workflow-relative-path` | Yes | Path to the `.xaml` file, relative to the project directory. |
+| `--activity-ref-id` | Yes | The `sap2010:WorkflowViewState.IdRef` on the target activity (e.g., `NClick_3`). |
+| `--reference-id` | Yes | OR element reference returned by `uia-configure-target` or `indicate-element`. |
+| `--target-property` | No | Activity property to attach the target to. Supports dotted paths for nested properties (e.g., `SearchedElement.Target`). Defaults to `Target`. |
+
+**When to use `--target-property`:** most UI activities (`NClick`, `NTypeInto`, `NGetText`) attach the target at `.Target`, so the default is correct. Some activities expose the target at a nested property (e.g., anchor-based activities use `SearchedElement.Target`). When the target sits anywhere other than `.Target`, pass `--target-property` explicitly.
+
+**Element reuse:** when the same element is referenced by multiple activities (e.g., the same field clicked and then typed into), call `link-element` once per activity with each activity's own `--activity-ref-id`.
+
+## Fallback: Embedding OR Entries When Linking Fails
+
+Use this path only when a `link-screen` or `link-element` call returns a non-zero exit or an error for a specific reference ID. Embed the OR XAML snippet directly into the matching activity — scoped to only the failed reference, not the whole screen.
+
+### 1. Get the screen XAML for the ApplicationCard
+
+```bash
+uip rpa uia object-repository get-screen-xaml \
+  --reference-id "<SCREEN_REFERENCE_ID>" \
+  --project-dir "<PROJECT_DIR>"
+```
+
+Returns a `<TargetApp>` element. Embed it inside the ApplicationCard:
+
+```xml
+<uix:NApplicationCard.TargetApp>
+  <!-- paste the returned <TargetApp ... /> here -->
+</uix:NApplicationCard.TargetApp>
+```
+
+### 2. Get element XAML for UI activities
+
+```bash
+uip rpa uia object-repository get-elements-xaml \
+  --reference-ids "<REF_1>,<REF_2>,<REF_3>" \
+  --project-dir "<PROJECT_DIR>"
+```
+
+Returns `<TargetAnchorable>` elements, one per reference ID, separated by `=== Element Name ===` headers. Embed each inside its activity's `.Target` property (or the nested property named on the activity, e.g., `SearchedElement.Target`):
+
+```xml
+<uix:NClick ...>
+  <uix:NClick.Target>
+    <!-- paste the returned <TargetAnchorable ... /> here -->
+  </uix:NClick.Target>
+</uix:NClick>
+
+<uix:NTypeInto ...>
+  <uix:NTypeInto.Target>
+    <!-- paste the returned <TargetAnchorable ... /> here -->
+  </uix:NTypeInto.Target>
+</uix:NTypeInto>
+
+<uix:NGetText ...>
+  <uix:NGetText.Target>
+    <!-- paste the returned <TargetAnchorable ... /> here -->
+  </uix:NGetText.Target>
+</uix:NGetText>
+```
+
+| Parameter | Source |
+|-----------|--------|
+| `<SCREEN_REFERENCE_ID>` | OR screen reference returned by `uia-configure-target` or `indicate-application` |
+| `<REF_1>,<REF_2>,...` | Comma-separated OR element references returned by `uia-configure-target` or `indicate-element` |
+
+When an element is used by multiple activities (e.g., the same field clicked and then typed into), use the same `<TargetAnchorable>` snippet in each activity's `.Target` property.


### PR DESCRIPTION
## Summary
- Replace XAML snippet embedding with a `link-screen` / `link-element` fast path for attaching OR entries to workflow activities; embedding remains as a per-ref fallback
- Add `skills/uipath-rpa/references/uia-target-attachment-guide.md` as the single source of truth for the IdRef contract, fast path, and fallback
- Update `ui-automation-guide.md`, `uia-configure-target-workflows.md`, `uia-multi-step-flows.md`, and `uia-parallel-xaml-authoring-guide.md` to point at the new guide and to reflect that write agents now insert plain activities with unique `sap2010:WorkflowViewState.IdRef` values and attach targets via the linker
- Scaffolding and screen-activity agent prompt templates stop pasting `TargetApp` / `TargetAnchorable` XAML into prompts — orchestrator passes only reference IDs plus the attachment guide contents

## Test plan
- [ ] Scaffolding agent produces a valid `.xaml` using `link-screen` against `NApplicationCard_1`
- [ ] Screen-activity agent inserts activities with unique IdRefs and links each element via `link-element` (including `--target-property` for nested targets)
- [ ] Reused-form case links the same element reference to multiple activity IdRefs
- [ ] Fallback embed path still works for a single failing reference ID without re-embedding the whole screen
- [ ] `get-errors` returns clean after attachment in both single-file and multi-screen parallel pipelines