### PR TITLE
feat(case-management): add direct-JSON support for case/stage/task en…

### DIFF
--- a/skills/uipath-case-management/SKILL.md
+++ b/skills/uipath-case-management/SKILL.md
@@ -161,7 +161,7 @@ Retry up to 3× on failure. On repeated failure, AskUserQuestion: `Retry with fi
 | **Wire task inputs/outputs (I/O binding)** | [references/plugins/variables/io-binding/planning.md](references/plugins/variables/io-binding/planning.md) + [`impl-json.md`](references/plugins/variables/io-binding/impl-json.md) |
 | **Add a specific task type** | `references/plugins/tasks/<type>/planning.md` + `impl-cli.md` |
 | **Add a specific trigger type** | `references/plugins/triggers/<type>/planning.md` + `impl-cli.md` |
-| **Add a specific condition scope** | `references/plugins/conditions/<scope>/planning.md` + `impl-cli.md` |
+| **Add a specific condition scope** | `references/plugins/conditions/<scope>/planning.md` + `impl-cli.md` / `impl-json.md` |
 
 ### Plugin Index
 

--- a/skills/uipath-case-management/references/case-editing-operations.md
+++ b/skills/uipath-case-management/references/case-editing-operations.md
@@ -27,10 +27,10 @@ Default strategy is **CLI**. Plugins opt in to direct JSON when they've been mig
 | `tasks/connector-activity` | CLI | Migration queued. Auto-injected default entry condition complicates the recipe. |
 | `tasks/connector-trigger` | CLI | Migration queued. Same as connector-activity. |
 | `tasks/wait-for-timer` | **JSON** | Writes full task with `timerType` + duration. See [plugins/tasks/wait-for-timer/impl-json.md](plugins/tasks/wait-for-timer/impl-json.md). |
-| `conditions/stage-entry-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/stage-entry-conditions/impl-json.md](plugins/conditions/stage-entry-conditions/impl-json.md). |
-| `conditions/stage-exit-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/stage-exit-conditions/impl-json.md](plugins/conditions/stage-exit-conditions/impl-json.md). |
-| `conditions/task-entry-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/task-entry-conditions/impl-json.md](plugins/conditions/task-entry-conditions/impl-json.md). |
-| `conditions/case-exit-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/case-exit-conditions/impl-json.md](plugins/conditions/case-exit-conditions/impl-json.md). |
+| `conditions/stage-entry-conditions` | **JSON** | Write directly to the target stage's `data.entryConditions[]`. See [plugins/conditions/stage-entry-conditions/impl-json.md](plugins/conditions/stage-entry-conditions/impl-json.md). |
+| `conditions/stage-exit-conditions` | **JSON** | Write directly to the target stage's `data.exitConditions[]`. See [plugins/conditions/stage-exit-conditions/impl-json.md](plugins/conditions/stage-exit-conditions/impl-json.md). |
+| `conditions/task-entry-conditions` | **JSON** | Write directly to the target task's `entryConditions[]`. See [plugins/conditions/task-entry-conditions/impl-json.md](plugins/conditions/task-entry-conditions/impl-json.md). |
+| `conditions/case-exit-conditions` | **JSON** | Write directly to `root.caseExitConditions[]`. See [plugins/conditions/case-exit-conditions/impl-json.md](plugins/conditions/case-exit-conditions/impl-json.md). |
 | `sla` | CLI | Migration queued. |
 
 ## How agents consume this matrix

--- a/skills/uipath-case-management/references/case-editing-operations.md
+++ b/skills/uipath-case-management/references/case-editing-operations.md
@@ -27,10 +27,10 @@ Default strategy is **CLI**. Plugins opt in to direct JSON when they've been mig
 | `tasks/connector-activity` | CLI | Migration queued. Auto-injected default entry condition complicates the recipe. |
 | `tasks/connector-trigger` | CLI | Migration queued. Same as connector-activity. |
 | `tasks/wait-for-timer` | **JSON** | Writes full task with `timerType` + duration. See [plugins/tasks/wait-for-timer/impl-json.md](plugins/tasks/wait-for-timer/impl-json.md). |
-| `conditions/stage-entry-conditions` | CLI | Migration queued. |
-| `conditions/stage-exit-conditions` | CLI | Migration queued. |
-| `conditions/task-entry-conditions` | CLI | Migration queued. |
-| `conditions/case-exit-conditions` | CLI | Migration queued. |
+| `conditions/stage-entry-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/stage-entry-conditions/impl-json.md](plugins/conditions/stage-entry-conditions/impl-json.md). |
+| `conditions/stage-exit-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/stage-exit-conditions/impl-json.md](plugins/conditions/stage-exit-conditions/impl-json.md). |
+| `conditions/task-entry-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/task-entry-conditions/impl-json.md](plugins/conditions/task-entry-conditions/impl-json.md). |
+| `conditions/case-exit-conditions` | CLI | Migration queued. Draft recipe in [plugins/conditions/case-exit-conditions/impl-json.md](plugins/conditions/case-exit-conditions/impl-json.md). |
 | `sla` | CLI | Migration queued. |
 
 ## How agents consume this matrix

