### PR TITLE
docs(maestro-flow): update connector binding docs for IS name and model.bindings.resourceKey

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -228,11 +228,14 @@ uip flow tidy <ProjectName>.flow --output json
 
 After validation passes, the user may want to test the flow end-to-end. **Do not run this without explicit user consent** — debug executes the flow for real (sends emails, posts messages, calls APIs). See Critical Rule #9.
 
+**Always refresh solution resources before debug** so that connection and process resource declarations are in sync with the project bindings:
+
 ```bash
+uip solution resource refresh <SolutionDir> --output json
 UIPCLI_LOG_LEVEL=info uip flow debug <path-to-project-dir> --output json
 ```
 
-The argument is the **project directory path** (the folder containing `project.uiproj`). Use `<ProjectName>/` from the solution dir, or `.` if already inside the project dir. This uploads the project to Studio Web, triggers a debug session in Orchestrator, and streams results.
+The argument to `resource refresh` is the **solution directory** (containing the `.uipx` file). The argument to `debug` is the **project directory path** (the folder containing `project.uiproj`). Use `<ProjectName>/` from the solution dir, or `.` if already inside the project dir. This uploads the project to Studio Web, triggers a debug session in Orchestrator, and streams results.
 
 > **Note:** Requires `uip login`. Debug is for **testing that the flow runs correctly** — not for publishing or viewing. To publish, use Step 9 instead.
 
