### PR TITLE
docs(tests): add playbook and /skill-compare command for A/B skill experiments

### DIFF
--- a/.claude/commands/generate-tasks.md
+++ b/.claude/commands/generate-tasks.md
@@ -46,7 +46,47 @@ For each gap, design a task:
 | Multi-step workflow with error handling, cross-component integration | integration |
 | Full build -> validate -> run lifecycle, artifact correctness | e2e |
 
-### 2b. Choose task_id
+### 2b. Choose tags
+
+Every generated task must carry tags from the **Tag Taxonomy** documented in [`tests/README.md`](../../tests/README.md#tag-taxonomy). The tags aren't decoration — they drive `make tags`, `/skill-compare`, and coverage slicing. Assemble the `tags:` list by picking one value per applicable dimension:
+
+| Dimension | Pick | Notes |
+|---|---|---|
+| **skill** (required) | `uipath-<name>` | Must match the target skill folder. Always first in the list. |
+| **tier** (required) | `smoke`, `integration`, or `e2e` | Always second in the list. From Phase 2a. |
+| **lifecycle** | `activate`, `generate`, `edit`, `validate`, `execute`, `deploy` | What is the agent being asked to do? Most smoke tests are `activate` or `validate`; most e2e are `generate` (green-field) or `edit` (brown-field); `execute` applies when the task actually runs the built artifact (e.g. `flow debug`). |
+| **scenario** | `green-field`, `brown-field`, `fixture` | Starting state. `green-field` = empty workspace. `brown-field` = existing project the agent modifies. `fixture` = pre-seeded inputs (e.g. a PDD file dropped in). Skip if the task is a single-CLI-command smoke test with no real workspace state. |
+| **feature** | `hitl`, `approval-gate`, `write-back`, `escalation`, `registry`, `connector-feature`, `connections`, `activities`, `records`, `entities`, `api-workflow`, `compliance`, `test-case`, `hooks`, `transform`, `http` | Zero or more. Only add a feature tag when the task genuinely exercises that capability. Do not invent new feature tags — if none of the closed-set values fit, omit the feature dimension and flag it in the Phase 4 summary so the taxonomy can be extended in a follow-up PR. |
+
+**Selection rules:**
+1. **Always include `skill` and `tier`.** Task YAMLs without both fail the tests/README contract.
+2. **Pick the most specific `lifecycle` that fits.** If the task both generates and validates (common), use `generate` — validation is implicit in the success criteria.
+3. **Do not repeat the skill name as a feature tag.** E.g. don't tag `uipath-agents` tasks with a bare `agent` feature. If you need to express "this maestro-flow task exercises an RPA resource node", use a descriptive feature tag and note it in the summary — but prefer existing closed-set tags when possible.
+4. **Feature tags are cross-cutting.** `hitl` on a maestro-flow task signals "this flow contains a HITL node" and is how cross-skill HITL coverage gets sliced. `registry` spans flow/agent/case registries. `escalation` spans HITL and agents.
+5. **Order tags consistently:** `[skill, tier, lifecycle, scenario, ...features]`. This matches existing tasks and makes grep/review easier.
+
+**Worked examples** (from existing tasks):
+
+```yaml
+# Green-field flow authoring that hits HITL + approval-gate + write-back
+tags: [uipath-human-in-the-loop, e2e, generate, green-field, hitl, approval-gate, write-back]
+
+# Smoke test that just lists IS connector activities
+tags: [uipath-platform, smoke, activate, activities]
+
+# E2E Data Fabric CRUD cycle on a live tenant
+tags: [uipath-data-fabric, e2e, execute, entities, records]
+
+# Brown-field RPA test case authored on an existing project
+tags: [uipath-rpa, integration, edit, brown-field, test-case]
+
+# Smoke test that exercises the Flow node registry
+tags: [uipath-maestro-flow, smoke, activate, registry]
+```
+
+Before writing the YAML, verify the assembled tag list against `grep -r "^tags:" tests/tasks/` output to confirm the combination isn't obviously wrong (e.g. `green-field` on a smoke test that doesn't create a project).
+
+### 2c. Choose task_id
 
 Convention: `skill-<domain>-<capability>`
 
@@ -70,7 +110,7 @@ If a skill is not listed, derive `<domain>` by stripping the `uipath-` prefix an
 
 Verify the chosen `task_id` does not appear in any existing task YAML (collected in Phase 1 step 5).
 
-### 2c. Write initial_prompt
+### 2d. Write initial_prompt
 
 General principles:
 1. Describe the GOAL, not the steps — the skill teaches the steps, and that is what we are testing.
@@ -79,7 +119,7 @@ General principles:
 
 **Learn the prompt style from existing tests.** Read all existing task YAMLs for the skill (and for other skills if this skill has none yet) to pick up the conventions currently in use — what instructions are included, how skill loading is handled, what constraints are specified. Mirror those conventions in the generated prompts rather than inventing new patterns.
 
-### 2d. Design success criteria
+### 2e. Design success criteria
 
 **Learn from existing tests.** Read the criteria patterns used in existing task YAMLs (collected in Phase 1 step 5–6) and use the same criterion types, weight scales, and threshold values for the same tier of test.
 
