### PR TITLE
feat(maestro-flow): improve skill description for intent matching

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-maestro-flow
-description: "[PREVIEW] UiPath Flow projects (.flow files) — orchestrate RPA, agents, apps. Create, edit, validate, run flows via uip CLI: nodes, variables, subflows, triggers. For XAML or C# workflows→uipath-rpa."
+description: "[PREVIEW] Build automations, orchestrate business processes, connect systems, and handle document/data workflows using UiPath Flows (.flow). Create, edit, validate, run via uip CLI. For C#/XAML workflows→uipath-rpa. For agents→uipath-agents."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 


### PR DESCRIPTION
## Summary
- Updated the `uipath-maestro-flow` SKILL.md description to better capture user intent signals
- New description front-loads action words (automate, orchestrate, connect systems, document/data workflows) so the skill triggers when users describe business problems — not just when they mention `.flow` files
- Keeps technical identity (`.flow`, `uip CLI`) and sibling redirects (`→uipath-rpa`, `→uipath-agents`)

**Before:** `[PREVIEW] UiPath Flow projects (.flow files) — orchestrate RPA, agents, apps. Create, edit, validate, run flows via uip CLI: nodes, variables, subflows, triggers. For XAML or C# workflows→uipath-rpa.`

**After:** `[PREVIEW] Build automations, orchestrate business processes, connect systems, and handle document/data workflows using UiPath Flows (.flow). Create, edit, validate, run via uip CLI. For C#/XAML workflows→uipath-rpa. For agents→uipath-agents.`

## Test plan
- [ ] Verify description is under 250 characters (237 chars)
- [ ] Confirm skill still triggers correctly for `.flow` file requests
- [ ] Confirm skill now triggers for intent-based requests (e.g., "automate my invoice process")

🤖 Generated with [Claude Code](https://claude.com/claude-code)