### PR TITLE
fix(hitl): align skill schema docs and tests with flow-workbench node definition

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -24,7 +24,7 @@ See [references/hitl-patterns.md](references/hitl-patterns.md) for the full busi
 ## Critical Rules
 
 1. **Confirm schema with the user before writing anything for quickform type.** Show the designed schema and wait for explicit confirmation.
-2. **Always wire at least the `completed` handle.** A HITL node with no outgoing edge on `completed` blocks the flow. Wire `cancelled` and `timeout` to end nodes or handlers unless the user explicitly defers them.
+2. **Always wire the `completed` handle.** A HITL node with no outgoing edge on `completed` blocks the flow forever. Only `completed` is available as an output handle.
 3. **Regenerate `variables.nodes` after adding the node.** Replace the entire `workflow.variables.nodes` array — do not append. See the reference docs for the algorithm.
 4. **Validate after every change.** Run `uip flow validate <file> --format json` after writing the node and edges.
 5. **Read the existing `.flow` file before adding.** Understand which nodes already exist and where the HITL checkpoint belongs in the flow.
@@ -136,7 +136,7 @@ Present the user with three options. Do not choose on their behalf or perform an
 ## Step 4 — Common configuration
 
 | Timeout | "How long before the task times out if nobody acts? (default: 24 hours)" |
-| Priority | "Is this normal priority, or high/critical?" |
+| Priority | "What priority should this task have? Options: Low, Medium, High (default: Medium)" |
 
 ---
 

--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -86,7 +86,7 @@ Read the existing `.flow` file to understand current nodes and edges. Use the Re
 2. **What the human needs to see** — data produced by upstream nodes
 3. **What the human must provide back** — data needed by downstream nodes
 4. **What actions they can take** — the named outcome buttons
-5. **Form type**: QuickForm (inline schema) or AppTask (deployed coded app)?
+5. **Form type**: QuickForm (`inputs.type = "quick"`, inline schema) or AppTask (`inputs.type = "custom"`, deployed coded app)?
 
 ---
 
@@ -119,11 +119,11 @@ Wait for confirmation. Do not proceed to schema design until the user confirms.
 
 Present the user with three options. Do not choose on their behalf or perform any registry search.
 
-| # | Option | Description |
-|---|---|---|
-| 1 | **QuickForm** | Inline typed form — fields rendered by Action Center from the schema you design here |
-| 2 | **New Coded Action App** | Scaffold a new React + TypeScript app inside the solution — full UI control |
-| 3 | **Existing Deployed App** | Reference an app already deployed to Orchestrator |
+| # | Option | `inputs.type` value | Description |
+|---|---|---|---|
+| 1 | **QuickForm** | `"quick"` | Inline typed form — fields rendered by Action Center from the schema you design here |
+| 2 | **New Coded Action App** | `"custom"` | Scaffold a new React + TypeScript app inside the solution — full UI control |
+| 3 | **Existing Deployed App** | `"custom"` | Reference an app already deployed to Orchestrator |
 
 | User selects | Next step |
 |---|---|
@@ -221,9 +221,9 @@ The Maestro HITL CLI is not yet available. Guide the user to add the HITL node m
 After completing the wiring:
 
 1. **What was inserted** — node ID, label, insertion point
-2. **Schema summary** — what the human will see (`inputs`), fill in (`outputs`/`inOuts`), and click (`outcomes`). For deployed action app show the actionSchema from the retrieve-configuration api response here.
+2. **Schema summary** — what the human will see (input-direction fields), fill in (output/inOut-direction fields), and click (outcomes). For deployed action app show the actionSchema from the retrieve-configuration api response here.
 3. **Edges wired** — which handles were connected and to which nodes; any handles left unwired
-4. **Runtime variables** — `<NodeId>.result` and `<NodeId>.status` and how to reference them
+4. **Runtime variables** — `$vars.<nodeId>.result` (object) and `$vars.<nodeId>.status` (string) and how to reference them downstream
 5. **Validation result** — pass or errors to fix
 6. **Next step** — pack and publish when ready via `uipath-development` skill
 

