### PR TITLE
feat(case-management): migrate stage-entry-conditions plugin to direct JSON

### DIFF
--- a/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/README.md
+++ b/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/README.md
@@ -1,0 +1,88 @@
+# stage-entry-conditions Golden Fixtures
+
+Compatibility fixture for the `stage-entry-conditions` plugin direct-JSON-write migration. Asserts that JSON emitted by the direct-write path is structurally equivalent to JSON produced by `uip maestro case stage-entry-conditions add` across all five stage-entry rule-types.
+
+> **Temporary — developer verification only.** These fixtures live outside the skill on purpose: they exist to verify migration correctness during the CLI → JSON shift, and will be removed once every plugin has migrated. Runtime agents do not load them.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `input.sdd-fragment.md` | Minimal sdd fragment exercising all five stage-entry rule-types |
+| `cli-output.json` | Captured from `uip maestro case cases add` + two `stages add` + five `stage-entry-conditions add` runs (CLI version used: 0.3.4 from `~/Documents/GitHub/cli` source build) |
+| `json-write-output.json` | Hand-written to match the direct-JSON-write spec in [`plugins/conditions/stage-entry-conditions/impl-json.md`](../../../skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md) |
+| `diff.sh` | Normalizes Stage / Condition / Rule IDs by slug, then diffs; passes if structurally equivalent |
+
+## Running the diff
+
+```bash
+./diff.sh
+```
+
+Exit 0 on equivalence; non-zero with a unified diff otherwise. Requires `jq` and `diff`.
+
+## Validation parity
+
+Both `cli-output.json` and `json-write-output.json` produce the same expected failure profile from `uip maestro case validate`:
+
+```
+Found 3 error(s) and 2 warning(s):
+  - [error] [nodes[trigger_1]] Trigger "Trigger 1" has no outgoing edges
+  - [warning] [nodes[<target>]] Stage "Target" has no tasks
+  - [error] [nodes[<target>]] Stage "Target" has no incoming edges
+  - [warning] [nodes[<upstream>]] Stage "Upstream" has no tasks
+  - [error] [nodes[<upstream>]] Stage "Upstream" has no incoming edges
+```
+
+These are expected — the fixture intentionally exercises entry conditions in isolation (no edges, no tasks, no exit conditions). The point is that both outputs produce the same failure profile, proving downstream CLI commands see them as equivalent.
+
+## Regenerating `cli-output.json`
+
+When the CLI version bumps:
+
+```bash
+WORK=$(mktemp -d)
+cd "$WORK"
+BIN=/Users/jundayin/Documents/GitHub/cli/packages/cli/dist/index.js  # or whichever uip binary
+
+node "$BIN" maestro case cases add --name "StageEntryProbe" --file caseplan.json --output json
+node "$BIN" maestro case stages add caseplan.json --label "Upstream" --description "Upstream stage" --output json
+node "$BIN" maestro case stages add caseplan.json --label "Target"   --description "Target stage"   --output json
+
+# Capture the Target and Upstream stage IDs from the output, then:
+UPSTREAM=$(node -e "const d=require('$WORK/caseplan.json'); console.log(d.nodes.find(n=>n.data.label==='Upstream').id)")
+TARGET=$(node -e   "const d=require('$WORK/caseplan.json'); console.log(d.nodes.find(n=>n.data.label==='Target').id)")
+
+node "$BIN" maestro case stage-entry-conditions add caseplan.json "$TARGET" --display-name "From case start"          --rule-type case-entered                                                                                 --output json
+node "$BIN" maestro case stage-entry-conditions add caseplan.json "$TARGET" --display-name "After Upstream completes" --rule-type selected-stage-completed --selected-stage-id "$UPSTREAM"                                    --output json
+node "$BIN" maestro case stage-entry-conditions add caseplan.json "$TARGET" --display-name "After Upstream exits"     --is-interrupting true --rule-type selected-stage-exited --selected-stage-id "$UPSTREAM"              --output json
+node "$BIN" maestro case stage-entry-conditions add caseplan.json "$TARGET" --display-name "User-routed"              --rule-type user-selected-stage                                                                        --output json
+node "$BIN" maestro case stage-entry-conditions add caseplan.json "$TARGET" --display-name "Fraud detected"           --is-interrupting true --rule-type wait-for-connector --condition-expression "event.fraudScore > 0.8" --output json
+
+cp caseplan.json <path-to-this-folder>/cli-output.json
+```
+
+Then re-run `./diff.sh` to confirm the direct-JSON-write fixture still matches. If the diff fails, the CLI output shape changed — update `json-write-output.json` and [`plugins/conditions/stage-entry-conditions/impl-json.md`](../../../skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md) to reflect the new spec.
+
+## Regenerating `json-write-output.json`
+
+Follow the JSON Recipe in [`plugins/conditions/stage-entry-conditions/impl-json.md`](../../../skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md). The Condition / Rule / Stage IDs in the current fixture are hand-picked to be distinct from any CLI output — they exercise the normalizer in `diff.sh`.
+
+## Current status
+
+Captured against CLI source build at `~/Documents/GitHub/cli` (package version `0.3.4`, ahead of the `0.1.21` binary on PATH, which lacks the `maestro case` subcommand).
+
+Key observations from this run:
+
+- `root.version: "v17"`, `root.publishVersion: 2`, `root.data.intsvcActivityConfig: "v2"`, `root.data.uipath.variables.inputOutputs: []`, `root.data.uipath.bindings: []` — all present on a fresh case. (Differs from the `stages` fixture README which captured against `0.1.21` and saw only `root.data: {}`.)
+- CLI appends new entry conditions to `data.entryConditions` via `.push()` (not `unshift`). Order matches insertion order.
+- `node.data.entryConditions` key does not exist on a regular Stage at creation time — it is created on first `stage-entry-conditions add`.
+- Field order inside a condition object: `id, displayName, rules, isInterrupting` (isInterrupting trails because `buildRule` sets it conditionally after `rules` is populated).
+- `displayName` is always emitted from `options.displayName` (string, even `undefined` would be serialized as missing — tested only with display names present).
+- Rule shape per rule-type (captured):
+    - `case-entered` → `{ rule, id }`
+    - `selected-stage-completed` → `{ rule, id, selectedStageId }`
+    - `selected-stage-exited` → `{ rule, id, selectedStageId }`
+    - `user-selected-stage` → `{ rule, id }`
+    - `wait-for-connector` → `{ rule, id, conditionExpression }`
+- `conditionExpression` is serialized only when passed; JSON.stringify drops `undefined` fields.

