### PR TITLE
feat(maestro-flow): add batch-transform and summarize pattern node plugins

### DIFF
--- a/skills/uipath-maestro-flow/references/author/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/author/CAPABILITY.md
@@ -65,6 +65,8 @@ Capability index for building new flows (greenfield) and editing existing flows 
 | **Embed an AI agent tightly coupled to this flow** | [plugins/inline-agent/](references/plugins/inline-agent/) |
 | **Create a resource that doesn't exist yet** | Use `core.logic.mock` placeholder — see [Edit/Write: Replace a mock](references/editing-operations-json.md#replace-a-mock-with-a-real-resource-node) + relevant plugin's `impl.md` |
 | **Add data transform nodes** | [plugins/transform/impl.md](references/plugins/transform/impl.md) |
+| **Add an LLM batch transform over CSV rows** | [plugins/batch-transform/impl.md](references/plugins/batch-transform/impl.md) — `uipath.pattern.batch-transform`, gated by tenant flag `canvas.nodes.batch-transform` |
+| **Summarize / synthesize one document with optional citations** | [plugins/summarize/impl.md](references/plugins/summarize/impl.md) — `uipath.pattern.deep-rag`, gated by tenant flag `canvas.nodes.summarize` |
 | **Create a subflow** | [plugins/subflow/impl.md](references/plugins/subflow/impl.md) + [Edit/Write: Create a subflow](references/editing-operations-json.md#create-a-subflow) |
 | **Add a delay or scheduled trigger** | [plugins/delay/](references/plugins/delay/) or [plugins/scheduled-trigger/](references/plugins/scheduled-trigger/) |
 | **Use queue nodes** | [plugins/queue/impl.md](references/plugins/queue/impl.md) |
@@ -117,6 +119,8 @@ Capability index for building new flows (greenfield) and editing existing flows 
   - [end](references/plugins/end/) — graceful flow completion
   - [terminate](references/plugins/terminate/) — abort on fatal error
   - [transform](references/plugins/transform/) — declarative filter/map/group-by
+  - [batch-transform](references/plugins/batch-transform/) — LLM-powered row-by-row CSV enrichment (`uipath.pattern.batch-transform`)
+  - [summarize](references/plugins/summarize/) — single-document synthesis / Q&A with optional citations (`uipath.pattern.deep-rag`)
   - [delay](references/plugins/delay/) — duration or date-based pause
   - [subflow](references/plugins/subflow/) — reusable node groups
   - [scheduled-trigger](references/plugins/scheduled-trigger/) — recurring schedule

--- a/skills/uipath-maestro-flow/references/author/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/references/planning-arch.md
@@ -94,6 +94,8 @@ Each plugin has a `planning.md` with full selection heuristics, ports, key input
 | `core.action.script` | [script](plugins/script/planning.md) | Custom logic, data transformation, computation, formatting |
 | `core.action.http.v2` | [http](plugins/http/planning.md) | Call a REST API — connector mode (IS auth) or manual mode (raw URL). Replaces deprecated `core.action.http` |
 | `core.action.transform` | [transform](plugins/transform/planning.md) | Declarative map, filter, or group-by on a collection |
+| `uipath.pattern.batch-transform` | [batch-transform](plugins/batch-transform/planning.md) | Append LLM-generated columns (category, summary, extracted entities) to every row of an attached CSV. Gated by tenant flag `canvas.nodes.batch-transform` |
+| `uipath.pattern.deep-rag` (Summarize) | [summarize](plugins/summarize/planning.md) | Comprehensive synthesis / Q&A over one attached document, with optional per-claim citations. Gated by tenant flag `canvas.nodes.summarize` |
 | `core.logic.delay` | [delay](plugins/delay/planning.md) | Pause execution for a duration or until a specific date |
 | `core.action.queue.create` | [queue](plugins/queue/planning.md) | Distribute work to robots — fire-and-forget |
 | `core.action.queue.create-and-wait` | [queue](plugins/queue/planning.md) | Distribute work to robots — wait for result |
@@ -176,6 +178,8 @@ Use this when defining edges. Every edge requires a `sourcePort` and `targetPort
 | `core.action.script` | `input` | `success`, `error` |
 | `core.action.http.v2` | `input` | `default`, `error`, `branch-{id}` (dynamic per `inputs.branches` entry) |
 | `core.action.transform` | `input` | `output`, `error` |
+| `uipath.pattern.batch-transform` | `input` | `output`, `error` |
+| `uipath.pattern.deep-rag` | `input` | `output`, `error` |
 | `core.logic.delay` | `input` | `output` |
 | `core.logic.decision` | `input` | `true`, `false` |
 | `core.logic.switch` | `input` | `case-{id}` (dynamic per case), `default` |
@@ -496,6 +500,13 @@ Quick decision guide. For full details, read the linked plugin's `planning.md`.
 
 - Agent is tightly coupled to this flow, not reused -> [inline-agent](plugins/inline-agent/planning.md) (`uipath.agent.autonomous`)
 - Agent is a published tenant resource, reused across flows -> [agent](plugins/agent/planning.md) (`uipath.core.agent.{key}`)
+
+### "I need an LLM to process rows of a CSV or summarize a document"
+
+- Add LLM-generated columns to every row of a CSV (classify, summarize, extract) -> [batch-transform](plugins/batch-transform/planning.md) (`uipath.pattern.batch-transform`)
+- Synthesize or answer questions over one attached document, with optional citations -> [summarize](plugins/summarize/planning.md) (`uipath.pattern.deep-rag`)
+- Small ad-hoc reshaping (map/filter/groupBy) without an LLM -> [transform](plugins/transform/planning.md)
+- Multi-step reasoning with tool use -> [inline-agent](plugins/inline-agent/planning.md) or [agent](plugins/agent/planning.md)
 
 ### "The flow needs something outside flow capabilities"
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
@@ -22,46 +22,7 @@ If the command errors with **"Node type not found: uipath.pattern.batch-transfor
 
 ## Adding / Editing
 
-For general add, delete, and wiring mechanics, see [editing-operations.md](../../editing-operations.md). The snippets below cover what is **specific** to Batch Transform.
-
-### Add the node via CLI
-
-```bash
-uip maestro flow node add <FlowName>.flow uipath.pattern.batch-transform \
-  --label "<LABEL>" \
-  --position <X>,<Y> \
-  --input '{
-    "attachment": "=js:$vars.<inputAttachmentVar>",
-    "prompt": "<INSTRUCTION describing every output column>",
-    "outputColumns": [
-      { "name": "<COLUMN_NAME>", "description": "<WHAT TO PUT IN THIS COLUMN>" }
-    ],
-    "enableWebSearchGrounding": false
-  }' \
-  --output json
-```
-
-`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object. The `outputColumns` array can have up to 10 entries. Omit `enableWebSearchGrounding` unless rows genuinely require web-fetched facts.
-
-**Save the returned node ID** — needed for wiring edges and downstream `$vars.{nodeId}.output` references.
-
-### Wire edges
-
-```bash
-uip maestro flow node list <FlowName>.flow --output json
-
-# Upstream file producer (e.g., HTTP, connector, agent) → Batch Transform
-uip maestro flow edge add <FlowName>.flow <upstreamNodeId> <btNodeId> \
-  --source-port <upstreamOutputPort> --target-port input --output json
-
-# Batch Transform success → downstream consumer
-uip maestro flow edge add <FlowName>.flow <btNodeId> <nextNodeId> \
-  --source-port output --target-port input --output json
-
-# Optional: error branch
-uip maestro flow edge add <FlowName>.flow <btNodeId> <errorHandlerId> \
-  --source-port error --target-port input --output json
-```
+Pattern nodes are OOTB BPMN service tasks — author them by editing the `.flow` JSON directly (Edit/Write). This is the canonical authoring path per [author/CAPABILITY.md rule 2](../../CAPABILITY.md): the `uip maestro flow node add` / `edge add` carve-out is reserved for connectors, connector-triggers, and managed HTTP, where the CLI populates product-managed state. For OOTB structural edits — adding the BT node, wiring its edges, adding the `attachment` flow input — use Edit/Write against the `.flow` file. See [editing-operations.md](../../editing-operations.md) for the JSON authoring mechanics; the snippets below cover what is **specific** to Batch Transform.
 
 ## JSON Structure
 