--- a/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
@@ -302,10 +302,8 @@ Merge rules:
       "appVersionRef": { "key": "<APP_VERSION_REF.key>", "name": "Invoice Approval" }
     },
     "schema": {
-      "inputs": [],
-      "outputs": [],
-      "inOuts": [],
-      "outcomes": [{ "name": "Submit", "type": "string" }]
+      "fields": [],
+      "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }]
     }
   },
   "model": { "type": "bpmn:UserTask", "serviceType": "Actions.HITL" }

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -28,33 +28,23 @@ Before designing the schema, ask these focused questions if the business descrip
 
 ## Step 2 — Design the Schema
 
-The CLI accepts this format for `--schema`:
+The node schema uses `fields[]` entries inside `inputs.schema`. Use these conceptual roles to plan the fields before writing the node JSON:
 
-```json
-{
-  "inputs":   [{ "name": "fieldName", "type": "string" }],
-  "outputs":  [{ "name": "fieldName", "type": "string" }],
-  "inOuts":   [{ "name": "fieldName", "type": "string" }],
-  "outcomes": [{ "name": "Approve",  "type": "string" }]
-}
-```
+| Role | `direction` value | Human can… | Use for |
+|---|---|---|---|
+| Input field | `"input"` | Read only | Context the human needs to make a decision |
+| Output field | `"output"` | Write | Data the automation needs back |
+| InOut field | `"inOut"` | Read + modify | Data the human can see and optionally correct |
 
-| Field | Human can… | Use for |
-|---|---|---|
-| `inputs` | Read only | Context the human needs to make a decision |
-| `outputs` | Write | Data the automation needs back |
-| `inOuts` | Read + modify | Data the human can see and optionally correct |
-| `outcomes` | Click one | Named action buttons |
-
-**Supported types:** `string`, `number`, `boolean`, `date`
+**Supported field types:** `text` (maps from `string`), `number`, `boolean`, `date`
 
 **Design rules:**
-- `inputs`: everything the human needs to decide — IDs, amounts, context
-- `outputs`: only what downstream nodes actually use
+- Input fields: everything the human needs to decide — IDs, amounts, context; bind to upstream node output via `binding`
+- Output fields: only what downstream nodes actually use; set `required: true` for mandatory outputs
 - `outcomes`: use domain-specific names (Approve/Reject, not just Submit)
 - Keep it focused — don't add fields the automation won't use
 
-**Show the designed schema to the user and confirm before running the CLI.**
+**Show the designed schema to the user and confirm before writing the node.**
 
 ---
 
@@ -172,10 +162,15 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
   ],
   "model": { "type": "bpmn:UserTask" },
   "inputDefinition": {
-    "channels": [],
+    "type": "quick",
     "schema": {
-      "inputs": [], "outputs": [], "inOuts": [],
-      "outcomes": [{ "name": "Submit", "type": "string" }]
+      "fields": [],
+      "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }]
+    },
+    "recipient": {
+      "channels": ["Email", "ActionCenter"],
+      "connections": {},
+      "assignee": { "type": "group" }
     },
     "timeout": "PT24H",
     "priority": "normal"

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -65,7 +65,7 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
       "connections": {},
       "assignee": { "type": "group" }
     },
-    "priority": "normal",
+    "priority": "Normal",
     "timeout": "PT24H",
     "schema": {
       "id": "a3f7c2d1-8b4e-4f9a-b2c5-6d8e1f3a7b9c",
@@ -153,9 +153,7 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
     {
       "position": "right",
       "handles": [
-        { "id": "completed", "label": "Completed", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } },
-        { "id": "cancelled", "label": "Cancelled", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } },
-        { "id": "timeout",   "label": "Timeout",   "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } }
+        { "id": "completed", "label": "Completed", "type": "source", "handleType": "output", "showButton": true, "constraints": { "forbiddenTargetCategories": ["trigger"] } }
       ],
       "visible": true
     }
@@ -173,11 +171,11 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
       "assignee": { "type": "group" }
     },
     "timeout": "PT24H",
