### PR TITLE
feat: add IS coded workflow test tasks and validation scripts (#ENGCE-56645)

### DIFF
--- a/skills/uipath-rpa/references/coded/integration-service-guide.md
+++ b/skills/uipath-rpa/references/coded/integration-service-guide.md
@@ -155,6 +155,7 @@ Create (or update) `.codedworkflows/ISConnections.cs`. One class per connector, 
 
 ```csharp
 // .codedworkflows/ISConnections.cs — managed by coding agent — regenerate via uipath-rpa skill when connections change.
+using UiPath.CodedWorkflows;
 using UiPath.IntegrationService.Activities.Runtime.CodedWorkflows;
 
 // Determine the namespace from other .cs files in the project root:

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_add_comment.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_add_comment.yaml
@@ -1,0 +1,118 @@
+task_id: uipath-coded-jira-add-comment
+description: >
+  Create a UiPath coded workflow (C#) that adds a comment on Jira ticket JTD-10
+  using the Jira Integration Service connector. Exercises coded workflow
+  scaffolding and connector usage.
+tags: [rpa, coded, jira, integration]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  setting_sources: ["user", "project"]
+  system_prompt: |
+    You are a UiPath automation coding agent. Complete tasks efficiently and directly.
+
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
+    - `uip rpa get-errors`
+    - `uip rpa build`
+    - `uip pack`
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath coded workflow project named "JiraAddComment" and generate
+  JiraAddComment.cs file that adds the comment "Comment added by coded workflow"
+  on Jira ticket JTD-10.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
+
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
+
+success_criteria:
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "JiraAddComment/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "JiraAddComment/JiraAddComment.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Coded workflow contains curated_add_comment, ticket ID, comment body, and IS wiring"
+    command: >-
+      python $TASK_DIR/validate_file_contains.py
+      "JiraAddComment/JiraAddComment.cs"
+      "curated_add_comment"
+      "JTD-10"
+      "issueIdOrKey"
+      "Comment added by coded workflow"
+      "ISConnections"
+      "Operation.Create"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Integration Service discovery ─────────────────────────────────────
+  - type: run_command
+    description: "Agent ran all required IS discovery commands"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "JiraAddComment/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "JiraAddComment/.project/ISBindingMetadata.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+llm_reviewer:
+  enabled: false

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_add_comment.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_add_comment.yaml
@@ -7,6 +7,7 @@ tags: [uipath-rpa, coded, jira, integration]
 max_iterations: 1
 
 agent:
+  type: claude-code
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_add_comment.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_add_comment.yaml
@@ -1,15 +1,12 @@
-task_id: uipath-coded-jira-add-comment
+task_id: skill-rpa-coded-jira-add-comment
 description: >
   Create a UiPath coded workflow (C#) that adds a comment on Jira ticket JTD-10
   using the Jira Integration Service connector. Exercises coded workflow
   scaffolding and connector usage.
-tags: [rpa, coded, jira, integration]
+tags: [uipath-rpa, coded, jira, integration]
 max_iterations: 1
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
@@ -1,0 +1,117 @@
+task_id: uipath-coded-jira-create-group
+description: >
+  Create a UiPath coded workflow (C#) that creates a new Jira group named
+  "CodedWorkflowTestGroup" using the Jira Integration Service connector.
+  Exercises coded workflow scaffolding and connector usage.
+tags: [rpa, coded, jira, default]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  setting_sources: ["user", "project"]
+  system_prompt: |
+    You are a UiPath automation coding agent. Complete tasks efficiently and directly.
+
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
+    - `uip rpa get-errors`
+    - `uip rpa build`
+    - `uip pack`
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath coded workflow project named "JiraCreateGroup" and generate
+  JiraCreateGroup.cs file that creates a new Jira group named "CodedWorkflowTestGroup".
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
+
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
+
+success_criteria:
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "JiraCreateGroup/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "JiraCreateGroup/JiraCreateGroup.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Coded workflow contains group resource, group name, and IS wiring"
+    command: >-
+      python $TASK_DIR/validate_file_contains.py
+      "JiraCreateGroup/JiraCreateGroup.cs"
+      "objectName: \"group\""
+      "CodedWorkflowTestGroup"
+      "Operation.Create"
+      "ActivityType.Generic"
+      "ISConnections"
+      "ExecuteAsync"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Integration Service discovery ─────────────────────────────────────
+  - type: run_command
+    description: "Agent ran all required IS discovery commands"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "JiraCreateGroup/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "JiraCreateGroup/.project/ISBindingMetadata.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+llm_reviewer:
+  enabled: false

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
@@ -1,15 +1,12 @@
-task_id: uipath-coded-jira-create-group
+task_id: skill-rpa-coded-jira-create-group
 description: >
   Create a UiPath coded workflow (C#) that creates a new Jira group named
   "CodedWorkflowTestGroup" using the Jira Integration Service connector.
   Exercises coded workflow scaffolding and connector usage.
-tags: [rpa, coded, jira, default]
+tags: [uipath-rpa, coded, jira, smoke]
 max_iterations: 1
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
@@ -7,6 +7,7 @@ tags: [uipath-rpa, coded, jira, smoke]
 max_iterations: 1
 
 agent:
+  type: claude-code
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
@@ -1,11 +1,9 @@
 task_id: skill-rpa-coded-jira-create-group
 description: >
-  Smoke test: validate code-generation logic for a UiPath coded workflow (C#)
-  that creates a new Jira group "CodedWorkflowTestGroup" via the Jira
-  Integration Service connector. Asserts the agent runs `uip is` discovery
-  commands and generates correct source; does not depend on Studio Desktop or
-  the `uip rpa` plugin.
-tags: [uipath-rpa, coded, jira, smoke]
+  Create a UiPath coded workflow (C#) that creates a new Jira group named
+  "CodedWorkflowTestGroup" using the Jira Integration Service connector.
+  Exercises coded workflow scaffolding and connector usage.
+tags: [uipath-rpa, coded, jira, integration]
 max_iterations: 1
 
 agent:
@@ -14,70 +12,64 @@ agent:
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.
 
-    ENVIRONMENT — Studio Desktop is NOT available in this sandbox. Skip every
-    uip CLI command that requires `--use-studio` or that auto-installs a Studio
-    plugin, including:
-    - `uip rpa create-project`
-    - `uip rpa install-or-update-packages`
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
     - `uip rpa get-errors`
     - `uip rpa build`
     - `uip pack`
-
-    DO use the `uip is` Integration Service commands to discover connectors,
-    activities, and resource schemas before writing the C# source. Generate the
-    source code files directly with the Write tool. Do not build, validate, or
-    diagnose.
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
 
 sandbox:
   driver: tempdir
   python: {}
 
 initial_prompt: |
-  Generate a UiPath coded workflow (C#) that creates a new Jira group named
-  "CodedWorkflowTestGroup" using the Jira Integration Service connector.
+  Create a UiPath coded workflow project named "JiraCreateGroup" and generate
+  JiraCreateGroup.cs file that creates a new Jira group named "CodedWorkflowTestGroup".
 
-  Studio Desktop is NOT available — do NOT run `uip rpa create-project`,
-  `uip rpa install-or-update-packages`, or any other `--use-studio` command.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
 
-  USE `uip is` commands to discover the Jira connector, its connections,
-  activities, and the `group` resource schema (e.g. `uip is connectors list`,
-  `uip is connections list`, `uip is activities list`, `uip is resources list`,
-  `uip is resources describe`). Use what you learn to write the correct C# code.
-
-  Then write these files at exactly these paths (relative to the working
-  directory) using the Write tool:
-    - JiraCreateGroup.cs   — the coded workflow class
-    - ISConnections.cs     — Integration Service connections wrapper
-
-  JiraCreateGroup.cs must:
-    - target the Jira "group" resource: `objectName: "group"`
-    - pass the group name "CodedWorkflowTestGroup"
-    - use `Operation.Create` and `ActivityType.Generic`
-    - reference `ISConnections` and call `ExecuteAsync`
-
-  Do NOT ask for approval, confirmation, or feedback. Stop once both files are
-  written.
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
 
 success_criteria:
-  - type: run_command
-    description: "Agent ran the required uip is discovery commands"
-    command: >-
-      python $TASK_DIR/validate_commands_executed.py
-      "uip\\s+is\\s+connectors\\s+list"
-      "uip\\s+is\\s+connections\\s+list"
-      "uip\\s+is\\s+activities\\s+list"
-      "uip\\s+is\\s+resources\\s+list"
-      "uip\\s+is\\s+resources\\s+describe"
-    timeout: 30
-    expected_exit_code: 0
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "JiraCreateGroup/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "JiraCreateGroup/JiraCreateGroup.cs"
     weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Generated JiraCreateGroup.cs contains group resource, group name, and IS wiring"
+    description: "Coded workflow contains group resource, group name, and IS wiring"
     command: >-
       python $TASK_DIR/validate_file_contains.py
-      "JiraCreateGroup.cs"
+      "JiraCreateGroup/JiraCreateGroup.cs"
       "objectName: \"group\""
       "CodedWorkflowTestGroup"
       "Operation.Create"
@@ -89,14 +81,33 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # ── Integration Service discovery ─────────────────────────────────────
   - type: run_command
-    description: "Generated ISConnections.cs exposes the IS connections wrapper class"
+    description: "Agent ran all required IS discovery commands"
     command: >-
-      python $TASK_DIR/validate_file_contains.py
-      "ISConnections.cs"
-      "ISConnections"
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
     timeout: 30
     expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "JiraCreateGroup/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "JiraCreateGroup/.project/ISBindingMetadata.json"
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_group.yaml
@@ -1,8 +1,10 @@
 task_id: skill-rpa-coded-jira-create-group
 description: >
-  Create a UiPath coded workflow (C#) that creates a new Jira group named
-  "CodedWorkflowTestGroup" using the Jira Integration Service connector.
-  Exercises coded workflow scaffolding and connector usage.
+  Smoke test: validate code-generation logic for a UiPath coded workflow (C#)
+  that creates a new Jira group "CodedWorkflowTestGroup" via the Jira
+  Integration Service connector. Asserts the agent runs `uip is` discovery
+  commands and generates correct source; does not depend on Studio Desktop or
+  the `uip rpa` plugin.
 tags: [uipath-rpa, coded, jira, smoke]
 max_iterations: 1
 
@@ -12,64 +14,70 @@ agent:
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.
 
-    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
-    even if a skill or reference guide suggests them:
+    ENVIRONMENT — Studio Desktop is NOT available in this sandbox. Skip every
+    uip CLI command that requires `--use-studio` or that auto-installs a Studio
+    plugin, including:
+    - `uip rpa create-project`
+    - `uip rpa install-or-update-packages`
     - `uip rpa get-errors`
     - `uip rpa build`
     - `uip pack`
-    Your job is ONLY to scaffold the project, install required packages, and write the
-    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+    DO use the `uip is` Integration Service commands to discover connectors,
+    activities, and resource schemas before writing the C# source. Generate the
+    source code files directly with the Write tool. Do not build, validate, or
+    diagnose.
 
 sandbox:
   driver: tempdir
   python: {}
 
 initial_prompt: |
-  Create a UiPath coded workflow project named "JiraCreateGroup" and generate
-  JiraCreateGroup.cs file that creates a new Jira group named "CodedWorkflowTestGroup".
+  Generate a UiPath coded workflow (C#) that creates a new Jira group named
+  "CodedWorkflowTestGroup" using the Jira Integration Service connector.
 
-  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
-  planning and implementation. Complete the project end-to-end in a single pass.
+  Studio Desktop is NOT available — do NOT run `uip rpa create-project`,
+  `uip rpa install-or-update-packages`, or any other `--use-studio` command.
 
-  Your goal is to scaffold the project, install
-  required packages, and write the source code. Stop once the .cs file is written.
+  USE `uip is` commands to discover the Jira connector, its connections,
+  activities, and the `group` resource schema (e.g. `uip is connectors list`,
+  `uip is connections list`, `uip is activities list`, `uip is resources list`,
+  `uip is resources describe`). Use what you learn to write the correct C# code.
+
+  Then write these files at exactly these paths (relative to the working
+  directory) using the Write tool:
+    - JiraCreateGroup.cs   — the coded workflow class
+    - ISConnections.cs     — Integration Service connections wrapper
+
+  JiraCreateGroup.cs must:
+    - target the Jira "group" resource: `objectName: "group"`
+    - pass the group name "CodedWorkflowTestGroup"
+    - use `Operation.Create` and `ActivityType.Generic`
+    - reference `ISConnections` and call `ExecuteAsync`
+
+  Do NOT ask for approval, confirmation, or feedback. Stop once both files are
+  written.
 
 success_criteria:
-  # ── Project scaffolding ────────────────────────────────────────────────
-  - type: command_executed
-    description: "Agent created a coded workflow project via uip CLI"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+rpa\s+create-project'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "project.json exists for the coded workflow project"
-    path: "JiraCreateGroup/project.json"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent installed the IntegrationService Activities package"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  # ── Coded workflow source ──────────────────────────────────────────────
-  - type: file_exists
-    description: "Coded workflow .cs file exists in the project"
-    path: "JiraCreateGroup/JiraCreateGroup.cs"
+  - type: run_command
+    description: "Agent ran the required uip is discovery commands"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Coded workflow contains group resource, group name, and IS wiring"
+    description: "Generated JiraCreateGroup.cs contains group resource, group name, and IS wiring"
     command: >-
       python $TASK_DIR/validate_file_contains.py
-      "JiraCreateGroup/JiraCreateGroup.cs"
+      "JiraCreateGroup.cs"
       "objectName: \"group\""
       "CodedWorkflowTestGroup"
       "Operation.Create"
@@ -81,33 +89,14 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  # ── Integration Service discovery ─────────────────────────────────────
   - type: run_command
-    description: "Agent ran all required IS discovery commands"
+    description: "Generated ISConnections.cs exposes the IS connections wrapper class"
     command: >-
-      python $TASK_DIR/validate_commands_executed.py
-      "uip\\s+rpa\\s+create-project"
-      "uip\\s+rpa\\s+install-or-update-packages"
-      "uip\\s+is\\s+connectors\\s+list"
-      "uip\\s+is\\s+connections\\s+list"
-      "uip\\s+is\\s+activities\\s+list"
-      "uip\\s+is\\s+resources\\s+list"
-      "uip\\s+is\\s+resources\\s+describe"
+      python $TASK_DIR/validate_file_contains.py
+      "ISConnections.cs"
+      "ISConnections"
     timeout: 30
     expected_exit_code: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
-  # ── Integration Service wiring ─────────────────────────────────────────
-  - type: file_exists
-    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
-    path: "JiraCreateGroup/.codedworkflows/ISConnections.cs"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "IS binding metadata .project/ISBindingMetadata.json exists"
-    path: "JiraCreateGroup/.project/ISBindingMetadata.json"
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_ticket.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_ticket.yaml
@@ -7,6 +7,7 @@ tags: [uipath-rpa, coded, jira, integration]
 max_iterations: 1
 
 agent:
+  type: claude-code
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_ticket.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_ticket.yaml
@@ -1,15 +1,12 @@
-task_id: uipath-coded-jira-create-ticket
+task_id: skill-rpa-coded-jira-create-ticket
 description: >
   Create a UiPath coded workflow (C#) that creates a new Bug issue in the Jira
   project "Jira_TM_Demo" using the Jira Integration Service connector. Exercises
   coded workflow scaffolding and connector usage.
-tags: [rpa, coded, jira, integration]
+tags: [uipath-rpa, coded, jira, integration]
 max_iterations: 1
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_ticket.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_create_ticket.yaml
@@ -1,0 +1,119 @@
+task_id: uipath-coded-jira-create-ticket
+description: >
+  Create a UiPath coded workflow (C#) that creates a new Bug issue in the Jira
+  project "Jira_TM_Demo" using the Jira Integration Service connector. Exercises
+  coded workflow scaffolding and connector usage.
+tags: [rpa, coded, jira, integration]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  setting_sources: ["user", "project"]
+  system_prompt: |
+    You are a UiPath automation coding agent. Complete tasks efficiently and directly.
+
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
+    - `uip rpa get-errors`
+    - `uip rpa build`
+    - `uip pack`
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath coded workflow project named "JiraCreateTicket" and generate
+  JiraCreateTicket.cs file that creates a new Jira issue of type "Bug" in the
+  project "Jira_TM_Demo".
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
+
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
+
+success_criteria:
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "JiraCreateTicket/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "JiraCreateTicket/JiraCreateTicket.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Coded workflow contains curated_create_issue, project key JTD, issue type Bug, and IS wiring"
+    command: >-
+      python $TASK_DIR/validate_file_contains.py
+      "JiraCreateTicket/JiraCreateTicket.cs"
+      "curated_create_issue"
+      "JTD"
+      "Bug"
+      "Operation.Create"
+      "ISConnections"
+      "ExecuteAsync"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Integration Service discovery ─────────────────────────────────────
+  - type: run_command
+    description: "Agent ran all required IS discovery commands including project and issuetype lookups"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+      "uip\\s+is\\s+resources\\s+execute"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "JiraCreateTicket/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "JiraCreateTicket/.project/ISBindingMetadata.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+llm_reviewer:
+  enabled: false

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_list_users.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_list_users.yaml
@@ -1,15 +1,12 @@
-task_id: uipath-coded-jira-list-users
+task_id: skill-rpa-coded-jira-list-users
 description: >
   Create a UiPath coded workflow (C#) that lists all Jira users whose name
   starts with "Per" using the Jira Integration Service connector. Exercises
   coded workflow scaffolding and connector usage.
-tags: [rpa, coded, jira, integration]
+tags: [uipath-rpa, coded, jira, integration]
 max_iterations: 1
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_list_users.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_list_users.yaml
@@ -7,6 +7,7 @@ tags: [uipath-rpa, coded, jira, integration]
 max_iterations: 1
 
 agent:
+  type: claude-code
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_list_users.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_jira_list_users.yaml
@@ -1,0 +1,117 @@
+task_id: uipath-coded-jira-list-users
+description: >
+  Create a UiPath coded workflow (C#) that lists all Jira users whose name
+  starts with "Per" using the Jira Integration Service connector. Exercises
+  coded workflow scaffolding and connector usage.
+tags: [rpa, coded, jira, integration]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  setting_sources: ["user", "project"]
+  system_prompt: |
+    You are a UiPath automation coding agent. Complete tasks efficiently and directly.
+
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
+    - `uip rpa get-errors`
+    - `uip rpa build`
+    - `uip pack`
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath coded workflow project named "JiraListUsers" and generate
+  JiraListUsers.cs file that lists all Jira users whose name starts with "Per".
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
+
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
+
+success_criteria:
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "JiraListUsers/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "JiraListUsers/JiraListUsers.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Coded workflow contains user_search resource, Per query, and IS wiring"
+    command: >-
+      python $TASK_DIR/validate_file_contains.py
+      "JiraListUsers/JiraListUsers.cs"
+      "user_search"
+      "Per"
+      "query"
+      "Operation.List"
+      "ISConnections"
+      "ExecuteAsync"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Integration Service discovery ─────────────────────────────────────
+  - type: run_command
+    description: "Agent ran all required IS discovery commands"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "JiraListUsers/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "JiraListUsers/.project/ISBindingMetadata.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+llm_reviewer:
+  enabled: false

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_netsuite_create_job_status.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_netsuite_create_job_status.yaml
@@ -7,6 +7,7 @@ tags: [uipath-rpa, coded, netsuite, integration]
 max_iterations: 1
 
 agent:
+  type: claude-code
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_netsuite_create_job_status.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_netsuite_create_job_status.yaml
@@ -1,15 +1,12 @@
-task_id: uipath-coded-netsuite-create-job-status
+task_id: skill-rpa-coded-netsuite-create-job-status
 description: >
   Create a UiPath coded workflow (C#) that adds a new job status named
   "CodedWorkflowTest" in Oracle NetSuite using the NetSuite Integration Service
   connector. Exercises coded workflow scaffolding and connector usage.
-tags: [rpa, coded, netsuite, integration]
+tags: [uipath-rpa, coded, netsuite, integration]
 max_iterations: 1
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_netsuite_create_job_status.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_netsuite_create_job_status.yaml
@@ -1,0 +1,118 @@
+task_id: uipath-coded-netsuite-create-job-status
+description: >
+  Create a UiPath coded workflow (C#) that adds a new job status named
+  "CodedWorkflowTest" in Oracle NetSuite using the NetSuite Integration Service
+  connector. Exercises coded workflow scaffolding and connector usage.
+tags: [rpa, coded, netsuite, integration]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  setting_sources: ["user", "project"]
+  system_prompt: |
+    You are a UiPath automation coding agent. Complete tasks efficiently and directly.
+
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
+    - `uip rpa get-errors`
+    - `uip rpa build`
+    - `uip pack`
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath coded workflow project named "NetSuiteCreateJobStatus" and generate
+  NetSuiteCreateJobStatus.cs file that adds a new job status named "CodedWorkflowTest"
+  in Oracle NetSuite.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
+
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
+
+success_criteria:
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "NetSuiteCreateJobStatus/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "NetSuiteCreateJobStatus/NetSuiteCreateJobStatus.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Coded workflow contains JobStatus resource, job status name, and IS wiring"
+    command: >-
+      python $TASK_DIR/validate_file_contains.py
+      "NetSuiteCreateJobStatus/NetSuiteCreateJobStatus.cs"
+      "JobStatus"
+      "CodedWorkflowTest"
+      "Operation.Create"
+      "ActivityType.Generic"
+      "ISConnections"
+      "ExecuteAsync"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Integration Service discovery ─────────────────────────────────────
+  - type: run_command
+    description: "Agent ran all required IS discovery commands"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "NetSuiteCreateJobStatus/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "NetSuiteCreateJobStatus/.project/ISBindingMetadata.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+llm_reviewer:
+  enabled: false

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_slack_message.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_slack_message.yaml
@@ -1,15 +1,12 @@
-task_id: uipath-coded-slack-message
+task_id: skill-rpa-coded-slack-message
 description: >
   Create a UiPath coded workflow (C#) that sends a message to the
-  Slack channel #test-ojal-channel using the Slack Integration Service
+  Slack channel #test-channel using the Slack Integration Service
   connector. Exercises coded workflow scaffolding and connector usage.
-tags: [rpa, coded, slack, default]
+tags: [uipath-rpa, coded, slack, e2e]
 max_iterations: 1
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.
@@ -29,7 +26,7 @@ sandbox:
 initial_prompt: |
   Create a UiPath coded workflow project named "SlackChannelMessage" and generate
   SlackChannelMessage.cs file that sends the message "Hello from coded workflow" 
-  to the Slack channel #test-ojal-channel.
+  to the Slack channel #test-channel.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Complete the project end-to-end in a single pass.
@@ -74,7 +71,7 @@ success_criteria:
       python $TASK_DIR/validate_file_contains.py
       "SlackChannelMessage/SlackChannelMessage.cs"
       "send_message_to_channel_v2"
-      "#test-ojal-channel"
+      "#test-channel"
       "Hello from coded workflow"
       "ISConnections"
       "Operation.Create"

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_slack_message.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_slack_message.yaml
@@ -1,0 +1,117 @@
+task_id: uipath-coded-slack-message
+description: >
+  Create a UiPath coded workflow (C#) that sends a message to the
+  Slack channel #test-ojal-channel using the Slack Integration Service
+  connector. Exercises coded workflow scaffolding and connector usage.
+tags: [rpa, coded, slack, default]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  setting_sources: ["user", "project"]
+  system_prompt: |
+    You are a UiPath automation coding agent. Complete tasks efficiently and directly.
+
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
+    - `uip rpa get-errors`
+    - `uip rpa build`
+    - `uip pack`
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath coded workflow project named "SlackChannelMessage" and generate
+  SlackChannelMessage.cs file that sends the message "Hello from coded workflow" 
+  to the Slack channel #test-ojal-channel.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
+
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
+
+success_criteria:
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "SlackChannelMessage/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "SlackChannelMessage/SlackChannelMessage.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Coded workflow contains channel, activity, message body, and IS wiring"
+    command: >-
+      python $TASK_DIR/validate_file_contains.py
+      "SlackChannelMessage/SlackChannelMessage.cs"
+      "send_message_to_channel_v2"
+      "#test-ojal-channel"
+      "Hello from coded workflow"
+      "ISConnections"
+      "Operation.Create"
+      "ExecuteAsync"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Integration Service discovery ─────────────────────────────────────
+  - type: run_command
+    description: "Agent ran all required IS discovery commands"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "SlackChannelMessage/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "SlackChannelMessage/.project/ISBindingMetadata.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+llm_reviewer:
+  enabled: false

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_slack_message.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_slack_message.yaml
@@ -7,6 +7,7 @@ tags: [uipath-rpa, coded, slack, e2e]
 max_iterations: 1
 
 agent:
+  type: claude-code
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_teams_get_group_members.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_teams_get_group_members.yaml
@@ -1,15 +1,12 @@
-task_id: uipath-coded-teams-get-group-members
+task_id: skill-rpa-coded-teams-get-group-members
 description: >
   Create a UiPath coded workflow (C#) that fetches all members from the
   Microsoft Teams team "Test Integration Service" using the Microsoft Teams
   Integration Service connector. Exercises coded workflow scaffolding and connector usage.
-tags: [rpa, coded, teams, integration]
+tags: [uipath-rpa, coded, teams, integration]
 max_iterations: 1
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_teams_get_group_members.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_teams_get_group_members.yaml
@@ -7,6 +7,7 @@ tags: [uipath-rpa, coded, teams, integration]
 max_iterations: 1
 
 agent:
+  type: claude-code
   setting_sources: ["user", "project"]
   system_prompt: |
     You are a UiPath automation coding agent. Complete tasks efficiently and directly.

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_teams_get_group_members.yaml
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/uipath_coded_teams_get_group_members.yaml
@@ -1,0 +1,120 @@
+task_id: uipath-coded-teams-get-group-members
+description: >
+  Create a UiPath coded workflow (C#) that fetches all members from the
+  Microsoft Teams team "Test Integration Service" using the Microsoft Teams
+  Integration Service connector. Exercises coded workflow scaffolding and connector usage.
+tags: [rpa, coded, teams, integration]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  setting_sources: ["user", "project"]
+  system_prompt: |
+    You are a UiPath automation coding agent. Complete tasks efficiently and directly.
+
+    ABSOLUTE RULES — these commands are banned, never run them under any circumstances,
+    even if a skill or reference guide suggests them:
+    - `uip rpa get-errors`
+    - `uip rpa build`
+    - `uip pack`
+    Your job is ONLY to scaffold the project, install required packages, and write the
+    source code. Stop as soon as the .cs file is written. Do not build, validate, or diagnose.
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath coded workflow project named "TeamsGetGroupMembers" and generate
+  TeamsGetGroupMembers.cs file that fetches all members from the Microsoft Teams
+  team "Test Integration Service".
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the project end-to-end in a single pass.
+
+  Your goal is to scaffold the project, install
+  required packages, and write the source code. Stop once the .cs file is written.
+
+success_criteria:
+  # ── Project scaffolding ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent created a coded workflow project via uip CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+create-project'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "project.json exists for the coded workflow project"
+    path: "TeamsGetGroupMembers/project.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent installed the IntegrationService Activities package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+install-or-update-packages'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Coded workflow source ──────────────────────────────────────────────
+  - type: file_exists
+    description: "Coded workflow .cs file exists in the project"
+    path: "TeamsGetGroupMembers/TeamsGetGroupMembers.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Coded workflow contains two-step team lookup, team name, and IS wiring"
+    command: >-
+      python $TASK_DIR/validate_file_contains.py
+      "TeamsGetGroupMembers/TeamsGetGroupMembers.cs"
+      "team-by-name"
+      "list-normalised-teams::members"
+      "Test Integration Service"
+      "team_id"
+      "PathParameters"
+      "ISConnections"
+      "Operation.List"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Integration Service discovery ─────────────────────────────────────
+  - type: run_command
+    description: "Agent ran all required IS discovery commands including team_id lookup"
+    command: >-
+      python $TASK_DIR/validate_commands_executed.py
+      "uip\\s+rpa\\s+create-project"
+      "uip\\s+rpa\\s+install-or-update-packages"
+      "uip\\s+is\\s+connectors\\s+list"
+      "uip\\s+is\\s+connections\\s+list"
+      "uip\\s+is\\s+activities\\s+list"
+      "uip\\s+is\\s+resources\\s+list"
+      "uip\\s+is\\s+resources\\s+describe"
+      "uip\\s+is\\s+resources\\s+execute"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # ── Integration Service wiring ─────────────────────────────────────────
+  - type: file_exists
+    description: "IS connections wrapper .codedworkflows/ISConnections.cs exists"
+    path: "TeamsGetGroupMembers/.codedworkflows/ISConnections.cs"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "IS binding metadata .project/ISBindingMetadata.json exists"
+    path: "TeamsGetGroupMembers/.project/ISBindingMetadata.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+llm_reviewer:
+  enabled: false

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/validate_commands_executed.py
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/validate_commands_executed.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Validate that the agent executed Bash commands matching all given regex patterns.
+
+Reads the agent transcript from $TRANSCRIPT_PATH env var (or first positional
+argument when it is an existing file path), then checks that every supplied
+regex pattern matches at least one Bash tool call in the transcript.
+
+Usage:
+    python validate_commands_executed.py <pattern1> [pattern2 ...]
+    python validate_commands_executed.py /path/to/transcript.json <pattern1> [pattern2 ...]
+
+Exits 0 if all patterns matched, 1 otherwise.
+"""
+import json
+import os
+import re
+import sys
+
+
+def load_bash_commands(transcript_path: str) -> list[str]:
+    with open(transcript_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    commands: list[str] = []
+    messages = data if isinstance(data, list) else data.get("messages", [])
+
+    for msg in messages:
+        content = msg.get("content", [])
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "tool_use":
+                    if block.get("name") == "Bash":
+                        cmd = block.get("input", {}).get("command", "")
+                        if cmd:
+                            commands.append(cmd)
+        for tc in msg.get("tool_calls", []):
+            if tc.get("function", {}).get("name") == "Bash":
+                try:
+                    cmd = json.loads(tc["function"].get("arguments", "{}")).get("command", "")
+                    if cmd:
+                        commands.append(cmd)
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
+    return commands
+
+
+def main() -> None:
+    args = sys.argv[1:]
+    transcript_path = os.environ.get("TRANSCRIPT_PATH")
+
+    if not transcript_path:
+        if args and os.path.isfile(args[0]):
+            transcript_path = args[0]
+            args = args[1:]
+        else:
+            print("FAIL: Transcript path not found. Set $TRANSCRIPT_PATH or pass it as the first argument.")
+            sys.exit(1)
+
+    if not args:
+        print("FAIL: No patterns provided.")
+        sys.exit(1)
+
+    try:
+        commands = load_bash_commands(transcript_path)
+    except FileNotFoundError:
+        print(f"FAIL: Transcript file not found: {transcript_path}")
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"FAIL: Could not parse transcript JSON: {e}")
+        sys.exit(1)
+
+    missing = [p for p in args if not any(re.search(p, cmd) for cmd in commands)]
+
+    if missing:
+        print(f"FAIL: {len(missing)} pattern(s) not found in {len(commands)} agent Bash command(s):")
+        for p in missing:
+            print(f"  - {p!r}")
+        sys.exit(1)
+
+    print(f"PASS: All {len(args)} pattern(s) matched across {len(commands)} agent Bash command(s).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/validate_file_contains.py
+++ b/tests/tasks/uipath-rpa/coded_workflow/IntegrationService/validate_file_contains.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Validate that a file contains all expected strings.
+
+Usage:
+    python validate_file_contains.py <file_path> <string1> [string2 ...]
+
+Exits 0 if all strings are found, 1 otherwise.
+"""
+import sys
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: validate_file_contains.py <file_path> <string1> [string2 ...]")
+        sys.exit(1)
+
+    file_path = sys.argv[1]
+    expected = sys.argv[2:]
+
+    try:
+        with open(file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+    except FileNotFoundError:
+        print(f"FAIL: File not found: {file_path}")
+        sys.exit(1)
+
+    missing = [s for s in expected if s not in content]
+    if missing:
+        print(f"FAIL: Missing strings in {file_path}:")
+        for s in missing:
+            print(f"  - {s!r}")
+        sys.exit(1)
+
+    print(f"PASS: All {len(expected)} string(s) found in {file_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add 7 Integration Service coded workflow test tasks covering Slack, Jira, NetSuite, and Microsoft Teams connectors. Include two shared Python validators (validate_file_contains.py, validate_commands_executed.py) that replace verbose per-check YAML blocks with single script invocations, and align success criteria with actual agent execution patterns observed from a reference run.