@@ -69,7 +30,7 @@ uip maestro flow edge add <FlowName>.flow <btNodeId> <errorHandlerId> \
 {
   "id": "categorizeRows",
   "type": "uipath.pattern.batch-transform",
-  "typeVersion": "1.0.0",
+  "typeVersion": "1.0",
   "display": { "label": "Categorize Invoices" },
   "inputs": {
     "attachment": "=js:$vars.invoiceCsv",
@@ -82,7 +43,7 @@ uip maestro flow edge add <FlowName>.flow <btNodeId> <errorHandlerId> \
   },
   "outputs": {
     "output": {
-      "type": "object",
+      "type": "file",
       "description": "Result file handle",
       "source": "=batchTransformResult",
       "var": "output"
@@ -93,19 +54,53 @@ uip maestro flow edge add <FlowName>.flow <btNodeId> <errorHandlerId> \
       "source": "=Error",
       "var": "error"
     }
-  },
-  "model": {
-    "type": "bpmn:ServiceTask",
-    "serviceType": "ECS.BatchTransform"
   }
 }
 ```
 
 Notes:
 
+- **No instance-level `model` block.** BPMN type and `serviceType: "ECS.BatchTransform"` live only in the corresponding `definitions[]` entry — copy that verbatim from `uip maestro flow registry get uipath.pattern.batch-transform --output json`. Per [author/CAPABILITY.md rule 16](../../CAPABILITY.md), node instances normally have no `model` block.
+- **`typeVersion` must match `definitions[<batch-transform>].version` exactly** — the registry currently emits `"1.0"` (one dot). Do not guess `"1.0.0"`.
 - `inputs.outputColumns` is an **array of objects** with exactly the keys `name` and `description`. Do not flatten to a map (`{ Category: "...", Summary: "..." }`) — the canvas editor and the BPMN serializer expect the array shape.
-- `model.bindings` is **absent** — Batch Transform is not a process or connector node; there is nothing to bind.
 - `outputs.output.source` is the literal `=batchTransformResult` — do not rewrite to `=result.output` or similar.
+
+## End-node output mapping
+
+If the flow surfaces the result file handle as a flow `out` variable (e.g. `result`), the End node must map it. Per [author/CAPABILITY.md rule 12](../../CAPABILITY.md), value-field expressions need the `=js:` prefix:
+
+```json
+{
+  "id": "end",
+  "type": "core.control.end",
+  "typeVersion": "1.0",
+  "outputs": {
+    "result": { "source": "=js:$vars.categorizeRows.output" }
+  }
+}
+```
+
+Without `=js:`, the runtime stores the literal string `"$vars.categorizeRows.output"` into the flow output instead of the real value.
+
+## Add via CLI (opt-in, not preferred)
+
+The `uip maestro flow node add` / `edge add` CLI is **not** the canonical authoring path for OOTB pattern nodes (see rule 2 above). Reach for it only when scripting in a context where Edit/Write isn't available. The shape:
+
+```bash
+uip maestro flow node add <FlowName>.flow uipath.pattern.batch-transform \
+  --label "<LABEL>" \
+  --input '{
+    "attachment": "=js:$vars.<inputAttachmentVar>",
+    "prompt": "<INSTRUCTION describing every output column>",
+    "outputColumns": [
+      { "name": "<COLUMN_NAME>", "description": "<WHAT TO PUT IN THIS COLUMN>" }
+    ],
+    "enableWebSearchGrounding": false
+  }' \
+  --output json
+```
+
+`attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object.
 
 ## Accessing Output
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
@@ -14,7 +14,7 @@ Confirm:
 - Output ports: `output`, `error`
 - `model.type` — `bpmn:ServiceTask`
 - `model.serviceType` — `ECS.BatchTransform`
-- `inputDefinition.properties` — `attachment` (string — Orchestrator Attachment Id), `prompt` (string), `enableWebSearchGrounding` (boolean), `outputColumns` (array of `{ name, description }`)
+- `inputDefinition.properties` — `attachment` (object — full Flow Attachment, **not** a bare id), `prompt` (string), `enableWebSearchGrounding` (boolean), `outputColumns` (array of `{ name, description }`). The schema declares `string` because Studio Web's file picker serializes the whole Attachment object into that slot at save time; the runtime parses it back as an object — pass the **whole** `{ FullName, Id, Metadata, MimeType }` object, not a GUID, URL, or path.
 - `outputDefinition.output.schema.properties` — `id`, `fileName`, `mimeType`
 - `outputDefinition.error.schema.required` — `code`, `message`, `detail`, `category`, `status`
 
@@ -31,7 +31,7 @@ uip maestro flow node add <FlowName>.flow uipath.pattern.batch-transform \
   --label "<LABEL>" \
   --position <X>,<Y> \
   --input '{
-    "attachment": "$vars.<upstreamNode>.output.<attachmentIdField>",
+    "attachment": "=js:$vars.<inputAttachmentVar>",
     "prompt": "<INSTRUCTION describing every output column>",
     "outputColumns": [
       { "name": "<COLUMN_NAME>", "description": "<WHAT TO PUT IN THIS COLUMN>" }
@@ -41,7 +41,7 @@ uip maestro flow node add <FlowName>.flow uipath.pattern.batch-transform \
   --output json
 ```
 
-`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to an **Orchestrator Attachment Id** string (a GUID) — point it at the field on the upstream node's output that carries the attachment id (not a file URL, file bytes, or a path). The `outputColumns` array can have up to 10 entries. Omit `enableWebSearchGrounding` unless rows genuinely require web-fetched facts.
+`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object. The `outputColumns` array can have up to 10 entries. Omit `enableWebSearchGrounding` unless rows genuinely require web-fetched facts.
 
 **Save the returned node ID** — needed for wiring edges and downstream `$vars.{nodeId}.output` references.
 
@@ -72,7 +72,7 @@ uip maestro flow edge add <FlowName>.flow <btNodeId> <errorHandlerId> \
   "typeVersion": "1.0.0",
   "display": { "label": "Categorize Invoices" },
   "inputs": {
-    "attachment": "$vars.fetchRows.output.attachmentId",
+    "attachment": "=js:$vars.invoiceCsv",
     "prompt": "Classify each invoice by category and write a one-line summary.",
     "enableWebSearchGrounding": false,
     "outputColumns": [
@@ -145,3 +145,4 @@ The validator checks that required inputs (`attachment`, `prompt`, `outputColumn
 - **Do not reshape `outputColumns` to a map** — the array-of-`{name, description}` shape is contractual with the canvas property panel and the BPMN `ECS.BatchTransform` serializer.
 - **Do not reference downstream rows inside the prompt** — each row is processed independently; there is no way to see sibling rows. Pre-aggregate or use [Summarize](../summarize/impl.md) on a synthesized document instead.
 - **Do not chain a Batch Transform's `$vars.{nodeId}.output` directly into a Script expecting rows** — it is a file handle, not a row array.
+- **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. Always pass the whole object via `=js:$vars.<name>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
@@ -1,0 +1,147 @@
+# Batch Transform Pattern Node — Implementation
+
+Batch Transform runs an LLM row-by-row over an attached CSV and appends LLM-generated columns. Node type: `uipath.pattern.batch-transform`. BPMN service task with `serviceType: "ECS.BatchTransform"`. No process bindings, no connection binding — inputs are the only source of configuration.
+
+## Registry Validation
+
+```bash
+uip maestro flow registry get uipath.pattern.batch-transform --output json
+```
+
+Confirm:
+
+- Input port: `input`
+- Output ports: `output`, `error`
+- `model.type` — `bpmn:ServiceTask`
+- `model.serviceType` — `ECS.BatchTransform`
+- `inputDefinition.properties` — `attachment` (string — Orchestrator Attachment Id), `prompt` (string), `enableWebSearchGrounding` (boolean), `outputColumns` (array of `{ name, description }`)
+- `outputDefinition.output.schema.properties` — `id`, `fileName`, `mimeType`
+- `outputDefinition.error.schema.required` — `code`, `message`, `detail`, `category`, `status`
+
+If the command errors with **"Node type not found: uipath.pattern.batch-transform"**, the CLI build predates Batch Transform support or the tenant's `canvas.nodes.batch-transform` server flag is off. Run `uip cli update` and `uip maestro flow registry pull --force`; if it still errors, confirm with your UiPath admin that the `canvas.nodes.batch-transform` flag is enabled on the tenant.
+
+## Adding / Editing
+
+For general add, delete, and wiring mechanics, see [editing-operations.md](../../editing-operations.md). The snippets below cover what is **specific** to Batch Transform.
+
+### Add the node via CLI
+
+```bash
+uip maestro flow node add <FlowName>.flow uipath.pattern.batch-transform \
+  --label "<LABEL>" \
+  --position <X>,<Y> \
+  --input '{
+    "attachment": "$vars.<upstreamNode>.output.<attachmentIdField>",
+    "prompt": "<INSTRUCTION describing every output column>",
+    "outputColumns": [
+      { "name": "<COLUMN_NAME>", "description": "<WHAT TO PUT IN THIS COLUMN>" }
+    ],
+    "enableWebSearchGrounding": false
+  }' \
+  --output json
+```
+
+`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to an **Orchestrator Attachment Id** string (a GUID) — point it at the field on the upstream node's output that carries the attachment id (not a file URL, file bytes, or a path). The `outputColumns` array can have up to 10 entries. Omit `enableWebSearchGrounding` unless rows genuinely require web-fetched facts.
+
+**Save the returned node ID** — needed for wiring edges and downstream `$vars.{nodeId}.output` references.
+
+### Wire edges
+
+```bash
+uip maestro flow node list <FlowName>.flow --output json
+
+# Upstream file producer (e.g., HTTP, connector, agent) → Batch Transform
+uip maestro flow edge add <FlowName>.flow <upstreamNodeId> <btNodeId> \
+  --source-port <upstreamOutputPort> --target-port input --output json
+
+# Batch Transform success → downstream consumer
+uip maestro flow edge add <FlowName>.flow <btNodeId> <nextNodeId> \
+  --source-port output --target-port input --output json
+
+# Optional: error branch
+uip maestro flow edge add <FlowName>.flow <btNodeId> <errorHandlerId> \
+  --source-port error --target-port input --output json
+```
+
+## JSON Structure
+
+```json
+{
+  "id": "categorizeRows",
+  "type": "uipath.pattern.batch-transform",
+  "typeVersion": "1.0.0",
+  "display": { "label": "Categorize Invoices" },
+  "inputs": {
+    "attachment": "$vars.fetchRows.output.attachmentId",
+    "prompt": "Classify each invoice by category and write a one-line summary.",
+    "enableWebSearchGrounding": false,
+    "outputColumns": [
+      { "name": "Category", "description": "One of: Utility, Software, Travel, Other" },
+      { "name": "Summary",  "description": "Plain-English one-line summary of the invoice" }
+    ]
+  },
+  "outputs": {
+    "output": {
+      "type": "object",
+      "description": "Result file handle",
+      "source": "=batchTransformResult",
+      "var": "output"
+    },
+    "error": {
+      "type": "object",
+      "description": "Error information if the batch job fails",
+      "source": "=Error",
+      "var": "error"
+    }
+  },
+  "model": {
+    "type": "bpmn:ServiceTask",
+    "serviceType": "ECS.BatchTransform"
+  }
+}
+```
+
+Notes:
+
+- `inputs.outputColumns` is an **array of objects** with exactly the keys `name` and `description`. Do not flatten to a map (`{ Category: "...", Summary: "..." }`) — the canvas editor and the BPMN serializer expect the array shape.
+- `model.bindings` is **absent** — Batch Transform is not a process or connector node; there is nothing to bind.
+- `outputs.output.source` is the literal `=batchTransformResult` — do not rewrite to `=result.output` or similar.
+
+## Accessing Output
+
+The result is a file handle, not the transformed rows themselves. To use the new columns downstream, feed the handle to another node that consumes files (another Batch Transform, a connector that uploads, a Script that parses):
+
+```javascript
+// Downstream Script node
+const resultFile = $vars.categorizeRows.output; // { id, fileName, mimeType }
+return { resultFileId: resultFile.id };
+```
+
+If you need the rows as JSON inside the flow, add a downstream step that fetches and parses the file — Batch Transform itself never materializes rows into `$vars`.
+
+## Validate
+
+```bash
+uip maestro flow validate <FlowName>.flow --output json
+```
+
+The validator checks that required inputs (`attachment`, `prompt`, `outputColumns`) are present and non-empty, and that `outputColumns` entries each have `name` and `description`.
+
+## Debug
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| `Node type not found: uipath.pattern.batch-transform` | CLI predates Batch Transform support, or tenant flag `canvas.nodes.batch-transform` is off | `uip cli update`, `uip maestro flow registry pull --force`; check with admin that `canvas.nodes.batch-transform` is enabled if still missing |
+| Validate rejects `outputColumns` | Wrong shape — e.g., passed a map `{ name: description }` or string array | Rewrite to `[{ "name": "...", "description": "..." }, ...]` |
+| Runtime error `exceeded maxColumns` | More than 10 output columns | Reduce to ≤10 or split into two Batch Transform nodes chained on the output file |
+| All rows produce blank values for a column | `description` is too vague or references fields not in the source CSV | Tighten the `description` — name the source column(s) the LLM should read from; test with a small sample first |
+| Latency spikes / higher cost than expected | `enableWebSearchGrounding: true` unnecessarily | Turn web search off unless rows need facts the LLM cannot infer from the row itself |
+| Output file has original row count but no new columns | Prompt asked for transformations that duplicate source columns — the LLM skipped them | Make sure every `outputColumns[].name` is **new** (not already in the source CSV) |
+
+## What NOT to Do
+
+- **Do not hand-author `model.bindings`** on the node — Batch Transform has no process or connector binding. Adding a `bindings` block will be stripped or cause validate errors.
+- **Do not pass `--source` on `uip maestro flow node add`** — `--source` is only for inline agent nodes (`uipath.agent.autonomous`). Batch Transform has no agent project behind it.
+- **Do not reshape `outputColumns` to a map** — the array-of-`{name, description}` shape is contractual with the canvas property panel and the BPMN `ECS.BatchTransform` serializer.
+- **Do not reference downstream rows inside the prompt** — each row is processed independently; there is no way to see sibling rows. Pre-aggregate or use [Summarize](../summarize/impl.md) on a synthesized document instead.
+- **Do not chain a Batch Transform's `$vars.{nodeId}.output` directly into a Script expecting rows** — it is a file handle, not a row array.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/planning.md
@@ -48,7 +48,7 @@ No artifact ports. Pattern-style nodes do not wire to resource files — the pro
 
 | Input | Required | Type | Description |
 | --- | --- | --- | --- |