-    "priority": "normal"
+    "priority": "Normal"
   },
   "outputDefinition": {
     "result": { "type": "object", "description": "Task result data", "source": "=result", "var": "result" },
-    "status": { "type": "string", "description": "Task completion status (completed, cancelled, timeout)", "source": "=status", "var": "status" }
+    "status": { "type": "string", "description": "Task completion status", "source": "=status", "var": "status" }
   }
 }
 ```
@@ -186,15 +184,13 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
 
 ## Edge Wiring
 
-Wire all three output handles. Edge ID format: `{sourceNodeId}-{sourcePort}-{targetNodeId}-{targetPort}` (append `-2`, `-3` on collision).
+Wire the `completed` output handle to the downstream node. Edge ID format: `{sourceNodeId}-{sourcePort}-{targetNodeId}-{targetPort}` (append `-2`, `-3` on collision).
 
 ```json
-{ "id": "invoiceReview1-completed-processApproval1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "processApproval1", "targetPort": "input" },
-{ "id": "invoiceReview1-cancelled-end1-input",             "sourceNodeId": "invoiceReview1", "sourcePort": "cancelled", "targetNodeId": "end1",             "targetPort": "input" },
-{ "id": "invoiceReview1-timeout-end2-input",               "sourceNodeId": "invoiceReview1", "sourcePort": "timeout",   "targetNodeId": "end2",             "targetPort": "input" }
+{ "id": "invoiceReview1-completed-processApproval1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "processApproval1", "targetPort": "input" }
 ```
 
-**Always wire `completed`.** A HITL node with no edge on `completed` blocks the flow forever. Wire `cancelled` and `timeout` to end nodes if no specific handler exists.
+**Always wire `completed`.** A HITL node with no edge on `completed` blocks the flow forever.
 
 ---
 
@@ -315,7 +311,7 @@ After the HITL node, downstream nodes can reference:
 |---|---|---|
 | `$vars.<nodeId>.result` | object | All `output` and `inOut` fields the human filled in |
 | `$vars.<nodeId>.result.<fieldVariable>` | varies | Individual field value (e.g. `$vars.invoiceReview1.result.decision`) |
-| `$vars.<nodeId>.status` | string | `"completed"`, `"cancelled"`, or `"timeout"` |
+| `$vars.<nodeId>.status` | string | `"completed"` when the human submits the task |
 
 **In a downstream script node:**
 ```javascript

--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -1,9 +1,12 @@
 task_id: skill-hitl-e2e-invoice-approval-greenfield
+# NOTE: "e2e" here means authoring end-to-end (greenfield JSON flow authoring).
+# This test does NOT deploy or execute the flow — it only validates the authored
+# .flow file JSON and the skill's ability to design and wire HITL nodes.
 description: >
-  E2E golden scenario (green field): agent builds a complete invoice approval
-  flow from scratch — detecting write-back + approval gate signals,
-  designing schema, adding HITL node, wiring all handles, and validating.
-  Real business use case. Full Discover -> Plan -> Build -> Verify loop.
+  Authoring E2E golden scenario (green field): agent builds a complete invoice
+  approval flow from scratch — detecting write-back + approval gate signals,
+  designing schema, adding HITL node, wiring all handles, and validating the
+  authored .flow file. Real business use case. Full Discover -> Plan -> Build -> Verify loop.
 tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write-back]
 
 agent:

--- a/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
@@ -1,8 +1,12 @@
 task_id: skill-hitl-e2e-ai-escalation-brownfield
+# NOTE: "e2e" here means authoring end-to-end (brownfield JSON flow editing).
+# This test does NOT deploy or execute the flow — it only validates the authored
+# .flow file JSON and the skill's ability to insert HITL nodes into existing flows.
 description: >
-  E2E golden scenario (brown field): agent reads an existing classification
-  flow and inserts a HITL escalation node on the low-confidence path. Real
-  business use case. Full Discover -> Plan -> Build -> Verify loop.
+  Authoring E2E golden scenario (brown field): agent reads an existing
+  classification flow and inserts a HITL escalation node on the low-confidence
+  path. Real business use case. Full Discover -> Plan -> Build -> Verify loop.
+  Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, brown-field, escalation, ai-agent]
 
 agent:

--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -1,9 +1,13 @@
 task_id: skill-hitl-e2e-gdpr-compliance-greenfield
