### PR TITLE
chore: replace `solution bundle` refs with `solution upload`

### DIFF
--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -70,7 +70,7 @@ Record each item with a short summary.
 ### 2e. Identify infrastructure dependencies
 
 Determine what environment each skill requires to be testable:
-- **Local-only** — Can run without cloud auth or special hardware (e.g., flow validate, solution bundle)
+- **Local-only** — Can run without cloud auth or special hardware (e.g., flow validate, solution pack)
 - **Cloud auth required** — Needs UiPath tenant authentication (e.g., platform ops, flow debug, deploy)
 - **Platform-specific** — Needs Windows, Studio Desktop, Servo CLI, display, browser extension, etc.
 
@@ -233,7 +233,7 @@ Use this template when the skill has at least one test task.
 Group by theme. Include cross-cutting features (variable management, expression syntax, planning phases, publishing, editing existing artifacts, etc.) that have no coverage:
 
 - **Control flow:** `core.logic.switch`, `core.logic.loop`, `core.logic.merge`, `core.subflow`, `core.logic.terminate`
-- **Publishing:** `uip solution bundle`, `uip solution upload`, `uip flow pack`
+- **Publishing:** `uip solution upload`, `uip flow pack`
 - **Planning:** Phase 1 arch plan generation, Phase 2 impl plan resolution, mermaid diagram validation
 - **Editing:** No test modifies an existing flow (all tests create from scratch)
 

--- a/skills/uipath-agents/references/coded-vs-lowcode-guide.md
+++ b/skills/uipath-agents/references/coded-vs-lowcode-guide.md
@@ -36,7 +36,7 @@ Reference for comparing **coded** (Python) and **low-code** (agent.json) agents.
 | Flow integration | Not supported | 5 patterns (inline, solution, external, tool variants) |
 | Solution support | Standalone projects | Full solution lifecycle |
 | Custom code | Full Python | None |
-| Sync | `uip codedagent push/pull` | `uip solution bundle/upload` |
+| Sync | `uip codedagent push/pull` | `uip solution upload` |
 
 ## Solution-Level Mixing
 

--- a/skills/uipath-agents/references/lowcode/agent-flow-integration.md
+++ b/skills/uipath-agents/references/lowcode/agent-flow-integration.md
@@ -109,7 +109,7 @@ See [embedding-in-flows.md](embedding-in-flows.md) for the full inline agent cre
 
 ## What Happens at Pack Time
 
-`flow-workbench` extracts inline agents during `uip solution bundle` / `uip solution pack`:
+`flow-workbench` extracts inline agents during `uip solution upload` / `uip solution pack`:
 
 1. Reads the inline agent directory referenced by `model.source` UUID
 2. Collects connected resource nodes via artifact handles

--- a/skills/uipath-agents/references/lowcode/agent-solution-guide.md
+++ b/skills/uipath-agents/references/lowcode/agent-solution-guide.md
@@ -354,14 +354,8 @@ uip solution project add ./MySolution/Agent2 ./MySolution/MySolution.uipx --outp
 
 ### Upload to Studio Web
 
-Always bundle first, then upload the `.uis` file. Do not pass a directory path directly to `uip solution upload`.
-
 ```bash
-# Step 1: Bundle to .uis
-uip solution bundle ./MySolution -d ./output --output json
-
-# Step 2: Upload the .uis file
-uip solution upload ./output/MySolution.uis --output json
+uip solution upload ./MySolution --output json
 ```
 
 ### Pack and publish

--- a/skills/uipath-agents/references/lowcode/cli-commands.md
+++ b/skills/uipath-agents/references/lowcode/cli-commands.md
@@ -87,16 +87,13 @@ uip solution project add "<AGENT_PROJECT_DIR>" [solutionFile] --output json
 
 Run from the solution directory. The first argument is the path to the agent project folder (positional, not `--project-path`). The optional second argument is the path to the `.uipx` solution file — if omitted, the CLI searches up from the project path to find the nearest `.uipx` automatically.
 
-### Bundle and Upload to Studio Web
+### Upload to Studio Web
 
-Bundle packages the solution directory into a `.uis` file; upload sends it to Studio Web.
+Upload sends the solution to Studio Web. Accepts a solution directory (containing `.uipx`), a `.uipx` file, or a `.uis` file.
 
 ```bash
-uip solution bundle . -d ./dist --output json
-uip solution upload ./dist/<SOLUTION_NAME>.uis --output json
+uip solution upload . --output json
 ```