-| `attachment` | Yes | string (Orchestrator Attachment Id) | The Orchestrator Attachment Id of the source CSV — a GUID identifying a file already uploaded to Orchestrator's Storage Buckets / Attachments store. Typically a `$vars.*` reference to an upstream node that produced the attachment (e.g., a connector, RPA node, or HTTP step that uploaded a CSV and returned its id), or a literal attachment id string. **Not** a file URL, byte stream, or local path. |
+| `attachment` | Yes | object (full Flow Attachment) | The full Flow Attachment object for the source CSV — shape `{ FullName, Id, Metadata, MimeType }`. Source it as a flow-level `in` variable of `type: "object"` populated by `uip maestro flow debug --file <name>=<path>`, or from an upstream node that emits a Flow Attachment. Reference the **whole object** with `=js:$vars.<name>` — never `.Id`, a GUID literal, URL, or path. The OOTB schema says `string` and Studio Web shows a file picker, but at runtime the engine deserializes the slot back to the object. |
 | `prompt` | Yes | string | The instruction describing what each output column should contain. Can reference column names from the source via natural language ("summarize the `Description` field"). |
 | `outputColumns` | Yes | array of `{ name, description }` | The columns to produce. Max 10. `name` is the column header; `description` tells the LLM what to put in it. |
 | `enableWebSearchGrounding` | No | boolean | When `true`, the LLM can issue web searches per row to ground its answer. Slower and costlier — use only when rows need external facts. Default `false`. |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/planning.md
