### PR TITLE
feat(case-management): add global-vars plugin

### DIFF
--- a/skills/uipath-case-management/SKILL.md
+++ b/skills/uipath-case-management/SKILL.md
@@ -153,6 +153,7 @@ Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fi
 | **Create a stage (regular or exception)** | [references/plugins/stages/planning.md](references/plugins/stages/planning.md) + `impl.md` |
 | **Connect nodes with edges** | [references/plugins/edges/planning.md](references/plugins/edges/planning.md) + `impl.md` |
 | **Configure SLA (default, conditional, escalation)** | [references/plugins/sla/planning.md](references/plugins/sla/planning.md) + `impl.md` |
+| **Declare global variables and arguments** | [references/plugins/variables/global-vars/planning.md](references/plugins/variables/global-vars/planning.md) + `impl.md` |
 | **Add a specific task type** | `references/plugins/tasks/<type>/planning.md` + `impl.md` |
 | **Add a specific trigger type** | `references/plugins/triggers/<type>/planning.md` + `impl.md` |
 | **Add a specific condition scope** | `references/plugins/conditions/<scope>/planning.md` + `impl.md` |
@@ -167,6 +168,7 @@ Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fi
 | [stages](references/plugins/stages/planning.md) | Regular and exception (a.k.a. secondary) stages |
 | [edges](references/plugins/edges/planning.md) | Edges between Trigger/Stage nodes (type inferred) |
 | [sla](references/plugins/sla/planning.md) | Default SLA, conditional SLA rules, escalation rules |
+| [global-vars](references/plugins/variables/global-vars/planning.md) | Case variables and arguments (inputs/outputs/inputOutputs) |
 
 **Task plugins** (`references/plugins/tasks/`):
 

--- a/skills/uipath-case-management/references/implementation.md
+++ b/skills/uipath-case-management/references/implementation.md
@@ -14,12 +14,17 @@ Execute the approved `tasks.md` plan by translating each declarative task specif
 > - Triggers → `plugins/triggers/<type>/impl.md`
 > - Conditions → `plugins/conditions/<scope>/impl.md`
 > - SLA → `plugins/sla/impl.md`
+> - Global variables & arguments → `plugins/variables/global-vars/impl.md`
 
 ---
 
 ## Step 6 — Create the Case project structure
 
 The case file must live inside a solution + project. Scaffolding commands (solution new → case init → project add) plus the `cases add` invocation that creates `caseplan.json` live in [`plugins/case/impl.md`](plugins/case/impl.md). Run them in order, then capture the initial Trigger node ID returned by `cases add` for use in Step 8.
+
+## Step 6.1 — Declare global variables and arguments
+
+For each variable/argument T-entry from `tasks.md §4.2.1`, write entries directly into `caseplan.json` per [`plugins/variables/global-vars/impl.md`](plugins/variables/global-vars/impl.md). This step populates `root.data.uipath.variables` (inputs, outputs, inputOutputs) and trigger output mappings. Execute these before adding stages — downstream tasks and conditions reference variables via `=vars.<id>`.
 
 ## Step 7 — Add stages
 

--- a/skills/uipath-case-management/references/planning.md
+++ b/skills/uipath-case-management/references/planning.md
@@ -14,6 +14,7 @@ Generate a reviewable task plan (`tasks.md`) from the design document (`sdd.md`)
 > - Triggers → `plugins/triggers/<type>/planning.md`
 > - Conditions → `plugins/conditions/<scope>/planning.md`
 > - SLA → `plugins/sla/planning.md`
+> - Global variables & arguments → `plugins/variables/global-vars/planning.md`
 
 ---
 
@@ -127,6 +128,14 @@ Title format: `Create case file "<name>"`
 
 Consult [`plugins/case/planning.md`](plugins/case/planning.md) for required fields (name, file path, case-identifier, identifier-type, case-app-enabled, description). Source all fields from sdd.md.
 
+### 4.2.1 Declare global variables and arguments
+
+Title format: `Declare <category> "<name>"` where category is `In argument`, `Out argument`, or `variable`.
+
+One T-entry per variable or argument from the sdd.md "Case Variables" table. Place these after the case file (T01) and trigger (T02), before stages. Consult [`plugins/variables/global-vars/planning.md`](plugins/variables/global-vars/planning.md) for the SDD-to-category mapping rules and entry format.
+
+Task-output variables (produced by tasks during execution) do NOT get T-entries here — they are wired automatically during task creation (§4.6).
+
 ### 4.3 Configure trigger (T02)
 
 Title format: `Configure <trigger-type> trigger "<name>"`
