### PR TITLE
fix(maestro-flow): add missing --output json flags and consolidate post-build prompt

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -283,16 +283,7 @@ For Orchestrator deployment when explicitly requested, see [references/flow-comm
 
 #### Post-build choice prompt
 
-When the build completes and it is time to offer next steps (see Completion Output → "Next step"), use `AskUserQuestion` to present a dropdown with these options (per Critical Rule #19):
-
-| Option | Action |
-|--------|--------|
-| **Publish to Studio Web** (default) | Run `uip solution resource refresh <SolutionDir> --output json` then `uip solution upload <SolutionDir> --output json` and share the Studio Web URL. |
-| **Debug the solution** | Run `uip solution resource refresh <SolutionDir> --output json` then `UIPCLI_LOG_LEVEL=info uip maestro flow debug <ProjectDir>` (see Step 8). Confirm consent first — debug executes the flow for real. |
-| **Deploy to Orchestrator** | Run `uip solution resource refresh <SolutionDir> --output json` then `uip maestro flow pack` + `uip solution publish` via the [/uipath:uipath-platform](/uipath:uipath-platform) skill. Only use when the user explicitly chooses this. |
-| **Something else** | Last option. Accept free-form string input and act on it (e.g., "just leave it", "pack but don't publish", "upload to a different tenant"). |
-
-Do not run any of these actions without an explicit user selection.
+When the build completes, present the next-step dropdown described in the [Completion Output](#completion-output) section. See the detailed action table there for what each option runs.
 
 ## Anti-Patterns
 
@@ -374,12 +365,15 @@ When you finish building or editing a flow, report to the user:
 5. **Mock placeholders** — list any `core.logic.mock` nodes that need to be replaced, and which skill to use
 6. **Missing connections** — any connector nodes that need connections the user must create
 7. **Next step** — use `AskUserQuestion` to present a dropdown with these options (Critical Rule #19):
-   - **Publish to Studio Web** — run `uip solution upload <SolutionDir>` and share the URL
-   - **Debug the solution** — run `uip maestro flow debug <ProjectDir>` (requires explicit consent — side effects are real)
-   - **Deploy to Orchestrator** — hand off to the [/uipath:uipath-platform](/uipath:uipath-platform) skill for `uip maestro flow pack` + `uip solution publish`
-   - **Something else** (last option) — accept free-form input and act on it
 
-   Do not run any of these actions automatically. Wait for the user's selection.
+   | Option | Action |
+   |--------|--------|
+   | **Publish to Studio Web** (default) | Run `uip solution resource refresh <SolutionDir> --output json` then `uip solution upload <SolutionDir> --output json` and share the Studio Web URL. |
+   | **Debug the solution** | Run `uip solution resource refresh <SolutionDir> --output json` then `UIPCLI_LOG_LEVEL=info uip maestro flow debug <ProjectDir> --output json` (see Step 8). Confirm consent first — debug executes the flow for real. |
+   | **Deploy to Orchestrator** | Run `uip solution resource refresh <SolutionDir> --output json` then `uip maestro flow pack` + `uip solution publish` via the [/uipath:uipath-platform](/uipath:uipath-platform) skill. Only use when the user explicitly chooses this. |
+   | **Something else** | Last option. Accept free-form string input and act on it (e.g., "just leave it", "pack but don't publish", "upload to a different tenant"). |
+
+   Do not run any of these actions without an explicit user selection.
 
 ## References
 

--- a/skills/uipath-maestro-flow/references/flow-editing-operations-cli.md
+++ b/skills/uipath-maestro-flow/references/flow-editing-operations-cli.md
@@ -112,7 +112,7 @@ The `--detail` JSON schema differs between connector activity nodes, connector t
 **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file:
 
 ```bash
-uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)"
+uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)" --output json
 ```
 
 ### Configure a managed HTTP node

--- a/skills/uipath-maestro-flow/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector-trigger/impl.md
@@ -123,7 +123,7 @@ Follow the [CLI: Replace manual trigger with connector trigger](../../flow-editi
 Use `node configure` with trigger-specific `--detail` fields:
 
 ```bash
-uip maestro flow node configure <PROJECT>.flow <triggerId> --detail '{
+uip maestro flow node configure <PROJECT>.flow <triggerId> --output json --detail '{
   "connectionId": "<CONNECTION_ID>",
   "folderKey": "<FOLDER_KEY>",
   "eventMode": "<EVENT_MODE>",
@@ -144,7 +144,7 @@ uip maestro flow node configure <PROJECT>.flow <triggerId> --detail '{
 
 The command populates `inputs.detail` (including the internal `configuration` blob) and creates workflow-level connection bindings.
 
-> **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)"`
+> **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)" --output json`
 
 ---
 

--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -114,12 +114,13 @@ After adding the node with `uip maestro flow node add`, configure it with the re
 
 ```bash
 uip maestro flow node configure <file> <nodeId> \
-  --detail '{"connectionId": "<id>", "folderKey": "<key>", "method": "POST", "endpoint": "/issues", "bodyParameters": {"fields.project.key": "ENGCE", "fields.issuetype.id": "10004"}}'
+  --detail '{"connectionId": "<id>", "folderKey": "<key>", "method": "POST", "endpoint": "/issues", "bodyParameters": {"fields.project.key": "ENGCE", "fields.issuetype.id": "10004"}}' \
+  --output json
 ```
 
 The `method` and `endpoint` values come from `connectorMethodInfo` in the `registry get` response (Step 2). The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names.
 
-> **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)"`
+> **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)" --output json`
 
 ---
 

--- a/skills/uipath-maestro-flow/references/plugins/flow/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/flow/impl.md
@@ -32,7 +32,7 @@ Confirm:
 
 - Input port: `input`
 - Output port: `output`
-- `model.serviceType` — `Orchestrator.StartAgenticProcess`
+- `model.serviceType` — `Orchestrator.StartAgenticProcess` (shared with agentic-process nodes; `resourceSubType: "Flow"` differentiates)
 - `model.bindings.resourceSubType` — `Flow`
 - `inputDefinition` — typically empty
 - `outputDefinition.error` — error schema

--- a/skills/uipath-maestro-flow/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/http/impl.md
@@ -55,7 +55,7 @@ uip maestro flow node configure <ProjectName>.flow <nodeId> \
     "method": "GET",
     "url": "/api/endpoint",
     "query": {"param1": "value1"}
-  }'
+  }' --output json
 ```
 
 **Manual mode** (no connector auth):
@@ -67,7 +67,7 @@ uip maestro flow node configure <ProjectName>.flow <nodeId> \
     "method": "GET",
     "url": "https://api.example.com/endpoint",
     "query": {"param1": "value1"}
-  }'
+  }' --output json
 ```
 
 **What the CLI handles automatically:**
