### PR TITLE
docs: update folders list commands for CLI redesign

### DIFF
--- a/skills/uipath-platform/references/orchestrator-guide.md
+++ b/skills/uipath-platform/references/orchestrator-guide.md
@@ -86,22 +86,23 @@ A job is a single execution of a process. Jobs have states:
 
 | Command | Description |
 |---------|-------------|
-| `uip or folders list` | List all folders (Standard and Solution only) |
-| `uip or folders list-current-user` | List **all** folders for current user — includes Personal Workspaces, Solution folders, and Standard folders not shown by `folders list` |
-| `uip or folders create <name>` | Create a folder (use `--parent <id>` for nesting) |
+| `uip or folders list` | List folders the current user has access to |
+| `uip or folders list --all` | List all folders in tenant (Standard + Solution). Supports `--type`, `--name`, `--path`, `--top-level`, `--order-by` |
+| `uip or folders create <name>` | Create a folder (use `--parent <key-or-path>` for nesting) |
 | `uip or folders get <key>` | Get folder details by key (GUID) or path |
 | `uip or folders edit <key>` | Edit folder properties |
 | `uip or folders move <key>` | Move folder (use `--parent` or `--root`) |
 | `uip or folders delete <key>` | Delete a folder |
 | `uip or folders runtimes <key>` | List available runtimes in folder |
 
-> **Finding Personal Workspaces:** `folders list` only returns Standard and Solution folders. Use `folders list-current-user` to find Personal Workspaces — it returns an `IsPersonal` field.
+> **`folders list` vs `folders list --all`:** By default, `list` returns only folders the current user is assigned to. Use `--all` to see all folders in the tenant (requires appropriate permissions). `--all` enables filtering: `--type standard|solution`, `--name`, `--path`, `--top-level`, `--order-by`.
 
 ```bash
 uip or folders list --output json
-uip or folders list-current-user --output json
+uip or folders list --all --output json
+uip or folders list --all --type standard --top-level --output json
 uip or folders create "Finance" --output json
-uip or folders create "Invoicing" --parent 12345 -d "Invoice processing" --output json
+uip or folders create "Invoicing" --parent "Finance" -d "Invoice processing" --output json
 ```
 
 ---

--- a/skills/uipath-platform/references/orchestrator-guide.md
+++ b/skills/uipath-platform/references/orchestrator-guide.md
@@ -95,12 +95,15 @@ A job is a single execution of a process. Jobs have states:
 | `uip or folders delete <key>` | Delete a folder |
 | `uip or folders runtimes <key>` | List available runtimes in folder |
 
-> **`folders list` vs `folders list --all`:** By default, `list` returns only folders the current user is assigned to. Use `--all` to see all folders in the tenant (requires appropriate permissions). `--all` enables filtering: `--type standard|solution`, `--name`, `--path`, `--top-level`, `--order-by`.
+> **`folders list` vs `folders list --all`:** By default, `list` returns only folders the current user is assigned to. Use `--all` to see all folders in the tenant (requires appropriate permissions). `--all` enables filtering: `--type standard|solution|personal`, `--name`, `--path`, `--top-level`, `--order-by`.
+>
+> **Personal Workspaces:** Use `--type personal` to list personal workspaces. This returns a different shape (Key, Name, OwnerName, OwnerKey, LastLogin). `--path` and `--top-level` are not supported with `--type personal` (workspaces are flat).
 
 ```bash
 uip or folders list --output json
 uip or folders list --all --output json
 uip or folders list --all --type standard --top-level --output json
+uip or folders list --all --type personal --output json
 uip or folders create "Finance" --output json
 uip or folders create "Invoicing" --parent "Finance" -d "Invoice processing" --output json
 ```

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -27,8 +27,8 @@ Manage folders, jobs, processes, machines, users, packages, and more. See [orche
 
 | Command | Description |
 |---|---|
-| `uip or folders list` | List all folders (Standard + Solution) |
-| `uip or folders list-current-user` | List all folders for current user — **includes Personal Workspaces** |
+| `uip or folders list` | List folders the current user has access to |
+| `uip or folders list --all` | List all folders in tenant (Standard + Solution). Supports `--type`, `--name`, `--path`, `--top-level`, `--order-by` |
 | `uip or folders create <name>` | Create a folder |
 | `uip or processes list` | List processes in folder (`--folder-path`) |
 | `uip or processes create <name>` | Create process binding |


### PR DESCRIPTION
## Summary

- Update `uip-commands.md` and `orchestrator-guide.md` to reflect the `folders list` CLI redesign
- `folders list` → current user's folders (was: all tenant folders)
- `folders list --all` → all tenant folders with filtering (`--type`, `--name`, `--path`, `--top-level`, `--order-by`)
- `folders list-current-user` removed from docs

## Related

- CLI PR: UiPath/cli#876

🤖 Generated with [Claude Code](https://claude.com/claude-code)