### PR TITLE
docs(tests): require UiPath private PyPI creds for make install

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -9,9 +9,17 @@ help:  ## Show available commands
 	@grep -E '^[a-zA-Z0-9_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 	  awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-install:  ## Install coder-eval into local .venv (requires Python 3.13+)
+install:  ## Install coder-eval into local .venv (requires Python 3.13+; UV_INDEX_UIPATH_USERNAME/PASSWORD optional for private ml-packages feed)
 	uv venv --python 3.13 $(VENV)
-	uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"
+	@if [ -n "$$UV_INDEX_UIPATH_USERNAME" ] && [ -n "$$UV_INDEX_UIPATH_PASSWORD" ]; then \
+	  echo "Using UiPath private PyPI feed (ml-packages)."; \
+	  UV_EXTRA_INDEX_URL="https://$$UV_INDEX_UIPATH_USERNAME:$$UV_INDEX_UIPATH_PASSWORD@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/" \
+	    uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"; \
+	else \
+	  echo "UV_INDEX_UIPATH_USERNAME/PASSWORD not set — installing without the UiPath private PyPI feed."; \
+	  echo "Set both variables before running 'make install' if you need packages from the ml-packages feed."; \
+	  uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"; \
+	fi
 	@echo ""
 	@echo "See https://github.com/UiPath/coder_eval for environment setup (.env, API keys, etc.)"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,18 +4,25 @@ Tests that verify AI agents can correctly use skills from this repository. Tests
 
 ## Prerequisites
 
-1. **coder-eval** — install from GitHub (creates a local `.venv`, requires Python 3.13+):
+1. **UiPath private PyPI credentials** (optional) — only needed if `coder-eval` resolves to packages on the UiPath Azure DevOps `ml-packages` feed. Export these **before** running `make install` to enable the private feed:
+   ```bash
+   export UV_INDEX_UIPATH_USERNAME=<your-ado-username>
+   export UV_INDEX_UIPATH_PASSWORD=<your-ado-pat>
+   ```
+   The Makefile composes these into `UV_EXTRA_INDEX_URL` for `uv pip install`. If either variable is empty, install continues against public PyPI only and prints a notice.
+
+2. **coder-eval** — install from GitHub (creates a local `.venv`, requires Python 3.13+):
    ```bash
    cd tests
    make install
    ```
 
-2. **uip CLI** — the UiPath CLI must be available:
+3. **uip CLI** — the UiPath CLI must be available:
    ```bash
    npm install -g @uipath/cli
    ```
 
-3. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for environment setup (`.env`, API keys, etc.).
+4. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for environment setup (`.env`, API keys, etc.).
 
 ## Running Tests
 


### PR DESCRIPTION
Align local test install with CI by composing UV_EXTRA_INDEX_URL from UV_INDEX_UIPATH_USERNAME/PASSWORD in tests/Makefile, and document the required exports in tests/README.md. Install now fails fast with a helpful message when either credential is missing.