### PR TITLE
test(uipath-maestro-flow): add 18 connector-feature integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# macOS
+.DS_Store
+**/.DS_Store
+
 # Python-generated files
 __pycache__/
 *.py[oc]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install all smoke integration e2e
+.PHONY: help install all smoke integration e2e tags
 
 SKILLS_REPO_PATH ?= $(shell cd .. && pwd)
 VENV := .venv
@@ -26,6 +26,18 @@ integration:  ## Run all integration tests
 
 e2e:  ## Run all end-to-end tests
 	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml --tags e2e -j 1 -v
+
+tags:  ## Run tests matching one or more tags: make tags TAGS="integration connector-feature" [EXPERIMENT=experiments/integration.yaml]
+	@if [ -z "$(TAGS)" ]; then echo "Usage: make tags TAGS=\"tag1 tag2\" [EXPERIMENT=experiments/<file>.yaml]"; exit 2; fi
+	@TAGS="$(TAGS)" python3 -c 'import os,re,sys,glob; \
+wanted=set(os.environ["TAGS"].split()); \
+files=sorted(glob.glob("tasks/**/*.yaml", recursive=True)); \
+matches=[]; \
+[matches.append(f) for f in files if (lambda m: m and wanted.issubset({t.strip() for t in m.group(1).split(",")}))(re.search(r"^tags:\s*\[([^\]]+)\]", open(f).read(), re.M))]; \
+print(f"Matched {len(matches)} task(s) for tags: {sorted(wanted)}"); \
+[print(f"  - {m}") for m in matches]; \
+sys.exit(0 if matches else 3)'
+	$(CODER_EVAL) run $(TASKS) -e $(or $(EXPERIMENT),experiments/default.yaml) $(foreach t,$(TAGS),--tags $(t)) -j 1 -v
 
 # Run all tests for a specific skill: make test-uipath-maestro-flow
 test-%:  ## Run all tests for a specific skill

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,11 @@ make integration
 # Run all e2e tests
 make e2e
 
+# Run tests matching a combination of tags (AND semantics — tasks must carry all listed tags) (defaults to experiments/default.yaml):
+make tags TAGS="integration connector-feature"
+# Optionally override the experiment config 
+make tags TAGS="integration connector-feature" EXPERIMENT=experiments/integration.yaml
+
 # Run all tests for a specific skill
 make test-uipath-maestro-flow
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -212,9 +212,14 @@ def _parse_json(stdout: str) -> dict | None:
 
 
 def _find_project(pattern: str) -> str:
-    projects = glob.glob(pattern, recursive=True)
+    projects = sorted(glob.glob(pattern, recursive=True))
     if not projects:
         _fail(f"No project.uiproj found matching {pattern}")
+    if len(projects) > 1:
+        joined = "\n  - ".join(projects)
+        _fail(
+            f"Multiple projects match {pattern!r} — refusing to guess:\n  - {joined}"
+        )
     return os.path.dirname(projects[0])
 
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -4,10 +4,19 @@ description: >
   CEQL filter expression
 tags: [uipath-maestro-flow, integration, connector-feature, ceql-where]
 
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
 sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |
@@ -35,3 +44,4 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -1,0 +1,44 @@
+task_id: skill-flow-ipe-ceql_where
+description: >
+  Tests the CEQL where query IS feature — configures a connector node with a
+  CEQL filter expression
+tags: [uipath-maestro-flow, integration, connector, ceql-where]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a flow called "CeqlWhereTest" with a manual trigger that lists all sharepoint sites that were created in the last 7 days.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "CeqlWhere test failed".
+  Route success to a final action that logs "CeqlWhere test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow references uipath-microsoft-onedrive and has Decision + Terminate nodes"
+    command: "python3 $TASK_DIR/check_ceql_where_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 8.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -2,14 +2,7 @@ task_id: skill-flow-ipe-ceql_where
 description: >
   Tests the CEQL where query IS feature — configures a connector node with a
   CEQL filter expression
-tags: [uipath-maestro-flow, integration, connector, ceql-where]
-
-task_timeout: 1500
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 50
+tags: [uipath-maestro-flow, integration, connector-feature, ceql-where]
 
 sandbox:
   driver: tempdir
