### PR TITLE
test(uipath-maestro-flow): add 4 e2e tests for high-priority coverage gaps

### DIFF
--- a/tests/tasks/uipath-maestro-flow/managed_http_v2/check_managed_http_v2.py
+++ b/tests/tasks/uipath-maestro-flow/managed_http_v2/check_managed_http_v2.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Managed HTTP v2: assert core.action.http.v2 is used and legacy v1 is not."""
+
+import glob
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import (  # noqa: E402
+    assert_output_int_in_range,
+    find_project_dir,
+    run_debug,
+)
+
+
+def _load_flow_types(project_dir: str) -> list[str]:
+    flows = glob.glob(os.path.join(project_dir, "*.flow"))
+    if not flows:
+        sys.exit(f"FAIL: No .flow file found in {project_dir}")
+    with open(flows[0]) as f:
+        flow = json.load(f)
+    return [n.get("type", "") for n in flow.get("nodes", [])]
+
+
+def main():
+    project_dir = find_project_dir()
+    types = _load_flow_types(project_dir)
+
+    has_v2 = any(t == "core.action.http.v2" for t in types)
+    has_v1 = any(t == "core.action.http" for t in types)
+
+    if not has_v2:
+        sys.exit(
+            f"FAIL: Expected at least one core.action.http.v2 node, found types: {types}"
+        )
+    if has_v1:
+        sys.exit(
+            f"FAIL: Flow uses deprecated core.action.http (v1). The http plugin mandates v2. Types: {types}"
+        )
+
+    payload = run_debug(timeout=240)
+    # Seattle temperature in Fahrenheit — loose bounds across seasons
+    assert_output_int_in_range(payload, -20, 120)
+    print("OK: core.action.http.v2 used; v1 absent; debug returned a plausible temperature")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/managed_http_v2/managed_http_v2.yaml
+++ b/tests/tasks/uipath-maestro-flow/managed_http_v2/managed_http_v2.yaml
@@ -1,0 +1,51 @@
+task_id: skill-flow-managed-http-v2
+description: >
+  Create a UiPath Flow that calls the open-meteo weather API using Managed HTTP
+  Request (core.action.http.v2) in manual mode. Exercises the deprecation of
+  core.action.http v1 — the http plugin mandates v2 for all HTTP requests,
+  including manual-auth calls. Verifies the agent chooses v2 and does not fall
+  back to the legacy v1 node type.
+tags: [uipath-maestro-flow, e2e, generate, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "ManagedHttpWeather" that fetches the
+  current temperature for Seattle from the open-meteo API
+  (https://api.open-meteo.com/v1/forecast?latitude=47.6&longitude=-122.3&current=temperature_2m&temperature_unit=fahrenheit)
+  and returns the temperature as a number output.
+
+  Use the Managed HTTP Request node in manual mode (no connector connection
+  needed — open-meteo is a public API).
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # -- Flow file validity --
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate ManagedHttpWeather/ManagedHttpWeather/ManagedHttpWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # -- Structural and execution checks --
+  - type: run_command
+    description: "Flow uses core.action.http.v2 (not deprecated v1) and returns a plausible temperature"
+    command: "python3 $TASK_DIR/check_managed_http_v2.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/managed_http_v2/managed_http_v2.yaml
+++ b/tests/tasks/uipath-maestro-flow/managed_http_v2/managed_http_v2.yaml
@@ -5,7 +5,7 @@ description: >
   core.action.http v1 — the http plugin mandates v2 for all HTTP requests,
   including manual-auth calls. Verifies the agent chooses v2 and does not fall
   back to the legacy v1 node type.
-tags: [uipath-maestro-flow, e2e, generate, ootb]
+tags: [uipath-maestro-flow, integration, generate, ootb]
 max_iterations: 1
 
 agent:

--- a/tests/tasks/uipath-maestro-flow/merge_parallel/check_merge_parallel.py
+++ b/tests/tasks/uipath-maestro-flow/merge_parallel/check_merge_parallel.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Parallel merge: assert a merge node synchronizes two parallel HTTP branches."""
+
+import glob
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    find_project_dir,
+    run_debug,
+)
+
+
+def _load_flow(project_dir: str) -> dict:
+    flows = glob.glob(os.path.join(project_dir, "*.flow"))
+    if not flows:
+        sys.exit(f"FAIL: No .flow file found in {project_dir}")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def main():
+    assert_flow_has_node_type(["core.logic.merge"])
+
+    project_dir = find_project_dir()
+    flow = _load_flow(project_dir)
+
+    merge_ids = [
+        n["id"] for n in flow.get("nodes", []) if n.get("type") == "core.logic.merge"
+    ]
+    if not merge_ids:
+        sys.exit("FAIL: No core.logic.merge node in the flow")
+
+    # Merge plugin: accepts multiple incoming edges on the same `input` port
+    incoming = [
+        e for e in flow.get("edges", []) if e.get("targetNodeId") in merge_ids
+    ]
+    if len(incoming) < 2:
+        sys.exit(
+            f"FAIL: Expected 2+ edges into the merge node to prove parallel "
+            f"synchronization, found {len(incoming)}: {incoming}"
+        )
+
+    # Both incoming paths must originate from HTTP nodes (v1 or v2)
+    http_ids = {
+        n["id"]
+        for n in flow.get("nodes", [])
+        if n.get("type", "").startswith("core.action.http")
+    }
+    upstream_sources = {_trace_upstream(flow, e["sourceNodeId"]) for e in incoming}
+    if not all(any(src in http_ids for src in chain) for chain in upstream_sources):
+        sys.exit(
+            f"FAIL: Expected both merge inputs to trace back to HTTP nodes. "
+            f"http_ids={http_ids}, upstream_chains={upstream_sources}"
+        )
+
+    payload = run_debug(timeout=240)
+    assert_outputs_contain(payload, ["Seattle", "Phoenix"])
+    print("OK: merge node with 2+ HTTP upstreams; debug returned both cities")
+
+
+def _trace_upstream(flow: dict, node_id: str, depth: int = 5) -> frozenset:
+    """Walk upstream from node_id up to `depth` hops, return set of visited ids."""
+    seen = set()
+    frontier = [node_id]
+    for _ in range(depth):
+        next_frontier = []
+        for nid in frontier:
+            if nid in seen:
+                continue
+            seen.add(nid)
+            for e in flow.get("edges", []):
+                if e.get("targetNodeId") == nid:
+                    next_frontier.append(e["sourceNodeId"])
+        frontier = next_frontier
+    return frozenset(seen)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/merge_parallel/merge_parallel.yaml
+++ b/tests/tasks/uipath-maestro-flow/merge_parallel/merge_parallel.yaml
@@ -1,0 +1,53 @@
+task_id: skill-flow-merge-parallel
+description: >
+  Create a UiPath Flow that fans out to two parallel HTTP calls (Seattle and
+  Phoenix open-meteo), then synchronizes them with a Merge node before
+  returning both temperatures. Exercises the core.logic.merge plugin and the
+  parallel-execution-with-merge topology pattern — neither is covered by any
+  existing test.
+tags: [uipath-maestro-flow, e2e, generate, ootb]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "ParallelCityWeather" that fetches the
+  current temperature for Seattle and Phoenix in parallel from open-meteo
+  (https://api.open-meteo.com/v1/forecast with latitude/longitude and
+  current=temperature_2m, temperature_unit=fahrenheit), synchronizes both
+  branches with a Merge node, and returns both temperatures in a single
+  output containing the strings "Seattle" and "Phoenix".
+
+  Both HTTP calls must run in parallel (fan out from the trigger, converge at
+  the Merge node) — do not wire them sequentially.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # -- Flow file validity --
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate ParallelCityWeather/ParallelCityWeather/ParallelCityWeather.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # -- Structural and execution checks --
+  - type: run_command
+    description: "Flow contains a merge node with two parallel HTTP inputs and debug returns both cities"
+    command: "python3 $TASK_DIR/check_merge_parallel.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/mock_placeholder/check_mock_placeholder.py
+++ b/tests/tasks/uipath-maestro-flow/mock_placeholder/check_mock_placeholder.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Mock placeholder: assert core.logic.mock present and no hallucinated RPA node."""
+
+import glob
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import find_project_dir  # noqa: E402
+
+
+def _load_flow(project_dir: str) -> dict:
+    flows = glob.glob(os.path.join(project_dir, "*.flow"))
+    if not flows:
+        sys.exit(f"FAIL: No .flow file found in {project_dir}")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def main():
+    project_dir = find_project_dir()
+    flow = _load_flow(project_dir)
+
+    types = [n.get("type", "") for n in flow.get("nodes", [])]
+
+    has_mock = any(t == "core.logic.mock" for t in types)
+    if not has_mock:
+        sys.exit(
+            f"FAIL: Expected a core.logic.mock placeholder for the unpublished "
+            f"RPA process per Critical Rule 14. Node types found: {types}"
+        )
+
+    # Agent must NOT hallucinate an RPA resource node when the process doesn't exist
+    hallucinated = [t for t in types if t.startswith("uipath.core.rpa")]
+    if hallucinated:
+        sys.exit(
+            f"FAIL: Flow references an RPA resource node that does not exist in "
+            f"the tenant. Anti-Pattern 7 says insert a mock, not hallucinate a "
+            f"resource key. Offending types: {hallucinated}"
+        )
+
+    print("OK: core.logic.mock present; no hallucinated RPA node")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/mock_placeholder/mock_placeholder.yaml
+++ b/tests/tasks/uipath-maestro-flow/mock_placeholder/mock_placeholder.yaml
@@ -1,0 +1,74 @@
+task_id: skill-flow-mock-placeholder
+description: >
+  Create a UiPath Flow that references an RPA process that has not yet been
+  published to the tenant. Per Critical Rule 14 and Anti-Pattern 7, the agent
+  must insert a core.logic.mock placeholder and tell the user which skill to
+  invoke (uipath-rpa) to create the real process — not hallucinate a resource
+  key, and not chain to another skill automatically. Local-only: no cloud
+  debug is performed because the mock node produces no side effects.
+tags: [uipath-maestro-flow, e2e, generate, ootb, mock]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "MockInvoicePipeline" that triggers
+  manually, invokes an RPA process called "GenerateInvoicePdf" to produce a
+  PDF from an invoice number, and returns the resulting file path as a string
+  output.
+
+  The RPA process "GenerateInvoicePdf" does NOT exist in the tenant yet.
+
+  Also save a report to report.json summarizing what you did, including which
+  skill the user should use to create the missing process:
+    {
+      "project_name": "MockInvoicePipeline",
+      "missing_resource": "GenerateInvoicePdf",
+      "next_skill": "<name of the skill that creates RPA processes>"
+    }
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Do NOT invoke other skills automatically. Only produce the handoff instructions in report.json.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # -- Flow file validity --
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate MockInvoicePipeline/MockInvoicePipeline/MockInvoicePipeline.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # -- Structural check: mock node is present --
+  - type: run_command
+    description: "Flow contains a core.logic.mock placeholder (not a hallucinated rpa node)"
+    command: "python3 $TASK_DIR/check_mock_placeholder.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  # -- Handoff: report points to the correct skill --
+  - type: json_check
+    description: "report.json names uipath-rpa as the skill that creates the missing process"
+    path: "report.json"
+    assertions:
+      - expression: "missing_resource"
+        operator: equals
+        expected: "GenerateInvoicePdf"
+      - expression: "next_skill"
+        operator: contains
+        expected: "uipath-rpa"
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/plan_artifacts/check_plan_artifacts.py
+++ b/tests/tasks/uipath-maestro-flow/plan_artifacts/check_plan_artifacts.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Plan artifacts: verify the built flow matches the plan's branching topology."""
+
+import glob
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.flow_check import find_project_dir  # noqa: E402
+
+
+def _load_flow(project_dir: str) -> dict:
+    flows = glob.glob(os.path.join(project_dir, "*.flow"))
+    if not flows:
+        sys.exit(f"FAIL: No .flow file found in {project_dir}")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def main():
+    project_dir = find_project_dir()
+    flow = _load_flow(project_dir)
+
+    types = [n.get("type", "") for n in flow.get("nodes", [])]
+
+    decision_count = sum(1 for t in types if t == "core.logic.decision")
+    end_count = sum(1 for t in types if t == "core.control.end")
+    http_count = sum(1 for t in types if t.startswith("core.action.http"))
+
+    if decision_count < 1:
+        sys.exit(f"FAIL: Expected ≥1 core.logic.decision node, found {decision_count}")
+    if end_count < 2:
+        sys.exit(
+            f"FAIL: Decision-branched flow needs two End nodes (one per path), found {end_count}"
+        )
+    if http_count < 1:
+        sys.exit(f"FAIL: Expected ≥1 HTTP node to fetch order details, found {http_count}")
+
+    # Every `out` variable must be mapped on every reachable End node (Critical Rule 12)
+    out_vars = [
+        v
+        for v in flow.get("variables", {}).get("globals", [])
+        if v.get("direction") == "out"
+    ]
+    if out_vars:
+        for n in flow.get("nodes", []):
+            if n.get("type") != "core.control.end":
+                continue
+            outputs = n.get("outputs") or {}
+            for v in out_vars:
+                name = v.get("id") or v.get("name")
+                if name and name not in outputs:
+                    sys.exit(
+                        f"FAIL: End node '{n.get('id')}' missing output mapping for "
+                        f"'out' variable '{name}' (Critical Rule 12)"
+                    )
+
+    print(
+        f"OK: flow has {decision_count} decision, {end_count} ends, {http_count} HTTP; "
+        f"out-var mappings present on every End"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/plan_artifacts/plan_artifacts.yaml
+++ b/tests/tasks/uipath-maestro-flow/plan_artifacts/plan_artifacts.yaml
@@ -1,0 +1,75 @@
+task_id: skill-flow-plan-artifacts
+description: >
+  Build a multi-node Flow and verify the agent produces BOTH planning
+  artifacts — <Solution>.arch.plan.md (Phase 1) and <Solution>.impl.plan.md
+  (Phase 2). Step 4 and Critical Rule 2 mandate these artifacts for multi-node
+  flows, but no existing test checks for them. The agent currently passes
+  every e2e by jumping straight to Step 5 — this test closes that gap.
+  Local-only: no cloud debug is performed.
+tags: [uipath-maestro-flow, e2e, generate, ootb, planning]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "OrderPipeline" that does the following:
+    1. Triggers manually with a numeric "orderId" input
+    2. Calls an HTTP endpoint to fetch order details (use open-meteo as a stub:
+       https://api.open-meteo.com/v1/forecast?latitude=47.6&longitude=-122.3&current=temperature_2m)
+    3. Uses a Script node to extract the temperature field as a numeric score
+    4. Branches on a Decision node: score >50 -> "priority" path, else -> "standard" path
+    5. Each path ends with its own End node outputting the label and score
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass, but follow the skill's workflow and produce BOTH planning artifacts along the way.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # -- Flow file validity --
+  - type: run_command
+    description: "uip flow validate passes on the flow file"
+    command: "uip flow validate OrderPipeline/OrderPipeline/OrderPipeline.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # -- Phase 1: architectural plan exists with mermaid diagram --
+  - type: file_exists
+    description: "Phase 1 architectural plan was written to the solution directory"
+    path: "OrderPipeline/OrderPipeline.arch.plan.md"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Arch plan contains a horizontal mermaid diagram per planning-arch.md rules"
+    path: "OrderPipeline/OrderPipeline.arch.plan.md"
+    includes:
+      - "graph LR"
+      - "mermaid"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # -- Phase 2: implementation plan exists --
+  - type: file_exists
+    description: "Phase 2 implementation plan was written to the solution directory"
+    path: "OrderPipeline/OrderPipeline.impl.plan.md"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # -- Structural check on the built flow --
+  - type: run_command
+    description: "Built flow has the expected decision + end topology from the plan"
+    command: "python3 $TASK_DIR/check_plan_artifacts.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Adds 4 e2e tasks for `uipath-maestro-flow` targeting the highest-priority coverage gaps identified in the coverage report. No skill content changes; tests only.

| Task | Gap Closed |
|------|-----------|
| `skill-flow-managed-http-v2` | `core.action.http.v2` (Managed HTTP) — plugin mandates v2; Anti-Patterns 16 & 17 previously untested |
| `skill-flow-merge-parallel` | `core.logic.merge` plugin — previously zero coverage; parallel-execution-with-merge topology |
| `skill-flow-mock-placeholder` | `core.logic.mock` — Critical Rule 14 + Anti-Pattern 7 (no skill chaining) |
| `skill-flow-plan-artifacts` | Step 4 planning artifacts (`.arch.plan.md`, `.impl.plan.md`) — previously unchecked |

Each task follows the existing `_shared/flow_check.py` pattern: `uip flow validate` run_command (weight 3.0) + a `check_<name>.py` run_command (weight 4.0–5.0) asserting topology and (where applicable) debug output.

### Infrastructure

| Task | Cloud auth | Debug executed |
|------|-----------|---------------|
| managed_http_v2 | Yes | Yes (open-meteo, public API) |
| merge_parallel | Yes | Yes (open-meteo × 2) |
| mock_placeholder | No | No (validate only — mock produces no side effects) |
| plan_artifacts | No | No (validate + artifact file checks only) |

## Test plan

- [ ] `make test-uipath-maestro-flow` — all 4 new tasks pass locally (or in the staging tenant CI)
- [ ] Spot-check `managed_http_v2` fails if the agent uses deprecated v1 (manually edit the produced flow and re-run the check script)
- [ ] Spot-check `mock_placeholder` fails if the agent hallucinates a `uipath.core.rpa-*` node instead of `core.logic.mock`
- [ ] Spot-check `plan_artifacts` fails if the `*.arch.plan.md` or `*.impl.plan.md` file is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)