@@ -1,0 +1,72 @@
+# Batch Transform Pattern Node — Planning
+
+The Batch Transform node runs an LLM over every row of an attached CSV (or similar tabular file) and appends one or more **LLM-generated columns** to each row. Think "row-wise enrichment with a prompt" — classification, summarization, entity extraction, categorization. It lives in the **Tool** section of the add-node panel (between Script and Transform).
+
+## Node Type
+
+`uipath.pattern.batch-transform`
+
+This is a fixed OOTB node type — no registry suffix, one version. It does not appear in `uip maestro flow registry list` unless the tenant has the platform-side `canvas.nodes.batch-transform` feature flag enabled. The uip CLI unconditionally requests this flag in its manifest fetch, so the node will appear once the server rolls the flag out to your tenant.
+
+## When to Use
+
+Use Batch Transform when the task is **"do this to every row"** and the per-row work requires natural-language reasoning that is impractical to express as code.
+
+### Selection Heuristics
+
+| Situation | Use Batch Transform? |
+| --- | --- |
+| Add LLM-generated columns to each row of a CSV (category, sentiment, one-line summary) | Yes |
+| Enrich rows with web-searched facts (e.g., look up a company's HQ city per row) | Yes — set `enableWebSearchGrounding: true` |
+| Small ad-hoc data shape change (rename, filter, groupBy) on an in-memory array | No — use [Transform](../transform/planning.md) |
+| Per-row side effects (API calls, DB writes) | No — use [Loop](../loop/planning.md) with the per-row action inside |
+| Reason over a **single** document and produce a synthesis with citations | No — use [Summarize](../summarize/planning.md) |
+| Row-count unknown but small (< 20) and the agent should decide how to reason | Consider [Agent](../agent/planning.md) with the collection in its context instead |
+
+### Anti-Patterns
+
+- **Do not use Batch Transform for deterministic work.** If the new column is a formula, regex match, or date reformat, use [Transform](../transform/planning.md) or [Script](../script/planning.md) — the LLM adds cost and latency for no accuracy gain.
+- **Do not use Batch Transform as a general loop.** It only produces new columns attached to the same rows; it cannot call APIs or perform side effects per row. Use [Loop](../loop/planning.md) for that.
+- **Do not pass reasoning-heavy instructions that depend on the whole document.** Each row is processed with only its own values plus the prompt — it cannot "see" other rows or an external document. For cross-row reasoning, pre-aggregate with [Transform](../transform/planning.md) first, or use [Summarize](../summarize/planning.md) over a synthesized attachment.
+
+## Ports
+
+| Port | Position | Direction | Use |
+| --- | --- | --- | --- |
+| `input` | left | target | Flow sequence input |
+| `output` | right | source | Produced file handle with the new columns appended |
+| `error` | right | source | Error handler (populated when the batch job fails) |
+
+No artifact ports. Pattern-style nodes do not wire to resource files — the prompt and column definitions live on the node inputs.
+
+## Output Variables
+
+- `$vars.{nodeId}.output` — file handle of the result CSV: `{ id, fileName, mimeType }`. Pass this to downstream nodes that consume files (e.g., another Batch Transform, a connector that uploads the result).
+- `$vars.{nodeId}.error` — populated on failure: `{ code, message, detail, category, status }`.
+
+## Key Inputs
+
+| Input | Required | Type | Description |
+| --- | --- | --- | --- |
+| `attachment` | Yes | string (Orchestrator Attachment Id) | The Orchestrator Attachment Id of the source CSV — a GUID identifying a file already uploaded to Orchestrator's Storage Buckets / Attachments store. Typically a `$vars.*` reference to an upstream node that produced the attachment (e.g., a connector, RPA node, or HTTP step that uploaded a CSV and returned its id), or a literal attachment id string. **Not** a file URL, byte stream, or local path. |
+| `prompt` | Yes | string | The instruction describing what each output column should contain. Can reference column names from the source via natural language ("summarize the `Description` field"). |
+| `outputColumns` | Yes | array of `{ name, description }` | The columns to produce. Max 10. `name` is the column header; `description` tells the LLM what to put in it. |
+| `enableWebSearchGrounding` | No | boolean | When `true`, the LLM can issue web searches per row to ground its answer. Slower and costlier — use only when rows need external facts. Default `false`. |
+
+### `outputColumns` shape
+
+```json
+[
+  { "name": "Category", "description": "One of: Invoice, Receipt, Contract, Other" },
+  { "name": "Summary",  "description": "One-line plain-English summary of the row" }
+]
+```
+
+Do not reshape — the canvas editor writes exactly this `{ name, description }` shape, and downstream serialization (BPMN `ECS.BatchTransform` service task) depends on it.
+
+## Planning Annotation
+
+In the architectural plan:
+
+- `pattern: batch-transform — <one-line purpose>` with a placeholder for the attachment source (usually a `$vars.<upstream>.output.*` file handle) and the list of output column names.
+- Call out `enableWebSearchGrounding` in **Open Questions** if the requirements hint at external lookups but are not explicit — the cost/latency jump warrants confirmation.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
@@ -22,43 +22,7 @@ If the command errors with **"Node type not found: uipath.pattern.deep-rag"**, t
 
 ## Adding / Editing
 
-For general add, delete, and wiring mechanics, see [editing-operations.md](../../editing-operations.md). The snippets below cover what is **specific** to Summarize.
-
-### Add the node via CLI
-
-```bash
-uip maestro flow node add <FlowName>.flow uipath.pattern.deep-rag \
-  --label "<LABEL>" \
-  --position <X>,<Y> \
-  --input '{
-    "attachment": "=js:$vars.<inputAttachmentVar>",
-    "prompt": "<INSTRUCTION for the synthesis>",
-    "returnCitations": true
-  }' \
-  --output json
-```
-
-`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object. Set `returnCitations: false` (or omit) when downstream consumers do not need page-level provenance.
-
-**Save the returned node ID** — needed for wiring edges and downstream `$vars.{nodeId}.output` references.
-
-### Wire edges
-
-```bash
-uip maestro flow node list <FlowName>.flow --output json
-
-# Upstream file producer (e.g., HTTP download, connector) → Summarize
-uip maestro flow edge add <FlowName>.flow <upstreamNodeId> <drNodeId> \
-  --source-port <upstreamOutputPort> --target-port input --output json
-
-# Summarize success → downstream consumer
-uip maestro flow edge add <FlowName>.flow <drNodeId> <nextNodeId> \
-  --source-port output --target-port input --output json
-
-# Optional: error branch
-uip maestro flow edge add <FlowName>.flow <drNodeId> <errorHandlerId> \
-  --source-port error --target-port input --output json
-```
+Pattern nodes are OOTB BPMN service tasks — author them by editing the `.flow` JSON directly (Edit/Write). This is the canonical authoring path per [author/CAPABILITY.md rule 2](../../CAPABILITY.md): the `uip maestro flow node add` / `edge add` carve-out is reserved for connectors, connector-triggers, and managed HTTP, where the CLI populates product-managed state. For OOTB structural edits — adding the Summarize node, wiring its edges, adding the `attachment` flow input — use Edit/Write against the `.flow` file. See [editing-operations.md](../../editing-operations.md) for the JSON authoring mechanics; the snippets below cover what is **specific** to Summarize.
 
 ## JSON Structure
 
@@ -66,7 +30,7 @@ uip maestro flow edge add <FlowName>.flow <drNodeId> <errorHandlerId> \
 {
   "id": "summarizeContract",
   "type": "uipath.pattern.deep-rag",
-  "typeVersion": "1.0.0",
+  "typeVersion": "1.0",
   "display": { "label": "Summarize Contract" },
   "inputs": {
     "attachment": "=js:$vars.contractDoc",
@@ -86,19 +50,51 @@ uip maestro flow edge add <FlowName>.flow <drNodeId> <errorHandlerId> \
       "source": "=Error",
       "var": "error"
     }
-  },
-  "model": {
-    "type": "bpmn:ServiceTask",
-    "serviceType": "ECS.DeepRag"
   }
 }
 ```
 
 Notes:
 
-- `model.bindings` is **absent** — Summarize is not a process or connector node; there is nothing to bind.
+- **No instance-level `model` block.** BPMN type and `serviceType: "ECS.DeepRag"` live only in the corresponding `definitions[]` entry — copy that verbatim from `uip maestro flow registry get uipath.pattern.deep-rag --output json`. Per [author/CAPABILITY.md rule 16](../../CAPABILITY.md), node instances normally have no `model` block.
+- **`typeVersion` must match `definitions[<deep-rag>].version` exactly** — the registry currently emits `"1.0"` (one dot). Do not guess `"1.0.0"`.
 - `outputs.output.source` is the literal `=deepRagResult` — do not rewrite.
 - Setting `returnCitations: true` populates `content.citations`; setting `false` omits the array entirely (the downstream consumer should tolerate either).
+
+## End-node output mapping
+
+If the flow surfaces the synthesized text or citations as flow `out` variables, the End node must map them. Per [author/CAPABILITY.md rule 12](../../CAPABILITY.md), value-field expressions need the `=js:` prefix:
+
+```json
+{
+  "id": "end",
+  "type": "core.control.end",
+  "typeVersion": "1.0",
+  "outputs": {
+    "summary":   { "source": "=js:$vars.summarizeContract.output.content.text" },
+    "citations": { "source": "=js:$vars.summarizeContract.output.content.citations" }
+  }
+}
+```
+
+Without `=js:`, the runtime stores the literal string (e.g. `"$vars.summarizeContract.output.content.text"`) into the flow output instead of the real value. When `returnCitations: false`, drop the `citations` mapping rather than mapping a missing field.
+
+## Add via CLI (opt-in, not preferred)
+
+The `uip maestro flow node add` / `edge add` CLI is **not** the canonical authoring path for OOTB pattern nodes (see rule 2 above). Reach for it only when scripting in a context where Edit/Write isn't available. The shape:
+
+```bash
+uip maestro flow node add <FlowName>.flow uipath.pattern.deep-rag \
+  --label "<LABEL>" \
+  --input '{
+    "attachment": "=js:$vars.<inputAttachmentVar>",
+    "prompt": "<INSTRUCTION for the synthesis>",
+    "returnCitations": true
+  }' \
+  --output json
+```
+
+`attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object. Set `returnCitations: false` (or omit) when downstream consumers do not need page-level provenance.
 
 ## Accessing Output
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
@@ -1,0 +1,142 @@
+# Summarize Pattern Node — Implementation
+
+Summarize synthesizes a response grounded in an attached document. Node type: `uipath.pattern.deep-rag`. BPMN service task with `serviceType: "ECS.DeepRag"`. No process bindings, no connection binding — inputs are the only source of configuration.
+
+## Registry Validation
+
+```bash
+uip maestro flow registry get uipath.pattern.deep-rag --output json
+```
+
+Confirm:
+
+- Input port: `input`
+- Output ports: `output`, `error`
+- `model.type` — `bpmn:ServiceTask`
+- `model.serviceType` — `ECS.DeepRag`
+- `inputDefinition.properties` — `attachment` (string — Orchestrator Attachment Id), `prompt` (string), `returnCitations` (boolean)
+- `outputDefinition.output.schema.properties.content` contains `text` (and `citations` when enabled)
+- `outputDefinition.error.schema.required` — `code`, `message`, `detail`, `category`, `status`
+
+If the command errors with **"Node type not found: uipath.pattern.deep-rag"**, the CLI build predates Summarize support or the tenant's `canvas.nodes.summarize` server flag is off. Run `uip cli update` and `uip maestro flow registry pull --force`; if it still errors, confirm with your UiPath admin that `canvas.nodes.summarize` is enabled on the tenant.
+
+## Adding / Editing
+
+For general add, delete, and wiring mechanics, see [editing-operations.md](../../editing-operations.md). The snippets below cover what is **specific** to Summarize.
+
+### Add the node via CLI
+
+```bash
+uip maestro flow node add <FlowName>.flow uipath.pattern.deep-rag \
+  --label "<LABEL>" \
+  --position <X>,<Y> \
+  --input '{
+    "attachment": "$vars.<upstreamNode>.output.<attachmentIdField>",
+    "prompt": "<INSTRUCTION for the synthesis>",
+    "returnCitations": true
+  }' \
+  --output json
+```
+
+`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to an **Orchestrator Attachment Id** string (a GUID) — point it at the field on the upstream node's output that carries the attachment id (not a file URL, file bytes, or a path). Set `returnCitations: false` (or omit) when downstream consumers do not need page-level provenance.
+
+**Save the returned node ID** — needed for wiring edges and downstream `$vars.{nodeId}.output` references.
+
+### Wire edges
+
+```bash
+uip maestro flow node list <FlowName>.flow --output json
+
+# Upstream file producer (e.g., HTTP download, connector) → Summarize
+uip maestro flow edge add <FlowName>.flow <upstreamNodeId> <drNodeId> \
+  --source-port <upstreamOutputPort> --target-port input --output json
+
+# Summarize success → downstream consumer
+uip maestro flow edge add <FlowName>.flow <drNodeId> <nextNodeId> \
+  --source-port output --target-port input --output json
+
+# Optional: error branch
+uip maestro flow edge add <FlowName>.flow <drNodeId> <errorHandlerId> \
+  --source-port error --target-port input --output json
+```
+
+## JSON Structure
+
+```json
+{
+  "id": "summarizeContract",
+  "type": "uipath.pattern.deep-rag",
+  "typeVersion": "1.0.0",
+  "display": { "label": "Summarize Contract" },
+  "inputs": {
+    "attachment": "$vars.uploadContract.output.attachmentId",
+    "prompt": "Write a 5-bullet executive summary covering scope, term, SLAs, penalties, and termination.",
+    "returnCitations": true
+  },
+  "outputs": {
+    "output": {
+      "type": "object",
+      "description": "Synthesis result",
+      "source": "=deepRagResult",
+      "var": "output"
+    },
+    "error": {
+      "type": "object",
+      "description": "Error information if the synthesis fails",
+      "source": "=Error",
+      "var": "error"
+    }
+  },
+  "model": {
+    "type": "bpmn:ServiceTask",
+    "serviceType": "ECS.DeepRag"
+  }
+}
+```
+
+Notes:
+
+- `model.bindings` is **absent** — Summarize is not a process or connector node; there is nothing to bind.
+- `outputs.output.source` is the literal `=deepRagResult` — do not rewrite.
+- Setting `returnCitations: true` populates `content.citations`; setting `false` omits the array entirely (the downstream consumer should tolerate either).
+
+## Accessing Output
+
+```javascript
+// Downstream Script node
+const result = $vars.summarizeContract.output;
+const text = result.content.text;                   // the synthesized prose
+const citations = result.content.citations ?? [];    // [{ ordinal, page, source }, ...]
+return {
+  summary: text,
+  citationCount: citations.length,
+};
+```
+
+If `returnCitations: false`, the `citations` array is not present. Guard with `?? []` or check `result.content.citations != null` before iterating.
+
+## Validate
+
+```bash
+uip maestro flow validate <FlowName>.flow --output json
+```
+
+The validator checks that required inputs (`attachment`, `prompt`) are present and non-empty.
+
+## Debug
+
+| Error | Cause | Fix |
+| --- | --- | --- |
+| `Node type not found: uipath.pattern.deep-rag` | CLI predates Summarize support, or tenant flag `canvas.nodes.summarize` is off | `uip cli update`, `uip maestro flow registry pull --force`; check with admin that `canvas.nodes.summarize` is enabled if still missing |
+| Runtime: synthesis returns empty `content.text` | Prompt too vague, or attachment unreadable (image-only PDF with no OCR, corrupted file) | Tighten the prompt; confirm the attachment type is supported and has selectable text |
+| `content.citations` missing even though set `returnCitations: true` | Downstream consumer read the node's `inputDefaults` before the runtime produced the output | Reference `$vars.{nodeId}.output.content.citations` only in nodes downstream of Summarize; do not precompute |
+| Large documents time out | Synthesis cost scales with doc size; single call is bounded | Split the document upstream (per-section Summarize calls + a final merge step) or move to a published [Agent](../agent/impl.md) with a context-grounding resource |
+| Wrong citations (pages off by one, wrong source) | The attached document's page numbering doesn't match the displayed page ordinal | Treat `ordinal` and `page` as advisory — present the source identifier alongside and let the reader verify |
+
+## What NOT to Do
+
+- **Do not hand-author `model.bindings`** on the node — Summarize has no process or connector binding. Adding a `bindings` block will be stripped or cause validate errors.
+- **Do not pass `--source` on `uip maestro flow node add`** — `--source` is only for inline agent nodes. Summarize has no agent project behind it.
+- **Do not chain Summarize for multi-turn chat.** It is single-turn; each call is independent. Use a published [Agent](../agent/impl.md) for conversational flows.
+- **Do not stuff `prompt` with entire document text.** The attachment is already ingested — the prompt should describe **the task**, not the input.
+- **Do not assume `content.citations` is always present.** When `returnCitations: false`, the field is omitted; downstream code must guard.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
@@ -14,7 +14,7 @@ Confirm:
 - Output ports: `output`, `error`
 - `model.type` — `bpmn:ServiceTask`
 - `model.serviceType` — `ECS.DeepRag`