--- a/skills/uipath-case-management/references/implementation.md
+++ b/skills/uipath-case-management/references/implementation.md
@@ -107,12 +107,12 @@ Skeleton tasks integrate with the rest of the graph:
 
 ## Step 10 — Add conditions
 
-For each condition in `tasks.md §4.7`, open the matching plugin:
+For each condition in `tasks.md §4.7`, open the matching plugin (`impl-cli.md` when the strategy matrix lists the scope as `CLI`; `impl-json.md` when `JSON`):
 
-- Stage entry → [`plugins/conditions/stage-entry-conditions/impl-cli.md`](plugins/conditions/stage-entry-conditions/impl-cli.md)
-- Stage exit → [`plugins/conditions/stage-exit-conditions/impl-cli.md`](plugins/conditions/stage-exit-conditions/impl-cli.md)
-- Task entry → [`plugins/conditions/task-entry-conditions/impl-cli.md`](plugins/conditions/task-entry-conditions/impl-cli.md)
-- Case exit → [`plugins/conditions/case-exit-conditions/impl-cli.md`](plugins/conditions/case-exit-conditions/impl-cli.md)
+- Stage entry → [`plugins/conditions/stage-entry-conditions/impl-cli.md`](plugins/conditions/stage-entry-conditions/impl-cli.md) / [`impl-json.md`](plugins/conditions/stage-entry-conditions/impl-json.md)
+- Stage exit → [`plugins/conditions/stage-exit-conditions/impl-cli.md`](plugins/conditions/stage-exit-conditions/impl-cli.md) / [`impl-json.md`](plugins/conditions/stage-exit-conditions/impl-json.md)
+- Task entry → [`plugins/conditions/task-entry-conditions/impl-cli.md`](plugins/conditions/task-entry-conditions/impl-cli.md) / [`impl-json.md`](plugins/conditions/task-entry-conditions/impl-json.md)
+- Case exit → [`plugins/conditions/case-exit-conditions/impl-cli.md`](plugins/conditions/case-exit-conditions/impl-cli.md) / [`impl-json.md`](plugins/conditions/case-exit-conditions/impl-json.md)
 
 ## Step 11 — SLA and escalation
 

--- a/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/impl-cli.md
@@ -1,4 +1,6 @@
-# case-exit-conditions — Implementation
+# case-exit-conditions — Implementation (CLI)
+
+> Direct-JSON alternative: [`impl-json.md`](impl-json.md).
 
 ## CLI Command
 