@@ -240,9 +243,12 @@ The argument is the **project directory path** (the folder containing `project.u
 
 ### Step 9 — Publish to Studio Web
 
-**This is the default publish target.** After tidy (Step 7), when the user wants to publish, view, or share the flow, upload the solution directly to Studio Web:
+**This is the default publish target.** After tidy (Step 7), when the user wants to publish, view, or share the flow, **refresh solution resources first**, then upload:
 
 ```bash
+# Sync resource declarations from project bindings
+uip solution resource refresh <SolutionDir> --output json
+
 # Upload the solution folder (containing the .uipx) to Studio Web
 uip solution upload <SolutionDir> --output json
 ```
@@ -259,9 +265,9 @@ When the build completes and it is time to offer next steps (see Completion Outp
 
 | Option | Action |
 |--------|--------|
-| **Publish to Studio Web** (default) | Run `uip solution upload <SolutionDir> --output json` and share the Studio Web URL. |
-| **Debug the solution** | Run `UIPCLI_LOG_LEVEL=info uip flow debug <ProjectDir>` (see Step 8). Confirm consent first — debug executes the flow for real. |
-| **Deploy to Orchestrator** | Run `uip flow pack` + `uip solution publish` via the [/uipath:uipath-platform](/uipath:uipath-platform) skill. Only use when the user explicitly chooses this. |
+| **Publish to Studio Web** (default) | Run `uip solution resource refresh <SolutionDir> --output json` then `uip solution upload <SolutionDir> --output json` and share the Studio Web URL. |
+| **Debug the solution** | Run `uip solution resource refresh <SolutionDir> --output json` then `UIPCLI_LOG_LEVEL=info uip flow debug <ProjectDir>` (see Step 8). Confirm consent first — debug executes the flow for real. |
+| **Deploy to Orchestrator** | Run `uip solution resource refresh <SolutionDir> --output json` then `uip flow pack` + `uip solution publish` via the [/uipath:uipath-platform](/uipath:uipath-platform) skill. Only use when the user explicitly chooses this. |
 | **Something else** | Last option. Accept free-form string input and act on it (e.g., "just leave it", "pack but don't publish", "upload to a different tenant"). |
 
 Do not run any of these actions without an explicit user selection.

--- a/skills/uipath-maestro-flow/references/flow-commands.md
+++ b/skills/uipath-maestro-flow/references/flow-commands.md
@@ -68,6 +68,16 @@ Requires `content/package-descriptor.json` and `content/operate.json` in the pro
 
 > **Note:** `pack` + `uip solution publish` deploys directly to Orchestrator — the user cannot visualize or edit the flow in Studio Web via this path. Only use this when the user explicitly asks to deploy to Orchestrator. The default publish path is `uip solution upload` (see below). See [uipath-platform](/uipath:uipath-platform) for `solution publish` commands.
 
+## uip solution resource refresh
+
+Re-scan all projects in the solution and sync resource declarations (connections, processes, queues, etc.) from their `bindings_v2.json` files. Creates new resources for bindings not yet in the solution, imports from Orchestrator when a matching resource exists. **Always run this before `uip solution upload` or `uip flow debug`.**
+
+```bash
+uip solution resource refresh <SolutionDir> --output json
+```
+
+The argument is the solution directory (containing the `.uipx` file). Defaults to the current directory if omitted.
+
 ## uip solution upload
 
 Upload a solution directly to Studio Web. **Requires `uip login`.**

--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -202,13 +202,22 @@ For every unique connection used in the flow, add **two entries** to top-level `
 | Field | Value |
 |-------|-------|
 | `id` | Unique string within the file. Descriptive (e.g. `bJiraConn`) or short random (e.g. `bKEFLMRB2`). |
-| `name` (connection binding) | `"<CONNECTOR_KEY> connection"` — must match the string inside the node's `model.context[].connection` placeholder (without `<bindings.` prefix and `>` suffix). |
+| `name` (connection binding) | The IS connection name (e.g. `"chandu.lella@uipath.com #3"`). `uip flow node configure` fetches this from IS automatically. When adding bindings by hand, use `"<CONNECTOR_KEY> connection"` as a placeholder — it must match the `model.context[].connection` placeholder (without `<bindings.` prefix and `>` suffix). |
 | `name` (folder binding) | Literal `"FolderKey"` — matches `<bindings.FolderKey>`. |
 | `type` | Always `"string"`. |
 | `resource` | Always `"Connection"` — capital C, case-sensitive. |
 | `resourceKey` | The connection UUID from `uip is connections list`. **Same UUID on both bindings.** |
 | `default` | Connection binding → connection UUID. Folder binding → folder key. |
 | `propertyAttribute` | `"ConnectionId"` or `"FolderKey"` — case matters. |
+
+`uip flow node configure` also sets `model.bindings.resourceKey` on the node (the connection UUID). This enables `flow-schema` to correlate the node with its Connection binding when generating `bindings_v2.json`. When adding bindings by hand, set this field on the node too:
+
+```json
+"model": {
+  "bindings": { "resourceKey": "<CONNECTION_UUID>" },
+  "context": [ ... ]
+}
+```
 
 **Share bindings across nodes using the same connection.** If two connector nodes share the same `<CONNECTION_UUID>`, reuse the same two entries — do not add duplicates. Matching is by `name`, so as long as the node's `connectorKey` matches the binding's `name` prefix, both nodes resolve the same connection.
 
@@ -268,13 +277,13 @@ At debug/pack time, the CLI derives `content/bindings_v2.json` from the top-leve
         "ConnectionId": {
           "defaultValue": "7622a703-5d85-4b55-849b-6c02315b9e6e",
           "isExpression": false,
-          "displayName": "uipath-atlassian-jira connection"
+          "displayName": "my-jira-connection"
         }
       },
       "metadata": {
         "ActivityName": "Create Issue",
         "BindingsVersion": "2.2",
-        "DisplayLabel": "uipath-atlassian-jira connection",
+        "DisplayLabel": "my-jira-connection",
         "UseConnectionService": "true",
         "Connector": "uipath-atlassian-jira"
       }


### PR DESCRIPTION
## Summary
- Update connector binding `name` field docs: `uip flow node configure` now fetches the real IS connection name instead of using `<connectorKey> connection`
- Document `model.bindings.resourceKey` on connector nodes — required for flow-schema to correlate nodes with Connection bindings when generating `bindings_v2.json`
- Update `bindings_v2.json` example to reflect IS connection names

Companion to UiPath/cli#866

Generated with [Claude Code](https://claude.com/claude-code)