@@ -187,7 +196,7 @@ SLA comes last. Consult [`plugins/sla/planning.md`](plugins/sla/planning.md) for
 
 ### 4.9 Not Covered section
 
-Add a brief section at the end of `tasks.md` listing things referenced in sdd.md but outside the scope of the `uip case` CLI (e.g., Data Fabric entity schemas, global variables). These stay as notes for the user.
+Add a brief section at the end of `tasks.md` listing things referenced in sdd.md but outside the scope of the `uip case` CLI (e.g., Data Fabric entity schemas). These stay as notes for the user.
 
 ---
 

--- a/skills/uipath-case-management/references/plugins/variables/global-vars/impl.md
+++ b/skills/uipath-case-management/references/plugins/variables/global-vars/impl.md
@@ -1,0 +1,126 @@
+# Global Variables — Implementation
+
+No CLI command exists for variable declaration. Edit `caseplan.json` directly (read → parse → mutate → write).
+
+## Target Paths
+
+| What | JSON path |
+|---|---|
+| In argument inputs | `root.data.uipath.variables.inputs[]` |
+| Out argument outputs | `root.data.uipath.variables.outputs[]` |
+| All internal variables | `root.data.uipath.variables.inputOutputs[]` |
+| Trigger output mappings | `nodes[<triggerIndex>].data.uipath.outputs[]` |
+
+Process In arguments first, then Out, then plain variables.
+
+## Uniqueness Rule
+
+Every `var` / `id` must be globally unique across the case. When a name collides, append a counter starting at 2:
+
+```
+"decision" exists → "decision2" → "decision3"
+"error" + "error2" exist → "error3"
+```
+
+The `source` and `name` fields keep the original value — only `var` / `id` / `target` get the suffix.
+
+## Variable Declaration (inputOutputs only)
+
+```json
+{ "id": "caseStatus", "name": "caseStatus", "type": "string", "custom": true, "elementId": "root" }
+```
+
+| Field | Notes |
+|---|---|
+| `id` | camelCase, globally unique |
+| `type` | `"string"` / `"number"` / `"boolean"` / `"date"` / `"array"` / `"object"` / `"jsonSchema"` |
+| `custom` | `true` for user-created variables |
+| `elementId` | `"root"` for user-created; `<stageId>-<taskId>` for task outputs |
+| `default` | Optional initial value (string-encoded) |
+| `body` | `jsonSchema` type only — the schema definition |
+
+## In Argument — 3 entries
+
+1. **Input variable** in `inputs[]` (random 9-char alphanumeric ID)
+2. **Companion inputOutput** in `inputOutputs[]` (name-based camelCase ID)
+3. **Trigger output mapping** on `triggerNode.data.uipath.outputs[]`
+
+```json
+// 1. inputs[]
+{ "id": "vkfPdQUYR", "name": "expenseId", "type": "string", "default": "", "elementId": "trigger_aB3cD4" }
+
+// 2. inputOutputs[]
+{ "id": "expenseId", "name": "expenseId", "type": "string", "elementId": "trigger_aB3cD4" }
+
+// 3. triggerNode.data.uipath.outputs[]
+{ "name": "expenseId", "type": "string", "source": "variables.vkfPdQUYR", "var": "expenseId" }
+```
+
+The trigger mapping bridges `inputs[]` to `inputOutputs[]` at runtime. Without it, `=vars.expenseId` would be empty.
+
+## Out Argument — 2 entries
+
+1. **Companion inputOutput** in `inputOutputs[]` (name-based ID, with `default` if specified)
+2. **Output variable** in `outputs[]` (random ID, `var` links to companion)
+
+```json
+// 1. inputOutputs[]
+{ "id": "finalDecision", "name": "finalDecision", "type": "string", "default": "", "elementId": "root" }
+
+// 2. outputs[]
+{ "id": "xR7mPqW2k", "name": "finalDecision", "type": "string", "var": "finalDecision" }
+```
+
+## InOut Argument
+
+Combines In + Out. Creates input + **one** shared companion IO + trigger mapping + output variable (output omits `var` — the In companion already exists).
+
+## Task Output → inputOutputs Wiring
+
+For every task output written, also append to `root.data.uipath.variables.inputOutputs[]`:
+
+```json
+// Task output on the task node
+{ "name": "AnomalyCheck", "var": "anomalyCheck", "id": "anomalyCheck",
+  "value": "anomalyCheck", "type": "string",
+  "source": "=AnomalyCheck", "target": "=anomalyCheck",
+  "elementId": "Stage_intake-tAnomalyXX" }
+
+// Corresponding inputOutputs entry on root
+{ "id": "anomalyCheck", "name": "AnomalyCheck",
+  "type": "string", "elementId": "Stage_intake-tAnomalyXX" }
+```
+
+Skip when a `custom: true` output reuses an existing variable from another element.
+
+## Custom Outputs (`custom: true`)
+
+Writes a fixed constant to a global variable when a task completes — not from the task's response.
+
+| Field | Standard Output | Custom Output |
+|-------|-----------------|---------------|
+| `source` | `"=<fieldName>"` | omitted |
+| `value` | variable ID string | `"=<literal>"` or `"=js:<expr>"` |
+| `custom` | omitted / `false` | `true` |
+| `target` | `"=<varId>"` | omitted |
+
+```json
+{ "name": "CustomerStatus", "type": "string",
+  "value": "=\"Documents received\"", "custom": true,
+  "id": "customerStatus", "var": "customerStatus",
+  "elementId": "Stage_pending-tDocAgent" }
+```
+
+If the custom output updates an existing variable, skip the `inputOutputs` entry.
+
+## jsonSchema Type
+
+```json
+{ "id": "caseData", "name": "caseData", "type": "jsonSchema",
+  "body": { "type": "object", "properties": { "status": { "type": "string" } } },
+  "_jsonSchema": { "type": "object", "properties": { "status": { "type": "string" } } } }
+```
+
+## Expression Syntax
+
+See [bindings-and-expressions.md](../../../bindings-and-expressions.md). Key rule: plain reads use `=vars.x`, comparisons use `=js:vars.x === 'val'`. Never use `$vars.x`.

