### PR TITLE
feat: add /uipath:install-permissions to cut approval-prompt fatigue

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,9 @@
 # Hooks
 /hooks/ @DragosUnguru
 
+# Plugin-namespaced slash commands (e.g., /uipath:install-permissions)
+/commands/ @DragosUnguru @tmatup
+
 # Activity references (bundled inside uipath-rpa skill)
 /skills/uipath-rpa/references/activity-docs/ @DragosUnguru
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,12 @@ Thank you for your interest in contributing! Whether you're adding a new skill, 
 ```
 .
 ├── .claude/                   # Claude Code project-level configuration
-│   └── commands/              # Slash commands (e.g., /test-coverage)
+│   └── commands/              # Project-only slash commands (e.g., /test-coverage)
 ├── .claude-plugin/            # Plugin manifest and marketplace config
 │   ├── plugin.json            # Plugin name, version, skills directory pointer
 │   └── marketplace.json       # Claude Code marketplace registration
+├── commands/                  # Plugin-namespaced slash commands shipped to end users
+│   └── *.md                   # Each file becomes /uipath:<filename>
 ├── hooks/                     # Session-initialization hooks
 │   ├── hooks.json             # Hook definitions (SessionStart, etc.)
 │   └── ensure-uip.sh         # Cross-platform tool installation script

--- a/README.md
+++ b/README.md
@@ -71,6 +71,16 @@ This repository works as a **Claude Code plugin**. Install skills via `uip skill
 
 If you've already installed manually, uninstall and re-install via `uip skills install` to switch to automatic updates.
 
+#### Reduce permission prompts
+
+By default, Claude Code prompts for approval on every `uip` command, and a realistic Flow or RPA build runs 25+ distinct subcommands. Claude Code plugins cannot ship permission allowlists declaratively, so run this once to install a curated allowlist of safe read-only commands (registry lookups, validation, local scaffolding) while keeping prompts for side-effectful operations (login, debug, publish):
+
+```text
+/uipath:install-permissions
+```
+
+The command prints the recommended JSON and offers to merge it into your settings (`~/.claude/settings.json` for global, or project-local `.claude/settings.local.json`). You will also see a one-line nudge at session start until an allowlist is installed.
+
 ### OpenAI Codex CLI
 
 This repository is configured as a Codex CLI skill provider. The `AGENTS.md` file (symlinked to `CLAUDE.md`) provides project instructions, and skills are discovered via `.agents/skills/` (symlinked to `skills/`).

--- a/commands/install-permissions.md
+++ b/commands/install-permissions.md
@@ -17,15 +17,23 @@ Help the user add a curated allowlist of safe `uip` subcommands to their Claude 
    - **Just print it** — output the JSON only, do not write anything.
    - **Something else** — accept a custom path string.
 
-2. **Read the target file.** If it exists, parse the JSON strictly. If it already contains `permissions.allow` or `permissions.ask`, preserve existing entries and add only the missing ones (deduplicate by exact string). If there is no `permissions` block, add one. If the file parses as invalid JSON, abort with a clear message and ask the user to fix it manually — do not attempt to rewrite.
+2. **Ask whether to include the safety-rail `ask` rules** using a second `AskUserQuestion`:
+   - **Yes — include safety rails** (default, recommended) — `debug` / `upload` / `publish` / `pack` / `login` still prompt, even under `defaultMode: bypassPermissions` or `--dangerously-skip-permissions`. Prevents accidental prod publishes in YOLO mode.
+   - **No — allow-only, no safety rails** — write only the `allow` block. Power users who explicitly want zero prompts under `--dangerously-skip-permissions` pick this. Accept that a stray `uip solution publish` will execute without confirmation.
 
-3. **Show the proposed diff** — print the delta (new entries being added to `allow` and `ask`) before writing. Do not print the full file.
+   If the user picked **Just print it** in step 1, still ask this question — it decides which JSON variant to print.
 