+# NOTE: "e2e" here means authoring end-to-end (greenfield JSON flow authoring).
+# This test does NOT deploy or execute the flow — it only validates the authored
+# .flow file JSON and the skill's ability to author compliance-pattern HITL nodes.
 description: >
-  E2E golden scenario (green field): agent builds a GDPR deletion request
-  flow with a privacy officer sign-off checkpoint. Tests proactive compliance
-  pattern detection, schema design with Reject path, timeout wiring.
+  Authoring E2E golden scenario (green field): agent builds a GDPR deletion
+  request flow with a privacy officer sign-off checkpoint. Tests proactive
+  compliance pattern detection, schema design with Reject path, timeout wiring.
   Real business use case. Full Discover -> Plan -> Build -> Verify loop.
+  Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, green-field, compliance, gdpr]
 
 agent:

--- a/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
@@ -1,9 +1,12 @@
 task_id: skill-hitl-e2e-multi-hitl-brownfield
+# NOTE: "e2e" here means authoring end-to-end (brownfield JSON flow editing).
+# This test does NOT deploy or execute the flow — it only validates the authored
+# .flow file JSON and the skill's ability to insert multiple HITL nodes.
 description: >
-  E2E golden scenario (brown field, complex): agent reads an existing HR
-  onboarding flow and inserts TWO separate HITL checkpoints — before
-  document validation and before IT provisioning. Tests multi-node
-  insertion and full validation of the combined flow.
+  Authoring E2E golden scenario (brown field, complex): agent reads an existing
+  HR onboarding flow and inserts TWO separate HITL checkpoints — before document
+  validation and before IT provisioning. Tests multi-node insertion and full
+  validation of the authored .flow file. Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, brown-field, multi-hitl, hr-onboarding]
 
 agent:

--- a/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
@@ -1,8 +1,12 @@
 task_id: skill-hitl-e2e-expense-approval-brownfield
+# NOTE: "e2e" here means authoring end-to-end (brownfield JSON flow editing).
+# This test does NOT deploy or execute the flow — it only validates the authored
+# .flow file JSON and the skill's ability to insert a HITL node into a minimal flow.
 description: >
-  E2E test (brown field): agent adds a HITL node between two existing nodes
-  in a minimal flow, wires the completed handle, and validates the result.
-  Tests C2 (brown field insert), C5 (completed handle), F1 and F2 (validate).
+  Authoring E2E test (brown field): agent adds a HITL node between two existing
+  nodes in a minimal flow, wires the completed handle, and validates the authored
+  .flow file. Tests C2 (brown field insert), C5 (completed handle), F1 and F2
+  (validate). Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, brown-field]
 
 agent:

--- a/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
@@ -1,8 +1,11 @@
 task_id: skill-hitl-e2e-invoice-approval-greenfield-simple
+# NOTE: "e2e" here means authoring end-to-end (greenfield flow project creation).
+# This test does NOT deploy or execute the flow — it only validates the authored
+# .flow file JSON and the skill's ability to scaffold and wire a new project.
 description: >
-  E2E test (green field): agent creates a new Flow project with a HITL
+  Authoring E2E test (green field): agent creates a new Flow project with a HITL
   checkpoint from scratch. Tests C1 (green field), B1-B3 (schema design),
-  C5 (completed handle), F1 (validate after add).
+  C5 (completed handle), F1 (validate after add). Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, green-field]
 
 agent:

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -1,10 +1,14 @@
 task_id: skill-hitl-e2e-apptask-brownfield
+# NOTE: "e2e" here means authoring end-to-end (brownfield AppTask node insertion).
+# This test does NOT execute the flow at runtime. It validates the skill's ability
+# to resolve a deployed app, write resource files, and author the HITL node JSON.
+# Skipped until a shared staging app + tenant are available for CI.
 description: >
