### PR TITLE
fix(maestro-flow): fix broken IS cross-skill links in connector plugins

### DIFF
--- a/skills/uipath-maestro-flow/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector-trigger/impl.md
@@ -95,7 +95,7 @@ Use the resolved IDs in the trigger's event parameter configuration.
 
 > **Paginate when looking up by name.** `execute list` returns one page (up to 1000 items) and surfaces `Data.Pagination.HasMore` + `Data.Pagination.NextPageToken`. If the target isn't on the first page, re-run with `--query "nextPage=<NextPageToken>"` until found or `HasMore` is `"false"`. Short-circuit as soon as the target name matches — don't pull every page.
 
-**Read [/uipath:uipath-platform — Integration Service — resources.md](/uipath:uipath-platform) for the full reference resolution workflow**, including pagination, describe failures, and fallback strategies.
+**Read [/uipath:uipath-platform — Integration Service — resources.md](../../../../uipath-platform/references/integration-service/resources.md) for the full reference resolution workflow**, including pagination, describe failures, and fallback strategies.
 
 ### Step 4 — Validate required event parameters
 

--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -44,7 +44,7 @@ uip is connections ping "<connection-id>" --output json
 
 **If `connections list` returns empty**, the CLI scoped to Personal Workspace by default — check other folders with `uip or folders list` + `--folder-key <key>` (Shared is the common case). If still not found, the connection doesn't exist — tell the user, and have them create one via the IS portal or `uip is connections create "<connector-key>"`.
 
-**Read [/uipath:uipath-platform — Integration Service — connections.md](/uipath:uipath-platform) for connection selection rules** (default preference, HTTP fallback, multi-connection disambiguation, no-connection recovery, ping verification).
+**Read [/uipath:uipath-platform — Integration Service — connections.md](../../../../uipath-platform/references/integration-service/connections.md) for connection selection rules** (default preference, HTTP fallback, multi-connection disambiguation, no-connection recovery, ping verification).
 
 ### Step 2 — Get enriched node definitions with connection
 
@@ -93,7 +93,7 @@ Use the resolved IDs (not display names) in the flow's node `inputs`. Present op
 
 > **Paginate when looking up by name.** `execute list` returns one page (up to 1000 items) and surfaces `Data.Pagination.HasMore` + `Data.Pagination.NextPageToken`. If the target isn't on the first page, re-run with `--query "nextPage=<NextPageToken>"` until found or `HasMore` is `"false"`. Short-circuit as soon as the target name matches — don't pull every page.
 
-**Read [/uipath:uipath-platform — Integration Service — resources.md](/uipath:uipath-platform) for the full reference resolution workflow**, including: identifying reference fields, dependency chains (resolve parent fields before children), pagination, describe failures, and fallback strategies.
+**Read [/uipath:uipath-platform — Integration Service — resources.md](../../../../uipath-platform/references/integration-service/resources.md) for the full reference resolution workflow**, including: identifying reference fields, dependency chains (resolve parent fields before children), pagination, describe failures, and fallback strategies.
 
 ### Step 5 — Validate required fields
 


### PR DESCRIPTION
## Summary
- Fixed 3 broken markdown links in connector plugin impl.md files that pointed to `/uipath:uipath-platform` (a skill invocation slug, not a valid file path)
- Updated links to use relative paths to the actual target files:
  - `connector-trigger/impl.md` → `resources.md`
  - `connector/impl.md` → `connections.md` and `resources.md`

## Changed files
- `skills/uipath-maestro-flow/references/plugins/connector-trigger/impl.md`
- `skills/uipath-maestro-flow/references/plugins/connector/impl.md`

## Test plan
- [ ] Verify relative links resolve correctly from each impl.md to the target files in `uipath-platform/references/integration-service/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)