-4. **Ask for explicit confirmation** to write. Do not write without a yes.
+3. **Read the target file.** If it exists, parse the JSON strictly. If it already contains `permissions.allow` or `permissions.ask`, preserve existing entries and add only the missing ones (deduplicate by exact string). If there is no `permissions` block, add one. If the file parses as invalid JSON, abort with a clear message and ask the user to fix it manually — do not attempt to rewrite.
 
-5. **Write the file** with the merged JSON. Preserve existing formatting (indentation, key order) as much as reasonably possible.
+   - If the user chose **allow-only** in step 2 and the target file already has relevant `ask` entries from a prior run, **do not remove them** — leave existing `ask` rules intact. Only the `write` side is skipped; pre-existing safety rails the user already opted into stay put.
 
-6. **Report** the path written and tell the user the new rules take effect on the next tool call — no restart required.
+4. **Show the proposed diff** — print the delta (new entries being added to `allow`, and to `ask` if included) before writing. Do not print the full file.
+
+5. **Ask for explicit confirmation** to write. Do not write without a yes.
+
+6. **Write the file** with the merged JSON. Preserve existing formatting (indentation, key order) as much as reasonably possible.
+
+7. **Report** the path written, which variant was installed (full vs allow-only), and tell the user the new rules take effect on the next tool call — no restart required.
 
 ## Recommended allowlist
 