--- a/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/cli-output.json
+++ b/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/cli-output.json
@@ -1,0 +1,160 @@
+{
+    "root": {
+        "id": "root",
+        "name": "StageEntryProbe",
+        "type": "case-management:root",
+        "caseIdentifier": "StageEntryProbe",
+        "caseAppEnabled": false,
+        "caseIdentifierType": "constant",
+        "version": "v17",
+        "publishVersion": 2,
+        "data": {
+            "intsvcActivityConfig": "v2",
+            "uipath": {
+                "variables": {
+                    "inputOutputs": []
+                },
+                "bindings": []
+            }
+        }
+    },
+    "nodes": [
+        {
+            "id": "Stage_eQtgaj",
+            "type": "case-management:Stage",
+            "position": {
+                "x": 600,
+                "y": 200
+            },
+            "style": {
+                "width": 304,
+                "opacity": 0.8
+            },
+            "measured": {
+                "width": 304,
+                "height": 128
+            },
+            "width": 304,
+            "zIndex": 1001,
+            "data": {
+                "label": "Target",
+                "parentElement": {
+                    "id": "root",
+                    "type": "case-management:root"
+                },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "tasks": [],
+                "description": "Target stage",
+                "entryConditions": [
+                    {
+                        "id": "Condition_DwYP14",
+                        "displayName": "From case start",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "case-entered",
+                                    "id": "Rule_VJRSuI"
+                                }
+                            ]
+                        ]
+                    },
+                    {
+                        "id": "Condition_pVuqVs",
+                        "displayName": "After Upstream completes",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "selected-stage-completed",
+                                    "id": "Rule_lmVjvp",
+                                    "selectedStageId": "Stage_U3uo8Q"
+                                }
+                            ]
+                        ]
+                    },
+                    {
+                        "id": "Condition_SczBZt",
+                        "displayName": "After Upstream exits",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "selected-stage-exited",
+                                    "id": "Rule_9Yaekr",
+                                    "selectedStageId": "Stage_U3uo8Q"
+                                }
+                            ]
+                        ],
+                        "isInterrupting": true
+                    },
+                    {
+                        "id": "Condition_G4YUhK",
+                        "displayName": "User-routed",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "user-selected-stage",
+                                    "id": "Rule_D3lMHN"
+                                }
+                            ]
+                        ]
+                    },
+                    {
+                        "id": "Condition_6RErA8",
+                        "displayName": "Fraud detected",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "wait-for-connector",
+                                    "id": "Rule_V5Hn8G",
+                                    "conditionExpression": "event.fraudScore > 0.8"
+                                }
+                            ]
+                        ],
+                        "isInterrupting": true
+                    }
+                ]
+            }
+        },
+        {
+            "id": "Stage_U3uo8Q",
+            "type": "case-management:Stage",
+            "position": {
+                "x": 100,
+                "y": 200
+            },
+            "style": {
+                "width": 304,
+                "opacity": 0.8
+            },
+            "measured": {
+                "width": 304,
+                "height": 128
+            },
+            "width": 304,
+            "zIndex": 1001,
+            "data": {
+                "label": "Upstream",
+                "parentElement": {
+                    "id": "root",
+                    "type": "case-management:root"
+                },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "tasks": [],
+                "description": "Upstream stage"
+            }
+        },
+        {
+            "id": "trigger_1",
+            "type": "case-management:Trigger",
+            "position": {
+                "x": 0,
+                "y": 0
+            },
+            "data": {
+                "label": "Trigger 1"
+            }
+        }
+    ],
+    "edges": []
+}

