### PR TITLE
feat(case-management): add io-binding and logging plugins, remove var bind

### DIFF
--- a/skills/uipath-case-management/SKILL.md
+++ b/skills/uipath-case-management/SKILL.md
@@ -37,7 +37,7 @@ End-to-end guide for creating UiPath Case Management definitions. Takes a design
 10. **After approval, re-read `tasks.md` before executing.** `tasks.md` is the complete handoff artifact — all IDs, inputs, outputs, and references are captured there.
 11. **Unresolved task resources produce skeleton tasks — never mock, never fabricate.** Keep the `<UNRESOLVED: ...>` marker on the `taskTypeId` / `type-id` / `connection-id` slot in `tasks.md`, and omit `inputs:` / `outputs:` from that task entry. At execution time, the task is created in `caseplan.json` with `--type` + `--display-name` only (skeleton task) — no task-type-id, no connection-id, no variable bindings. Task-entry conditions and `selected-tasks-completed` rules still reference the skeleton's `TaskId`, so the workflow structure stays reviewable. The user attaches the real resource + bindings externally before runtime. See [references/skeleton-tasks.md](references/skeleton-tasks.md). Never fabricate a task-type-id or connection-id to "fill the gap".
 12. **Persist every registry resolution to `registry-resolved.json`** with full detail: search query, all matched results, selected result, rationale. This is the debug audit trail.
-13. **Cross-task references** use `"Stage Name"."Task Name".output_name` in planning and resolve to `--source-stage <id> --source-task <id> --source-output <name>` at execution time. Every ref must point to a task already in `tasks.md` order. Discover output names via `uip case tasks describe` — do not fabricate. See [references/bindings-and-expressions.md](references/bindings-and-expressions.md).
+13. **Cross-task references** use `"Stage Name"."Task Name".output_name` in planning and resolve to `=vars.<outputVarId>` at execution time by reading the source output's `var` field from caseplan.json. Every ref must point to a task already in `tasks.md` order. Discover output names via `uip case tasks describe` — do not fabricate. See [references/bindings-and-expressions.md](references/bindings-and-expressions.md) and [references/plugins/variables/io-binding/impl.md](references/plugins/variables/io-binding/impl.md).
 14. **Expression prefixes are fixed:** `=metadata.`, `=js:`, `=vars.`, `=datafabric.`, `=bindings.`, `=orchestrator.JobAttachments`, `=response`, `=result`, `=Error`, `=jsonString:`. Plain strings without a prefix are literals, not expressions.
 15. **Connector integration uses the 3-step pipeline**: `get-connector` → `get-connection` → (optional) `tasks describe --connection-id`. One plugin (`connector-activity` / `connector-trigger` / event-`trigger`) per integration pattern — schema is data-driven. See [references/connector-integration.md](references/connector-integration.md).
 16. **Enrichable non-connector task types** (`process`, `agent`, `rpa`, `action`, `api-workflow`, `case-management`) pass `--task-type-id` on `tasks add` to auto-populate inputs/outputs. Connector variants use `tasks add-connector` with `--type-id` + `--connection-id` instead.
@@ -154,6 +154,7 @@ Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fi
 | **Connect nodes with edges** | [references/plugins/edges/planning.md](references/plugins/edges/planning.md) + `impl.md` |
 | **Configure SLA (default, conditional, escalation)** | [references/plugins/sla/planning.md](references/plugins/sla/planning.md) + `impl.md` |
 | **Declare global variables and arguments** | [references/plugins/variables/global-vars/planning.md](references/plugins/variables/global-vars/planning.md) + `impl.md` |
+| **Wire task inputs/outputs (I/O binding)** | [references/plugins/variables/io-binding/planning.md](references/plugins/variables/io-binding/planning.md) + `impl.md` |
 | **Add a specific task type** | `references/plugins/tasks/<type>/planning.md` + `impl.md` |
 | **Add a specific trigger type** | `references/plugins/triggers/<type>/planning.md` + `impl.md` |
 | **Add a specific condition scope** | `references/plugins/conditions/<scope>/planning.md` + `impl.md` |