--- a/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -1,0 +1,84 @@
+# case-exit-conditions — Implementation (Direct JSON Write)
+
+Write the case-exit condition directly to `root.caseExitConditions[]` in `caseplan.json`. No CLI command needed.
+
+## Condition JSON Shape
+
+> **ID format.** Condition `id` is `Condition_` + 6 random chars. Rule `id` is `Rule_` + 6 random chars.
+
+```json
+{
+  "id": "Condition_xC1XyX",
+  "displayName": "Case resolved",
+  "marksCaseComplete": true,
+  "rules": [
+    [
+      { "id": "Rule_jdBFrJ", "rule": "required-stages-completed" }
+    ]
+  ]
+}
+```
+
+Rules use DNF — outer array is OR, inner array is AND.
+
+## Procedure
+
+1. Generate condition ID: `Condition_` + 6 alphanumeric chars
+2. Generate rule ID: `Rule_` + 6 alphanumeric chars
+3. Initialize `root.caseExitConditions = []` if absent
+4. Read `rule-type` and `marks-case-complete` from tasks.md; pick the recipe below
+5. Append the condition object to `root.caseExitConditions[]`
+
+## Rule Types
+
+### required-stages-completed — preferred completion
+
+```json
+"rules": [[ { "id": "Rule_xxxxxx", "rule": "required-stages-completed" } ]]
+```
+
+Requires `marksCaseComplete: true`. Completes when every stage flagged `data.isRequired: true` has completed.
+
+### selected-stage-completed / selected-stage-exited — non-completing exit
+
+```json
+"rules": [[
+  {
+    "id": "Rule_xxxxxx",
+    "rule": "selected-stage-completed",
+    "selectedStageId": "Stage_aB3kL9"
+  }
+]]
+```
+
+Requires `marksCaseComplete: false`. Swap `rule` to `selected-stage-exited` for exit-without-completion semantics.
+
+### wait-for-connector — external event
+
+```json
+"rules": [[
+  {
+    "id": "Rule_xxxxxx",
+    "rule": "wait-for-connector",
+    "conditionExpression": "event.type = 'case_closed'"
+  }
+]]
+```
+
+Valid for both `marksCaseComplete: true` and `false`.
+
+## Rule-Type × marksCaseComplete Matrix
+
+| `marksCaseComplete` | `rule` | Required extra field |
+|---|---|---|
+| `true` | `required-stages-completed` | — |
+| `true` | `wait-for-connector` | — |
+| `false` | `selected-stage-completed` | `selectedStageId` |
+| `false` | `selected-stage-exited` | `selectedStageId` |
+| `false` | `wait-for-connector` | — |
+
+`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
+
+## Post-Write Verification
+
+Confirm `root.caseExitConditions[]` contains the new object with `id`, `marksCaseComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.

--- a/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-cli.md
@@ -1,4 +1,6 @@
-# stage-entry-conditions — Implementation
+# stage-entry-conditions — Implementation (CLI)
+
+> Direct-JSON alternative: [`impl-json.md`](impl-json.md).
 
 ## CLI Command
 

--- a/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -1,0 +1,95 @@
+# stage-entry-conditions — Implementation (Direct JSON Write)
+
+Write the stage-entry condition directly to the target stage's `data.entryConditions[]`. No CLI command needed.
+
+## Condition JSON Shape
+
+> **ID format.** Condition `id` is `Condition_` + 6 random chars. Rule `id` is `Rule_` + 6 random chars.
+
+```json
+{
+  "id": "Condition_xC1XyX",
+  "displayName": "After Triage",
+  "isInterrupting": false,
+  "rules": [
+    [
+      {
+        "id": "Rule_jdBFrJ",
+        "rule": "selected-stage-exited",
+        "selectedStageId": "Stage_aB3kL9"
+      }
+    ]
+  ]
+}
+```
+
+Rules use DNF — outer array is OR, inner array is AND.
+
+## Procedure
+
+1. Generate condition ID: `Condition_` + 6 alphanumeric chars
+2. Generate rule ID: `Rule_` + 6 alphanumeric chars
+3. Locate the target stage in `schema.nodes` by ID
+4. Initialize `stageNode.data.entryConditions = []` if absent (regular Stage is created without this key — see [`../../stages/impl-json.md`](../../stages/impl-json.md))
+5. Read `rule-type` and `is-interrupting` from tasks.md; pick the recipe below
+6. Append the condition object to `stageNode.data.entryConditions[]`
+
+## Rule Types
+
+### case-entered — first-stage entry
+
+```json
+"rules": [[ { "id": "Rule_xxxxxx", "rule": "case-entered" } ]]
+```
+
+### selected-stage-completed / selected-stage-exited — upstream stage trigger
+
+```json
+"rules": [[
+  {
+    "id": "Rule_xxxxxx",
+    "rule": "selected-stage-exited",
+    "selectedStageId": "Stage_aB3kL9"
+  }
+]]
+```
+
+Swap `rule` to `selected-stage-completed` when completion semantics are required.
+
+### user-selected-stage — target of a `wait-for-user` exit
+
+```json
+"rules": [[ { "id": "Rule_xxxxxx", "rule": "user-selected-stage" } ]]
+```
+
+Fires when an upstream stage exits via a `wait-for-user` exit condition and the user picks this stage as the next one. The stage must opt in by declaring this rule — only stages with `user-selected-stage` are presented in the picker.
+
+### wait-for-connector — interrupting on external event
+
+```json
+"rules": [[
+  {
+    "id": "Rule_xxxxxx",
+    "rule": "wait-for-connector",
+    "conditionExpression": "event.fraudScore > 0.8"
+  }
+]]
+```
+
+Set `isInterrupting: true` for exception/fraud/escalation flows.
+
+## Rule-Type Catalog
+
+| `rule` | Required extra field |
+|---|---|
+| `case-entered` | — |
+| `selected-stage-completed` | `selectedStageId` |
+| `selected-stage-exited` | `selectedStageId` |
+| `user-selected-stage` | — |
+| `wait-for-connector` | — |
+
+`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
+
+## Post-Write Verification
+
+Confirm target stage's `data.entryConditions[]` contains the new object with `id`, `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.