@@ -104,7 +104,7 @@ uip maestro flow node configure <Project>.flow <nodeId> \
     "authentication": "manual",
     "method": "GET",
     "url": "=js:`https://api.example.com/users/${$vars.userId}`"
-  }'
+  }' --output json
 ```
 
 ### Step 4 — (Optional) Configure response branches for content-based routing
@@ -120,7 +120,7 @@ uip maestro flow node configure <ProjectName>.flow <nodeId> \
       { "id": "hasItems",  "name": "Has Items",  "conditionExpression": "$self.output.body.items.length > 0" },
       { "id": "empty",     "name": "Empty",      "conditionExpression": "$self.output.body.items.length == 0" }
     ]
-  }'
+  }' --output json
 ```
 
 > **Do not prefix `conditionExpression` with `=js:`** — HTTP branch conditions are auto-evaluated as JS (same rule as decision/switch expressions).


### PR DESCRIPTION
## Summary

Skill review (scored **4.7/5**) identified three consistency issues in the `uipath-maestro-flow` skill:

- **Add missing `--output json` to 9 `node configure` CLI examples** across `connector/impl.md`, `connector-trigger/impl.md`, `http/impl.md`, and `flow-editing-operations-cli.md` — violating Critical Rule #4 ("ALWAYS use `--output json` on all `uip` commands when parsing output programmatically")
- **Consolidate duplicated Post-build choice prompt** — the publish/debug/deploy options table was duplicated between the "Post-build choice prompt" section and the "Completion Output" section in SKILL.md. Replaced the duplicate with a cross-reference; the Completion Output section is now the single authoritative source with full action details
- **Clarify `serviceType` in `flow/impl.md`** — Flow nodes share `Orchestrator.StartAgenticProcess` with agentic-process nodes, differentiated by `resourceSubType: "Flow"`. Added an inline note to prevent future confusion with copy-paste errors

## Test plan

- [ ] Verify `node configure` commands still work with `--output json` appended (non-breaking — the flag is already supported)
- [ ] Confirm the Completion Output section in SKILL.md renders correctly with the action table
- [ ] Spot-check that the cross-reference link from Post-build to Completion Output resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)