--- a/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/diff.sh
+++ b/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/diff.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+#
+# stage-entry-conditions golden diff — asserts the direct-JSON-write output is
+# structurally equivalent to the CLI output after normalizing random IDs.
+#
+# Normalizer strategy:
+#   - Stage IDs → `Stage_<label-slug>` (from `data.label`).
+#   - Condition IDs → `Condition_<displayName-slug>` (from `displayName`).
+#   - Rule IDs → `Rule_<rule-type>_<parent-displayName-slug>_<index>` (from
+#     the containing condition's `displayName` and the rule's position, so two
+#     rules of the same type in the same condition still disambiguate).
+#   - Trigger ID `trigger_1` is stable (fixed literal) so no normalization.
+#   - `selectedStageId` strings are remapped through the stage ID map.
+#
+# Usage:
+#   ./diff.sh
+#
+# Exit 0 on equivalence; non-zero otherwise.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CLI="$HERE/cli-output.json"
+JSW="$HERE/json-write-output.json"
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Missing dependency: $1" >&2; exit 2; }
+}
+
+need jq
+need diff
+
+normalize() {
+  local input="$1"
+  jq -c '
+    # Stage ID remap: Stage_* → Stage_<label-slug>
+    def stage_remap:
+      [ .nodes[]
+        | select(.type == "case-management:Stage" or .type == "case-management:ExceptionStage")
+        | { key: .id,
+            value: ("Stage_" + ((.data.label // "unknown")
+                                | gsub("[^A-Za-z0-9]"; ""))) } ]
+      | from_entries;
+
+    # Condition ID remap: Condition_* → Condition_<displayName-slug>
+    # Rule ID remap: Rule_* → Rule_<rule-type>_<condition-displayName-slug>_<index>
+    def id_maps:
+      [ .nodes[]
+        | select(.type == "case-management:Stage" or .type == "case-management:ExceptionStage")
+        | (.data.entryConditions // [])[]
+        | . as $cond
+        | ( { key: $cond.id,
+              value: ("Condition_" + (($cond.displayName // "unknown")
+                                       | gsub("[^A-Za-z0-9]"; ""))) }
+          ),
+          ( ($cond.rules // [])
+            | to_entries[]
+            | .key as $groupIdx
+            | .value | to_entries[]
+            | .key as $ruleIdx
+            | .value as $rule
+            | { key: $rule.id,
+                value: ("Rule_" + $rule.rule + "_"
+                         + (($cond.displayName // "unknown")
+                            | gsub("[^A-Za-z0-9]"; ""))
+                         + "_" + ($groupIdx|tostring) + "_" + ($ruleIdx|tostring)) } ) ];
+
+    def apply(remap):
+      walk(
+        if type == "string" then
+          . as $s
+          | if remap | has($s) then remap[$s] else $s end
+        else . end
+      );
+
+    . as $doc
+    | ($doc | stage_remap) as $stageRemap
+    | ($doc | id_maps) as $idList
+    | ($idList | from_entries) as $condRuleRemap
+    | ($stageRemap * $condRuleRemap) as $remap
+    | $doc | apply($remap)
+  ' "$input" | jq -S .
+}
+
+CLI_NORM="$(mktemp)"
+JSW_NORM="$(mktemp)"
+trap 'rm -f "$CLI_NORM" "$JSW_NORM"' EXIT
+
+normalize "$CLI"  > "$CLI_NORM"
+normalize "$JSW" > "$JSW_NORM"
+
+if diff -u "$CLI_NORM" "$JSW_NORM"; then
+  echo "OK: stage-entry-conditions golden — cli-output.json ≡ json-write-output.json (after ID normalization)"
+  exit 0
+else
+  echo "FAIL: stage-entry-conditions golden diverged — see unified diff above" >&2
+  exit 1
+fi

--- a/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/input.sdd-fragment.md
+++ b/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/input.sdd-fragment.md
@@ -1,0 +1,22 @@
+# Minimal sdd fragment — stage-entry-conditions plugin
+
+Exercises all five stage-entry rule-types by attaching five entry conditions to a single target stage. Intentionally omits edges, tasks, and stage exit rules — validation is expected to fail on those orthogonal concerns.
+
+## Stages
+
+| Stage | Purpose |
+|---|---|
+| Upstream | Source stage referenced by `selected-stage-*` rules. |
+| Target | Receives all five entry conditions below. |
+
+## Target — Entry Conditions
+
+| # | Display name | Rule type | is-interrupting | Extra |
+|---|---|---|---|---|
+| 1 | From case start | `case-entered` | (default `false`) | — |
+| 2 | After Upstream completes | `selected-stage-completed` | (default `false`) | selected-stage = "Upstream" |
+| 3 | After Upstream exits | `selected-stage-exited` | `true` | selected-stage = "Upstream" |
+| 4 | User-routed | `user-selected-stage` | (default `false`) | — |
+| 5 | Fraud detected | `wait-for-connector` | `true` | condition-expression = `event.fraudScore > 0.8` |
+
+Each condition is a separate T-task in `tasks.md` per the plugin's "No omission" rule.

--- a/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/json-write-output.json
+++ b/docs/uipath-case-management/migration-fixtures/stage-entry-conditions/json-write-output.json
@@ -1,0 +1,160 @@
+{
+    "root": {
+        "id": "root",
+        "name": "StageEntryProbe",
+        "type": "case-management:root",
+        "caseIdentifier": "StageEntryProbe",
+        "caseAppEnabled": false,
+        "caseIdentifierType": "constant",
+        "version": "v17",
+        "publishVersion": 2,
+        "data": {
+            "intsvcActivityConfig": "v2",
+            "uipath": {
+                "variables": {
+                    "inputOutputs": []
+                },
+                "bindings": []
+            }
+        }
+    },
+    "nodes": [
+        {
+            "id": "Stage_aB3kL9",
+            "type": "case-management:Stage",
+            "position": {
+                "x": 600,
+                "y": 200
+            },
+            "style": {
+                "width": 304,
+                "opacity": 0.8
+            },
+            "measured": {
+                "width": 304,
+                "height": 128
+            },
+            "width": 304,
+            "zIndex": 1001,
+            "data": {
+                "label": "Target",
+                "parentElement": {
+                    "id": "root",
+                    "type": "case-management:root"
+                },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "tasks": [],
+                "description": "Target stage",
+                "entryConditions": [
+                    {
+                        "id": "Condition_Ab12Cd",
+                        "displayName": "From case start",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "case-entered",
+                                    "id": "Rule_Xy7zQw"
+                                }
+                            ]
+                        ]
+                    },
+                    {
+                        "id": "Condition_Ef34Gh",
+                        "displayName": "After Upstream completes",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "selected-stage-completed",
+                                    "id": "Rule_Mn8pLk",
+                                    "selectedStageId": "Stage_cD4mNt"
+                                }
+                            ]
+                        ]
+                    },
+                    {
+                        "id": "Condition_Ij56Kl",
+                        "displayName": "After Upstream exits",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "selected-stage-exited",
+                                    "id": "Rule_Qr9sTv",
+                                    "selectedStageId": "Stage_cD4mNt"
+                                }
+                            ]
+                        ],
+                        "isInterrupting": true
+                    },
+                    {
+                        "id": "Condition_Mn78Op",
+                        "displayName": "User-routed",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "user-selected-stage",
+                                    "id": "Rule_Uv1wXy"
+                                }
+                            ]
+                        ]
+                    },
+                    {
+                        "id": "Condition_Qr90St",
+                        "displayName": "Fraud detected",
+                        "rules": [
+                            [
+                                {
+                                    "rule": "wait-for-connector",
+                                    "id": "Rule_Bc2dEf",
+                                    "conditionExpression": "event.fraudScore > 0.8"
+                                }
+                            ]
+                        ],
+                        "isInterrupting": true
+                    }
+                ]
+            }
+        },
+        {
+            "id": "Stage_cD4mNt",
+            "type": "case-management:Stage",
+            "position": {
+                "x": 100,
+                "y": 200
+            },
+            "style": {
+                "width": 304,
+                "opacity": 0.8
+            },
+            "measured": {
+                "width": 304,
+                "height": 128
+            },
+            "width": 304,
+            "zIndex": 1001,
+            "data": {
+                "label": "Upstream",
+                "parentElement": {
+                    "id": "root",
+                    "type": "case-management:root"
+                },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "tasks": [],
+                "description": "Upstream stage"
+            }
+        },
+        {
+            "id": "trigger_1",
+            "type": "case-management:Trigger",
+            "position": {
+                "x": 0,
+                "y": 0
+            },
+            "data": {
+                "label": "Trigger 1"
+            }
+        }
+    ],
+    "edges": []
+}