@@ -97,7 +137,7 @@ Operators for `json_check` assertions: `equals`, `gte`, `lte`, `gt`, `lt`, `cont
 
 **Criteria must be verifiable.** Only assert on things that can actually be checked in the sandbox. Do not assert on cloud-dependent state if the test is local-only. Do not use `command_executed` for commands the agent might not need to run.
 
-### 2e. Configure agent and sandbox
+### 2f. Configure agent and sandbox
 
 **Learn from existing tests.** Read the experiment configs and existing task YAMLs to determine what needs to be specified vs. what can be inherited. Only include `agent:` and `max_iterations` fields when they differ from the experiment defaults for the chosen test type.
 
@@ -197,7 +237,7 @@ For skills without a common artifact format, keep check scripts self-contained. 
 For each generated YAML file:
 1. Read the file back and verify the YAML structure is correct (proper indentation, no unescaped colons in values, matching quotes). If `pyyaml` is available, run `python3 -c "import yaml; yaml.safe_load(open('<path>'))"` as an additional check.
 2. Verify `task_id` is unique across all existing task YAMLs in the repo.
-3. Verify `tags` array includes the skill name as first element and test type as second.
+3. Verify `tags` array conforms to the Tag Taxonomy: skill name first, tier (`smoke`/`integration`/`e2e`) second, followed by optional `lifecycle`, `scenario`, and `feature` values drawn from the closed vocabularies in Phase 2b. Any tag outside those sets must be flagged in the summary, not silently emitted.
 4. Verify `sandbox.driver` is set to `tempdir`.
 5. Verify file paths in `success_criteria` are consistent with what `initial_prompt` asks the agent to create.
 6. For check scripts: verify they are syntactically valid Python (`python3 -c "import py_compile; py_compile.compile('<path>', doraise=True)"`).
@@ -225,6 +265,7 @@ Infrastructure notes:
 
 1. **Read the skill thoroughly.** Every SKILL.md, every reference file. Generated prompts must use correct CLI commands, flags, project structures, and naming conventions from the skill.
 2. **Follow existing test patterns.** Read existing task YAMLs (both for the target skill and other skills) to learn current conventions for agent config, prompt style, and criteria patterns. Mirror those conventions rather than hardcoding assumptions that may become stale.
+3. **Honor the Tag Taxonomy.** Emitted `tags:` must draw from the closed vocabularies in [`tests/README.md`](../../tests/README.md#tag-taxonomy). Never invent new feature tags inline — if no existing value fits, omit the feature dimension and raise it in the Phase 4b summary so the taxonomy can be extended deliberately.
 3. **Minimal prompts.** Describe goals, not steps. The skill teaches the steps — that is what we are testing.
 4. **Realistic criteria.** Only assert on things that can actually be checked in the sandbox. Do not assert on cloud state if the test runs locally. Do not use `command_executed` for commands the agent might not need to run.
 5. **No duplicate task_ids.** Check all existing YAMLs across all skills before generating.

--- a/.claude/commands/skill-compare.md
+++ b/.claude/commands/skill-compare.md
@@ -4,14 +4,20 @@ Run an apples-to-apples A/B comparison between two refs of the skills repo — e
 
 **Input:** `$ARGUMENTS`
 - `<ref_a> <ref_b>` — required, the two refs to compare. Each ref is either a **branch name** (local or remote-tracking) or a **commit SHA** (short or full, must already be in the local object database). The two refs can be any mix of the two kinds.
-- `<skill_name>` — optional third argument. Restricts the task set to `tests/tasks/<skill_name>/`. Defaults to all tasks (warn the user: this can be slow and expensive).
+- `<task_selector>` — optional third argument. Restricts which tasks run. Defaults to **all tasks** (warn the user: this can be slow and expensive). Accepts three forms; pick the most specific one that fits the question:
+  - **Skill name** (bare word): `uipath-maestro-flow` → all task files under `tests/tasks/uipath-maestro-flow/`. Use this when the comparison is scoped to one skill.
+  - **Tag filter** with `tags:` prefix: `tags:smoke` or `tags:smoke,init` → comma-separated tags, OR semantics (any task carrying any of these tags). Forwarded to `coder-eval run --tags`. Use this for cross-skill slices like "only smoke tests" or "only e2e + connector tests".
+  - **Path glob** with `paths:` prefix: `paths:tasks/uipath-maestro-flow/init_validate.yaml` or `paths:tasks/*/smoke_*.yaml` (comma-separated globs allowed). Use this when you want a hand-picked subset.
 - `<n_reps>` — optional fourth argument. Reps per variant. Defaults to `3`. Accept integers 1–5.
 
 **Examples:**
 - `/skill-compare main feat/my-change uipath-maestro-flow` — two branches, scoped to one skill.
-- `/skill-compare main a1b2c3d uipath-maestro-flow` — branch vs. commit SHA (e.g. regression-check a specific commit).
-- `/skill-compare a1b2c3d e4f5g6h uipath-maestro-flow` — two SHAs (compare two historical points on the same or different branches).
-- `/skill-compare main feat/my-change` — two branches, all skills, N=3.
+- `/skill-compare main a1b2c3d uipath-maestro-flow` — branch vs. commit SHA, scoped to one skill.
+- `/skill-compare a1b2c3d e4f5g6h uipath-maestro-flow` — two SHAs (compare two historical points).
+- `/skill-compare main feat/my-change tags:smoke` — two branches, only smoke tests across all skills.
+- `/skill-compare main feat/my-change tags:smoke,init 5` — smoke OR init tasks, N=5.
+- `/skill-compare main feat/my-change paths:tasks/uipath-maestro-flow/init_validate.yaml,tasks/uipath-maestro-flow/registry_discovery.yaml` — two specific files.
+- `/skill-compare main feat/my-change` — all tasks across all skills, N=3 (slow + expensive; expect to be re-prompted at Phase 5).
 
 **Ref slugs** (used in filenames and worktree paths):
 - Branch: replace `/` with `-` and strip any leading `origin/`. Example: `feat/my-change` → `feat-my-change`.
@@ -45,7 +51,11 @@ Run an apples-to-apples A/B comparison between two refs of the skills repo — e
    - If none match: stop and report the ref as not found. For SHAs that might be unfetched, hint at `git fetch origin` or `git fetch origin <sha>` (git supports fetching by SHA on most remotes).
 4. Reject the call if the two refs resolve to the **same commit SHA** — comparing identical content produces no signal. Treat `main` and `a1b2c3d` as identical if `main` currently points at `a1b2c3d`; warn the user and stop.
 5. Reject the call if `<n_reps>` is outside `1..5`. N=1 is allowed for a fast signal check but warn it's underpowered for decisions.
-6. If `<skill_name>` is provided, verify `tasks/<skill_name>/` exists (relative to `tests/`). If not, list available skills under `tasks/*/` and stop.
+6. If `<task_selector>` is provided, classify and validate it:
+   - **`tags:` prefix** → split the rest on `,` and record as a tag list. No filesystem check at this stage; Phase 5 will warn if the tag list matches zero task files.
+   - **`paths:` prefix** → split the rest on `,` and record as a glob list (paths relative to `tests/`). For each glob, check it expands to at least one existing `.yaml` file under `tests/tasks/`. If any glob expands to zero files, stop and list which one was empty.
+   - **Bare word** (no prefix) → treat as a skill name. Verify `tasks/<word>/` exists (relative to `tests/`). If not, list available skills under `tasks/*/` and stop.
+   - **Anything else** (e.g. `tags:` with no list, `paths:` outside `tests/tasks/`) → stop with a usage message showing the three accepted forms.
 7. For each ref, decide whether to create or reuse a worktree at `../skills-<slug>`:
    - If the path does not exist → create it in Phase 3.
    - If it exists, check `git -C .. worktree list --porcelain`:
@@ -134,9 +144,12 @@ Do not include a `bare` variant. This command compares two skill configurations 
 
 ## Phase 5 — Resolve the task set and confirm
 
-1. Resolve the task list. **Sort the output** so ordering is deterministic across runs (filesystem traversal order is not guaranteed, and an unsorted list can produce run-to-run permutation noise):
-   - If `<skill_name>` was provided: `find tasks/<skill_name> -name '*.yaml' -type f | sort`
-   - Otherwise: `find tasks -name '*.yaml' -type f | sort`
+1. Resolve the task list and the extra `coder-eval` flags from the `<task_selector>` classification recorded in Phase 1 step 6. **Sort the output** so ordering is deterministic across runs (filesystem traversal order is not guaranteed, and an unsorted list can produce run-to-run permutation noise):
+   - **Skill name** (or no selector): expand to `find tasks/<skill_name> -name '*.yaml' -type f | sort` (or `find tasks -name '*.yaml' -type f | sort` for no selector). No extra flags.
+   - **Tags**: expand to `find tasks -name '*.yaml' -type f | sort` (the full set), and add `--tags <tag1>,<tag2>,...` to the `coder-eval run` invocation. `coder-eval` does the tag filtering at runtime; passing the full file list keeps the resolution logic uniform.
+   - **Paths**: expand each glob in order with `ls <glob> 2>/dev/null` (relative to `tests/`), concatenate, then `| sort -u` to dedupe. Stop if the final list is empty.
+
+   After resolution, if the final task count is zero (e.g. tags matched no files), stop and report which selector matched nothing.
 2. Estimate cost and time as a rough planning aid only — actuals depend on model pricing and task complexity. A task at the experiment defaults (`max_turns: 20`, `task_timeout: 600`) usually completes in a few minutes and spends a nontrivial amount in API tokens. Multiply the per-task estimate by `num_tasks × num_variants × n_reps` for the total.
 3. Present a confirmation prompt via `AskUserQuestion` with these options:
    - **Run now** — proceeds to Phase 6.
@@ -162,6 +175,7 @@ SKILLS_REPO_PATH=$(cd .. && pwd) \
   .venv/bin/coder-eval run <resolved-task-files> \
   -e experiments/compare-<ref_a_slug>-vs-<ref_b_slug>.yaml \
   --run-dir "$RUN_DIR" \
+  [--tags <tag1>,<tag2>,...]   # only when <task_selector> was tags:...
   -j 1 -v
 ```
 
@@ -210,7 +224,7 @@ Write `<RUN_DIR>/comparison-report.md` with this structure:
 **Hypothesis:** <from Phase 2>
 **Run:** `<RUN_DIR basename>`
 **Model:** <from experiment defaults>
-**Tasks:** <count> (skill filter: <skill_name or "all">)
+**Tasks:** <count> (selector: <verbatim task_selector or "all">)
 **N:** <n_reps> rep(s) per variant
 
 ## Variants
@@ -287,7 +301,7 @@ Leave the generated experiment YAML in place after a completed run unless the us
 - **Worktree path exists at a non-worktree directory, or on a different branch:** stop, print `git worktree remove` instructions. Don't overwrite. (If the path is already a valid worktree on the target branch, reuse it — see Phase 1 step 7.)
 - **SHA drift before run (Phase 6):** stop and ask the user whether to regenerate the YAML with new SHAs or reset the worktree to the pinned commit.
 - **`coder-eval` not installed:** print the `make install` command from `tests/README.md` and stop.
-- **Task set empty:** stop. Either the skill filter matched nothing, or there are no task YAMLs.
+- **Task set empty:** stop and report which selector matched zero files. Possible causes: skill folder doesn't exist, tag list matches nothing, path globs don't expand to any `.yaml` files.
 - **Partial run (interrupted):** report on whatever data exists, mark incomplete variants in the results table, skip the recommendation and say "incomplete run — rerun to decide".
 
 ## Anti-patterns

--- a/.claude/commands/skill-compare.md
+++ b/.claude/commands/skill-compare.md
@@ -1,24 +1,27 @@
 # Skill Comparison Experiment
 
-Run an apples-to-apples A/B comparison between two branches of the skills repo and produce a decision-ready report. Automates the workflow described in [`tests/experiments/skill-comparison-playbook.md`](../../tests/experiments/skill-comparison-playbook.md).
+Run an apples-to-apples A/B comparison between two refs of the skills repo — each ref is either a branch or a commit SHA — and produce a decision-ready report. Automates the workflow described in [`tests/experiments/skill-comparison-playbook.md`](../../tests/experiments/skill-comparison-playbook.md).
 
 **Input:** `$ARGUMENTS`
-- `<branch_a> <branch_b>` — required, the two branches to compare. Must both exist locally or on a remote.
+- `<ref_a> <ref_b>` — required, the two refs to compare. Each ref is either a **branch name** (local or remote-tracking) or a **commit SHA** (short or full, must already be in the local object database). The two refs can be any mix of the two kinds.
 - `<skill_name>` — optional third argument. Restricts the task set to `tests/tasks/<skill_name>/`. Defaults to all tasks (warn the user: this can be slow and expensive).
 - `<n_reps>` — optional fourth argument. Reps per variant. Defaults to `3`. Accept integers 1–5.
 
 **Examples:**
-- `/skill-compare main feat/my-change uipath-maestro-flow`
-- `/skill-compare main feat/my-change uipath-maestro-flow 5`
-- `/skill-compare main feat/my-change` (all skills, N=3)
+- `/skill-compare main feat/my-change uipath-maestro-flow` — two branches, scoped to one skill.
+- `/skill-compare main a1b2c3d uipath-maestro-flow` — branch vs. commit SHA (e.g. regression-check a specific commit).
+- `/skill-compare a1b2c3d e4f5g6h uipath-maestro-flow` — two SHAs (compare two historical points on the same or different branches).
+- `/skill-compare main feat/my-change` — two branches, all skills, N=3.
+
+**Ref slugs** (used in filenames and worktree paths):
+- Branch: replace `/` with `-` and strip any leading `origin/`. Example: `feat/my-change` → `feat-my-change`.
+- SHA: resolve to the 7-char short form via `git rev-parse --short`. Example: `a1b2c3defabc` → `a1b2c3d`. Short SHAs are already filename-safe; no further transformation.
 
 **Output:**
-- A new experiment YAML at `tests/experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml`
-- Worktrees at `../skills-<branch_a_slug>` and `../skills-<branch_b_slug>` relative to the repo root
-- Run results under `tests/runs/compare-<branch_a_slug>-vs-<branch_b_slug>-<timestamp>/`
-- Comparison report at `tests/runs/compare-<branch_a_slug>-vs-<branch_b_slug>-<timestamp>/comparison-report.md`
-
-Branch name slugs: replace `/` with `-` and strip any leading `origin/`. Example: `feat/my-change` → `feat-my-change`.
+- A new experiment YAML at `tests/experiments/compare-<ref_a_slug>-vs-<ref_b_slug>.yaml`
+- Worktrees at `../skills-<ref_a_slug>` and `../skills-<ref_b_slug>` relative to the repo root
+- Run results under `tests/runs/compare-<ref_a_slug>-vs-<ref_b_slug>-<timestamp>/`
+- Comparison report at `tests/runs/compare-<ref_a_slug>-vs-<ref_b_slug>-<timestamp>/comparison-report.md`
 
 **Working directory.** Every phase runs from `tests/`. All git operations use `git -C ..` to target the repo root. Worktree paths like `../skills-<slug>` resolve alongside the repo, one level above `tests/`.
 
@@ -27,22 +30,28 @@ Branch name slugs: replace `/` with `-` and strip any leading `origin/`. Example
 ## Phase 1 — Parse & validate
 
 1. Parse `$ARGUMENTS`: require at least two non-empty tokens. If fewer than 2, print usage and stop.
-2. Normalize each branch name:
-   - Strip leading `origin/` if present.
-   - Reject branch names that start with `-` — they can be misread as git flags. Stop with a usage message.
-   - Record the original (e.g. `feat/foo`) and the slug (e.g. `feat-foo`) separately.
-3. Reject the call if `<branch_a> == <branch_b>` — comparing a branch to itself produces no signal.
-4. Reject the call if `<n_reps>` is outside `1..5`. N=1 is allowed for a fast signal check but warn it's underpowered for decisions.
-5. For each branch, verify it exists. Use `--` to terminate flag parsing so branch names can never be misread as options:
+2. For each ref, reject inputs that start with `-` — they can be misread as git flags. Stop with a usage message.
+3. **Classify each ref as branch or SHA.** Use `--` to terminate flag parsing throughout:
    ```bash
-   git -C .. rev-parse --verify -- "<branch>" >/dev/null 2>&1
+   # Is it a branch (local or remote-tracking)?
+   git -C .. show-ref --verify --quiet "refs/heads/<ref>"         && kind=branch     # local branch
+   git -C .. show-ref --verify --quiet "refs/remotes/origin/<ref>" && kind=branch-remote  # remote-only
+   # Otherwise, does it resolve to a commit in the local object database?
+   [ "$(git -C .. cat-file -t "<ref>" 2>/dev/null)" = "commit" ]  && kind=sha
    ```
-   If the local ref fails, retry with `origin/<branch>` and record that the branch is remote-only (will need a tracking branch during worktree setup). If still not found, stop and tell the user which branch is missing.
+   - If `kind=branch`: strip leading `origin/` from the recorded ref if present. Slug = branch name with `/` → `-`.
+   - If `kind=branch-remote`: record the remote-only flag — Phase 3 will need `-b <branch> origin/<branch>` to create a tracking branch. Slug = branch name with `/` → `-`.
+   - If `kind=sha`: resolve to the 7-char short form with `git -C .. rev-parse --short --verify -- "<ref>"`. Slug = the short SHA. Record the pinned SHA as the short form.
+   - If none match: stop and report the ref as not found. For SHAs that might be unfetched, hint at `git fetch origin` or `git fetch origin <sha>` (git supports fetching by SHA on most remotes).
+4. Reject the call if the two refs resolve to the **same commit SHA** — comparing identical content produces no signal. Treat `main` and `a1b2c3d` as identical if `main` currently points at `a1b2c3d`; warn the user and stop.
+5. Reject the call if `<n_reps>` is outside `1..5`. N=1 is allowed for a fast signal check but warn it's underpowered for decisions.
 6. If `<skill_name>` is provided, verify `tasks/<skill_name>/` exists (relative to `tests/`). If not, list available skills under `tasks/*/` and stop.
-7. For each branch, decide whether to create or reuse a worktree at `../skills-<slug>`:
+7. For each ref, decide whether to create or reuse a worktree at `../skills-<slug>`:
    - If the path does not exist → create it in Phase 3.
-   - If it exists, check `git -C .. worktree list --porcelain`. If it's a registered worktree already on the target branch, **reuse it** (skip Phase 3's `worktree add` for this branch and go straight to SHA capture).
-   - If it exists but is not a worktree, or is a worktree on a different branch, **stop** and tell the user to remove it (`git worktree remove`) or point the command at different worktree paths. Do not overwrite.
+   - If it exists, check `git -C .. worktree list --porcelain`:
+     - Branch kind: reuse if the worktree is already on that branch.
+     - SHA kind: reuse if the worktree has a detached HEAD at the pinned short SHA (compare `git -C <path> rev-parse --short HEAD`).
+   - If it exists but isn't a worktree, or is at the wrong branch/SHA, **stop** and tell the user to remove it (`git worktree remove`) or point the command at a different worktree path. Do not overwrite.
 
 ## Phase 2 — Ask for the hypothesis
 
@@ -52,19 +61,24 @@ Save the answer — it goes into the comparison report and the experiment YAML d
 
 ## Phase 3 — Create worktrees
 
-For each branch, skip if Phase 1 flagged it for reuse. Otherwise run, from `tests/`:
+For each ref, skip if Phase 1 flagged it for reuse. Otherwise, from `tests/`, run the command that matches the ref's kind:
 
+**Branch (local):**
 ```bash
 git -C .. worktree add ../skills-<slug> -- <branch>
 ```
 
-If the branch is remote-only (from Phase 1), first create a tracking branch:
-
+**Branch (remote-only):** create a tracking branch at the same time:
 ```bash
 git -C .. worktree add -b <branch> ../skills-<slug> -- origin/<branch>
 ```
 
-The `--` terminator prevents branch names starting with `-` from being parsed as flags.
+**SHA:** create a detached-HEAD worktree pinned at that commit. No local branch is created, so a SHA input never pollutes your branch list:
+```bash
+git -C .. worktree add --detach ../skills-<slug> <sha>
+```
+
+The `--` terminator prevents branch names starting with `-` from being parsed as flags; it's not required with `--detach` since the SHA form is unambiguous.
 
 Record each worktree's absolute path. Capture the commit SHA (short form):
 
@@ -72,42 +86,44 @@ Record each worktree's absolute path. Capture the commit SHA (short form):
 git -C ../skills-<slug> rev-parse --short HEAD
 ```
 
-Keep these SHAs in context — they're re-checked in Phase 6 and reported in Phase 8.
+For SHA-kind refs, this should equal the pinned SHA from Phase 1 step 3 — if it doesn't, stop (the worktree is at the wrong commit). Keep these SHAs in context; they're re-checked in Phase 6 and reported in Phase 8.
 
 If any worktree add fails, stop and report. Do not attempt to clean up partial state — the user should inspect.
 
 ## Phase 4 — Generate the experiment YAML
 
-Start from [`tests/experiments/skill-comparison-template.yaml`](../../tests/experiments/skill-comparison-template.yaml). Write the generated file to `tests/experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml`.
+Start from [`tests/experiments/skill-comparison-template.yaml`](../../tests/experiments/skill-comparison-template.yaml). Write the generated file to `tests/experiments/compare-<ref_a_slug>-vs-<ref_b_slug>.yaml`.
 
 Fill in:
-- `experiment_id`: `compare-<branch_a_slug>-vs-<branch_b_slug>`
+- `experiment_id`: `compare-<ref_a_slug>-vs-<ref_b_slug>`
 - `description`: the hypothesis from Phase 2
-- One variant per branch. Variant IDs must be the slugs.
+- One variant per ref. Variant IDs must be the slugs.
 - Absolute worktree paths in each variant's `plugins[].path`.
-- A pinned-SHA comment on the line above each variant, e.g. `# pinned: feat/my-change @ a1b2c3d`.
+- A pinned-SHA comment on the line above each variant. Format depends on ref kind:
+  - Branch ref: `# pinned: <branch> @ <sha>` — e.g. `# pinned: feat/my-change @ a1b2c3d`.
+  - SHA ref: `# pinned: <sha>` — e.g. `# pinned: a1b2c3d` (no branch; the input was the SHA itself).
 
 Suffix rule for rep variants:
-- **N=1** → one variant per branch, `variant_id` is the bare slug (e.g. `variant_id: main`). No `-rN` suffix.
+- **N=1** → one variant per ref, `variant_id` is the bare slug (e.g. `variant_id: main` or `variant_id: a1b2c3d`). No `-rN` suffix.
 - **N>1** → duplicate each variant N times with `-r1`, `-r2`, ... `-rN` suffixes on the `variant_id`, starting at `-r1`. All reps of a variant share the same path.
 
 Example for N=3:
 
 ```yaml
   - variant_id: <slug>-r1
-    # pinned: <branch> @ <sha>
+    # pinned: <ref> (@ <sha> if branch, or just <sha> if SHA)
     agent:
       plugins:
         - type: "local"
           path: "<abs-worktree-path>"
   - variant_id: <slug>-r2
-    # pinned: <branch> @ <sha>
+    # pinned: <ref> (@ <sha> if branch, or just <sha> if SHA)
     agent:
       plugins:
         - type: "local"
           path: "<abs-worktree-path>"
   - variant_id: <slug>-r3
-    # pinned: <branch> @ <sha>
+    # pinned: <ref> (@ <sha> if branch, or just <sha> if SHA)
     agent:
       plugins:
         - type: "local"
@@ -141,10 +157,10 @@ git -C ../skills-<slug> rev-parse --short HEAD    # for each worktree — must m
 Pick a deterministic run directory so concurrent runs can't be confused with ours. Use a slug + timestamp:
 
 ```bash
-RUN_DIR="runs/compare-<branch_a_slug>-vs-<branch_b_slug>-$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="runs/compare-<ref_a_slug>-vs-<ref_b_slug>-$(date +%Y%m%d-%H%M%S)"
 SKILLS_REPO_PATH=$(cd .. && pwd) \
   .venv/bin/coder-eval run <resolved-task-files> \
-  -e experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml \
+  -e experiments/compare-<ref_a_slug>-vs-<ref_b_slug>.yaml \
   --run-dir "$RUN_DIR" \
   -j 1 -v
 ```
@@ -161,8 +177,8 @@ Stream output. If the run fails mid-way, capture the partial results and continu
 
    | variant | success rate | avg score | avg duration | total tokens |
    |---|---|---|---|---|
-   | <branch_a> | ... | ... | ... | ... |
-   | <branch_b> | ... | ... | ... | ... |
+   | <ref_a> | ... | ... | ... | ... |
+   | <ref_b> | ... | ... | ... | ... |
 
    If N>1, aggregate across `-r1`/`-r2`/`-rN`: use mean for score/duration/tokens, and `passed_runs / total_runs` for success rate per task.
 
@@ -189,7 +205,7 @@ Stream output. If the run fails mid-way, capture the partial results and continu
 Write `<RUN_DIR>/comparison-report.md` with this structure:
 
 ```markdown
