### PR TITLE
feat: add uipath-access-policy-governance skill [PLT-100770]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,3 +64,6 @@
 # Data Fabric skill (CLI entity/record management)
 /skills/uipath-data-fabric/ @aditi-goyal-uipath
 /tests/tasks/uipath-data-fabric/ @aditi-goyal-uipath
+
+# Access Policy Governance skill (CLI-based ToolUsePolicy management)
+/skills/uipath-gov-access-policy/ @UiPath/AuthZ @sriramva-uipath @bansal-anushree @jianjunwang2

--- a/skills/uipath-gov-access-policy/SKILL.md
+++ b/skills/uipath-gov-access-policy/SKILL.md
@@ -1,0 +1,348 @@
+---
+name: uipath-gov-access-policy
+description: "[PREVIEW] UiPath access policies (`uip gov access-policy`): govern tool-use when an Actor Process invokes a child Resource. Selection + Actor Process + Actor Identity rules. For product settings→uipath-gov-aops-policy."
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+# UiPath Access Policy Governance
+
+Skill for authoring UiPath **access policies** of type `ToolUsePolicy` via the `uip gov access-policy` CLI. The `ToolUsePolicy` type **governs tool-use / resource-use** inside Agents and workflow automations: when an Actor Process tries to invoke a child Resource/Tool, the policy decides whether the call is allowed. The `uip gov access-policy` surface returns other policy types as well, but they are out of scope for this skill.
+
+## Scenario this skill governs
+
+When an **Actor Process** (an executable workflow — Maestro, Flow, Case Management, or Agent) invokes a child **Resource/Tool** (another Agent, Maestro, Flow, Case Management, API Workflow, or RPA) as a tool use, the PDP evaluates every applicable access policy and returns an aggregate `Allow` / `Deny` decision. This skill authors those policies.
+
+A policy decides its per-call outcome from three rule blocks — **Selection Rule** (`selectors[]`), **Actor Process Rule** (`executableRule`), and **Actor Identity Rule** (`actorRule`). See [Key Concepts § The three rule blocks](#the-three-rule-blocks-selection--actor-process--actor-identity) for the full structural shape and constraints.
+
+Evaluation flow for a single tool-use request:
+1. **PDP selects** every policy whose Selection Rule matches the Resource/Tool.
+2. For each selected policy, the PDP evaluates its Actor Process Rule AND Actor Identity Rule against the request. Both pass ⇒ the policy contributes `Allow`; otherwise it does not contribute (no-match).
+3. **Aggregation:** if **any** non-simulated policy contributes `Allow`, the final enforcement is `Allow`. Otherwise the request falls through to the runtime default (`Deny` / `NoOp`). `enforcement: "Deny"` is not authorable — Deny is the runtime default when no Allow policy matches (Critical Rule #2).
+4. Policies with `status: "Simulated"` are evaluated but excluded from aggregation (see [Key Concepts § Enforcement and status](#enforcement-and-status)).
+
+> **Terminology.** A Governance **Access Policy** is the broad category — `uip gov access-policy` can list, get, evaluate, or delete policies of multiple types. This skill authors the `ToolUsePolicy` type, which gates resource-vs-executable **tool use**. Access policies are **distinct from Automation Ops Governance Policies** (product runtime / design-time behavior for Studio, StudioX, Assistant, Robot, AI Trust Layer, …), handled by the sibling `uipath-gov-aops-policy` skill. For product settings, route there.
+
+## When to Use This Skill
+
+Activate on both **explicit access-policy requests** and **natural-language tool-use / resource-use governance intent**.
+
+**Explicit requests:**
+- User asks to create, update, delete, list, get, or evaluate an access policy
+- User mentions `uip gov access-policy`, `ToolUsePolicy`, or `tool-use policy`
+- User asks "which executables / users can call this resource?" or the inverse
+
+**Tool-use / resource-use governance intent:**
+- "When my Agent calls `<sub-agent / flow / process>`, allow/block it" — tool-use governance at the Actor Process ↔ Resource boundary
+- "Only `<Actor Process>` should be able to invoke `<Resource>`"
+- "Allow / let / permit `<Actor Process>` to use `<Resource>`" — e.g. "allow the Production Maestro to invoke the Production Agent"
+- "Block / deny / restrict `<tag>` `<Resource>` from `<Actor Process>`" — silently translate to an Allow shape (Critical Rule #2). The Spec narrative shows only the Allow framing; do not surface the translation to the user.
+- "Restrict agent / flow / RPA tool use by tag" — e.g. "only Production-tagged agents may be invoked"
+- "Only `<user / robot user / group / admin>` can trigger `<tool-use>`" — Actor Identity governance (emit `actorRule`; only `User` and `Group` types — robots resolve to `User`, ExternalApplication is unsupported)
+- "Exclude `<tag-or-UUID>` resources from `<Actor Process>`" — flip via the `None` operator on tags, values, or both
+
+**Sibling redirect:** if the user wants to govern **product settings** (Studio, StudioX, AI Trust Layer, Robot feature flags), that is the `uip gov aops-policy` surface — hand off to `uipath-gov-aops-policy`.
+
+## Recognize Intent → Pick the Right Plugin Blocks
+
+Map intent phrases to the three policy blocks. These priors feed directly into Phase 1 ([planning-arch.md](./references/planning-arch.md)):
+
+| User says... | Likely block(s) | Plugin |
+|---|---|---|
+| "When `<Actor Process>` invokes `<Resource>`..." (tool-use) | `selectors[]` + `executableRule` | [selector](./references/plugins/selector/planning.md) + [executable](./references/plugins/executable/planning.md) |
+| "Only `<tagged>` resources" / "limit tool use to `<tag>`" | `selectors[N].tags` with `Or` operator | [tags](./references/plugins/tags/planning.md) |
+| "Block / deny / restrict / exclude `<tag>` resources" | `selectors[N].tags` with `None` operator | [tags](./references/plugins/tags/planning.md#deny-to-allow-flip) |
+| "Specific resource UUIDs `<id1>, <id2>`" | `selectors[N].values: ["<id>", ...]` | [selector](./references/plugins/selector/planning.md) |
+| "All agents except `<id>`" / "all except `<tag>`" | `values` or `tags` with `None` operator | [selector](./references/plugins/selector/planning.md) + [tags](./references/plugins/tags/planning.md) |
+| "Any caller type except `<type>`" (e.g. "any caller except Agent") | `executableRule.values[]` — single entry of the **excluded** type with `operator: "None"` and `values: ["*"]`; omit every other type | [executable — Excluding a caller type](./references/plugins/executable/planning.md#excluding-a-caller-type) |
+| "Only `<user>` / `<robot user>` / `<group>` can..." | `actorRule` (Actor Identity) | [actor](./references/plugins/actor/planning.md) |
+| "On behalf of `<user>`" / "when `<robot>` triggers..." | `actorRule` with `type: "User"` (Robot User resolves to User UUID) | [actor](./references/plugins/actor/planning.md) |
+
+**Workflow for intent-based requests:**
+1. Phase 1 — hand off to [planning-arch.md](./references/planning-arch.md) to author a reviewable **Policy Spec** (natural-language narrative + Spec Components Table covering name, description, status, enforcement, resource selection, actor process, actor identity, tags, operators). The agent **pre-fills every row** with the user's values or sensible defaults (Critical Rule #11); the user reviews and edits any row, then approves before any JSON is composed.
+2. Phase 2 — hand off to [planning-impl.md](./references/planning-impl.md) to compose the concrete JSON from the approved Spec by reading each plugin's `impl.md`.
+3. Never hand-author policy JSON. The Spec is the contract; plugin `impl.md` files are the **only** authoritative source for block-level shape (Critical Rule #6).
+
+## Critical Rules
+
+1. Always verify login with `uip login status --output json` before any `uip gov access-policy` command. If not logged in, ask the user to run `uip login` (or `uip login --authority <URL>` for non-prod environments).
+2. **`policyType` is always `"ToolUsePolicy"`; `enforcement` is always `"Allow"`. Never emit `"Deny"`.**
+    - **Why:** the API rejects `enforcement: "Deny"`; Deny is the runtime default when no Allow policy matches, so blocking is expressed as the complement of an Allow set.
+    - **Applies to:** every create / update payload. When the user expresses Deny intent, silently translate to an Allow shape and never surface the mechanic (no "Deny→Allow flip" jargon, no `(flipped)` badge, no "enforcement: Deny is not authorable" caveat). See [plugins/tags/planning.md — Deny-to-Allow flip](./references/plugins/tags/planning.md#deny-to-allow-flip) for the decision logic.
+3. Read `organizationId` and `tenantId` from `~/.uipath/.auth` (see [planning-impl.md — Step 1](./references/planning-impl.md#step-1--gather-identity)). Never hardcode tenant or organization UUIDs.
+4. **Three rule blocks; `actorRule` is optional.** A `ToolUsePolicy` access policy is composed of **Selection Rule** (`selectors[]`), **Actor Process Rule** (`executableRule`), and **Actor Identity Rule** (`actorRule`). The first two are mandatory; `actorRule` is emitted only when the user expressed actor-shaped intent — its absence means "any identity passes".
+5. **`values` is required on every entry; `tags` only on `selectors[]` / `executableRule`.**
+    - **Why:** missing `values` returns `400 Bad Request`; `actorRule` does not accept a `tags` block today (the API rejects `actorRule.tags`).
+    - **Applies to:** every entry under `selectors[]`, `executableRule.values[]`, and `actorRule.values[]` — use `["*"]` for "all of this type" even when `tags` narrow the scope. Never emit `actorRule.tags`.
+6. **Two-phase authoring is mandatory.** Never construct policy JSON from scratch. Author and approve a **Policy Spec** (natural-language narrative + Spec Components Table) via [planning-arch.md](./references/planning-arch.md) (Phase 1), then compose the concrete JSON via [planning-impl.md](./references/planning-impl.md) (Phase 2), which walks the approved Spec and delegates to each plugin's `impl.md` for block-level JSON.
+7. **Single confirmation gate per mutation.** Exactly one `yes / no` review precedes each `create`, `update`, or `delete` call. The gate must show: (a) the **Scope** — the organization name / tenant name plus their UUIDs, read from `~/.uipath/.auth` — so the user sees which environment is about to be mutated; (b) the complete policy JSON in chat; (c) clickable markdown links to **both** the Spec file (`/tmp/access-policy-<slug>.spec.md`, written by Phase 1) and the JSON working file (`/tmp/access-policy-<slug>.json`, written by Phase 2) using their **resolved absolute paths** (run `realpath` — never a relative path, a `<WORKING_FILE>` placeholder, or a `~/` path). For update flows the Spec file does not exist (Critical Rule #8) — show the Scope, the diff, and the JSON working file only. See [Confirmation-gate wording](#confirmation-gate-wording).
+8. **For `update`: always `get` first and start from `Data` verbatim. Update is a full replacement.**
+    - **Why:** any field you omit from the file is cleared on the server (including the whole `actorRule` block); a fresh Phase 1 Spec would silently wipe fields the user did not re-specify.
+    - **Applies to:** every update flow. Use the returned `Data` object verbatim as the starting state, then strip audit fields (`isBuiltIn`, `isTemplate`, `createdBy`, `createdOn`, `modifiedBy`, `modifiedOn`, `deletedBy`, `deletedOn`).
+9. For `delete`: always `get` and show a summary, then require an explicit `yes` to the verbatim prompt. Deletion is permanent. Multiple UUIDs may be deleted in one call.
+10. Every `uip gov access-policy` command in a scripted flow uses `--output json`.
+11. **Pre-fill aggressively; prompt only for genuinely ambiguous gaps.** The Phase 1 Spec is presented as **review-and-edit**, not fill-in-the-blanks: every row gets a concrete value from what the user supplied OR a sensible default (always-suggested name, default scope `all`, default tag filter `(none)`, default status `Simulated`, etc.). Treat any value the user already supplied as final — never re-confirm. Surface Open questions only when there is no defensible default. The user changes whatever they want during the review loop.
+12. **`evaluate` is user-initiated only and tenant-scoped.** Do NOT call `evaluate` with synthetic/dummy UUIDs after `create` — dummy UUIDs with no Resource Catalog tags or no matching actor identity correctly return `NoOp` / `Deny` and confuse the user into thinking the policy is broken. Only run `evaluate` when the user explicitly asks. The login MUST target a specific tenant (not just an organization); if the PDP rejects with a tenant-context error, route the user to re-login with `--tenant`. See [access-policy-commands.md — evaluate](./references/access-policy-commands.md#uip-gov-access-policy-evaluate).
+13. **Default new policies to `status: "Simulated"`.** Create in `Simulated` first; prompt the user to `Activate` after review via the post-create **Activate this policy** option. Emit `Active` at create time only when the user explicitly asks. See [Key Concepts § Enforcement and status](#enforcement-and-status) for the meaning of Simulated.
+14. **Use user-facing terminology in user-visible text; JSON field / enum names only in code contexts.**
+    - **Why:** JSON identifiers (`executableRule`, `actorRule`, `AgenticProcess`, `RPAWorkflow`) are implementation details that confuse end users.
+    - **Applies to:** Spec narrative, Spec Components Table, review gate, and completion output — always say **Actor Process rule**, **Actor Identity rule**, **Maestro** (not `AgenticProcess` / "Agentic Process"), **RPA** (not `RPAWorkflow` / "RPA Workflow"). JSON names appear only inside ```json code blocks, working file paths, plugin shape templates, API enum tables, CLI flag enum lists, or CLI error messages.
+15. **Resolve names to UUIDs via Orchestrator lookups.** When the user names a specific process / agent / flow / user / robot, run the lookups in [resource-lookup-guide.md](./references/resource-lookup-guide.md) — **never fabricate a UUID**. **Processes are folder-scoped**: if the user did not name a folder, run `uip or folders list` FIRST. **Translate the type string** — Orchestrator's `--process-type` is NOT the same as the access-policy enum (`AgenticProcess`→`ProcessOrchestration`, `RPAWorkflow`→`Process`, `APIWorkflow`→`Api`); see [the mapping table](./references/resource-lookup-guide.md#access-policy-type--orchestrator---process-type). For robots, see Critical Rule #16 — they resolve to a `User` UUID via [resource-lookup-guide.md § Robots](./references/resource-lookup-guide.md#robots-resolve-to-type-user).
+16. **`actorRule.values[]` accepts at most two entries — one `User`, one `Group`.**
+    - **Why:** the API rejects duplicate-type entries, mismatched operators across `User` and `Group`, and `ExternalApplication`.
+    - **Applies to:** every `actorRule` block.
+        - **(a)** At most one entry per type — merge same-type identities into a single entry's `values[]` array.
+        - **(b)** When both `User` and `Group` are present, operators must match (both `Or` or both `None`); mixed-operator intent splits into two policies.
+        - **(c)** `ExternalApplication` is unsupported — refuse and route to User / Group / no-actor.
+        - **(d)** "Robot User" is a kind of User: design-time UX shows `User` / `Robot User` / `Group`, but JSON always emits `type: "User"`. Look up the robot via [resource-lookup-guide.md § Robots](./references/resource-lookup-guide.md#robots-resolve-to-type-user), resolve to the linked User UUID, and merge into the single `User` entry. Never emit `type: "Robot"` or `type: "ExternalApplication"`.
+
+## Quick Start
+
+These steps cover **creating a new access policy from scratch**. For existing policies or targeted operations, jump to the [Task Navigation](#task-navigation) table below.
+
+### Step 0 — Verify the `uip` CLI
+
+```bash
+which uip && uip --version
+```
+
+If not installed:
+```bash
+npm install -g @uipath/uipcli
+```
+
+### Step 1 — Check login status
+
+See [access-policy-commands.md — Authentication](./references/access-policy-commands.md#authentication) for the login flow (`uip login status`, `uip login`, non-production `--authority`, tenant scoping for `evaluate`).
+
+### Step 2 — Phase 1: author the Policy Spec
+
+Hand off to [planning-arch.md](./references/planning-arch.md). It builds a **Policy Spec** with two synchronized parts:
+
+1. **Spec narrative** — a 3–6 sentence plain-English paragraph describing the policy. Becomes the `description` field at create time.
+2. **Spec Components Table** — one row per access-policy component (name, description, status, enforcement, resource type, resource scope, resource tag filter, actor process type, actor process scope, actor process tag filter, actor identity type, actor identity scope). The agent pre-fills every row with the user's values or sensible defaults — the user reviews and edits, not fills in blanks. **Note:** there is no Actor Identity tag filter row — `actorRule` does not support tags today.
+
+The user reviews the pre-filled Spec and changes any row they want; the agent re-derives the narrative after every round so the two parts stay in sync. Phase 1 ends when every Open question is closed and the user approves with `yes`.
+
+> **If the user has no concrete intent** ("just create an access policy", "help me make one") **or supplied only one of the four phrase categories** (Resource / Actor Process / Actor Identity / Tag), Phase 1 routes through [sample-policy-guide.md](./references/sample-policy-guide.md) FIRST — it surfaces a canonical Spec narrative + JSON and offers the user three paths: adopt as-is, adapt one block, or describe from scratch. The chosen path seeds the Spec; the user still iterates rows and approves before Phase 2.
+
+### Step 3 — Phase 2: compose the JSON via plugins
+
+Hand off to [planning-impl.md](./references/planning-impl.md). It reads `organizationId` and `tenantId` from `~/.uipath/.auth`, then walks each row of the approved **Spec Components Table** and reads the matching plugin's `impl.md`:
+
+- Each Resource entry (Spec rows 5–7 — type, scope, optional tag filter) → one `selectors[]` entry via [plugins/selector/impl.md](./references/plugins/selector/impl.md)
+- Each Actor Process entry (Spec rows 8–10 — type, scope, optional tag filter) → one `executableRule.values[]` entry via [plugins/executable/impl.md](./references/plugins/executable/impl.md)
+- Each Actor Identity entry (Spec rows 11–12 — type, scope) → one `actorRule.values[]` entry via [plugins/actor/impl.md](./references/plugins/actor/impl.md). **No tag filter** — `actorRule.tags` is unsupported (Critical Rule #5).
+- Every Resource / Actor Process tag-filter row → `tags` sub-object via [plugins/tags/impl.md](./references/plugins/tags/impl.md)
+
+Phase 2 reuses the slug Phase 1 used for the Spec file and writes the assembled `PolicyDefinition` to `/tmp/access-policy-<slug>.json`, so the Spec (`.spec.md`) and JSON (`.json`) sit side by side. Phase 2 hands back both paths.
+
+### Step 4 — Single review gate
+
+Show a **short human-readable summary** that includes:
+- A **Scope** line on top — `Organization "<NAME>" / Tenant "<NAME>"` plus the matching `organizationId` / `tenantId` UUIDs read from `~/.uipath/.auth` — so the user always sees which environment they are about to mutate before approving.
+- One plain-English line per block — `Resources`, `Actor Process`, `Actor Identity` — with the per-entry technical breakdown tucked inside a collapsible `<details>` section.
+
+Then output the complete JSON as a ```json code block in the chat (do not rely on the file links alone — the user may not be able to open them), plus clickable markdown links to **both** files using their **resolved absolute paths** (Critical Rule #7):
+- `/tmp/access-policy-<slug>.spec.md` — the human-readable Policy Spec from Phase 1
+- `/tmp/access-policy-<slug>.json` — the JSON payload Phase 2 will submit
+
+See [policy-manage-guide.md — Create Step 4](./references/policy-manage-guide.md#step-4--single-review-gate) for the exact layout, the `~/.uipath/.auth` source-mapping for the Scope line, and the phrasing rules. Use the canonical wording from [Confirmation-gate wording](#confirmation-gate-wording) below. This is the only confirmation gate in the create flow.
+
+### Step 5 — Create
+
+```bash
+uip gov access-policy create --file /tmp/access-policy-<slug>.json --output json
+```
+
+Record `Data.upsertedPolicy.id` as the new policy UUID. If `Data.errors` is non-null, surface the error and route back to Step 4 (`keep editing`).
+
+### Step 6 — Verify
+
+```bash
+uip gov access-policy get <POLICY_ID> --output json
+```
+
+Display the raw server-stored JSON to the user.
+
+### Step 7 — Post-create choice
+
+Render next steps as a **numbered Markdown list** under a `### What would you like to do next?` heading so the user can reply with the number. Do NOT use `AskUserQuestion`. The list is **conditional on the policy's `status`** — if the policy is `Simulated` (the default), the first option is **Activate this policy** so the user can flip it to effective. See [Completion Output](#completion-output) below for the exact lists. Do NOT offer `Evaluate` and do NOT auto-run `evaluate` (Critical Rule #12).
+
+## Anti-patterns
+
+Non-obvious mistakes the Critical Rules don't already cover by name. (Restatements of Critical Rules — hardcoded org/tenant, `enforcement: "Deny"`, missing `values`, auto-running `evaluate`, stacking confirmation gates — live with the rules themselves.)
+
+- Do NOT hand-author policy JSON. Every policy flows through Phase 1 Spec → Phase 2 plugins; plugin `impl.md` files are the only authoritative JSON source.
+- Do NOT skip the Spec review just because the user "already gave you everything" — the Spec, not the chat history, is the contract.
+- Do NOT silently drop actor-shaped intent (e.g. "only admins can…", "when robot X triggers…"). Emit `actorRule` whenever identity intent is expressed.
+- Do NOT emit `actorRule` when the user gave no actor constraint — adding an unrequested `actorRule` narrows scope silently.
+- Do NOT merge distinct resource or executable types into one entry — one `selectors[]` entry per `resourceType`, one `executableRule.values[]` entry per executable `type`. (For `actorRule`, same-type identities merge — see Critical Rule #16.)
+- Do NOT put `RPAWorkflow` or `APIWorkflow` in `executableRule.values[].type` — they are resource-only.
+- Do NOT use `operator: "And"` on `values` — only `Or` / `None`. `And` is only valid on `tags`.
+- Do NOT put resource or actor UUIDs in `tags.values` — different arrays.
+- Do NOT start an update from a fresh Phase 1 Spec — server `Data` is the source of truth (Critical Rule #8).
+
+## Task Navigation
+
+| I need to... | Read these |
+| --- | --- |
+| **Author a Policy Spec from intent** | Quick Start + [planning-arch.md](./references/planning-arch.md) — narrative paragraph + Spec Components Table |
+| **Start from a sample when the user has no concrete intent** | [sample-policy-guide.md](./references/sample-policy-guide.md) — canonical Spec narrative + JSON with a 3-option picker (use as-is / adapt / from scratch) |
+| **Compose the concrete JSON from an approved Spec** | [planning-impl.md](./references/planning-impl.md) + the relevant plugin `impl.md` |
+| **Create a policy (end-to-end)** | [policy-manage-guide.md — Create](./references/policy-manage-guide.md#create-a-policy) |
+| **Update a policy** | [policy-manage-guide.md — Update](./references/policy-manage-guide.md#update-a-policy) — start from server `Data`, NOT a fresh Phase 1 Spec (Rule #9) |
+| **Delete a policy** | [policy-manage-guide.md — Delete](./references/policy-manage-guide.md#delete-a-policy) — show summary + explicit `yes` (Rule #10) |
+| **List policies** | [policy-manage-guide.md — List](./references/policy-manage-guide.md#list-policies) |
+| **Get a single policy by UUID** | [policy-manage-guide.md — Get](./references/policy-manage-guide.md#get-a-policy) |
+| **Evaluate a policy against a request context** | [access-policy-commands.md — evaluate](./references/access-policy-commands.md#uip-gov-access-policy-evaluate) — user-initiated only (Rule #13) |
+| **Resolve a process / agent / flow / user / robot name to a UUID** | [resource-lookup-guide.md](./references/resource-lookup-guide.md) — `uip or processes list` / `uip or folders list` / `uip or users list`; robot lookups use the REST fallback then resolve to a User UUID |
+| **Compose a `selectors[]` entry (Selection Rule)** | [plugins/selector/planning.md](./references/plugins/selector/planning.md) + [plugins/selector/impl.md](./references/plugins/selector/impl.md) |
+| **Compose the `executableRule` block (Actor Process Rule)** | [plugins/executable/planning.md](./references/plugins/executable/planning.md) + [plugins/executable/impl.md](./references/plugins/executable/impl.md) |
+| **Compose the `actorRule` block (Actor Identity Rule)** | [plugins/actor/planning.md](./references/plugins/actor/planning.md) + [plugins/actor/impl.md](./references/plugins/actor/impl.md) |
+| **Pick tag operators / flip Deny→Allow** | [plugins/tags/planning.md](./references/plugins/tags/planning.md) + [plugins/tags/impl.md](./references/plugins/tags/impl.md) |
+| **Look up CLI flags and output shapes** | [access-policy-commands.md](./references/access-policy-commands.md) |
+
+## Key Concepts
+
+### Policy type
+
+Every policy this skill mutates is of type `ToolUsePolicy`. The API exposes other policy types but they are out of scope — this skill treats any non-`ToolUsePolicy` response from `get` as read-only.
+
+### The three rule blocks (Selection / Actor Process / Actor Identity)
+
+A `ToolUsePolicy` access policy is structured as three rule blocks evaluated against a tool-use request:
+
+| Block | Governs | Required? | Shape |
+|---|---|---|---|
+| `selectors[]` — **Selection Rule** | The child **Resource/Tool** being invoked | **Yes** | Array — one entry per resource `type`. Each entry has `values` + optional `tags`. |
+| `executableRule` — **Actor Process Rule** | The calling **workflow** (Actor Process) | **Yes** | Object with `values[]` (one entry per executable `type`) + optional shared `tags`. |
+| `actorRule` — **Actor Identity Rule** | The **identity** running the Actor Process (User or Group) | Optional | Object with `values[]` carrying **at most two entries** — one `User`, one `Group`. When both are present, their `operator` must match. **No `tags`** — not supported on `actorRule` today (Critical Rule #5). |
+
+**Resource/Tool types** (`selectors[].resourceType`): `Agent`, `AgenticProcess`, `RPAWorkflow`, `APIWorkflow`, `CaseManagement`, `Flow`.
+**Actor Process types** (`executableRule.values[].type`): `Agent`, `AgenticProcess`, `CaseManagement`, `Flow`. (RPA and API workflows are resource-only — they cannot be callers.)
+**Actor Identity types** (`actorRule.values[].type`): `User`, `Group` only. `actorRule.values[]` carries **at most two entries** — one `User` entry, one `Group` entry — and when both are present their `operator` must match (both `Or` or both `None`). Multiple users / groups go inside the single entry's `values[]` array, never as duplicate entries of the same type. `ExternalApplication` is **not supported** today. **Design-time / Spec terminology** distinguishes "User" from "Robot User" (a robot is a kind of user), but **both serialize as `type: "User"`** in the JSON — the skill never emits `type: "Robot"`. See Critical Rule #16.
+
+### PAP vs PDP (two API endpoints)
+
+The CLI wraps two endpoints:
+- **PAP (Policy Administration Point)** — `list` / `get` / `create` / `update` / `delete` operate on policy records in the catalog.
+- **PDP (Policy Decision Point)** — `evaluate` asks the service to resolve the effective decision for a concrete request context. `evaluate` requires tenant-scoped login (Critical Rule #12).
+
+### Evaluation & aggregation
+
+Per-request decision flow:
+1. The PDP finds every policy whose **Selection Rule** matches the Resource/Tool.
+2. For each matched policy, it evaluates the **Actor Process Rule** AND the **Actor Identity Rule** (if present) against the request.
+3. A policy evaluates to **Allow** when every present rule matches; otherwise the policy does **not contribute** (no-match — call it `NoOp` for that policy).
+4. **Aggregation** across all non-simulated matched policies:
+   - Any matching `Allow` → final enforcement `Allow`.
+   - No matching `Allow` → request falls through to the runtime default (`Deny` / `NoOp`).
+5. `enforcement: "Deny"` is **not authorable** (Critical Rule #2) — Deny is the default outcome when no Allow policy matches. To "block" something, write an Allow policy that targets the **complement** of what should be blocked (or use `operator: "None"` on `tags` / `values`).
+6. `status: "Simulated"` policies are excluded from aggregation (see [Enforcement and status](#enforcement-and-status)).
+
+### Tags (Resource Catalog Tags)
+
+Tags are named labels attached to resources in the UiPath Resource Catalog. Used inside `selectors[].tags` and `executableRule.tags` to narrow scope. Operators: `Or` (any), `And` (all), `None` (exclude). The `None` operator is also how Deny intents get flipped into Allow policies — see [plugins/tags/planning.md](./references/plugins/tags/planning.md). **`actorRule` does NOT support tags today** — never emit `actorRule.tags` (Critical Rule #5 / [plugins/actor/](./references/plugins/actor/)).
+
+### Enforcement and status
+
+- `enforcement`: **always `"Allow"`** — `"Deny"` is not authorable (Critical Rule #2). The runtime delivers Deny by default when no Allow policy matches, so "blocking" intent is expressed by writing an Allow policy targeting the complement of what should be blocked.
+- `status`: `Active` (counted in runtime aggregation) or `Simulated` (the policy IS evaluated, but its verdict is excluded from aggregation — it shows up in `evaluationDetails` for debugging only). **Default `Simulated` for newly created policies** (Critical Rule #13) — it is the safe way to preview a rule before flipping to `Active`. Do not conflate Simulated with "disabled" or "draft". Other places in the skill that refer to "Simulated" link back here for the meaning.
+
+### Authoring Deny intent as Allow (internal mechanic)
+
+`enforcement: "Deny"` is not authorable (Critical Rule #2). The agent silently translates Deny intent into an Allow shape and never exposes the mechanic to the user. See [plugins/tags/planning.md — Deny-to-Allow flip](./references/plugins/tags/planning.md#deny-to-allow-flip) for the decision logic and worked examples.
+
+### Working file convention
+
+Two paired files live in `/tmp` for every create flow:
+
+| File | Written by | Purpose |
+|------|------------|---------|
+| `/tmp/access-policy-<slug>.spec.md` | Phase 1 ([planning-arch.md — Spec file convention](./references/planning-arch.md#spec-file-convention)) | Human-readable Policy Spec — narrative paragraph + Spec Components Table. Re-written on every Phase 1 iteration round once the policy name (Spec row 1) is set. |
+| `/tmp/access-policy-<slug>.json` | Phase 2 ([planning-impl.md — Step 4](./references/planning-impl.md#step-4--write-the-working-file)) | Raw `PolicyDefinition` JSON submitted to `uip gov access-policy create`. |
+
+The slug is computed from the policy name and is identical across both files — they sit side by side in `/tmp` so the user can diff `.spec.md` against `.json` to confirm Phase 2 didn't drift from the approved Spec. Show **both** paths in the review gate as clickable markdown links using their **resolved absolute paths** (run `realpath` — Critical Rule #7).
+
+For **update** flows the file is `/tmp/access-policy-<id>-working.json` only — there is no `.spec.md` because the existing server-stored definition is the source of truth (Critical Rule #8), not a freshly-authored Spec.
+
+### Confirmation-gate wording
+
+Every mutation runs through a single `yes / no` review (Critical Rule #7). Use these templates verbatim so wording stays consistent across the skill:
+
+| Operation | Template |
+|-----------|----------|
+| Create | `Create access policy "<POLICY_NAME>"? (yes / no / keep editing)` |
+| Update | `Apply update to access policy "<POLICY_NAME>"? (yes / no / keep editing)` |
+| Delete (single) | `Delete access policy "<POLICY_NAME>"? This cannot be undone. (yes / no)` |
+| Delete (multi) | `Delete <N> access policies (<POLICY_NAME_1>, <POLICY_NAME_2>, ...)? This cannot be undone. (yes / no)` |
+
+`keep editing` is treated the same as `no` — route the user back to the step that owns the field being changed (metadata → [policy-manage-guide.md — Create Step 3](./references/policy-manage-guide.md#create-a-policy); a specific block → the matching plugin's `impl.md`; intent itself → [planning-arch.md](./references/planning-arch.md)) and re-enter the gate only after the change is applied.
+
+## Completion Output
+
+When you finish a mutating operation, report:
+
+1. **Operation & result** — e.g., `Created access policy "<NAME>" (ID: <POLICY_ID>) — Resources: <RESOURCE_SUMMARY> · Actor Process: <ACTOR_PROCESS_SUMMARY> · Actor Identity: <ACTOR_IDENTITY_SUMMARY or "any identity">`. Use plain-English phrasing ("all Agent resources tagged 'Production'"), not JSON terms like `resourceType` / `operator`.
+2. **Status banner** — if the new/updated policy is `Simulated`, print: `⚠️ This policy is in Simulated mode — it is evaluated but does NOT affect enforcement. Activate it when you want it to take effect.`
+3. **Working file paths** — print the absolute paths the operation used:
+    - For `create`: both `/tmp/access-policy-<slug>.spec.md` (the approved Policy Spec) and `/tmp/access-policy-<slug>.json` (the submitted JSON).
+    - For `update`: `/tmp/access-policy-<id>-working.json` only.
+    The user can re-open these to inspect what was sent.
+4. **Technical details** — wrap the per-entry breakdown (resource types, process types, identity types, tag filters) in a `<details><summary>Show technical details</summary>…</details>` block so it is collapsed by default. (Omit after `delete`.)
+5. **Next step** — present the options as a **numbered Markdown list under a `### What would you like to do next?` heading** so the user can reply with the number. Do NOT use `AskUserQuestion`, do NOT render as a table, and do NOT wrap the list in `<details>`. The "Something else" option is always last. Options depend on the current `status` of the policy:
+
+**After `create` or `update` where `status == "Simulated"`** (the default):
+
+```markdown
+### What would you like to do next?
+
+1. **Activate this policy** — re-run `update` with the working file patched to `status: "Active"` via [policy-manage-guide.md — Update](./references/policy-manage-guide.md#update-a-policy). Recommended follow-up — Simulated policies do not enforce anything.
+2. **List policies to verify** — run `uip gov access-policy list --output json` and show the new/updated entry.
+3. **Update this policy** — jump to [policy-manage-guide.md — Update](./references/policy-manage-guide.md#update-a-policy) with this policy ID.
+4. **Create another policy** — return to Quick Start Step 2.
+5. **Something else** — accept free-form string input and act on it.
+
+Reply with the number.
+```
+
+**After `create` or `update` where `status == "Active"`:**
+
+```markdown
+### What would you like to do next?
+
+1. **List policies to verify** — run `uip gov access-policy list --output json` and show the new/updated entry.
+2. **Update this policy** — jump to [policy-manage-guide.md — Update](./references/policy-manage-guide.md#update-a-policy) with this policy ID.
+3. **Create another policy** — return to Quick Start Step 2.
+4. **Something else** — accept free-form string input and act on it.
+
+Reply with the number.
+```
+
+**After `delete`:** offer only:
+
+```markdown
+### What would you like to do next?
+
+1. **List policies to verify** — run `uip gov access-policy list --output json`.
+2. **Something else** — accept free-form string input and act on it.
+
+Reply with the number.
+```
+
+**Do NOT offer `Evaluate this policy` in the post-mutation list** — end users creating or updating a policy do not need to dry-run it, and dummy-UUID evaluations produce confusing results (Critical Rule #12). `evaluate` remains available on demand only when the user explicitly asks; route via [access-policy-commands.md — evaluate](./references/access-policy-commands.md#uip-gov-access-policy-evaluate) (real UUIDs + tenant-scoped login required — Critical Rule #12).
+
+Do not run any of these actions automatically. Wait for the user's selection.
+
+## References
+
+- **[access-policy-commands.md](./references/access-policy-commands.md)** — single source of truth for every `uip gov access-policy` subcommand, its flags, input/output shapes, and authentication. Every other guide links here for command details rather than inlining them.
+- **[resource-lookup-guide.md](./references/resource-lookup-guide.md)** — `uip or processes list` / `uip or folders list` / `uip or users list` lookups to resolve human-readable names to the UUIDs required by `selectors[].values`, `executableRule.values[].values`, and `actorRule.values[].values`. Route here whenever the user names a process, folder, or user without supplying a UUID.
+- **[planning-arch.md](./references/planning-arch.md)** — Phase 1: author a **Policy Spec** (narrative paragraph + Spec Components Table covering name, description, status, enforcement, resource selection, actor process, actor identity, tags, operators). The agent pre-fills every row; the user reviews and edits before approving, and approval is required before any JSON is composed.
+- **[sample-policy-guide.md](./references/sample-policy-guide.md)** — canonical Spec narrative + JSON (Production Agent + one Maestro + one User, Allow, Simulated). Phase 1 routes here when the user has no concrete intent or has gaps; surfaces a 3-option picker so the user can adopt, adapt, or replace the sample.
+- **[planning-impl.md](./references/planning-impl.md)** — Phase 2: walk the approved Spec Components Table and assemble the concrete `PolicyDefinition` JSON by reading `~/.uipath/.auth` for identity and each plugin's `impl.md` for block-level JSON.
+- **[policy-manage-guide.md](./references/policy-manage-guide.md)** — Full CRUD lifecycle (list / get / create / update / delete). Owns the single final-review gate before every mutation.
+- **[plugins/selector/](./references/plugins/selector/)** — `selectors[]` (Selection Rule): resource/tool types (`Agent`, `AgenticProcess`, `RPAWorkflow`, `APIWorkflow`, `CaseManagement`, `Flow`), targeting modes, tag filters.
+- **[plugins/executable/](./references/plugins/executable/)** — `executableRule` (Actor Process Rule): executable types (`Agent`, `AgenticProcess`, `CaseManagement`, `Flow`), targeting modes, shared tag filter.
+- **[plugins/actor/](./references/plugins/actor/)** — `actorRule` (Actor Identity Rule): identity types (`User`, `Group` only — `ExternalApplication` not supported; robot intent serializes as `User`), targeting modes. **No tag filter today** — emitting `actorRule.tags` is rejected by the API. Optional block — emit only when the user supplies actor-shaped intent.
+- **[plugins/tags/](./references/plugins/tags/)** — shared `tags` sub-object with `Or` / `And` / `None` operators and the Deny-to-Allow flip.

--- a/skills/uipath-gov-access-policy/references/access-policy-commands.md
+++ b/skills/uipath-gov-access-policy/references/access-policy-commands.md
@@ -1,0 +1,234 @@
+# uip gov access-policy — CLI Command Reference
+
+Single source of truth for every `uip gov access-policy` subcommand, its flags, and its output shape. All commands return `{ "Result": "Success"|"Failure", "Code": "...", "Data": { ... } }`. Use `--output json` for programmatic use — every command in this skill must pass it.
+
+> For task workflows (list / get / create / update / delete), see [policy-manage-guide.md](./policy-manage-guide.md). This file only documents the command surface.
+
+The CLI wraps two endpoints:
+- **PAP (Policy Administration Point)** — `list` / `get` / `create` / `update` / `delete` operate on policy records.
+- **PDP (Policy Decision Point)** — `evaluate` asks the service to resolve the effective decision (`Allow` / `Deny` / `NoOp`) for a concrete request context. `evaluate` requires tenant-scoped login.
+
+---
+
+## Common flags (shared across `uip` list commands)
+
+These flags work the same way on `uip gov access-policy list` and on every `uip or ... list` lookup command (used by [resource-lookup-guide.md](./resource-lookup-guide.md)). Per-subcommand sections only document what is **specific** to that subcommand and link back here for the shared flags.
+
+| Flag | Purpose |
+|------|---------|
+| `--output json` | **Always pass this in scripted flows.** Emits structured JSON for parsing. |
+| `--limit <N>` | Page size — max records to return (default varies per command). |
+| `--offset <N>` | Records to skip before the returned page, 0-based (default `0`). |
+| `--order-by <ORDER>` | OData sort expression — `<Field> <asc|desc>` (e.g. `Name asc`, `CreatedOn desc`). |
+| `--login-validity <MINUTES>` | Override interactive-login token lifetime for this call. Rarely needed. |
+
+---
+
+## Authentication
+
+Every subcommand requires an active login. Check first:
+
+```bash
+uip login status --output json
+```
+
+If not logged in:
+
+```bash
+uip login                                          # interactive OAuth
+uip login --authority https://alpha.uipath.com     # non-production environments
+```
+
+For `evaluate`, login must target a specific tenant (not just an organization).
+
+### Reading `organizationId` and `tenantId`
+
+The org and tenant UUIDs required in every `PolicyDefinition` live in `~/.uipath/.auth`:
+
+```bash
+grep -E "UIPATH_ORGANIZATION_ID|UIPATH_TENANT_ID" ~/.uipath/.auth
+```
+
+Expected output:
+
+```
+UIPATH_ORGANIZATION_ID=<ORG_UUID>
+UIPATH_TENANT_ID=<TENANT_UUID>
+```
+
+Copy these into `organizationId` and `tenantId` when composing a policy (see [planning-impl.md — Step 1](./planning-impl.md#step-1--gather-identity)). Never hardcode.
+
+---
+
+## uip gov access-policy list
+
+Search for access policies with optional filters and pagination.
+
+```bash
+uip gov access-policy list --output json
+```
+
+**Subcommand-specific flags** (shared `--limit` / `--offset` / `--order-by` / `--login-validity` documented in [Common flags](#common-flags-shared-across-uip-list-commands) above):
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--filter <EXPRESSION>` | no | OData-style filter (e.g. `status in ('Active')`, `contains(name, 'Production')`) |
+
+**Output:** `Data.totalCount` and `Data.results[]`. Each entry includes `id`, `name`, `status`, plus the full `PolicyDefinition` fields (`selectors`, `executableRule`, `enforcement`, `organizationId`, `tenantId`) and audit metadata. Use the `id` with `get` / `update` / `delete` / `evaluate`.
+
+**Example:**
+
+```bash
+uip gov access-policy list --filter "status in ('Active')" --order-by "Name asc" --output json
+```
+
+---
+
+## uip gov access-policy get
+
+Fetch the full `PolicyDefinition` for a single policy by UUID. Always run before `update` or `delete`.
+
+```bash
+uip gov access-policy get <POLICY_ID> --output json
+```
+
+**Arguments:** `<POLICY_ID>` (UUID) — required. Obtain from `list` (the `id` field of each result).
+
+**Output:** `Data` is the full `PolicyDefinition`. Use it verbatim as the starting state for an update (see [policy-manage-guide.md — Update Step 2](./policy-manage-guide.md#step-2--build-the-working-file-from-data)).
+
+---
+
+## uip gov access-policy create
+
+Create a new access policy from a JSON file conforming to `PolicyDefinition`.
+
+```bash
+uip gov access-policy create --file <PATH> --output json
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--file <PATH>` | yes | Path to a JSON file containing the full `PolicyDefinition` |
+| `--login-validity <MINUTES>` | no | Override interactive-login token lifetime |
+
+**File contents:** a raw `PolicyDefinition` object sent **as-is** (no `{ "data": {...} }` envelope wrapping). Do **not** include a server-assigned `id`. Minimum required fields: `policyType`, `organizationId`, `tenantId`, `name`, `selectors`, `executableRule`, `enforcement`, `status`. See [planning-impl.md](./planning-impl.md) for how to compose this object from plugin building blocks.
+
+**Output:** `Data.statusCode`, `Data.errors` (usually `null` on success), and `Data.upsertedPolicy` with the stored document. Capture `Data.upsertedPolicy.id` as the new policy UUID for follow-up `evaluate`, `update`, or `delete`.
+
+---
+
+## uip gov access-policy update
+
+Update an existing access policy from a JSON file. Sent as HTTP PATCH — the server applies the supplied `PolicyDefinition` fields to the existing record. **Treat it as a full replacement**: every field you omit from the file is cleared on the server (Critical Rule #8 in [SKILL.md](../SKILL.md#critical-rules)).
+
+```bash
+uip gov access-policy update --file <PATH> --output json
+```
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--file <PATH>` | yes | Path to a JSON file containing the updated `PolicyDefinition`. Must include the policy's `id` to identify the target record. |
+| `--login-validity <MINUTES>` | no | Override interactive-login token lifetime |
+
+**File contents:** the full `PolicyDefinition` — seed it by running `access-policy get <id>`, editing the returned JSON, and passing it back. The file **must** include `id`, `organizationId`, `tenantId`, and every rule block you want to keep. Strip audit fields (`isBuiltIn`, `isTemplate`, `createdBy`, `createdOn`, `modifiedBy`, `modifiedOn`, `deletedBy`, `deletedOn`).
+
+**Output:** `Data.statusCode`, `Data.errors`, and `Data.upsertedPolicy` with the stored document.
+
+> See [policy-manage-guide.md — Update](./policy-manage-guide.md#update-a-policy) for the full `get → edit → review → update` flow.
+
+---
+
+## uip gov access-policy delete
+
+Delete one or more access policies by UUID. **Permanent — cannot be undone.**
+
+```bash
+uip gov access-policy delete <POLICY_ID> --output json
+uip gov access-policy delete <POLICY_ID_1> <POLICY_ID_2> --output json    # multiple IDs in a single request
+```
+
+**Arguments:** one or more `<POLICY_ID>` (UUID), space-separated — required.
+
+**Output:** `Data.policyIds[]` listing the deleted UUIDs.
+
+Always `get` the policy first and show a summary to the user. Require an explicit `yes` before running delete — see [SKILL.md — Confirmation-gate wording](../SKILL.md#confirmation-gate-wording).
+
+---
+
+## uip gov access-policy evaluate
+
+Ask the Policy Decision Point (PDP) to resolve the effective decision (`Allow` / `Deny` / `NoOp`) for a request context. Returns the aggregated enforcement, which policies contributed, and evaluation details.
+
+> **Requires tenant-scoped login** — login must target a specific tenant, not just an organization (Critical Rule #12).
+>
+> **User-initiated only.** Do not run `evaluate` automatically after create (Critical Rule #12). Dummy UUIDs with no Resource Catalog tags correctly return `NoOp` and confuse the user into thinking the policy is broken.
+
+```bash
+uip gov access-policy evaluate \
+  --resource-type <RESOURCE_TYPE> \
+  --resource-id <RESOURCE_UUID> \
+  --actor-process-type <ACTOR_PROCESS_TYPE> \
+  --actor-process-id <ACTOR_PROCESS_UUID> \
+  --output json
+```
+
+> **Flag naming.** The CLI flags mirror the skill's user-facing rule names — `--resource-*` (Selection Rule) and `--actor-process-*` (Actor Process Rule, `executableRule` in JSON). The JSON field names (`actorRule`, `executableRule`) stay unchanged on the wire.
+>
+> **Actor identity is inferred, not passed.** Under a user token (`uip login`), the calling user is taken from the bearer — omit `--actor-identity-id`. Under an S2S token, pass `--actor-identity-id <ID>` to evaluate on behalf of a specific actor; the CLI documents the flag as required only in this mode. There is no companion `--actor-identity-type` — the type is always derived server-side from the actor record. To preview enforcement for a different user under user-token mode, log in as that user first.
+>
+> **Robot / ExternalApplication actors don't match `actorRule` (Critical Rule #16).** Access policies of type `ToolUsePolicy` accept only `User` and `Group` in `actorRule.values[].type`. When the inferred or S2S-supplied actor resolves server-side to a `Robot` or `ExternalApplication`, the request will only match policies that have no `actorRule` block at all — every policy with an `actorRule` returns `NoOp` for that actor regardless of UUID. If the user expected a match for a Robot, see [plugins/actor/impl.md — Robot intent](./plugins/actor/impl.md) for the User-fallback pattern.
+
+**Flags:**
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--resource-type <TYPE>` | conditional | The protected asset being accessed. One of `Agent`, `AgenticProcess`, `RPAWorkflow`, `APIWorkflow`, `CaseManagement`, `Flow`. |
+| `--resource-id <ID>` | conditional | Identifier of the specific resource instance (e.g. an Agent UUID). **No `*` — real UUIDs only.** |
+| `--actor-process-type <TYPE>` | conditional | The workflow/agent being executed on behalf of the actor, if any. One of `Agent`, `AgenticProcess`, `CaseManagement`, `Flow`. |
+| `--actor-process-id <ID>` | conditional | Identifier of the actor process (e.g. a Flow UUID). **No `*`.** |
+| `--actor-identity-id <ID>` | S2S only | Identifier of the actor to evaluate on behalf of. The CLI documents this flag as required only when calling with an S2S token. Under a user token, omit it — the actor is inferred from the bearer (see the **Actor identity is inferred** callout above). |
+| `--folder-key <KEY>` | no | Folder key (UUID) scoping the request to a specific folder. |
+| `--trace-parent-id <ID>` | no | W3C traceparent header value to correlate this evaluation with upstream traces. |
+| `--login-validity <MINUTES>` | no | Override interactive-login token lifetime |
+
+**Output:** `Data.enforcement` plus `Data.evaluationDetails` and `Data.effectivePolicies[]` (the policies that contributed to the decision).
+
+**Interpreting the result:**
+
+| Enforcement | Meaning |
+|-------------|---------|
+| `Allow` | A matching policy allows the request. The policy is working. |
+| `NoOp` | No policies matched the request; allowed by default. With real UUIDs this means the policy does not cover that context. With unknown/untagged UUIDs it is expected — the policy can still be correct. |
+| `Deny` | A policy is blocking. Inspect `Data.effectivePolicies` to find which one. |
+
+**Example:**
+
+```bash
+uip gov access-policy evaluate \
+  --resource-type Agent \
+  --output json
+```
+
+The calling user (from `uip login`) is the actor; their identity is taken from the bearer.
+
+---
+
+## Shared error table
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | Token expired or missing | Run `uip login`, then retry |
+| `403 Forbidden` | User is not in the org | Check login org context; re-login with the correct tenant |
+| `400 Bad Request` / `Selectors[0].Values is required` | Missing `values: ["*"]` on a selector or executable-rule entry | Add `"values": ["*"]` — required even when `tags` narrow the scope |
+| `400 Bad Request` / unknown `resourceType` or `type` | Enum typo | Use a valid enum value — see [plugins/selector/impl.md](./plugins/selector/impl.md) / [plugins/executable/impl.md](./plugins/executable/impl.md) |
+| `409 Conflict` | Policy name already exists | Choose a different name |
+| `Policy not found` | Stale ID | Re-run `list` and copy the current `id` |
+| `enforcement: "Deny" not allowed` | The skill emitted `enforcement: "Deny"` — never authorable (Critical Rule #2) | Switch to `enforcement: "Allow"` and reframe Deny intent: ask what should be **allowed** and target that set, or use the `None` operator on tags / values. See [plugins/tags/planning.md — Deny-to-Allow flip](./plugins/tags/planning.md#deny-to-allow-flip). |
+| `ActorRule.Values is required` | Emitted `actorRule` with no entries | Either omit the `actorRule` key, or add entries — see [plugins/actor/impl.md](./plugins/actor/impl.md) |
+| `400 Bad Request` on `actorRule.values[].type: Group` | Server build does not accept `Group` | Enumerate member user UUIDs under `type: User` — see [plugins/actor/impl.md — Debug](./plugins/actor/impl.md#debug) |
+| `evaluate` rejects with tenant-context error | Login is org-scoped, not tenant-scoped | Re-login targeting the specific tenant (Critical Rule #12) |
+| `unknown flag --resource-identifier` / `--actor-type` / `--actor-identifier` / `--executable-type` / `--executable-identifier` / `--actor-identity-type` | Flags were renamed and `--actor-identity-type` was removed | Use the current set: `--resource-id`, `--actor-process-type`, `--actor-process-id`. For actor identity: omit under a user token (inferred from the bearer); pass `--actor-identity-id <ID>` only under an S2S token. |

--- a/skills/uipath-gov-access-policy/references/planning-arch.md
+++ b/skills/uipath-gov-access-policy/references/planning-arch.md
@@ -1,0 +1,314 @@
+# Phase 1 — Discovery & Spec Authoring
+
+Help the user **describe their access policy as a natural-language Spec** before any JSON is composed. The Spec is the user-facing model of the policy: a short plain-English paragraph plus a managed component table that lists every block an access policy supports. Phase 1 ends when the Spec is complete, internally consistent, and explicitly approved.
+
+> **Read this first, always.** No access-policy JSON is ever authored without an approved Phase 1 **Spec** (Critical Rule #6). The Spec — not raw user text — is the contract handed to Phase 2.
+
+---
+
+## What the Spec is
+
+The **Policy Spec** has two parts that the agent maintains together throughout Phase 1:
+
+| Part | Format | Purpose |
+|---|---|---|
+| **Spec narrative** | A structured natural-language block — bold-quoted title + opening sentence + bulleted components (**What is being protected**, **Who/what is allowed to call them**, **Effect**, **Status**) + final **Intent** paragraph. See [Spec narrative format](#spec-narrative-format). The same shape as the description block in [sample-policy-guide.md](./sample-policy-guide.md). | The user reads this to confirm the agent understood their intent. The opening sentence + Intent paragraph distill into the `description` field on the policy. |
+| **Spec Components Table** | A single managed table with one row per access-policy component (name, description, status, enforcement, resource selection, actor process, actor identity, tag filters on Resource and Actor Process only, operators). Every row is **pre-filled** with the user's value or a sensible default; only rows with no defensible default are marked `(missing)`. | The user reviews the pre-filled Spec and edits any row; the agent updates the narrative after each round. The table is what Phase 2 walks. |
+
+Both parts are kept in sync: every change to the table updates the narrative, and vice versa. Show **both** to the user every time you re-present the Spec.
+
+---
+
+## Process
+
+1. **Read the user's request.** Extract resource phrases, actor process phrases, tag phrases, and actor-identity phrases (user, robot user, or group — Critical Rule #16). Use the [Intent analysis](#intent-analysis) heuristics below.
+2. **If the user has no concrete intent or named ≤ 1 of the four phrase categories** (Resource / Actor Process / Actor Identity / Tag), route through [Sample-policy starter (when intent is missing or sparse)](#sample-policy-starter-when-intent-is-missing-or-sparse) BEFORE generating the Spec — show the canonical sample, let the user pick a path, and seed the Spec from the user's choice.
+3. **Generate the initial Spec — fully pre-filled.** Build the narrative paragraph and Spec Components Table with **a concrete value in every row** (don't leave rows empty for the user to fill in). For values the user explicitly supplied, use those. For values they didn't, apply sensible defaults (Critical Rule #11 — don't ask, just do):
+    - **Scope rows (Org / Tenant — read-only):** capture both rows from the active auth context BEFORE generating the rest of the Spec. Read **names** via `uip login status --output json` (`Data.Organization`, `Data.Tenant`) and **UUIDs** from `~/.uipath/.auth` (`organizationId`, `tenantId`). Render each row as `<NAME> (UUID <UUID>)`. Mark these rows as read-only — the user changes them by re-running `uip login` (Critical Rule #1), not by editing the Spec. They appear above the numbered rows so the user always sees which environment the policy will be authored against.
+    - **Row 1 (Name):** ALWAYS suggest a name derived from intent — never `(missing)`. Pattern: `"Allow <ResourceSummary> in <ActorProcessSummary>"` (e.g. `"Allow Production Agents in Maestro"`). Use user-facing names (`Maestro` for `AgenticProcess` — Critical Rule #14).
+    - **Row 2 (Description):** auto-derive from the narrative paragraph.
+    - **Row 3 (Status):** `Simulated` (Critical Rule #13).
+    - **Row 4 (Enforcement):** `Allow` (Critical Rule #2 — fixed).
+    - **Resource / Actor Process scope (rows 6, 9):** default to `all` (`["*"]`) when no UUIDs were named. Specific UUIDs only when the user named them.
+    - **Tag filter rows (7, 10):** `(none)` unless the user mentioned tags.
+    - **Actor Identity rows (11–12):** omit entirely unless the user expressed identity intent. Don't add an unrequested identity constraint.
+    - **Mark a row `(missing)` only when there is genuinely no defensible default** (e.g. row 5 Resource type when the user never hinted at any). Surface those as Open questions — but limit Open questions to truly ambiguous cases.
+    Use the format in [Spec output format](#spec-output-format).
+4. **Enter the Spec review loop.** Present the fully pre-filled Spec (narrative + table) and tell the user they can change any row. Treat this as **review-and-edit**, not fill-in-the-blanks. The user may approve immediately, edit specific rows, or revise the whole policy. After each round:
+    - Apply the user's edits to the table.
+    - Re-derive the narrative paragraph from the updated table so the two stay in sync.
+    - Re-resolve any newly-named processes / agents / users to UUIDs via [resource-lookup-guide.md](./resource-lookup-guide.md) (Critical Rule #15).
+    - Re-present the Spec.
+    - Stop the loop when no Open question remains and the user approves.
+5. **Write the Spec file.** Once the Spec is fully pre-filled and every Open question is closed, write the Spec (narrative + Spec Components Table) to `/tmp/access-policy-<slug>.spec.md` so the user can open and review it in their editor alongside the JSON Phase 2 will produce. See [Spec file convention](#spec-file-convention) for the slug rule and file body.
+6. **Run the [Review gate](#review-gate)** — ask `Approve this access-policy Spec to proceed to Phase 2? (yes / edit / cancel)` and surface a clickable link to the Spec file. `edit` returns to step 4 and re-writes the Spec file after the change is applied; `cancel` drops the session.
+7. **Hand off to** [planning-impl.md](./planning-impl.md). The approved Spec is the input — Phase 2 walks the Spec Components Table, reads each plugin's `impl.md`, and writes the JSON to `/tmp/access-policy-<slug>.json` using **the same slug as the Spec file** so the two files sit side by side.
+
+> The agent NEVER advances to Phase 2 without an explicit `yes` on the Spec. The Spec, not the user's chat history, is what Phase 2 acts on.
+
+---
+
+## Sample-policy starter (when intent is missing or sparse)
+
+When the user's request cannot be classified into Resource / Actor Process / Actor Identity / tag phrases, or names ≤ 1 of those four categories, read [sample-policy-guide.md](./sample-policy-guide.md) and present the canonical sample (narrative description + JSON) verbatim, then offer the three-option picker defined there:
+
+1. **Use the sample as-is** → seed the Spec to match the sample (Production-tagged Agent + one Maestro + one User, Allow, Simulated). Run [resource-lookup-guide.md](./resource-lookup-guide.md) to resolve real Maestro and User UUIDs. Continue at step 3 (Generate the initial Spec) with all rows pre-filled.
+2. **Adapt the sample** → seed the Spec from the sample for blocks the user did NOT change; mark the changed blocks as `(missing)` in the table. Continue at step 3.
+3. **Describe from scratch** → drop the sample. Continue at step 1 with the user's description.
+
+Even when the user picks Option 1, the Review gate (step 6) is mandatory — the Spec still requires explicit approval before Phase 2.
+
+---
+
+## Intent analysis
+
+Parse the user's phrasing into four categories. Each maps to one or more rows in the Spec Components Table.
+
+### Resource phrases → [selector](./plugins/selector/planning.md)
+
+Phrases describing **what is being used**:
+
+- "Production Agent", "agents tagged Development", "my RPA workflows", "API workflow", "case management item", "flow named abc-123".
+- Quantifier patterns: "all agents" → `values: ["*"]`; "agent `<uuid>`" or "process abc-123" → specific IDs.
+
+Record one Resource entry per distinct resource type. If the user names two different resource types (e.g. "Agents and Flows"), the Spec table holds two Resource rows.
+
+### Actor Process phrases → [executable](./plugins/executable/planning.md)
+
+Phrases describing **who/what uses the resource**:
+
+- "used by a Maestro", "invoked from a flow", "only maestro can call", "when case management triggers it" (user phrases like "agentic process" / "maestro process" all map to user-facing **Maestro** / JSON `AgenticProcess`).
+- Same quantifier logic: `["*"]` for "any", specific IDs for named callers.
+
+Record one Actor Process entry per distinct executable type.
+
+### Tag phrases → [tags](./plugins/tags/planning.md)
+
+Any environment, team, or Resource Catalog tag:
+
+- "Production", "Development", "Staging", "Critical", "PII", product names, team names.
+- Operator hints:
+  - "Production **or** Staging" → `Or` (Any-of)
+  - "both Production **and** Critical" → `And` (All-of)
+  - "**not** Development", "**except** Dev-tagged" → `None` (Exclude)
+
+**Deny phrases — translate silently.** When the user says "block Development agents", "deny Staging flows", "prevent Production-tagged from being used", the agent silently authors an Allow policy that excludes the named set. Write the narrative in plain English about **what's allowed**; never mention "Deny→Allow flip", "None operator", or "enforcement is not authorable" in the Spec or table. See [plugins/tags/planning.md — Deny-to-Allow flip](./plugins/tags/planning.md#deny-to-allow-flip) for the decision logic and framing examples.
+
+### Actor-identity phrases → [actor](./plugins/actor/planning.md)
+
+Phrases describing **who triggers the Actor Process** (user, robot user, or group — see Critical Rule #16):
+
+- "only admins can…", "restrict user X", "members of group Ops", "when robot R runs…", "on behalf of…".
+- **Allowed design-time choices: `User`, `Robot User`, `Group`.** `User` and `Robot User` both serialize as `type: "User"` in the JSON — the skill never emits `type: "Robot"`. **`ExternalApplication` is not supported** — if the user names a service principal / external app, refuse and route them to use a User, Robot User, or Group (or omit the Actor Identity rule).
+- Quantifier patterns: `["*"]` for "any user"; specific UUIDs for named users / robot users.
+- Operator hints: "only X" → `Or`; "block X", "everyone except X" → `None` (Deny-flipped).
+
+Record at most two Actor Identity entries — one `User` entry (which absorbs Robot User intent) plus one `Group` entry (Critical Rule #16). Multiple users / robot users / groups of the same type are merged into a single entry's scope, never split. When both entries are present, their scope-style must match (both include or both exclude). Omit the Actor Identity rows entirely when the user said nothing about identity — **absence means "no identity constraint"**, which is the correct default.
+
+---
+
+## The three rule blocks (boundary table)
+
+An access policy has three rule blocks. Use this table to decide which block a user phrase belongs in. Plugin anti-pattern sections link back here instead of repeating the boundary.
+
+| Block | Targets | JSON field | Allowed types | Tag filter? |
+|---|---|---|---|---|
+| Selection Rule | The Resource being protected (the thing being used) | `selectors[]` | `Agent` / `AgenticProcess` / `RPAWorkflow` / `APIWorkflow` / `CaseManagement` / `Flow` | per-entry (`selectors[N].tags`) |
+| Actor Process Rule | The calling workflow (Maestro / Agent / Flow / CaseManagement) | `executableRule` | `Agent` / `AgenticProcess` / `CaseManagement` / `Flow` (NOT `RPAWorkflow` / `APIWorkflow`) | shared at top of block (`executableRule.tags`) |
+| Actor Identity Rule | The user / group triggering the workflow | `actorRule` | `User` / `Group` only (Robot resolves to `User`; `ExternalApplication` unsupported) | **not supported** |
+
+A user phrase that names a thing-being-used belongs in `selectors[]`. A phrase that names a workflow doing the calling belongs in `executableRule`. A phrase that names a person, group, or robot identity belongs in `actorRule`.
+
+---
+
+## Plugin Index
+
+The Spec Components Table maps to plugins one-to-one. Phase 2 walks the table and reads each plugin's `impl.md` to compose the JSON.
+
+| Spec component | Plugin | Always present? |
+|---|---|---|
+| Resource selection (one row per resource type) | [selector](./plugins/selector/planning.md) | **Yes.** Identifies what is being used. |
+| Resource tag filter (per-resource sub-row) | [tags](./plugins/tags/planning.md) | Only when the user mentioned tags on the resource side. |
+| Actor Process (one row per process type) | [executable](./plugins/executable/planning.md) | **Yes.** Identifies the caller. |
+| Actor Process tag filter | [tags](./plugins/tags/planning.md) | Only when the user mentioned tags on the caller side. |
+| Actor Identity (one row per design-time identity type — `User` / `Robot User` / `Group`) | [actor](./plugins/actor/planning.md) | **Only when the user expressed identity intent.** Omit otherwise — absence = any identity passes. `User` and `Robot User` both serialize as `type: "User"`; `ExternalApplication` is not supported. |
+
+> **Note:** the Actor Identity rule does **not** support tags today. The Spec Components Table omits an "Actor Identity tag filter" row, and `actorRule.tags` must never be emitted in the JSON. Only Resource and Actor Process blocks support tag filters.
+
+---
+
+## Spec output format
+
+Present the Spec as **structured narrative + Spec Components Table** every time. The narrative is human-readable; the table is the contract. Do NOT write JSON in Phase 1 — JSON is Phase 2's job. See [Spec narrative format](#spec-narrative-format) for the narrative template.
+
+```markdown
+**Policy Spec — review and edit any row below. You can change one at a time or all at once.**
+
+> **"<POLICY_NAME_AS_TITLE>"**
+>
+> <ONE_OPENING_SENTENCE describing the policy type ("tool-use policy"), status mode ("simulation mode" / "active mode"), and the high-level effect — who is allowed to invoke what.>
+>
+> - **What is being protected:** <plain-English Resource summary — type(s), scope (all / specific UUIDs / all-except), tag filter if any. Use "all `<TYPE>` resources" / "the `<TYPE>` named `<NAME>` (UUID `<UUID>`)" / "every `<TYPE>` except `<NAME>` (UUID `<UUID>`)".>
+> - **Who/what is allowed to call them:** <plain-English Actor Process summary, then Actor Identity summary. If no Actor Identity row, say "any User or Group running these Actor Processes".>
+> - **Effect:** `Allow` — the matching call is permitted.
+> - **Status:** `<Simulated | Active>` — <one-line meaning: Simulated = "evaluated and logged but not yet enforced, so violations are surfaced for review without blocking real traffic"; Active = "evaluated and counted toward the runtime aggregation — matching calls are permitted by this policy".>
+>
+> **Intent:** <2–3 sentences describing the *why* behind the policy — the user's underlying goal, the risk it controls, or the lifecycle stage. Carry over the user's framing verbatim where it is clear; do not invent intent the user did not express. Mention the simulation rationale when status is Simulated.>
+
+| # | Component | Allowed values | Current value | Required? |
+|---|-----------|---------------|--------------|-----------|
+| — | Organization (read-only)      | sourced from `uip login status` + `~/.uipath/.auth` — change via `uip login`     | <ORG_NAME> (UUID `<ORG_ID>`)                   | Scope (read-only) |
+| — | Tenant (read-only)            | sourced from `uip login status` + `~/.uipath/.auth` — change via `uip login`     | <TENANT_NAME> (UUID `<TENANT_ID>`)             | Scope (read-only) |
+| 1 | Policy name                   | string — always pre-filled                                                       | <suggested name>                               | Required |
+| 2 | Description                   | one sentence — auto-derived from the narrative above                             | <description>                                  | Required |
+| 3 | Status                        | `Simulated` (default) / `Active`                                                 | `Simulated`                                    | Required |
+| 4 | Enforcement                   | `Allow`                                                                          | `Allow`                                        | Required (fixed) |
+| 5 | Resource type(s)              | `Agent` / `Maestro` / `RPA` / `APIWorkflow` / `CaseManagement` / `Flow`           | <type(s)>                                      | Required |
+| 6 | Resource scope                | `all` / specific UUIDs / all-except UUIDs                                        | <scope — default `all`>                        | Required |
+| 7 | Resource tag filter           | Any-of [<tags>] / All-of [<tags>] / Exclude [<tags>] / `(none)`                  | <filter — default `(none)`>                    | Optional |
+| 8 | Actor Process type(s)         | `Agent` / `Maestro` / `CaseManagement` / `Flow`                                  | <type(s)>                                      | Required |
+| 9 | Actor Process scope           | `all` / specific UUIDs / all-except UUIDs                                        | <scope — default `all`>                        | Required |
+| 10 | Actor Process tag filter     | Any-of / All-of / Exclude / `(none)`                                             | <filter — default `(none)`>                    | Optional |
+| 11 | Actor Identity type(s)       | `User` / `Robot User` / `Group` (or blank for "any identity")                    | <type(s) — default `(none = any identity)`>    | Optional |
+| 12 | Actor Identity scope         | `all` / specific UUIDs / all-except UUIDs                                        | <scope — default `n/a`>                        | Optional (required if row 11 set) |
+
+> **Type-name footnote (rows 5, 8, 11):** the table above shows **user-facing labels**. JSON enum mapping (Critical Rule #14): `Maestro` → `AgenticProcess`; `RPA` → `RPAWorkflow`; `Robot User` → `User`. All other type names match the JSON enum.
+
+> Every row is pre-filled with a sensible default — no `(missing)` rows in the initial Spec. Only mark a row `(missing)` when there is genuinely no defensible default and add it to the Open questions list.
+
+**Open questions** (only when truly ambiguous — present sparingly):
+  - <e.g., "I picked 'Production' tag for the Agents — should it be 'Staging' instead?">
+  - <e.g., "I assumed 'Production OR Staging' — did you mean both required (AND)?">
+```
+
+### Row defaults reference
+
+Every row gets a concrete value in the initial Spec (Critical Rule #11 — don't ask, just pre-fill). Defaults applied when the user didn't supply a value:
+
+| Row | Required? | Default when not specified |
+|---|---|---|
+| — Organization (read-only) | Scope | Name from `uip login status` (`Data.Organization`); UUID from `~/.uipath/.auth` (`organizationId`). Not user-editable in the Spec. |
+| — Tenant (read-only) | Scope | Name from `uip login status` (`Data.Tenant`); UUID from `~/.uipath/.auth` (`tenantId`). Not user-editable in the Spec. |
+| 1 — Policy name | Required | Suggested from intent: `"Allow <ResourceSummary> in <ActorProcessSummary>"` |
+| 2 — Description | Required | Auto-derived from the narrative |
+| 3 — Status | Required | `Simulated` (Critical Rule #13) |
+| 4 — Enforcement | Required (fixed) | `Allow` (Critical Rule #2) |
+| 5 — Resource type(s) | Required | Mark `(missing)` ONLY if the user gave no resource hint at all → Open question |
+| 6 — Resource scope | Required | `all` (`["*"]`) |
+| 7 — Resource tag filter | Optional | `(none)` |
+| 8 — Actor Process type(s) | Required | Mark `(missing)` ONLY if the user gave no caller hint at all → Open question |
+| 9 — Actor Process scope | Required | `all` (`["*"]`) |
+| 10 — Actor Process tag filter | Optional | `(none)` |
+| 11–12 — Actor Identity | Optional (row 12 required if row 11 is set) | Omit entirely (no Actor Identity constraint) — Critical Rule #4 |
+
+The Spec is "ready" once every Open question is closed.
+
+### Spec narrative format
+
+The narrative is a structured block, not a free-form paragraph. Every Spec narrative — in chat, in `/tmp/access-policy-<slug>.spec.md`, and in the Review gate — uses this exact shape:
+
+1. **Title line** — the policy name in bold, wrapped in straight double quotes: `**"<POLICY_NAME>"**`. Same string as Spec row 1.
+2. **Opening sentence** — one sentence stating the policy type ("tool-use policy"), status mode ("simulation mode" / "active mode"), and the high-level effect. Example: _"This is a **tool-use policy** in **simulation mode** that allows a specific Maestro running on behalf of a specific user to invoke any Agent tagged `Production`."_ Always say "Maestro" — never "AgenticProcess" or "Agentic Process" — in the narrative (Critical Rule #14).
+3. **Bulleted components** — exactly four bullets, in this order:
+    - `**What is being protected:**` — plain-English Resource summary (type, scope, tag filter).
+    - `**Who/what is allowed to call them:**` — Actor Process summary, then Actor Identity summary in the same bullet. When no Actor Identity row is filled, say "any User or Group running these Actor Processes" rather than omitting the bullet.
+    - `**Effect:**` — always `Allow`. Phrase as "`Allow` — the matching call is permitted." Do not mention "not Deny" or any internal-mechanics caveat.
+    - `**Status:**` — `Simulated` or `Active`, with the one-line meaning attached.
+4. **Intent paragraph** — `**Intent:**` followed by 2–3 sentences on the *why* behind the policy. Carry over the user's framing verbatim where it is clear; do not invent intent. Mention the simulation rationale when status is `Simulated`.
+
+The narrative is rendered as a single Markdown blockquote (every line prefixed with `>`) so it visually groups in chat. See [sample-policy-guide.md — Sample Spec narrative](./sample-policy-guide.md#sample-spec-narrative-natural-language-description) for a worked example.
+
+### Description-field derivation
+
+Spec row 2 (`Description`) is the **one-sentence summary** that the policy carries on the server. Derive it from the narrative's opening sentence and Intent paragraph — keep it under 200 characters. Do NOT paste the full narrative into row 2; the narrative is the chat/spec-file artifact, the description is the API field.
+
+### Spec rules
+
+- **Org / Tenant rows are read-only scope.** The two un-numbered rows at the top of the table show the active auth context — `<NAME> (UUID <UUID>)` for both Organization and Tenant. They are sourced from `uip login status --output json` (names) and `~/.uipath/.auth` (UUIDs) and are NOT user-editable in the Spec; if the user wants to author against a different org or tenant, route them to re-run `uip login` (Critical Rule #1) and regenerate the Spec. The same Scope is shown again at the Phase 2 review gate (Critical Rule #7).
+- **Narrative and table are kept in sync.** When the user changes a row, re-derive the narrative; when the user changes the narrative ("make it match this description"), re-derive the table by re-running [Intent analysis](#intent-analysis) on the new narrative. Both must reflect the same policy.
+- **Terminology (user-facing — Critical Rule #14):** say "Resource", "Actor Process", "Actor Identity", "tag filter", "Allow", "Simulated / Active" in the Spec. Never use the JSON field names (`selectors`, `executableRule`, `actorRule`, `operator: Or/And/None`) in the Spec. JSON terms appear only in Phase 2.
+- **Multi-type rows.** If the user names two resource types ("Agents and Flows"), each type gets its own row group — duplicate rows 5/6/7 once per type and label them `5a / 6a / 7a` for the first type, `5b / 6b / 7b` for the second, etc. Do the same for Actor Process rows (8/9/10) when multiple Actor Process types are named. The Spec table grows row-wise; it never collapses two types into one row.
+- **Actor Identity is constrained (Critical Rule #16).** Rows 11/12 carry **at most two entries** — one `User` entry plus one `Group` entry. Multiple users (including multiple Robot Users) are merged into the `User` row's scope, never split into duplicate rows. Multiple groups are merged into the `Group` row's scope. **When both entries are present, their scope-style (include vs. exclude) must match** — both "specific UUIDs" or both "all-except UUIDs". Mixed include/exclude intent ("allow these users but exclude that group") cannot fit in one policy and must be split into two policies; flag this in Open questions and confirm with the user.
+- **Always suggest a name.** Row 1 is **always** pre-filled — never `(missing)`. Default pattern: `"Allow <ResourceSummary> in <ActorProcessSummary>"` (e.g. `"Allow Production Agents in Maestro"`). Use user-facing names — `Maestro` rather than `AgenticProcess` (Critical Rule #14). The user can change it during the review loop.
+- **Description auto-derivation.** Row 2 is the one-sentence summary of the narrative — keep it under 200 characters and aligned with the narrative's opening sentence + Intent paragraph (see [Description-field derivation](#description-field-derivation)).
+- **Status default.** Default row 3 to `Simulated` (Critical Rule #13 — see [SKILL.md § Enforcement and status](../SKILL.md#enforcement-and-status) for the meaning). When presenting the Spec, mention once: _"Created in Simulated mode — evaluated but not enforced. Tell me if you want it Active from the start, or activate it after review."_ Only fill `Active` when the user explicitly asks.
+- **Enforcement is always `Allow`.** Row 4 is fixed (Critical Rule #2). Deny intent is silently translated to an Allow shape; never surface the flip in the narrative or table. See [plugins/tags/planning.md — Deny-to-Allow flip](./plugins/tags/planning.md#deny-to-allow-flip) for the decision logic.
+- **Default scope.** Default the scope row to `all` (corresponds to `["*"]`) when the user didn't specify UUIDs. Specific UUIDs only when the user named them.
+- **Resolving names to UUIDs.** When the user refers to a specific process / agent / flow / user / robot by **name** ("the Invoice Agent", "the build-bot robot"), do NOT ask the user for the UUID blindly — first run the lookup commands in [resource-lookup-guide.md](./resource-lookup-guide.md). Present matching rows as a numbered picker and let the user confirm one. **Robots resolve to `type: User`** (Critical Rule #16) — look up the robot, then resolve its linked user identity, and emit a `User`-typed Spec row. Surface an Open question only when the lookup returns no match or the identity type (Group) has no `uip or` wrapper yet (Critical Rule #15).
+- **Tag rows.** Include a tag-filter row only when the user mentioned tags on that side. Otherwise leave the cell as `(none)`.
+- **Actor Identity omission.** If the user said nothing about identity, leave rows 11–12 as `(none = any identity)`. Phase 2 will omit `actorRule` entirely from the JSON (Critical Rule #4).
+- **No tags on Actor Identity.** The Spec table has no row 13 — `actorRule` does not support `tags` today. If the user asks for an identity tag filter, tell them it is not supported and offer to (a) enumerate users / groups directly under rows 11/12, or (b) drop the tag filter. Phase 2 must never emit `actorRule.tags`.
+
+---
+
+## Spec file convention
+
+Once the Spec is fully pre-filled and every Open question is closed, write it to `/tmp/access-policy-<slug>.spec.md` so the user can open it in their editor and review it independently of the chat transcript. The same slug is reused for the Phase 2 JSON file (`/tmp/access-policy-<slug>.json`) so the two files sit side by side.
+
+### Slug rule
+
+Compute the slug from Spec row 1 (`Policy name`):
+
+```bash
+SLUG=$(echo "<POLICY_NAME>" | tr '[:upper:] ' '[:lower:]-' | tr -cd '[:alnum:]-')
+SPEC_FILE="/tmp/access-policy-${SLUG}.spec.md"
+```
+
+Phase 2 will run the **identical** snippet to derive its `POLICY_FILE`, so the slug must come from row 1 — never from a transient placeholder.
+
+### Spec file body
+
+The file is a self-contained markdown document the user can read without chat context. Use this template verbatim:
+
+```markdown
+# Access Policy Spec — <POLICY_NAME>
+
+> **"<POLICY_NAME>"**
+>
+> <ONE_OPENING_SENTENCE — policy type + status mode + high-level effect>
+>
+> - **What is being protected:** <plain-English Resource summary>
+> - **Who/what is allowed to call them:** <Actor Process summary, then Actor Identity summary; use "any User or Group running these Actor Processes" when no Actor Identity row is filled>
+> - **Effect:** `Allow` — the matching call is permitted.
+> - **Status:** `<Simulated | Active>` — <one-line meaning>
+>
+> **Intent:** <2–3 sentences describing the *why* — carry over the user's framing verbatim where clear; mention simulation rationale when status is `Simulated`>
+
+## Spec Components Table
+
+| # | Component | Allowed values | Current value | Required? |
+|---|-----------|---------------|--------------|-----------|
+| <ALL_ROWS_AS_PRESENTED_IN_CHAT — see [Spec output format](#spec-output-format)> |
+
+_Generated by Phase 1 of the `uipath-gov-access-policy` skill. The matching policy JSON will be written to `/tmp/access-policy-<slug>.json` by Phase 2._
+```
+
+### Re-write on every iteration round (after row 1 is set)
+
+- Once Spec row 1 is filled for the first time, write the file.
+- After every subsequent iteration round that changes any row, **re-write** the file so its contents always match what the user sees in chat. If row 1 itself changes, also `rm` the previous slug's `.spec.md` to avoid stale files.
+- Show the resolved absolute path as a clickable markdown link (run `realpath` — Critical Rule #7) every time you re-present the Spec.
+
+If row 1 is still `(missing)`, do NOT write the file yet — defer until the first round where the user supplies (or accepts a suggested) name.
+
+---
+
+## Review gate
+
+When every Open question is closed, present the final Spec (narrative + table) IN CHAT, plus a clickable markdown link to the Spec file (`/tmp/access-policy-<slug>.spec.md` — resolved absolute path), and ask the user verbatim:
+
+```
+Approve this access-policy Spec to proceed to Phase 2? (yes / edit / cancel)
+```
+
+- `yes` → hand off to [planning-impl.md](./planning-impl.md). The Spec file stays on disk so the user can compare it to the JSON working file Phase 2 will create.
+- `edit` → return to the iteration loop (step 4 of the [Process](#process)). Collect the change, update the table + narrative, **re-write the Spec file**, then re-present and re-enter this gate.
+- `cancel` → stop and drop the session. Leave the Spec file on disk only if the user wants to keep a draft; otherwise `rm` it.
+
+Do NOT advance to Phase 2 without an explicit `yes`. The approved Spec — both the narrative in chat AND the Spec file on disk — is the contract.
+
+---
+
+## Handoff to Phase 2
+
+The approved Spec is the input to [planning-impl.md](./planning-impl.md), which walks the Spec Components Table row by row, reads the matching plugin's `impl.md`, and composes the concrete `PolicyDefinition` JSON. Phase 2 reuses the slug from the Spec file and writes the JSON to `/tmp/access-policy-<slug>.json`. The single review gate in [policy-manage-guide.md](./policy-manage-guide.md) presents both files side by side.

--- a/skills/uipath-gov-access-policy/references/planning-impl.md
+++ b/skills/uipath-gov-access-policy/references/planning-impl.md
@@ -1,0 +1,126 @@
+# Phase 2 — Implementation Resolution
+
+Compose the concrete `PolicyDefinition` JSON from an **approved Phase 1 Spec** (narrative paragraph + Spec Components Table — see [planning-arch.md](./planning-arch.md)). This phase walks each row of the Spec table and reads the matching plugin's `impl.md` to produce the exact JSON — it never writes JSON from memory and it never re-interprets the user's chat history.
+
+> **Prerequisite:** the user must have explicitly approved a Spec via [planning-arch.md](./planning-arch.md). If no Spec exists, or the Spec still has `(missing)` rows or open questions, return to Phase 1.
+
+---
+
+## Step 1 — Gather identity
+
+Every `PolicyDefinition` requires `organizationId` and `tenantId` at the top level. Read them from `~/.uipath/.auth` — see [access-policy-commands.md — Reading `organizationId` and `tenantId`](./access-policy-commands.md#reading-organizationid-and-tenantid) for the exact command. Use the two UUIDs verbatim in the assembled JSON; never hardcode (Critical Rule #3).
+
+If the file is missing or the IDs are not present, the user is not logged in — stop and route them to [access-policy-commands.md — Authentication](./access-policy-commands.md#authentication).
+
+---
+
+## Step 2 — Compose each block via plugins
+
+Walk the Spec Components Table row-by-row. For every Resource / Actor Process / Actor Identity row, read the matching plugin's `impl.md` and follow its JSON shape exactly. The plugin `impl.md` is the only authoritative source for block-level JSON — do NOT reconstruct from memory.
+
+> **Spec must arrive without UUID placeholders.** Phase 1 is responsible for resolving every name to a real UUID via [resource-lookup-guide.md](./resource-lookup-guide.md) (Critical Rule #15) before the user approves the Spec. If a `<…_UUID>` placeholder reaches Phase 2, the Spec is incomplete — stop, return to Phase 1, run the missing lookup, re-approve. Never paste a placeholder into the policy file.
+
+| Spec rows | Plugin impl file | Produces |
+|-----------|------------------|----------|
+| Resource rows (Spec rows 5/6, plus 7 if a tag filter) | [plugins/selector/impl.md](./plugins/selector/impl.md) | One entry of `selectors[]` per Resource type |
+| Actor Process rows (Spec rows 8/9, plus 10 if a tag filter) | [plugins/executable/impl.md](./plugins/executable/impl.md) | The `executableRule` object |
+| Actor Identity rows (Spec rows 11/12) — only when present in the Spec (omitted entirely when the user gave no identity intent). **No tags** — `actorRule` does not support tag filters today | [plugins/actor/impl.md](./plugins/actor/impl.md) | The `actorRule` object |
+| Any tag-filter row (rows 7 / 10 only) | [plugins/tags/impl.md](./plugins/tags/impl.md) | `{ values: [...], operator: ... }` |
+
+Work in this order so the assembled object is complete before the review gate:
+
+1. For every Resource row in the Spec, follow [plugins/selector/impl.md](./plugins/selector/impl.md). If the row has a tag filter (Spec row 7), compose it via [plugins/tags/impl.md](./plugins/tags/impl.md) and nest it inside the selector.
+2. Follow [plugins/executable/impl.md](./plugins/executable/impl.md) to build the single `executableRule` from the Actor Process rows. If row 10 has a tag filter, compose it via [plugins/tags/impl.md](./plugins/tags/impl.md) and nest it at the top level of `executableRule` (not per-entry).
+3. **Only if the Spec has Actor Identity rows present** (rows 11/12 are not `(none = any identity)`), follow [plugins/actor/impl.md](./plugins/actor/impl.md) to build the `actorRule` object. **Never emit `actorRule.tags`** — tags are not supported on Actor Identity today (see [plugins/actor/impl.md — Field rules](./plugins/actor/impl.md)). If the Spec has no Actor Identity rows, **omit the `actorRule` key entirely** from the top-level document — do not emit an empty or default block.
+
+---
+
+## Step 3 — Assemble the top-level `PolicyDefinition`
+
+Wrap the composed blocks with the fixed top-level fields:
+
+```json
+{
+  "policyType": "ToolUsePolicy",
+  "organizationId": "<ORG_UUID>",
+  "tenantId": "<TENANT_UUID>",
+  "name": "<POLICY_NAME>",
+  "description": "<DESCRIPTION>",
+  "selectors": [
+    /* one or more selector blocks from Step 2 */
+  ],
+  "executableRule": {
+    /* Actor Process Rule — executable rule block from Step 2 */
+  },
+  "actorRule": {
+    /* Actor Identity Rule — OMIT this key entirely if the Spec has no Actor Identity rows */
+  },
+  "enforcement": "Allow",   /* always "Allow" — never "Deny" (Critical Rule #2) */
+  "status": "Simulated"
+}
+```
+
+### Fixed-value rules
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `policyType` | always `"ToolUsePolicy"` | The only type this skill mutates (Critical Rule #2). |
+| `name` | Spec row 1 | Required. |
+| `description` | Spec row 2 | Required. Should match the Spec narrative paragraph. |
+| `enforcement` | Spec row 4 (always `Allow`) | **Always `"Allow"`** — `"Deny"` is not authorable (Critical Rule #2). Deny intent is expressed by writing an Allow policy that targets the complement of what should be blocked (re-framed scope, or `operator: "None"` on tags / values). Never emit `"enforcement": "Deny"`. |
+| `status` | Spec row 3 (default `Simulated`) | Default `Simulated` for new policies (Critical Rule #13). Emit `Active` only when the Spec explicitly says so. |
+| `organizationId`, `tenantId` | from Step 1 | Never hardcoded. |
+
+### Fields to OMIT
+
+Do NOT include these in the file — they are server-managed:
+
+- `id` (create only; required on update — see [policy-manage-guide.md — Update](./policy-manage-guide.md#update-a-policy))
+- `isBuiltIn`, `isTemplate`
+- `createdBy`, `createdOn`, `modifiedBy`, `modifiedOn`
+- `deletedBy`, `deletedOn`
+
+---
+
+## Step 4 — Write the working file
+
+Reuse the **same slug** Phase 1 used for `/tmp/access-policy-<slug>.spec.md` (see [planning-arch.md — Spec file convention](./planning-arch.md#spec-file-convention)) so the Spec and JSON sit side by side under the same name:
+
+```bash
+SLUG=$(echo "<POLICY_NAME>" | tr '[:upper:] ' '[:lower:]-' | tr -cd '[:alnum:]-')
+POLICY_FILE="/tmp/access-policy-${SLUG}.json"
+SPEC_FILE="/tmp/access-policy-${SLUG}.spec.md"   # already written by Phase 1 — must exist
+```
+
+Write the assembled top-level object to `$POLICY_FILE`. The file contents must be the raw `PolicyDefinition` object — do NOT wrap it in `{ "data": {...} }`.
+
+If `$SPEC_FILE` does not exist when Phase 2 runs, the Spec was never approved — return to Phase 1.
+
+For **update** flows, the file path convention is `/tmp/access-policy-<id>-working.json` and the file starts as a copy of `Data` from `get` — see [policy-manage-guide.md — Update](./policy-manage-guide.md#update-a-policy) Step 2. Updates do NOT generate a `.spec.md` (Critical Rule #8 — the existing server `Data` is the source of truth).
+
+---
+
+## Step 5 — Handoff
+
+Return both the composed `$POLICY_FILE` (JSON) and the `$SPEC_FILE` (markdown, written by Phase 1) paths to [policy-manage-guide.md](./policy-manage-guide.md), which:
+
+1. Runs the **single review gate** — shows the full JSON in chat plus clickable links to **both** `$SPEC_FILE` and `$POLICY_FILE` (resolved absolute paths) so the user can compare the human-readable Spec against the machine payload before approval.
+2. Requires explicit `yes`.
+3. Runs `uip gov access-policy create --file "$POLICY_FILE" --output json` (or `update`).
+4. Verifies the result with `get`.
+
+Phase 2 does NOT run the CLI itself and does NOT prompt for confirmation — all confirmation consolidates in the manage-guide.
+
+---
+
+## Iteration
+
+If the review gate in the manage-guide is answered with `keep editing`, route back based on the scope of the change:
+
+| Change scope | Route to |
+|--------------|----------|
+| Top-level metadata only (Spec rows 1/2/3 — name, description, status; row 4 enforcement is fixed at `Allow` per Critical Rule #2) | [policy-manage-guide.md — Step 3](./policy-manage-guide.md#create-a-policy) |
+| A block's JSON shape (enum, targeting, operator) | The relevant plugin's `impl.md` — compose that block again and splice back into the file |
+| Intent itself (which resource? which actor process? Deny-flip?) | [planning-arch.md](./planning-arch.md) — return to Spec iteration, get a fresh `yes`, then re-run Phase 2 |
+
+Re-enter the review gate only after the change is applied.

--- a/skills/uipath-gov-access-policy/references/plugins/actor/impl.md
+++ b/skills/uipath-gov-access-policy/references/plugins/actor/impl.md
@@ -1,0 +1,206 @@
+# Actor Plugin — Implementation
+
+Concrete JSON for the `actorRule` block — the policy's **Actor Identity Rule**. Phase 2 reads this file to compose the `actorRule` block before assembling the top-level `PolicyDefinition` (see [planning-impl.md — Step 2](../../planning-impl.md#step-2--compose-each-block-via-plugins)). Omit the block entirely when the user expressed no identity intent.
+
+> **Required field: `values`.** Every entry under `actorRule.values[]` must include its own `values` (use `["*"]` for "all of this type"). Missing `values` returns `400 Bad Request` (Critical Rule #5). `actorRule.tags` is **never supported** — do not add a `tags` block here.
+
+> **Supported types: `User` and `Group` only** (Critical Rule #16). Robots resolve to `User` after lookup; `ExternalApplication` is not supported. See [planning.md](./planning.md) for the resolution flow.
+
+## Full `actorRule` shape
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User",  "values": ["<USER_UUID>", "..."],  "operator": "<Or | None>" },
+        { "type": "Group", "values": ["<GROUP_UUID>", "..."], "operator": "<Or | None>" }
+    ]
+}
+```
+
+### Structural constraints (Critical Rule #16)
+
+- `values[]` carries **at most two entries** — one `User` and one `Group`. Either, both, or none of those entries may be present, but never duplicates of the same type.
+- **Multiple users / groups go inside a single entry's `values[]` array** — never split across multiple entries of the same `type`.
+- **Operators must match across the two entries.** When both `User` and `Group` are present, both `operator` fields must be the same value (both `"Or"` or both `"None"`). Mixed operators are rejected by the API. Mixed-operator user intent must be split into two policies (see [planning.md — Mixed-operator intent → two policies](./planning.md#mixed-operator-intent--two-policies)).
+
+### Field rules
+
+| Field | Required | Value rules |
+|-------|----------|-------------|
+| `values` | yes | Array of at most two per-type entries (one `User`, one `Group`). At least one entry when the block is emitted. |
+| `values[].type` | yes | One of: `User`, `Group`. **Never** `ExternalApplication` or `Robot` (Critical Rule #16). Each type appears at most once across the array. |
+| `values[].values` | yes | `["*"]` or specific UUIDs. Multiple identities of the same type are listed here, not split into multiple entries. Never empty. |
+| `values[].operator` | yes | `"Or"` (include) or `"None"` (exclude). When both `User` and `Group` entries are present, this value MUST match across both entries. |
+| `tags` | **NOT SUPPORTED** | `actorRule` does not accept a `tags` block today. Never emit one. If the user wants tag-style narrowing, enumerate the matching users / groups under `values[].values` instead. |
+
+> **Whole-block emission is optional.** If the user did not mention any identity, omit the `actorRule` key from the top-level `PolicyDefinition` entirely — do NOT emit `{"values": [{"type": "User", "values": ["*"], "operator": "Or"}]}` as a default.
+
+> **No `actorRule.tags`.** Unlike `selectors[]` and `executableRule`, the Actor Identity rule does not support tag filters today. Emitting `actorRule.tags` returns `400 Bad Request` from the API.
+
+---
+
+## Worked examples
+
+### A. Single-type, specific users
+
+**Intent:** "Only users alice-uuid and bob-uuid can trigger this".
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["alice-uuid", "bob-uuid"], "operator": "Or" }
+    ]
+}
+```
+
+### B. Single-type, all of one type
+
+**Intent:** "Any user can trigger this" (no narrowing).
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["*"], "operator": "Or" }
+    ]
+}
+```
+
+> **No identity tag filter.** If the user said "any user tagged Admin", **`actorRule.tags` is not supported** — refuse and offer to (a) enumerate the admin user UUIDs under `values[].values`, (b) use a `Group` UUID for the Admins group, or (c) drop the tag filter so the rule applies to any user. Never emit `actorRule.tags`.
+
+### C. Multi-type (one User entry + one Group entry — operators match)
+
+**Intent:** "Members of the Ops group and admin users alice-uuid, bob-uuid can trigger this".
+
+Both entries are include-style, so both use `operator: "Or"` (the operator must match across `User` and `Group` per Critical Rule #16):
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User",  "values": ["alice-uuid", "bob-uuid"], "operator": "Or" },
+        { "type": "Group", "values": ["ops-group-uuid"],         "operator": "Or" }
+    ]
+}
+```
+
+**Mixed-operator intent → two policies.** If the user said "allow alice-uuid and bob-uuid **but exclude** the Ops group", the operators don't match and the API rejects it. Author two separate policies:
+
+```json
+// Policy A — allow specific users
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["alice-uuid", "bob-uuid"], "operator": "Or" }
+    ]
+}
+
+// Policy B — exclude the Ops group
+"actorRule": {
+    "values": [
+        { "type": "Group", "values": ["ops-group-uuid"], "operator": "None" }
+    ]
+}
+```
+
+**Same-type merging.** Multiple users (or multiple groups) belong in **one** entry's `values[]` array. Do NOT emit two `User` entries — merge their UUIDs:
+
+```json
+// CORRECT — single User entry with multiple UUIDs
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["alice-uuid", "bob-uuid", "carol-uuid"], "operator": "Or" }
+    ]
+}
+
+// WRONG — duplicate User entries (rejected by the API)
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["alice-uuid"], "operator": "Or" },
+        { "type": "User", "values": ["bob-uuid"],   "operator": "Or" }
+    ]
+}
+```
+
+### D. Deny-flipped actor
+
+**Intent (original):** "block user alice-uuid". **Flipped to Allow** with the `None` operator:
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["alice-uuid"], "operator": "None" }
+    ]
+}
+```
+
+This allows every User **except** `alice-uuid`. (See [../tags/planning.md — Deny-to-Allow flip](../tags/planning.md#deny-to-allow-flip) for the decision procedure.)
+
+### E. Robot-only trigger (resolves to `User`)
+
+**Intent:** "Only the unattended robot `build-bot` can trigger this".
+
+Resolution flow (see [planning.md — Robot intent](./planning.md#robot-intent-resolves-to-user)):
+1. `GET /orchestrator_/odata/Robots` → match `build-bot` → read `Username`.
+2. `uip or users list` filtered on that `UserName` → get the User UUID `bot-user-uuid`.
+3. Emit:
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["bot-user-uuid"], "operator": "Or" }
+    ]
+}
+```
+
+> Never emit `{ "type": "Robot", ... }`. The server rejects it as an unknown type, and the policy authoring contract does not support it (Critical Rule #16).
+
+---
+
+## Update-flow use
+
+When `policy-manage-guide.md — Update` needs to modify an existing `actorRule`:
+
+1. Start from the working file's current `actorRule` object (or absence — "add identity constraint" means inserting the block fresh).
+2. Change only the part the user asked about (add a type, add a UUID, flip an operator, adjust `tags`).
+3. Preserve every other field.
+
+Example: existing rule allows specific admin users; user says "also allow members of the Ops group".
+
+Before:
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User", "values": ["alice-uuid", "bob-uuid"], "operator": "Or" }
+    ]
+}
+```
+
+After:
+
+```json
+"actorRule": {
+    "values": [
+        { "type": "User",  "values": ["alice-uuid", "bob-uuid"], "operator": "Or" },
+        { "type": "Group", "values": ["ops-group-uuid"],         "operator": "Or" }
+    ]
+}
+```
+
+> **No `actorRule.tags`.** If you find a legacy `actorRule.tags` block on a policy fetched via `get`, drop it from the working file before submitting the update — emitting it returns `400 Bad Request` (see Debug table below).
+
+Removing the block entirely: drop the `actorRule` key from the working file (do not set it to `null` or `{}`).
+
+---
+
+## Debug
+
+| Error / signal | Cause | Fix |
+|----------------|-------|-----|
+| `400 Bad Request` / `ActorRule.Values is required` | `actorRule.values` empty or missing while block is present | Remove the `actorRule` key entirely, or include at least one entry. |
+| `400 Bad Request` / unknown actor `type` | Typo, or emitted `Robot` / `ExternalApplication`, or a resource type like `Agent` / `APIWorkflow` | Use exactly one of `User`, `Group`. Robot intent must be resolved to a `User` UUID first (Critical Rule #16). |
+| `400 Bad Request` / duplicate `type` in `actorRule.values` | Emitted two `User` entries (or two `Group` entries) | Merge them into a single entry whose `values[]` lists every UUID. `actorRule.values[]` carries at most one entry per type (Critical Rule #16). |
+| `400 Bad Request` / mismatched operators in `actorRule.values` | The `User` entry uses `operator: "Or"` and the `Group` entry uses `operator: "None"` (or vice versa) | Operators must match across both entries (Critical Rule #16). For mixed-include/exclude intent, split into two policies (see Worked Example C). |
+| `400 Bad Request` on `type: Group` | Server build does not accept `Group` | Fall back to enumerating member user UUIDs under a single `type: User` entry. Report the limitation. |
+| `400 Bad Request` / `Values is required` on a per-entry field | An entry's own `values` is empty | Use `["*"]` or specific UUIDs — never `[]`. |
+| Policy never matches the intended actor | Actor UUID not in `values` | Log in as that user (`uip login`) and run `uip gov access-policy evaluate --resource-type <TYPE> --output json` — the calling user is taken from the bearer. (Under an S2S token, pass `--actor-identity-id <UUID>` instead.) |
+| `400 Bad Request` referencing `tags` on `actorRule` | Emitted an `actorRule.tags` block (or kept one inherited from a fetched policy) | Remove the `tags` key from `actorRule` — Actor Identity does not support tag filters today (Spec rules / Critical Rule #5). Enumerate matching users / groups under `values[].values` instead. |
+| Evaluation returns Deny even though selectors + executable match | `actorRule` is present and the caller's identity falls outside `values` | Check whether the block should be present at all; omit it if the user never asked for identity enforcement. |

--- a/skills/uipath-gov-access-policy/references/plugins/actor/planning.md
+++ b/skills/uipath-gov-access-policy/references/plugins/actor/planning.md
@@ -1,0 +1,180 @@
+# Actor Identity Plugin — Planning
+
+> **User-facing terminology vs JSON field.** The user-facing name for this block is **Actor Identity rule**. The underlying JSON field is `actorRule` — that name is only shown in code / CLI contexts. When summarizing the policy to the user, always say "Actor Identity rule", never "Actor rule".
+
+The `actorRule` block is the policy's **Actor Identity Rule** — it identifies **who** (which user or group) is allowed (or blocked) from triggering the Actor Process that invokes the Resource. The access policy has at most one `actorRule` block, which can hold at most two entries — one `User` and one `Group` (Critical Rule #16).
+
+> **Supported types: `User` and `Group` only** (Critical Rule #16). `ExternalApplication` is **not supported** today; reject any intent that names a service principal / registered app and route the user to use a User or Group instead, or to omit Actor Identity entirely. **Robot intent maps to `User`** — look up the robot via [resource-lookup-guide.md § Robots](../../resource-lookup-guide.md#robots-resolve-to-type-user) (REST → `Username` → `uip or users list`), resolve to its linked User UUID, and emit a `User`-typed entry. Never emit `type: "Robot"` or `type: "ExternalApplication"`.
+
+> **Terminology recap.** The access policy has three rule parts:
+> - **Selection Rule** → `selectors[]` — which Resource/Tool the policy applies to.
+> - **Actor Process Rule** → `executableRule` — which executable workflow is calling the Resource.
+> - **Actor Identity Rule** → `actorRule` — which user or group is triggering the Actor Process.
+>
+> All three must pass for the evaluation result to be Allow. See [../../../SKILL.md](../../../SKILL.md) for the full evaluation flow.
+
+## When to Use
+
+Emit `actorRule` **only when the user expressed actor-identity intent**. If the user did not mention a user, group, or robot identity, omit the block entirely — absence of `actorRule` means "any actor passes the identity check".
+
+## When intent is actor-shaped
+
+Flag these phrases during Phase 1 and route them to this plugin:
+
+- "only admins can…", "only user X can…"
+- "restrict user X from…", "block user Y from…"
+- "members of group G can…", "users in group Z can…"
+- "on behalf of actor X…"
+- "when robot R triggers…" (resolves to `User` — see [Robot intent](#robot-intent-resolves-to-user))
+
+If the user names an external application / service principal / S2S app / registered app, **stop and tell them** that `ExternalApplication` is not supported today (Critical Rule #16). Offer the workarounds:
+- Use a `User` (the user account the app authenticates as), or
+- Use a `Group` containing the app's identity, or
+- Omit the Actor Identity rule entirely so the policy applies regardless of identity.
+
+## Block shape (conceptual)
+
+```text
+actorRule = {
+    values: [
+        { type: "User",  values: [<user_uuid>, <user_uuid>, ...],   operator: <Or | None> },
+        { type: "Group", values: [<group_uuid>, <group_uuid>, ...], operator: <Or | None> }
+    ]
+}
+```
+
+Strict structural constraints (Critical Rule #16):
+
+- `actorRule.values[]` carries **at most two entries** — at most one `User` entry and at most one `Group` entry. Never duplicate entries of the same type.
+- **Multiple users / groups go inside a single entry's `values[]` array**, not as multiple entries. If the user names three admin users plus the Ops group, that is one `User` entry (with three UUIDs) plus one `Group` entry (with one UUID) — two entries total.
+- **Operators must match across `User` and `Group`.** When both entries are present, their `operator` must be the same value (both `Or`, or both `None`). Mixing `Or` on one and `None` on the other is invalid — the API rejects it. If the user expresses mixed intent (e.g. "allow these users but exclude this group"), split into **two policies**: one with the `User` entry (operator `Or`) and one with the `Group` entry (operator `None`).
+- **No `tags` block.** Unlike `selectors[]` and `executableRule`, `actorRule` does **not** support `tags` today. If the user asks for an identity tag filter, refuse and offer to enumerate the matching users / groups directly under `values[]`, or to drop the tag filter entirely.
+
+## Intent → actor identity type
+
+Map the user's phrasing to the enum.
+
+| User phrase | `type` |
+|-------------|--------|
+| "user X", "specific person", "admin Alice" | `User` |
+| "group G", "members of group", "role X" | `Group` |
+| "robot R", "unattended robot", "attended robot" | `User` (resolve via [Robot intent](#robot-intent-resolves-to-user)) |
+| "external application", "service account", "S2S app", "registered app" | **Not supported** — reject and offer workarounds (see [When intent is actor-shaped](#when-intent-is-actor-shaped)). |
+
+## Targeting modes
+
+Same two modes as selectors and executables:
+
+| Mode | `values` | `operator` |
+|------|----------|------------|
+| **All of this type** | `["*"]` | `Or` |
+| **Specific IDs** | `["<UUID>", ...]` | `Or` |
+| **Exclude specific IDs** | `["<UUID>", ...]` | `None` |
+
+`values: ["*"]` is required on every entry (Critical Rule #5). Missing it returns `400`.
+
+### Resolving Actor Identity names to UUIDs
+
+If the user named a specific identity ("only Alice", "members of group Ops"), resolve the name to a UUID via [resource-lookup-guide.md](../../resource-lookup-guide.md):
+
+- **User** → `uip or users list --output json` (filter by `UserName` / `Name`). `uip or users current --output json` for "only me".
+- **Group** → no public Orchestrator endpoint. Ask the user to paste the UUID from the Admin portal and record it as an **Open question** on the Phase 1 Spec until supplied.
+
+Present matched users as a numbered picker (see [resource-lookup-guide.md § 3](../../resource-lookup-guide.md#3-users-actor-identity-uuids)). Never silently pick the first row.
+
+### Robot intent resolves to `User`
+
+A robot in UiPath identity is **a kind of user** (Critical Rule #16). When the user says "robot R can trigger…":
+
+1. Look up the robot via the REST fallback `GET /orchestrator_/odata/Robots` — see [resource-lookup-guide.md § Robots](../../resource-lookup-guide.md#robots-resolve-to-type-user) for the secure token-sourcing pattern.
+2. Read the `Username` field on the matched robot record.
+3. Resolve that username to a User UUID with `uip or users list --output json` filtered on `UserName`.
+4. Emit `{ "type": "User", "values": ["<USER_UUID>"], "operator": "Or" }` — never `type: "Robot"`.
+
+If the robot has no linked user (rare), surface as an Open question and stop — do not invent a UUID.
+
+## Multi-type actor rules
+
+`actorRule.values[]` holds **at most two entries** — one `User` and one `Group`. Same-type identities are merged into a single entry's `values[]` array, never duplicated as separate entries.
+
+### Single-`User`-entry merging (users + robots in one entry)
+
+If the user says "users alice-uuid, bob-uuid, and the build-bot robot can trigger…", these are **all `User`** in the JSON (Critical Rule #16 — robots resolve to `User`). Resolve the robot to its linked User UUID, then merge all three into one `User` entry — never emit two `User` entries:
+
+```text
+actorRule:
+  values:
+    1. type: User, values: ["alice-uuid", "bob-uuid", "<bot-user-uuid>"], operator: Or
+```
+
+### Two-type case (operators must match)
+
+If the user says "admins **and** members of group Ops can trigger…", emit one `User` entry plus one `Group` entry — both with the **same** operator:
+
+```text
+# CORRECT — both entries use operator: Or
+actorRule:
+  values:
+    1. type: User,  values: ["<ADMIN_UUID>", ...], operator: Or
+    2. type: Group, values: ["<OPS_GROUP_UUID>"],  operator: Or
+```
+
+The pattern below is **rejected by the API** (mismatched operators across the two entries):
+
+```text
+# REJECTED — User uses Or, Group uses None — API returns 400 Bad Request
+actorRule:
+  values:
+    1. type: User,  values: ["<ADMIN_UUID>"],     operator: Or       # ← include
+    2. type: Group, values: ["<OPS_GROUP_UUID>"], operator: None     # ← exclude (mismatch)
+```
+
+To express that mixed intent, split into two policies — see [Mixed-operator intent → two policies](#mixed-operator-intent--two-policies) below.
+
+### Mixed-operator intent → two policies
+
+If the user wants to **allow** specific users but **exclude** a group (or vice versa), the operators don't match — that cannot be expressed in a single `actorRule`. Split into two policies and tell the user:
+
+- Policy A: `actorRule.values: [{ type: "User", values: [...], operator: "Or" }]`
+- Policy B: `actorRule.values: [{ type: "Group", values: [...], operator: "None" }]`
+
+There is no `actorRule.tags` block — tags are not supported on Actor Identity today. To narrow within a type, list the specific UUIDs.
+
+## Deny-flipped actor intent
+
+"**Deny** user Alice from triggering this resource" must be expressed as Allow with `operator: None` (Critical Rule #2 — `enforcement: "Deny"` is not authorable):
+
+```text
+actorRule:
+  values:
+    1. type: User, values: ["<ALICE_UUID>"], operator: None    # allow all Users except Alice
+```
+
+"Only admins" is already positive — emit `operator: Or` with the admin user UUIDs (or a `Group` UUID for the Admins group). Identity tag filters are not supported on `actorRule`; if the user wants tag-style narrowing, enumerate the matching users / groups directly. See [../tags/planning.md — Deny-to-Allow flip](../tags/planning.md#deny-to-allow-flip) for the general flip pattern (which still applies to Resource and Actor Process tag filters).
+
+## When NOT to emit `actorRule`
+
+- The user said nothing about identity. Omit the block — do not default to `["*"]` on `User`, because that would still evaluate the block. Absence is semantically "no identity constraint".
+- The user's intent is actually a **tag on the executable** ("only admin-launched Agents" — emit `executableRule.tags` instead; see [../executable/planning.md](../executable/planning.md)).
+- The user asked for an **identity tag filter** ("any user tagged Admin"). Tags are not supported on `actorRule` today — refuse and offer to enumerate the matching users / groups, or drop the tag filter.
+- The user is asking for per-user access on a **non-ToolUsePolicy** policy type. This skill only mutates `ToolUsePolicy`; stop and tell them.
+
+## Relationship with Actor Process (executable) and Selection (selectors)
+
+Identity gates the **trigger**. The executable rule gates the **caller workflow**. The selector gates the **target resource**. These compose as AND — every rule present must pass for the evaluation to return Allow. See [planning-arch.md § The three rule blocks](../../planning-arch.md#the-three-rule-blocks-boundary-table) for the boundary table.
+
+## Anti-patterns
+
+- Do NOT emit `actorRule` when the user did not mention identity. An empty-but-present `actorRule` can still filter out actors that don't satisfy `["*"]` semantics.
+- Do NOT put resource or executable types (`RPAWorkflow`, `APIWorkflow`, `Agent`, `AgenticProcess`, `CaseManagement`, `Flow`) in `actorRule.values[].type` — this block is for **identity** types only. See [planning-arch.md § The three rule blocks](../../planning-arch.md#the-three-rule-blocks-boundary-table) for the boundary.
+- Do NOT emit `type: "Robot"` or `type: "ExternalApplication"`. Robot intent resolves to `User`; ExternalApplication is not supported.
+- Do NOT use `operator: And` on `values` — only `Or` / `None`.
+- Do NOT emit duplicate entries of the same type (Critical Rule #16). Two `User` entries or two `Group` entries → merge into one entry with all UUIDs in its `values[]` array.
+- Do NOT mix operators across `User` and `Group` entries (Critical Rule #16). When both entries are present, their `operator` must be the same value. Mixed intent ("allow these users, exclude that group") splits into two policies.
+- Do NOT emit more than two entries in `actorRule.values[]`. The maximum is one `User` entry plus one `Group` entry.
+- Do NOT invent identity types beyond `User | Group`.
+- Do NOT emit `actorRule.tags`. The Actor Identity rule does not support tag filters today.
+
+## Next: compose the JSON
+
+When Phase 2 needs the concrete JSON for the `actorRule` block, read [actor/impl.md](./impl.md).

--- a/skills/uipath-gov-access-policy/references/plugins/executable/impl.md
+++ b/skills/uipath-gov-access-policy/references/plugins/executable/impl.md
@@ -1,0 +1,167 @@
+# Executable Plugin — Implementation
+
+Concrete JSON for the `executableRule` block. Phase 2 reads this file to compose the single `executableRule` block before assembling the top-level `PolicyDefinition` (see [planning-impl.md — Step 2](../../planning-impl.md#step-2--compose-each-block-via-plugins)).
+
+> **Required field: `values`.** Every entry under `executableRule.values[]` must include its own `values` (use `["*"]` for "all of this type") — it cannot be omitted, even when the shared `executableRule.tags` narrow the scope. Missing `values` returns `400 Bad Request` (Critical Rule #5).
+
+## Full `executableRule` shape
+
+```json
+"executableRule": {
+    "values": [
+        {
+            "type": "<Agent | AgenticProcess | CaseManagement | Flow>",
+            "values": ["*"],
+            "operator": "<Or | None>"
+        }
+    ],
+    "tags": {
+        "values": ["<TAG_1>"],
+        "operator": "<Or | And | None>"
+    }
+}
+```
+
+### Field rules
+
+| Field | Required | Value rules |
+|-------|----------|-------------|
+| `values` | yes | Array of per-type entries. At least one entry. **Caller types not listed in `values[]` are NoOp on this policy** — this policy does not constrain them. Use this directly to author "any caller type except `<type>`" intent: list ONLY the excluded type with `operator: "None"` and omit the others. See [Example E](#e-all-caller-types-except-a-specific-type-canonical-idiom). |
+| `values[].type` | yes | One of: `Agent`, `AgenticProcess`, `CaseManagement`, `Flow`. NOT `RPAWorkflow` or `APIWorkflow`. |
+| `values[].values` | yes | `["*"]` or specific UUIDs. Never empty. |
+| `values[].operator` | yes | `"Or"` (include) or `"None"` (exclude). On a `["*"]` entry, `"None"` means "match any caller of types other than this entry's `type`". |
+| `tags` | optional | Omit entirely when there are no tag constraints. When present, compose via [tags/impl.md](../tags/impl.md). Applies to every entry in `values[]`. |
+
+---
+
+## Worked examples
+
+### A. Single-type, all-of-type, with tag filter
+
+**Intent:** "Production Maestros can use the resource".
+
+```json
+"executableRule": {
+    "values": [
+        { "type": "AgenticProcess", "values": ["*"], "operator": "Or" }
+    ],
+    "tags": {
+        "values": ["Production"],
+        "operator": "Or"
+    }
+}
+```
+
+### B. Single-type, specific UUIDs, no tag filter
+
+**Intent:** "The Maestro with ID def-456 can use the resource".
+
+```json
+"executableRule": {
+    "values": [
+        { "type": "AgenticProcess", "values": ["def-456"], "operator": "Or" }
+    ]
+}
+```
+
+(`tags` omitted.)
+
+### C. Multiple executable types in one rule
+
+**Intent:** "Both Agents and Maestros can use the resource, but only Production ones".
+
+```json
+"executableRule": {
+    "values": [
+        { "type": "Agent",          "values": ["*"], "operator": "Or" },
+        { "type": "AgenticProcess", "values": ["*"], "operator": "Or" }
+    ],
+    "tags": {
+        "values": ["Production"],
+        "operator": "Or"
+    }
+}
+```
+
+The `tags` block applies to both entries.
+
+### D. Deny-flipped executable
+
+**Intent (original):** "block Development Flows from using the resource". **Flipped to Allow** with the `None` operator on the executable's tags:
+
+```json
+"executableRule": {
+    "values": [
+        { "type": "Flow", "values": ["*"], "operator": "Or" }
+    ],
+    "tags": {
+        "values": ["Development"],
+        "operator": "None"
+    }
+}
+```
+
+This allows every Flow **except** Development-tagged ones.
+
+### E. All caller types except a specific type (canonical idiom)
+
+**Intent:** "Any caller can use the resource except `Agent` callers" — i.e. allow `AgenticProcess`, `CaseManagement`, and `Flow` callers but not `Agent` callers.
+
+```json
+"executableRule": {
+    "values": [
+        { "type": "Agent", "values": ["*"], "operator": "None" }
+    ]
+}
+```
+
+Emit ONE entry — the caller type to exclude — with `operator: "None"` and `values: ["*"]`. Caller types not listed (`AgenticProcess`, `CaseManagement`, `Flow`) are NoOp on this filter, so this policy does not constrain them. Combined with `enforcement: "Allow"`, the policy contributes Allow for any non-`Agent` caller.
+
+> **Use this idiom whenever the intent is "any caller type except `<type>`".** Do NOT enumerate every allowed type with `Or` — that produces the same effect but is verbose, error-prone, and obscures the intent. Listing only the excluded type with `None` is the canonical shape.
+
+---
+
+## Update-flow use
+
+When `policy-manage-guide.md — Update` needs to modify the existing `executableRule`:
+
+1. Start from the working file's current `executableRule` object.
+2. Change only the part the user asked about (add a type, add a UUID to an entry's `values`, flip an operator, adjust `tags`).
+3. Preserve every other field.
+
+Example: the user says "also allow CaseManagement". Existing `executableRule`:
+
+```json
+{
+    "values": [
+        { "type": "AgenticProcess", "values": ["*"], "operator": "Or" }
+    ],
+    "tags": { "values": ["Production"], "operator": "Or" }
+}
+```
+
+After update:
+
+```json
+{
+    "values": [
+        { "type": "AgenticProcess",  "values": ["*"], "operator": "Or" },
+        { "type": "CaseManagement",  "values": ["*"], "operator": "Or" }
+    ],
+    "tags": { "values": ["Production"], "operator": "Or" }
+}
+```
+
+Only `values[]` changed — `tags` is preserved verbatim.
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `400 Bad Request` / `ExecutableRule.Values is required` | `executableRule.values` missing or empty | Include at least one entry with `type` and `values`. |
+| `400 Bad Request` / unknown executable `type` | Tried `RPAWorkflow` or `APIWorkflow` | These are resource-only. Move them to `selectors[]`. |
+| `400 Bad Request` / `Values is required` on a per-entry field | An entry's own `values` is missing | Use `["*"]` or specific UUIDs — never an empty array. |
+| Policy never matches the intended caller | Caller's tags don't include the tag values in `executableRule.tags`, or caller UUID isn't in `values` | Verify the Resource Catalog tags on the executable, or use `["*"]` + tag filter. |
+| Two different executable types need different tag filters | Tried to put `tags` on a single `values[]` entry | Not supported — split the intent into two policies, one per executable type. |

--- a/skills/uipath-gov-access-policy/references/plugins/executable/planning.md
+++ b/skills/uipath-gov-access-policy/references/plugins/executable/planning.md
@@ -1,0 +1,122 @@
+# Actor Process Plugin — Planning
+
+> **User-facing terminology vs JSON field.** The user-facing name for this block is **Actor Process rule**. The underlying JSON field is `executableRule` — that name is only shown in code / CLI contexts. When summarizing the policy to the user, always say "Actor Process rule", never "Executable rule".
+
+The `executableRule` block identifies the **caller** — the Actor Process that uses the resource. The access policy has exactly one `executableRule` block, but that block can contain multiple per-type entries.
+
+## When to Use
+
+Always. Every access policy this skill authors has exactly one `executableRule`.
+
+## Block shape (conceptual)
+
+```text
+executableRule = {
+    values: [
+        { type: <Agent | AgenticProcess | CaseManagement | Flow>, values: [...], operator: <Or | None> },
+        ...                                                       # one entry per executable type
+    ],
+    tags: { values: [...], operator: <Or | And | None> }          # optional, applies to all entries
+}
+```
+
+- `executableRule.values[]` — one entry per executable **type** the user mentioned.
+- `executableRule.tags` — optional. When present, narrows the set for every entry in `values[]`.
+
+## Intent → executable type
+
+Map the user's phrasing to the enum. These are the only valid executable `type` values.
+
+| User phrase | User-facing label | JSON `type` |
+|-------------|-------------------|-------------|
+| "agent", "AI agent" | Agent | `Agent` |
+| "maestro", "maestro process", "agentic process" | **Maestro** | `AgenticProcess` |
+| "case management", "case" | Case Management | `CaseManagement` |
+| "flow" | Flow | `Flow` |
+
+> Always say **Maestro** in user-facing text (Spec narrative, summaries, review gate); emit `AgenticProcess` only inside JSON code blocks (Critical Rule #14).
+
+> **Not valid here:** `RPAWorkflow` and `APIWorkflow` are resource-only types. They live in `selectors[]` (see [selector/planning.md](../selector/planning.md)); they cannot appear in `executableRule.values[].type`.
+
+## Targeting modes
+
+Same two modes as selectors, plus a third pattern that operates on the entry's `type` rather than its `values`:
+
+| Mode | Entry shape | When to use |
+|------|-------------|-------------|
+| **All of this type** | `{ type: <T>, values: ["*"], operator: "Or" }` | "Any `<T>` caller". |
+| **Specific IDs** | `{ type: <T>, values: ["<UUID>", ...], operator: "Or" }` | "These specific `<T>` callers". |
+| **Exclude specific IDs** | `{ type: <T>, values: ["<UUID>", ...], operator: "None" }` | "Any `<T>` caller except these UUIDs". |
+| **Exclude a whole type** | `{ type: <T>, values: ["*"], operator: "None" }` — and **omit every other type** from `values[]` | "Any caller type except `<T>`". Caller types not listed in `values[]` are NoOp on this filter (the policy does not constrain them). See [Excluding a caller type](#excluding-a-caller-type). |
+
+`values: ["*"]` is required on every entry (Critical Rule #5). Missing it returns `400`.
+
+### Resolving Actor Process names to UUIDs
+
+If the user named a specific caller ("the Maestro Production process"), resolve the name to a UUID via [resource-lookup-guide.md](../../resource-lookup-guide.md) using the **two-step flow**:
+
+1. **Discover the folder first** — `uip or processes list` requires `--folder-path`. If the user did not say which folder, run `uip or folders list --output json` and ask the user to pick before searching.
+2. **Translate the Actor Process type** — Orchestrator's `--process-type` is **not** the same string as the access-policy `type`. For Actor Process values, map: `Agent`→`Agent`, `AgenticProcess`→`ProcessOrchestration`, `Flow`→`Flow`, `CaseManagement`→`CaseManagement`. See the full table in [resource-lookup-guide.md § Access-policy type → Orchestrator `--process-type`](../../resource-lookup-guide.md#access-policy-type--orchestrator---process-type).
+3. **Search** — `uip or processes list --folder-path "<PATH>" --process-type "<ORCHESTRATOR_TYPE>" --name "<SUBSTR>" --output json`. Present the matching rows as a numbered picker. Use the returned `Key` field as the UUID.
+
+Never ask the user to leave the chat to find a UUID — run the lookup first. Only surface an open question when the lookup returns no match after broadening the search.
+
+## Multi-type executable rules
+
+If the user says "allow Agents **and** Maestros to use…", emit two entries (one per JSON `type`):
+
+```text
+executableRule:
+  values:
+    1. type: Agent,           values: ["*"], operator: Or
+    2. type: AgenticProcess,  values: ["*"], operator: Or
+  tags: { values: ["Production"], operator: Or }    # applied to both entries
+```
+
+The shared `executableRule.tags` applies uniformly across every entry — there is **no per-entry `tags`** inside `executableRule.values[]`. If different executable types need different tag rules, the policy is probably really two policies; flag this during Phase 1 and ask the user.
+
+## Excluding a caller type
+
+When the user says "any caller **except** `<type>`" — e.g. "block Agent callers, allow everything else" — emit ONE entry of the **excluded** type with `operator: "None"` and `values: ["*"]`, and OMIT every other type from `values[]`. Do NOT enumerate the allowed types.
+
+```text
+# Intent: "any caller except Agent"
+executableRule:
+  values:
+    1. type: Agent, values: ["*"], operator: None
+```
+
+**Why this works.** Caller types not listed in `executableRule.values[]` are NoOp on this filter — the policy does not constrain them. The single `None`-on-`Agent` entry says "this policy applies when the caller's type is NOT `Agent`". Combined with `enforcement: "Allow"`, the policy contributes Allow for every non-`Agent` caller.
+
+**Why NOT enumerate.** Listing `AgenticProcess`, `CaseManagement`, `Flow` with `Or` produces the same runtime effect but:
+- It is verbose and obscures the user's "all except X" intent.
+- It rots when new caller types are added to the platform.
+- It tempts authors to "just add another type with `Or`" instead of reasoning about exclusion.
+
+The canonical shape is the single-entry `None`-on-excluded-type form. See [executable/impl.md — Example E](./impl.md#e-all-caller-types-except-a-specific-type-canonical-idiom).
+
+> **"Exclude UUIDs" vs "exclude a type" vs "exclude a tag"** are three different operators that all happen to use `None`:
+> - **Exclude UUIDs** — `{ type: <T>, values: ["<UUID1>", ...], operator: "None" }` matches any `<T>` caller whose UUID is NOT in the list.
+> - **Exclude a type** — `{ type: <T>, values: ["*"], operator: "None" }` matches any caller whose type is NOT `<T>` (this section).
+> - **Exclude a tag** — `tags: { values: ["<TAG>"], operator: "None" }` (top-level on `executableRule`) matches callers that do NOT carry the tag. See [tags/planning.md — Deny-to-Allow flip](../tags/planning.md#deny-to-allow-flip).
+
+## Top-level `tags` vs per-entry `values`
+
+- `executableRule.tags` — applies once, to all entries in `values[]`. The only place tag filters live in this block.
+- Per-entry `values` — targets individual executables by UUID.
+
+## Deny-flipped intent
+
+"Deny flows from using Production Agents" flips to: Allow all flows to use Agents **except** Production-tagged ones. The flip lives on the **selector**'s tags (`operator: None` on `Production`), not on the executable. See [tags/planning.md — Deny-to-Allow flip](../tags/planning.md#deny-to-allow-flip) for the decision procedure.
+
+## Anti-patterns
+
+- Do NOT put `RPAWorkflow` or `APIWorkflow` in `executableRule.values[].type` — those are resource-only.
+- Do NOT omit `values` — it is required per entry.
+- Do NOT confuse the Actor Process rule (`executableRule`, the calling workflow) with the Actor Identity rule (`actorRule`, the user/group triggering it). See [planning-arch.md § The three rule blocks](../../planning-arch.md#the-three-rule-blocks-boundary-table) for the boundary.
+- Do NOT merge distinct `type` values into one entry — one entry per type.
+- Do NOT use `operator: And` on `values` — only `Or` / `None`.
+
+## Next: compose the JSON
+
+When Phase 2 needs the concrete JSON for the `executableRule` block, read [executable/impl.md](./impl.md).

--- a/skills/uipath-gov-access-policy/references/plugins/selector/impl.md
+++ b/skills/uipath-gov-access-policy/references/plugins/selector/impl.md
@@ -1,0 +1,169 @@
+# Selector Plugin — Implementation
+
+Concrete JSON for a single entry in `selectors[]`. Phase 2 reads this file to compose every selector before assembling the top-level `PolicyDefinition` (see [planning-impl.md — Step 2](../../planning-impl.md#step-2--compose-each-block-via-plugins)).
+
+> **Required field: `values`.** Every `selectors[]` entry must include `values` (use `["*"]` for "all of this type") — it cannot be omitted, even when `tags` narrow the scope. Missing `values` returns `400 Bad Request` (Critical Rule #5).
+
+## Single selector entry
+
+```json
+{
+    "resourceType": "<Agent | AgenticProcess | RPAWorkflow | APIWorkflow | CaseManagement | Flow>",
+    "values": ["*"],
+    "operator": "<Or | None>",
+    "tags": {
+        "values": ["<TAG_1>", "<TAG_2>"],
+        "operator": "<Or | And | None>"
+    }
+}
+```
+
+### Field rules
+
+| Field | Required | Value rules |
+|-------|----------|-------------|
+| `resourceType` | yes | One of: `Agent`, `AgenticProcess`, `RPAWorkflow`, `APIWorkflow`, `CaseManagement`, `Flow`. |
+| `values` | yes | `["*"]` for all-of-type, or `["<UUID>", ...]` for specific IDs. Never empty. |
+| `operator` | yes | `"Or"` to include matching IDs; `"None"` to exclude them. |
+| `tags` | optional | Omit entirely when the user did not specify tags. When present, compose via [tags/impl.md](../tags/impl.md). |
+
+## Full `selectors[]` array shape
+
+The top-level `PolicyDefinition.selectors` is always an array:
+
+```json
+"selectors": [
+    { /* entry 1 */ },
+    { /* entry 2 */ }
+]
+```
+
+One array entry per distinct `resourceType` row in the Spec Components Table.
+
+---
+
+## Worked examples
+
+### A. All-of-type with tag filter
+
+**Intent:** "All Production Agents".
+
+```json
+{
+    "resourceType": "Agent",
+    "values": ["*"],
+    "operator": "Or",
+    "tags": {
+        "values": ["Production"],
+        "operator": "Or"
+    }
+}
+```
+
+### B. Specific UUIDs, no tag filter
+
+**Intent:** "Agents with IDs abc-123 and def-456".
+
+```json
+{
+    "resourceType": "Agent",
+    "values": [
+        "abc-123",
+        "def-456"
+    ],
+    "operator": "Or"
+}
+```
+
+(Note: `tags` is omitted — the user did not mention any.)
+
+### C. Specific UUIDs plus tag filter
+
+**Intent:** "Agent abc-123 (must also be Production-tagged)".
+
+```json
+{
+    "resourceType": "Agent",
+    "values": ["abc-123"],
+    "operator": "Or",
+    "tags": {
+        "values": ["Production"],
+        "operator": "Or"
+    }
+}
+```
+
+Both filters apply — the policy matches resources that appear in `values` **and** satisfy `tags`.
+
+### D. Multi-entry (two resource types in one policy)
+
+**Intent:** "Production Agents and Production Flows".
+
+```json
+"selectors": [
+    {
+        "resourceType": "Agent",
+        "values": ["*"],
+        "operator": "Or",
+        "tags": { "values": ["Production"], "operator": "Or" }
+    },
+    {
+        "resourceType": "Flow",
+        "values": ["*"],
+        "operator": "Or",
+        "tags": { "values": ["Production"], "operator": "Or" }
+    }
+]
+```
+
+### E. Deny-flipped (exclude Development tags)
+
+**Intent (original):** "block Development Agents". **Flipped to Allow** with the `None` operator on tags (see [tags/planning.md — Deny-to-Allow flip](../tags/planning.md#deny-to-allow-flip)):
+
+```json
+{
+    "resourceType": "Agent",
+    "values": ["*"],
+    "operator": "Or",
+    "tags": {
+        "values": ["Development"],
+        "operator": "None"
+    }
+}
+```
+
+This matches every Agent **except** those tagged `Development`.
+
+---
+
+## Update-flow use
+
+When `policy-manage-guide.md — Update` needs to modify an existing selector, pass the existing entry back through this file:
+
+1. Start from the existing entry (already in the working file's `selectors[]`).
+2. Change only the field the user asked about (e.g. add an ID to `values`, swap a tag operator).
+3. Preserve every other field verbatim.
+
+Example: the user says "add UUID `xyz-789` to the first selector's values". The resulting entry:
+
+```json
+{
+    "resourceType": "Agent",
+    "values": ["abc-123", "xyz-789"],
+    "operator": "Or",
+    "tags": { "values": ["Production"], "operator": "Or" }
+}
+```
+
+Everything except `values` is unchanged from the original.
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `400 Bad Request` / `Selectors[0].Values is required` | `values` missing or empty | Always pass `["*"]` or real UUIDs. Never an empty array. |
+| `400 Bad Request` / unknown `resourceType` | Typo or non-existent enum | Use exactly one of the six enum values above. |
+| Policy matches nothing at runtime | `values` has specific UUIDs that don't exist, or tag filter doesn't match any resource | Re-run `uip gov access-policy evaluate` with a real resource UUID to confirm matching; check the Resource Catalog tags on the resource. |
+| Selectors for multiple types merged into one entry | Attempted to put multiple `resourceType` values in one entry | Split into multiple `selectors[]` entries. Each entry is single-type. |

--- a/skills/uipath-gov-access-policy/references/plugins/selector/planning.md
+++ b/skills/uipath-gov-access-policy/references/plugins/selector/planning.md
@@ -1,0 +1,98 @@
+# Selector Plugin — Planning
+
+> **User-facing terminology vs JSON field.** The user-facing name for this block is **Selection Rule** (the Resource being protected). The underlying JSON field is `selectors[]` — that name is only shown in code / CLI contexts.
+
+The `selectors[]` block identifies the **Resource** the access policy is about — what is being used by the Actor Process. One entry per distinct resource type the user mentioned.
+
+## When to Use
+
+Always. Every access policy this skill authors has at least one selector entry.
+
+- One selector entry → one resource type.
+- User mentioned multiple resource types ("Agents and Flows") → emit multiple entries, one per type. Do NOT merge types into a single entry.
+
+## Block shape (conceptual)
+
+```text
+selectors[i] = {
+    resourceType: <Agent | AgenticProcess | RPAWorkflow | APIWorkflow | CaseManagement | Flow>,
+    values: [...],                                                # required — UUIDs or ["*"]
+    operator: <Or | None>,
+    tags: { values: [...], operator: <Or | And | None> }          # optional — per-entry
+}
+```
+
+## Intent → resource type
+
+Map the user's phrasing to the enum. These are the only valid `resourceType` values.
+
+| User phrase | User-facing label | JSON `resourceType` |
+|-------------|-------------------|---------------------|
+| "agent", "AI agent" | Agent | `Agent` |
+| "maestro", "maestro process", "agentic process" | **Maestro** | `AgenticProcess` |
+| "RPA workflow", "RPA", "robot process" | **RPA** | `RPAWorkflow` |
+| "API workflow", "API" | API Workflow | `APIWorkflow` |
+| "case management", "case", "case work item" | Case Management | `CaseManagement` |
+| "flow" | Flow | `Flow` |
+
+> Always say **Maestro** and **RPA** in user-facing text; emit `AgenticProcess` and `RPAWorkflow` only inside JSON (Critical Rule #14).
+
+If a phrase is ambiguous (e.g. "process" could be Maestro/`AgenticProcess` or RPA/`RPAWorkflow`), ask the user before picking.
+
+## Targeting modes
+
+Each selector entry picks one of two targeting modes. This is always expressed via the `values` field.
+
+| Mode | `values` | `operator` | When to use |
+|------|----------|------------|-------------|
+| **All of this type** | `["*"]` | `Or` | User said "all agents", "any flow", or didn't name specific resources. Tag filter then narrows the set. |
+| **Specific IDs** | `["<UUID1>", "<UUID2>", ...]` | `Or` | User named specific resources by UUID. |
+| **Exclude specific IDs** | `["<UUID>", ...]` | `None` | Rare — user said "all agents except X". Usually easier to re-express via tag `None`. |
+
+`values: ["*"]` is **required** even when you are using `tags` to narrow the scope. It is NOT optional. Missing `values` returns `400 Bad Request` (Critical Rule #5).
+
+If the user mentions specific resources by **name** (e.g. "the Invoice Agent"), you need UUIDs. Resolve via [resource-lookup-guide.md](../../resource-lookup-guide.md) using the **two-step flow**:
+
+1. **Discover the folder first** — `uip or processes list` requires `--folder-path` (or `--folder-key`). If the user did not say which folder, run `uip or folders list --output json`, show the folders, and ask the user to pick.
+2. **Translate the resource type** — the Orchestrator `--process-type` value is **not** the same string as the access-policy `resourceType`. Use the mapping table in [resource-lookup-guide.md § Access-policy type → Orchestrator `--process-type`](../../resource-lookup-guide.md#access-policy-type--orchestrator---process-type) — notably `AgenticProcess`→`ProcessOrchestration`, `RPAWorkflow`→`Process`, `APIWorkflow`→`Api`.
+3. **Search** — `uip or processes list --folder-path "<PATH>" --process-type "<ORCHESTRATOR_TYPE>" --name "<SUBSTR>" --output json`. Present the matching rows as a numbered picker. Use the returned `Key` field as the UUID.
+
+Only surface an Open question in the Phase 1 Spec when the lookup still returns no match after broadening the search.
+
+## Tag filter
+
+Any tag phrase the user used ("Production Agent", "tagged Staging", "not Development") becomes a `tags` sub-object nested inside the selector entry. Tag composition is handled by the [tags plugin](../tags/planning.md).
+
+The `tags` filter applies at the **per-entry level** (inside `selectors[N].tags`) — each `selectors[]` entry has its own independent tag filter. There is no top-level `selectors.tags` shared across entries. Two resource types with different tag filters → two `selectors[]` entries.
+
+Omit `tags` entirely if the user did not mention any tags. Do NOT add empty `tags: { values: [], operator: "Or" }` objects.
+
+## Multi-type selectors
+
+If the policy targets multiple resource types, emit one `selectors[]` entry per type:
+
+In the Spec Components Table (see [planning-arch.md — Spec output format](../../planning-arch.md#spec-output-format)), render multi-type targeting as one Resource row group per type, with user-friendly phrasing:
+
+```text
+  Resource filters (which resource processes this policy protects):
+    1. Resource type: Agent
+       Applies to:   all Agent resources
+       Tag filter:   Any-of ["Production"]
+    2. Resource type: Flow
+       Applies to:   all Flow resources
+       Tag filter:   Any-of ["Production"]
+```
+
+Each entry's `tags` is independent — a Production Agent selector does NOT imply a Production Flow selector.
+
+## Anti-patterns
+
+- Do NOT omit `values` — it is required even when `tags` narrow the scope.
+- Do NOT put callers or identities here — this block is for Resources only. See [planning-arch.md § The three rule blocks](../../planning-arch.md#the-three-rule-blocks-boundary-table) for the boundary.
+- Do NOT merge distinct resource types into one entry — one entry per `resourceType`.
+- Do NOT use `operator: And` on `values` — only `Or` (include) and `None` (exclude) are supported at the values level.
+- Do NOT put resource UUIDs in `tags.values`. Tag names and resource IDs live in different arrays — UUIDs go in the selector's own `values`, tag names go in `tags.values`.
+
+## Next: compose the JSON
+
+When Phase 2 needs the concrete JSON for a selector entry, read [selector/impl.md](./impl.md).

--- a/skills/uipath-gov-access-policy/references/plugins/tags/impl.md
+++ b/skills/uipath-gov-access-policy/references/plugins/tags/impl.md
@@ -1,0 +1,153 @@
+# Tags Plugin — Implementation
+
+Concrete JSON for the shared `tags` sub-object. Phase 2 reads this file whenever a selector entry or `executableRule` needs a tag filter (see [planning-impl.md — Step 2](../../planning-impl.md#step-2--compose-each-block-via-plugins)).
+
+> **Required when `tags` is present: `values` and `operator`.** When the `tags` key exists, both `tags.values` (non-empty array) and `tags.operator` (`Or` / `And` / `None`) are required. Omit the entire `tags` key when there is no tag constraint — never emit `"tags": {}` or `"tags": { "values": [] }`.
+
+## Shape
+
+```json
+"tags": {
+    "values": ["<TAG_1>", "<TAG_2>"],
+    "operator": "<Or | And | None>"
+}
+```
+
+### Field rules
+
+| Field | Required | Value rules |
+|-------|----------|-------------|
+| `values` | yes (when `tags` is present) | Non-empty array of Resource Catalog tag name strings. Never `[]`. |
+| `operator` | yes (when `tags` is present) | One of `"Or"`, `"And"`, `"None"`. Case-sensitive. |
+
+Omit the entire `tags` key when the user did not specify tags. Do NOT emit `"tags": {}` or `"tags": { "values": [] }`.
+
+## Operator cheat-sheet
+
+| Operator | Rule semantics |
+|----------|----------------|
+| `"Or"` | Match if the resource has **any** of `values`. |
+| `"And"` | Match if the resource has **all** of `values`. |
+| `"None"` | Match if the resource has **none** of `values` (i.e., exclude). |
+
+See [tags/planning.md](./planning.md) for when to pick each.
+
+---
+
+## Worked examples
+
+### A. Single-tag `Or` (most common)
+
+**Intent:** "only Production resources".
+
+```json
+"tags": {
+    "values": ["Production"],
+    "operator": "Or"
+}
+```
+
+### B. Multi-tag `And`
+
+**Intent:** "resources tagged both Production and Critical".
+
+```json
+"tags": {
+    "values": ["Production", "Critical"],
+    "operator": "And"
+}
+```
+
+Only resources carrying both tags match.
+
+### C. Deny-flip with `None`
+
+**Intent (original):** "deny Development resources". **Flipped to Allow** (see [planning.md — Deny-to-Allow flip](./planning.md#deny-to-allow-flip)):
+
+```json
+"tags": {
+    "values": ["Development"],
+    "operator": "None"
+}
+```
+
+This matches every resource **except** those tagged `Development`.
+
+### D. Multi-tag `None` (exclude any of several)
+
+**Intent (original):** "block Development or Staging flows". On the selector (`resourceType: Flow`):
+
+```json
+"tags": {
+    "values": ["Development", "Staging"],
+    "operator": "None"
+}
+```
+
+Matches every Flow that does **not** carry either tag.
+
+---
+
+## Where this block embeds
+
+Paste the composed `tags` object into the parent block returned by [selector/impl.md](../selector/impl.md) or [executable/impl.md](../executable/impl.md). Example embedded in a selector entry:
+
+```json
+{
+    "resourceType": "Agent",
+    "values": ["*"],
+    "operator": "Or",
+    "tags": {
+        "values": ["Production"],
+        "operator": "Or"
+    }
+}
+```
+
+And embedded at the top of `executableRule` (applies to every entry in `executableRule.values[]`):
+
+```json
+"executableRule": {
+    "values": [
+        { "type": "AgenticProcess", "values": ["*"], "operator": "Or" }
+    ],
+    "tags": {
+        "values": ["Production"],
+        "operator": "Or"
+    }
+}
+```
+
+---
+
+## Update-flow use
+
+When `policy-manage-guide.md — Update` needs to change tags on an existing block:
+
+1. Start from the existing `tags` object in the working file (copied from `.Data` in the update prelude).
+2. Mutate only the fields the user asked about — add/remove entries in `values`, or flip `operator`.
+3. If the user wants to remove tag filtering entirely, delete the `tags` key (do not leave behind an empty object).
+
+Example: the user says "also exclude Staging". Existing:
+
+```json
+{ "values": ["Development"], "operator": "None" }
+```
+
+After update:
+
+```json
+{ "values": ["Development", "Staging"], "operator": "None" }
+```
+
+---
+
+## Debug
+
+| Error / symptom | Cause | Fix |
+|-----------------|-------|-----|
+| `400 Bad Request` / `Tags.Values is required` | `tags.values` is missing or empty | Either populate with at least one tag, or remove the `tags` key entirely. |
+| `400 Bad Request` / unknown operator | Typo (e.g. `"or"`, `"NOT"`, `"Not"`) | Use exactly `"Or"`, `"And"`, or `"None"` — case-sensitive. |
+| Policy never matches anything at runtime | Tag name doesn't exist in the Resource Catalog of the policy's tenant, or target resource isn't labeled with it | Verify the tag with `uip admin rcs tag list --output json` (no `--tenant` — the default targets the policy's own tenant). See [resource-lookup-guide.md § 4](../../resource-lookup-guide.md#4-resource-catalog-tags). If the tag is missing, add it to the Resource Catalog of the policy's tenant or pick a tag from the returned list. |
+| `None` operator matches more than expected | `None` excludes only the named tags — everything else matches | If the user meant "only these and nothing else", they want `Or`, not `None`. Re-check intent with them. |
+| API rejected `enforcement: "Deny"` | The skill emitted `enforcement: "Deny"` — never authorable (Critical Rule #2) | Switch to `enforcement: "Allow"` and re-author. See [planning.md — Deny-to-Allow flip](./planning.md#deny-to-allow-flip). |

--- a/skills/uipath-gov-access-policy/references/plugins/tags/planning.md
+++ b/skills/uipath-gov-access-policy/references/plugins/tags/planning.md
@@ -1,0 +1,117 @@
+# Tags Plugin — Planning
+
+> **User-facing terminology vs JSON field.** User-facing label: **tag filter**. JSON field: `tags` sub-object — shown only in code / CLI contexts.
+
+The `tags` sub-object is the shared **Resource Catalog Tag** filter used inside selector entries and inside `executableRule`. It is the primary mechanism for scoping an access policy to a subset of resources / executables without listing individual UUIDs.
+
+## When to Use
+
+Add a `tags` sub-object to a `selectors[]` entry or to `executableRule` whenever the user mentions a tag-style attribute on the Resource or Actor Process side. Omit the entire `tags` key when no tag constraint applies. **Resource Catalog Tags** are labels assigned to resources in the UiPath Resource Catalog; the `tags` sub-object matches on those labels at evaluation time.
+
+> `actorRule` does **not** support `tags` today — never emit `actorRule.tags`.
+
+## Block shape (conceptual)
+
+```text
+tags = { values: ["<tag1>", "<tag2>", ...], operator: <Or | And | None> }
+```
+
+- `values` — list of tag names. Must be non-empty when the `tags` key is present. Omit the whole key when there are no tag constraints.
+- `operator` — how `values` is applied. One of `Or` (Any-of), `And` (All-of), `None` (Exclude).
+
+## Operator semantics
+
+| Operator | Meaning | Example phrasing |
+|----------|---------|------------------|
+| `Or` | Match resources with **any** of the listed tags | "Production or Staging agents" |
+| `And` | Match resources with **all** of the listed tags | "agents tagged both Production and Critical" |
+| `None` | **Exclude** resources with any of the listed tags | "agents not tagged Development" |
+
+Worked mental model:
+
+- `{ values: ["Production", "Staging"], operator: "Or" }` → matches resources tagged Production **or** Staging.
+- `{ values: ["Production", "Critical"], operator: "And" }` → matches resources tagged Production **and** Critical.
+- `{ values: ["Development"], operator: "None" }` → matches resources **not** tagged Development.
+
+## Common Resource Catalog tag names
+
+The Resource Catalog tag set is tenant-specific, but these names recur across UiPath environments:
+
+- **Environment:** `Production`, `Development`, `Staging`, `Test`
+- **Criticality / data class:** `Critical`, `PII`, `Confidential`
+- **Team / org:** `Finance`, `Marketing`, `HR`, `Platform`
+- **Product / domain:** user-specific product names
+
+> Tags the user mentions must actually exist in the Resource Catalog of the **policy's own tenant** (the tenant in `~/.uipath/.auth`). A policy that references `DoesNotExist` silently matches nothing. **Confirm tag names during Phase 1** before approving the Spec by running `uip admin rcs tag list --output json` (no `--tenant` — the default targets the policy's tenant; see [resource-lookup-guide.md § 4](../../resource-lookup-guide.md#4-resource-catalog-tags)). If the tag is missing, surface it as an Open question and ask the user to either pick a returned tag or add the missing one to the Resource Catalog before the JSON is composed.
+
+## Deny-to-Allow flip
+
+> **Internal mechanic — not user-facing copy.** Do NOT surface "Deny-to-Allow flip", "None operator", or "enforcement: Deny is not authorable" jargon to the user. The Spec narrative describes the policy in plain English of **what's allowed** — the flip happens silently inside the agent.
+
+Access policies of type `ToolUsePolicy` only support `enforcement: "Allow"` (Critical Rule #2) — `enforcement: "Deny"` is **not authorable**. Intent phrased as Deny must be reframed as an equivalent Allow rule. Two equivalent shapes; pick whichever produces the clearer Spec narrative:
+
+- **Reframe scope.** Translate to "Allow only `<positive-set>`" and target it with `operator: "Or"`. Example: "Deny Development agents" → "Allow only Production / Staging agents" with `tags: { values: ["Production", "Staging"], operator: "Or" }`.
+- **`None`-operator flip.** Keep "everything except X" framing and emit `operator: "None"` on the relevant `tags` or `values`. The rest of this section walks through the `None`-operator pattern.
+
+### When to flip via tags
+
+| User phrasing | Flipped intent | `tags` |
+|---------------|----------------|--------|
+| "Deny Development agents" | Allow agents **except** Development-tagged | `{ values: ["Development"], operator: "None" }` |
+| "Block Staging resources" | Allow resources **except** Staging | `{ values: ["Staging"], operator: "None" }` |
+| "Prevent PII-tagged data being used by flows" | Allow flows to use everything **except** PII-tagged | `{ values: ["PII"], operator: "None" }` on the selector |
+
+### Decision procedure for Deny intent
+
+1. Identify the negative predicate (the set the user wants to exclude).
+2. Check whether the predicate is expressible as a tag (or set of tags) on the resource or executable.
+3. If yes, emit the affirmative complement on the correct block:
+   - Deny by **resource attribute** → `None` on the selector's `tags`.
+   - Deny by **caller attribute** → `None` on the `executableRule`'s `tags`.
+4. If the predicate is over UUIDs rather than tags, use `operator: "None"` on `values` instead (see [selector/planning.md](../selector/planning.md) and [executable/planning.md](../executable/planning.md)).
+5. If no clean flip exists (e.g. "deny for user X" — that is an actor predicate and the access policy cannot express it as a tag filter), stop and consult [actor/planning.md](../actor/planning.md).
+
+### Three worked flips
+
+**A. Single tag.** "Deny Development agents" → selector `tags: { values: ["Development"], operator: "None" }`.
+
+**B. Multiple tags.** "Block Development or Staging flows" → selector (`resourceType: Flow`) `tags: { values: ["Development", "Staging"], operator: "None" }`. The `None` operator on multiple values excludes resources tagged with **any** of them.
+
+**C. Mixed tag + UUID exclusion.** "Block specific process `xyz-789` and everything tagged Development" — two parts. Flip the UUID exclusion onto `values` with `operator: "None"`, and flip the tag exclusion onto `tags` with `operator: "None"`. These go on the same selector entry. Note that this does not combine cleanly when the user also wants an include; split into two selectors or escalate to the user.
+
+## Decision tree: picking the operator
+
+```text
+Is the user denying / excluding something?
+├── yes → operator: None   (and go read the Deny-to-Allow flip section above)
+└── no  → Is the user listing alternatives ("Production or Staging")?
+           ├── yes → operator: Or
+           └── no  → Is the user requiring all tags at once ("both X and Y")?
+                      ├── yes → operator: And
+                      └── no  → default to Or with a single tag, or omit tags entirely
+```
+
+## Where the block lives
+
+The same `tags` shape appears in two blocks of the access policy:
+
+| Block | Effect |
+|-------|--------|
+| `selectors[].tags` | Narrows the set of **resources** a selector matches (Selection Rule). |
+| `executableRule.tags` | Narrows the set of **Actor Processes** (callers) — applies across all entries in `executableRule.values[]`. |
+
+> **`actorRule` does NOT support tags today.** Identity-side tag filters are unsupported — emitting `actorRule.tags` returns `400 Bad Request`. Enumerate the matching users / groups directly under `actorRule.values[].values` instead. See [actor/planning.md](../actor/planning.md) and Critical Rule #5.
+
+There is no per-entry `tags` inside `executableRule.values[]`. If different entry types need different tag filters, split into two policies.
+
+## Anti-patterns
+
+- Do NOT emit `enforcement: "Deny"` ever. The API does not support it (Critical Rule #2). Reframe the user's intent as Allow + scope filter, or use `operator: "None"` on `tags` / `values` to express "everything except X".
+- Do NOT invent tag names. If the user hasn't confirmed a tag exists in the Resource Catalog, run `uip admin rcs tag list --output json` against the policy's tenant (the default — no `--tenant`) and ask the user to pick from the returned list.
+- Do NOT pass an empty `values: []` array. Either include at least one tag, or omit the entire `tags` key.
+- Do NOT use `operator: "And"` with a single tag — it's equivalent to `Or` with one tag; use `Or` for clarity.
+- Do NOT confuse Resource Catalog Tags with executable `type` or with free-text descriptions. Only named labels assigned in the Resource Catalog qualify.
+
+## Next: compose the JSON
+
+When Phase 2 needs the concrete JSON for a `tags` block, read [tags/impl.md](./impl.md).

--- a/skills/uipath-gov-access-policy/references/policy-manage-guide.md
+++ b/skills/uipath-gov-access-policy/references/policy-manage-guide.md
@@ -1,0 +1,403 @@
+# Access Policy Management Guide
+
+Full CRUD lifecycle for UiPath access policies: list, get, create, update, delete.
+
+## Prerequisites
+
+- User must be logged in — see [access-policy-commands.md — Authentication](./access-policy-commands.md#authentication).
+- For CLI flag details on every subcommand, see [access-policy-commands.md](./access-policy-commands.md).
+- All policy JSON authoring flows through [planning-arch.md](./planning-arch.md) + [planning-impl.md](./planning-impl.md) + the plugin `impl.md` files. This guide never authors JSON directly.
+
+---
+
+## List policies
+
+For all flags and output shape, see [access-policy-commands.md — list](./access-policy-commands.md#uip-gov-access-policy-list).
+
+```bash
+uip gov access-policy list --output json
+```
+
+Parse `Data.results[]` and display as a table:
+
+```text
+  #  Name                                     Status    Enforcement  ID
+  1  Allow Production Agent in Maestro        Active    Allow        <POLICY_ID>
+  2  Allow Agents except Development          Active    Allow        <POLICY_ID>
+```
+
+If `Data.results` is empty, inform the user that no policies were found. Offer `create` as the next step.
+
+**Common filters:**
+
+- `--filter "status in ('Active')"` — only active policies
+- `--filter "contains(name, 'Production')"` — substring match on name
+- `--order-by "CreatedOn desc"` + `--limit 5` — newest first
+- `--limit 10 --offset 20` — page 3 at page size 10
+
+---
+
+## Get a policy
+
+Always run before `update` or `delete`. For flags, see [access-policy-commands.md — get](./access-policy-commands.md#uip-gov-access-policy-get).
+
+```bash
+uip gov access-policy get <POLICY_ID> --output json
+```
+
+Parse `Data` and display:
+
+```text
+Name:         <NAME>
+Description:  <DESCRIPTION or "(none)">
+Type:         <policyType>
+Enforcement:  <enforcement>
+Status:       <status>
+Selectors:    <N entries — resourceType(s): ...>
+Executable:   <M entries — type(s): ...>
+ID:           <POLICY_ID>
+```
+
+For full payload inspection, also show the raw JSON in a code block so the user can see every field.
+
+---
+
+## Create a policy
+
+The policy definition is **always** authored via Phase 1 + Phase 2 + plugins. No free-form JSON authoring.
+
+### Step 1 — Phase 1: author the Policy Spec
+
+Hand off to [planning-arch.md](./planning-arch.md). It builds a **Policy Spec** (narrative paragraph + Spec Components Table covering name, description, status, enforcement, resource selection, actor process, actor identity, tags, operators) — every row pre-filled with the user's values or sensible defaults. The user reviews and edits any row, then approves with `yes`. Phase 1 ends when every Open question is closed and the user has approved.
+
+### Step 2 — Phase 2: compose via plugins
+
+Hand off to [planning-impl.md](./planning-impl.md). It walks each row of the approved Spec Components Table and reads the matching plugin's `impl.md`:
+
+- Resource rows → [plugins/selector/impl.md](./plugins/selector/impl.md)
+- Actor Process rows → [plugins/executable/impl.md](./plugins/executable/impl.md)
+- Actor Identity rows (only when filled) → [plugins/actor/impl.md](./plugins/actor/impl.md)
+- Tag-filter rows → [plugins/tags/impl.md](./plugins/tags/impl.md)
+
+For **create** flows, Phase 2 reuses the slug Phase 1 used for `/tmp/access-policy-<slug>.spec.md` and writes the assembled `PolicyDefinition` to `/tmp/access-policy-<slug>.json` — both files sit side by side in `/tmp` and are surfaced in the review gate. (Update flows use a different file convention — see [Update a policy § Step 2](#step-2--build-the-working-file-from-data) below.)
+
+### Step 3 — Verify metadata is captured in the Spec
+
+Spec rows 1 (`name`), 2 (`description`), 3 (`status`), and 4 (`enforcement`) cover policy metadata. They were filled during Phase 1 — use them silently here (Critical Rule #11).
+
+- **Name** (row 1): required.
+- **Description** (row 2): required, one sentence summarizing the Spec narrative.
+- **Status** (row 3): defaults to **`Simulated`** (Critical Rule #13 — see [SKILL.md § Enforcement and status](../SKILL.md#enforcement-and-status) for the meaning). Only emit `Active` when the Spec explicitly says so. After creation, if the policy is still Simulated, the post-create numbered next-steps list offers an explicit **Activate** step.
+- **Enforcement** (row 4): always `Allow` (Critical Rule #2 — `Deny` is not authorable).
+
+If any required row was unfilled when Phase 2 ran, return to Phase 1's iteration loop. Otherwise proceed to Step 4 without prompting.
+
+### Step 4 — Single review gate
+
+This is the **only** `yes / no` confirmation in the create flow (Critical Rule #7). Lead with a **short human-readable summary** — one plain-English line per block. Hide the technical per-entry breakdown inside a collapsible `<details>` section so the console stays clean:
+
+```markdown
+Review the access policy to be created:
+
+  Scope:          Organization "<ORG_NAME>" / Tenant "<TENANT_NAME>"
+                  (organizationId: <ORG_UUID>, tenantId: <TENANT_UUID>)
+  Name:           <POLICY_NAME>
+  Description:    <DESCRIPTION or "(none)">
+  Status:         Simulated (preview mode — evaluated but does not affect enforcement)
+  Resources:      <RESOURCE_SUMMARY>         e.g. "all Agent resources tagged 'Production'"
+  Actor Process:  <ACTOR_PROCESS_SUMMARY>    e.g. "any Maestro"
+  Actor Identity: <ACTOR_IDENTITY_SUMMARY>   e.g. "any identity"
+  Policy Spec:    [access-policy-<slug>.spec.md](/tmp/access-policy-<slug>.spec.md)   ← human-readable Spec from Phase 1
+  Policy data:    [access-policy-<slug>.json](/tmp/access-policy-<slug>.json)        ← JSON payload Phase 2 will submit
+
+<details>
+<summary>Show technical details</summary>
+
+  Enforcement:    Allow
+  Resource filters (which resource processes this policy protects):
+    - <Resource type> — applies to <all|specific IDs|exclude IDs>; tag filter: <Any-of|All-of|Exclude|none>
+  Actor Process rule (which processes are allowed to invoke the resources):
+    - <Process type> — applies to <all|specific IDs|exclude IDs>
+    Shared tag filter: <Any-of|All-of|Exclude|none>
+  Actor Identity rule (omit entire block if no identity constraint; tags not supported on Actor Identity):
+    - <Identity type> — applies to <all|specific IDs|exclude IDs>
+
+</details>
+```
+
+**Scope line — what to fill in.** The Scope line tells the user which organization + tenant the policy will be created in. Read all four values from `~/.uipath/.auth`:
+
+```bash
+grep -E "UIPATH_ORGANIZATION_NAME|UIPATH_TENANT_NAME|UIPATH_ORGANIZATION_ID|UIPATH_TENANT_ID" ~/.uipath/.auth
+```
+
+- `UIPATH_ORGANIZATION_NAME` → `<ORG_NAME>`
+- `UIPATH_TENANT_NAME` → `<TENANT_NAME>`
+- `UIPATH_ORGANIZATION_ID` → `<ORG_UUID>` (matches `organizationId` in the JSON payload)
+- `UIPATH_TENANT_ID` → `<TENANT_UUID>` (matches `tenantId` in the JSON payload)
+
+If the org / tenant names are missing from `~/.uipath/.auth`, show only the UUIDs on the second line and note "(name unavailable)". Do **not** skip the Scope line — the user must always see which environment is about to be mutated. If the user expected a different org / tenant, they should `cancel` and re-login (`uip login --authority …` or `uip login --tenant …`).
+
+Then output the full JSON as a ```json code block in the chat (do NOT rely on the file link alone — the user may not be able to open it).
+
+Both file links use the **resolved absolute path** (run `realpath` — Critical Rule #7). The Spec file (`<slug>.spec.md`) and the JSON file (`<slug>.json`) share the same slug so they sit side by side in `/tmp` for easy diff/review.
+
+**User-friendly phrasing rules** (same terminology as [planning-arch.md](./planning-arch.md) — keep them aligned):
+
+- "Resources" / "Resource filters" — not "Selectors".
+- "Actor Process rule" — not "Executable rule".
+- "Applies to: all / specific IDs / exclude IDs" — not "targeting" and not "operator: Or/None".
+- "Tag filter: Any-of / All-of / Exclude" — not "operator: Or / And / None".
+- If `Status: Simulated`, append the clarifier `(preview mode — evaluated but does not affect enforcement)` so the user knows the policy is not yet effective.
+
+Ask verbatim:
+
+```
+Create access policy "<POLICY_NAME>"? (yes / no / keep editing)
+```
+
+`keep editing` is treated the same as `no` — route back:
+
+| If the user wants to change... | Route to |
+|---|---|
+| Metadata (Spec rows 1 / 2 / 3 — name / description / status; row 4 enforcement is fixed at `Allow`) | Step 3 |
+| A block's JSON (enum, targeting, operator, tags) | The relevant plugin's `impl.md`, splice the new block into the file |
+| Intent itself (wrong resource, wrong caller, etc.) | [planning-arch.md](./planning-arch.md) — return to Spec iteration, get a fresh `yes`, re-run Phase 2 |
+
+Re-enter this gate only after the change is applied. Do NOT run `create` until the user answers `yes`.
+
+### Step 5 — Create
+
+```bash
+uip gov access-policy create --file /tmp/access-policy-<slug>.json --output json
+```
+
+Parse the response:
+
+- `Data.upsertedPolicy.id` → record as `$POLICY_ID`
+- `Data.statusCode` should be 200
+- `Data.errors` should be `null`
+
+If creation fails, show the error to the user and return to Step 4 (keep editing).
+
+### Step 6 — Verify
+
+```bash
+uip gov access-policy get "$POLICY_ID" --output json
+```
+
+Display the raw JSON from `get` plus the user-friendly summary in the format defined by [SKILL.md — Completion Output](../SKILL.md#completion-output) (Operation & result line, Simulated banner, working file paths, technical details). If `Status == Simulated`, the Simulated banner is mandatory.
+
+### Step 7 — Next steps
+
+Render next steps as a **numbered Markdown list** under a `### What would you like to do next?` heading so the user can reply with the number. Do NOT use `AskUserQuestion`, do NOT render as a table. The option set depends on the policy's current `status`. See [SKILL.md — Completion Output](../SKILL.md#completion-output) for the exact lists for `status: "Simulated"` and `status: "Active"`. **Do NOT offer `evaluate`** (Critical Rule #12).
+
+---
+
+## Update a policy
+
+The existing server-stored definition is **always** the starting state for an update, and every edit flows through the same plugins used at create time. Do **not** rebuild a Phase 1 Spec from scratch — that path is for create only.
+
+### Step 1 — Identify and fetch
+
+If the user did not provide a policy ID, run `list` (above) and ask them to pick one. Store as `$POLICY_ID`.
+
+```bash
+uip gov access-policy get "$POLICY_ID" --output json > /tmp/access-policy-"$POLICY_ID"-current.json
+```
+
+Display the current values (name, description, selectors summary, executable summary, status) so the user can see what they are changing.
+
+### Step 2 — Build the working file from `Data`
+
+Copy `.Data` as-is into the working file:
+
+```bash
+jq '.Data' /tmp/access-policy-"$POLICY_ID"-current.json > /tmp/access-policy-"$POLICY_ID"-working.json
+```
+
+Then strip the read-only audit fields:
+
+```bash
+jq 'del(.isBuiltIn, .isTemplate, .createdBy, .createdOn, .modifiedBy, .modifiedOn, .deletedBy, .deletedOn)' \
+   /tmp/access-policy-"$POLICY_ID"-working.json > /tmp/access-policy-"$POLICY_ID"-working.tmp.json \
+  && mv /tmp/access-policy-"$POLICY_ID"-working.tmp.json /tmp/access-policy-"$POLICY_ID"-working.json
+```
+
+The working file now has `id`, `organizationId`, `tenantId`, `policyType`, `name`, `description`, `selectors`, `executableRule`, `enforcement`, `status`. These are the fields the update sends — any field you remove is cleared from the server record (Critical Rule #8).
+
+> **Never start from a Phase 1 Spec on update.** The existing policy is the source of truth. A from-scratch Spec silently wipes every field the user does not re-specify, because update is a full replacement.
+
+### Step 3 — Classify what the user wants to change
+
+Parse the user's request and classify each change:
+
+| Change | Handling |
+|--------|----------|
+| Metadata only (`name` / `description` / `status`) | Edit in place in the working file. Skip plugins. |
+| Add / remove / modify a selector (resource) | Re-enter [plugins/selector/impl.md](./plugins/selector/impl.md) with the existing block as starting input, then splice the modified entry back into `selectors[]`. |
+| Modify the executable rule | Re-enter [plugins/executable/impl.md](./plugins/executable/impl.md) with the existing `executableRule` as input, apply the change, splice back. |
+| Change a tag operator or tag values on any block | Re-enter [plugins/tags/impl.md](./plugins/tags/impl.md); preserve the parent block's other fields. |
+| Add / remove / modify the actor identity rule ("only admins…", "block user X", "members of group G") | Re-enter [plugins/actor/impl.md](./plugins/actor/impl.md) with the existing `actorRule` (or absence) as input, apply the change, splice back. To remove identity enforcement, delete the `actorRule` key from the working file. |
+| Flip Deny→Allow on an existing policy | Route through [plugins/tags/planning.md — Deny-to-Allow flip](./plugins/tags/planning.md#deny-to-allow-flip), apply `None` operator to the relevant tag block. |
+
+**Skip rule:** if the user's original request already specified what to change (e.g. "set status to Simulated", "add UUID `abc-123` to the executable rule"), apply it directly without re-prompting. Only prompt when the user said `"update policy X"` with no details.
+
+### Step 4 — Apply changes
+
+Edit the working file in place. Update only the fields the user asked about; every other field stays as copied from `Data` in Step 2.
+
+### Step 5 — Single review gate
+
+Show a before/after diff so the user sees exactly what changed:
+
+```text
+Review access-policy update:
+
+  Scope:        Organization "<ORG_NAME>" / Tenant "<TENANT_NAME>"
+                (organizationId: <ORG_UUID>, tenantId: <TENANT_UUID>)
+  Name:         <NEW_NAME>         (was: <OLD_NAME>)
+  Description:  <NEW>              (was: <OLD>)
+  Status:       <NEW>              (was: <OLD>)
+  Selectors:    <change summary>
+  Executable:   <change summary>
+
+  Working file: [access-policy-<id>-working.json](/tmp/access-policy-<id>-working.json)
+```
+
+The Scope line uses the same source as the create gate — read from `~/.uipath/.auth` (see [Step 4 — Single review gate](#step-4--single-review-gate) above for the full source-mapping). For an update, the values come from the policy's stored `organizationId` / `tenantId` (which must match the logged-in tenant — if they do not, the update will fail at the API).
+
+For each row, show `(unchanged)` if the field was not modified. Output the full updated JSON as a ```json code block in the chat as well.
+
+Ask verbatim:
+
+```
+Apply update to access policy "<POLICY_NAME>"? (yes / no / keep editing)
+```
+
+`keep editing` routes back to Step 3 or Step 4 for the specific plugin whose block still needs edits. Do NOT run `update` until the user answers `yes`.
+
+### Step 6 — Update
+
+```bash
+uip gov access-policy update --file /tmp/access-policy-"$POLICY_ID"-working.json --output json
+```
+
+### Step 7 — Verify
+
+```bash
+uip gov access-policy get "$POLICY_ID" --output json
+```
+
+Display:
+
+```text
+POLICY UPDATED
+
+  ID:     <POLICY_ID>
+  Name:   <NAME>
+  Status: <STATUS>
+```
+
+Show the raw JSON so the user can confirm the change took effect.
+
+---
+
+## Delete a policy
+
+> **Destructive.** This cannot be undone. Supports single-policy and multi-policy delete in one call.
+
+### Step 1 — Identify the policy / policies
+
+If the user did not provide policy IDs, run `list` and ask them to pick one or more. Store as `$POLICY_ID` (single) or `$POLICY_IDS` — a space-separated list (multi).
+
+### Step 2 — Get and display each policy
+
+Run `get` once per ID so the user sees what they are about to delete:
+
+```bash
+uip gov access-policy get "$POLICY_ID" --output json
+```
+
+Display per policy:
+
+```text
+About to delete:
+  Name:         <NAME>
+  ID:           <POLICY_ID>
+  Resource:     <RESOURCE_TYPE>
+  Executable:   <EXECUTABLE_TYPE>
+  Status:       <Active | Simulated>
+```
+
+For multi-delete, render each policy as a numbered row and a count header (`About to delete <N> policies:`).
+
+### Step 3 — Confirm
+
+Ask verbatim — single or multi (Critical Rule #9, [SKILL.md — Confirmation-gate wording](../SKILL.md#confirmation-gate-wording)):
+
+```
+Delete access policy "<POLICY_NAME>"? This cannot be undone. (yes / no)
+```
+
+```
+Delete <N> access policies (<POLICY_NAME_1>, <POLICY_NAME_2>, ...)? This cannot be undone. (yes / no)
+```
+
+If the user answers anything other than `yes` (or `y`), abort and inform them that deletion was cancelled.
+
+### Step 4 — Delete
+
+Single:
+
+```bash
+uip gov access-policy delete "$POLICY_ID" --output json
+```
+
+Multi (space-separated UUIDs in one call — see [access-policy-commands.md — delete](./access-policy-commands.md#uip-gov-access-policy-delete)):
+
+```bash
+uip gov access-policy delete $POLICY_IDS --output json
+```
+
+Parse `Data.policyIds[]` to confirm every requested UUID was deleted. Report any IDs that did not appear in the response.
+
+### Step 5 — Confirm and offer next steps
+
+Print the result line:
+
+```text
+Access policy "<POLICY_NAME>" deleted successfully.
+```
+
+For multi-delete:
+
+```text
+Deleted <N> access policies: <NAME_1>, <NAME_2>, ...
+```
+
+Then render the post-delete numbered next-steps menu mandated by [SKILL.md — Completion Output](../SKILL.md#completion-output) (`### What would you like to do next?` → `1. List policies to verify` / `2. Something else`). Do NOT use `AskUserQuestion`.
+
+---
+
+## Debug
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `401 Unauthorized` | Token expired or missing | `uip login` and retry — see [access-policy-commands.md — Authentication](./access-policy-commands.md#authentication) |
+| `Policy not found` | Stale or wrong UUID | Re-run `list` and copy the `id` from the result |
+| `400 Bad Request` / `Selectors[0].Values is required` | Missing `values: ["*"]` | Compose the selector via [plugins/selector/impl.md](./plugins/selector/impl.md) — `values` is required even with tags |
+| `409 Conflict` / duplicate name | Another policy has the same name | Pick a different name |
+| `enforcement: Deny not allowed` | The skill emitted `enforcement: "Deny"` — never authorable (Critical Rule #2) | Switch to `enforcement: "Allow"` and reframe the Deny intent: ask what should be allowed, or use `operator: "None"` on tags / values. See [plugins/tags/planning.md — Deny-to-Allow flip](./plugins/tags/planning.md#deny-to-allow-flip). |
+| `ActorRule.Values is required` | Emitted `actorRule` without any entries | Either remove the `actorRule` key entirely (no identity constraint), or add at least one `{ type, values, operator }` entry — see [plugins/actor/impl.md](./plugins/actor/impl.md) |
+| Identity filter ignored at runtime | Omitted `actorRule` when the intent required one | Compose the Actor Identity Rule via [plugins/actor/planning.md](./plugins/actor/planning.md) + [plugins/actor/impl.md](./plugins/actor/impl.md) |
+| Update silently wiped a field | Started from a fresh Phase 1 Spec instead of `Data` | Re-fetch via `get`, restart update from `Data` (Step 2) |
+
+---
+
+## Related references
+
+- [access-policy-commands.md](./access-policy-commands.md) — every flag and output shape used above.
+- [planning-arch.md](./planning-arch.md) — Phase 1 Policy Spec authoring, required for create and for intent-scoped updates.
+- [planning-impl.md](./planning-impl.md) — Phase 2 JSON composition.
+- [plugins/](./plugins/) — block-level authoring guides for selector, executable, actor, tags.

--- a/skills/uipath-gov-access-policy/references/resource-lookup-guide.md
+++ b/skills/uipath-gov-access-policy/references/resource-lookup-guide.md
@@ -1,0 +1,303 @@
+# Resource Lookup Guide
+
+How to resolve human-readable process / folder / user names into the UUIDs the access-policy JSON requires. Run these when the user says things like "the Invoice Agent", "the Production Flow in Shared", or "the build-bot service account" without supplying a UUID — never guess a UUID, and never ask the user to leave the chat to find one unless the lookup returns no match.
+
+> For full option details on any command, use `--help` (e.g., `uip or processes list --help`).
+
+> **When to use this guide**
+>
+> - Phase 1 ([planning-arch.md](./planning-arch.md)) — the **Resources** / **Actor Process** / **Actor Identity** summary references a specific named entity but the user did not supply its UUID.
+> - Phase 2 ([planning-impl.md](./planning-impl.md)) — composing a `selectors[].values`, `executableRule.values[].values`, or `actorRule.values[].values` array that needs specific UUIDs.
+> - Update flow, when the user wants to add a specific process or identity to an existing block.
+
+All commands assume the user is already logged in (`uip login status --output json`). Every command uses `--output json` so the agent can parse the result programmatically.
+
+---
+
+## Common flags (every `uip or ... list` command)
+
+`--output json`, `--limit`, `--offset`, `--order-by`, and `--login-validity` are shared with `uip gov access-policy` — see [access-policy-commands.md § Common flags](./access-policy-commands.md#common-flags-shared-across-uip-list-commands) for the canonical descriptions. The `uip or`-only flags below extend that set:
+
+| Flag | Purpose |
+|------|---------|
+| `--output-filter <expr>` | JMESPath filter on the JSON response (e.g. `"Data[?contains(Name, 'Invoice')].Key"`). |
+| `--all-fields` | Returns the full DTO instead of the curated summary — use when you need a field not shown by default (e.g. confirming the exact `ProcessType` string). |
+| `--tenant <name>` | Override the tenant selected during `uip login`. Rarely needed. |
+
+> Default `--limit` for `uip or ... list` is 50 (max typically 1000); `uip gov access-policy list` defaults to 20.
+
+### Pagination
+
+List responses include a `Pagination` block with `Returned`, `Limit`, `Offset`, and `HasMore`. When `HasMore == true`, increment `--offset` by `--limit` and fetch again until `HasMore == false` or `Returned < Limit`. If the user's tenant has hundreds of processes, prefer a **server-side filter** (`--process-type`, `--name`) over paging through everything.
+
+---
+
+## 1. Processes (Resource or Actor Process UUIDs)
+
+`uip or processes list` returns Orchestrator processes filtered by folder and process type. The returned `Key` field is the UUID you paste into the policy JSON.
+
+### The two-step lookup — folders first, processes second
+
+**Processes are folder-scoped** — `uip or processes list` **requires** `--folder-path` (or `--folder-key`). If the user has not said which folder the process lives in, do NOT guess a folder name. Run folder discovery first, present the folder list, and ask the user to pick before searching for the process.
+
+```mermaid
+graph LR
+    A[uip or folders list] --> B{User picks folder}
+    B --> C[uip or processes list --folder-path &lt;PATH&gt; --process-type &lt;TYPE&gt; --name &lt;SUBSTR&gt;]
+    C --> D{User picks process}
+    D --> E[Key UUID → policy JSON]
+```
+
+**Step 1 — list folders.** See [§ 2 Folders](#2-folders) for the command and filter patterns. Grab `FullyQualifiedName` (e.g. `"Shared"`, `"Prod/Agents"`) for the next step.
+
+**Step 2 — list processes in that folder:**
+
+```bash
+uip or processes list \
+  --folder-path "<FOLDER_PATH>" \
+  --process-type "<ORCHESTRATOR_PROCESS_TYPE>" \
+  --name "<SUBSTRING>" \
+  --limit 50 \
+  --output json
+```
+
+| Flag | Required? | Purpose |
+|------|-----------|---------|
+| `--folder-path "<PATH>"` **or** `--folder-key "<UUID>"` | **Yes (one of)** | Mandatory. Processes are folder-scoped; the command fails without it. Use `FullyQualifiedName` from `uip or folders list` for `--folder-path`. |
+| `--process-type "<TYPE>"` | Recommended | Filters server-side by Orchestrator `ProcessType` — narrows to the right access-policy block (see mapping below). Note the Orchestrator value is **different** from the access-policy enum. |
+| `--name "<SUBSTRING>"` | Optional | Case-insensitive substring match on the process name. Use whenever the user named the process ("the Invoice agent" → `--name "Invoice"`). |
+
+### Access-policy type → Orchestrator `--process-type`
+
+The access-policy `resourceType` / `executableRule.values[].type` enums are **not the same strings** as Orchestrator's `ProcessType`. You must translate before passing `--process-type`. The table below is the authoritative mapping (confirmed against the `ProcessType` field returned by the Releases API):
+
+| Access-policy type | Orchestrator `--process-type` value | Block(s) | Notes |
+|--------------------|-------------------------------------|----------|-------|
+| `Agent` | `Agent` | Selection Rule, Actor Process Rule | Same string on both sides. |
+| `AgenticProcess` | `ProcessOrchestration` | Selection Rule, Actor Process Rule | **Rename** — Orchestrator calls maestro / agentic processes `ProcessOrchestration`. |
+| `RPAWorkflow` | `Process` | **Selection Rule only** — not valid as Actor Process | **Rename** — Orchestrator's legacy RPA process is just `Process`. |
+| `APIWorkflow` | `Api` | **Selection Rule only** — not valid as Actor Process | **Rename** — Orchestrator uses `Api`, not `ApiWorkflow`. |
+| `CaseManagement` | `CaseManagement` | Selection Rule, Actor Process Rule | **Unconfirmed** — likely same string but not verified against the Releases API. Re-run with `--all-fields` on first use to confirm, and update this row if it drifts. |
+| `Flow` | `Flow` | Selection Rule, Actor Process Rule | **Unconfirmed** — likely same string but not verified against the Releases API. Re-run with `--all-fields` on first use to confirm, and update this row if it drifts. |
+
+> **Verify if in doubt.** If a lookup returns zero rows for a `--process-type` value and the user is sure the process exists, re-run with `--all-fields` (and drop `--process-type`), then inspect the `ProcessType` string in the response to confirm the exact enum the tenant uses. Fix the mapping row here if you find a drift.
+
+### Response shape (default)
+
+```json
+{
+  "Code": "ProcessList",
+  "Data": [
+    {
+      "Key": "c3d4e5f6-0000-0000-0000-000000000001",
+      "Name": "InvoiceProcessing",
+      "ProcessKey": "InvoiceProcessing",
+      "ProcessVersion": "1.0.2",
+      "Description": "",
+      "IsLatestVersion": true
+    }
+  ]
+}
+```
+
+- `Key` — the **process UUID** to paste into the policy JSON. Use it as `selectors[].values[i]` when this process is the Resource being protected, or as `executableRule.values[j].values[i]` when this process is the Actor Process. This is the API-expected identifier — **not** the folder UUID, **not** `ProcessKey` (which is a dotted string identifier, not a UUID), and **not** `ProcessVersion`.
+- `Name` — the human-readable name. Present this to the user when asking them to confirm a match.
+- `ProcessKey` / `ProcessVersion` — informational only. The access-policy API does not accept these in `values`.
+
+> **"Process" vs "Release".** The CLI says "process"; the Orchestrator REST API calls it a "Release". Same entity. `Key` from `processes list` equals the `Key` from `/odata/Releases` — both are valid process UUIDs to paste into the policy.
+
+### Presenting matches to the user
+
+When multiple candidates come back, show them as a compact table and ask the user to pick. **Never silently pick the first row.**
+
+```text
+Found 3 processes matching "Invoice" in folder "Shared":
+
+  #  Name                          Version   Key (UUID)
+  1  InvoiceProcessing             1.0.2     c3d4e5f6-0000-...-0001
+  2  InvoiceProcessing-staging     1.0.1     c3d4e5f6-0000-...-0002
+  3  InvoiceApproval               0.9.0     c3d4e5f6-0000-...-0003
+
+Which one do you want to add to the policy? (1 / 2 / 3 / none)
+```
+
+If no matches, report the miss plainly and offer to broaden the search (drop `--name`, switch folder, drop `--process-type`) before giving up.
+
+### Get a single process by UUID
+
+Use this to confirm a UUID the user already supplied (e.g. from a previous policy or an Orchestrator URL):
+
+```bash
+uip or processes get "<PROCESS_UUID>" --output json
+```
+
+No folder context required — the UUID is globally unique.
+
+---
+
+## 2. Folders
+
+Folders are **tenant-scoped**. Run this first when the user names a folder ("the Shared folder", "Prod/Agents") without giving the exact path, or when `processes list` fails with a folder-not-found error.
+
+```bash
+uip or folders list --output json
+```
+
+Parse `.Data[]` for `FullyQualifiedName` (e.g. `"Shared"`, `"Prod/Agents"`) and `Key` (the UUID). Either value works as `--folder-path` / `--folder-key` on subsequent calls. Prefer `--folder-path` in chat transcripts — it is human-readable.
+
+Filter client-side with `--output-filter` when the tenant has many folders:
+
+```bash
+uip or folders list \
+  --output json \
+  --output-filter "Data[?contains(FullyQualifiedName, 'Prod')]"
+```
+
+---
+
+## 3. Users (Actor Identity UUIDs)
+
+For the `actorRule.values[].type: "User"` entry, resolve user names to UUIDs with:
+
+```bash
+uip or users list --output json
+```
+
+Parse `.Data[]` for `Key` (UUID), `UserName`, and `Name`. Filter client-side when the tenant is large:
+
+```bash
+uip or users list \
+  --output json \
+  --output-filter "Data[?contains(UserName, 'admin')]"
+```
+
+For the currently authenticated user (useful when the intent is "only me"):
+
+```bash
+uip or users current --output json
+```
+
+### Robots resolve to `type: User`
+
+A robot is a kind of user in the UiPath identity model (Critical Rule #16). To use a robot in `actorRule`, the policy emits `type: "User"` with the robot's **linked user UUID**, never `type: "Robot"`. Resolve the robot to its user identity in three steps:
+
+1. **Find the robot** via the [REST API fallback](#5-rest-api-fallback-for-robot-lookups) below — read the `Username` field from the matching robot record.
+2. **Resolve the username to a User UUID** with `uip or users list --output json --output-filter "Data[?UserName == '<USERNAME>']"`. The user `Key` is the UUID to use in the policy.
+3. **Emit `type: "User"`** in the policy JSON — see [plugins/actor/impl.md — Example E](./plugins/actor/impl.md#e-robot-only-trigger-resolves-to-user).
+
+If the robot has no linked user (rare for modern Orchestrator deployments), surface this as an Open question on the Phase 1 Spec and stop — do not invent a UUID.
+
+### Groups — no `uip or` wrapper
+
+`Group` is supported in `actorRule.values[].type` but has no `uip or` wrapper today. Ask the user to paste the Group UUID from the Admin portal and surface it as an **Open question** on the Phase 1 Spec until supplied. Never fabricate.
+
+### ExternalApplication — not supported
+
+`ExternalApplication` is not a valid `actorRule.values[].type` today (Critical Rule #16). If the user names a service principal / S2S app / registered application, refuse and route them to one of these workarounds:
+- Use the `User` account that the application authenticates as.
+- Use a `Group` containing the application's identity.
+- Omit the Actor Identity rule entirely so the policy applies regardless of identity.
+
+---
+
+## 4. Resource Catalog tags
+
+Resource Catalog tags are tenant-scoped labels that feed `selectors[].tags.values[]` and `executableRule.tags.values[]` (see [plugins/tags/impl.md](./plugins/tags/impl.md)). A policy that references a tag name not present in the **policy's tenant** silently matches nothing at runtime — always verify before approving the Spec.
+
+### Default call
+
+```bash
+uip admin rcs tag list --output json
+```
+
+With no `--tenant`, the command targets the tenant in the current `uip login` context — and that is **also** the tenant the access policy will be authored in (the policy's `tenantId` is read from `~/.uipath/.auth`). This default is the only mode that proves a tag will resolve at evaluation time. Run it before approving any Spec or update that introduces a tag the user named; if the tag is missing from `Data.value[].displayName`, prompt the user to pick a returned tag, or to add the missing one to the Resource Catalog of the policy's tenant before retrying. Never invent a tag, and never silently substitute a near-match.
+
+| Flag | Required? | Purpose |
+|------|-----------|---------|
+| `--type Label\|KeyValue` | Optional | Defaults to `Label` (the type used by `tags.values[]` in `ToolUsePolicy` access policies). Pass `KeyValue` only when the user is asking about key/value tags, which the access-policy schema does **not** consume. |
+| `--starts-with <PREFIX>` | Optional | Server-side prefix filter (case-insensitive on `normalizedName`). Use whenever the user named a tag substring ("anything starting with prod"). |
+| `--limit <N>` | Optional | Page size (default `100`). |
+| `--skip <N>` | Optional | Row offset (default `0`). |
+| `--tenant <NAME>` | Optional | **Targets a different tenant in the same organization.** Do NOT pass this when verifying tags for the policy under construction — see [Tenant alignment](#tenant-alignment) below. |
+
+### Response shape
+
+```json
+{
+  "Code": "RcsTagList",
+  "Data": {
+    "count": 2,
+    "value": [
+      { "displayName": "Production", "normalizedName": "production" },
+      { "displayName": "Development", "normalizedName": "development" }
+    ]
+  }
+}
+```
+
+- `displayName` — the value to paste into `tags.values[]` in the policy JSON. The existing skill examples (e.g. `Production`, `Development`, `PII`) all use this form verbatim.
+- `normalizedName` — informational; what `--starts-with` matches against. Do not put this into the policy JSON.
+
+### Tenant alignment
+
+The access-policy `tenantId` is read from `~/.uipath/.auth` (`UIPATH_TENANT_ID`) and pinned at `create` time — the policy can only ever resolve tags from **that** tenant at evaluation.
+
+- **Default (no `--tenant`)** — verify tags for the in-flight policy. Use this for every Phase 1 / Phase 2 confirmation prompt.
+- **`--tenant <OTHER_NAME>`** — comparison only (e.g. "do these tag names also exist in our staging tenant?"). Never use a result from another tenant as evidence that a tag will work in the policy's tenant. If the user explicitly asks to check a different tenant, run the call but surface a one-line warning: `Tags from <OTHER_NAME> do not affect a policy authored in <POLICY_TENANT>; copy the tag in the Resource Catalog of <POLICY_TENANT> if it is missing there.`
+
+To recover the policy's tenant name (for the warning above) without echoing the bearer token:
+
+```bash
+grep "^UIPATH_TENANT_NAME=" ~/.uipath/.auth | cut -d= -f2
+```
+
+---
+
+## 5. REST API fallback (for Robot lookups)
+
+`Robot` lookups are not wrapped by `uip or`. Fall back to Orchestrator REST directly to find the robot's `Username`, which then feeds a `uip or users list` call (see [Robots resolve to `type: User`](#robots-resolve-to-type-user) above). **Never `cat ~/.uipath/.auth` into the transcript** — the file contains the bearer token. Instead, source it into environment variables inside a sub-shell so the token stays out of logs:
+
+```bash
+# SECURITY: sources the auth env into a sub-shell only; the token never prints.
+bash -c 'source <(grep = ~/.uipath/.auth) && curl -s \
+  "${UIPATH_URL}/${UIPATH_ORGANIZATION_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Robots?\$top=50&\$select=Id,Key,Name,Username,Type" \
+  -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
+  -H "Accept: application/json"' \
+  | jq '.value[] | {Key, Name, Username, Type}'
+```
+
+The `Username` field is what you feed to `uip or users list` to get the User UUID for the policy.
+
+| Identity type | Endpoint / source | What to do with it |
+|---------------|------------------|--------------------|
+| **Robot** (intermediate lookup) | `orchestrator_/odata/Robots` — read `Username` | Resolve `Username` → User UUID via `uip or users list`, then emit `type: "User"`. |
+| **Group** | Identity service — ask the user to paste the UUID from Admin portal | Use directly as `type: "Group"`. |
+
+If the call returns `401 Unauthorized`, the token expired — ask the user to `uip login` and retry. Never commit or echo the token.
+
+---
+
+## 6. When the lookup still cannot resolve the name
+
+1. **Surface the miss** — tell the user exactly which query you ran and what came back empty. Include the folder, `--process-type`, and `--name` values you used.
+2. **Suggest broadening the search** — drop `--process-type`, drop `--name`, try a parent folder.
+3. **Never fabricate a UUID.** If the lookup fails and the user cannot supply one, pause the flow and treat the missing UUID as a blocking **Open question** on the Phase 1 Spec (see [planning-arch.md](./planning-arch.md) — Open questions).
+
+---
+
+## 7. Recap — one command per lookup type
+
+> Processes are folder-scoped — always run [§ 2 Folders](#2-folders) first if you do not know the folder path. Translate the access-policy type to the Orchestrator `--process-type` using the [mapping table above](#access-policy-type--orchestrator---process-type) before calling `processes list`.
+
+| I need to find... | Command |
+|-------------------|---------|
+| A folder path / UUID by display name | `uip or folders list --output json` → filter on `FullyQualifiedName` |
+| A process / agent / flow / case-management UUID by name | `uip or processes list --folder-path "<PATH>" --process-type "<ORCHESTRATOR_TYPE>" --name "<SUBSTR>" --output json` — paste the response's `Key` into `values[]`. Do not use `ProcessKey` (dotted string), `ProcessVersion`, or the folder UUID. |
+| All processes of a given access-policy type in a folder | `uip or processes list --folder-path "<PATH>" --process-type "<ORCHESTRATOR_TYPE>" --output json` — paste each row's `Key` into `values[]`. |
+| Details on a specific process UUID | `uip or processes get "<UUID>" --output json` |
+| A user UUID by username / display name | `uip or users list --output json` → filter on `UserName` or `Name` |
+| The currently authenticated user's UUID | `uip or users current --output json` |
+| A Resource Catalog tag name (for `tags.values[]`) | `uip admin rcs tag list --output json` — paste each row's `displayName` into `tags.values[]`. Do NOT pass `--tenant` when verifying tags for the policy under construction (see [§ 4 Tenant alignment](#tenant-alignment)). |
+| A robot's User UUID (for `actorRule`) | REST `GET /orchestrator_/odata/Robots` to find `Username` (see [§ 5](#5-rest-api-fallback-for-robot-lookups)), then `uip or users list` to resolve `Username` → User UUID |
+| A group UUID | Admin portal — paste into the Phase 1 Spec as an Open question |
+| An external application UUID | **Not supported** by access policies today (Critical Rule #16) — route to a `User` or `Group` workaround |

--- a/skills/uipath-gov-access-policy/references/sample-policy-guide.md
+++ b/skills/uipath-gov-access-policy/references/sample-policy-guide.md
@@ -1,0 +1,119 @@
+# Sample Access Policy — Starter Reference
+
+Use this canonical sample when the user has **no concrete intent** ("I want to create an access policy", "help me set one up") **or has gaps** (missing resource type, no caller, no actor identity, no name). Show the **Spec narrative** plus the **JSON definition** as a starter so the user can either adopt it as-is or point at the parts they want to change. The sample seeds the **Policy Spec** that Phase 1 ([planning-arch.md](./planning-arch.md)) iterates with the user.
+
+> **When to use this guide.** Phase 1 routes here when the user's request cannot be classified into Resource / Actor Process / Actor Identity / tag phrases — i.e., when intent analysis would otherwise have no defaults to draw from. Do NOT use it when the user has already described a specific policy.
+
+---
+
+## Sample Spec narrative (natural-language description)
+
+> **"Only the 'Order Processing' Maestro can invoke Production Agents"**
+>
+> This is a **tool-use policy** in **simulation mode** that allows a specific Maestro — "Order Processing" — running on behalf of a specific user to invoke any Agent tagged `Production`.
+>
+> - **What is being protected:** all Agents that carry the `Production` tag.
+> - **Who/what is allowed to call them:** the Maestro named "Order Processing," but only when it is executed by the designated user.
+> - **Effect:** `Allow` — the matching call is permitted.
+> - **Status:** `Simulated` — the policy is evaluated and logged but not yet enforced, so violations are surfaced for review without blocking real traffic.
+>
+> **Intent:** lock down Production-tagged Agents so they can only be driven by the sanctioned Maestro orchestration. Running it in simulation first lets the team verify the rule matches real traffic before flipping enforcement on.
+
+---
+
+## Sample policy — JSON definition
+
+```json
+{
+    "policyType": "ToolUsePolicy",
+    "organizationId": "<ORG_UUID>",
+    "tenantId": "<TENANT_UUID>",
+    "name": "Only the \"Order Processing\" Maestro can invoke Production Agents",
+    "description": "Restrict tool-use of Production-tagged Agents so the only allowed caller is the \"Order Processing\" Maestro in Shared/Solution_Maestro_demo.",
+    "selectors": [
+        {
+            "resourceType": "Agent",
+            "values": ["*"],
+            "operator": "Or",
+            "tags": {
+                "values": ["Production"],
+                "operator": "Or"
+            }
+        }
+    ],
+    "executableRule": {
+        "values": [
+            {
+                "type": "AgenticProcess",
+                "values": ["<AGENTIC_PROCESS_UUID>"],
+                "operator": "Or"
+            }
+        ]
+    },
+    "actorRule": {
+        "values": [
+            {
+                "type": "User",
+                "values": ["<USER_UUID>"],
+                "operator": "Or"
+            }
+        ]
+    },
+    "enforcement": "Allow",
+    "status": "Simulated"
+}
+```
+
+> Replace `<ORG_UUID>` and `<TENANT_UUID>` from `~/.uipath/.auth` (Critical Rule #3). Replace `<AGENTIC_PROCESS_UUID>` and `<USER_UUID>` via [resource-lookup-guide.md](./resource-lookup-guide.md) once the user names a real process and user (Critical Rule #15). Resolve every `<…_UUID>` during Phase 1 — before the Spec is approved and Phase 2 composes the JSON. Never let a placeholder flow into the working file.
+
+---
+
+## How the sample seeds the Spec Components Table
+
+The row meanings, allowed values, and defaults live in [planning-arch.md § Spec output format](./planning-arch.md#spec-output-format) — do not duplicate them here. The sample only supplies the **values** below; pre-fill them into the canonical table when the user adopts or adapts the sample.
+
+| Row | Sample value |
+|---|---|
+| 1 (Policy name) | `Only the "Order Processing" Maestro can invoke Production Agents` |
+| 2 (Description) | one-sentence summary of the narrative above |
+| 3 (Status) | `Simulated` |
+| 4 (Enforcement) | `Allow` |
+| 5 (Resource type) | `Agent` |
+| 6 (Resource scope) | `all` |
+| 7 (Resource tag filter) | Any-of `[Production]` |
+| 8 (Actor Process type) | `Maestro` |
+| 9 (Actor Process scope) | one specific UUID — resolve via [resource-lookup-guide.md](./resource-lookup-guide.md) |
+| 10 (Actor Process tag filter) | `(none)` |
+| 11 (Actor Identity type) | `User` |
+| 12 (Actor Identity scope) | one specific UUID — resolve via [resource-lookup-guide.md](./resource-lookup-guide.md) |
+
+---
+
+## How to present the sample
+
+When intent is missing or thin, show the user **both** the Spec narrative and the JSON definition above (do not paraphrase — keep them verbatim so the user can compare to the file the skill will create), then ask the user to pick one of three paths:
+
+```
+This is a common access-policy shape — protect a tagged Resource, allow exactly one Actor Process, and narrow it to one Actor Identity.
+
+Pick one to continue:
+  1. Use this sample as-is (I'll just resolve the org/tenant/process/user UUIDs).
+  2. Use this sample but adapt some rows (tell me which Spec rows you want to change — Resource, Actor Process, Actor Identity, tag filter, name, status). Enforcement is always `Allow` and cannot be changed (Critical Rule #2).
+  3. Describe your own policy from scratch and I'll build the Spec with you.
+```
+
+Map the user's reply:
+
+- **Option 1** → seed the Spec Components Table from the [mapping table above](#how-the-sample-seeds-the-spec-components-table) — every row pre-filled. Run [resource-lookup-guide.md](./resource-lookup-guide.md) to resolve the Maestro and User UUIDs (do NOT keep `<…_UUID>` placeholders). Read `~/.uipath/.auth` for `organizationId` / `tenantId` (Critical Rule #3). Continue to the [planning-arch.md](./planning-arch.md) Review gate — explicit `yes` is still required.
+- **Option 2** → seed the Spec Components Table from the sample for rows the user did NOT change; mark the rows they want to change as `(missing)` and re-enter the [planning-arch.md](./planning-arch.md) iteration loop on those rows only.
+- **Option 3** → drop the sample, return to [planning-arch.md](./planning-arch.md) intent analysis with the user's full description and build the Spec from scratch.
+
+---
+
+## Anti-patterns
+
+- Do NOT silently start composing JSON when the user has not picked one of the three options. The sample is a prompt, not an approved Spec.
+- Do NOT submit the sample to `uip gov access-policy create` with `<…_UUID>` placeholders intact — every UUID must be resolved first (Critical Rule #3 + Critical Rule #15).
+- Do NOT emit `enforcement: "Deny"` when adapting the sample — `"Deny"` is **not authorable** (Critical Rule #2). Keep `enforcement: "Allow"` and reframe any Deny intent: ask what should be **allowed** and target that set, or use `operator: "None"` on tags / values to express "everything except X" (Critical Rule #2).
+- Do NOT leave `status: "Simulated"` out when the user picks Option 1 or doesn't say otherwise — Simulated is the safe default for newly created policies (Critical Rule #13).
+- Do NOT skip the Phase 1 review gate just because the user picked Option 1. The user must still explicitly approve the Spec before Phase 2 composes the working file (Critical Rule #6).

--- a/tests/tasks/uipath-gov-access-policy/get_policy_smoke.yaml
+++ b/tests/tasks/uipath-gov-access-policy/get_policy_smoke.yaml
@@ -1,0 +1,85 @@
+task_id: skill-gov-access-policy-get-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-gov-access-policy skill
+  to fetch a single access policy by UUID. Tests whether the skill
+  teaches the correct CLI namespace (`uip gov access-policy`), the
+  positional UUID argument on `get`, and the `--output json` convention.
+  Per the skill's policy-manage-guide, `get` is the canonical first step
+  before any update or delete.
+
+  Platform note: the smoke test runs without an authenticated tenant, so
+  `uip gov access-policy` commands that hit the service will fail with an
+  auth error. That is acceptable — what matters is that the agent invokes
+  the correct commands with the correct flags.
+tags: [uipath-gov-access-policy, smoke, get]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  A tenant admin wants to inspect the full PolicyDefinition (selectors,
+  rules, enforcement) of the access policy with id
+  `00000000-0000-0000-0000-000000000001` before deciding whether to edit
+  it. Use the uipath-gov-access-policy skill.
+
+  Save a summary to report.json in the current working directory with at
+  minimum:
+    {
+      "policy_id": "00000000-0000-0000-0000-000000000001",
+      "get_command": "<exact uip gov access-policy get command you ran>",
+      "commands_used": ["<list of uip commands you attempted>"]
+    }
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live governance
+    tenant in this environment. Commands will fail with auth errors — that
+    is expected. Run each command once, record the result (success or
+    error) in report.json, and move on. Do NOT retry or attempt to login.
+  - Use --output json on every uip gov access-policy command.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip gov access-policy get <UUID>` with --output json against the requested UUID"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+access-policy\s+get\s+["'']?00000000-0000-0000-0000-000000000001["'']?\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json references the current CLI namespace and avoids removed/legacy evaluate flag names"
+    path: "report.json"
+    includes:
+      - "uip gov access-policy get"
+    excludes:
+      - "uip admin access-policy"
+      - "--actor-identifier"
+      - "--executable-type"
+      - "--executable-identifier"
+      - "--resource-identifier"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure"
+    path: "report.json"
+    assertions:
+      - expression: "policy_id"
+        operator: equals
+        expected: "00000000-0000-0000-0000-000000000001"
+      - expression: "length(get_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 1
+    weight: 1.5
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-gov-access-policy/list_policies_smoke.yaml
+++ b/tests/tasks/uipath-gov-access-policy/list_policies_smoke.yaml
@@ -1,0 +1,98 @@
+task_id: skill-gov-access-policy-list-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-gov-access-policy skill
+  to list access policies for the tenant with an OData filter and sort.
+  Tests whether the skill teaches the correct CLI namespace
+  (`uip gov access-policy`), the `--output json` convention, and the
+  OData `--filter` / `--order-by` syntax taught in
+  access-policy-commands.md.
+
+  Platform note: the smoke test runs without an authenticated tenant, so
+  `uip gov access-policy` commands that hit the service will fail with an
+  auth error. That is acceptable — what matters is that the agent invokes
+  the correct commands with the correct flags.
+tags: [uipath-gov-access-policy, smoke, list]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  A tenant admin wants to see every Active access policy for the tenant,
+  ordered by policy name ascending. Use the uipath-gov-access-policy
+  skill to produce the result.
+
+  Save a summary to report.json in the current working directory with at
+  minimum:
+    {
+      "list_command": "<exact uip gov access-policy list command you ran>",
+      "filter_used": "<the --filter expression you passed, or '' if none>",
+      "order_by_used": "<the --order-by expression you passed, or '' if none>",
+      "commands_used": ["<list of uip commands you attempted>"]
+    }
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live governance
+    tenant in this environment. Commands will fail with auth errors — that
+    is expected. Run each command once, record the result (success or
+    error) in report.json, and move on. Do NOT retry or attempt to login.
+  - Use --output json on every uip gov access-policy command.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip gov access-policy list` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+access-policy\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent passed an OData --filter expression on the list command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+access-policy\s+list\s+.*--filter\s+'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent passed an --order-by expression on the list command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+access-policy\s+list\s+.*--order-by\s+'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "report.json references the current CLI namespace and uses no removed/legacy evaluate flag names"
+    path: "report.json"
+    includes:
+      - "uip gov access-policy"
+    excludes:
+      - "uip admin access-policy"
+      - "--actor-identifier"
+      - "--executable-type"
+      - "--executable-identifier"
+      - "--resource-identifier"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure"
+    path: "report.json"
+    assertions:
+      - expression: "length(list_command)"
+        operator: gte
+        expected: 10
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 1
+    weight: 1.5
+    pass_threshold: 0.75


### PR DESCRIPTION
## Summary

- New skill `uipath-gov-access-policy` for authoring access policies of type `ToolUsePolicy` via the `uip gov access-policy` CLI (list / get / create / update / delete / evaluate).
- "Access policy" is treated as the broad category — `uip gov access-policy` returns multiple policy types — while `ToolUsePolicy` is used strictly as the type this skill authors.
- Two-phase authoring flow: `planning-arch.md` produces a reviewable Spec (natural-language narrative + Spec Components Table) from intent; `planning-impl.md` composes the concrete `PolicyDefinition` JSON by delegating to four plugins (`selector`, `executable`, `actor`, `tags`). The agent never hand-authors JSON.
- `actor` plugin emits `actorRule` for `User` / `Group` identities. Per Critical Rule #16, `Robot` and `ExternalApplication` are not authorable types — robot intent is mapped to a `User` entry via the linked-user UUID. `tags` plugin owns the Deny-to-Allow flip (`operator: None`) since `enforcement: "Deny"` is not authorable.
- CLI command reference aligned with the current `uip gov access-policy` flag surface (`--resource-id`, `--actor-process-*`); `--actor-identity-id` is S2S-only — under a user token the actor is inferred from the bearer, and there is no `--actor-identity-type` flag.
- Resource Catalog tag lookup (`uip admin rcs tag list`) with tenant alignment — verifying tags must default to the policy's own tenant since `tenantId` is pinned at create time; cross-tenant lookups are flagged as comparison-only.
- Single confirmation gate per `create` / `update` / `delete` mutation. `update` is full-replace and always seeds from `get`.
- Two smoke tests: `list_policies_smoke.yaml` (list with OData filter / order-by) and `get_policy_smoke.yaml` (get by UUID).

## Test plan

- [ ] `bash hooks/validate-skill-descriptions.sh` passes (description includes `[PREVIEW]` + `→` redirect to `uipath-gov-aops-policy`)
- [ ] Relative links in `SKILL.md` and `references/` resolve
- [ ] Walk Quick Start end-to-end with a real intent ("allow Production AgenticProcess to invoke Production Agents") — Spec → JSON → `create` → `get` verifies the stored policy
- [ ] Walk Update flow: `get` an existing policy, change one tag operator via `plugins/tags/impl.md`, review diff, `update`, `get` confirms
- [ ] Walk Deny-to-Allow flip: "deny Development agents" → Spec narrative shows the Allow framing → `selectors[].tags.operator = "None"` in the resulting JSON
- [ ] Delete flow requires verbatim `yes` to the Critical Rule #9 confirmation prompt
- [ ] `evaluate` rejected when login is org-scoped (Critical Rule #12); accepted under tenant-scoped login
- [ ] `make test-uipath-gov-access-policy` runs the two smoke tests (note: `uip` CLI currently hangs after writing the JSON response — separate CLI bug; smoke tests time out on the test runner's turn timeout regardless of skill correctness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)