-  E2E test (AppTask surface): agent inserts a HITL node backed by an existing
-  deployed Action App into a brownfield flow. Tests the full AppTask path:
-  credentials from ~/.uipath/.auth, solution context resolution, app search,
-  retrieve-configuration, resource file writing, debug overwrites, node JSON
-  with inputs.type=custom.
+  Authoring E2E test (AppTask surface): agent inserts a HITL node backed by an
+  existing deployed Action App into a brownfield flow. Tests the full AppTask
+  authoring path: credentials from ~/.uipath/.auth, solution context resolution,
+  app search, retrieve-configuration, resource file writing, debug overwrites,
+  node JSON with inputs.type=custom. Does not deploy or execute the flow.
 tags: [uipath-human-in-the-loop, e2e, brown-field, apptask]
 skip: true
 # Blocked: requires live tenant with a deployed Action App and ~/.uipath/.auth

--- a/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
@@ -1,8 +1,8 @@
-task_id: skill-hitl-quality-all-handles
+task_id: skill-hitl-quality-completed-handle-and-result
 description: >
-  Quality test: agent must wire all 3 HITL handles (completed, cancelled,
-  timeout) to distinct downstream nodes and validate. Tests C5, C6, C7,
-  C8, F2.
+  Quality test: agent must wire the completed handle to a downstream node
+  and demonstrate how to read the human's decision using $vars.<nodeId>.result
+  in the next script node. Tests C5, C6, F2.
 tags: [uipath-human-in-the-loop, integration, edge-wiring]
 
 sandbox:
@@ -13,19 +13,18 @@ initial_prompt: |
   Create a flow called "PurchaseOrderApproval" with the following structure:
   - A manual trigger
   - A HITL node for purchase order approval (label: "PO Approval")
-  - A script node for approved orders (id: "processApproved", label: "Process PO")
-  - A script node for cancellations (id: "handleCancelled", label: "Handle Cancellation")
-  - A script node for timeouts (id: "escalateTimeout", label: "Escalate Timeout")
+  - A script node that reads the human's decision after the HITL step
+    (id: "processResult", label: "Process Result")
 
-  Wire ALL three HITL handles:
-  - completed -> processApproved
-  - cancelled -> handleCancelled
-  - timeout -> escalateTimeout
+  Wire the completed handle from the HITL node to processResult. In the
+  processResult script node body, show how to read the human's decision using
+  $vars.<hitl-node-id>.result.
 
   Validate after adding and wiring. Save results to report.json:
   {
     "hitl_node_id": "<id>",
-    "handles_wired": ["completed", "cancelled", "timeout"],
+    "handles_wired": ["completed"],
+    "result_variable_expression": "$vars.<hitl-node-id>.result",
     "commands_used": ["<list>"],
     "validation_passed": true
   }
@@ -40,12 +39,10 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "All three handles are wired in the flow file"
+    description: "completed handle is wired in the flow file"
     path: "PurchaseOrderApproval/flow_files/PurchaseOrderApproval.flow"
     includes:
       - '"completed"'
-      - '"cancelled"'
-      - '"timeout"'
     weight: 2.0
     pass_threshold: 1.0
 
@@ -58,12 +55,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: json_check
-    description: "report.json shows all 3 handles wired and validation passed"
+    description: "report.json shows completed handle wired and validation passed"
     path: "report.json"
     assertions:
       - expression: "length(handles_wired)"
         operator: gte
-        expected: 3
+        expected: 1
       - expression: "validation_passed"
         operator: equals
         expected: true
@@ -71,11 +68,10 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "All 3 handle names present in report"
+    description: "report.json references $vars result expression"
     path: "report.json"
     includes:
-      - "completed"
-      - "cancelled"
-      - "timeout"
+      - "$vars"
+      - ".result"
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
@@ -15,7 +15,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": "<true or false — your assessment>",
+    "hitl_needed": <true or false>,
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<field names the human will see>"],

--- a/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
@@ -1,8 +1,8 @@
-task_id: skill-hitl-activation-explicit
+task_id: skill-hitl-smoke-explicit
 description: >
-  Activation test: agent should trigger the uipath-human-in-the-loop skill
+  Smoke test: agent should trigger the uipath-human-in-the-loop skill
   when explicitly asked to add a HITL node. Verifies the skill fires for
-  direct HITL language.
+  direct HITL language and that the agent identifies the correct pattern.
 tags: [uipath-human-in-the-loop, smoke]
 
 sandbox:
@@ -15,7 +15,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": true,
+    "hitl_needed": "<true or false — your assessment>",
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<field names the human will see>"],
@@ -37,6 +37,14 @@ success_criteria:
     includes:
       - '"hitl_needed": true'
     weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Agent named a specific pattern (non-empty pattern field)"
+    path: "recommendation.json"
+    includes:
+      - "approval"
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: file_contains

--- a/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
@@ -16,7 +16,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": "<true or false — your assessment>",
+    "hitl_needed": <true or false>,
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<field names>"],

--- a/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
@@ -1,7 +1,8 @@
-task_id: skill-hitl-activation-compliance
+task_id: skill-hitl-smoke-approval-gate
 description: >
-  Activation test: agent should detect a compliance checkpoint pattern from
-  regulatory language. Verifies the skill fires on audit/sign-off signals.
+  Smoke test: agent should detect an approval gate pattern and recommend
+  HITL even though the user said "approve" rather than "HITL". Verifies
+  proactive business-language-based triggering.
 tags: [uipath-human-in-the-loop, smoke]
 
 sandbox:
@@ -9,18 +10,18 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Automate GDPR data deletion requests. Each request requires documented
-  sign-off from our data privacy officer before the deletion actually runs —
-  we need an audit trail for every decision.
+  Build a UiPath Flow that extracts expense report data and emails it to
+  finance — but a manager must approve each expense report before the email
+  is sent.
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": true,
+    "hitl_needed": "<true or false — your assessment>",
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
-      "inputs": ["<what the privacy officer will see>"],
-      "outputs": ["<what they fill in>"],
-      "outcomes": ["<their decision options>"]
+      "inputs": ["<field names>"],
+      "outputs": ["<field names>"],
+      "outcomes": ["<button names>"]
     }
   }
 
@@ -40,9 +41,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Agent identified compliance/audit pattern"
+    description: "Agent identified an approval gate pattern"
     path: "recommendation.json"
     includes:
-      - "complian"
+      - "approval"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
@@ -1,6 +1,6 @@
-task_id: skill-hitl-activation-escalation
+task_id: skill-hitl-smoke-escalation
 description: >
-  Activation test: agent should detect an exception escalation pattern from
+  Smoke test: agent should detect an exception escalation pattern from
   AI confidence threshold language. Verifies the skill fires on escalation
   signals without explicit HITL mention.
 tags: [uipath-human-in-the-loop, smoke]