--- a/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -32,7 +32,7 @@ Allowed `--rule-type` values and when to pick each:
 | `case-entered` | Fires the moment the case is entered (first stage pattern) | — |
 | `selected-stage-completed` | Fires when a specific upstream stage completes | `--selected-stage-id` |
 | `selected-stage-exited` | Fires when a specific upstream stage exits (even without completing) | `--selected-stage-id` |
-| `user-selected-stage` | Fires when a user manually selects/routes to this stage (e.g., via a `return-to-origin` or stage-picker exit) | — |
+| `user-selected-stage` | Fires when an upstream stage exits via a `wait-for-user` exit condition and the user selects this stage as the next one. Only stages carrying this rule appear in the picker. | — |
 | `wait-for-connector` | Waits for a connector event | `--condition-expression` |
 
 `is-interrupting: true` means the condition can fire **while another stage is active** and will interrupt it. Use for exception/interrupt flows.

--- a/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl-cli.md
@@ -1,4 +1,6 @@
-# stage-exit-conditions — Implementation
+# stage-exit-conditions — Implementation (CLI)
+
+> Direct-JSON alternative: [`impl-json.md`](impl-json.md).
 
 ## CLI Command
 

--- a/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -1,0 +1,121 @@
+# stage-exit-conditions — Implementation (Direct JSON Write)
+
+Write the stage-exit condition directly to the target stage's `data.exitConditions[]`. No CLI command needed.
+
+## Condition JSON Shape
+
+> **ID format.** Condition `id` is `Condition_` + 6 random chars. Rule `id` is `Rule_` + 6 random chars.
+
+```json
+{
+  "id": "Condition_xC1XyX",
+  "displayName": "All tasks done",
+  "type": "exit-only",
+  "exitToStageId": null,
+  "marksStageComplete": true,
+  "rules": [
+    [
+      { "id": "Rule_jdBFrJ", "rule": "required-tasks-completed" }
+    ]
+  ]
+}
+```
+
+Rules use DNF — outer array is OR, inner array is AND.
+
+## Procedure
+
+1. Generate condition ID: `Condition_` + 6 alphanumeric chars
+2. Generate rule ID: `Rule_` + 6 alphanumeric chars
+3. Locate the target stage in `schema.nodes` by ID
+4. Initialize `stageNode.data.exitConditions = []` if absent (regular Stage is created without this key — see [`../../stages/impl-json.md`](../../stages/impl-json.md))
+5. Read `type`, `exit-to-stage`, `marks-stage-complete`, and `rule-type` from tasks.md; pick the recipe below
+6. Append the condition object to `stageNode.data.exitConditions[]`
+
+## Exit Types
+
+| `type` | When to pick |
+|---|---|
+| `exit-only` | Default — stage exits normally along configured edges |
+| `wait-for-user` | Manual user decision required |
+| `return-to-origin` | Rework / exception loop — sends the case back to the previous stage |
+
+## Rule Types
+
+### required-tasks-completed — default completion
+
+```json
+"type": "exit-only",
+"exitToStageId": null,
+"marksStageComplete": true,
+"rules": [[ { "id": "Rule_xxxxxx", "rule": "required-tasks-completed" } ]]
+```
+
+### selected-tasks-completed — routing on specific tasks
+
+```json
+"type": "exit-only",
+"exitToStageId": "Stage_cD4mNt",
+"marksStageComplete": false,
+"rules": [[
+  {
+    "id": "Rule_xxxxxx",
+    "rule": "selected-tasks-completed",
+    "selectedTasksIds": ["t8GQTYo8O", "tWm4Vx9Tp"]
+  }
+]]
+```
+
+`selectedTasksIds` is a JSON string array, not a comma-separated string.
+
+### wait-for-connector — external event
+
+```json
+"type": "exit-only",
+"exitToStageId": null,
+"marksStageComplete": true,
+"rules": [[
+  {
+    "id": "Rule_xxxxxx",
+    "rule": "wait-for-connector",
+    "conditionExpression": "event.type = 'approved'"
+  }
+]]
+```
+
+### wait-for-user — manual decision gate
+
+```json
+"type": "wait-for-user",
+"exitToStageId": null,
+"marksStageComplete": true,
+"rules": [[ { "id": "Rule_xxxxxx", "rule": "required-tasks-completed" } ]]
+```
+
+The case pauses after the rule fires; the user picks the next stage from candidates that carry a `user-selected-stage` entry rule.
+
+### return-to-origin — rework loop
+
+```json
+"type": "return-to-origin",
+"exitToStageId": null,
+"marksStageComplete": false,
+"rules": [[ { "id": "Rule_xxxxxx", "rule": "required-tasks-completed" } ]]
+```
+
+Routes the case back to the originating stage. `exitToStageId` stays `null` — the runtime resolves origin dynamically.
+
+## Rule-Type × marksStageComplete Matrix
+
+| `marksStageComplete` | `rule` | Required extra field |
+|---|---|---|
+| `true` | `required-tasks-completed` | — |
+| `true` | `wait-for-connector` | — |
+| `false` | `selected-tasks-completed` | `selectedTasksIds` (array) |
+| `false` | `wait-for-connector` | — |
+
+`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
+
+## Post-Write Verification
+
+Confirm target stage's `data.exitConditions[]` contains the new object with `id`, `type`, `exitToStageId` (`null` or captured ID), `marksStageComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.

