### PR TITLE
fix(case-management): migrate wait-for-timer to direct JSON write

### DIFF
--- a/skills/uipath-case-management/references/case-editing-operations.md
+++ b/skills/uipath-case-management/references/case-editing-operations.md
@@ -17,6 +17,7 @@ Default strategy is **CLI**. Plugins opt in to direct JSON when they've been mig
 | `triggers/timer` | CLI | Migration queued. |
 | `triggers/event` | CLI | Migration queued. |
 | `variables/global-vars` | **JSON** | No CLI exists for variable declaration — always written directly into `caseplan.json`. See [plugins/variables/global-vars/impl-json.md](plugins/variables/global-vars/impl-json.md). |
+| `variables/io-binding` | **JSON** | Direct write to `task.data.inputs[i].value`. No CLI needed. See [plugins/variables/io-binding/impl-json.md](plugins/variables/io-binding/impl-json.md). |
 | `tasks/process` | CLI | Migration queued. |
 | `tasks/agent` | CLI | Migration queued. |
 | `tasks/rpa` | CLI | Migration queued. |
@@ -25,7 +26,7 @@ Default strategy is **CLI**. Plugins opt in to direct JSON when they've been mig
 | `tasks/case-management` | CLI | Migration queued. |
 | `tasks/connector-activity` | CLI | Migration queued. Auto-injected default entry condition complicates the recipe. |
 | `tasks/connector-trigger` | CLI | Migration queued. Same as connector-activity. |
-| `tasks/wait-for-timer` | CLI | Migration queued. |
+| `tasks/wait-for-timer` | **JSON** | Writes full task with `timerType` + duration. See [plugins/tasks/wait-for-timer/impl-json.md](plugins/tasks/wait-for-timer/impl-json.md). |
 | `conditions/stage-entry-conditions` | CLI | Migration queued. |
 | `conditions/stage-exit-conditions` | CLI | Migration queued. |
 | `conditions/task-entry-conditions` | CLI | Migration queued. |

--- a/skills/uipath-case-management/references/plugins/tasks/wait-for-timer/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/tasks/wait-for-timer/impl-json.md
@@ -1,0 +1,87 @@
+# wait-for-timer task — Implementation (Direct JSON Write)
+
+Write the timer task directly to `caseplan.json`. No CLI command needed.
+
+## Task JSON Shape
+
+> **ID and elementId format.** Task `id` is `t` + 8 random chars. `elementId` is the composite `${stageId}-${taskId}`.
+
+```json
+{
+  "id": "tWm4Vx9Tp",
+  "type": "wait-for-timer",
+  "displayName": "Approval Escalation Timer",
+  "elementId": "Stage_aB3kL9-tWm4Vx9Tp",
+  "isRequired": false,
+  "shouldRunOnlyOnce": true,
+  "data": {
+    "timerType": "timeDuration",
+    "timeDuration": "PT3M"
+  }
+}
+```
+
+## Procedure
+
+**Step 1 — Create task with empty data:**
+
+1. Generate task ID: `t` + 8 alphanumeric chars (unique across all tasks)
+2. Generate elementId: `<stageId>-<taskId>`
+3. Write the task with `"data": {}` to the target stage's `tasks[]` array (in its own task set)
+
+```json
+{
+  "id": "tWm4Vx9Tp",
+  "type": "wait-for-timer",
+  "displayName": "Approval Escalation Timer",
+  "elementId": "Stage_aB3kL9-tWm4Vx9Tp",
+  "isRequired": false,
+  "shouldRunOnlyOnce": true,
+  "data": {}
+}
+```
+
+**Step 2 — Populate timer details:**
+
+4. Read the timer type from tasks.md (`every`, `at`, or `time-cycle`)
+5. Set `data.timerType` and the corresponding duration field (see below)
+
+**Step 3 (separate):** Entry conditions are added in Step 10
+
+## Timer Types
+
+### timeDuration — fixed delay
+
+```json
+"data": { "timerType": "timeDuration", "timeDuration": "PT3M" }
+```
+
+ISO 8601 duration format (e.g., `PT3M`, `PT1H30M`, `P2D`). Time units use `PT` prefix, date units use `P` (no `T`). Weeks → `P7D` (Luxon doesn't output `W`).
+
+### timeDate — specific datetime
+
+```json
+"data": { "timerType": "timeDate", "timeDate": "2026-04-26T09:00:00.000+00:00" }
+```
+
+ISO 8601 datetime with timezone offset. Always include milliseconds and offset.
+
+### timeCycle — repeating interval
+
+```json
+"data": { "timerType": "timeCycle", "timeCycle": "R5/2026-03-03T12:00:00.000+00:00/PT1H" }
+```
+
+Composite format: `R{repeatCount}/{startDatetime}/{duration}`
+
+| Example | Meaning |
+|---|---|
+| `R/PT15S` | Every 15 seconds, infinite |
+| `R5/PT1H` | Every hour, 5 times |
+| `R/2026-03-03T12:00:00.000+00:00/P1D` | Daily starting March 3, infinite |
+
+Omit repeatCount segment for infinite (`R/...`). Omit datetime segment if no start time (`R/PT1H`).
+
+## Post-Write Verification
+
+Confirm task exists in the correct stage with `type: "wait-for-timer"` and `data.timerType` + duration field set.

--- a/skills/uipath-case-management/references/skeleton-tasks.md
+++ b/skills/uipath-case-management/references/skeleton-tasks.md
@@ -69,7 +69,7 @@ uip maestro case tasks add-connector <file> <stage-id> \
 
 ### In-stage timer
 
-Timers are a built-in type — they are never skeletons because they have no registry dependency. Use [`plugins/tasks/wait-for-timer/impl-cli.md`](plugins/tasks/wait-for-timer/impl-cli.md).
+Timers are a built-in type — they are never skeletons because they have no registry dependency. Use [`plugins/tasks/wait-for-timer/impl-json.md`](plugins/tasks/wait-for-timer/impl-json.md).
 
 ## Resulting JSON Shape
 


### PR DESCRIPTION
## Summary
- Replace CLI `tasks add --type wait-for-timer` with direct JSON writing in `wait-for-timer/impl.md`
- The CLI creates timer tasks with empty `data: {}` — duration is never set. Direct write sets `timerType` + `timeDuration`/`timeDate`/`timeCycle` in one step
- Documents all 3 timer types with JSON examples, confirmed against FE source (`DateUtil.ts`, `TimerFormControl.tsx`)
- Drops deprecated `lane` field

## Timer types supported
- `timeDuration` — fixed delay (`PT3M`, `PT1H30M`, `P2D`)
- `timeDate` — specific datetime (`2026-04-26T09:00:00.000+00:00`)
- `timeCycle` — repeating interval (`R5/2026-03-03T12:00:00.000+00:00/PT1H`)

## Test plan
- [x] Compared old (CLI) vs new (direct write) JSON for "Approval Escalation Timer" from expense SDD
- [x] Confirmed timer schema against FE source (Node.d.ts, CaseManagementJsonTaskWaitForTimerSchema.ts)
- [x] Confirmed ISO 8601 duration format and timeCycle composite format against FE tests (DateUtil.test.ts)

Fixes known-issue #3 from sdd_expense-mgmt test run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)