-# Skill Comparison: <branch_a> vs <branch_b>
+# Skill Comparison: <ref_a> vs <ref_b>
 
 **Hypothesis:** <from Phase 2>
 **Run:** `<RUN_DIR basename>`
@@ -198,15 +214,15 @@ Write `<RUN_DIR>/comparison-report.md` with this structure:
 **N:** <n_reps> rep(s) per variant
 
 ## Variants
-- `<branch_a>` @ `<sha_a>`
-- `<branch_b>` @ `<sha_b>`
+- `<ref_a>` @ `<sha_a>`
+- `<ref_b>` @ `<sha_b>`
 
 ## Results
 <results table from Phase 7 step 1>
 
 ## Head-to-head
-- <branch_a> wins: <count>
-- <branch_b> wins: <count>
+- <ref_a> wins: <count>
+- <ref_b> wins: <count>
 - Ties: <count>
 
 ## Divergent tasks
@@ -243,26 +259,31 @@ Do **not** run `git worktree remove` or `git branch -d` yourself. Print cleanup 
 **If the run completed (Phase 7 produced a report):**
 ```bash
 # Once the user has acted on the recommendation:
-git worktree remove ../skills-<branch_a_slug>
-git worktree remove ../skills-<branch_b_slug>
+git worktree remove ../skills-<ref_a_slug>
+git worktree remove ../skills-<ref_b_slug>
+```
 
+If the losing ref was a **branch** (not a SHA), also consider:
+```bash
 # Optional — delete the losing branch (only if it was merged or you're sure you don't want it):
 git branch -d <losing_branch>
 ```
 
+SHA-kind refs create no local branch, so nothing to delete there.
+
 **If the user cancelled at Phase 5 (no run happened):**
 ```bash
 # Nothing ran — clean up the worktrees and generated YAML:
-git worktree remove ../skills-<branch_a_slug>
-git worktree remove ../skills-<branch_b_slug>
-rm tests/experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml
+git worktree remove ../skills-<ref_a_slug>
+git worktree remove ../skills-<ref_b_slug>
+rm tests/experiments/compare-<ref_a_slug>-vs-<ref_b_slug>.yaml
 ```
 
 Leave the generated experiment YAML in place after a completed run unless the user asks to delete it — it's a record of what was tested and is safe to commit or discard later.
 
 ## Error handling
 
-- **Branch not found:** stop, print which branch is missing and how to fetch (`git fetch origin <branch>`).
+- **Ref not found:** stop, print which ref is missing. For branches, suggest `git fetch origin <branch>`. For SHAs, suggest `git fetch origin` (or `git fetch origin <sha>` if the SHA isn't reachable from any known remote ref).
 - **Worktree path exists at a non-worktree directory, or on a different branch:** stop, print `git worktree remove` instructions. Don't overwrite. (If the path is already a valid worktree on the target branch, reuse it — see Phase 1 step 7.)
 - **SHA drift before run (Phase 6):** stop and ask the user whether to regenerate the YAML with new SHAs or reset the worktree to the pinned commit.
 - **`coder-eval` not installed:** print the `make install` command from `tests/README.md` and stop.

--- a/.claude/commands/skill-compare.md
+++ b/.claude/commands/skill-compare.md
@@ -15,10 +15,12 @@ Run an apples-to-apples A/B comparison between two branches of the skills repo a
 **Output:**
 - A new experiment YAML at `tests/experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml`
 - Worktrees at `../skills-<branch_a_slug>` and `../skills-<branch_b_slug>` relative to the repo root
-- Run results under `tests/runs/<timestamp>/`
-- Comparison report at `tests/runs/<timestamp>/comparison-report.md`
+- Run results under `tests/runs/compare-<branch_a_slug>-vs-<branch_b_slug>-<timestamp>/`
+- Comparison report at `tests/runs/compare-<branch_a_slug>-vs-<branch_b_slug>-<timestamp>/comparison-report.md`
 
 Branch name slugs: replace `/` with `-` and strip any leading `origin/`. Example: `feat/my-change` → `feat-my-change`.
+
+**Working directory.** Every phase runs from `tests/`. All git operations use `git -C ..` to target the repo root. Worktree paths like `../skills-<slug>` resolve alongside the repo, one level above `tests/`.
 
 ---
 
@@ -27,46 +29,50 @@ Branch name slugs: replace `/` with `-` and strip any leading `origin/`. Example
 1. Parse `$ARGUMENTS`: require at least two non-empty tokens. If fewer than 2, print usage and stop.
 2. Normalize each branch name:
    - Strip leading `origin/` if present.
+   - Reject branch names that start with `-` — they can be misread as git flags. Stop with a usage message.
    - Record the original (e.g. `feat/foo`) and the slug (e.g. `feat-foo`) separately.
 3. Reject the call if `<branch_a> == <branch_b>` — comparing a branch to itself produces no signal.
 4. Reject the call if `<n_reps>` is outside `1..5`. N=1 is allowed for a fast signal check but warn it's underpowered for decisions.
-5. For each branch, verify it exists:
+5. For each branch, verify it exists. Use `--` to terminate flag parsing so branch names can never be misread as options:
    ```bash
-   git -C <repo_root> rev-parse --verify "<branch>" >/dev/null 2>&1
+   git -C .. rev-parse --verify -- "<branch>" >/dev/null 2>&1
    ```
    If the local ref fails, retry with `origin/<branch>` and record that the branch is remote-only (will need a tracking branch during worktree setup). If still not found, stop and tell the user which branch is missing.
-6. If `<skill_name>` is provided, verify `tests/tasks/<skill_name>/` exists. If not, list available skills under `tests/tasks/*/` and stop.
-7. Check that the target worktree paths are free:
-   ```bash
-   test ! -e ../skills-<slug>  # for each branch
-   ```
-   If a path exists, stop and ask the user to remove it (`git worktree remove`) before rerunning — do **not** overwrite.
+6. If `<skill_name>` is provided, verify `tasks/<skill_name>/` exists (relative to `tests/`). If not, list available skills under `tasks/*/` and stop.
+7. For each branch, decide whether to create or reuse a worktree at `../skills-<slug>`:
+   - If the path does not exist → create it in Phase 3.
+   - If it exists, check `git -C .. worktree list --porcelain`. If it's a registered worktree already on the target branch, **reuse it** (skip Phase 3's `worktree add` for this branch and go straight to SHA capture).
+   - If it exists but is not a worktree, or is a worktree on a different branch, **stop** and tell the user to remove it (`git worktree remove`) or point the command at different worktree paths. Do not overwrite.
 
 ## Phase 2 — Ask for the hypothesis
 
-Before doing anything destructive, ask the user (via `AskUserQuestion`) for a one-sentence hypothesis being tested. Example prompt: *"What's the hypothesis? (one sentence, e.g., 'Collapsing per-node planning+impl docs does not hurt success rate')"*. Use `Something else` as the last option if presenting suggestions.
+Before doing anything destructive, ask the user for a one-sentence hypothesis being tested. Use a plain free-form text prompt (not `AskUserQuestion` — that tool is for enumerated choices, and hypotheses are open-ended). Example prompt: *"What's the hypothesis for this comparison? One sentence. For example: 'Collapsing per-node planning+impl docs does not hurt success rate.'"*
 
 Save the answer — it goes into the comparison report and the experiment YAML description.
 
 ## Phase 3 — Create worktrees
 
-For each branch, from the repo root:
+For each branch, skip if Phase 1 flagged it for reuse. Otherwise run, from `tests/`:
 
 ```bash
-git worktree add ../skills-<slug> <branch>
+git -C .. worktree add ../skills-<slug> -- <branch>
 ```
 
 If the branch is remote-only (from Phase 1), first create a tracking branch:
 
 ```bash
-git worktree add -b <branch> ../skills-<slug> origin/<branch>
+git -C .. worktree add -b <branch> ../skills-<slug> -- origin/<branch>
 ```
+
+The `--` terminator prevents branch names starting with `-` from being parsed as flags.
 
 Record each worktree's absolute path. Capture the commit SHA (short form):
 
 ```bash
 git -C ../skills-<slug> rev-parse --short HEAD
 ```
+
+Keep these SHAs in context — they're re-checked in Phase 6 and reported in Phase 8.
 
 If any worktree add fails, stop and report. Do not attempt to clean up partial state — the user should inspect.
 
@@ -81,7 +87,11 @@ Fill in:
 - Absolute worktree paths in each variant's `plugins[].path`.
 - A pinned-SHA comment on the line above each variant, e.g. `# pinned: feat/my-change @ a1b2c3d`.
 
-If `<n_reps>` > 1: duplicate each variant N times with `-r1`, `-r2`, ... `-rN` suffixes on the `variant_id`. All reps of a variant share the same path. Example for N=3:
+Suffix rule for rep variants:
+- **N=1** → one variant per branch, `variant_id` is the bare slug (e.g. `variant_id: main`). No `-rN` suffix.
+- **N>1** → duplicate each variant N times with `-r1`, `-r2`, ... `-rN` suffixes on the `variant_id`, starting at `-r1`. All reps of a variant share the same path.
+
+Example for N=3:
 
 ```yaml
   - variant_id: <slug>-r1
@@ -108,10 +118,10 @@ Do not include a `bare` variant. This command compares two skill configurations 
 
 ## Phase 5 — Resolve the task set and confirm
 
-1. Resolve the task list:
-   - If `<skill_name>` was provided: `find tests/tasks/<skill_name> -name '*.yaml' -type f`
-   - Otherwise: `find tests/tasks -name '*.yaml' -type f`
-2. Estimate cost and time. A rough per-task budget is **~5 minutes and ~$0.50** at the experiment defaults (`max_turns: 20`, `task_timeout: 600`). Multiply by `num_tasks × num_variants × n_reps`.
+1. Resolve the task list. **Sort the output** so ordering is deterministic across runs (filesystem traversal order is not guaranteed, and an unsorted list can produce run-to-run permutation noise):
+   - If `<skill_name>` was provided: `find tasks/<skill_name> -name '*.yaml' -type f | sort`
+   - Otherwise: `find tasks -name '*.yaml' -type f | sort`
+2. Estimate cost and time as a rough planning aid only — actuals depend on model pricing and task complexity. A task at the experiment defaults (`max_turns: 20`, `task_timeout: 600`) usually completes in a few minutes and spends a nontrivial amount in API tokens. Multiply the per-task estimate by `num_tasks × num_variants × n_reps` for the total.
 3. Present a confirmation prompt via `AskUserQuestion` with these options:
    - **Run now** — proceeds to Phase 6.
    - **Show me the experiment YAML first** — opens the generated file for review, then re-prompts.
@@ -122,24 +132,32 @@ Do not proceed without explicit confirmation. The run can take hours and cost re
 
 ## Phase 6 — Run
 
-From inside `tests/`:
+Before running, **re-check each worktree's SHA** against the SHA captured in Phase 3. If either differs (the user pulled, committed, or checked out a different ref in the worktree between Phase 3 and now), stop and ask the user whether to (a) regenerate the YAML with the new SHAs, or (b) reset the worktree to the pinned commit. Never run with stale metadata.
 
 ```bash
+git -C ../skills-<slug> rev-parse --short HEAD    # for each worktree — must match Phase 3
+```
+
+Pick a deterministic run directory so concurrent runs can't be confused with ours. Use a slug + timestamp:
+
+```bash
+RUN_DIR="runs/compare-<branch_a_slug>-vs-<branch_b_slug>-$(date +%Y%m%d-%H%M%S)"
 SKILLS_REPO_PATH=$(cd .. && pwd) \
   .venv/bin/coder-eval run <resolved-task-files> \
   -e experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml \
+  --run-dir "$RUN_DIR" \
   -j 1 -v
 ```
+
+Record `tests/$RUN_DIR` as the run directory — everything downstream reads from there.
 
 Keep `-j 1`. Parallel execution introduces timing noise (shared API rate limits, disk contention) that can distort small variant effects. If the user explicitly asks for parallelism, honor it but note the caveat in the report.
 
 Stream output. If the run fails mid-way, capture the partial results and continue to Phase 7 with whatever data exists.
 
-Find the run directory: it's the newest subdirectory of `tests/runs/` created after the command started. Record its absolute path.
-
 ## Phase 7 — Analyze
 
-1. Read `tests/runs/<timestamp>/experiment.md` and each variant's `variant.json`. Build a results table:
+1. Read `<RUN_DIR>/experiment.md` and each variant's `variant.json` (where `<RUN_DIR>` is the path recorded at the end of Phase 6). Build a results table:
 
    | variant | success rate | avg score | avg duration | total tokens |
    |---|---|---|---|---|
@@ -148,28 +166,33 @@ Find the run directory: it's the newest subdirectory of `tests/runs/` created af
 
    If N>1, aggregate across `-r1`/`-r2`/`-rN`: use mean for score/duration/tokens, and `passed_runs / total_runs` for success rate per task.
 
-2. Identify divergent tasks. A task is divergent if its scores differ between variants by more than 0.1, **or** one variant succeeded while the other hit `TIMEOUT`/`MAX_TURNS_EXHAUSTED`/`FAILURE`. Ties (same status, scores within 0.1) are not divergent.
+2. Identify divergent tasks. Use the per-task `passed` boolean (from `success_criteria` in `task.json`) and the reliability score, in this order:
+   - **Hard divergence** — one variant's `passed` is `true` and the other's is `false` for the same task. Always a divergence, regardless of scores.
+   - **Soft divergence** — both variants have the same `passed` value but their reliability scores differ by more than `0.1` (chosen so that swings within one scoring tier — e.g., `0.533` → `0.562` on the same partial-pass task — don't register as divergences).
+   - **Tie** — everything else.
+
+   Do not key divergence on the `status` field (`SUCCESS` / `FAILURE` / `TIMEOUT` / `MAX_TURNS_EXHAUSTED`). A task can score 0.95 and still be `FAILURE`; a task can hit `MAX_TURNS_EXHAUSTED` and still partially pass.
 
 3. For each divergent task, read the losing variant's `task.json` transcript and extract a one-line root cause. Look for:
-   - **Timeout at `MAX_TURNS=0`** — agent never got a turn. Infrastructure issue, discard.
+   - **Timeout at `MAX_TURNS=0`** — agent never got a turn. Infrastructure issue, discard this divergence.
    - **Rabbit hole** — agent repeatedly retried a failing approach. Cite the specific command or error that looped.
    - **Missed workflow step** — agent skipped a critical rule (e.g., didn't run a required setup command). Cite the skipped step.
    - **Validation failure** — generated artifact was wrong. Cite what was wrong.
 
 4. Count reliability signals:
-   - Head-to-head wins per variant (divergent-task wins only).
-   - Flip rate across reps: for each task at N>1, how often does the same variant win? Flip rate >0 is a high-variance signal.
-   - Token efficiency: percent difference between variants' total tokens. Only material at >10%.
+   - **Head-to-head wins** per variant — count divergent-task wins only. A win requires the winner's `passed` to be `true` OR the winner's score to be higher by more than 0.1.
+   - **Flip rate** (N>1 only) — for each task, determine the winning variant in each rep. A task is "flipped" if not all reps produced the same winner (ties across reps are not flips). Report `flip_rate = flipped_tasks / tasks_with_at_least_one_non_tie_rep`. Flip rate `> 0` is a high-variance signal.
+   - **Token efficiency** — percent difference between variants' total tokens. Only material at `> 10%`.
 
 ## Phase 8 — Write the comparison report
 
-Write `tests/runs/<timestamp>/comparison-report.md` with this structure:
+Write `<RUN_DIR>/comparison-report.md` with this structure:
 
 ```markdown
 # Skill Comparison: <branch_a> vs <branch_b>
 
 **Hypothesis:** <from Phase 2>