--- a/skills/uipath-case-management/SKILL.md
+++ b/skills/uipath-case-management/SKILL.md
@@ -161,7 +161,7 @@ Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fi
 | **Wire task inputs/outputs (I/O binding)** | [references/plugins/variables/io-binding/planning.md](references/plugins/variables/io-binding/planning.md) + [`impl-json.md`](references/plugins/variables/io-binding/impl-json.md) |
 | **Add a specific task type** | `references/plugins/tasks/<type>/planning.md` + `impl-cli.md` |
 | **Add a specific trigger type** | `references/plugins/triggers/<type>/planning.md` + `impl-cli.md` |
-| **Add a specific condition scope** | `references/plugins/conditions/<scope>/planning.md` + `impl-cli.md` |
+| **Add a specific condition scope** | `references/plugins/conditions/<scope>/planning.md` + `impl-cli.md` (`impl-json.md` for migrated scopes — see the strategy matrix) |
 
 ### Plugin Index
 

--- a/skills/uipath-case-management/references/case-editing-operations.md
+++ b/skills/uipath-case-management/references/case-editing-operations.md
@@ -26,7 +26,7 @@ Default strategy is **CLI**. Plugins opt in to direct JSON when they've been mig
 | `tasks/connector-activity` | CLI | Migration queued. Auto-injected default entry condition complicates the recipe. |
 | `tasks/connector-trigger` | CLI | Migration queued. Same as connector-activity. |
 | `tasks/wait-for-timer` | CLI | Migration queued. |