--- a/skills/uipath-case-management/references/plugins/variables/global-vars/planning.md
+++ b/skills/uipath-case-management/references/plugins/variables/global-vars/planning.md
@@ -1,0 +1,48 @@
+# Global Variables — Planning
+
+Case-level data lives in `root.data.uipath.variables`. The key distinction is **variables** vs **arguments**:
+
+| Concept | Arrays | When |
+|---|---|---|
+| **Variable** | `inputOutputs[]` only | Internal data shared between stages |
+| **In argument** | `inputs[]` + companion `inputOutputs[]` + trigger output mapping | Data passed into the case at start |
+| **Out argument** | `outputs[]` + companion `inputOutputs[]` | Data returned to caller when case ends |
+
+## SDD-to-Category Mapping
+
+From the SDD "Case Variables" table:
+
+1. Listed in Trigger "Initial Variable Mapping" → **In argument**
+2. Marked as returned to caller → **Out argument**
+3. Everything else → **Variable**
+
+## tasks.md Entry Format
+
+One T-entry per variable/argument. Place after case file (T01) and trigger (T02), before stages:
+
+```markdown
+## T03: Declare In argument "employeeName"
+- category: In
+- type: string
+- triggerId: <trigger-node-id>
+
+## T04: Declare variable "caseStatus"
+- category: Variable
+- type: string
+- default: "Open"
+
+## T05: Declare Out argument "finalDecision"
+- category: Out
+- type: string
+- verify: Confirm entry exists in root.data.uipath.variables
+```
+
+Task-output variables are wired automatically during task creation (§4.6) — no T-entry needed here.
+
+## Types
+
+`"string"` | `"number"` | `"boolean"` | `"date"` | `"object"` | `"array"` | `"jsonSchema"`
+
+## Naming
+
+camelCase IDs (`=vars.claimId`). See [impl.md](impl.md) for uniqueness rules and ID generation.


### PR DESCRIPTION
## Summary
- Add `references/plugins/variables/global-vars/` plugin (planning.md + impl.md) for declaring case variables and In/Out/InOut arguments
- Port from `feat/uipath-case-skillonly` (572c45b), simplified 55% (391→174 lines) with expression syntax deduplicated to `bindings-and-expressions.md`
- Wire into SKILL.md plugin index, planning.md (new §4.2.1), and implementation.md (new Step 6.1)

## What the plugin covers
- SDD-to-category mapping (In argument / Out argument / Variable)
- In argument 3-entry pattern (inputs[] + companion inputOutputs[] + trigger output mapping)
- Out argument 2-entry pattern (companion inputOutputs[] + outputs[])
- Variable uniqueness rules (counter suffix matching FE `toUniqueCamelCase`)
- Task output → inputOutputs wiring
- Custom outputs, jsonSchema type

## Test plan
- [x] Verified planning rules against expense management SDD (52 variables: 10 In args, 0 Out args, 42 variables)
- [x] Ran implementation script producing caseplan.json with correct inputs/outputs/inputOutputs/trigger mappings
- [x] All IDs unique, defaults preserved, types correct
- [ ] Run existing case-management evals to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)