@@ -16,7 +16,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": true,
+    "hitl_needed": "<true or false — your assessment>",
     "pattern": "<which business pattern applies>",
     "insertion_point": "<where in the flow the HITL node should go>",
     "proposed_schema": {
@@ -46,4 +46,12 @@ success_criteria:
     includes:
       - "escalat"
     weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Agent proposed an insertion point after the AI classifier"
+    path: "recommendation.json"
+    includes:
+      - "classif"
+    weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
@@ -16,7 +16,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": "<true or false — your assessment>",
+    "hitl_needed": <true or false>,
     "pattern": "<which business pattern applies>",
     "insertion_point": "<where in the flow the HITL node should go>",
     "proposed_schema": {

--- a/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
@@ -17,7 +17,7 @@ initial_prompt: |
   Analyze whether this flow needs any human checkpoints. Write a
   recommendation.json file with:
   {
-    "hitl_needed": "<true or false — your assessment>",
+    "hitl_needed": <true or false>,
     "pattern": "<pattern name if applicable>",
     "reason": "<why HITL is or is not needed>",
     "proposed_insertion_point": "<where in the flow>"

--- a/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
@@ -1,6 +1,6 @@
-task_id: skill-hitl-activation-writeback
+task_id: skill-hitl-smoke-writeback
 description: >
-  Activation test: agent should proactively detect a write-back validation
+  Smoke test: agent should proactively detect a write-back validation
   pattern when the user describes an AI agent writing to a system of record
   WITHOUT explicitly asking for HITL. Verifies proactive recommendation.
 tags: [uipath-human-in-the-loop, smoke]
@@ -17,7 +17,7 @@ initial_prompt: |
   Analyze whether this flow needs any human checkpoints. Write a
   recommendation.json file with:
   {
-    "hitl_needed": true or false,
+    "hitl_needed": "<true or false — your assessment>",
     "pattern": "<pattern name if applicable>",
     "reason": "<why HITL is or is not needed>",
     "proposed_insertion_point": "<where in the flow>"
@@ -39,7 +39,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Agent cited write-back or validation as the reason"
+    description: "Agent named a write-back or validation pattern"
     path: "recommendation.json"
     includes:
       - "write"

--- a/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
@@ -1,8 +1,7 @@
-task_id: skill-hitl-activation-approval-gate
+task_id: skill-hitl-smoke-compliance
 description: >
-  Activation test: agent should detect an approval gate pattern and recommend
-  HITL even though the user said "approve" rather than "HITL". Verifies
-  proactive business-language-based triggering.
+  Smoke test: agent should detect a compliance checkpoint pattern from
+  regulatory language. Verifies the skill fires on audit/sign-off signals.
 tags: [uipath-human-in-the-loop, smoke]
 
 sandbox:
@@ -10,18 +9,18 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Build a UiPath Flow that extracts expense report data and emails it to
-  finance — but a manager must approve each expense report before the email
-  is sent.
+  Automate GDPR data deletion requests. Each request requires documented
+  sign-off from our data privacy officer before the deletion actually runs —
+  we need an audit trail for every decision.
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": true,
+    "hitl_needed": "<true or false — your assessment>",
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
-      "inputs": ["<field names>"],
-      "outputs": ["<field names>"],
-      "outcomes": ["<button names>"]
+      "inputs": ["<what the privacy officer will see>"],
+      "outputs": ["<what they fill in>"],
+      "outcomes": ["<their decision options>"]
     }
   }
 
@@ -41,9 +40,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Agent identified an approval gate pattern"
+    description: "Agent identified compliance/audit pattern"
     path: "recommendation.json"
     includes:
-      - "approval"
+      - "complian"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
@@ -15,7 +15,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": "<true or false — your assessment>",
+    "hitl_needed": <true or false>,
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<what the privacy officer will see>"],

--- a/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
@@ -43,6 +43,6 @@ success_criteria:
     description: "Agent identified compliance/audit pattern"
     path: "recommendation.json"
     includes:
-      - "complian"
+      - "audit"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
@@ -16,7 +16,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": "<true or false — your assessment>",
+    "hitl_needed": <true or false>,
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<what the human sees — already extracted fields>"],

--- a/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
@@ -1,6 +1,6 @@
-task_id: skill-hitl-activation-data-enrichment
+task_id: skill-hitl-smoke-data-enrichment
 description: >
-  Activation test: agent should detect a data enrichment pattern where a
+  Smoke test: agent should detect a data enrichment pattern where a
   human must fill in incomplete extracted data before the flow continues.
 tags: [uipath-human-in-the-loop, smoke]
 
@@ -16,7 +16,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": true,
+    "hitl_needed": "<true or false — your assessment>",
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<what the human sees — already extracted fields>"],
@@ -38,6 +38,14 @@ success_criteria:
     includes:
       - '"hitl_needed": true'
     weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Agent identified a data enrichment pattern"
+    path: "recommendation.json"
+    includes:
+      - "enrich"
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: file_contains

--- a/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
@@ -41,14 +41,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Agent identified a data enrichment pattern"
-    path: "recommendation.json"
-    includes:
-      - "enrich"
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_contains
     description: "Agent used inOuts (not just outputs) for the fill-in fields"
     path: "recommendation.json"
     includes:

--- a/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
@@ -10,14 +10,15 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Process all invoices under $500 automatically — extract the data, validate
-  the amounts, and post them directly to SAP with no manual review whatsoever.
-  This should be fully automated end-to-end.
-
-  Write a recommendation.json file with:
+  Our automated invoice pipeline handles all invoices from a single verified
+  supplier (AcmeCorp) with fixed pricing and pre-approved budgets. Every
+  invoice follows the same template: extract 5 fixed fields, validate against
+  PO numbers, post to SAP. There are no exceptions and no edge cases — the
+  business has signed off on full automation with no human review steps for
+  this supplier. Create a recommendation.json with:
   {
     "hitl_needed": <true or false>,
-    "reason": "<why HITL is or is not needed>"
+    "reason": "<why>"
   }
 
 success_criteria:

--- a/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
@@ -16,7 +16,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": "<true or false — your assessment>",
+    "hitl_needed": <true or false>,
     "reason": "<why HITL is or is not needed>"
   }
 

--- a/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
@@ -1,6 +1,6 @@
-task_id: skill-hitl-activation-neg-automated
+task_id: skill-hitl-smoke-neg-automated
 description: >
-  Negative activation test: agent must NOT recommend HITL when the user
+  Negative smoke test: agent must NOT recommend HITL when the user
   explicitly requests a fully automated flow with no human review. Verifies
   the skill does not produce false positives.
 tags: [uipath-human-in-the-loop, smoke]
@@ -16,7 +16,7 @@ initial_prompt: |
 
   Write a recommendation.json file with:
   {
-    "hitl_needed": true or false,
+    "hitl_needed": "<true or false — your assessment>",
     "reason": "<why HITL is or is not needed>"
   }
 
@@ -34,4 +34,3 @@ success_criteria:
       - '"hitl_needed": false'
     weight: 3.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-human-in-the-loop/smoke_08_neg_admin.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_08_neg_admin.yaml
@@ -16,7 +16,7 @@ initial_prompt: |
   Write an answer.json file with:
   {
     "answer": "<your guidance on how to reassign Action Center tasks>",
-    "hitl_authoring_needed": "<true or false — is this an authoring task?>"
+    "hitl_authoring_needed": <true or false>
   }
 
 success_criteria:

--- a/tests/tasks/uipath-human-in-the-loop/smoke_08_neg_admin.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_08_neg_admin.yaml
@@ -1,6 +1,6 @@
-task_id: skill-hitl-activation-neg-admin
+task_id: skill-hitl-smoke-neg-admin
 description: >
-  Negative activation test: agent must NOT use the uipath-human-in-the-loop
+  Negative smoke test: agent must NOT use the uipath-human-in-the-loop
   skill for Action Center runtime administration queries. This is task
   management, not automation authoring.
 tags: [uipath-human-in-the-loop, smoke]
@@ -16,7 +16,7 @@ initial_prompt: |
   Write an answer.json file with:
   {
     "answer": "<your guidance on how to reassign Action Center tasks>",
-    "hitl_authoring_needed": false
+    "hitl_authoring_needed": "<true or false — is this an authoring task?>"
   }
 
 success_criteria:
@@ -33,4 +33,3 @@ success_criteria:
       - '"hitl_authoring_needed": false'
     weight: 2.0
     pass_threshold: 1.0
-


### PR DESCRIPTION
## Summary

- **SKILL.md**: corrected `inputs.type` values (`"quick"`/`"custom"`), runtime variable refs (`$vars.<nodeId>.result`, `$vars.<nodeId>.status`)
- **hitl-node-quickform.md**: replaced flat `inputs[]/outputs[]/inOuts[]` schema doc with `fields[]` + `direction` format; added `recipient` object, correct `outcomes` shape with `id`/`isPrimary`/`action`
- **hitl-node-apptask.md**: same schema fix for AppTask node JSON
- **Smoke tests**: renamed `activation_*` → `smoke_*` (tags already said `smoke`); removed pre-filled `hitl_needed: true` from prompts (circular validation — agent now must infer the value); added pattern-specific assertions
- **e2e tests**: added `# NOTE:` clarifying authoring-only scope (not deploy+run), updated descriptions

## Motivation

The skill was documenting the wrong schema format — flat `inputs[]`/`outputs[]`/`inOuts[]` arrays that don't exist in the actual node JSON. The real format uses `schema.fields[]` with per-field `direction`. Also the smoke tests were circular: prompts told the agent to write `hitl_needed: true`, then validated that `hitl_needed == true`.

## Related

- Companion CLI PR: `feat/flow-hitl-node` in uipcli
- Sandeepan's PR #220 already merged — these fixes build on top of that