-**Run:** `<timestamp>`
+**Run:** `<RUN_DIR basename>`
 **Model:** <from experiment defaults>
 **Tasks:** <count> (skill filter: <skill_name or "all">)
 **N:** <n_reps> rep(s) per variant
@@ -193,7 +216,7 @@ Write `tests/runs/<timestamp>/comparison-report.md` with this structure:
 <list any task where reps flipped winners, otherwise "none">
 
 ## Recommendation
-<one of: "merge <branch>", "do not merge <branch>", "inconclusive — rerun at N=<higher>", with a one-paragraph justification>
+<one of the three verdicts below, with a one-paragraph justification>
 
 ## Caveats
 <any of these that apply, each as one bullet>
@@ -203,14 +226,23 @@ Write `tests/runs/<timestamp>/comparison-report.md` with this structure:
 - Token gap <X>%; not material.
 ```
 
-Keep it under one screen of text. The report is for a decision, not a novel.
+**Decision rule for the recommendation** — apply in order, the first match wins:
+
+1. **`inconclusive — rerun at N≥3`** if any of: `N == 1`, `flip_rate > 0`, every divergence had a `MAX_TURNS=0` / infrastructure root cause, or the run was partial/interrupted.
+2. **`merge <winner>`** if one variant has strictly more head-to-head wins than the other AND `flip_rate == 0` across all divergent tasks AND `N ≥ 3`.
+3. **`do not merge — no material difference`** if head-to-head wins are tied (including 0–0 with all tasks tied) AND token efficiency gap is `≤ 10%`.
+
+If none of these apply, default to `inconclusive` and explain why in the justification.
+
+Keep the report under one screen of text. It is for a decision, not a novel.
 
 ## Phase 9 — Cleanup instructions
 
-Do **not** run `git worktree remove` or `git branch -d` yourself. Tell the user to clean up manually after they've acted on the recommendation:
+Do **not** run `git worktree remove` or `git branch -d` yourself. Print cleanup instructions appropriate to how the command ended:
 
+**If the run completed (Phase 7 produced a report):**
 ```bash
-# When the comparison is resolved:
+# Once the user has acted on the recommendation:
 git worktree remove ../skills-<branch_a_slug>
 git worktree remove ../skills-<branch_b_slug>
 
@@ -218,12 +250,21 @@ git worktree remove ../skills-<branch_b_slug>
 git branch -d <losing_branch>
 ```
 
-Leave the generated experiment YAML in place unless the user asks to delete it — it's a record of what was tested and is safe to commit or discard later.
+**If the user cancelled at Phase 5 (no run happened):**
+```bash
+# Nothing ran — clean up the worktrees and generated YAML:
+git worktree remove ../skills-<branch_a_slug>
+git worktree remove ../skills-<branch_b_slug>
+rm tests/experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml
+```
+
+Leave the generated experiment YAML in place after a completed run unless the user asks to delete it — it's a record of what was tested and is safe to commit or discard later.
 
 ## Error handling
 
 - **Branch not found:** stop, print which branch is missing and how to fetch (`git fetch origin <branch>`).
-- **Worktree path exists:** stop, print `git worktree remove` instructions. Don't overwrite.
+- **Worktree path exists at a non-worktree directory, or on a different branch:** stop, print `git worktree remove` instructions. Don't overwrite. (If the path is already a valid worktree on the target branch, reuse it — see Phase 1 step 7.)
+- **SHA drift before run (Phase 6):** stop and ask the user whether to regenerate the YAML with new SHAs or reset the worktree to the pinned commit.
 - **`coder-eval` not installed:** print the `make install` command from `tests/README.md` and stop.
 - **Task set empty:** stop. Either the skill filter matched nothing, or there are no task YAMLs.
 - **Partial run (interrupted):** report on whatever data exists, mark incomplete variants in the results table, skip the recommendation and say "incomplete run — rerun to decide".

--- a/.claude/commands/skill-compare.md
+++ b/.claude/commands/skill-compare.md
@@ -107,37 +107,41 @@ Start from [`tests/experiments/skill-comparison-template.yaml`](../../tests/expe
 Fill in:
 - `experiment_id`: `compare-<ref_a_slug>-vs-<ref_b_slug>`
 - `description`: the hypothesis from Phase 2
-- One variant per ref. Variant IDs must be the slugs.
+- `defaults.repeats`: set to `<n_reps>` (the value from `$ARGUMENTS`, default 3). This replaces the per-variant duplication approach — coder_eval's native repeats support fans out each (task, variant) pair into `<n_reps>` replicates automatically.
+- One variant per ref (no `-rN` suffixes). Variant IDs must be the slugs.
 - Absolute worktree paths in each variant's `plugins[].path`.
 - A pinned-SHA comment on the line above each variant. Format depends on ref kind:
   - Branch ref: `# pinned: <branch> @ <sha>` — e.g. `# pinned: feat/my-change @ a1b2c3d`.
   - SHA ref: `# pinned: <sha>` — e.g. `# pinned: a1b2c3d` (no branch; the input was the SHA itself).
 
-Suffix rule for rep variants:
-- **N=1** → one variant per ref, `variant_id` is the bare slug (e.g. `variant_id: main` or `variant_id: a1b2c3d`). No `-rN` suffix.
-- **N>1** → duplicate each variant N times with `-r1`, `-r2`, ... `-rN` suffixes on the `variant_id`, starting at `-r1`. All reps of a variant share the same path.
-
-Example for N=3:
+Example (shown for N=3):
 
 ```yaml
-  - variant_id: <slug>-r1
-    # pinned: <ref> (@ <sha> if branch, or just <sha> if SHA)
+defaults:
+  ...
+  repeats: 3
+  agent:
+    ...
+    system_prompt: |
+      You are a coding agent. Work only inside your current working directory.
+      Do NOT read, list, or access any files outside your working directory.
+      In particular, do NOT access the plugin directories — those are loaded by
+      the skill system and you do not need to read them directly.
+
+variants:
+  # pinned: main @ a1b2c3d
+  - variant_id: main
     agent:
       plugins:
         - type: "local"
-          path: "<abs-worktree-path>"
-  - variant_id: <slug>-r2
-    # pinned: <ref> (@ <sha> if branch, or just <sha> if SHA)
+          path: "<abs-worktree-path-main>"
+
+  # pinned: feat/my-change @ e4f5g6h
+  - variant_id: feat-my-change
     agent:
       plugins:
         - type: "local"
-          path: "<abs-worktree-path>"
-  - variant_id: <slug>-r3
-    # pinned: <ref> (@ <sha> if branch, or just <sha> if SHA)
-    agent:
-      plugins:
-        - type: "local"
-          path: "<abs-worktree-path>"
+          path: "<abs-worktree-path-variant>"
 ```
 
 Do not include a `bare` variant. This command compares two skill configurations — add baselines manually if needed.
@@ -175,9 +179,12 @@ SKILLS_REPO_PATH=$(cd .. && pwd) \
   .venv/bin/coder-eval run <resolved-task-files> \
   -e experiments/compare-<ref_a_slug>-vs-<ref_b_slug>.yaml \
   --run-dir "$RUN_DIR" \
