### PR TITLE
feat(hooks): add opt-in session logger for debug ease

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ c/
 
 # macOS Finder metadata
 **/.DS_Store
+
+# UiPath session logs
+**/.uipath-logs/

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,0 +1,100 @@
+# Plugin Hooks
+
+Shell scripts invoked by Claude Code at plugin lifecycle events. Wired up in [`hooks.json`](./hooks.json).
+
+| Script | Event(s) | Purpose |
+|--------|----------|---------|
+| [`ensure-uip.sh`](./ensure-uip.sh) | `SessionStart` (once) | Installs/updates `@uipath/cli`, `@uipath/servo`, and `@uipath/rpa-tool` |
+| [`uipath-session-logger.sh`](./uipath-session-logger.sh) | `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `SessionEnd` | Opt-in session capture for debugging |
+| [`validate-skill-descriptions.sh`](./validate-skill-descriptions.sh) | Git pre-commit | Enforces the 250-character limit on skill `description` frontmatter |
+
+## Session Logger — Enable / Disable
+
+The logger is **off by default**. Turn it on by exporting `UIPATH_SESSION_LOG` before starting Claude Code:
+
+```bash
+# bash / zsh
+export UIPATH_SESSION_LOG=1
+claude
+
+# PowerShell
+$env:UIPATH_SESSION_LOG = "1"
+claude
+```
+
+Values that enable capture (case-insensitive): `1`, `true`, `yes`, `on`. Anything else — including unset, empty, `0`, `false` — disables it.
+
+Disable:
+
+```bash
+unset UIPATH_SESSION_LOG   # bash / zsh
+Remove-Item Env:UIPATH_SESSION_LOG   # PowerShell
+```
+
+Toggling mid-session only affects future hook invocations — already-captured events stay on disk.
+
+## Session Logger — What Gets Captured
+
+Logs land at `<cwd>/.uipath-logs/<session-id>/`, keyed by Claude Code's own session id (so `claude --resume` appends to the same folder).
+
+```
+.uipath-logs/<session-id>/
+├── session.json              # session_id, cwd, start_ts, UIPATH_* env
+├── prompts.jsonl             # one line per UserPromptSubmit
+├── tools.jsonl               # pre/post entries per tool call
+├── project-snapshot/         # *.uis / solution.json / project.json at SessionStart
+└── summary.json              # written on Stop / SessionEnd
+```
+
+Single JSON string fields larger than 64 KiB are replaced with `{"truncated": true, "bytes": N}`. The full payload is still available in Claude Code's own transcript at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`.
+
+## Session Logger — Quick Recipes
+
+```bash
+# Latest capture
+LATEST=$(ls -1dt .uipath-logs/*/ | head -1)
+
+# Every Bash command the agent ran
+jq -r 'select(.phase=="pre" and .tool=="Bash") | .input.command' \
+   "$LATEST/tools.jsonl"
+
+# Tool calls that returned an error
+jq 'select(.phase=="post")
+    | select((.response | tostring | test("\"is_error\"\\s*:\\s*true"))
+          or ((.response.exit_code? // 0) != 0))' \
+   "$LATEST/tools.jsonl"
+
+# Summary
+jq . "$LATEST/summary.json"
+```
+
+## .gitignore
+
+Never commit `.uipath-logs/`. Captured payloads may contain orchestrator tokens, PATs, tenant URLs, or customer data. Add to your project's `.gitignore`:
+
+```gitignore
+# UiPath session capture
+.uipath-logs/
+```
+
+## Dependencies
+
+`uipath-session-logger.sh` requires `jq`. If `jq` is not on `PATH`, the logger emits a single warning to stderr and becomes a no-op for the rest of the session.
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install -y jq
+# macOS
+brew install jq
+# Windows (Git Bash)
+winget install jqlang.jq
+```
+
+## Contract
+
+All hook scripts in this directory MUST:
+
+1. Work on Windows (Git Bash / MSYS), macOS, and Linux.
+2. Never block the user's session for more than the `timeout` declared in `hooks.json`.
+3. Exit 0 for non-fatal failures. Only exit non-zero when the session genuinely cannot continue (e.g., required tooling missing for `ensure-uip.sh`).
+4. Be idempotent — safe to invoke multiple times.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -24,7 +24,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" UserPromptSubmit",
-            "timeout": 10
+            "timeout": 10,
+            "async": true
           }
         ]
       }
@@ -35,7 +36,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" PreToolUse",
-            "timeout": 10
+            "timeout": 10,
+            "async": true
           }
         ]
       }
@@ -46,7 +48,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" PostToolUse",
-            "timeout": 10
+            "timeout": 10,
+            "async": true
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -9,6 +9,66 @@
             "timeout": 180,
             "once": true,
             "statusMessage": "Checking uip, servo and rpa-tool installation..."
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" SessionStart",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" UserPromptSubmit",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" PreToolUse",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" PostToolUse",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" Stop",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/uipath-session-logger.sh\" SessionEnd",
+            "timeout": 15
           }
         ]
       }

--- a/hooks/uipath-session-logger.sh
+++ b/hooks/uipath-session-logger.sh
@@ -119,12 +119,57 @@ case "$EVENT" in
   SessionStart)
     # session.json — one-shot; do not overwrite a resumed session's metadata.
     if [ ! -f "$LOG_DIR/session.json" ]; then
-      ENV_JSON="$(env | awk -F= '/^UIPATH_/{k=$1; sub(/^[^=]*=/,""); printf "%s\t%s\n", k, $0}' \
+      # Secret-free subset of UIPATH_* env vars. Tokens are filtered out.
+      ENV_JSON="$(env \
+        | awk -F= '/^UIPATH_/ && !/^UIPATH_(ACCESS|REFRESH|ID)_TOKEN=/ && !/^UIPATH_CLIENT_SECRET=/ {k=$1; sub(/^[^=]*=/,""); printf "%s\t%s\n", k, $0}' \
         | jq -R -s '
             split("\n") | map(select(length>0)) | map(split("\t")) |
             map({key: .[0], value: .[1]}) | from_entries
           ' 2>/dev/null)"
       [ -z "$ENV_JSON" ] && ENV_JSON='{}'
+
+      # Pull non-secret identity from ~/.uipath/.auth (dotenv format written by `uip login`).
+      UIPATH_URL_VAL=""
+      UIPATH_ORG_VAL=""
+      UIPATH_ORG_ID_VAL=""
+      UIPATH_TENANT_VAL=""
+      UIPATH_TENANT_ID_VAL=""
+      AUTH_FILE="$HOME/.uipath/.auth"
+      if [ -f "$AUTH_FILE" ]; then
+        UIPATH_URL_VAL="$(awk -F= '/^UIPATH_URL=/{sub(/^[^=]*=/,""); print; exit}' "$AUTH_FILE" 2>/dev/null)"
+        UIPATH_ORG_VAL="$(awk -F= '/^UIPATH_ORGANIZATION_NAME=/{sub(/^[^=]*=/,""); print; exit}' "$AUTH_FILE" 2>/dev/null)"
+        UIPATH_ORG_ID_VAL="$(awk -F= '/^UIPATH_ORGANIZATION_ID=/{sub(/^[^=]*=/,""); print; exit}' "$AUTH_FILE" 2>/dev/null)"
+        UIPATH_TENANT_VAL="$(awk -F= '/^UIPATH_TENANT_NAME=/{sub(/^[^=]*=/,""); print; exit}' "$AUTH_FILE" 2>/dev/null)"
+        UIPATH_TENANT_ID_VAL="$(awk -F= '/^UIPATH_TENANT_ID=/{sub(/^[^=]*=/,""); print; exit}' "$AUTH_FILE" 2>/dev/null)"
+      fi
+      # Env vars override the auth file if both are set.
+      UIPATH_URL_VAL="${UIPATH_URL:-$UIPATH_URL_VAL}"
+      UIPATH_ORG_VAL="${UIPATH_ORGANIZATION_NAME:-$UIPATH_ORG_VAL}"
+      UIPATH_ORG_ID_VAL="${UIPATH_ORGANIZATION_ID:-$UIPATH_ORG_ID_VAL}"
+      UIPATH_TENANT_VAL="${UIPATH_TENANT_NAME:-$UIPATH_TENANT_VAL}"
+      UIPATH_TENANT_ID_VAL="${UIPATH_TENANT_ID:-$UIPATH_TENANT_ID_VAL}"
+
+      STUDIO_WEB_LINK=""
+      if [ -n "$UIPATH_URL_VAL" ] && [ -n "$UIPATH_ORG_VAL" ] && [ -n "$UIPATH_TENANT_VAL" ]; then
+        STUDIO_WEB_LINK="${UIPATH_URL_VAL%/}/${UIPATH_ORG_VAL}/${UIPATH_TENANT_VAL}/studio_/"
+      fi
+
+      UIPATH_BLOCK="$(jq -n \
+        --arg url "$UIPATH_URL_VAL" \
+        --arg org "$UIPATH_ORG_VAL" \
+        --arg org_id "$UIPATH_ORG_ID_VAL" \
+        --arg tenant "$UIPATH_TENANT_VAL" \
+        --arg tenant_id "$UIPATH_TENANT_ID_VAL" \
+        --arg sw "$STUDIO_WEB_LINK" \
+        '{
+          url: ($url | select(length>0)),
+          organization: ($org | select(length>0)),
+          organization_id: ($org_id | select(length>0)),
+          tenant: ($tenant | select(length>0)),
+          tenant_id: ($tenant_id | select(length>0)),
+          studio_web_link: ($sw | select(length>0))
+        } | with_entries(select(.value != null))' 2>/dev/null)"
+      [ -z "$UIPATH_BLOCK" ] && UIPATH_BLOCK='{}'
 
       jq -n \
         --arg session_id "$SESSION_ID" \
@@ -132,7 +177,8 @@ case "$EVENT" in
         --arg event "$EVENT" \
         --arg ts "$TS" \
         --argjson env "$ENV_JSON" \
-        '{session_id:$session_id, cwd:$cwd, hook_event_name:$event, start_ts:$ts, env:$env}' \
+        --argjson uipath "$UIPATH_BLOCK" \
+        '{session_id:$session_id, cwd:$cwd, hook_event_name:$event, start_ts:$ts, uipath:$uipath, env:$env}' \
         > "$LOG_DIR/session.json" 2>/dev/null \
         || warn "failed to write session.json"
     fi
@@ -224,6 +270,51 @@ case "$EVENT" in
     PROMPT_COUNT=0
     [ -f "$PROMPTS_FILE" ] && PROMPT_COUNT="$(wc -l < "$PROMPTS_FILE" | tr -d ' ')"
 
+    # Carry over the uipath identity block captured at SessionStart.
+    UIPATH_BLOCK='{}'
+    if [ -f "$SESSION_FILE" ]; then
+      UIPATH_BLOCK="$(jq -c '.uipath // {}' "$SESSION_FILE" 2>/dev/null)"
+      [ -z "$UIPATH_BLOCK" ] && UIPATH_BLOCK='{}'
+    fi
+
+    # Connector activities matrix — scan project snapshot + tools.jsonl for
+    # UiPath Integration Service activity/package references. Patterns covered:
+    #   UiPath.<Connector>.IntegrationService[.Activities][.<Activity>]
+    #   UiPath.IntegrationService.Activities.<Connector>[.<Activity>]
+    SNAP_DIR="$LOG_DIR/project-snapshot"
+    CONN_RAW="$(
+      {
+        [ -d "$SNAP_DIR" ] && find "$SNAP_DIR" -type f -exec \
+          grep -ohE 'UiPath\.[A-Za-z0-9]+\.IntegrationService(\.Activities)?(\.[A-Za-z0-9]+)?' {} + 2>/dev/null
+        [ -d "$SNAP_DIR" ] && find "$SNAP_DIR" -type f -exec \
+          grep -ohE 'UiPath\.IntegrationService\.Activities\.[A-Za-z0-9]+(\.[A-Za-z0-9]+)?' {} + 2>/dev/null
+        [ -f "$TOOLS_FILE" ] && \
+          grep -ohE 'UiPath\.[A-Za-z0-9]+\.IntegrationService(\.Activities)?(\.[A-Za-z0-9]+)?' "$TOOLS_FILE" 2>/dev/null
+        [ -f "$TOOLS_FILE" ] && \
+          grep -ohE 'UiPath\.IntegrationService\.Activities\.[A-Za-z0-9]+(\.[A-Za-z0-9]+)?' "$TOOLS_FILE" 2>/dev/null
+      } | sort
+    )"
+
+    CONN_MATRIX='{}'
+    if [ -n "$CONN_RAW" ]; then
+      CONN_MATRIX="$(printf '%s\n' "$CONN_RAW" | jq -R -s '
+        def parse:
+          (capture("^UiPath\\.(?<connector>[A-Za-z0-9]+)\\.IntegrationService(\\.Activities)?(\\.(?<activity>[A-Za-z0-9]+))?$"; "")) //
+          (capture("^UiPath\\.IntegrationService\\.Activities\\.(?<connector>[A-Za-z0-9]+)(\\.(?<activity>[A-Za-z0-9]+))?$"; "")) //
+          null;
+        split("\n") | map(select(length>0)) | map(parse) | map(select(. != null))
+        | group_by(.connector)
+        | map({
+            key: .[0].connector,
+            value: {
+              references: length,
+              activities: (map(.activity // empty) | unique)
+            }
+          }) | from_entries
+      ' 2>/dev/null)"
+      [ -z "$CONN_MATRIX" ] && CONN_MATRIX='{}'
+    fi
+
     TOTAL_BYTES=0
     for f in "$SESSION_FILE" "$PROMPTS_FILE" "$TOOLS_FILE"; do
       [ -f "$f" ] || continue
@@ -239,6 +330,8 @@ case "$EVENT" in
       --argjson error_count "$ERROR_COUNT" \
       --argjson prompt_count "$PROMPT_COUNT" \
       --argjson total_bytes "$TOTAL_BYTES" \
+      --argjson uipath "$UIPATH_BLOCK" \
+      --argjson connector_activities "$CONN_MATRIX" \
       --arg event "$EVENT" \
       '{
         session_id:$session_id,
@@ -248,6 +341,8 @@ case "$EVENT" in
         tool_counts:$tool_counts,
         error_count:$error_count,
         total_bytes:$total_bytes,
+        uipath:$uipath,
+        connector_activities:$connector_activities,
         finalized_on:$event
       }' > "$LOG_DIR/summary.json" 2>/dev/null \
       || warn "failed to write summary.json"

--- a/hooks/uipath-session-logger.sh
+++ b/hooks/uipath-session-logger.sh
@@ -1,0 +1,268 @@
+#!/bin/bash
+# Opt-in Claude Code session logger for UiPath skills.
+# Wired into hooks.json — invoked as:
+#   uipath-session-logger.sh <EVENT_NAME>
+# with the hook JSON payload on stdin.
+#
+# ── How to enable ────────────────────────────────────────────────────
+# The logger is a no-op unless UIPATH_SESSION_LOG is set to one of
+# 1, true, yes, on (case-insensitive). Example:
+#
+#   export UIPATH_SESSION_LOG=1   # bash / zsh
+#   claude                        # (re)start Claude Code
+#
+# PowerShell:
+#   $env:UIPATH_SESSION_LOG = "1"
+#   claude
+#
+# Disable with: unset UIPATH_SESSION_LOG   (or remove the env var).
+#
+# ── What gets captured ───────────────────────────────────────────────
+# Written to <cwd>/.uipath-logs/<session-id>/:
+#   session.json            session_id, cwd, start timestamp, UIPATH_* env
+#   prompts.jsonl           one line per user prompt
+#   tools.jsonl             pre/post entries per tool invocation
+#   project-snapshot/       copy of *.uis / solution.json / project.json
+#   summary.json            written on Stop / SessionEnd
+#
+# Single JSON string fields larger than 64 KiB are replaced with
+#   {"truncated": true, "bytes": N}
+# The full payload is still available in Claude Code's own transcript
+# under ~/.claude/projects/<encoded-cwd>/<session-id>.jsonl.
+#
+# Add `.uipath-logs/` to .gitignore — captured payloads may contain
+# orchestrator tokens, tenant URLs, PATs, or customer data.
+#
+# ── Dependencies ─────────────────────────────────────────────────────
+# Requires jq on PATH. If jq is missing, the logger emits a single
+# warning on stderr and becomes a no-op for the rest of the session.
+#
+# See hooks/README.md for more detail.
+
+EVENT="${1:-}"
+
+# ── Enablement gate ──────────────────────────────────────────────────
+# Any failure below this line is swallowed — we must never block the user.
+case "$(printf '%s' "${UIPATH_SESSION_LOG:-}" | tr '[:upper:]' '[:lower:]')" in
+  1|true|yes|on) ;;
+  *) exit 0 ;;
+esac
+
+warn() { printf '[uipath-session-logger] %s\n' "$*" >&2; }
+
+# All further errors are caught and logged; the script still exits 0.
+{
+
+set +e
+
+if ! command -v jq >/dev/null 2>&1; then
+  warn "jq not found on PATH — capture disabled for this session. Install jq to enable."
+  exit 0
+fi
+
+# ── Read payload ─────────────────────────────────────────────────────
+# Hook JSON is delivered on stdin. Buffer it once; reuse for every query.
+PAYLOAD="$(cat)"
+if [ -z "$PAYLOAD" ]; then
+  warn "empty hook payload for event=$EVENT"
+  exit 0
+fi
+
+# jq helper — returns empty string on parse failure instead of failing.
+jget() { printf '%s' "$PAYLOAD" | jq -r "$1 // empty" 2>/dev/null; }
+
+SESSION_ID="$(jget '.session_id')"
+CWD_FROM_HOOK="$(jget '.cwd')"
+CWD="${CWD_FROM_HOOK:-$(pwd)}"
+
+if [ -z "$SESSION_ID" ]; then
+  warn "missing .session_id in payload for event=$EVENT"
+  exit 0
+fi
+
+LOG_DIR="$CWD/.uipath-logs/$SESSION_ID"
+mkdir -p "$LOG_DIR" 2>/dev/null || { warn "cannot create $LOG_DIR"; exit 0; }
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# Truncate any string field > TRUNC_BYTES; replace with a marker object.
+# 64 KiB keeps single-tool logs reasonable while preserving most CLI output.
+TRUNC_BYTES=65536
+
+# Walks the given JSON value; for each string field larger than TRUNC_BYTES,
+# replaces it with {truncated, bytes, sha256}. Non-string values are untouched.
+truncate_large_strings() {
+  local raw="$1"
+  printf '%s' "$raw" | jq --argjson limit "$TRUNC_BYTES" '
+    def walk_trunc:
+      if type == "string" and (length > $limit) then
+        { truncated: true, bytes: length }
+      elif type == "array" then
+        map(walk_trunc)
+      elif type == "object" then
+        with_entries(.value |= walk_trunc)
+      else
+        .
+      end;
+    walk_trunc
+  ' 2>/dev/null
+}
+
+# Append a JSON object (one line) to a JSONL file.
+append_jsonl() {
+  local file="$1" obj="$2"
+  printf '%s\n' "$obj" >> "$file" 2>/dev/null || warn "append failed: $file"
+}
+
+# ── Event dispatch ───────────────────────────────────────────────────
+case "$EVENT" in
+  SessionStart)
+    # session.json — one-shot; do not overwrite a resumed session's metadata.
+    if [ ! -f "$LOG_DIR/session.json" ]; then
+      ENV_JSON="$(env | awk -F= '/^UIPATH_/{k=$1; sub(/^[^=]*=/,""); printf "%s\t%s\n", k, $0}' \
+        | jq -R -s '
+            split("\n") | map(select(length>0)) | map(split("\t")) |
+            map({key: .[0], value: .[1]}) | from_entries
+          ' 2>/dev/null)"
+      [ -z "$ENV_JSON" ] && ENV_JSON='{}'
+
+      jq -n \
+        --arg session_id "$SESSION_ID" \
+        --arg cwd "$CWD" \
+        --arg event "$EVENT" \
+        --arg ts "$TS" \
+        --argjson env "$ENV_JSON" \
+        '{session_id:$session_id, cwd:$cwd, hook_event_name:$event, start_ts:$ts, env:$env}' \
+        > "$LOG_DIR/session.json" 2>/dev/null \
+        || warn "failed to write session.json"
+    fi
+
+    # project-snapshot — copy *.uis / solution.json / project.json from cwd.
+    SNAP="$LOG_DIR/project-snapshot"
+    mkdir -p "$SNAP" 2>/dev/null
+    copied=0
+    for pattern in '*.uis' 'solution.json' 'project.json'; do
+      for src in "$CWD"/$pattern; do
+        [ -e "$src" ] || continue
+        cp -p "$src" "$SNAP/" 2>/dev/null && copied=$((copied+1))
+      done
+    done
+    if [ "$copied" -eq 0 ]; then
+      rmdir "$SNAP" 2>/dev/null
+    fi
+    ;;
+
+  UserPromptSubmit)
+    PROMPT="$(jget '.prompt')"
+    OBJ="$(jq -n -c \
+      --arg ts "$TS" \
+      --arg session_id "$SESSION_ID" \
+      --arg prompt "$PROMPT" \
+      '{ts:$ts, session_id:$session_id, prompt:$prompt}' 2>/dev/null)"
+    [ -n "$OBJ" ] && append_jsonl "$LOG_DIR/prompts.jsonl" "$OBJ"
+    ;;
+
+  PreToolUse)
+    TOOL="$(jget '.tool_name')"
+    RAW_INPUT="$(printf '%s' "$PAYLOAD" | jq -c '.tool_input // null' 2>/dev/null)"
+    SAFE_INPUT="$(truncate_large_strings "$RAW_INPUT")"
+    [ -z "$SAFE_INPUT" ] && SAFE_INPUT='null'
+
+    OBJ="$(jq -n -c \
+      --arg ts "$TS" \
+      --arg session_id "$SESSION_ID" \
+      --arg tool "$TOOL" \
+      --argjson input "$SAFE_INPUT" \
+      '{ts:$ts, session_id:$session_id, phase:"pre", tool:$tool, input:$input}' 2>/dev/null)"
+    [ -n "$OBJ" ] && append_jsonl "$LOG_DIR/tools.jsonl" "$OBJ"
+    ;;
+
+  PostToolUse)
+    TOOL="$(jget '.tool_name')"
+    RAW_RESP="$(printf '%s' "$PAYLOAD" | jq -c '.tool_response // null' 2>/dev/null)"
+    SAFE_RESP="$(truncate_large_strings "$RAW_RESP")"
+    [ -z "$SAFE_RESP" ] && SAFE_RESP='null'
+
+    DURATION_MS="$(jget '.tool_duration_ms')"
+    [ -z "$DURATION_MS" ] && DURATION_MS='null'
+
+    OBJ="$(jq -n -c \
+      --arg ts "$TS" \
+      --arg session_id "$SESSION_ID" \
+      --arg tool "$TOOL" \
+      --argjson response "$SAFE_RESP" \
+      --argjson duration "$DURATION_MS" \
+      '{ts:$ts, session_id:$session_id, phase:"post", tool:$tool, response:$response, duration_ms:$duration}' 2>/dev/null)"
+    [ -n "$OBJ" ] && append_jsonl "$LOG_DIR/tools.jsonl" "$OBJ"
+    ;;
+
+  Stop|SessionEnd)
+    TOOLS_FILE="$LOG_DIR/tools.jsonl"
+    PROMPTS_FILE="$LOG_DIR/prompts.jsonl"
+    SESSION_FILE="$LOG_DIR/session.json"
+
+    START_TS='null'
+    [ -f "$SESSION_FILE" ] && START_TS="$(jq -c '.start_ts // null' "$SESSION_FILE" 2>/dev/null)"
+
+    TOOL_COUNTS='{}'
+    ERROR_COUNT=0
+    if [ -f "$TOOLS_FILE" ]; then
+      TOOL_COUNTS="$(jq -s -c '
+        map(select(.phase=="pre")) | group_by(.tool)
+        | map({key:.[0].tool, value:length}) | from_entries
+      ' "$TOOLS_FILE" 2>/dev/null)"
+      ERROR_COUNT="$(jq -s '
+        map(select(.phase=="post")
+            | select((.response | tostring | test("\"is_error\"\\s*:\\s*true"))
+                  or ((.response.exit_code? // 0) != 0)))
+        | length
+      ' "$TOOLS_FILE" 2>/dev/null)"
+    fi
+    [ -z "$TOOL_COUNTS" ] && TOOL_COUNTS='{}'
+    [ -z "$ERROR_COUNT" ] && ERROR_COUNT=0
+
+    PROMPT_COUNT=0
+    [ -f "$PROMPTS_FILE" ] && PROMPT_COUNT="$(wc -l < "$PROMPTS_FILE" | tr -d ' ')"
+
+    TOTAL_BYTES=0
+    for f in "$SESSION_FILE" "$PROMPTS_FILE" "$TOOLS_FILE"; do
+      [ -f "$f" ] || continue
+      size=$(wc -c < "$f" | tr -d ' ')
+      TOTAL_BYTES=$((TOTAL_BYTES + size))
+    done
+
+    jq -n \
+      --arg session_id "$SESSION_ID" \
+      --argjson start_ts "$START_TS" \
+      --arg end_ts "$TS" \
+      --argjson tool_counts "$TOOL_COUNTS" \
+      --argjson error_count "$ERROR_COUNT" \
+      --argjson prompt_count "$PROMPT_COUNT" \
+      --argjson total_bytes "$TOTAL_BYTES" \
+      --arg event "$EVENT" \
+      '{
+        session_id:$session_id,
+        start_ts:$start_ts,
+        end_ts:$end_ts,
+        prompt_count:$prompt_count,
+        tool_counts:$tool_counts,
+        error_count:$error_count,
+        total_bytes:$total_bytes,
+        finalized_on:$event
+      }' > "$LOG_DIR/summary.json" 2>/dev/null \
+      || warn "failed to write summary.json"
+    ;;
+
+  *)
+    # Unknown event — ignore silently.
+    ;;
+esac
+
+} 2>&1 | while IFS= read -r line; do
+  # Forward only our tagged warnings to the real stderr; swallow the rest.
+  case "$line" in
+    '[uipath-session-logger]'*) printf '%s\n' "$line" >&2 ;;
+  esac
+done
+
+exit 0


### PR DESCRIPTION
Adds a plugin hook that records tool calls, user prompts, and any UiPath solution (.uis / solution.json / project.json) present at session start into ./.uipath-logs/<session-id>/. Capture is off by default and never fails the session. Intended to make skill runs reproducible when filing bug reports.

Enable by setting UIPATH_SESSION_LOG to 1, true, yes, or on (case-insensitive) before starting Claude Code:

    export UIPATH_SESSION_LOG=1
    claude

Disable with: unset UIPATH_SESSION_LOG. Requires jq on PATH; without jq the logger no-ops with a single stderr warning.

See hooks/README.md for the full capture layout, enable/disable commands, analysis recipes, and the cross-platform contract. The uipath-session-logs skill that teaches agents about this feature ships in a separate PR (branch: skill-uipath-session-logs).

Changes:
- hooks/uipath-session-logger.sh — cross-platform logger driving SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop, and SessionEnd; truncates single fields > 64 KiB; never exits non-zero
- hooks/hooks.json — registers the new hook events alongside ensure-uip
- hooks/README.md — documents all three scripts and the session logger enable/disable flow