### PR TITLE
feat(case-management): version-check uip binary before upgrading in p…

### DIFF
--- a/skills/uipath-case-management/references/planning.md
+++ b/skills/uipath-case-management/references/planning.md
@@ -21,14 +21,23 @@ Generate a reviewable task plan (`tasks.md`) from the design document (`sdd.md`)
 
 ## Step 0 — Resolve the `uip` binary
 
-`uip` is installed via npm. If it is not on PATH (common in nvm environments):
+`uip` is installed via npm. Resolve the binary (it may not be on PATH in nvm environments), capture its version, and upgrade only when the installed version is **older** than the latest published `@uipath/cli` — dev builds may be newer than the npm release, leave those alone:
 
 ```bash
 UIP=$(command -v uip 2>/dev/null || echo "$(npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip")
+CURRENT=$($UIP --version 2>/dev/null | awk '{print $NF}')
+LATEST=$(npm view @uipath/cli version 2>/dev/null)
+OLDEST=$(printf '%s\n%s\n' "$LATEST" "$CURRENT" | sort -V | head -n1)
+if [ -z "$CURRENT" ] || { [ "$CURRENT" != "$LATEST" ] && [ "$OLDEST" = "$CURRENT" ]; }; then
+  npm install -g @uipath/cli@latest
+  UIP=$(command -v uip 2>/dev/null || echo "$(npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip")
+fi
 $UIP --version
 ```
 
 Use `$UIP` in place of `uip` for all subsequent commands if the plain `uip` command isn't found.
+
+If `npm install -g` fails with a permission error, prompt the user to re-run it with the appropriate privileges (e.g., `sudo npm install -g @uipath/cli@latest`) — do not retry automatically.
 
 ## Step 1 — Check login and pull registry
 


### PR DESCRIPTION
Resolve the uip binary, read its version, and only `npm install -g
@uipath/cli@latest` when the installed version is older than the
published one — dev builds can be newer than npm, so leave those
alone. If the global install fails with a permission error, prompt
the user rather than retrying automatically.