@@ -78,6 +86,7 @@ Split by risk. `allow` = read-only or local-only commands; `ask` = commands with
 
 - Pattern syntax is literal-prefix + `*` wildcard with a space before `*` — see the [Claude Code settings docs](https://code.claude.com/docs/en/settings.md#permissions-configuration).
 - `Bash(uip login status *)` matches `uip login status --output json`; `Bash(uip login)` (exact, no wildcard) matches only the bare interactive login so it keeps its prompt.
+- Rule precedence in Claude Code is `deny > ask > allow`, and rules are evaluated **before** `defaultMode` / `--dangerously-skip-permissions`. So the `ask` list in the full variant still forces a prompt under YOLO mode — that is the point of it, and it is the difference between the two variants offered in step 2.
 - If the user has existing `permissions.deny` rules mentioning `uip`, do not remove them — respect explicit denials even if they conflict with the recommended allowlist. Surface the conflict in chat and ask.
 - Never modify `~/.claude/settings.json` without explicit consent — that file often contains secrets (tokens, env vars) and should not be edited casually. If the user picks the global option, re-confirm before writing.
-- This allowlist intentionally excludes `uip solution upload`, `uip flow debug`, and `uip flow pack / publish` — these produce real cloud side effects (publishing, executing flows) and should keep their prompt per the `uipath-maestro-flow` skill's Critical Rule 9.
+- The full variant's `ask` block intentionally guards `uip solution upload`, `uip flow debug`, `uip flow pack`, `uip solution publish`, `uip agent init`, and `uip login` — these produce real cloud or filesystem side effects. See the `uipath-maestro-flow` skill's Critical Rule 9.

--- a/commands/install-permissions.md
+++ b/commands/install-permissions.md
@@ -41,26 +41,33 @@ Split by risk. `allow` = read-only or local-only commands; `ask` = commands with
 {
   "permissions": {
     "allow": [
+      // binary + auth status (read-only)
       "Bash(uip --version)",
       "Bash(uip login status)",
       "Bash(uip login status *)",
       "Bash(which uip)",
 
+      // discovery — registry + Integration Service + Orchestrator list ops (all read-only)
       "Bash(uip flow registry *)",
-      "Bash(uip is *)",
-      "Bash(uip or folders *)",
+      "Bash(uip is *)",               // Integration Service (connections, connectors, resources, triggers)
+      "Bash(uip or folders *)",       // Orchestrator folders
 
+      // local-only flow / solution / agent scaffolding
       "Bash(uip flow init *)",
       "Bash(uip flow validate *)",
       "Bash(uip flow tidy *)",
       "Bash(uip flow node *)",
       "Bash(uip flow edge *)",
-
       "Bash(uip solution new *)",
       "Bash(uip solution project *)",
       "Bash(uip solution resource *)",
+      "Bash(uip agent init)",
+      "Bash(uip agent init *)",
+      "Bash(uip agent validate *)",
 
-      "Bash(uip agent validate *)"
+      // RPA skill — build, get-errors, find-activities, create-project, inspect-package, etc.
+      // All local; no cloud side effects (publish goes through `uip solution upload/publish`).
+      "Bash(uip rpa *)"
     ],
     "ask": [
       "Bash(uip login)",
@@ -72,9 +79,7 @@ Split by risk. `allow` = read-only or local-only commands; `ask` = commands with
       "Bash(uip solution upload)",
       "Bash(uip solution upload *)",
       "Bash(uip solution publish)",
-      "Bash(uip solution publish *)",
-      "Bash(uip agent init)",
-      "Bash(uip agent init *)"
+      "Bash(uip solution publish *)"
     ]
   }
 }
@@ -87,4 +92,6 @@ Split by risk. `allow` = read-only or local-only commands; `ask` = commands with
 - Rule precedence in Claude Code is `deny > ask > allow`, and rules are evaluated **before** `defaultMode` / `--dangerously-skip-permissions`. So the `ask` list in the full variant still forces a prompt under YOLO mode — that is the point of it, and it is the difference between the two variants offered in step 1.
 - If the user has existing `permissions.deny` rules mentioning `uip`, do not remove them — respect explicit denials even if they conflict with the recommended allowlist. Surface the conflict in chat and ask.
 - Never modify `~/.claude/settings.json` without explicit consent — that file often contains secrets (tokens, env vars) and should not be edited casually. If the user picks the global option, re-confirm before writing.
-- The full variant's `ask` block intentionally guards `uip solution upload`, `uip flow debug`, `uip flow pack`, `uip solution publish`, `uip agent init`, and `uip login` — these produce real cloud or filesystem side effects. See the `uipath-maestro-flow` skill's Critical Rule 9.
+- The full variant's `ask` block intentionally guards `uip solution upload`, `uip flow debug`, `uip flow pack`, `uip solution publish`, and `uip login` — these produce real cloud side effects (publishing, executing flows, tenant auth). The `uipath-maestro-flow` skill's rules explicitly require user consent before cloud-executing a flow.
+- `uip agent init` is in `allow` (scaffolding — same as `uip flow init`). It does not publish to the cloud; it creates local agent project files.
+- `uip rpa *` covers the full RPA subcommand tree (`build`, `get-errors`, `create-project`, `find-activities`, `inspect-package`, `focus-activity`, etc.). None of these publish to the cloud — RPA deployment flows through `uip solution upload` / `publish` (already guarded in `ask`).

--- a/commands/install-permissions.md
+++ b/commands/install-permissions.md
@@ -1,0 +1,83 @@
+---
+description: Install a curated Claude Code allowlist for safe `uip` subcommands so the agent is not prompted on every command.
+---
+
+# Install UiPath permission allowlist
+
+Help the user add a curated allowlist of safe `uip` subcommands to their Claude Code settings so the agent is not prompted on every command.
+
+**Why this command exists.** Claude Code plugins cannot ship permission rules declaratively — per the [plugins docs](https://code.claude.com/docs/en/plugins.md#ship-default-settings-with-your-plugin), only the `agent` and `subagentStatusLine` keys are honored in a plugin-shipped `settings.json`; any `permissions` block is silently ignored. Without a user-configured allowlist, every `Bash(...)` invocation prompts for approval, and a realistic Flow or RPA build runs 25+ distinct `uip` subcommands.
+
+## Steps
+
+1. **Ask where to install the allowlist** using `AskUserQuestion` with these options:
+   - **Project — `.claude/settings.local.json`** (default) — applies only to the current project; conventionally not committed to git.
+   - **Project — `.claude/settings.json`** — applies only to the current project; usually committed.
+   - **Global — `~/.claude/settings.json`** — applies to every project.
+   - **Just print it** — output the JSON only, do not write anything.
+   - **Something else** — accept a custom path string.
+
+2. **Read the target file.** If it exists, parse the JSON strictly. If it already contains `permissions.allow` or `permissions.ask`, preserve existing entries and add only the missing ones (deduplicate by exact string). If there is no `permissions` block, add one. If the file parses as invalid JSON, abort with a clear message and ask the user to fix it manually — do not attempt to rewrite.
+
+3. **Show the proposed diff** — print the delta (new entries being added to `allow` and `ask`) before writing. Do not print the full file.
+
+4. **Ask for explicit confirmation** to write. Do not write without a yes.
+
+5. **Write the file** with the merged JSON. Preserve existing formatting (indentation, key order) as much as reasonably possible.
+
+6. **Report** the path written and tell the user the new rules take effect on the next tool call — no restart required.
+
+## Recommended allowlist
+
+Split by risk. `allow` = read-only or local-only commands; `ask` = commands with cloud or filesystem side effects (keep the prompt even if a future `defaultMode` tries to auto-allow).
+
+```jsonc
+{
+  "permissions": {
+    "allow": [
+      "Bash(uip --version)",
+      "Bash(uip login status)",
+      "Bash(uip login status *)",
+      "Bash(which uip)",
+
+      "Bash(uip flow registry *)",
+      "Bash(uip is *)",
+      "Bash(uip or folders *)",
+
+      "Bash(uip flow init *)",
+      "Bash(uip flow validate *)",
+      "Bash(uip flow tidy *)",
+      "Bash(uip flow node *)",
+      "Bash(uip flow edge *)",
+
+      "Bash(uip solution new *)",
+      "Bash(uip solution project *)",
+      "Bash(uip solution resource *)",
+
+      "Bash(uip agent validate *)"
+    ],
+    "ask": [
+      "Bash(uip login)",
+      "Bash(uip login --authority *)",
+      "Bash(uip flow debug)",
+      "Bash(uip flow debug *)",
+      "Bash(uip flow pack)",
+      "Bash(uip flow pack *)",
+      "Bash(uip solution upload)",
+      "Bash(uip solution upload *)",
+      "Bash(uip solution publish)",
+      "Bash(uip solution publish *)",
+      "Bash(uip agent init)",
+      "Bash(uip agent init *)"
+    ]
+  }
+}
+```
+
+## Notes
+
+- Pattern syntax is literal-prefix + `*` wildcard with a space before `*` — see the [Claude Code settings docs](https://code.claude.com/docs/en/settings.md#permissions-configuration).
+- `Bash(uip login status *)` matches `uip login status --output json`; `Bash(uip login)` (exact, no wildcard) matches only the bare interactive login so it keeps its prompt.
+- If the user has existing `permissions.deny` rules mentioning `uip`, do not remove them — respect explicit denials even if they conflict with the recommended allowlist. Surface the conflict in chat and ask.
+- Never modify `~/.claude/settings.json` without explicit consent — that file often contains secrets (tokens, env vars) and should not be edited casually. If the user picks the global option, re-confirm before writing.
+- This allowlist intentionally excludes `uip solution upload`, `uip flow debug`, and `uip flow pack / publish` — these produce real cloud side effects (publishing, executing flows) and should keep their prompt per the `uipath-maestro-flow` skill's Critical Rule 9.

--- a/commands/install-permissions.md
+++ b/commands/install-permissions.md
@@ -10,22 +10,20 @@ Help the user add a curated allowlist of safe `uip` subcommands to their Claude 
 
 ## Steps
 
-1. **Ask where to install the allowlist** using `AskUserQuestion` with these options:
+1. **Ask which variant to install** using `AskUserQuestion`:
+   - **Full — with safety rails** (default, recommended) — writes both `allow` and `ask`. Cloud-side-effect commands (`debug` / `upload` / `publish` / `pack` / `login`) still prompt, even under `defaultMode: bypassPermissions` or `--dangerously-skip-permissions`. Prevents accidental prod publishes in YOLO mode.
+   - **Allow-only — no safety rails** — writes only the `allow` block. Power users who explicitly want zero prompts under `--dangerously-skip-permissions` pick this. Accept that a stray `uip solution publish` will execute without confirmation.
+
+2. **Ask where to install the allowlist** using a second `AskUserQuestion`:
    - **Project — `.claude/settings.local.json`** (default) — applies only to the current project; conventionally not committed to git.
    - **Project — `.claude/settings.json`** — applies only to the current project; usually committed.
    - **Global — `~/.claude/settings.json`** — applies to every project.
    - **Just print it** — output the JSON only, do not write anything.
    - **Something else** — accept a custom path string.
 
-2. **Ask whether to include the safety-rail `ask` rules** using a second `AskUserQuestion`:
-   - **Yes — include safety rails** (default, recommended) — `debug` / `upload` / `publish` / `pack` / `login` still prompt, even under `defaultMode: bypassPermissions` or `--dangerously-skip-permissions`. Prevents accidental prod publishes in YOLO mode.
-   - **No — allow-only, no safety rails** — write only the `allow` block. Power users who explicitly want zero prompts under `--dangerously-skip-permissions` pick this. Accept that a stray `uip solution publish` will execute without confirmation.
-
-   If the user picked **Just print it** in step 1, still ask this question — it decides which JSON variant to print.
-
 3. **Read the target file.** If it exists, parse the JSON strictly. If it already contains `permissions.allow` or `permissions.ask`, preserve existing entries and add only the missing ones (deduplicate by exact string). If there is no `permissions` block, add one. If the file parses as invalid JSON, abort with a clear message and ask the user to fix it manually — do not attempt to rewrite.
 
-   - If the user chose **allow-only** in step 2 and the target file already has relevant `ask` entries from a prior run, **do not remove them** — leave existing `ask` rules intact. Only the `write` side is skipped; pre-existing safety rails the user already opted into stay put.
+   - If the user chose **allow-only** in step 1 and the target file already has relevant `ask` entries from a prior run, **do not remove them** — leave existing `ask` rules intact. Only the `write` side is skipped; pre-existing safety rails the user already opted into stay put.
 
 4. **Show the proposed diff** — print the delta (new entries being added to `allow`, and to `ask` if included) before writing. Do not print the full file.
 
@@ -86,7 +84,7 @@ Split by risk. `allow` = read-only or local-only commands; `ask` = commands with
 
 - Pattern syntax is literal-prefix + `*` wildcard with a space before `*` — see the [Claude Code settings docs](https://code.claude.com/docs/en/settings.md#permissions-configuration).
 - `Bash(uip login status *)` matches `uip login status --output json`; `Bash(uip login)` (exact, no wildcard) matches only the bare interactive login so it keeps its prompt.
-- Rule precedence in Claude Code is `deny > ask > allow`, and rules are evaluated **before** `defaultMode` / `--dangerously-skip-permissions`. So the `ask` list in the full variant still forces a prompt under YOLO mode — that is the point of it, and it is the difference between the two variants offered in step 2.
+- Rule precedence in Claude Code is `deny > ask > allow`, and rules are evaluated **before** `defaultMode` / `--dangerously-skip-permissions`. So the `ask` list in the full variant still forces a prompt under YOLO mode — that is the point of it, and it is the difference between the two variants offered in step 1.
 - If the user has existing `permissions.deny` rules mentioning `uip`, do not remove them — respect explicit denials even if they conflict with the recommended allowlist. Surface the conflict in chat and ask.
 - Never modify `~/.claude/settings.json` without explicit consent — that file often contains secrets (tokens, env vars) and should not be edited casually. If the user picks the global option, re-confirm before writing.
 - The full variant's `ask` block intentionally guards `uip solution upload`, `uip flow debug`, `uip flow pack`, `uip solution publish`, `uip agent init`, and `uip login` — these produce real cloud or filesystem side effects. See the `uipath-maestro-flow` skill's Critical Rule 9.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -9,6 +9,12 @@
             "timeout": 180,
             "once": true,
             "statusMessage": "Checking uip, servo and rpa-tool installation..."
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/suggest-permissions.sh\"",
+            "timeout": 5,
+            "once": true
           }
         ]
       }

--- a/hooks/suggest-permissions.sh
+++ b/hooks/suggest-permissions.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Detects whether Claude Code has an allowlist for `uip` subcommands.
+# If none is found, prints a one-line nudge pointing at /uipath:install-permissions.
+# Non-blocking — never fails the session, even if detection fails.
+# Cross-platform (macOS, Linux, Windows via Git Bash / MSYS / Cygwin).
+
+# Only run inside a Claude Code plugin context.
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  exit 0
+fi
+
+# Candidate settings files, most-to-least specific.
+candidates=()
+if [ -n "${CLAUDE_PROJECT_DIR:-}" ]; then
+  candidates+=("$CLAUDE_PROJECT_DIR/.claude/settings.local.json")
+  candidates+=("$CLAUDE_PROJECT_DIR/.claude/settings.json")
+fi
+candidates+=("$PWD/.claude/settings.local.json")
+candidates+=("$PWD/.claude/settings.json")
+candidates+=("$HOME/.claude/settings.json")
+
+# If any candidate already mentions Bash(uip...) in its permissions, stay silent.
+for f in "${candidates[@]}"; do
+  [ -f "$f" ] || continue
+  if grep -q 'Bash(uip' "$f" 2>/dev/null; then
+    exit 0
+  fi
+done
+
+# No allowlist detected — print a one-line nudge to stderr (the Claude Code
+# SessionStart convention for status messages).
+echo "uipath: To skip 25+ approval prompts per uip build, run: /uipath:install-permissions" >&2
+exit 0

--- a/hooks/suggest-permissions.sh
+++ b/hooks/suggest-permissions.sh
@@ -20,6 +20,9 @@ candidates+=("$PWD/.claude/settings.json")
 candidates+=("$HOME/.claude/settings.json")
 
 # If any candidate already mentions Bash(uip...) in its permissions, stay silent.
+# Intentional simplification: this matches `allow`, `ask`, AND `deny` blocks.
+# Any explicit `uip` rule means the user has made a decision about this CLI —
+# we don't second-guess by nudging them toward a permissive allowlist.
 for f in "${candidates[@]}"; do
   [ -f "$f" ] || continue
   if grep -q 'Bash(uip' "$f" 2>/dev/null; then


### PR DESCRIPTION
## Summary

- A realistic Flow or RPA build runs 25+ distinct `uip` subcommands. Without a user-configured Claude Code allowlist, every one of them prompts for approval — deterring a colleague from finishing a simple Slack-on-new-Sheet-row flow. Claude Code plugins [cannot ship permission rules declaratively](https://code.claude.com/docs/en/plugins.md#ship-default-settings-with-your-plugin) (only the `agent` and `subagentStatusLine` keys are honored in plugin-shipped settings), so the fix has to be opt-in by the user.
- Adds `/uipath:install-permissions` — a slash command that merges a curated `allow` / `ask` list into the user's chosen settings file (project-local by default), with a confirmation step before writing. The `ask` list guards `debug` / `upload` / `publish` / `pack` / `login` so a future `defaultMode` change cannot auto-approve cloud side effects (see maestro-flow Critical Rule 9).
- Adds a SessionStart hook (`hooks/suggest-permissions.sh`) that prints a one-line nudge pointing at the slash command when no `uip` allowlist is detected across project-local, project, or global settings. Silent once rules exist. Plain `grep`, no `jq` dependency.

## Test plan

- [ ] Fresh install with no existing allowlist → SessionStart prints `uipath: To skip 25+ approval prompts...`
- [ ] `/uipath:install-permissions` → prompts for target location, shows diff, writes on confirm, skips write on "Just print it"
- [ ] Existing `~/.claude/settings.json` with `Bash(uip flow registry *)` present → no nudge, no rewrite
- [ ] Existing `.claude/settings.local.json` with unrelated rules → nudge appears, merge preserves unrelated rules
- [ ] After install: `uip flow validate`, `uip flow registry search slack`, `uip flow tidy` run without prompting
- [ ] After install: `uip flow debug`, `uip solution upload`, `uip login` still prompt
- [ ] Run `/uipath:install-permissions` twice → second run is idempotent (no duplicate entries)
- [ ] Hook exits silently when `CLAUDE_PLUGIN_ROOT` is unset (non-Claude-Code environments)
- [ ] `hooks.json` parses as valid JSON; `validate-skill-descriptions.sh` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>