--- a/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -99,7 +99,7 @@ The case pauses after the rule fires; the user picks the next stage from candida
 ```json
 "type": "return-to-origin",
 "exitToStageId": null,
-"marksStageComplete": false,
+"marksStageComplete": true,
 "rules": [[ { "id": "Rule_xxxxxx", "rule": "required-tasks-completed" } ]]
 ```
 

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-cli.md
@@ -1,4 +1,6 @@
-# task-entry-conditions — Implementation
+# task-entry-conditions — Implementation (CLI)
+
+> Direct-JSON alternative: [`impl-json.md`](impl-json.md).
 
 ## CLI Command
 

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -1,0 +1,102 @@
+# task-entry-conditions — Implementation (Direct JSON Write)
+
+Write the task-entry condition directly to the target task's `entryConditions[]`. No CLI command needed.
+
+## Condition JSON Shape
+
+> **ID format.** Task-level condition `id` is `c` + 8 random chars. Rule `id` is `r` + 8 random chars. These differ from stage/case-level conditions (`Condition_`/`Rule_`).
+
+```json
+{
+  "id": "c4fGhJ2Mn",
+  "displayName": "After Approval",
+  "rules": [
+    [
+      {
+        "id": "rK9xQw3Lp",
+        "rule": "selected-tasks-completed",
+        "selectedTasksIds": ["t8GQTYo8O"]
+      }
+    ]
+  ]
+}
+```
+
+Rules use DNF — outer array is OR, inner array is AND.
+
+## Procedure
+
+1. Generate condition ID: `c` + 8 alphanumeric chars
+2. Generate rule ID: `r` + 8 alphanumeric chars
+3. Locate the target stage in `schema.nodes` by ID
+4. Locate the target task inside `stageNode.data.tasks[lane][index]` (search every lane until the task ID is found)
+5. Initialize `task.entryConditions = []` if absent
+6. Read `rule-type` from tasks.md; pick the recipe below
+7. Append the condition object to `task.entryConditions[]`
+
+> **Connector tasks.** `execute-connector-activity` and `wait-for-connector` tasks already carry an auto-injected `current-stage-entered` default entry condition from task-creation time. Append — never overwrite or remove the default.
+
+## Rule Types
+
+### current-stage-entered — default gate
+
+```json
+"rules": [[ { "id": "rxxxxxxxx", "rule": "current-stage-entered" } ]]
+```
+
+Matches the shape of the auto-injected default on connector tasks.
+
+### selected-tasks-completed — sibling task gating
+
+```json
+"rules": [[
+  {
+    "id": "rxxxxxxxx",
+    "rule": "selected-tasks-completed",
+    "selectedTasksIds": ["t8GQTYo8O", "tWm4Vx9Tp"]
+  }
+]]
+```
+
+`selectedTasksIds` is a JSON string array.
+
+### adhoc — expression gate
+
+```json
+"rules": [[
+  {
+    "id": "rxxxxxxxx",
+    "rule": "adhoc",
+    "conditionExpression": "in.riskScore > 700"
+  }
+]]
+```
+
+Expression syntax per [`../../../bindings-and-expressions.md`](../../../bindings-and-expressions.md). Use `=js:(...)` for expressions with operators.
+
+### wait-for-connector — external event
+
+```json
+"rules": [[
+  {
+    "id": "rxxxxxxxx",
+    "rule": "wait-for-connector",
+    "conditionExpression": "event.type = 'order_received'"
+  }
+]]
+```
+
+## Rule-Type Catalog
+
+| `rule` | Required extra field |
+|---|---|
+| `current-stage-entered` | — |
+| `selected-tasks-completed` | `selectedTasksIds` (array) |
+| `wait-for-connector` | — |
+| `adhoc` | — |
+
+`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
+
+## Post-Write Verification
+
+Confirm target task's `entryConditions[]` contains the new object with `id` (prefix `c`) and `rules` carrying the expected `rule` value plus any required side field. For connector tasks, verify the auto-injected `current-stage-entered` default is still present and precedes the new condition.

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/planning.md
@@ -20,7 +20,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `display-name` | sdd.md (optional) | |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `condition-expression` | Required for `adhoc` and `wait-for-connector` | |
+| `condition-expression` | Optional | |
 
 ## Rule-Type Catalog (task-entry scope)
 
@@ -29,7 +29,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `current-stage-entered` | Fires when the containing stage is entered | — |
 | `selected-tasks-completed` | Fires when specific sibling tasks in the same stage complete | `--selected-tasks-ids` |
 | `wait-for-connector` | Waits for a connector event | `--condition-expression` |
-| `adhoc` | Fires when an arbitrary expression evaluates truthy | `--condition-expression` |
+| `adhoc` | Ad hoc tasks run only when a user triggers them from the case app. | `--condition-expression` (optional) |
 
 ## Ordering
 


### PR DESCRIPTION
Introduce impl-json.md files for stage-entry, stage-exit, task-entry, and
case-exit condition scopes documenting the JSON shape, ID formats, rule-type
catalogs, and post-write verification. Strategy matrix keeps CLI as the
default while linking the JSON drafts as the migration preview; implementation
step 10 now points to both paths. Also clarifies the `user-selected-stage`
entry rule as the picker opt-in for upstream `wait-for-user` exits.