-| `conditions/stage-entry-conditions` | CLI | Migration queued. |
+| `conditions/stage-entry-conditions` | **JSON** | Migrated. See [plugins/conditions/stage-entry-conditions/impl-json.md](plugins/conditions/stage-entry-conditions/impl-json.md). |
 | `conditions/stage-exit-conditions` | CLI | Migration queued. |
 | `conditions/task-entry-conditions` | CLI | Migration queued. |
 | `conditions/case-exit-conditions` | CLI | Migration queued. |

--- a/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-cli.md
@@ -55,18 +55,23 @@ The stage node's `data.entryConditions` array gains:
 
 ```json
 {
-  "id": "cond00000001",
+  "id": "Condition_xxxxxx",
   "displayName": "After Triage",
-  "isInterrupting": false,
   "rules": [
     [
-      { "rule": "selected-stage-exited", "id": "...", "selectedStageId": "stg_triage_id" }
+      { "rule": "selected-stage-exited", "id": "Rule_xxxxxx", "selectedStageId": "Stage_xxxxxx" }
     ]
   ]
 }
 ```
 
-Rules use DNF — outer array is OR, inner array is AND. Adding rules via `edit --rule-type` appends new rules (see `case-commands.md`).
+IDs follow the CLI's `prefixedId` scheme: `Condition_` + 6 random chars, `Rule_` + 6 random chars. See [`../../../case-editing-operations-json.md § ID Generation`](../../../case-editing-operations-json.md#id-generation).
+
+`isInterrupting` is emitted **only** when `--is-interrupting` is passed — the key is absent otherwise. When present it trails after `rules`.
+
+Rules use DNF — outer array is OR, inner array is AND. Adding rules via `edit --rule-type` appends a new outer-group (new OR-clause), not a new inner AND-term. See `case-commands.md`.
+
+For the full per-rule-type JSON shape (all five rule-types) and the direct-JSON-write recipe, see [`impl-json.md`](impl-json.md).
 
 ## Post-Add Validation
 