@@ -169,6 +170,8 @@ Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fi
 | [edges](references/plugins/edges/planning.md) | Edges between Trigger/Stage nodes (type inferred) |
 | [sla](references/plugins/sla/planning.md) | Default SLA, conditional SLA rules, escalation rules |
 | [global-vars](references/plugins/variables/global-vars/planning.md) | Case variables and arguments (inputs/outputs/inputOutputs) |
+| [io-binding](references/plugins/variables/io-binding/planning.md) | Task input/output wiring, cross-task references, JSON shapes |
+| [logging](references/plugins/logging/impl.md) | Shared issue log — format, severity levels, file dump |
 
 **Task plugins** (`references/plugins/tasks/`):
 
@@ -209,7 +212,7 @@ Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fi
 - **Do NOT group multiple sdd.md tasks under one T-number.** Each task, trigger, edge, or condition gets its own numbered entry.
 - **Do NOT fabricate input or output names in cross-task references.** Run `uip case tasks describe` to discover actual names. A fabricated name becomes a silent runtime null.
 - **Do NOT fabricate expression syntax for conditional SLA rules.** Describe the condition in natural language; the execution phase determines the exact expression form.
-- **Do NOT fabricate task-type-ids or connection-ids.** When a resource is unresolved, use skeleton-task creation: `tasks add --type <t> --display-name <n>` with no `--task-type-id`, and for connectors `tasks add-connector --type <t> --display-name <n>` with no `--type-id` / `--connection-id`. Skip input/output bindings entirely — `var bind` needs a resolved schema. See [references/skeleton-tasks.md](references/skeleton-tasks.md).
+- **Do NOT fabricate task-type-ids or connection-ids.** When a resource is unresolved, use skeleton-task creation: `tasks add --type <t> --display-name <n>` with no `--task-type-id`, and for connectors `tasks add-connector --type <t> --display-name <n>` with no `--type-id` / `--connection-id`. Skip input/output bindings entirely — skeletons have no input schema. See [references/skeleton-tasks.md](references/skeleton-tasks.md).
 - **Do NOT invoke other skills automatically.** If the case needs a process, agent, or action that doesn't exist, emit a skeleton task (per Rule #11) and list the missing resources in the completion report so the user can register them externally. On-demand resource creation is a future milestone, not today.
 - **Do NOT place multiple tasks in the same lane.** The FE renders same-lane tasks stacked in one column, which is unreadable for non-trivial stages. Give each task its own `--lane` index. Lane carries no execution semantics — it's layout only.
 - **Do NOT edit `content/*.bpmn` files.** They are auto-generated and will be overwritten.

--- a/skills/uipath-case-management/references/bindings-and-expressions.md
+++ b/skills/uipath-case-management/references/bindings-and-expressions.md
@@ -1,17 +1,19 @@
 # Bindings & Expressions Reference
 
-How to wire values into task inputs — expression prefixes, cross-task output references, and the `uip case var bind` CLI.
+How to wire values into task inputs — expression prefixes, cross-task output references, and direct JSON editing.
 
 ## Two Binding Modes
 
 Every task input is wired using one of two modes. Pick based on the source of the value.
 
-| Mode | Tasks.md syntax | CLI form |
-|------|-----------------|---------|
-| **Literal or expression** | `input = "<value>"` | `uip case var bind <file> <stage-id> <task-id> <input-name> --value "<value>"` |
-| **Cross-task reference** | `input <- "Stage"."Task".output` | `uip case var bind <file> <stage-id> <task-id> <input-name> --source-stage <id> --source-task <id> --source-output <name>` |
+| Mode | Tasks.md syntax | Implementation |
+|------|-----------------|----------------|
+| **Literal or expression** | `input = "<value>"` | Write `"<value>"` to `task.data.inputs[i].value` in caseplan.json |
+| **Cross-task reference** | `input <- "Stage"."Task".output` | Resolve source output's `var` → write `"=vars.<var>"` to target input's `value` |
 
-Exactly one of `--value` or all three `--source-*` options must be provided — not both.
+For the full JSON shapes and binding procedure, see [plugins/variables/io-binding/impl.md](plugins/variables/io-binding/impl.md).
+
+For connector tasks, pass expressions inline in `--input-values` at creation time — see [plugins/tasks/connector-activity/impl.md](plugins/tasks/connector-activity/impl.md).
 
 ## Expression Prefixes
 