@@ -38,7 +31,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: "uip\\s+flow\\s+validate"
     min_count: 1
+    require_success: true
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""CEQL where: verify the flow targets the SharePoint connector, has
+Decision + Terminate nodes for the success/failure routing, and has the
+connector node configured with a ``where`` CEQL filter — both as a
+``queryParameters.where`` entry and as a ``savedFilterTrees.where`` entry
+inside the connector ``configuration`` blob."""
+
+import glob
+import json
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
+from _shared.flow_check import assert_flow_has_node_type  # noqa: E402
+
+CONNECTOR_KEY = "uipath-microsoft-onedrive"
+FLOW_GLOB = "**/CeqlWhereTest*.flow"
+
+
+def _find_flow() -> str:
+    flows = glob.glob(FLOW_GLOB, recursive=True)
+    if not flows:
+        sys.exit(f"FAIL: No flow file matching {FLOW_GLOB}")
+    return flows[0]
+
+
+def _find_connector_node(flow: dict) -> dict:
+    for node in flow.get("nodes") or []:
+        node_type = node.get("type", "")
+        if CONNECTOR_KEY in node_type and node_type.startswith("uipath.connector."):
+            return node
+    sys.exit(
+        f"FAIL: No connector node with type containing "
+        f"'uipath.connector.{CONNECTOR_KEY}...' found"
+    )
+
+
+def _parse_configuration(detail: dict) -> dict:
+    """``inputs.detail.configuration`` is stored as ``=jsonString:{...}``.
+    Strip the prefix and parse the JSON payload."""
+    raw = detail.get("configuration")
+    if not isinstance(raw, str) or not raw.strip():
+        sys.exit("FAIL: connector node inputs.detail.configuration is missing or empty")
+    payload = re.sub(r"^\s*=jsonString:\s*", "", raw)
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: inputs.detail.configuration is not valid JSON: {e}")
+
+
+def assert_where_configured(node: dict) -> None:
+    detail = (node.get("inputs") or {}).get("detail") or {}
+    if not detail:
+        sys.exit("FAIL: connector node is missing inputs.detail")
+
+    query_params = detail.get("queryParameters") or {}
+    where_value = query_params.get("where")
+    if not isinstance(where_value, str) or not where_value.strip():
+        sys.exit(
+            "FAIL: connector node inputs.detail.queryParameters.where "
+            "must be a non-empty string"
+        )
+
+    config = _parse_configuration(detail)
+
+    essential = config.get("essentialConfiguration") or {}
+    saved_trees = essential.get("savedFilterTrees") or {}
+    where_tree = saved_trees.get("where")
+    if not isinstance(where_tree, dict):
+        sys.exit(
+            "FAIL: inputs.detail.configuration.essentialConfiguration."
+            "savedFilterTrees.where is missing — the CEQL filter must be "
+            "persisted in the filter builder tree"
+        )
+
+    filters = where_tree.get("filters")
+    if not isinstance(filters, list) or not filters:
+        sys.exit(
+            "FAIL: savedFilterTrees.where.filters is empty — "
+            "add at least one filter entry (e.g. createdDateTime operator)"
+        )
+
+    first = filters[0]
+    if not first.get("id"):
+        sys.exit("FAIL: savedFilterTrees.where.filters[0].id is missing")
+    if not first.get("operator"):
+        sys.exit("FAIL: savedFilterTrees.where.filters[0].operator is missing")
+    value = first.get("value")
+    if not isinstance(value, dict) or value.get("value") in (None, ""):
+        sys.exit("FAIL: savedFilterTrees.where.filters[0].value.value is missing")
+
+
+def main():
+    flow_path = _find_flow()
+    with open(flow_path) as f:
+        flow = json.load(f)
+    if "nodes" not in flow or "edges" not in flow:
+        sys.exit("FAIL: Flow missing 'nodes' or 'edges'")
+
+    raw = open(flow_path).read()
+    if CONNECTOR_KEY not in raw:
+        sys.exit(f"FAIL: Connector key {CONNECTOR_KEY!r} not found in {flow_path}")
+
+    connector_node = _find_connector_node(flow)
+    assert_where_configured(connector_node)
+
+    assert_flow_has_node_type(["decision", "terminate"])
+
+    print(
+        f"OK: {len(flow['nodes'])} nodes, {len(flow['edges'])} edges; "
+        f"{CONNECTOR_KEY} referenced; Decision and Terminate nodes present; "
+        f"where filter configured in queryParameters and savedFilterTrees"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
@@ -94,11 +94,11 @@ def assert_where_configured(node: dict) -> None:
 def main():
     flow_path = _find_flow()
     with open(flow_path) as f:
-        flow = json.load(f)
+        raw = f.read()
+    flow = json.loads(raw)
     if "nodes" not in flow or "edges" not in flow:
         sys.exit("FAIL: Flow missing 'nodes' or 'edges'")
 
-    raw = open(flow_path).read()
     if CONNECTOR_KEY not in raw:
         sys.exit(f"FAIL: Connector key {CONNECTOR_KEY!r} not found in {flow_path}")
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-complex_array
+description: >
+  Tests the complex array IS feature — configures a connector node with a
+  complex array field on the Act! 365 connector.
+tags: [uipath-maestro-flow, integration, connector, complex-array]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "ComplexArrayTest" with a manual trigger.
+  You need a flow that records a sales interaction in Act! 365 and associates it
+  with several contacts in one call. Discover the right Act! 365 add-activity
+  operation and populate the contacts field (a complex array of contact IDs).
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "ComplexArray test failed".
+  Route success to a final action that logs "ComplexArray test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/ComplexArrayTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-act-act365"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/ComplexArrayTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-act-act365' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/ComplexArrayTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-complex_array
 description: >
   Tests the complex array IS feature — configures a connector node with a
   complex array field on the Act! 365 connector.
-tags: [uipath-maestro-flow, integration, connector, complex-array]
+tags: [uipath-maestro-flow, integration, connector-feature, complex-array]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-dtl_load_by_default_false
 description: >
   Tests the DTL loadByDefault=false IS feature — configures a connector node
   where dropdown values load only on user interaction on the WooCommerce connector.
-tags: [uipath-maestro-flow, integration, connector, dtl-load-by-default-false]
+tags: [uipath-maestro-flow, integration, connector-feature, dtl-load-by-default-false]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-dtl_load_by_default_false
+description: >
+  Tests the DTL loadByDefault=false IS feature — configures a connector node
+  where dropdown values load only on user interaction on the WooCommerce connector.
+tags: [uipath-maestro-flow, integration, connector, dtl-load-by-default-false]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "DTLLoadByDefaultFalseTest" with a manual trigger.
+  You need a flow that lists WooCommerce products filtered by an attribute term
+  the caller picks from a dropdown that loads on demand. Discover the
+  list-products operation and configure its attribute-term field — a DTL field
+  whose values are loaded only on user interaction (loadByDefault=false).
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "DTLLoadByDefaultFalse test failed".
+  Route success to a final action that logs "DTLLoadByDefaultFalse test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultFalseTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-automattic-woocommerce"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultFalseTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-automattic-woocommerce' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultFalseTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-dtl_load_by_default_true
 description: >
   Tests the DTL loadByDefault=true IS feature — configures a connector node
   where a dropdown is pre-populated on the Azure connector.
-tags: [uipath-maestro-flow, integration, connector, dtl-load-by-default-true]
+tags: [uipath-maestro-flow, integration, connector-feature, dtl-load-by-default-true]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-dtl_load_by_default_true
+description: >
+  Tests the DTL loadByDefault=true IS feature — configures a connector node
+  where a dropdown is pre-populated on the Azure connector.
+tags: [uipath-maestro-flow, integration, connector, dtl-load-by-default-true]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "DTLLoadByDefaultTrueTest" with a manual trigger.
+  You need a flow that provisions a new Azure resource group in a chosen region.
+  Discover the create-resource-group operation and pick the region from the
+  location dropdown (a DTL-backed field whose values load by default).
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "DTLLoadByDefaultTrue test failed".
+  Route success to a final action that logs "DTLLoadByDefaultTrue test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultTrueTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-microsoft-azure"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultTrueTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-azure' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultTrueTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-enhanced_enum
+description: >
+  Tests the enhanced enum IS feature — configures a connector node with an
+  enhanced enum field with display labels on the WooCommerce connector.
+tags: [uipath-maestro-flow, integration, connector, enhanced-enum]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "EnhancedEnumTest" with a manual trigger.
+  You need a flow that retrieves WooCommerce product reviews sorted either
+  ascending or descending by the caller's choice. Discover the
+  get-product-reviews operation and pick the sort value from the enhanced-enum
+  order field (which exposes display labels alongside raw values).
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "EnhancedEnum test failed".
+  Route success to a final action that logs "EnhancedEnum test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnhancedEnumTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-automattic-woocommerce"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnhancedEnumTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-automattic-woocommerce' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnhancedEnumTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-enhanced_enum
 description: >
   Tests the enhanced enum IS feature — configures a connector node with an
   enhanced enum field with display labels on the WooCommerce connector.
-tags: [uipath-maestro-flow, integration, connector, enhanced-enum]
+tags: [uipath-maestro-flow, integration, connector-feature, enhanced-enum]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-enum
+description: >
+  Tests the enum IS feature — configures a connector node with an enum field
+  on the Azure connector for storage account kind.
+tags: [uipath-maestro-flow, integration, connector, enum]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "EnumTest" with a manual trigger.
+  You need a flow that provisions a new Azure Storage Account and chooses a
+  storage-account kind (BlobStorage, FileStorage, StorageV2, etc.) from the
+  allowed enum values. Discover the create-storage-account operation and set the
+  enum field appropriately.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "Enum test failed".
+  Route success to a final action that logs "Enum test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnumTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-microsoft-azure"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnumTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-azure' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnumTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-enum
 description: >
   Tests the enum IS feature — configures a connector node with an enum field
   on the Azure connector for storage account kind.
-tags: [uipath-maestro-flow, integration, connector, enum]
+tags: [uipath-maestro-flow, integration, connector-feature, enum]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-field_actions
+description: >
+  Tests the field actions IS feature — configures a connector node with
+  field action dependencies on the WooCommerce connector.
+tags: [uipath-maestro-flow, integration, connector, field-actions]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "FieldActionsTest" with a manual trigger.
+  You need a flow that lists products from a WooCommerce store filtered by a
+  specific attribute term (for example, products tagged with a particular
+  color). Discover the right WooCommerce list/search operation and wire the
+  attribute-term field so its dependent field actions resolve correctly.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "FieldActions test failed".
+  Route success to a final action that logs "FieldActions test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FieldActionsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-automattic-woocommerce"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FieldActionsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-automattic-woocommerce' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FieldActionsTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-field_actions
 description: >
   Tests the field actions IS feature — configures a connector node with
   field action dependencies on the WooCommerce connector.
-tags: [uipath-maestro-flow, integration, connector, field-actions]
+tags: [uipath-maestro-flow, integration, connector-feature, field-actions]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-file_picker
 description: >
   Tests the FolderPicker IS feature — configures a connector node with a
   folder picker field on the Egnyte connector.
-tags: [uipath-maestro-flow, integration, connector, file-picker]
+tags: [uipath-maestro-flow, integration, connector-feature, file-picker]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-file_picker
+description: >
+  Tests the FolderPicker IS feature — configures a connector node with a
+  folder picker field on the Egnyte connector.
+tags: [uipath-maestro-flow, integration, connector, file-picker]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "FilePickerTest" with a manual trigger.
+  You need a flow that fires whenever a new folder is created under a designated
+  parent folder in Egnyte. Discover the Egnyte trigger and select the parent
+  folder via the folder-picker control.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "FilePicker test failed".
+  Route success to a final action that logs "FilePicker test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FilePickerTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-egnyte-egnyte"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FilePickerTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-egnyte-egnyte' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FilePickerTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-filter_builder
 description: >
   Tests the FilterBuilder IS feature — configures a connector node with a
   filter builder on the SAP S/4HANA Cloud connector's where parameter.
-tags: [uipath-maestro-flow, integration, connector, filter-builder]
+tags: [uipath-maestro-flow, integration, connector-feature, filter-builder]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-filter_builder
+description: >
+  Tests the FilterBuilder IS feature — configures a connector node with a
+  filter builder on the SAP S/4HANA Cloud connector's where parameter.
+tags: [uipath-maestro-flow, integration, connector, filter-builder]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "FilterBuilderTest" with a manual trigger.
+  You need a flow that queries SAP S/4HANA Cloud for a set of entity records
+  matching a business filter (for example, active customers in a specific
+  country). Discover the right connector operation and compose the filter
+  condition using the filter-builder control on the query parameter.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "FilterBuilder test failed".
+  Route success to a final action that logs "FilterBuilder test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FilterBuilderTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-sap-s4hanacloud"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FilterBuilderTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-sap-s4hanacloud' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/FilterBuilderTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-generate_schema
+description: >
+  Tests the GenerateSchema IS feature — configures a connector node with
+  schema generation on the Azure Application Insights connector.
+tags: [uipath-maestro-flow, integration, connector, generate-schema]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "GenerateSchemaTest" with a manual trigger.
+  You need a flow that runs a KQL query against an Azure Application Insights
+  workspace and returns the result with a generated output schema. Discover the
+  Application Insights execute-query operation and rely on the generate-schema
+  action to shape the response.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "GenerateSchema test failed".
+  Route success to a final action that logs "GenerateSchema test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/GenerateSchemaTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-microsoft-azureapplicationinsights"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/GenerateSchemaTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-azureapplicationinsights' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/GenerateSchemaTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-generate_schema
 description: >
   Tests the GenerateSchema IS feature — configures a connector node with
   schema generation on the Azure Application Insights connector.
-tags: [uipath-maestro-flow, integration, connector, generate-schema]
+tags: [uipath-maestro-flow, integration, connector-feature, generate-schema]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-list_curated
 description: >
   Tests the curated List operation IS feature — configures a connector node
   with curated list fields on the Google Tasks connector.
-tags: [uipath-maestro-flow, integration, connector, list-curated]
+tags: [uipath-maestro-flow, integration, connector-feature, list-curated]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-list_curated
+description: >
+  Tests the curated List operation IS feature — configures a connector node
+  with curated list fields on the Google Tasks connector.
+tags: [uipath-maestro-flow, integration, connector, list-curated]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "ListCuratedTest" with a manual trigger.
+  You need a flow that fetches every task from a specific Google Tasks list.
+  Discover the curated list operation for Google Tasks and wire it so the
+  curated fields are surfaced on the node output.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "ListCurated test failed".
+  Route success to a final action that logs "ListCurated test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/ListCuratedTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-google-tasks"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/ListCuratedTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-google-tasks' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/ListCuratedTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-method_override
 description: >
   Tests the method override display name IS feature — configures a connector
   node with method-level overrides on the Azure connector.
-tags: [uipath-maestro-flow, integration, connector, method-override]
+tags: [uipath-maestro-flow, integration, connector-feature, method-override]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-method_override
+description: >
+  Tests the method override display name IS feature — configures a connector
+  node with method-level overrides on the Azure connector.
+tags: [uipath-maestro-flow, integration, connector, method-override]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "MethodOverrideTest" with a manual trigger.
+  You need a flow that retrieves the registration token for an Azure Virtual
+  Desktop / Windows 365 host pool in a given resource group. Discover the right
+  Azure host-pool operation — its registration-info token fields use
+  method-level display-name overrides.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "MethodOverride test failed".
+  Route success to a final action that logs "MethodOverride test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/MethodOverrideTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-microsoft-azure"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/MethodOverrideTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-azure' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/MethodOverrideTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-multiselect
 description: >
   Tests the multiselect IS feature — configures a connector node with a
   multiselect field on the Act! 365 connector.
-tags: [uipath-maestro-flow, integration, connector, multiselect]
+tags: [uipath-maestro-flow, integration, connector-feature, multiselect]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-multiselect
+description: >
+  Tests the multiselect IS feature — configures a connector node with a
+  multiselect field on the Act! 365 connector.
+tags: [uipath-maestro-flow, integration, connector, multiselect]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "MultiselectTest" with a manual trigger.
+  You need a flow that creates a new contact in Act! 365 and assigns the contact
+  to several groups at once. Discover the create-contact operation and populate
+  the multi-select groups field with multiple values.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "Multiselect test failed".
+  Route success to a final action that logs "Multiselect test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/MultiselectTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-act-act365"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/MultiselectTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-act-act365' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/MultiselectTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-path_params
 description: >
   Tests the path parameters IS feature — configures a connector node with a
   path parameter on the Google Tasks connector.
-tags: [uipath-maestro-flow, integration, connector, path-params]
+tags: [uipath-maestro-flow, integration, connector-feature, path-params]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-path_params
+description: >
+  Tests the path parameters IS feature — configures a connector node with a
+  path parameter on the Google Tasks connector.
+tags: [uipath-maestro-flow, integration, connector, path-params]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "PathParamsTest" with a manual trigger.
+  You need a flow that deletes a single task from a specific Google Tasks list.
+  Discover the right delete operation and provide both the task list ID (path
+  parameter) and the task ID.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "PathParams test failed".
+  Route success to a final action that logs "PathParams test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/PathParamsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-google-tasks"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/PathParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-google-tasks' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/PathParamsTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-query_params
 description: >
   Tests the query parameters IS feature — configures a connector node with a
   query parameter on the Google Tasks connector.
-tags: [uipath-maestro-flow, integration, connector, query-params]
+tags: [uipath-maestro-flow, integration, connector-feature, query-params]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-query_params
+description: >
+  Tests the query parameters IS feature — configures a connector node with a
+  query parameter on the Google Tasks connector.
+tags: [uipath-maestro-flow, integration, connector, query-params]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "QueryParamsTest" with a manual trigger.
+  You need a flow that lists all Google Tasks including hidden ones. Discover
+  the right Google Tasks list operation and set its "show hidden" query
+  parameter so hidden tasks are returned.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "QueryParams test failed".
+  Route success to a final action that logs "QueryParams test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/QueryParamsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-google-tasks"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/QueryParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-google-tasks' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/QueryParamsTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-required_groups
 description: >
   Tests the required groups IS feature — configures a connector node where at
   least one field from each required group must be populated on the Teams connector.
-tags: [uipath-maestro-flow, integration, connector, required-groups]
+tags: [uipath-maestro-flow, integration, connector-feature, required-groups]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-required_groups
+description: >
+  Tests the required groups IS feature — configures a connector node where at
+  least one field from each required group must be populated on the Teams connector.
+tags: [uipath-maestro-flow, integration, connector, required-groups]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "RequiredGroupsTest" with a manual trigger.
+  You need a flow that replies to a Microsoft Teams channel message with one or
+  more file attachments. Discover the reply-to-channel-message operation and
+  populate the attachments field — the activity enforces required-group rules,
+  so at least one field from each required group must be filled in.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "RequiredGroups test failed".
+  Route success to a final action that logs "RequiredGroups test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/RequiredGroupsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-microsoft-teams"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/RequiredGroupsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-teams' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/RequiredGroupsTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-searchable_joins
 description: >
   Tests the searchable joins IS feature — configures a connector node with
   a join on a related object on the Salesforce connector.
-tags: [uipath-maestro-flow, integration, connector, searchable-joins]
+tags: [uipath-maestro-flow, integration, connector-feature, searchable-joins]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -1,0 +1,64 @@
+task_id: skill-flow-ipe-searchable_joins
+description: >
+  Tests the searchable joins IS feature — configures a connector node with
+  a join on a related object on the Salesforce connector.
+tags: [uipath-maestro-flow, integration, connector, searchable-joins]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "SearchableJoinsTest" with a manual trigger.
+  You need a flow that queries Salesforce accounts and returns each account
+  together with its related opportunities. Discover the Salesforce account
+  operation and configure a searchable join against the related object.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "SearchableJoins test failed".
+  Route success to a final action that logs "SearchableJoins test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/SearchableJoinsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-salesforce-sfdc"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/SearchableJoinsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-salesforce-sfdc' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/SearchableJoinsTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
@@ -16,6 +16,7 @@ sandbox:
   driver: tempdir
   python: {}
   node:
+    # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
       - "@uipath/cli@0.1.21"
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-ipe-upload
 description: >
   Tests the multipart file upload IS feature — configures a connector node
   with a file upload field on the Google Speech-to-Text connector.
-tags: [uipath-maestro-flow, integration, connector, upload]
+tags: [uipath-maestro-flow, integration, connector-feature, upload]
 
 task_timeout: 1500
 agent:

--- a/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-ipe-upload
+description: >
+  Tests the multipart file upload IS feature — configures a connector node
+  with a file upload field on the Google Speech-to-Text connector.
+tags: [uipath-maestro-flow, integration, connector, upload]
+
+task_timeout: 1500
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 50
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/cli@0.1.21"
+initial_prompt: |
+  Create a new Flow project called "UploadTest" with a manual trigger.
+  You need a flow that takes a short audio file and produces a text transcript
+  using Google Cloud's Speech-to-Text service. Discover the right connector and
+  operation, wire the audio file through the multipart upload input, and return
+  the transcript.
+  Add a Decision node to check whether the call succeeded.
+  Route failure to a Terminate node with error message "Upload test failed".
+  Route success to a final action that logs "Upload test passed".
+  Validate the final flow file.
+
+success_criteria:
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/UploadTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has a connector node referencing uipath-google-speechtotext"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/UploadTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-google-speechtotext' in content, 'Connector key not found'; print('OK: connector key present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow has Decision and Terminate nodes"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/UploadTest*.flow',recursive=True); assert flows; f=json.load(open(flows[0])); types=[n.get('type','') for n in f['nodes']]; assert any('decision' in t.lower() for t in types), 'No Decision node'; assert any('terminate' in t.lower() for t in types), 'No Terminate node'; print('OK: Decision and Terminate nodes present')\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "uip flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+max_iterations: 1


### PR DESCRIPTION
## Summary
Connector-feature coverage lives with the rest of the `uipath-maestro-flow` tests. No skill content changes — tests only.

Each task targets one Integration Service connector feature, discovered by the `connector-finder` scanner. The agent must configure a connector node with that feature end-to-end and validate the resulting `.flow` file.

| Feature | Connector | Activity |
|---------|-----------|----------|
| upload | uipath-google-speechtotext | Convert Short Speech to Text |
| filterBuilder | uipath-sap-s4hanacloud | Query Entity |
| filePicker | uipath-egnyte-egnyte | Folder Created |
| fieldActions | uipath-automattic-woocommerce | List Records |
| complexArray | uipath-act-act365 | Add Activity |
| ceqlWhere | uipath-microsoft-onedrive | List Records with List of Sites object |
| queryParams | uipath-google-tasks | List Records |
| pathParams | uipath-google-tasks | Delete Record |
| generateSchema | uipath-microsoft-azureapplicationinsights | generateSchema |
| methodOverride | uipath-microsoft-azure | hostPools::resourceGroups |
| listCurated | uipath-google-tasks | List Tasks |
| searchableJoins | uipath-salesforce-sfdc | Account |
| multiselect | uipath-act-act365 | Create Contact |
| dtlLoadByDefaultTrue | uipath-microsoft-azure | Create Resource Group |
| dtlLoadByDefaultFalse | uipath-automattic-woocommerce | List Records |
| enum | uipath-microsoft-azure | Create Storage Account |
| enhancedEnum | uipath-automattic-woocommerce | Get Product Reviews |
| requiredGroups | uipath-microsoft-teams | Reply to Channel Message |

### Transforms applied during port

- `task_id: flow-*` → `task_id: skill-flow-*` (matches repo convention)
- `tags: [flow, ...]` → `tags: [uipath-maestro-flow, integration, ...]`
- Prompts reference `uipath-maestro-flow` (not `uipath-flow`)
- `connector_feature_prompts.csv` kept as source-of-truth index

All other fields (success_criteria, sandbox.node.env_packages pinning `@uipath/cli@0.1.21`, max_turns: 50) preserved from the source PR.

## Test plan

- [x] `make integration` picks up all 18 new tasks (filtered by `integration` tag)
- [x] Confirm `task_id` uniqueness across the repo (already verified locally — no duplicates)
- There are some known failures but we are doing EDD and fixing things as we find them. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)