+  --repeats <n_reps> \
   [--tags <tag1>,<tag2>,...]   # only when <task_selector> was tags:...
   -j 1 -v
 ```
+
+The `--repeats` flag overrides the `repeats:` value in the experiment YAML at runtime, so the YAML can stay committed with `repeats: 1` as a safe default while runs always use the CLI-supplied value.
 
 Record `tests/$RUN_DIR` as the run directory — everything downstream reads from there.
 
@@ -194,7 +201,7 @@ Stream output. If the run fails mid-way, capture the partial results and continu
    | <ref_a> | ... | ... | ... | ... |
    | <ref_b> | ... | ... | ... | ... |
 
-   If N>1, aggregate across `-r1`/`-r2`/`-rN`: use mean for score/duration/tokens, and `passed_runs / total_runs` for success rate per task.
+   If N>1, coder_eval produces per-replicate output under `<RUN_DIR>/<variant>/<task>/00/`, `01/`, etc. Aggregate across replicates: use mean for score/duration/tokens, and `passed_runs / total_runs` for success rate per task. The top-level `variant.json` already includes aggregated statistics when `repeats > 1`; prefer those over manual aggregation.
 
 2. Identify divergent tasks. Use the per-task `passed` boolean (from `success_criteria` in `task.json`) and the reliability score, in this order:
    - **Hard divergence** — one variant's `passed` is `true` and the other's is `false` for the same task. Always a divergence, regardless of scores.
@@ -211,7 +218,7 @@ Stream output. If the run fails mid-way, capture the partial results and continu
 
 4. Count reliability signals:
    - **Head-to-head wins** per variant — count divergent-task wins only. A win requires the winner's `passed` to be `true` OR the winner's score to be higher by more than 0.1.
-   - **Flip rate** (N>1 only) — for each task, determine the winning variant in each rep. A task is "flipped" if not all reps produced the same winner (ties across reps are not flips). Report `flip_rate = flipped_tasks / tasks_with_at_least_one_non_tie_rep`. Flip rate `> 0` is a high-variance signal.
+   - **Flip rate** (N>1 only) — for each task, compare the winning variant across replicates (`00/`, `01/`, ...). A task is "flipped" if not all replicates produced the same winner (ties across replicates are not flips). Report `flip_rate = flipped_tasks / tasks_with_at_least_one_non_tie_replicate`. Flip rate `> 0` is a high-variance signal.
    - **Token efficiency** — percent difference between variants' total tokens. Only material at `> 10%`.
 
 ## Phase 8 — Write the comparison report

--- a/.claude/commands/skill-compare.md
+++ b/.claude/commands/skill-compare.md
@@ -1,0 +1,238 @@
+# Skill Comparison Experiment
+
+Run an apples-to-apples A/B comparison between two branches of the skills repo and produce a decision-ready report. Automates the workflow described in [`tests/experiments/skill-comparison-playbook.md`](../../tests/experiments/skill-comparison-playbook.md).
+
+**Input:** `$ARGUMENTS`
+- `<branch_a> <branch_b>` — required, the two branches to compare. Must both exist locally or on a remote.
+- `<skill_name>` — optional third argument. Restricts the task set to `tests/tasks/<skill_name>/`. Defaults to all tasks (warn the user: this can be slow and expensive).
+- `<n_reps>` — optional fourth argument. Reps per variant. Defaults to `3`. Accept integers 1–5.
+
+**Examples:**
+- `/skill-compare main feat/my-change uipath-maestro-flow`
+- `/skill-compare main feat/my-change uipath-maestro-flow 5`
+- `/skill-compare main feat/my-change` (all skills, N=3)
+
+**Output:**
+- A new experiment YAML at `tests/experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml`
+- Worktrees at `../skills-<branch_a_slug>` and `../skills-<branch_b_slug>` relative to the repo root
+- Run results under `tests/runs/<timestamp>/`
+- Comparison report at `tests/runs/<timestamp>/comparison-report.md`
+
+Branch name slugs: replace `/` with `-` and strip any leading `origin/`. Example: `feat/my-change` → `feat-my-change`.
+
+---
+
+## Phase 1 — Parse & validate
+
+1. Parse `$ARGUMENTS`: require at least two non-empty tokens. If fewer than 2, print usage and stop.
+2. Normalize each branch name:
+   - Strip leading `origin/` if present.
+   - Record the original (e.g. `feat/foo`) and the slug (e.g. `feat-foo`) separately.
+3. Reject the call if `<branch_a> == <branch_b>` — comparing a branch to itself produces no signal.
+4. Reject the call if `<n_reps>` is outside `1..5`. N=1 is allowed for a fast signal check but warn it's underpowered for decisions.
+5. For each branch, verify it exists:
+   ```bash
+   git -C <repo_root> rev-parse --verify "<branch>" >/dev/null 2>&1
+   ```
+   If the local ref fails, retry with `origin/<branch>` and record that the branch is remote-only (will need a tracking branch during worktree setup). If still not found, stop and tell the user which branch is missing.
+6. If `<skill_name>` is provided, verify `tests/tasks/<skill_name>/` exists. If not, list available skills under `tests/tasks/*/` and stop.
+7. Check that the target worktree paths are free:
+   ```bash
+   test ! -e ../skills-<slug>  # for each branch
+   ```
+   If a path exists, stop and ask the user to remove it (`git worktree remove`) before rerunning — do **not** overwrite.
+
+## Phase 2 — Ask for the hypothesis
+
+Before doing anything destructive, ask the user (via `AskUserQuestion`) for a one-sentence hypothesis being tested. Example prompt: *"What's the hypothesis? (one sentence, e.g., 'Collapsing per-node planning+impl docs does not hurt success rate')"*. Use `Something else` as the last option if presenting suggestions.
+
+Save the answer — it goes into the comparison report and the experiment YAML description.
+
+## Phase 3 — Create worktrees
+
+For each branch, from the repo root:
+
+```bash
+git worktree add ../skills-<slug> <branch>
+```
+
+If the branch is remote-only (from Phase 1), first create a tracking branch:
+
+```bash
+git worktree add -b <branch> ../skills-<slug> origin/<branch>
+```
+
+Record each worktree's absolute path. Capture the commit SHA (short form):
+
+```bash
+git -C ../skills-<slug> rev-parse --short HEAD
+```
+
+If any worktree add fails, stop and report. Do not attempt to clean up partial state — the user should inspect.
+
+## Phase 4 — Generate the experiment YAML
+
+Start from [`tests/experiments/skill-comparison-template.yaml`](../../tests/experiments/skill-comparison-template.yaml). Write the generated file to `tests/experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml`.
+
+Fill in:
+- `experiment_id`: `compare-<branch_a_slug>-vs-<branch_b_slug>`
+- `description`: the hypothesis from Phase 2
+- One variant per branch. Variant IDs must be the slugs.
+- Absolute worktree paths in each variant's `plugins[].path`.
+- A pinned-SHA comment on the line above each variant, e.g. `# pinned: feat/my-change @ a1b2c3d`.
+
+If `<n_reps>` > 1: duplicate each variant N times with `-r1`, `-r2`, ... `-rN` suffixes on the `variant_id`. All reps of a variant share the same path. Example for N=3:
+
+```yaml
+  - variant_id: <slug>-r1
+    # pinned: <branch> @ <sha>
+    agent:
+      plugins:
+        - type: "local"
+          path: "<abs-worktree-path>"
+  - variant_id: <slug>-r2
+    # pinned: <branch> @ <sha>
+    agent:
+      plugins:
+        - type: "local"
+          path: "<abs-worktree-path>"
+  - variant_id: <slug>-r3
+    # pinned: <branch> @ <sha>
+    agent:
+      plugins:
+        - type: "local"
+          path: "<abs-worktree-path>"
+```
+
+Do not include a `bare` variant. This command compares two skill configurations — add baselines manually if needed.
+
+## Phase 5 — Resolve the task set and confirm
+
+1. Resolve the task list:
+   - If `<skill_name>` was provided: `find tests/tasks/<skill_name> -name '*.yaml' -type f`
+   - Otherwise: `find tests/tasks -name '*.yaml' -type f`
+2. Estimate cost and time. A rough per-task budget is **~5 minutes and ~$0.50** at the experiment defaults (`max_turns: 20`, `task_timeout: 600`). Multiply by `num_tasks × num_variants × n_reps`.
+3. Present a confirmation prompt via `AskUserQuestion` with these options:
+   - **Run now** — proceeds to Phase 6.
+   - **Show me the experiment YAML first** — opens the generated file for review, then re-prompts.
+   - **Cancel** — stops. Tell the user how to clean up (Phase 9 instructions) even though nothing has run yet, because the worktrees and YAML still exist.
+   - **Something else** — accept free-form input (e.g., "drop reps to 1", "limit to smoke tasks") and re-plan accordingly.
+
+Do not proceed without explicit confirmation. The run can take hours and cost real money.
+
+## Phase 6 — Run
+
+From inside `tests/`:
+
+```bash
+SKILLS_REPO_PATH=$(cd .. && pwd) \
+  .venv/bin/coder-eval run <resolved-task-files> \
+  -e experiments/compare-<branch_a_slug>-vs-<branch_b_slug>.yaml \
+  -j 1 -v
+```
+
+Keep `-j 1`. Parallel execution introduces timing noise (shared API rate limits, disk contention) that can distort small variant effects. If the user explicitly asks for parallelism, honor it but note the caveat in the report.
+
+Stream output. If the run fails mid-way, capture the partial results and continue to Phase 7 with whatever data exists.
+
+Find the run directory: it's the newest subdirectory of `tests/runs/` created after the command started. Record its absolute path.
+
+## Phase 7 — Analyze
+
+1. Read `tests/runs/<timestamp>/experiment.md` and each variant's `variant.json`. Build a results table:
+
+   | variant | success rate | avg score | avg duration | total tokens |
+   |---|---|---|---|---|
+   | <branch_a> | ... | ... | ... | ... |
+   | <branch_b> | ... | ... | ... | ... |
+
+   If N>1, aggregate across `-r1`/`-r2`/`-rN`: use mean for score/duration/tokens, and `passed_runs / total_runs` for success rate per task.
+
+2. Identify divergent tasks. A task is divergent if its scores differ between variants by more than 0.1, **or** one variant succeeded while the other hit `TIMEOUT`/`MAX_TURNS_EXHAUSTED`/`FAILURE`. Ties (same status, scores within 0.1) are not divergent.
+
+3. For each divergent task, read the losing variant's `task.json` transcript and extract a one-line root cause. Look for:
+   - **Timeout at `MAX_TURNS=0`** — agent never got a turn. Infrastructure issue, discard.
+   - **Rabbit hole** — agent repeatedly retried a failing approach. Cite the specific command or error that looped.
+   - **Missed workflow step** — agent skipped a critical rule (e.g., didn't run a required setup command). Cite the skipped step.
+   - **Validation failure** — generated artifact was wrong. Cite what was wrong.
+
+4. Count reliability signals:
+   - Head-to-head wins per variant (divergent-task wins only).
+   - Flip rate across reps: for each task at N>1, how often does the same variant win? Flip rate >0 is a high-variance signal.
+   - Token efficiency: percent difference between variants' total tokens. Only material at >10%.
+
+## Phase 8 — Write the comparison report
+
+Write `tests/runs/<timestamp>/comparison-report.md` with this structure:
+
+```markdown
+# Skill Comparison: <branch_a> vs <branch_b>
+
+**Hypothesis:** <from Phase 2>
+**Run:** `<timestamp>`
+**Model:** <from experiment defaults>
+**Tasks:** <count> (skill filter: <skill_name or "all">)
+**N:** <n_reps> rep(s) per variant
+
+## Variants
+- `<branch_a>` @ `<sha_a>`
+- `<branch_b>` @ `<sha_b>`
+
+## Results
+<results table from Phase 7 step 1>
+
+## Head-to-head
+- <branch_a> wins: <count>
+- <branch_b> wins: <count>
+- Ties: <count>
+
+## Divergent tasks
+<one bullet per divergent task with: task id, scores per variant, one-line root cause>
+
+## Flip rate (N > 1 only)
+<list any task where reps flipped winners, otherwise "none">
+
+## Recommendation
+<one of: "merge <branch>", "do not merge <branch>", "inconclusive — rerun at N=<higher>", with a one-paragraph justification>
+
+## Caveats
+<any of these that apply, each as one bullet>
+- N=<n> is low for decisions; flip rate X% on Y tasks.
+- Both divergent tasks were timeouts; high variance.
+- One variant hit MAX_TURNS=0 on <task> (agent never got a turn).
+- Token gap <X>%; not material.
+```
+
+Keep it under one screen of text. The report is for a decision, not a novel.
+
+## Phase 9 — Cleanup instructions
+
+Do **not** run `git worktree remove` or `git branch -d` yourself. Tell the user to clean up manually after they've acted on the recommendation:
+
+```bash
+# When the comparison is resolved:
+git worktree remove ../skills-<branch_a_slug>
+git worktree remove ../skills-<branch_b_slug>
+
+# Optional — delete the losing branch (only if it was merged or you're sure you don't want it):
+git branch -d <losing_branch>
+```
+
+Leave the generated experiment YAML in place unless the user asks to delete it — it's a record of what was tested and is safe to commit or discard later.
+
+## Error handling
+
+- **Branch not found:** stop, print which branch is missing and how to fetch (`git fetch origin <branch>`).
+- **Worktree path exists:** stop, print `git worktree remove` instructions. Don't overwrite.
+- **`coder-eval` not installed:** print the `make install` command from `tests/README.md` and stop.
+- **Task set empty:** stop. Either the skill filter matched nothing, or there are no task YAMLs.
+- **Partial run (interrupted):** report on whatever data exists, mark incomplete variants in the results table, skip the recommendation and say "incomplete run — rerun to decide".
+
+## Anti-patterns
+
+- **Never skip Phase 5's confirmation.** This command spends money. Always confirm before `coder-eval run`.
+- **Never auto-clean worktrees or branches.** Destructive. User decides.
+- **Never conclude from N=1 alone.** If N=1 was chosen for speed, the recommendation in Phase 8 must say "rerun at N≥3 before deciding".
+- **Never mix task sets between variants.** Both variants run the same tasks, same count. That's the whole point of A/B.
+- **Never include a `bare` baseline unless the user asks.** This command is a two-way comparison. Baselines are a separate question.
+- **Never commit the generated experiment YAML automatically.** The user decides whether it's worth keeping.

--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -8,6 +8,8 @@ Analyze what a skill teaches vs what its tests verify. Produce a gap analysis wi
 
 **Output:** Markdown report(s) in `tests/reports/<skill-name>.md` (e.g., `tests/reports/uipath-maestro-flow.md`), unless the user specifies a different path. Overwrite existing reports at the same path.
 
+**Feed-forward contract.** This report is the primary input to `/generate-tasks <skill> [focus]`. Write gap titles as short noun phrases and suggested task IDs the way you'd want them typed back as a focus string (e.g. "Brown-field editing of existing flows" → `generate-tasks uipath-maestro-flow Brown-field editing of existing flows`).
+
 ---
 
 ## Phase 1 — Discovery
@@ -69,10 +71,12 @@ Record each item with a short summary.
 
 ### 2e. Identify infrastructure dependencies
 
-Determine what environment each skill requires to be testable:
-- **Local-only** — Can run without cloud auth or special hardware (e.g., flow validate, solution pack)
-- **Cloud auth required** — Needs UiPath tenant authentication (e.g., platform ops, flow debug, deploy)
-- **Platform-specific** — Needs Windows, Studio Desktop, Servo CLI, display, browser extension, etc.
+Determine what environment each skill requires to be testable. Use the same phrasing as existing task prompts and `/skill-compare` so readers can grep across docs:
+
+- **Local-only** — no cloud auth or special hardware (e.g., flow validate, solution pack)
+- **Requires cloud auth** — needs UiPath tenant authentication (e.g., platform ops, flow debug, deploy)
+- **Requires Windows + Studio Desktop** — needs Studio installed (task prompts typically note "Studio Desktop is NOT available" when skipping these)
+- **Requires browser extension / Servo CLI / display** — desktop/browser automation skills
 
 Tag each skill with its dependencies. This informs which tests are feasible to write and run in CI.
 
@@ -85,7 +89,18 @@ Extract these fields:
 ```
 task_id         — unique test identifier (e.g., "skill-flow-calculator")
 description     — what the test validates
-tags            — array; first element = skill name, second = test type (smoke/integration/e2e)
+tags            — array carrying values from the five Tag Taxonomy dimensions
+                  documented in tests/README.md. Position convention:
+                  [skill, tier, lifecycle, scenario, ...features]
+                    skill     — uipath-<name>                                 (required)
+                    tier      — smoke | integration | e2e                      (required)
+                    lifecycle — activate | generate | edit | validate | execute | deploy
+                    scenario  — green-field | brown-field | fixture
+                    features  — hitl, approval-gate, write-back, escalation, registry,
+                                connector-feature, connections, activities, records,
+                                entities, api-workflow, compliance, test-case, hooks,
+                                transform, http (0..n)
+                  Record every dimension; Phase 4f keys off all of them, not just tier.
 initial_prompt  — the prompt given to the agent
 success_criteria — array of assertion objects
 ```
@@ -141,26 +156,97 @@ A step is "tested" if at least one test exercises the CLI commands or file opera
 
 A rule is "Direct" if a test would catch its violation. A rule is "Indirect" if following the rule is necessary but not checked. Example: Rule 4 ("always use `--output json`") is directly tested by `init_validate.yaml`'s `command_pattern: 'uip\s+.*--output\s+json'`. Rule 7 ("every node needs a definitions entry") is indirect — a flow without definitions would fail validation, but no test checks the definitions array.
 
-### 4d. Anti-pattern coverage
+### 4d. Path coverage (when applicable)
 
-An anti-pattern is "tested" only if a test would catch the agent doing the wrong thing. This is rare — most test suites lack negative tests.
+Some skills teach ≥2 implementation **paths** — alternate ways to accomplish the same task. Regressions in real projects frequently live in one path while the other keeps passing, so path coverage is its own axis.
 
-### 4e. Weighted overall score
+Identify paths from SKILL.md and references. Common examples:
+
+| Skill | Paths |
+|---|---|
+| `uipath-rpa` | Coded (C#), XAML |
+| `uipath-rpa-legacy` | Cross-platform Legacy, Windows-only Legacy |
+| `uipath-agents` | LangGraph, LlamaIndex, OpenAI Agents, Simple Function, low-code |
+| `uipath-maestro-flow` (agents) | low-code, inline-flow |
+| `uipath-coded-apps` | Coded Web App, Coded Action App |
+| `uipath-human-in-the-loop` | greenfield HITL in `.flow`, brownfield HITL in `.flow`, HITL in coded agents |
+
+A path is "covered" if at least one test exercises it (look at the `authoring`, `lifecycle`, `scenario`, or skill-specific tags on each task, plus the prompt content). For single-path skills, this dimension is **N/A**.
+
+### 4e. Anti-patterns (diagnostic, not scored)
+
+Report anti-patterns covered in a per-skill table, but do **NOT** include them in the weighted overall score. Across the repo, anti-pattern coverage is effectively 0% everywhere — keeping it at 15% weight was deadweight that compressed scores without adding signal. The "Negative-test gap" signal in Phase 4g already surfaces skills with ≥3 anti-patterns and zero negative tests, which is the actionable version.
+
+### 4f. Weighted overall score
+
+Weights reflect what tests actually catch:
 
 | Dimension | Weight | Rationale |
 |---|---|---|
-| Components | 40% | Core of what the skill teaches |
-| Workflow steps | 20% | Sequential correctness |
-| Critical rules | 25% | Guard against expensive mistakes |
-| Anti-patterns | 15% | Usually need dedicated negative tests |
+| Components | 55% | Core of what the skill teaches; where regressions actually land |
+| Workflow steps | 30% | Sequential correctness across the lifecycle |
+| Critical rules | 15% | Guard against expensive mistakes (low because most rules are Indirect in practice) |
+| Path coverage | — / 15% | N/A for single-path skills; 15% when applicable |
 
-Formula: `overall = 0.40 * comp% + 0.20 * step% + 0.25 * rule% + 0.15 * anti%`
+**N/A handling.** When a skill is missing a dimension (common cases documented below), mark it **N/A** in the Summary table and **renormalize** the remaining weights proportionally — do NOT score it as 0%. Example: a catalog skill (`uipath-platform`) with no Critical Rules section and a single path has weights renormalized to Components 65% / Steps 35%.
+
+| Skill shape | Typical N/A dimensions | Effective weights |
+|---|---|---|
+| Workflow-heavy, multi-path (e.g. `uipath-rpa`, `uipath-agents`, `uipath-maestro-flow`) | — | Comp 45% / Steps 25% / Rules 15% / Path 15% |
+| Workflow-heavy, single-path (e.g. `uipath-case-management`, `uipath-human-in-the-loop`) | Path | Comp 55% / Steps 30% / Rules 15% |
+| Command-catalog skills (e.g. `uipath-platform`, `uipath-servo`, `uipath-test`, `uipath-feedback`, `uipath-data-fabric`) | Rules, Path, Steps (often) | Comp 100% (or Comp 65% / Steps 35% if the skill has explicit workflow steps) |
+| Planning skills (e.g. `uipath-planner`, `uipath-solution-design`) | Components (often), Rules (sometimes), Path | Steps 70% / Rules 30% (or Steps 100% if no rules section) |
+| Agent-orchestration skills (e.g. `uipath-diagnostics`) | Path, sometimes Components | Components 55% (sub-agents + phases) / Steps 30% / Rules 15% |
+
+Formula: `overall = sum(applicable_weight_i * dimension_pct_i) / sum(applicable_weight_i)`
 
 For skills with **no tests**: overall = 0%.
 
+### 4h. Test-density diagnostics (sidecar, not scored)
+
+Report these alongside the Summary table to flag structural fragility that a high coverage score might hide. None of these feed the weighted score — they're red-flag indicators for readers.
+
+- **Total tests** — already in Summary.
+- **Tests per component (median)** — if `0`, most components are untested even when the coverage score looks OK.
+- **Tests per component (max)** — if one component has >50% of the tests, coverage is concentrated and fragile.
+- **Single-test-dominance flag** — emit a warning bullet if any one test task accounts for more than 1/3 of all Direct component hits. That test becomes a single point of failure for the coverage number.
+
+### 4i. Tag-dimension coverage (sidecar diagnostic)
+
+For each skill that has at least one test, compute which values from the Tag Taxonomy are exercised. Report the three variable dimensions (the `skill` dimension is trivially covered and `tier` is already reported in the Summary table):
+
+- **Lifecycle** — tick each of `activate`, `generate`, `edit`, `validate`, `execute`, `deploy` if any test carries that tag.
+- **Scenario** — tick each of `green-field`, `brown-field`, `fixture`.
+- **Feature** — list the feature tags present vs a reasonable "expected" set for this skill (derived from the skill's SKILL.md — e.g. `uipath-human-in-the-loop` should exercise `hitl`, `approval-gate`, `write-back`, `escalation`; `uipath-maestro-flow` should exercise `registry`, `connector-feature`, `transform`, `http`, …). If the skill's vocabulary is open, just list what's present without the ✗ column.
+
+This is structured data for the per-skill report (see template below). It is NOT folded into the weighted overall score — adding it on top of Components/Steps would double-count (a missing `edit` lifecycle already shows up as a workflow-step gap).
+
+### 4j. Automatic gap signals
+
+Run these checks and emit findings into the "Coverage Gaps — Priority Ranked" section with the specified priority. The goal is consistent, data-driven flagging across skills rather than ad-hoc prose:
+
+| Signal | Condition | Priority | Gap title template |
+|---|---|---|---|
+| **Lifecycle gap (edit)** | The skill teaches an edit workflow (it documents modifying an existing artifact — common for `uipath-maestro-flow`, `uipath-rpa`, `uipath-agents`) but no test carries the `edit` lifecycle tag. | **High** | "Editing existing `<artifact>`" |
+| **Scenario gap (brown-field)** | All tests carry `green-field` (or no scenario tag), and the skill explicitly supports modifying existing projects. | **Medium** | "Brown-field modification of existing `<artifact>`" |
+| **Negative-test gap** | The skill's SKILL.md lists ≥3 anti-patterns and zero tests assert on any of them. | **High** | "Negative tests for anti-patterns" |
+| **Tier gap** | The skill has tests but is missing a tier (smoke-only, integration-only, or e2e-only). | **High** (if smoke or e2e is missing — those are the minimum bar), **Medium** (integration missing) | "Missing `<tier>` tier" |
+
+Whenever a signal fires, the corresponding recommendation in Phase 5's Recommendations section must include the tag list that would address it (e.g. a "Brown-field modification" recommendation ships with `(e2e, edit, brown-field, …)`).
+
 ## Phase 5 — Write reports
 
-Create `tests/reports/` if needed. Write one report per skill at `tests/reports/<skill-name>.md` (e.g., `tests/reports/uipath-maestro-flow.md`). When more than one skill is analyzed, also write `tests/reports/summary.md` with the roll-up table comparing all skills. If the user specified a custom output path, use that instead. Overwrite any existing report at the same path.
+Create `tests/reports/` if needed.
+
+**Output rules:**
+
+| Invocation | Files written |
+|---|---|
+| Single skill (e.g. `uipath-maestro-flow`) | `tests/reports/<skill-name>.md` only. |
+| `all` (or empty) | One per-skill report **and** the roll-up: `tests/reports/<skill-name>.md` for every skill plus `tests/reports/SUMMARY.md`. |
+| User-specified custom path | Use that path instead. |
+
+Overwrite any existing report at the same path. The summary file name is `SUMMARY.md` (uppercase), matching the directory structure documented in `tests/README.md`.
 
 ---
 
@@ -184,17 +270,26 @@ Use this template when the skill has at least one test task.
 | Components covered (direct + indirect) | X / Y (Z%) |
 | Components covered (direct only) | X / Y (Z%) |
 | Workflow steps covered | X / Y (Z%) |
-| Critical rules covered (direct) | X / Y (Z%) |
-| Anti-patterns covered | X / Y (Z%) |
-| **Estimated overall coverage** | **Z%** |
+| Critical rules covered (direct) | X / Y (Z%) *or* N/A (no Critical Rules section) |
+| Path coverage | X / Y (Z%) *or* N/A (single-path skill) |
+| **Estimated overall coverage** | **Z%** (weights: Comp W1% / Steps W2% / Rules W3% / Path W4% — renormalized over applicable dimensions) |
 
-> **Infrastructure:** <what this skill requires to run tests — e.g., "Cloud auth required for debug/deploy tests. Local-only for validate/bundle.">
+Anti-patterns are inventoried in the Anti-Patterns section below but are **not** part of the overall score (see Phase 4e).
+
+### Test-density diagnostics
+
+- Total test tasks: N
+- Median tests per component: X
+- Max tests per component: X (on `<component>`)
+- ⚠ *single-test-dominance:* emit this bullet only when one test accounts for >1/3 of Direct component hits — name the test.
+
+> **Infrastructure:** <what this skill requires to run tests — e.g., "Requires cloud auth for debug/deploy tests. Local-only for validate/bundle.">
 
 ## Test Inventory
 
 | Test ID | Type | Tags | Description | Components Exercised |
 |---------|------|------|-------------|---------------------|
-| skill-flow-calculator | e2e | generate, ootb | Multiply two inputs via script node | `core.action.script`, input vars, output vars, validate, debug |
+| skill-flow-calculator | e2e | generate, green-field, transform | Multiply two inputs via script node | `core.action.script`, input vars, output vars, validate, debug |
 
 ## Component Coverage
 
@@ -222,11 +317,49 @@ Use this template when the skill has at least one test task.
 | 7 | Every node needs definitions | — | Yes | all e2e (validation would fail without them) |
 | 5 | Edit .flow ONLY | — | — | — |
 
-### Anti-Patterns (X/Y covered)
+### Path Coverage (X/Y paths exercised)
+
+Applicable only when the skill documents ≥2 implementation paths. Otherwise write "N/A — single-path skill" and skip the table.
+
+| Path | Exercised | Test(s) |
+|------|-----------|---------|
+| Coded (C#) | Yes | skill-rpa-coded-test-case |
+| XAML | No | — |
+
+### Anti-Patterns (X/Y covered — diagnostic only, NOT in overall score)
 
 | # | Anti-Pattern | Covered | Test(s) | Notes |
 |---|-------------|---------|---------|-------|
 | 1 | Never guess node schemas | No | — | Would need negative test |
+
+### Tag-Dimension Coverage
+
+Sidecar diagnostic — see Phase 4i. Not part of the weighted overall score.
+
+**Lifecycle**
+
+| Value | Tests | Status |
+|---|---|---|
+| `activate` | skill-flow-registry-discovery | ✓ |
+| `generate` | skill-flow-calculator, skill-flow-reading-list, … | ✓ |
+| `edit` | — | ✗ |
+| `validate` | skill-flow-init-validate | ✓ |
+| `execute` | skill-flow-calculator, skill-flow-dice-roller | ✓ |
+| `deploy` | — | ✗ |
+
+**Scenario**
+
+| Value | Tests | Status |
+|---|---|---|
+| `green-field` | all | ✓ |
+| `brown-field` | — | ✗ |
+| `fixture` | — | ✗ |
+
+**Feature tags in use**
+
+`registry` (2), `transform` (3), `http` (1), `connector-feature` (18), …
+
+(For skills with a clear "expected" feature set — e.g., HITL should exercise `hitl`, `approval-gate`, `write-back`, `escalation` — use the same Status column with ✓/✗. For skills with an open feature vocabulary, just list counts.)
 
 ## Untested Features
 
@@ -239,11 +372,13 @@ Group by theme. Include cross-cutting features (variable management, expression 
 
 ## Coverage Gaps — Priority Ranked
 
+Gap titles are short noun phrases — the exact string a reader would paste into `/generate-tasks <skill> <focus>`. Include entries emitted by the Phase 4g automatic signals (lifecycle gap, scenario gap, negative-test gap, tier gap) alongside skill-specific gaps.
+
 ### High Priority
 
 Gaps where an agent getting it wrong would cause expensive failures or silent bugs.
 
-1. **<Gap title>** — <What's untested, specific risk>. *Suggested test:* `<suggested-task-id>` (type) — <one sentence describing the test>.
+1. **<Gap title — noun phrase>** — <What's untested, specific risk>. *Suggested test:* `<suggested-task-id>` (tier, lifecycle, scenario, …features) — <one sentence describing the test>.
 
 ### Medium Priority
 
@@ -255,11 +390,10 @@ Gaps in edge cases or features that other tests partially cover indirectly.
 
 ## Recommendations
 
-> **Minimum bar:** Every skill must have at least 1 smoke test and 1 e2e test (per CONTRIBUTING.md). Flag any skill that falls below this threshold.
+Top 5–10 tests to write next, ordered by how much coverage they add. Each recommendation carries the full proposed tag list so `/generate-tasks` can consume it verbatim.
 
-Top 5–10 tests to write next, ordered by how much coverage they add:
-
-1. **`<suggested-task-id>`** (e2e) — Covers: `core.logic.loop`, `core.logic.merge`, `core.action.transform`, iteration pattern. *Why:* The entire control-flow family is untested; a single test with a loop-and-merge topology covers 4 components.
+1. **`<suggested-task-id>`** (e2e, generate, green-field, transform) — Covers: `core.logic.loop`, `core.logic.merge`, `core.action.transform`, iteration pattern. *Why:* The entire control-flow family is untested; a single test with a loop-and-merge topology covers 4 components.
+2. **`skill-flow-edit-loop`** (e2e, edit, brown-field, registry) — Covers: editing an existing flow, adding a loop node to an existing topology. *Why:* No test carries the `edit` lifecycle or `brown-field` scenario — modifying existing flows is a first-class workflow in this skill.
 ```
 
 ---
@@ -311,9 +445,10 @@ List all components grouped by category. Use a compact format — no Direct/Indi
 
 ## Recommended Starter Tests
 
-Recommend 2 smoke tests and 2 e2e tests to establish baseline coverage. For each:
+Recommend 2 smoke tests and 2 e2e tests to establish baseline coverage (per CONTRIBUTING.md minimum bar: 1 smoke + 1 e2e). For each, include the full proposed tag list so `/generate-tasks` can consume the recommendation verbatim:
 
-1. **`<suggested-task-id>`** (type) — Covers: <components, rules>. *Why:* <rationale>. <Infrastructure note if needed.>
+1. **`<suggested-task-id>`** (smoke, generate, green-field) — Covers: <components, rules>. *Why:* <rationale>. <Infrastructure note if needed.>
+2. **`<suggested-task-id>`** (e2e, generate, green-field, <feature>) — Covers: <…>. *Why:* <…>.
 ```
 
 ---
@@ -329,12 +464,15 @@ Produce this whenever more than one skill is analyzed (including `all` mode).
 
 ## Overview
 
-| Skill | Tests | Components (direct) | Workflow | Rules | Anti-Patterns | Overall | Infra |
-|-------|-------|---------------------|----------|-------|---------------|---------|-------|
-| uipath-maestro-flow | 10 | 6/24 (25%) | 6/9 (67%) | 1/16 (6%) | 0/13 (0%) | 33% | Cloud auth |
-| uipath-rpa | 0 | 0/39 (0%) | 0/8 (0%) | 0/21 (0%) | 0/30 (0%) | 0% | Windows + Studio |
+| Skill | Tests | Components (direct) | Workflow | Rules | Paths | Overall | Tests/Comp (med) | Infra |
+|-------|-------|---------------------|----------|-------|-------|---------|------------------|-------|
+| uipath-maestro-flow | 49 | 6/24 (25%) | 6/9 (67%) | 1/16 (6%) | 1/2 (50%) | 33% | 2 | Requires cloud auth |
+| uipath-rpa | 2 | 0/39 (0%) | 0/8 (0%) | 0/21 (0%) | 1/2 (50%) | 8% | 0 | Requires Windows + Studio |
+| uipath-platform | 5 | 2/12 (17%) | N/A | N/A | N/A | 17% | 0 | Requires cloud auth |
 
-**Totals:** N tests across M skills. X components inventoried, Y directly tested (Z%). A workflow steps, B covered. C critical rules, D directly tested. E anti-patterns, F tested.
+Overall is weighted and renormalized across applicable dimensions (see Phase 4e). N/A cells mean the skill is missing that dimension (e.g. no Critical Rules section, single-path skill, catalog skill with no workflow steps) — weights redistribute proportionally.
+
+**Totals:** N tests across M skills. X components inventoried, Y directly tested (Z%). A workflow steps, B covered. C critical rules, D directly tested. E multi-path skills, F with full path coverage. Anti-patterns are inventoried per skill but intentionally excluded from the overall score.
 
 ## Skills Without Tests
 
@@ -364,18 +502,21 @@ Observations that span multiple skills. Look for:
 
 ## Minimum Bar Check
 
-> Every skill must have at least 1 smoke test and 1 e2e test (per CONTRIBUTING.md).
+> Every skill must have at least 1 smoke test and 1 e2e test (per CONTRIBUTING.md). This is the **only** place the minimum-bar check lives — per-skill Recommendations sections link back here rather than restating the rule.
 
-| Skill | Has Smoke | Has E2E | Status |
-|-------|-----------|---------|--------|
-| uipath-maestro-flow | Yes (2) | Yes (8) | Meets minimum |
-| uipath-rpa | No | No | Below minimum |
+The table also surfaces the **tier gap** signal from Phase 4g: a skill with tests but missing a tier (smoke-only, e2e-only) is flagged even if it technically meets the smoke+e2e minimum.
+
+| Skill | Smoke | Integration | E2E | Status |
+|-------|-------|-------------|-----|--------|
+| uipath-maestro-flow | 2 | 5 | 8 | Meets minimum |
+| uipath-rpa | 0 | 0 | 0 | Below minimum (missing smoke + e2e) |
+| uipath-data-fabric | 2 | 0 | 1 | Tier gap (no integration tier) |
 
 ## Top 10 Recommended Tests
 
-Across all skills, prioritized by coverage impact. Prefer tests that are feasible to implement (local-only or cloud-auth-only over platform-specific).
+Across all skills, prioritized by coverage impact. Prefer tests that are feasible to implement (local-only or cloud-auth-only over platform-specific). Each recommendation carries the full proposed tag list so `/generate-tasks` can lift it verbatim.
 
-1. **`skill-<name>-<capability>`** (<skill>, <type>) — <what it covers and why>. <Infra note if needed.>
+1. **`skill-<name>-<capability>`** (<skill>, tier, lifecycle, scenario, …features) — <what it covers and why>. <Infra note if needed.>
 ```
 
 ---
@@ -392,3 +533,5 @@ Across all skills, prioritized by coverage impact. Prefer tests that are feasibl
 8. **Match recommendations to existing test patterns.** Look at how existing tests are structured (YAML format, check script patterns, tag conventions) and suggest new tests that follow the same patterns. Recommend realistic tests — flag infrastructure dependencies and prefer tests that can run in CI (local-only or cloud-auth-only).
 9. **Anti-patterns come from SKILL.md only.** Count items in the main Anti-Patterns / What NOT to Do section. Do not trawl reference files for additional "never do X" statements — those are implementation-level guidance, not skill-level anti-patterns.
 10. **Flag infrastructure requirements.** Every report should note what environment the skill needs for testing. The summary should include an Infra column so readers can quickly see which skills are CI-testable vs platform-gated.
+11. **Tag every recommendation.** Suggested tests in the Gaps and Recommendations sections must carry the proposed tag list (tier, lifecycle, scenario, features) from the Tag Taxonomy. These recommendations feed `/generate-tasks` — the validated tag set must travel with them so no inference is required downstream.
+12. **Minimum bar lives in the summary.** The smoke+e2e minimum-bar check lives in the summary's Minimum Bar Check section and nowhere else. Per-skill reports may note the status but must not restate the rule — link back to the summary instead.

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,7 +97,7 @@ Experiment files define shared agent defaults per test type. Tasks inherit these
 | `integration.yaml` | Integration | 2 | 30 | 900s | 300s |
 | `e2e.yaml` | E2E | 2 | 40 | 1200s | 300s |
 
-For **A/B comparisons between two skill variants** (e.g. `main` vs a feature branch), see [`experiments/skill-comparison-playbook.md`](experiments/skill-comparison-playbook.md) and the [`experiments/skill-comparison-template.yaml`](experiments/skill-comparison-template.yaml). The playbook covers worktree setup, SHA pinning for reproducibility, getting N>1, and interpreting divergent tasks. To automate the whole flow, use the `/skill-compare <branch_a> <branch_b> [skill] [n_reps]` slash command.
+For **A/B comparisons between two skill variants** (e.g. `main` vs a feature branch, or two historical commits), see [`experiments/skill-comparison-playbook.md`](experiments/skill-comparison-playbook.md) and the [`experiments/skill-comparison-template.yaml`](experiments/skill-comparison-template.yaml). The playbook covers worktree setup, SHA pinning for reproducibility, getting N>1, and interpreting divergent tasks. To automate the whole flow, use the `/skill-compare <ref_a> <ref_b> [skill] [n_reps]` slash command — each ref can be a branch name or a commit SHA.
 
 Task files should **not** duplicate the full `agent:` block — the experiment provides the defaults. Only specify fields that differ from the experiment:
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,6 +97,8 @@ Experiment files define shared agent defaults per test type. Tasks inherit these
 | `integration.yaml` | Integration | 2 | 30 | 900s | 300s |
 | `e2e.yaml` | E2E | 2 | 40 | 1200s | 300s |
 
+For **A/B comparisons between two skill variants** (e.g. `main` vs a feature branch), see [`experiments/skill-comparison-playbook.md`](experiments/skill-comparison-playbook.md) and the [`experiments/skill-comparison-template.yaml`](experiments/skill-comparison-template.yaml). The playbook covers worktree setup, SHA pinning for reproducibility, getting N>1, and interpreting divergent tasks. To automate the whole flow, use the `/skill-compare <branch_a> <branch_b> [skill] [n_reps]` slash command.
+
 Task files should **not** duplicate the full `agent:` block — the experiment provides the defaults. Only specify fields that differ from the experiment:
 
 ```yaml

--- a/tests/README.md
+++ b/tests/README.md
@@ -67,6 +67,40 @@ Tests are organized into three types, distinguished by **tags** (not directories
 | `integration` | Correct output across diverse scenarios, error paths, anti-patterns | Daily |
 | `e2e` | Full lifecycle: Explore -> Plan -> Build -> Validate -> Deploy -> Run | Daily/weekly (check [Dashboard](https://dataexplorer.azure.com/dashboards/20cc55fe-33ae-4973-a951-855e76528219))|
 
+## Tag Taxonomy
+
+Every task's `tags:` list is a flat array, but tags come from a small set of **dimensions** with closed vocabularies. Pick one value per dimension that applies; skip dimensions that genuinely don't apply to the task. Stick to these values — ad-hoc tags (e.g. one-off feature names) make tag filtering noisy and useless.
+
+| Dimension | Purpose | Values (closed set) |
+|---|---|---|
+| **skill** | Which skill is under test | `uipath-<name>` — must match the skill folder name (e.g. `uipath-maestro-flow`, `uipath-rpa`). Required on every task. |
+| **tier** | Test depth / cost | `smoke`, `integration`, `e2e`. Required on every task. |
+| **lifecycle** | What the agent is asked to do | `activate`, `generate`, `edit`, `validate`, `execute`, `deploy` |
+| **scenario** | Starting state handed to the agent | `green-field` (empty workspace), `brown-field` (existing project), `fixture` (pre-seeded inputs) |
+| **feature** | Cross-cutting capability under test | `hitl`, `approval-gate`, `write-back`, `escalation`, `registry`, `connector-feature`, `connections`, `activities`, `records`, `entities`, `api-workflow`, `compliance`, `test-case`, `hooks`, `transform`, `http` |
+
+### Rules
+
+1. **Always tag `skill` and `tier`.** Those two are mandatory — they drive `make` targets and the coverage reports.
+2. **Use only the closed-set values above.** If you think a new value is needed, propose it in the PR — do not invent tags inline. New tags should be broad enough to apply to at least three tasks.
+3. **One value per dimension.** Don't tag both `smoke` and `e2e` on the same task; pick the tier the task actually tests.
+4. **`feature` is optional and additive.** A task can carry multiple feature tags if it genuinely exercises multiple (e.g. `hitl` + `approval-gate`). Don't use `feature` tags as task identifiers — that's what `task_id` is for.
+5. **No skill-name collisions.** Don't tag a maestro-flow task with `rpa` or `agent` as a feature — use `uipath-rpa` / `uipath-agents` only for the skill under test. If you need to express "this maestro-flow task exercises an RPA resource node", add a feature tag like `rpa-resource` after discussing in the PR.
+
+### Example
+
+```yaml
+tags: [uipath-human-in-the-loop, e2e, generate, green-field, hitl, approval-gate, write-back]
+#      ^^ skill                   ^^ tier ^^ lifecycle ^^ scenario   ^^^^^^^^^^^^^^^^^^^^^ feature
+```
+
+### Useful slices this enables
+
+- `make tags TAGS="smoke"` → every skill's entry-gate checks.
+- `make tags TAGS="integration connector-feature"` → connector-feature coverage across skills.
+- `make tags TAGS="e2e green-field"` → end-to-end authoring from scratch, across skills.
+- `make tags TAGS="brown-field edit"` → modification-on-existing-project behavior.
+
 ## Directory Structure
 
 ```
@@ -134,8 +168,8 @@ initial_prompt: |
 1. Create `tests/tasks/<skill-name>/` matching the skill folder name under `skills/`.
 2. Add at minimum **1 smoke test** and **1 e2e test** (required for every new skill PR).
 3. Use minimal prompts — the goal is to test whether the skill guides the agent correctly, not to hand-hold it.
-4. Tag every task appropriately: `smoke`, `integration`, or `e2e`.
-5. Always include the skill directory name as a tag (e.g., `uipath-maestro-flow`, `uipath-rpa`).
+4. Tag every task using the [Tag Taxonomy](#tag-taxonomy): required `skill` + `tier`, plus `lifecycle`, `scenario`, and `feature` where applicable.
+5. Stick to the closed-vocabulary values. Propose new tags in the PR — do not invent them inline.
 
 ### Task ID Convention
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,7 +97,7 @@ Experiment files define shared agent defaults per test type. Tasks inherit these
 | `integration.yaml` | Integration | 2 | 30 | 900s | 300s |
 | `e2e.yaml` | E2E | 2 | 40 | 1200s | 300s |
 
-For **A/B comparisons between two skill variants** (e.g. `main` vs a feature branch, or two historical commits), see [`experiments/skill-comparison-playbook.md`](experiments/skill-comparison-playbook.md) and the [`experiments/skill-comparison-template.yaml`](experiments/skill-comparison-template.yaml). The playbook covers worktree setup, SHA pinning for reproducibility, getting N>1, and interpreting divergent tasks. To automate the whole flow, use the `/skill-compare <ref_a> <ref_b> [skill] [n_reps]` slash command — each ref can be a branch name or a commit SHA.
+For **A/B comparisons between two skill variants** (e.g. `main` vs a feature branch, or two historical commits), see [`experiments/skill-comparison-playbook.md`](experiments/skill-comparison-playbook.md) and the [`experiments/skill-comparison-template.yaml`](experiments/skill-comparison-template.yaml). The playbook covers worktree setup, SHA pinning for reproducibility, getting N>1, and interpreting divergent tasks. To automate the whole flow, use the `/skill-compare <ref_a> <ref_b> [task_selector] [n_reps]` slash command — each ref can be a branch name or a commit SHA, and `task_selector` accepts a skill name (`uipath-maestro-flow`), tag list (`tags:smoke,init`), or path globs (`paths:tasks/uipath-maestro-flow/*.yaml`).
 
 Task files should **not** duplicate the full `agent:` block — the experiment provides the defaults. Only specify fields that differ from the experiment:
 

--- a/tests/experiments/sherif-skill-comparison.yaml
+++ b/tests/experiments/sherif-skill-comparison.yaml
@@ -1,0 +1,48 @@
+# Experiment: Skills vs No-Skills evaluation (agent SDK tasks)
+#
+# Tests 4 conditions to measure the impact of documentation and skills:
+#   bare              — bare scaffolding only
+#   docs              — adds CLAUDE.md + .agent/ reference docs
+#   plugin            — docs + skills plugin
+#   bare-plugin       — skills plugin only, no docs
+#
+# Overrides default.yaml to use bypassPermissions (needed for unattended runs).
+# Plugin variants load the skills plugin; the model decides whether to invoke skills.
+#
+# Uses template overlays (appended after each task's base template):
+#   overlays/agent/docs — contains CLAUDE.md, AGENTS.md, .agent/ reference files
+#
+# Prerequisites:
+#   - Set SKILLS_PLUGIN_PATH env var to your skills plugin directory
+#     (e.g., ~/uipath/uipath-claude-plugins/plugins/uipath-coded-agents)
+#   - Task YAML files should use uipath-starter as base template (no docs baked in)
+
+experiment_id: skills-eval
+description: "Compare impact of docs and skills on agent SDK coding tasks"
+
+defaults:
+  max_iterations: 1
+  repeats: 1
+  agent:
+    type: claude-code
+    permission_mode: bypassPermissions
+    system_prompt: |
+      You are a coding agent. Work only inside your current working directory.
+      Do NOT read, list, or access any files outside your working directory.
+      In particular, do NOT access the plugin directories — those are loaded by
+      the skill system and you do not need to read them directly.
+
+variants:
+  - variant_id: bare
+
+  - variant_id: sherif-skills
+    agent:
+      plugins:
+        - type: "local"
+          path: "/Users/religa/src/exp/skills"
+
+  - variant_id: main-skills
+    agent:
+      plugins:
+        - type: "local"
+          path: "/Users/religa/src/skills"

--- a/tests/experiments/skill-comparison-playbook.md
+++ b/tests/experiments/skill-comparison-playbook.md
@@ -11,25 +11,30 @@ Write the hypothesis in one sentence before touching any YAML. Examples:
 
 If you can't state it in one sentence, the experiment will not produce a clear answer. Split it.
 
-## 2. Set up variants as branches in one repo
+## 2. Set up variants as refs in one repo
 
 **Do not** use two separate clones. Diverging clones drift on unrelated files, so you can no longer claim the only difference is the change you're testing.
 
-Instead, one repo, one branch per variant, all checked out in parallel via `git worktree`:
+Instead, one repo, one ref per variant, all checked out in parallel via `git worktree`. A variant ref can be either a **branch** (what you'll normally use — the change lives on a branch) or a **commit SHA** (when you want to pin a specific historical point, e.g. a tagged release or a reproducibility check against a past run):
 
 ```bash
 # From the skills repo root
-git worktree add ../skills-main     main                          # baseline
-git worktree add ../skills-variantb   feat/my-change     # variant under test
+
+# Branch variants (the common case)
+git worktree add ../skills-main     main                     # baseline branch
+git worktree add ../skills-variantb feat/my-change           # variant under test
+
+# SHA variants (when you need an exact historical point)
+git worktree add --detach ../skills-a1b2c3d a1b2c3d          # detached HEAD at that commit
 ```
 
-Each worktree is a full working copy on its own branch. They share the `.git` dir, so there's no duplication of history and branches stay in sync. When the experiment is done, delete the worktrees with `git worktree remove`.
+Each worktree is a full working copy. Branch worktrees track their branch and move if you `pull`; SHA worktrees are detached HEADs that won't move unless you explicitly check out a different ref. All worktrees share the `.git` dir, so there's no duplication of history. When the experiment is done, delete the worktrees with `git worktree remove`.
 
-For three-way comparisons (baseline vs A vs B) add a third worktree on a third branch.
+For three-way comparisons (baseline vs A vs B) add a third worktree on a third ref.
 
 ## 3. Pin each variant to a commit SHA
 
-Record the SHA of each branch in the experiment YAML as a comment. This is the single most important reproducibility step. Paths drift; SHAs don't.
+Record the SHA of each ref in the experiment YAML as a comment. This is the single most important reproducibility step. Paths drift; branches move; SHAs don't. (If the ref was already a SHA, this is a no-op — it's already pinned.)
 
 ```yaml
   - variant_id: variantb

--- a/tests/experiments/skill-comparison-playbook.md
+++ b/tests/experiments/skill-comparison-playbook.md
@@ -1,0 +1,155 @@
+# Skill Comparison Experiments — Playbook
+
+How to run an apples-to-apples A/B on a skill variant (e.g. "does this restructuring of the skill beat main?"). Use this when the question is *"should we merge this change?"* — not when you're adding a new skill or debugging a single task.
+
+## 1. Decide what you're comparing
+
+Write the hypothesis in one sentence before touching any YAML. Examples:
+
+- *"Collapsing per-node `planning.md`+`impl.md` into one `flow-plan.md` does not hurt success rate."*
+- *"Dropping the mandatory two-phase planning workflow improves token efficiency without a success-rate regression."*
+
+If you can't state it in one sentence, the experiment will not produce a clear answer. Split it.
+
+## 2. Set up variants as branches in one repo
+
+**Do not** use two separate clones. Diverging clones drift on unrelated files, so you can no longer claim the only difference is the change you're testing.
+
+Instead, one repo, one branch per variant, all checked out in parallel via `git worktree`:
+
+```bash
+# From the skills repo root
+git worktree add ../skills-main     main                          # baseline
+git worktree add ../skills-variantb   feat/my-change     # variant under test
+```
+
+Each worktree is a full working copy on its own branch. They share the `.git` dir, so there's no duplication of history and branches stay in sync. When the experiment is done, delete the worktrees with `git worktree remove`.
+
+For three-way comparisons (baseline vs A vs B) add a third worktree on a third branch.
+
+## 3. Pin each variant to a commit SHA
+
+Record the SHA of each branch in the experiment YAML as a comment. This is the single most important reproducibility step. Paths drift; SHAs don't.
+
+```yaml
+  - variant_id: variantb
+    # pinned: feat/my-change @ a1b2c3d
+    agent:
+      plugins:
+        - type: "local"
+          path: "/Users/you/src/skills-variantb"
+```
+
+A month from now, `git checkout a1b2c3d` in either worktree reconstructs exactly what ran. Without the SHA, "variantb" means whatever happens to be at that path today.
+
+## 4. Control the prompt and the environment
+
+Divergent tasks are worth analyzing only if the variants were actually running under the same conditions. Before kicking off:
+
+- **Prompts must not name the skill.** If the task prompt says "use the uipath-maestro-flow skill", you're testing whether the skill's *name* triggers, not the skill's *content*. Edit task YAML prompts to describe goals, not skill names.
+- **Run with `cwd` outside the skill repo.** Running inside the repo lets the agent read skill source files directly via `Read`, bypassing the plugin system. Use `sandbox.driver: tempdir` (all existing tasks already do this).
+- **Disable user-level plugins.** Anything in `~/.claude/plugins/` loads in addition to the experiment plugin and pollutes the comparison. Confirm the variant's `plugins` list is the only source.
+- **Lock the model.** Set `model: claude-sonnet-4-6` (or whichever) in `defaults.agent`. Don't let variants pick up different defaults.
+
+## 5. Pick the task set
+
+Start with every task for the affected skill. You want a wide net to find where the variants diverge — not a narrow test that confirms your prior.
+
+```bash
+find tasks/uipath-maestro-flow -name '*.yaml'
+```
+
+After the first pass, if you have a decision to make, re-run **only the divergent tasks** at higher N (see next step). The tied tasks don't need more reps — they're tied.
+
+## 6. Get more than N=1 per task
+
+`coder-eval` has no `--reps` flag. One task under one variant runs once. That's fine for finding *where* variants diverge, but it's not enough to make a decision — timeouts and `MAX_TURNS` outcomes have high run-to-run variance.
+
+Two workable options:
+
+**Option A — duplicate the variant with distinct IDs** (recommended for automation):
+
+```yaml
+variants:
+  - variant_id: variantb-r1
+    agent: { plugins: [...] }
+  - variant_id: variantb-r2
+    agent: { plugins: [...] }
+  - variant_id: variantb-r3
+    agent: { plugins: [...] }
+```
+
+Each variant runs the full task set once. Aggregate across the `r1`/`r2`/`r3` variants in analysis.
+
+**Option B — re-run the experiment in a shell loop**:
+
+```bash
+for i in 1 2 3; do
+  SKILLS_REPO_PATH=$(cd .. && pwd) \
+    .venv/bin/coder-eval run tasks/uipath-maestro-flow/*.yaml \
+    -e experiments/my-comparison.yaml \
+    --run-dir runs/compare-$(date +%F)-rep-$i
+done
+```
+
+Lower effort to set up, harder to analyze (three separate run dirs to combine).
+
+**Rule of thumb:** N ≥ 3 before calling anything decisive. For any task that diverged at N=1, push to N ≥ 5 on just that task.
+
+## 7. Run and capture output
+
+```bash
+cd tests
+SKILLS_REPO_PATH=$(cd .. && pwd) \
+  .venv/bin/coder-eval run tasks/uipath-maestro-flow/*.yaml \
+  -e experiments/my-comparison.yaml \
+  -j 1 -v
+```
+
+Results land in `runs/<timestamp>/`. The aggregator writes:
+
+- `experiment.md` — per-variant aggregates and per-task comparison
+- `<variant-id>/variant.json` — machine-readable variant totals
+- `run.md` — flattened per-task table across all variants
+
+Keep `-j 1` for comparison runs. Parallel execution can introduce timing noise (shared API rate limits, disk contention) that distorts small variant effects.
+
+## 8. Interpret the numbers
+
+Look at, in order:
+
+1. **Head-to-head wins and ties.** Most tasks will tie — that's expected, and "skill content is good enough for easy tasks and not good enough for hard ones" is a valid finding. Focus on the divergent tasks.
+2. **Why each divergence happened.** Read the agent transcript (`task.json` → `transcript`) for the divergent tasks. A win caused by a timeout on one side is weak evidence; a win caused by a deterministic workflow difference is strong evidence.
+3. **Token usage as a tiebreaker.** When success rates are close, the cheaper variant wins — if and only if the token gap is material (>10%).
+4. **Variance.** If the same task flips between reps (N≥3), note the flip rate. A 2/3 → 1/3 task is not a decisive win.
+
+Common false positives to watch for:
+- **Timeouts on both sides.** High-variance outcomes. Don't weight these heavily.
+- **One variant times out at `MAX_TURNS=0`.** The agent never got a turn — you're measuring infrastructure, not the skill.
+- **Small N head-to-head wins.** At N=1, 2 wins out of 24 tasks is noise if the divergent tasks are both timeouts.
+
+## 9. Decide and record
+
+Write a short report in the run directory before moving on. Minimum contents:
+
+- Hypothesis (from step 1)
+- SHAs of each variant
+- Task count, N, model
+- Result table (success rate, score, tokens)
+- Divergent tasks with one-line root-cause
+- Decision: merge / don't merge / rerun at higher N
+
+Commit the experiment YAML and the report into the repo (or link to the run ID in Slack). Ad-hoc experiments tend to disappear — if you don't commit the config, you cannot redo the experiment later.
+
+## 10. Clean up
+
+```bash
+git worktree remove ../skills-variantb
+git branch -d feat/my-change    # or -D if merged via squash
+```
+
+If the variant wins and gets merged, delete the worktree and branch. If it loses, keep the branch around under a `exp/*` prefix for a few weeks in case you want to revisit.
+
+## Template
+
+See [`skill-comparison-template.yaml`](skill-comparison-template.yaml) for a minimal, annotated starting point. Copy, rename, fill in the SHAs, run.

--- a/tests/experiments/skill-comparison-playbook.md
+++ b/tests/experiments/skill-comparison-playbook.md
@@ -48,7 +48,7 @@ Divergent tasks are worth analyzing only if the variants were actually running u
 
 - **Prompts must not name the skill.** If the task prompt says "use the uipath-maestro-flow skill", you're testing whether the skill's *name* triggers, not the skill's *content*. Edit task YAML prompts to describe goals, not skill names.
 - **Run with `cwd` outside the skill repo.** Running inside the repo lets the agent read skill source files directly via `Read`, bypassing the plugin system. Use `sandbox.driver: tempdir` (all existing tasks already do this).
-- **Disable user-level plugins.** Anything in `~/.claude/plugins/` loads in addition to the experiment plugin and pollutes the comparison. Confirm the variant's `plugins` list is the only source.
+- **Confirm the experiment's `plugins` list is the only plugin source.** If you also have plugins installed at the user level (`~/.claude/plugins/`), they load in addition to the experiment's plugins and can pollute the comparison. Check with `ls ~/.claude/plugins/` before the run; temporarily move any entries aside if they overlap in scope with the skill under test.
 - **Lock the model.** Set `model: claude-sonnet-4-6` (or whichever) in `defaults.agent`. Don't let variants pick up different defaults.
 
 ## 5. Pick the task set

--- a/tests/experiments/skill-comparison-template.yaml
+++ b/tests/experiments/skill-comparison-template.yaml
@@ -1,0 +1,84 @@
+# Skill Comparison Experiment — Template
+#
+# Copy this file, rename it (e.g. experiments/my-comparison.yaml), fill in the
+# variant paths + SHAs, and run:
+#
+#   SKILLS_REPO_PATH=$(cd .. && pwd) \
+#     .venv/bin/coder-eval run tasks/<skill>/*.yaml \
+#     -e experiments/my-comparison.yaml -j 1 -v
+#
+# Read experiments/skill-comparison-playbook.md first. The playbook covers
+# worktree setup, SHA pinning, prompt hygiene, and how to get N>1.
+
+experiment_id: skill-comparison-<short-name>     # TODO: rename, e.g. "main-vs-variantb"
+description: "One-sentence hypothesis under test"
+
+# ---------------------------------------------------------------------------
+# Defaults — apply to every variant unless overridden.
+# Use bypassPermissions for unattended comparison runs (no prompts).
+# Lock the model so variants don't pick up different defaults.
+# ---------------------------------------------------------------------------
+defaults:
+  max_iterations: 1
+  task_timeout: 600
+  turn_timeout: 300
+  agent:
+    type: claude-code
+    permission_mode: bypassPermissions
+    model: claude-sonnet-4-6
+    max_turns: 20
+    allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+# ---------------------------------------------------------------------------
+# Variants — one entry per condition you're comparing.
+#
+# Setup (see playbook step 2):
+#   git worktree add ../skills-main    main
+#   git worktree add ../skills-variant feat/my-change
+#
+# Record the commit SHA of each worktree in the comment above the variant.
+# The path is what the runner uses; the SHA is what makes the run reproducible.
+# ---------------------------------------------------------------------------
+variants:
+  # Current main — the version you'd keep if the change loses.
+  # pinned: main @ <fill-in-sha>
+  - variant_id: main
+    agent:
+      plugins:
+        - type: "local"
+          path: "/ABSOLUTE/PATH/TO/skills-main"        # TODO: worktree path
+
+  # Variant under test.
+  # pinned: feat/my-change @ <fill-in-sha>
+  - variant_id: variant
+    agent:
+      plugins:
+        - type: "local"
+          path: "/ABSOLUTE/PATH/TO/skills-variant"     # TODO: worktree path
+
+# ---------------------------------------------------------------------------
+# For N>1: duplicate each variant with suffixed IDs (see playbook step 6).
+# Uncomment and edit the block below if you want 3 reps per condition in
+# one run instead of scripting a loop.
+# ---------------------------------------------------------------------------
+#
+#  - variant_id: main-r2
+#    agent:
+#      plugins:
+#        - type: "local"
+#          path: "/ABSOLUTE/PATH/TO/skills-main"
+#  - variant_id: main-r3
+#    agent:
+#      plugins:
+#        - type: "local"
+#          path: "/ABSOLUTE/PATH/TO/skills-main"
+#  - variant_id: variant-r2
+#    agent:
+#      plugins:
+#        - type: "local"
+#          path: "/ABSOLUTE/PATH/TO/skills-variant"
+#  - variant_id: variant-r3
+#    agent:
+#      plugins:
+#        - type: "local"
+#          path: "/ABSOLUTE/PATH/TO/skills-variant"

--- a/tests/experiments/skill-comparison-template.yaml
+++ b/tests/experiments/skill-comparison-template.yaml
@@ -17,17 +17,24 @@ description: "One-sentence hypothesis under test"
 # Defaults — apply to every variant unless overridden.
 # Use bypassPermissions for unattended comparison runs (no prompts).
 # Lock the model so variants don't pick up different defaults.
+# Pass --repeats N at CLI time to override repeats without editing this file.
 # ---------------------------------------------------------------------------
 defaults:
-  max_iterations: 1
-  task_timeout: 600
+  max_iterations: 2
+  task_timeout: 1200
   turn_timeout: 300
+  repeats: 1
   agent:
     type: claude-code
     permission_mode: bypassPermissions
     model: claude-sonnet-4-6
     max_turns: 20
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+    system_prompt: |
+      You are a coding agent. Work only inside your current working directory.
+      Do NOT read, list, or access any files outside your working directory.
+      In particular, do NOT access the plugin directories — those are loaded by
+      the skill system and you do not need to read them directly.
 
 # ---------------------------------------------------------------------------
 # Variants — one entry per condition you're comparing.
@@ -57,28 +64,7 @@ variants:
           path: "/ABSOLUTE/PATH/TO/skills-variant"     # TODO: worktree path
 
 # ---------------------------------------------------------------------------
-# For N>1: duplicate each variant with suffixed IDs (see playbook step 6).
-# Uncomment and edit the block below if you want 3 reps per condition in
-# one run instead of scripting a loop.
+# For N>1: pass --repeats N to coder-eval run at CLI time instead of
+# duplicating variants here. The repeats: 1 default above is overridden
+# by the --repeats flag without needing to edit this file.
 # ---------------------------------------------------------------------------
-#
-#  - variant_id: main-r2
-#    agent:
-#      plugins:
-#        - type: "local"
-#          path: "/ABSOLUTE/PATH/TO/skills-main"
-#  - variant_id: main-r3
-#    agent:
-#      plugins:
-#        - type: "local"
-#          path: "/ABSOLUTE/PATH/TO/skills-main"
-#  - variant_id: variant-r2
-#    agent:
-#      plugins:
-#        - type: "local"
-#          path: "/ABSOLUTE/PATH/TO/skills-variant"
-#  - variant_id: variant-r3
-#    agent:
-#      plugins:
-#        - type: "local"
-#          path: "/ABSOLUTE/PATH/TO/skills-variant"


### PR DESCRIPTION
## Summary

Adds a documented workflow for running apples-to-apples comparisons between two skill variants.

Motivated by the recent sherif-vs-main experiment, where several issues made the result hard to act on:
- **N=1 per task** with no easy way to ask for more reps — two of the 24 tasks diverged, but both divergences were timeouts (classic high-variance outcomes), so the +8.3pp success-rate delta wasn't decisive.
- **Two separate full clones** (`~/src/skills` and `~/src/exp/skills`), which can drift on files unrelated to the change being tested — so the variants weren't cleanly isolated to the intended diff.
- **No recorded commit SHAs**, so reproducing the run a week later would mean running against whatever happens to be at those paths today.

This PR adds the missing tooling so future experiments start from a known-good recipe.

## What's in this PR

- **`tests/experiments/skill-comparison-playbook.md`** — 10-step guide: hypothesis framing, git-worktree setup (one repo, branches checked out in parallel), SHA pinning in the YAML comments, prompt hygiene (don't name the skill, keep `cwd` outside the skill repo, disable user-level plugins), task selection, how to get N>1 via duplicated variants, and how to interpret divergent tasks vs ties.
- **`tests/experiments/skill-comparison-template.yaml`** — minimal two-variant template with `bypassPermissions`, locked model, and SHA-pinning comment lines. Commented-out block shows how to duplicate variants for N=3 reps in a single run.
- **`.claude/commands/skill-compare.md`** — `/skill-compare <branch_a> <branch_b> [skill] [n_reps]` slash command that automates the playbook: validates branches exist, asks the user for a one-sentence hypothesis, creates worktrees, captures SHAs, generates the experiment YAML from the template, confirms before spending money, runs `coder-eval`, analyzes divergences from the transcripts, and writes a decision-ready `comparison-report.md` into the run directory.
- **`tests/README.md`** — pointer paragraph after the experiment-configs table directing readers to the playbook, template, and `/skill-compare` command.

## Design notes

- The slash command explicitly **does not auto-clean worktrees or branches** — destructive and easy to regret, so it prints cleanup commands for the user to run manually.
- The slash command explicitly **does not auto-commit the generated experiment YAML** — that's the user's call.
- Any divergence the command surfaces gets a root-cause line pulled from the losing variant's transcript, so the report distinguishes "timeout, high variance" from "deterministic workflow difference".

## Test plan

- [ ] Run `/skill-compare main docs/skill-comparison-workflow uipath-maestro-flow 3` end-to-end (self-comparison — should produce ~100% ties and zero divergences, confirms the plumbing works).
- [ ] Verify the generated experiment YAML has correct SHAs and absolute worktree paths.
- [ ] Verify the comparison report is written to `tests/runs/<timestamp>/comparison-report.md` and is under one screen.
- [ ] Confirm worktrees are not auto-removed after the run.
- [ ] Skim the playbook doc for anything that contradicts the slash command's behavior.