@@ -34,7 +36,7 @@ When using the literal/expression mode, the `--value` string can start with one 
 
 ## Cross-Task References
 
-Cross-task references wire the output of an earlier task into an input of a later task. The planning syntax uses **names** (human-readable), which the implementation phase translates to **IDs** when executing `uip case var bind`.
+Cross-task references wire the output of an earlier task into an input of a later task. The planning syntax uses **names** (human-readable), which the implementation phase resolves to variable IDs via direct JSON lookup.
 
 ### Planning syntax (in `tasks.md`)
 
@@ -68,18 +70,18 @@ Missing any of the three → halt planning and ask the user; do not fabricate.
 
 ### Implementation translation
 
-The execution phase resolves names to IDs using the case JSON:
+The execution phase resolves names to IDs by reading caseplan.json:
 
-```bash
-# Pseudo-code the skill follows:
-src_stage_id = find_stage_id_by_display_name(case.json, "Stage Name")
-src_task_id  = find_task_id_by_display_name(case.json, src_stage_id, "Task Name")
-
-uip case var bind <file> <target-stage-id> <target-task-id> <input-name> \
-  --source-stage "$src_stage_id" \
-  --source-task  "$src_task_id" \
-  --source-output "output_name"
+```python
+# Pseudo-code:
+src_stage = find_node_by_label(nodes, "Stage Name")
+src_task  = find_task_by_name(src_stage, "Task Name")
+src_output = find_output_by_name(src_task, "output_name")
+target_input.value = f"=vars.{src_output['var']}"
+# Write updated caseplan.json back to disk
 ```
+
+See [plugins/variables/io-binding/impl.md](plugins/variables/io-binding/impl.md) for the full procedure.
 
 ## Examples
 

--- a/skills/uipath-case-management/references/implementation.md
+++ b/skills/uipath-case-management/references/implementation.md
@@ -15,8 +15,18 @@ Execute the approved `tasks.md` plan by translating each declarative task specif
 > - Conditions → `plugins/conditions/<scope>/impl.md`
 > - SLA → `plugins/sla/impl.md`
 > - Global variables & arguments → `plugins/variables/global-vars/impl.md`
+> - Task I/O binding → `plugins/variables/io-binding/impl.md`
+> - Logging → `plugins/logging/impl.md`
 
 ---
+
+## Issue Log — Initialize Before Step 6
+
+Before any build step, initialize an empty issue list. All plugins append to this shared list during execution. See [`plugins/logging/impl.md`](plugins/logging/impl.md) for the entry format, severity levels, and file schema.
+
+```python
+issues = []  # shared across all steps — passed to each plugin
+```
 
 ## Step 6 — Create the Case project structure
 
@@ -42,26 +52,14 @@ For multi-trigger cases, add the additional triggers first via the appropriate t
 
 For each task entry in `tasks.md §4.6`, open the matching plugin's `impl.md` (`plugins/tasks/<type>/impl.md`) and run its command. **Capture the `TaskId` returned in `--output json`** — cross-task references and conditions need it.
 
-After adding a task, bind its inputs per the two modes documented in [bindings-and-expressions.md](bindings-and-expressions.md):
+After adding a task, bind its inputs by editing `caseplan.json` directly per [`plugins/variables/io-binding/impl.md`](plugins/variables/io-binding/impl.md):
 
-**Literal / expression mode** (for `input_name = "<value>"`):
+1. Read `caseplan.json`, find the task's `data.inputs[]` by name.
+2. For literals/expressions (`input = "<value>"`): write the value string to `input.value`.
+3. For cross-task references (`input <- "Stage"."Task".output`): resolve the source output's `var` field from the JSON, then write `=vars.<var>` to the target input's `value`.
+4. Write `caseplan.json` back.
 
-```bash
-uip case var bind <file> <stage-id> <task-id> <input-name> --value "<value>" --output json
-```
-
-**Cross-task reference mode** (for `input_name <- "Stage Name"."Task Name".output_name`):
-
-1. Look up the source stage ID and source task ID from the capture map built in Steps 7 and 9.
-2. Run:
-
-```bash
-uip case var bind <file> <target-stage-id> <target-task-id> <input-name> \
-  --source-stage <source-stage-id> \
-  --source-task <source-task-id> \
-  --source-output <output-name> \
-  --output json
-```
+For **connector tasks**, pass variable references inline in `--input-values` at creation time (e.g., `"=vars.amount"`). Resolve cross-task `var` IDs from `caseplan.json` before constructing the `--input-values` JSON.
 
 **Binding order.** Process tasks in the order listed in `tasks.md` (already dependency-sorted by `order: after T<n>`). Bind each task's inputs immediately after adding it. If a cross-task reference points to a task not yet added, halt — `tasks.md` ordering is wrong; report to the user.
 
@@ -91,12 +89,12 @@ uip case tasks add-connector <file> <stage-id> \
   --output json
 ```
 