-
-Note: `upload` accepts a solution directory (containing `.uipx`), a `.uipx` file, or a `.uis` file as its positional argument. Uploading the directory directly skips the separate bundle step.
 
 ### Pack Solution for Orchestrator
 
@@ -162,9 +159,8 @@ uip solution project add "MyAgent" --output json
 # 3. Edit agent.json, then validate
 uip agent validate MyAgent --output json
 
-# 4. Bundle + upload to Studio Web (for visual development)
-uip solution bundle . -d ./dist --output json
-uip solution upload ./dist/MySolution.uis --output json
+# 4. Upload to Studio Web (for visual development)
+uip solution upload . --output json
 
 # 5. Pack + publish + deploy to Orchestrator
 uip solution pack . ./dist -v "1.0.0" --output json
@@ -187,8 +183,7 @@ uip solution deploy run \
 | Scaffold inline agent | `uip agent init "<FLOW_PROJECT_DIR>" --inline-in-flow --output json` | Any directory |
 | Register project | `uip solution project add "<PATH>" --output json` | Solution directory |
 | Validate + migrate | `uip agent validate [path] --output json` | Agent dir or any directory with path |
-| Bundle for Studio Web | `uip solution bundle . -d ./dist --output json` | Solution directory |
-| Upload to Studio Web | `uip solution upload ./dist/<NAME>.uis --output json` | Any directory |
+| Upload to Studio Web | `uip solution upload . --output json` | Solution directory |
 | Pack | `uip solution pack . ./dist -v "1.0.0" --output json` | Solution directory |
 | Publish | `uip solution publish ./dist/<PKG>.zip --output json` | Any directory |
 | Deploy | `uip solution deploy run --name ... --output json` | Any directory |

--- a/skills/uipath-agents/references/lowcode/quickstart.md
+++ b/skills/uipath-agents/references/lowcode/quickstart.md
@@ -127,16 +127,18 @@ Read [agent-json-format.md](agent-json-format.md) for the full schema.
 
 ### Step 5 — Publish to Studio Web or deploy to Orchestrator
 
-Ask the user before proceeding.
+Ask the user before proceeding. There are two separate paths:
 
-**Always bundle first, then upload the `.uis` file.** Do NOT pass a directory path directly to `uip solution upload` — always go through `uip solution bundle` first to produce a `.uis` artifact, then upload that file.
-
+**Studio Web** (default — for visual editing and sharing):
 ```bash
-# Step 1: Bundle to .uis
-uip solution bundle . -d ./dist --output json
+uip solution upload . --output json
+```
 
-# Step 2: Upload the .uis file to Studio Web
-uip solution upload ./dist/<SOLUTION_NAME>.uis --output json
+**Orchestrator** (for production deployment — only when explicitly requested):
+```bash
+uip solution pack . ./dist -v "1.0.0" --output json
+uip solution publish ./dist/<SOLUTION_NAME>.1.0.0.zip --output json
+uip solution deploy run --name "<NAME>" --package-name "<SOLUTION_NAME>" --package-version "1.0.0" --output json
 ```
 
 ---

--- a/skills/uipath-platform/references/solution-guide.md
+++ b/skills/uipath-platform/references/solution-guide.md
@@ -171,7 +171,6 @@ uip solution deploy run -n "MyDeployment" --package-name "MySolution" --package-
 
 | Command | Description |
 |---------|-------------|
-| `uip solution bundle <solutionPath>` | Bundle solution directory into a .uis file (`-d` for destination) |
 | `uip solution upload <solutionPath>` | Upload solution to UiPath Studio Web (directory, .uipx, or .uis) |
 | `uip solution resource refresh [solutionPath]` | Re-scan projects and sync resource declarations from bindings |
 | `uip solution project import --source <path>` | Copy external project into solution and register in .uipx |


### PR DESCRIPTION
## Summary
- The `solution bundle` CLI command was removed (UiPath/cli#TBD)
- `solution upload` accepts directories directly and bundles internally
- Simplifies skill docs from two-step `bundle + upload` to single-step `upload`
- Updates flow-commands.md, SKILL.md, and solution-guide.md

## Test plan
- [ ] Skill docs render correctly
- [ ] `solution upload <dir>` workflow matches updated instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)