--- a/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -1,0 +1,148 @@
+---
+direct-json: supported
+---
+
+# stage-entry-conditions — JSON Implementation
+
+Authoritative when the matrix in [`case-editing-operations.md`](../../../case-editing-operations.md) lists `conditions/stage-entry-conditions = JSON`. Cross-cutting direct-JSON rules live in [`case-editing-operations-json.md`](../../../case-editing-operations-json.md). For the CLI fallback, see [`impl-cli.md`](impl-cli.md).
+
+## Purpose
+
+Attach one entry condition (with one initial rule) to a Stage or ExceptionStage node's `data.entryConditions[]`. Controls when the stage may be entered.
+
+## Input spec (from `tasks.md`)
+
+| Field | Required | Notes |
+|---|---|---|
+| `target-stage` | yes | Resolves to a captured `Stage_xxxxxx` / ExceptionStage ID from the stages plugin. |
+| `display-name` | optional | String. When absent, the condition is written without `displayName`. |
+| `is-interrupting` | optional | Boolean. When absent, the key is **omitted** — do not emit `isInterrupting: false`. Only write the key when `sdd.md` declares the field. |
+| `rule-type` | yes | One of `case-entered`, `selected-stage-completed`, `selected-stage-exited`, `user-selected-stage`, `wait-for-connector`. |
+| `selected-stage` | conditional | Required for `selected-stage-completed` and `selected-stage-exited`. Resolves to a captured stage ID. |
+| `condition-expression` | conditional | Required for `wait-for-connector`. Optional (but persisted when provided) for the other four rule-types. |
+
+## ID generation
+
+- Condition prefix: `Condition_`, suffix length 6 → `Condition_xxxxxx`
+- Rule prefix: `Rule_`, suffix length 6 → `Rule_xxxxxx`
+- Algorithm: per [`case-editing-operations-json.md § ID Generation`](../../../case-editing-operations-json.md#id-generation)
+
+Record `T<n> → Condition_xxxxxx` in `id-map.json` (kind `stage-entry-condition`, plus `stageId` for the attachment target).
+
+## Attachment rules
+
+1. Locate the stage node by `target-stage` ID in `schema.nodes`. It must be `case-management:Stage` or `case-management:ExceptionStage`.
+2. If `data.entryConditions` is absent (regular Stage, no prior conditions), create it as `[]` before appending. Do not touch `entryConditions` on any other node type.
+3. Append the new condition object via `.push()` (insertion-order preserved — matches the CLI).
+
+Do **not** modify any other fields on the stage (position, label, isRequired, etc.).
+
+## Recipe — Condition object (shared across rule-types)
+
+```json
+{
+  "id": "<Condition_xxxxxx>",
+  "displayName": "<from sdd.md — omit key if not provided>",
+  "rules": [
+    [ <rule object from matrix below> ]
+  ]
+}
+```
+
+Append `"isInterrupting": true` (or `false`) **only** when `sdd.md` declared the field. Emit it **after** `rules` to match the CLI's field order.
+
+**Field order inside the condition object:** `id` → `displayName` → `rules` → `isInterrupting` (when present). JSON consumers do not require this order, but preserving it simplifies the golden diff against the CLI.
+
+**Rules structure is DNF** — outer array is OR, inner arrays are AND. The `add` path always writes `rules: [[<rule>]]` (one group, one rule). Additional rules (added later via `edit --rule-type`) are appended as **new outer-array groups**, not nested in the existing group:
+
+```json
+"rules": [
+  [ { ..."rule 1" } ],
+  [ { ..."rule 2 (added later)" } ]
+]
+```
+
+## Recipe — Rule object per rule-type
+
+All five rule-types share `rule` (string literal matching the rule-type) and `id` (`Rule_xxxxxx`). Extra fields depend on the rule-type:
+
+| `rule-type` | Rule JSON shape |
+|---|---|
+| `case-entered` | `{ "rule": "case-entered", "id": "<Rule_xxxxxx>" }` |
+| `selected-stage-completed` | `{ "rule": "selected-stage-completed", "id": "<Rule_xxxxxx>", "selectedStageId": "<Stage_xxxxxx>" }` |
+| `selected-stage-exited` | `{ "rule": "selected-stage-exited", "id": "<Rule_xxxxxx>", "selectedStageId": "<Stage_xxxxxx>" }` |
+| `user-selected-stage` | `{ "rule": "user-selected-stage", "id": "<Rule_xxxxxx>" }` |
+| `wait-for-connector` | `{ "rule": "wait-for-connector", "id": "<Rule_xxxxxx>", "conditionExpression": "<expr>" }` |
+
+Emit `conditionExpression` **only** when `sdd.md` provides it. JavaScript's `JSON.stringify` drops `undefined` values, so the CLI omits the key whenever no expression was passed — the JSON recipe matches by simply not writing the key.
+
+For `selected-stage-*` rule-types, `selectedStageId` is required. It must match an ID already present in `schema.nodes` (a previously captured Stage / ExceptionStage).
+
+## Recipe — Full example
+
+Stage `Stage_0F0DDI` receives an interrupting `selected-stage-exited` entry condition referencing `Stage_c4Vx6R`:
+
+```json
+{
+  "id": "Condition_NynOjv",
+  "displayName": "After Upstream exits",
+  "rules": [
+    [
+      {
+        "rule": "selected-stage-exited",
+        "id": "Rule_SLlw0L",
+        "selectedStageId": "Stage_c4Vx6R"
+      }
+    ]
+  ],
+  "isInterrupting": true
+}
+```
+
+Pushed onto `nodes[<Stage_0F0DDI>].data.entryConditions`.
+
+## Semantic position
+
+- The condition is appended to `stageNode.data.entryConditions[]` (not prepended). CLI uses `.push()`.
+- Multiple conditions on the same stage produce multiple array entries. Order follows the `tasks.md` T-entry order.
+- `entryConditions` is created on the regular Stage on first add. ExceptionStage already carries `entryConditions: []` from its creation, so the array is guaranteed to exist.
+
+## Post-write validation
+
+After writing, confirm:
+
+- The target stage's `data.entryConditions[]` contains an object with the generated `Condition_xxxxxx` ID.
+- The condition's `rules[0][0].rule` matches the declared rule-type.
+- For `selected-stage-*` rule-types, `rules[0][0].selectedStageId` points to an existing Stage / ExceptionStage node.
+- For `wait-for-connector`, `rules[0][0].conditionExpression` is a non-empty string.
+- `isInterrupting` is present iff `sdd.md` declared it; absent otherwise.
+
+Run `uip maestro case validate <file> --output json` after all stage-entry-conditions for this plugin's batch are added. Validation does not fail on isolated entry conditions — only on orthogonal concerns (orphan stages, missing edges, missing tasks, missing exit conditions on ExceptionStage). Expect the usual "no incoming edges / no tasks" failures at this stage of the build.
+
+## Edit semantics — appending a rule to an existing condition
+
+CLI `stage-entry-conditions edit <file> <stage-id> <condition-id> --rule-type <new-type>` appends a new rule as a **new outer-group** (new OR-clause). Direct-JSON-write matches:
+
+1. Locate the condition by `id` in `data.entryConditions`.
+2. `condition.rules.push([<new rule object>])` — wrap in a new single-element array.
+3. Update `displayName` / `isInterrupting` in place when those flags are provided.
+
+Removing rules requires `remove` + re-`add` on the CLI path. Direct-JSON-write can splice `rules[]` in place, but the current migration target is `add`-only; `remove` stays on the CLI path until its migration PR.
+
+## Known CLI divergences
+
+None today. The JSON recipe is structurally equivalent to the CLI output (IDs aside). Differences to be aware of:
+
+- `isInterrupting` is conditional — the CLI writes it only when `--is-interrupting` is passed. The JSON recipe must preserve this conditional-omission behavior rather than defaulting to `false` (otherwise the golden diff drifts). When `sdd.md` does not declare `is-interrupting`, the field stays absent; at runtime the case engine treats absence as `false`.
+- Field order inside the condition object (`id` → `displayName` → `rules` → `isInterrupting`) is a CLI artifact of key-insertion order. The JSON recipe matches for diff cleanliness; downstream consumers do not depend on it.
+
+## Compatibility
+
+Captured against the `0.3.4` CLI source build at `~/Documents/GitHub/cli` (the `0.1.21` binary on PATH lacks `maestro case`). See [`docs/uipath-case-management/migration-fixtures/stage-entry-conditions/`](../../../../../../docs/uipath-case-management/migration-fixtures/stage-entry-conditions/) for fixtures.
+
+- [x] **Golden diff:** normalized `json-write-output.json` matches `cli-output.json` after Stage / Condition / Rule ID normalization — `docs/uipath-case-management/migration-fixtures/stage-entry-conditions/diff.sh` passes.
+- [x] **Rule-type coverage:** all five stage-entry rule-types (`case-entered`, `selected-stage-completed`, `selected-stage-exited`, `user-selected-stage`, `wait-for-connector`) are exercised in the fixture and produce matching JSON shapes.
+- [x] **Validation parity:** both outputs produce the same expected failure profile (3 errors + 2 warnings — orphan stages, missing edges/tasks). `uip maestro case validate` raises no complaint about any of the entry conditions themselves.
+- [ ] **Downstream CLI mutation append:** `uip maestro case stage-entry-conditions edit --rule-type <...>` applied against the direct-JSON-written condition — not yet exercised.
+- [ ] **Round-trip:** CLI-written condition → direct-JSON-write adds a second condition on the same stage → `uip maestro case validate` passes — not yet exercised.
+- [ ] **Studio Web render:** `uip solution upload` and visual confirmation — not yet exercised.


### PR DESCRIPTION
## Summary

- Second plugin in the CLI → direct-JSON migration (after stages pilot #297). Ships `impl-json.md` for `stage-entry-conditions` covering all five rule-types, flips the strategy matrix, fixes known-wrong placeholder IDs in `impl-cli.md`, and adds a golden fixture.
- Authored from CLI source (`cli/packages/case-tool/src/commands/stage-entry-conditions.ts` + `buildRule` in `schema-helpers.ts`) and verified empirically against CLI output from the `0.3.4` source build. Golden diff passes.
- No runtime behavior change for CLI users — JSON path is opt-in via the strategy matrix.

## What changed

| File | Change |
|---|---|
| `skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md` | **New.** Full JSON recipe: per-rule-type shapes, conditional `isInterrupting`, DNF rules structure, edit-append semantics, post-write validation, compatibility checklist. |
| `skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-cli.md` | Fix placeholder IDs (`cond00000001` → `Condition_xxxxxx`, `Rule_xxxxxx`). Clarify conditional `isInterrupting`. Cross-link to `impl-json.md`. |
| `skills/uipath-case-management/references/case-editing-operations.md` | Matrix row `conditions/stage-entry-conditions`: `CLI` → `JSON`. |
| `skills/uipath-case-management/SKILL.md` | Condition-scope reference row: nod that migrated scopes use `impl-json.md` per the matrix. |
| `docs/uipath-case-management/migration-fixtures/stage-entry-conditions/` | **New.** Golden fixture with all 5 rule-types — `input.sdd-fragment.md`, `cli-output.json`, `json-write-output.json`, `diff.sh`, `README.md`. Outside the skill; verification-only. |

## Ground truth captured

Empirical output shapes (from `uip maestro case stage-entry-conditions add`, CLI 0.3.4):

- Condition: `{ id: "Condition_xxxxxx", displayName, rules: [[rule]], isInterrupting? }` — `isInterrupting` key present **only when** `--is-interrupting` is passed.
- Rule per type:
  - `case-entered` → `{ rule, id }`
  - `selected-stage-completed` → `{ rule, id, selectedStageId }`
  - `selected-stage-exited` → `{ rule, id, selectedStageId }`
  - `user-selected-stage` → `{ rule, id }`
  - `wait-for-connector` → `{ rule, id, conditionExpression }`
- CLI `.push()`es conditions (insert order preserved).
- `data.entryConditions` is absent on a regular Stage at creation time and gets created on first add.
- DNF: `add` writes `rules: [[rule]]`; `edit --rule-type` pushes a new outer OR-group.

## Test plan

- [x] `docs/uipath-case-management/migration-fixtures/stage-entry-conditions/diff.sh` passes (Stage / Condition / Rule IDs normalized by slug, CLI ≡ JSON-write)
- [x] `uip maestro case validate` produces the same expected failure profile (3 errors + 2 warnings — orphan stages, missing edges/tasks/exit conditions) against both `cli-output.json` and `json-write-output.json`
- [x] All 5 stage-entry rule-types exercised in the fixture
- [ ] Downstream CLI-edit append against JSON-written condition — deferred to rollup migration
- [ ] Studio Web render — deferred to rollup migration

## Follow-ups

- `stage-exit-conditions` next (separate PR — confirmed plan with reviewer to keep PRs small).
- Downstream round-trip + Studio Web render cover the whole migration at the end, not per plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)