-**Skip `uip case var bind` entirely for skeleton tasks** — it rejects bindings without a resolved task-type schema. Capture the intended wiring from the fenced `wiring notes` code block in `tasks.md` into the completion report so the user knows what to hook up after registering the resource.
+**Skip all input binding for skeleton tasks** — they have no inputs (created without `--task-type-id`). Capture the intended wiring from the fenced `wiring notes` code block in `tasks.md` into the completion report so the user knows what to hook up after registering the resource.
 
 Skeleton tasks integrate with the rest of the graph:
 - **Task-entry conditions** use the captured skeleton `TaskId` normally.
 - **Stage-exit `selected-tasks-completed`** rules reference skeleton `TaskId`s normally.
-- **Cross-task variable bindings** are deferred — the user adds them via `uip case var bind` after attaching the real resource.
+- **Cross-task variable bindings** are deferred — the user binds them after attaching the real resource.
 
 ## Step 10 — Add conditions
 
@@ -122,6 +120,10 @@ On success: `{ Result: "Success", Code: "CaseValidate", Data: { File, Status: "V
 On failure: output lists `[error]` and `[warning]` entries with path and message. Fix the reported issues (usually via a targeted re-run of the earlier step) and re-run `validate`.
 
 **Retry policy.** Up to 3 validation retries per session. After the 3rd failure, halt and ask the user with **AskUserQuestion**: show the remaining errors and options — `Retry with fix`, `Pause for manual edit`, `Abort`.
+
+## Step 12.1 — Dump issue log
+
+Write the issue list to `tasks/build-issues.md` per [`plugins/logging/impl.md`](plugins/logging/impl.md), grouped by plugin with a summary index. This file is the source of truth for the completion report. Write it even if zero issues were logged (confirms a clean build).
 
 ## Step 13 — Post-build prompt
 

--- a/skills/uipath-case-management/references/planning.md
+++ b/skills/uipath-case-management/references/planning.md
@@ -15,6 +15,7 @@ Generate a reviewable task plan (`tasks.md`) from the design document (`sdd.md`)
 > - Conditions → `plugins/conditions/<scope>/planning.md`
 > - SLA → `plugins/sla/planning.md`
 > - Global variables & arguments → `plugins/variables/global-vars/planning.md`
+> - Task I/O binding → `plugins/variables/io-binding/planning.md`
 
 ---
 

--- a/skills/uipath-case-management/references/plugins/logging/impl.md
+++ b/skills/uipath-case-management/references/plugins/logging/impl.md
@@ -1,0 +1,65 @@
+# Logging — Implementation
+
+Unified issue log for the implementation phase. Initialized by `implementation.md`, written to by any plugin, dumped to markdown after build.
+
+## Setup
+
+Initialize before Step 6:
+
+```python
+issues = []
+```
+
+## Entry Format
+
+```python
+issues.append({
+    "severity": "ERROR",       # "ERROR" | "WARNING" | "SKIPPED"
+    "step": "9",               # implementation step number
+    "plugin": "io-binding",    # plugin name — used for grouping in the output file
+    "message": "human-readable description"
+})
+```
+
+| Severity | Meaning | Build effect |
+|---|---|---|
+| `ERROR` | Required element missing — operation skipped | Binding/wiring incomplete |
+| `WARNING` | Possible problem — operation proceeded | May cause runtime issues |
+| `SKIPPED` | Intentionally deferred — skeleton/unresolved | User must complete manually |
+
+## Dump
+
+After Step 12 (validate), group issues by `plugin` and write to `tasks/build-issues.md`:
+
+```markdown
+# Build Issues — <CaseName>
+
+**Case file:** caseplan.json | **Timestamp:** <ISO>
+
+| Category | Errors | Warnings | Skipped |
+|---|---|---|---|
+| [io-binding](#io-binding) | 3 | 1 | 2 |
+| [global-vars](#global-vars) | 1 | 0 | 0 |
+| **Total** | **4** | **1** | **2** |
+
+---
+
+## io-binding
+
+### Errors
+
+| Step | Issue |
+|---|---|
+| 9 | Input `amount` not found on task "Validate Expense Data" |
+
+### Skipped
+
+| Step | Task | Reason |
+|---|---|---|
+| 9 | Run Compliance Check | No inputs — skeleton task |
+```
+
+- Omit severity subsections with zero entries
+- Plugins with zero issues: write `No issues.` under the heading
+- Write the file even if zero total issues — confirms a clean build
+- The completion report (Step 13) reads this file directly

--- a/skills/uipath-case-management/references/plugins/variables/bindings/impl.md
+++ b/skills/uipath-case-management/references/plugins/variables/bindings/impl.md
@@ -1,0 +1,60 @@
+# Resource Bindings — Implementation (PLACEHOLDER)
+
+> **Status**: Placeholder — not referenced by SKILL.md or planning/implementation docs.
+> Currently the skill relies on CLI commands (`tasks add --task-type-id`) to auto-create bindings.
+> This file documents the JSON-level binding structure for future direct-write support.
+
+## What Bindings Are
+
+`root.data.uipath.bindings[]` stores resource metadata for tasks — process names, folder paths, connection IDs. Tasks reference these indirectly via `=bindings.<id>` instead of storing literal values.
+
+```json
+// root.data.uipath.bindings[]
+{
+  "id": "bG0SraLpg",
+  "name": "name",
+  "type": "string",
+  "resource": "process",
+  "resourceSubType": "ProcessOrchestration",
+  "resourceKey": "Shared.MyProcess",
+  "default": "MyProcess",
+  "propertyAttribute": "name"
+}
+```
+
+## Per Task Type
+
+| Task Type | `resource` | `resourceSubType` | Bindings Created |
+|---|---|---|---|
+| process | `"process"` | `"ProcessOrchestration"` | name + folderPath |
+| action | `"app"` | — | name + folderPath |
+| agent | `"process"` | `"Agent"` | name + folderPath |
+| rpa | `"process"` | — | name + folderPath |
+| api-workflow | `"process"` | `"Api"` | name + folderPath |
+| case-management | `"process"` | `"CaseManagement"` | name + folderPath |
+| connector (event trigger) | `"Connection"` | — | ConnectionId + folderKey |
+
+## Task References Bindings
+
+```json
+// task.data
+{
+  "name": "=bindings.bG0SraLpg",
+  "folderPath": "=bindings.bH1iJK2lm"
+}
+```
+
+## Deduplication
+
+Multiple tasks referencing the same resource share one binding. Deduped by `default + resource + resourceKey`. The FE checks before creating a new binding.
+
+## Binding ID Generation
+
+IDs use `b` prefix + 8 alphanumeric chars (e.g., `bG0SraLpg`). Generated via `createBinding()` in `FPSFormControlUtils.ts`.
+
+## TODO — Direct Write Migration
+
+When moving from CLI to direct JSON editing:
+1. Create binding entries in `root.data.uipath.bindings[]` before task creation
+2. Set `task.data.name = "=bindings.<id>"` and `task.data.folderPath = "=bindings.<id>"`
+3. Apply deduplication check before creating new bindings

--- a/skills/uipath-case-management/references/plugins/variables/io-binding/impl.md
+++ b/skills/uipath-case-management/references/plugins/variables/io-binding/impl.md
@@ -1,0 +1,103 @@
+# I/O Binding — Implementation
+
+Wire task inputs by editing `caseplan.json` directly. Runs after all tasks are created and enriched (Step 9) and after global variable + output wiring is complete.
+
+## Task Input Shape
+
+`task.data.inputs[]` — binding = setting `value`:
+
+```json
+{ "name": "in_CustomerId", "type": "string",
+  "id": "vA1b2C3d4", "var": "vA1b2C3d4",
+  "elementId": "Stage_verify-tKYC001",
+  "value": "=vars.customerId" }
+```
+
+Inputs are auto-populated with empty `value` after `tasks add --task-type-id`. Input IDs are random (`v` + 8 chars).
+
+## Task Output Shape
+
+`task.data.outputs[]` — read-only, set at enrichment:
+
+```json
+{ "name": "KycResult", "type": "string",
+  "id": "kycResult", "var": "kycResult", "value": "kycResult",
+  "source": "=KycResult", "target": "=kycResult",
+  "elementId": "Stage_verify-tKYC001" }
+```
+
+Output IDs are name-based camelCase per [uniqueness rule](../global-vars/impl.md#uniqueness-rule). `source` reads from the task response — never changes even when `var` is counter-suffixed.
+
+## Binding Procedure
+
+For each task input in `tasks.md`:
+
+**Literals/expressions** — write the value string directly to `input.value`:
+```
+"=vars.amount"  |  "=metadata.ExternalId"  |  "50"  |  "=js:new Date()"
+```
+
+**Cross-task references** (`input <- "Stage A"."Task X".outputName`) — resolve first:
+
+1. Find Stage A by `data.label`, Task X by `displayName`
+2. Find output by `name` in `task.data.outputs[]`, read its `var` field
+3. Write `=vars.<var>` to target input's `value`
+
+```python
+src_output = find_output_by_name(src_task, "outputName")
+target_input["value"] = f"=vars.{src_output['var']}"
+```
+
+After all bindings, verify every bound input has a non-empty `value` and every `=vars.X` points to an existing variable ID.
+
+## Connector Tasks
+
+Connector inputs are set at creation time via `--input-values`, not post-creation. Plain prefixes work directly. Resolve cross-task `var` IDs **before** constructing the JSON:
+
+```bash
+--input-values '{"body":{"email":"=vars.employeeEmail","caseRef":"=metadata.ExternalId"}}'
+```
+
+Use `=js:()` only for expressions with operators (e.g., `=js:(vars.amount > 5000)`). See [connector-activity/impl.md](../../../plugins/tasks/connector-activity/impl.md).
+
+## End-to-End: Task A Output → Task B Input
+
+"Validate Expense Data" produces `validationResult`, consumed by "Enrich Employee Details":
+
+```json
+// 1. Task A output (auto-enriched) — Stage "Submission", task.data.outputs[]
+{ "name": "ValidationResult", "var": "validationResult", "id": "validationResult",
+  "value": "validationResult", "source": "=ValidationResult", "target": "=validationResult",
+  "type": "string", "elementId": "Stage_submit-tValidate01" }
+
+// 2. Root inputOutputs entry (per global-vars output wiring)
+{ "id": "validationResult", "name": "ValidationResult",
+  "type": "string", "elementId": "Stage_submit-tValidate01" }
+
+// 3. Task B input after binding — value set to =vars.<output.var>
+{ "name": "in_ValidationResult", "value": "=vars.validationResult",
+  "type": "string", "id": "vXr9pQ2mK", "var": "vXr9pQ2mK",
+  "elementId": "Stage_submit-tEnrich02" }
+```
+
+All three must exist: output on Task A, inputOutputs entry on root, bound input on Task B. If any is missing, the error handling below will catch it.
+
+## Error Handling
+
+All issues go to the shared issue list per [logging/impl.md](../../logging/impl.md). No fuzzy matching, no auto-creation, no retries.
+
+| Check | Severity | Action |
+|---|---|---|
+| Skeleton task (no `data.inputs[]`) | `SKIPPED` | Skip all bindings |
+| Input name not found (exact match) | `ERROR` | Skip binding — log available inputs |
+| Source output not found (exact match) | `ERROR` | Skip binding — log available outputs |
+| `=vars.X` not in `inputs[]`/`outputs[]`/`inputOutputs[]` | `ERROR` | Skip binding |
+| Type mismatch (input vs variable) | `WARNING` | Proceed |
+
+Example log entry:
+
+```python
+issues.append({"severity": "ERROR", "step": "9", "plugin": "io-binding",
+    "message": f'input "{name}" not found on task "{task}" — available: {available}',
+    "context": {"task": task, "stage": stage, "input": name, "available": available}})
+```

--- a/skills/uipath-case-management/references/plugins/variables/io-binding/planning.md
+++ b/skills/uipath-case-management/references/plugins/variables/io-binding/planning.md
@@ -1,0 +1,36 @@
+# I/O Binding — Planning
+
+Trust the SDD. Emit inputs/outputs exactly as declared. There is no `caseplan.json` yet — all validation happens during [implementation](impl.md).
+
+## Discovering Input/Output Names
+
+1. **SDD per-task tables** — primary source. Each task lists input/output field names, types, and variable bindings.
+2. **`uip case tasks describe --type <type> --id "<taskTypeId>" --output json`** — validates SDD names and discovers additional fields (e.g., standard `Error` output). When SDD names differ from `tasks describe`, note the mapping:
+   ```markdown
+   - inputs:
+     - in_Amount = "=vars.amount"   # SDD calls this "amount", process arg is "in_Amount"
+   ```
+3. **Unresolved taskTypeId** — `tasks describe` unavailable. Follow [skeleton-tasks](../../../skeleton-tasks.md) — omit `inputs:`/`outputs:`, capture wiring intent in a fenced code block.
+
+Do not fabricate names not in the SDD or `tasks describe`. Do not validate variable existence or scoping — those checks belong in implementation.
+
+## Input/Output Notation
+
+For the full notation and expression prefixes, see [bindings-and-expressions.md](../../../bindings-and-expressions.md). Quick reference:
+
+| Source | Notation | Example |
+|---|---|---|
+| Cross-task output | `input <- "Stage"."Task".output` | `emails <- "Triage"."Fetch Inbox".emails` |
+| Global variable | `input = "=vars.<id>"` | `caseId = "=vars.caseId"` |
+| Metadata | `input = "=metadata.<field>"` | `caseRef = "=metadata.ExternalId"` |
+| Literal | `input = "<value>"` | `maxResults = "50"` |
+
+Record discovered outputs on each task entry (`outputs: kycResult, riskScore, error`) so downstream cross-task references can be validated during implementation.
+
+## Scoping
+
+| Task location | Can reference |
+|---|---|
+| Regular stage task | Earlier stages + same stage earlier tasks + root variables |
+| Exception stage task | ALL tasks across ALL stages |
+| Adhoc task | ALL tasks |


### PR DESCRIPTION
## Summary
- Add **io-binding plugin** (`planning.md` + `impl.md`) for direct JSON editing of task input/output wiring, replacing `uip case var bind` CLI
- Add **logging plugin** (`impl.md`) for unified issue tracking across all implementation steps, dumped to `tasks/build-issues.md` grouped by plugin
- Add **bindings placeholder** (`impl.md`, unreferenced) for future direct-write migration of resource bindings
- Remove `var bind` references from 12 instructional files (implementation.md, all 7 task plugins, skeleton-tasks.md, bindings-and-expressions.md, SKILL.md)

## Key design decisions
- **Planning trusts the SDD** — no variable/scoping validation during planning, all validation deferred to implementation where caseplan.json exists
- **No fuzzy matching, no auto-creation, no retries** — errors are logged and skipped, fix belongs in the earlier step that should have created the missing resource
- **Connector inputs** use plain prefixes (`=vars.X`, `=metadata.X`) in `--input-values` at creation time; `=js:()` only for complex expressions
- **Issue log** is markdown (not JSON) — grouped by plugin with summary index, directly includable in completion report

## Files changed (16)
- **New:** `plugins/variables/io-binding/planning.md` (36 lines), `impl.md` (103 lines)
- **New:** `plugins/logging/impl.md` (55 lines)
- **New:** `plugins/variables/bindings/impl.md` (60 lines, placeholder, unreferenced)
- **Modified:** SKILL.md, implementation.md, planning.md, bindings-and-expressions.md, skeleton-tasks.md, 7 task plugin impl.md files

## Test plan
- [x] Tested planning output (tasks-io-binding.md) against expense SDD — 3 tasks, 11 bindings
- [x] Tested implementation (apply_bindings.py) — all 11 bindings applied, 0 issues
- [x] Verified: global_var → task.input, cross-task same stage, cross-task across stages
- [x] Generated example build-issues.md with all 5 error types (ERROR/WARNING/SKIPPED)
- [ ] Run existing case-management evals to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)