### PR TITLE
fix(uipath-maestro-flow): correct http.v2 output port name to 'default'

### DIFF
--- a/skills/uipath-maestro-flow/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/impl.md
@@ -12,7 +12,7 @@
 uip flow registry get core.action.http.v2 --output json
 ```
 
-Confirm: input port `input`, output port `output`, model serviceType `Intsvc.UnifiedHttpRequest`.
+Confirm: input port `input`, output port `default`, model serviceType `Intsvc.UnifiedHttpRequest`.
 
 ## Critical: Use `node configure`
 
@@ -77,14 +77,14 @@ uip flow node configure <ProjectName>.flow <nodeId> \
 
 ### Step 4 — Wire edges
 
-The managed HTTP node uses port `output`:
+The managed HTTP node uses port `default`:
 
 ```bash
 uip flow edge add <ProjectName>.flow <upstreamNodeId> <nodeId> \
   --source-port <port> --target-port input --output json
 
 uip flow edge add <ProjectName>.flow <nodeId> <downstreamNodeId> \
-  --source-port output --target-port input --output json
+  --source-port default --target-port input --output json
 ```
 
 ## Debug


### PR DESCRIPTION
## Summary
- `core.action.http.v2` output handle id is `default`, not `output` (confirmed via `uip flow registry get core.action.http.v2`)
- Incorrect port name in impl.md would cause edge wiring commands to fail at runtime

https://github.com/UiPath/cli/pull/807

## Test plan
- [ ] Verify `uip flow registry get core.action.http.v2 --output json` shows `"id": "default"` for the output handle