-- `inputDefinition.properties` — `attachment` (string — Orchestrator Attachment Id), `prompt` (string), `returnCitations` (boolean)
+- `inputDefinition.properties` — `attachment` (object — full Flow Attachment, **not** a bare id), `prompt` (string), `returnCitations` (boolean). The schema declares `string` because Studio Web's file picker serializes the whole Attachment object into that slot at save time; the runtime parses it back as an object — pass the **whole** `{ FullName, Id, Metadata, MimeType }` object, not a GUID, URL, or path.
 - `outputDefinition.output.schema.properties.content` contains `text` (and `citations` when enabled)
 - `outputDefinition.error.schema.required` — `code`, `message`, `detail`, `category`, `status`
 
@@ -31,14 +31,14 @@ uip maestro flow node add <FlowName>.flow uipath.pattern.deep-rag \
   --label "<LABEL>" \
   --position <X>,<Y> \
   --input '{
-    "attachment": "$vars.<upstreamNode>.output.<attachmentIdField>",
+    "attachment": "=js:$vars.<inputAttachmentVar>",
     "prompt": "<INSTRUCTION for the synthesis>",
     "returnCitations": true
   }' \
   --output json
 ```
 
-`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to an **Orchestrator Attachment Id** string (a GUID) — point it at the field on the upstream node's output that carries the attachment id (not a file URL, file bytes, or a path). Set `returnCitations: false` (or omit) when downstream consumers do not need page-level provenance.
+`--input` accepts a JSON object; the CLI merges it into the node's `inputs`. `attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object. Set `returnCitations: false` (or omit) when downstream consumers do not need page-level provenance.
 
 **Save the returned node ID** — needed for wiring edges and downstream `$vars.{nodeId}.output` references.
 
@@ -69,7 +69,7 @@ uip maestro flow edge add <FlowName>.flow <drNodeId> <errorHandlerId> \
   "typeVersion": "1.0.0",
   "display": { "label": "Summarize Contract" },
   "inputs": {
-    "attachment": "$vars.uploadContract.output.attachmentId",
+    "attachment": "=js:$vars.contractDoc",
     "prompt": "Write a 5-bullet executive summary covering scope, term, SLAs, penalties, and termination.",
     "returnCitations": true
   },
@@ -140,3 +140,4 @@ The validator checks that required inputs (`attachment`, `prompt`) are present a
 - **Do not chain Summarize for multi-turn chat.** It is single-turn; each call is independent. Use a published [Agent](../agent/impl.md) for conversational flows.
 - **Do not stuff `prompt` with entire document text.** The attachment is already ingested — the prompt should describe **the task**, not the input.
 - **Do not assume `content.citations` is always present.** When `returnCitations: false`, the field is omitted; downstream code must guard.
+- **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. Always pass the whole object via `=js:$vars.<name>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/planning.md
@@ -1,0 +1,66 @@
+# Summarize Pattern Node — Planning
+
+The Summarize node runs comprehensive document synthesis over an attached file (PDF, Word, etc.): ingest, retrieve, reason, and return prose — optionally with per-sentence citations back to the source pages. It sits in the **Document Processing** category of the add-node panel.
+
+## Node Type
+
+`uipath.pattern.deep-rag`
+
+(The wire type still reads `deep-rag` even though the canvas display name is "Summarize" — the node type is contractual with the runtime serializer and was not renamed.)
+
+Fixed OOTB node type — no registry suffix, one version. It does not appear in `uip maestro flow registry list` unless the tenant has the platform-side `canvas.nodes.summarize` feature flag enabled. The uip CLI unconditionally requests this flag in its manifest fetch, so the node will appear once the server rolls it out to your tenant.
+
+## When to Use
+
+Use Summarize when the task is **"read this document and produce a thorough answer"** — summarization, Q&A, compliance checks, executive briefs — where depth matters and traceability back to the source is valuable.
+
+### Selection Heuristics
+
+| Situation | Use Summarize? |
+| --- | --- |
+| Summarize a long document (contract, policy, research paper) | Yes |
+| Answer a free-form question grounded in one attached document | Yes |
+| Produce a report where every claim must cite the source page | Yes — set `returnCitations: true` |
+| Short, single-turn Q&A over small text in-memory | No — use [Agent](../agent/planning.md) or [Script](../script/planning.md) |
+| Row-by-row enrichment of tabular data | No — use [Batch Transform](../batch-transform/planning.md) |
+| Multi-document retrieval across a corpus | No — Summarize is scoped to one attachment per call. Chain multiple Summarize nodes (one per doc) and merge results, or use a published [Agent](../agent/planning.md) with a context-grounding resource |
+| The user wants to chat with the document | No — Summarize is single-turn. Use an [Agent](../agent/planning.md) with a context resource for conversational behavior |
+
+### Anti-Patterns
+
+- **Do not use Summarize for small/simple text.** For a few paragraphs inline in `$vars`, a [Script](../script/planning.md) or [Agent](../agent/planning.md) is cheaper and faster.
+- **Do not use Summarize as a general agent.** It cannot call tools, escalate, or loop — it is a single synthesis step. For multi-step reasoning with tool use, use an [Agent](../agent/planning.md).
+- **Do not chain multiple Summarize nodes to emulate multi-document retrieval if the answer requires cross-document reasoning.** Per-document synthesis then merging loses cross-doc grounding. Use a published [Agent](../agent/planning.md) with a proper retrieval resource instead.
+
+## Ports
+
+| Port | Position | Direction | Use |
+| --- | --- | --- | --- |
+| `input` | left | target | Flow sequence input |
+| `output` | right | source | Synthesis text (plus citations if enabled) |
+| `error` | right | source | Error handler |
+
+No artifact ports. Pattern-style nodes do not wire to resource files — the prompt lives on the node inputs.
+
+## Output Variables
+
+- `$vars.{nodeId}.output` — an object with:
+  - `id` — the result identifier
+  - `content.text` — the synthesized prose
+  - `content.citations` — optional array (present only when `returnCitations: true`) of `{ ordinal, page, source }` pointing back to the attachment
+- `$vars.{nodeId}.error` — populated on failure: `{ code, message, detail, category, status }`.
+
+## Key Inputs
+
+| Input | Required | Type | Description |
+| --- | --- | --- | --- |
+| `attachment` | Yes | string (Orchestrator Attachment Id) | The Orchestrator Attachment Id of the document to synthesize — a GUID identifying a file already uploaded to Orchestrator's Storage Buckets / Attachments store. Typically a `$vars.*` reference to an upstream node that produced the attachment (e.g., a connector, RPA node, or HTTP step that uploaded a file and returned its id), or a literal attachment id string. **Not** a file URL, byte stream, or local path. |
+| `prompt` | Yes | string | The task instruction — e.g., "Write a 3-paragraph executive summary", "List every SLA penalty clause", "Answer: what is the termination notice period?". |
+| `returnCitations` | No | boolean | When `true`, the `content.citations` array is populated with per-claim page references. Default `false`. |
+
+## Planning Annotation
+
+In the architectural plan:
+
+- `pattern: summarize — <one-line purpose>` with a placeholder for the attachment source (usually a `$vars.<upstream>.output.*` file handle) and a short summary of the prompt.
+- If the downstream step needs to display or audit sources, call out `returnCitations: true` explicitly in the node table; otherwise leave it `false`.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/planning.md
@@ -54,7 +54,7 @@ No artifact ports. Pattern-style nodes do not wire to resource files — the pro
 
 | Input | Required | Type | Description |
 | --- | --- | --- | --- |
-| `attachment` | Yes | string (Orchestrator Attachment Id) | The Orchestrator Attachment Id of the document to synthesize — a GUID identifying a file already uploaded to Orchestrator's Storage Buckets / Attachments store. Typically a `$vars.*` reference to an upstream node that produced the attachment (e.g., a connector, RPA node, or HTTP step that uploaded a file and returned its id), or a literal attachment id string. **Not** a file URL, byte stream, or local path. |
+| `attachment` | Yes | object (full Flow Attachment) | The full Flow Attachment object for the document — shape `{ FullName, Id, Metadata, MimeType }`. Source it as a flow-level `in` variable of `type: "object"` populated by `uip maestro flow debug --file <name>=<path>`, or from an upstream node that emits a Flow Attachment. Reference the **whole object** with `=js:$vars.<name>` — never `.Id`, a GUID literal, URL, or path. The OOTB schema says `string` and Studio Web shows a file picker, but at runtime the engine deserializes the slot back to the object. |
 | `prompt` | Yes | string | The task instruction — e.g., "Write a 3-paragraph executive summary", "List every SLA penalty clause", "Answer: what is the termination notice period?". |
 | `returnCitations` | No | boolean | When `true`, the `content.citations` array is populated with per-claim page references. Default `false`. |
 

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
@@ -22,11 +22,13 @@ sandbox:
 
 initial_prompt: |
   Create a UiPath Flow project named "BatchTransformDemo" that uses a Batch
-  Transform pattern node to enrich rows of a CSV. The flow takes one input
-  variable named `attachmentId` (the Orchestrator Attachment Id of the CSV).
+  Transform pattern node to enrich rows of a CSV. The flow takes one `in`
+  variable of `type: "object"` named `csvAttachment` — the full Flow Attachment
+  object for the source CSV (shape `{ FullName, Id, Metadata, MimeType }`).
   The Batch Transform node must:
 
-    - have its `attachment` input wired to the flow input variable
+    - have its `attachment` input wired to the flow input variable as the
+      WHOLE object (`=js:$vars.csvAttachment`, not `.Id` or any subfield)
     - use this prompt: `Classify each row by category and write a one-line summary.`
     - declare two output columns:
         - `Category`     — One of: Utility, Software, Travel, Other

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
@@ -1,0 +1,63 @@
+task_id: skill-flow-batch-transform
+description: >
+  Create a UiPath Flow that runs a Batch Transform pattern node over a CSV
+  attachment to append two LLM-generated columns (Category, Summary) per row.
+  Exercises Batch Transform node discovery, the `outputColumns` array shape,
+  and wiring of the `attachment` input from a flow-level input variable.
+  A `flow debug` step is intentionally omitted — Batch Transform requires a
+  pre-uploaded Orchestrator attachment and the ECS.BatchTransform service
+  backend, neither of which the test sandbox can provision deterministically.
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:batch-transform]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "BatchTransformDemo" that uses a Batch
+  Transform pattern node to enrich rows of a CSV. The flow takes one input
+  variable named `attachmentId` (the Orchestrator Attachment Id of the CSV).
+  The Batch Transform node must:
+
+    - have its `attachment` input wired to the flow input variable
+    - use this prompt: `Classify each row by category and write a one-line summary.`
+    - declare two output columns:
+        - `Category`     — One of: Utility, Software, Travel, Other
+        - `Summary`      — Plain-English one-line summary of the row
+    - leave `enableWebSearchGrounding` at its default
+
+  Wire the Batch Transform's `output` port through to an End node and surface
+  the result file handle as a flow output variable named `result`.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its
+  workflow steps exactly — in particular, the batch-transform plugin's
+  `outputColumns` shape (array of `{ name, description }`).
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate BatchTransformDemo/BatchTransformDemo/BatchTransformDemo.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks (node type, inputs, outputColumns shape) ─────────
+  - type: run_command
+    description: "Flow has a Batch Transform node with required inputs and the {name,description} outputColumns shape"
+    command: "python3 $TASK_DIR/check_batch_transform_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
@@ -11,6 +11,10 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
      `=js:$vars.<name>` — not `.Id`, `.FullName`, or any subfield. The runtime
      wants the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`.
   5. The referenced flow input variable is declared `type: "object"`.
