### PR TITLE
feat(case-management): add `min` (minutes) as an SLA duration unit

### DIFF
--- a/skills/uipath-case-management/references/case-commands.md
+++ b/skills/uipath-case-management/references/case-commands.md
@@ -934,14 +934,14 @@ uip maestro case sla rules list <file>
 uip maestro case sla rules remove <file> <index>
 ```
 
-SLA units: `h` (hours), `d` (days), `w` (weeks), `m` (months).
+SLA units: `min` (minutes), `h` (hours), `d` (days), `w` (weeks), `m` (months).
 
 Options for `sla set`:
 | Flag | Description |
 |------|-------------|
 | `<file>` | **(required)** Path to the case management JSON file |
 | `--count <count>` | **(required)** SLA duration count (positive integer) |
-| `--unit <unit>` | **(required)** SLA duration unit: `h`, `d`, `w`, `m` |
+| `--unit <unit>` | **(required)** SLA duration unit: `min`, `h`, `d`, `w`, `m` |
 | `--stage-id <id>` | Stage ID to set the SLA on (omit for root-level) |
 
 Options for `sla get` / `sla remove`:
@@ -968,7 +968,7 @@ Options for `sla rules add`:
 | `<file>` | **(required)** Path to the case management JSON file |
 | `--expression <expr>` | **(required)** Condition expression for the SLA rule |
 | `--count <count>` | **(required)** SLA duration count (positive integer) |
-| `--unit <unit>` | **(required)** SLA duration unit: `h`, `d`, `w`, `m` |
+| `--unit <unit>` | **(required)** SLA duration unit: `min`, `h`, `d`, `w`, `m` |
 
 Condition rules are prepended before the default rule (`=js:true`) so they are evaluated first. Output codes: `SlaSet`, `SlaFound`, `SlaRemoved`, `EscalationRuleAdded`, `EscalationRulesList`, `EscalationRuleRemoved`, `SlaRuleAdded`, `SlaRulesList`, `SlaRuleRemoved`.
 

--- a/skills/uipath-case-management/references/case-schema.md
+++ b/skills/uipath-case-management/references/case-schema.md
@@ -343,7 +343,7 @@ Not every rule type is valid at every level — see each condition plugin's `imp
 }
 ```
 
-Time units: `"h"` (hours), `"d"` (days), `"w"` (weeks), `"m"` (months).
+Time units: `"min"` (minutes), `"h"` (hours), `"d"` (days), `"w"` (weeks), `"m"` (months).
 Escalation `triggerInfo.type`: `"at-risk"` or `"sla-breached"`.
 Escalation `action.recipients[].scope`: `"User"` or `"UserGroup"`.
 

--- a/skills/uipath-case-management/references/plugins/sla/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/sla/impl-cli.md
@@ -6,6 +6,7 @@ Three CLI sub-operations cover SLA authoring: `set`, `escalation`, `rules`. Run 
 
 | Unit | Meaning |
 |------|---------|
+| `min` | minutes |
 | `h` | hours |
 | `d` | days |
 | `w` | weeks |
@@ -17,10 +18,10 @@ Three CLI sub-operations cover SLA authoring: `set`, `escalation`, `rules`. Run 
 
 ```bash
 # Root-level
-uip maestro case sla set <file> --count <n> --unit <h|d|w|m> --output json
+uip maestro case sla set <file> --count <n> --unit <min|h|d|w|m> --output json
 
 # Per-stage
-uip maestro case sla set <file> --count <n> --unit <h|d|w|m> --stage-id <stage-id> --output json
+uip maestro case sla set <file> --count <n> --unit <min|h|d|w|m> --stage-id <stage-id> --output json
 ```
 
 ### Example
@@ -43,7 +44,7 @@ Stage: `nodes[].data.sla = { count: 2, unit: "w" }` on the matching stage.
 uip maestro case sla rules add <file> \
   --expression "<expr>" \
   --count <n> \
-  --unit <h|d|w|m> \
+  --unit <min|h|d|w|m> \
   --output json
 ```
 
@@ -53,7 +54,7 @@ uip maestro case sla rules add <file> \
 uip maestro case sla rules add caseplan.json \
   --expression "=js:vars.priority === 'Urgent'" \
   --count 30 \
-  --unit m \
+  --unit min \
   --output json
 ```
 
@@ -62,7 +63,7 @@ uip maestro case sla rules add caseplan.json \
 Root: `root.data.slaRules[]` gains an entry:
 
 ```json
-{ "expression": "=js:vars.priority === 'Urgent'", "count": 30, "unit": "m" }
+{ "expression": "=js:vars.priority === 'Urgent'", "count": 30, "unit": "min" }
 ```
 
 Rules are evaluated in array order — first truthy expression wins. The default SLA (from `sla set`) acts as the fallback.

--- a/skills/uipath-case-management/references/plugins/sla/planning.md
+++ b/skills/uipath-case-management/references/plugins/sla/planning.md
@@ -35,7 +35,7 @@ Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage >
 | Field | Source | Notes |
 |-------|--------|-------|
 | `count` | sdd.md duration number | Positive integer |
-| `unit` | sdd.md duration unit | `h` \| `d` \| `w` \| `m` |
+| `unit` | sdd.md duration unit | `min` \| `h` \| `d` \| `w` \| `m` |
 | `stage-id` | sdd.md target (root vs stage) | Omit for root |
 
 ### Conditional SLA rule (`sla rules add`)
@@ -86,7 +86,7 @@ SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each t
 ## T<n>: Add conditional SLA rule for root case — <condition summary>
 - condition: "<natural-language condition from sdd.md>"
 - count: 30
-- unit: m
+- unit: min
 - order: after T<m>
 - verify: Confirm Result: Success
 ```


### PR DESCRIPTION
Document `min` alongside `h`/`d`/`w`/`m` in the SLA unit list across
impl-cli.md, planning.md, case-commands.md, and case-schema.md. Updates
the "30-minute SLA" conditional-rule example to use `unit: min`, which
also corrects a latent inconsistency where the example previously used
`unit: m` (months) to express a 30-minute duration.