+  6. The flow declares an `out` variable named `result`, and at least one End
+     node maps it via `outputs.result.source` using a `=js:$vars.<bt>.output`
+     reference (not a bare `$vars.…` literal — rule 12 requires the `=js:`
+     prefix).
 """
 
 import glob
@@ -92,6 +96,47 @@ def _check_attachment_is_whole_object(flow: dict, attachment) -> None:
         )
 
 
+_OUTPUT_MAPPING_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\b")
+
+
+def _check_result_output_mapping(flow: dict, bt_node_id: str) -> None:
+    """The flow surfaces the BT result as an `out` variable `result`. Verify
+    the variable exists and at least one End node maps it correctly.
+
+    Each End node may carry an `outputs.<varId>.source` for every `out`
+    variable; the source MUST use `=js:$vars.<bt>.output` (rule 12).
+    """
+    globals_ = (flow.get("variables") or {}).get("globals") or []
+    result_var = next(
+        (v for v in globals_ if v.get("id") == "result" and v.get("direction") == "out"),
+        None,
+    )
+    if result_var is None:
+        _fail(
+            "flow has no `out` variable with id='result'. The task prompt asks for the "
+            "Batch Transform result file handle to be surfaced as a flow output named `result`."
+        )
+
+    end_nodes = [n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"]
+    if not end_nodes:
+        _fail("flow has no End node — required to terminate the path and map outputs")
+
+    mapped_on = []
+    for end in end_nodes:
+        src = ((end.get("outputs") or {}).get("result") or {}).get("source")
+        if not isinstance(src, str) or not src.strip():
+            continue
+        m = _OUTPUT_MAPPING_REF.match(src.strip())
+        if m and m.group(1) == bt_node_id:
+            mapped_on.append(end.get("id"))
+    if not mapped_on:
+        _fail(
+            "no End node maps `outputs.result.source` to `=js:$vars."
+            f"{bt_node_id}.output` (or similar). Without an `=js:` mapping per rule 12, "
+            "the flow output is the literal string instead of the real BT result handle."
+        )
+
+
 def main():
     flow = _read_flow()
     node = _find_node(flow)
@@ -103,11 +148,12 @@ def main():
 
     _check_attachment_is_whole_object(flow, inputs.get("attachment"))
     _check_outputColumns(inputs.get("outputColumns"))
+    _check_result_output_mapping(flow, node["id"])
 
     print(
         f"OK: {NODE_TYPE} node present; prompt set; attachment is whole-object ref to a "
         f"`type: object` flow input; outputColumns has {len(inputs['outputColumns'])} "
-        "{name,description} entries"
+        "{name,description} entries; End node maps `result` via `=js:` reference"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
@@ -7,12 +7,15 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
   2. `inputs.prompt` is non-empty.
   3. `inputs.outputColumns` is an array of objects with `name` + `description`
      keys (not flattened to a `{name: description}` map and not a string array).
-  4. `inputs.attachment` is wired (non-empty), and is **not** a literal empty
-     string — typically a `$vars.*` reference.
+  4. `inputs.attachment` is wired to the WHOLE flow input object via
+     `=js:$vars.<name>` — not `.Id`, `.FullName`, or any subfield. The runtime
+     wants the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`.
+  5. The referenced flow input variable is declared `type: "object"`.
 """
 
 import glob
 import json
+import re
 import sys
 
 NODE_TYPE = "uipath.pattern.batch-transform"
@@ -62,6 +65,33 @@ def _check_outputColumns(value) -> None:
                 )
 
 
+_ATTACHMENT_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\s*$")
+
+
+def _check_attachment_is_whole_object(flow: dict, attachment) -> None:
+    if not isinstance(attachment, str) or not attachment.strip():
+        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
+    m = _ATTACHMENT_REF.match(attachment.strip())
+    if not m:
+        _fail(
+            f"inputs.attachment={attachment!r} must be `=js:$vars.<name>` referencing the WHOLE "
+            "Flow Attachment object — not a bare id, GUID, URL, path, or subfield like `.Id`."
+        )
+    var_name = m.group(1)
+    globals_ = (flow.get("variables") or {}).get("globals") or []
+    var = next((v for v in globals_ if v.get("id") == var_name), None)
+    if var is None:
+        _fail(
+            f"inputs.attachment references `$vars.{var_name}` but no flow `globals` variable "
+            f"with id={var_name!r} exists. Declare it as an `in` variable of type `object`."
+        )
+    if var.get("type") != "object":
+        _fail(
+            f"flow input variable `{var_name}` has type={var.get('type')!r}; must be `object` "
+            "to hold the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`."
+        )
+
+
 def main():
     flow = _read_flow()
     node = _find_node(flow)
@@ -71,15 +101,13 @@ def main():
     if not isinstance(prompt, str) or not prompt.strip():
         _fail("inputs.prompt missing or empty")
 
-    attachment = inputs.get("attachment")
-    if not isinstance(attachment, str) or not attachment.strip():
-        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
-
+    _check_attachment_is_whole_object(flow, inputs.get("attachment"))
     _check_outputColumns(inputs.get("outputColumns"))
 
     print(
-        f"OK: {NODE_TYPE} node present; prompt set; attachment wired; "
-        f"outputColumns has {len(inputs['outputColumns'])} {{name,description}} entries"
+        f"OK: {NODE_TYPE} node present; prompt set; attachment is whole-object ref to a "
+        f"`type: object` flow input; outputColumns has {len(inputs['outputColumns'])} "
+        "{name,description} entries"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""BatchTransformDemo: structural check for the Batch Transform pattern node.
+
+Generation-only — does not run `uip maestro flow debug`. Verifies:
+
+  1. Exactly one `uipath.pattern.batch-transform` node is present.
+  2. `inputs.prompt` is non-empty.
+  3. `inputs.outputColumns` is an array of objects with `name` + `description`
+     keys (not flattened to a `{name: description}` map and not a string array).
+  4. `inputs.attachment` is wired (non-empty), and is **not** a literal empty
+     string — typically a `$vars.*` reference.
+"""
+
+import glob
+import json
+import sys
+
+NODE_TYPE = "uipath.pattern.batch-transform"
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/BatchTransformDemo*.flow", recursive=True)
+    if not flows:
+        _fail("no BatchTransformDemo*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _find_node(flow: dict) -> dict:
+    matches = [n for n in flow.get("nodes", []) if n.get("type") == NODE_TYPE]
+    if not matches:
+        types = sorted({n.get("type") for n in flow.get("nodes", [])})
+        _fail(f"no node with type {NODE_TYPE!r}; types seen: {types}")
+    if len(matches) > 1:
+        _fail(f"expected exactly one {NODE_TYPE} node, found {len(matches)}")
+    return matches[0]
+
+
+def _check_outputColumns(value) -> None:
+    if not isinstance(value, list):
+        _fail(
+            f"inputs.outputColumns must be a list, got {type(value).__name__}. "
+            "The batch-transform plugin docs require the array-of-objects shape."
+        )
+    if not value:
+        _fail("inputs.outputColumns is empty — at least one column is required")
+    for i, col in enumerate(value):
+        if not isinstance(col, dict):
+            _fail(
+                f"inputs.outputColumns[{i}] is {type(col).__name__}, expected dict "
+                "with 'name' and 'description' keys"
+            )
+        for key in ("name", "description"):
+            if key not in col or not isinstance(col[key], str) or not col[key].strip():
+                _fail(
+                    f"inputs.outputColumns[{i}].{key} is missing or empty. "
+                    "Each entry must have non-empty 'name' and 'description'."
+                )
+
+
+def main():
+    flow = _read_flow()
+    node = _find_node(flow)
+    inputs = node.get("inputs") or {}
+
+    prompt = inputs.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        _fail("inputs.prompt missing or empty")
+
+    attachment = inputs.get("attachment")
+    if not isinstance(attachment, str) or not attachment.strip():
+        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
+
+    _check_outputColumns(inputs.get("outputColumns"))
+
+    print(
+        f"OK: {NODE_TYPE} node present; prompt set; attachment wired; "
+        f"outputColumns has {len(inputs['outputColumns'])} {{name,description}} entries"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""SummarizeDemo: structural check for the Summarize pattern node.
+
+Generation-only — does not run `uip maestro flow debug`. Verifies:
+
+  1. Exactly one `uipath.pattern.deep-rag` node is present (the wire type
+     stays `deep-rag` even though the canvas display name is "Summarize").
+  2. `inputs.prompt` is non-empty.
+  3. `inputs.attachment` is wired (non-empty), typically a `$vars.*` reference.
+  4. `inputs.returnCitations` is the boolean `true` (per the prompt's request).
+"""
+
+import glob
+import json
+import sys
+
+NODE_TYPE = "uipath.pattern.deep-rag"
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/SummarizeDemo*.flow", recursive=True)
+    if not flows:
+        _fail("no SummarizeDemo*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _find_node(flow: dict) -> dict:
+    matches = [n for n in flow.get("nodes", []) if n.get("type") == NODE_TYPE]
+    if not matches:
+        types = sorted({n.get("type") for n in flow.get("nodes", [])})
+        _fail(
+            f"no node with type {NODE_TYPE!r}; types seen: {types}. "
+            f"Note: the wire type stays 'deep-rag' even though the display name is 'Summarize'."
+        )
+    if len(matches) > 1:
+        _fail(f"expected exactly one {NODE_TYPE} node, found {len(matches)}")
+    return matches[0]
+
+
+def main():
+    flow = _read_flow()
+    node = _find_node(flow)
+    inputs = node.get("inputs") or {}
+
+    prompt = inputs.get("prompt")
+    if not isinstance(prompt, str) or not prompt.strip():
+        _fail("inputs.prompt missing or empty")
+
+    attachment = inputs.get("attachment")
+    if not isinstance(attachment, str) or not attachment.strip():
+        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
+
+    return_citations = inputs.get("returnCitations")
+    if return_citations is not True:
+        _fail(
+            f"inputs.returnCitations must be the boolean true (the prompt requested citations), "
+            f"got {return_citations!r}"
+        )
+
+    print(f"OK: {NODE_TYPE} node present; prompt set; attachment wired; returnCitations=true")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
@@ -11,6 +11,10 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
      wants the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`.
   4. The referenced flow input variable is declared `type: "object"`.
   5. `inputs.returnCitations` is the boolean `true` (per the prompt's request).
+  6. The flow declares `out` variables `summary` and `citations`, and at least
+     one End node maps each via `outputs.<var>.source` using a
+     `=js:$vars.<dr>.output.content.<field>` reference (rule 12 — value-field
+     expressions need the `=js:` prefix).
 """
 
 import glob
@@ -71,6 +75,47 @@ def _check_attachment_is_whole_object(flow: dict, attachment) -> None:
         )
 
 
+_OUTPUT_MAPPING_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\b")
+
+
+def _check_output_mappings(flow: dict, dr_node_id: str) -> None:
+    """The flow surfaces synthesis text + citations as `out` variables. Verify
+    both variables exist and at least one End node maps each correctly.
+
+    Each End node may carry an `outputs.<varId>.source` for every `out`
+    variable; the source MUST use `=js:$vars.<dr>.output.content.<field>`.
+    """
+    globals_ = (flow.get("variables") or {}).get("globals") or []
+    for var_id in ("summary", "citations"):
+        if not any(v.get("id") == var_id and v.get("direction") == "out" for v in globals_):
+            _fail(
+                f"flow has no `out` variable with id={var_id!r}. The task prompt asks for "
+                f"`{var_id}` to be surfaced as a flow output."
+            )
+
+    end_nodes = [n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"]
+    if not end_nodes:
+        _fail("flow has no End node — required to terminate the path and map outputs")
+
+    for var_id in ("summary", "citations"):
+        mapped = False
+        for end in end_nodes:
+            src = ((end.get("outputs") or {}).get(var_id) or {}).get("source")
+            if not isinstance(src, str) or not src.strip():
+                continue
+            m = _OUTPUT_MAPPING_REF.match(src.strip())
+            if m and m.group(1) == dr_node_id:
+                mapped = True
+                break
+        if not mapped:
+            _fail(
+                f"no End node maps `outputs.{var_id}.source` to "
+                f"`=js:$vars.{dr_node_id}.output.content.<field>` (or similar). Without an "
+                "`=js:` mapping per rule 12, the flow output is the literal string instead "
+                "of the real synthesis result."
+            )
+
+
 def main():
     flow = _read_flow()
     node = _find_node(flow)
@@ -89,9 +134,12 @@ def main():
             f"got {return_citations!r}"
         )
 
+    _check_output_mappings(flow, node["id"])
+
     print(
         f"OK: {NODE_TYPE} node present; prompt set; attachment is whole-object ref to a "
-        "`type: object` flow input; returnCitations=true"
+        "`type: object` flow input; returnCitations=true; End node maps "
+        "`summary` and `citations` via `=js:` references"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
@@ -6,15 +6,20 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
   1. Exactly one `uipath.pattern.deep-rag` node is present (the wire type
      stays `deep-rag` even though the canvas display name is "Summarize").
   2. `inputs.prompt` is non-empty.
-  3. `inputs.attachment` is wired (non-empty), typically a `$vars.*` reference.
-  4. `inputs.returnCitations` is the boolean `true` (per the prompt's request).
+  3. `inputs.attachment` is wired to the WHOLE flow input object via
+     `=js:$vars.<name>` — not `.Id`, `.FullName`, or any subfield. The runtime
+     wants the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`.
+  4. The referenced flow input variable is declared `type: "object"`.
+  5. `inputs.returnCitations` is the boolean `true` (per the prompt's request).
 """
 
 import glob
 import json
+import re
 import sys
 
 NODE_TYPE = "uipath.pattern.deep-rag"
+_ATTACHMENT_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\s*$")
 
 
 def _fail(msg: str):
@@ -42,6 +47,30 @@ def _find_node(flow: dict) -> dict:
     return matches[0]
 
 
+def _check_attachment_is_whole_object(flow: dict, attachment) -> None:
+    if not isinstance(attachment, str) or not attachment.strip():
+        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
+    m = _ATTACHMENT_REF.match(attachment.strip())
+    if not m:
+        _fail(
+            f"inputs.attachment={attachment!r} must be `=js:$vars.<name>` referencing the WHOLE "
+            "Flow Attachment object — not a bare id, GUID, URL, path, or subfield like `.Id`."
+        )
+    var_name = m.group(1)
+    globals_ = (flow.get("variables") or {}).get("globals") or []
+    var = next((v for v in globals_ if v.get("id") == var_name), None)
+    if var is None:
+        _fail(
+            f"inputs.attachment references `$vars.{var_name}` but no flow `globals` variable "
+            f"with id={var_name!r} exists. Declare it as an `in` variable of type `object`."
+        )
+    if var.get("type") != "object":
+        _fail(
+            f"flow input variable `{var_name}` has type={var.get('type')!r}; must be `object` "
+            "to hold the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`."
+        )
+
+
 def main():
     flow = _read_flow()
     node = _find_node(flow)
@@ -51,9 +80,7 @@ def main():
     if not isinstance(prompt, str) or not prompt.strip():
         _fail("inputs.prompt missing or empty")
 
-    attachment = inputs.get("attachment")
-    if not isinstance(attachment, str) or not attachment.strip():
-        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
+    _check_attachment_is_whole_object(flow, inputs.get("attachment"))
 
     return_citations = inputs.get("returnCitations")
     if return_citations is not True:
@@ -62,7 +89,10 @@ def main():
             f"got {return_citations!r}"
         )
 
-    print(f"OK: {NODE_TYPE} node present; prompt set; attachment wired; returnCitations=true")
+    print(
+        f"OK: {NODE_TYPE} node present; prompt set; attachment is whole-object ref to a "
+        "`type: object` flow input; returnCitations=true"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
@@ -23,10 +23,12 @@ sandbox:
 initial_prompt: |
   Create a UiPath Flow project named "SummarizeDemo" that uses a Summarize
   pattern node to synthesize a response over an attached document. The flow
-  takes one input variable named `attachmentId` (the Orchestrator Attachment
-  Id of the document). The Summarize node must:
+  takes one `in` variable of `type: "object"` named `documentAttachment` —
+  the full Flow Attachment object for the document (shape
+  `{ FullName, Id, Metadata, MimeType }`). The Summarize node must:
 
-    - have its `attachment` input wired to the flow input variable
+    - have its `attachment` input wired to the flow input variable as the
+      WHOLE object (`=js:$vars.documentAttachment`, not `.Id` or any subfield)
     - use this prompt: `Write a 5-bullet executive summary covering scope, term, SLAs, penalties, and termination.`
     - set `returnCitations` to `true`
 

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
@@ -1,0 +1,61 @@
+task_id: skill-flow-summarize
+description: >
+  Create a UiPath Flow that runs a Summarize pattern node (`uipath.pattern.deep-rag`)
+  over a single document attachment to produce a synthesized text response with
+  per-claim citations enabled. Exercises Summarize node discovery, the
+  `returnCitations` boolean input, and wiring of the `attachment` input from a
+  flow-level input variable. A `flow debug` step is intentionally omitted —
+  Summarize requires a pre-uploaded Orchestrator attachment and the ECS.DeepRag
+  service backend, neither of which the test sandbox can provision deterministically.
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:summarize]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath Flow project named "SummarizeDemo" that uses a Summarize
+  pattern node to synthesize a response over an attached document. The flow
+  takes one input variable named `attachmentId` (the Orchestrator Attachment
+  Id of the document). The Summarize node must:
+
+    - have its `attachment` input wired to the flow input variable
+    - use this prompt: `Write a 5-bullet executive summary covering scope, term, SLAs, penalties, and termination.`
+    - set `returnCitations` to `true`
+
+  Wire the Summarize node's `output` port through to an End node and surface
+  the synthesized text + citations as flow output variables `summary` and
+  `citations`.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its
+  workflow steps exactly — in particular, note that the wire-level node type is
+  `uipath.pattern.deep-rag` even though the canvas display name is "Summarize".
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate SummarizeDemo/SummarizeDemo/SummarizeDemo.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks (node type, inputs, returnCitations boolean) ─────
+  - type: run_command
+    description: "Flow has a Summarize (deep-rag) node with prompt, attachment wired, and returnCitations=true"
+    command: "python3 $TASK_DIR/check_summarize_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Adds plugin reference docs and `coder-eval` integration tests for the two LLM-driven Flow Patterns nodes — `uipath.pattern.batch-transform` (Batch Transform, in the **Tool** category per [flow-workbench #1434](https://github.com/UiPath/flow-workbench/pull/1434)) and `uipath.pattern.deep-rag` (Summarize, in **Document Processing**). Each is gated by its own per-node platform feature flag — `canvas.nodes.batch-transform` and `canvas.nodes.summarize` respectively.

## What's in this PR

**Plugin docs** under `skills/uipath-maestro-flow/references/author/references/plugins/`:

- `batch-transform/{planning,impl}.md` — when-to-use vs Transform / Loop / Agent / Summarize, port layout (`input` → `output` / `error`), `outputColumns` array-of-`{name,description}` shape (with the contractual warning about the BPMN serializer rejecting the flattened `{name: description}` map), `enableWebSearchGrounding` trade-off
- `summarize/{planning,impl}.md` — when-to-use vs Agent / Script / Batch Transform, citation handling (`returnCitations`, `content.citations` shape, must-guard semantics when `false`), wire-vs-display-name note (canvas display name "Summarize" but wire `nodeType` stays `deep-rag`)
- **`attachment` input is the full Flow Attachment object** (`{ FullName, Id, Metadata, MimeType }`) — both plugins call this out explicitly because the OOTB schema declares `string` and Studio Web shows a file picker, but the runtime engine deserializes the slot back to the object. Bare-id mistakes pass `flow validate` cleanly and fault at runtime; the docs include a "What NOT to Do" entry warning about this.
- **Authoring path is JSON, not CLI.** Per [author/CAPABILITY.md rule 2](skills/uipath-maestro-flow/references/author/CAPABILITY.md), the `uip maestro flow node add` / `edge add` CLI is reserved for connectors / connector-triggers / managed-HTTP carve-outs. Pattern nodes are OOTB BPMN service tasks → JSON authoring (Edit/Write) leads; the CLI snippet is relegated to an opt-in "not preferred" section.
- **No instance-level `model` block** in the JSON examples. Per rule 16, BPMN type and `serviceType` live only in `definitions[].model`, copied verbatim from `registry get`. `typeVersion` is `"1.0"` (one dot — matches `definitions[<node>].version`), not `"1.0.0"`.
- **Explicit "End-node output mapping" section** calling out the rule-12 `=js:` requirement on `outputs.<varId>.source` for any flow `out` variable that surfaces the pattern node's result.

**Index updates**:

- `references/author/CAPABILITY.md` — new Common-tasks rows for both nodes (with their per-node FFs inline) and entries in the plugin overview list
- `references/author/references/planning-arch.md` — pattern node rows in the Actions table, Standard Port Reference entries, and a new "I need an LLM to process rows of a CSV or summarize a document" routing block

**Tests** under `tests/tasks/uipath-maestro-flow/single_node/`:

- `batch_transform/{batch_transform.yaml, check_batch_transform_flow.py}`
- `summarize/{summarize.yaml, check_summarize_flow.py}`

Both follow the existing `outlook_trigger_inbox` shape (generation-only, `integration` tag) since Pattern nodes need a tenant FF + ECS service backend to actually execute. Auto-discovered by `make integration` via the tag — no experiment-level wiring needed.

The check scripts assert (a) the **whole-object attachment shape** — `inputs.attachment` matches `=js:$vars.<name>` (not a subfield like `.Id`) AND the referenced flow `globals` variable has `type: "object"`; and (b) **End-node output mapping** — the flow's `out` variables (`result` for BT; `summary` + `citations` for Summarize) are mapped on at least one End node via `outputs.<var>.source = =js:$vars.<node>.output…`. The latter catches rule-12 regressions where validate passes but the flow output is the literal string `"$vars.…"` at runtime.

## Test evidence

Ran `skill-flow-batch-transform` and `skill-flow-summarize` locally against alpha (`https://alpha.uipath.com`, ECS / dev_test, where `canvas.nodes.batch-transform` and `canvas.nodes.summarize` are both ON), driving Claude Code via `coder-eval` and the UiPath LLM Gateway proxy. Both flows authored end-to-end correctly per the updated docs:

**Batch Transform** (`runs/2026-05-07_10-45-48/default/skill-flow-batch-transform/`):

```
nodes: [('start', 'core.trigger.manual'),
        ('batchTransform', 'uipath.pattern.batch-transform'),
        ('end', 'core.control.end')]
vars:  [('csvAttachment', 'object', 'in'),
        ('result',         'object', 'out')]
batchTransform instance keys: ['display', 'id', 'inputs', 'outputs', 'type', 'typeVersion']
typeVersion: 1.0           ← matches definitions[<bt>].version
model on instance: None    ← BPMN type lives only in definitions[].model
End outputs.result.source: =js:$vars.batchTransform.output
attachment: =js:$vars.csvAttachment   (whole-object ref)
prompt:     'Classify each row by category and write a one-line summary.'
outputColumns: [{name=Category, description=...}, {name=Summary, description=...}]
```

`check_batch_transform_flow.py` →

> OK: uipath.pattern.batch-transform node present; prompt set; attachment is whole-object ref to a `type: object` flow input; outputColumns has 2 {name,description} entries; End node maps `result` via `=js:` reference

**Summarize** (`runs/2026-05-07_10-45-48/default/skill-flow-summarize/`):

```
nodes: [('start', 'core.trigger.manual'),
        ('summarize', 'uipath.pattern.deep-rag'),
        ('end', 'core.control.end')]
vars:  [('documentAttachment', 'object', 'in'),
        ('summary',            'string', 'out'),
        ('citations',          'array',  'out')]
summarize instance keys: ['display', 'id', 'inputs', 'outputs', 'type', 'typeVersion']
typeVersion: 1.0           ← matches definitions[<dr>].version
model on instance: None
End outputs.summary.source:   =js:$vars.summarize.output.content.text
End outputs.citations.source: =js:$vars.summarize.output.content.citations
attachment: =js:$vars.documentAttachment   (whole-object ref)
prompt:     'Write a 5-bullet executive summary covering scope, term, SLAs, penalties, and termination.'
returnCitations: true
```

`check_summarize_flow.py` →

> OK: uipath.pattern.deep-rag node present; prompt set; attachment is whole-object ref to a `type: object` flow input; returnCitations=true; End node maps `summary` and `citations` via `=js:` references

In both cases `uip maestro flow validate` passed cleanly (`coder-eval` `run_command` criterion = 1.0) and the structural checks pass when run directly against the produced artifacts.

### Heads-up on coder-eval scoring

`coder-eval` reports each task as `score=0.375` because the `run_command` criterion that invokes `python3 $TASK_DIR/check_*_flow.py` doesn't expand `$TASK_DIR` on Windows (every peer test that uses this convention — `decision`, `rpa`, `api_workflow`, `outlook_trigger_inbox`, `subflow`, etc. — has the same Windows-only behavior). On Linux/CI the substitution works and the same checks pass. The substantive verdicts above were obtained by running the check scripts directly with the cwd set to each task's sandbox dir.

## Rollout

This PR ships dormant for end-users until **both** Batch Transform and Summarize are GA on the platform. The skill changes are gated by the per-node feature flags (`canvas.nodes.batch-transform` / `canvas.nodes.summarize`), which are off in prod today. Once the platform flips them on, the docs become discoverable to coding agents the moment the flags activate — no follow-up coordination required. Each PR (this one + UiPath/cli#848) can land independently.

## Pairs with

- [UiPath/cli#848](https://github.com/UiPath/cli/pull/848) — adds `FLAG_BATCH_TRANSFORM` and `FLAG_SUMMARIZE` to `buildFeatureFlagResolver` in `node-sync-service` so both nodes pass `ManifestClient`'s client-side filter once the platform flags are on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
