### PR TITLE
fix: update skills to be aware of layout format

### DIFF
--- a/skills/uipath-maestro-flow/references/flow-editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/flow-editing-operations-json.md
@@ -329,7 +329,7 @@ Edit the start node in-place (no delete/re-add needed):
    }
    ```
 
-2. Add a `subflows.<SUBFLOW_NODE_ID>` entry with its own nodes, edges, and variables:
+2. Add a `subflows.<SUBFLOW_NODE_ID>` entry with its own nodes, edges, variables, and layout:
    ```json
    {
      "subflows": {
@@ -345,6 +345,12 @@ Edit the start node in-place (no delete/re-add needed):
              { "id": "<OUT_VAR>", "direction": "out", "type": "..." }
            ],
            "nodes": []
+         },
+         "layout": {
+           "nodes": {
+             "sfStart": { "position": { "x": 200, "y": 144 }, "size": { "width": 96, "height": 96 }, "collapsed": false },
+             "sfEnd":   { "position": { "x": 400, "y": 144 }, "size": { "width": 96, "height": 96 }, "collapsed": false }
+           }
          }
        }
      }
@@ -354,6 +360,7 @@ Edit the start node in-place (no delete/re-add needed):
 3. Subflow's `in` variables must match the parent node's `inputs` keys
 4. Map all `out` variables on the subflow's End node `outputs`
 5. Parent-scope `$vars` are NOT visible inside the subflow — pass values via inputs
+6. Subflow node positions go in the **subflow's own** `layout.nodes` — not in the top-level `layout.nodes`. Each subflow has an independent layout scope.
 
 See [subflow/impl.md](plugins/subflow/impl.md) for the full JSON structure and rules.
 

--- a/skills/uipath-maestro-flow/references/flow-file-format.md
+++ b/skills/uipath-maestro-flow/references/flow-file-format.md
@@ -148,6 +148,10 @@ Each key in `layout.nodes` is a node `id`. Every node in the `nodes` array shoul
 - Standard size is `{ "width": 96, "height": 96 }` for all node types
 - Never use vertical (top-to-bottom) layout
 
+**Subflow layout is scoped.** Each subflow entry in `subflows.<id>` has its **own** `layout.nodes` map for the nodes inside that subflow. Do NOT put subflow node positions in the top-level `layout.nodes` — they live alongside the subflow's `nodes`/`edges`/`variables`. See [subflow/impl.md](plugins/subflow/impl.md).
+
+**Legacy files.** Older `.flow` files stored position/size inline as `node.ui`. The workbench auto-upgrades these on first save — on read, it merges `node.ui` into the in-memory model; on write, it extracts everything back into the top-level `layout` map and strips `ui` from nodes. When authoring or editing JSON directly, always emit the new shape (top-level `layout`, no `ui` on nodes) — do not hand-migrate existing files, just re-save them in the workbench.
+
 ## Edge — both ports required
 
 ```json

--- a/skills/uipath-maestro-flow/references/flow-file-format.md
+++ b/skills/uipath-maestro-flow/references/flow-file-format.md
@@ -150,8 +150,6 @@ Each key in `layout.nodes` is a node `id`. Every node in the `nodes` array shoul
 
 **Subflow layout is scoped.** Each subflow entry in `subflows.<id>` has its **own** `layout.nodes` map for the nodes inside that subflow. Do NOT put subflow node positions in the top-level `layout.nodes` — they live alongside the subflow's `nodes`/`edges`/`variables`. See [subflow/impl.md](plugins/subflow/impl.md).
 
-**Legacy files.** Older `.flow` files stored position/size inline as `node.ui`. The workbench auto-upgrades these on first save — on read, it merges `node.ui` into the in-memory model; on write, it extracts everything back into the top-level `layout` map and strips `ui` from nodes. When authoring or editing JSON directly, always emit the new shape (top-level `layout`, no `ui` on nodes) — do not hand-migrate existing files, just re-save them in the workbench.
-
 ## Edge — both ports required
 
 ```json

--- a/skills/uipath-maestro-flow/references/plugins/subflow/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/subflow/impl.md
@@ -170,6 +170,13 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
           }
         ],
         "nodes": []
+      },
+      "layout": {
+        "nodes": {
+          "subflow1Start": { "position": { "x": 200, "y": 144 }, "size": { "width": 96, "height": 96 }, "collapsed": false },
+          "script1":       { "position": { "x": 400, "y": 144 }, "size": { "width": 96, "height": 96 }, "collapsed": false },
+          "subflow1End":   { "position": { "x": 600, "y": 144 }, "size": { "width": 96, "height": 96 }, "collapsed": false }
+        }
       }
     }
   }
@@ -185,7 +192,8 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
 5. Parent-scope `$vars` are **not** visible inside the subflow — pass values explicitly via inputs
 6. Subflow nodes must have inline `outputs` defined on them (Start node needs `outputs.output`, Script nodes need `outputs.output` and `outputs.error`)
 7. Subflows can be nested (subflow inside subflow), up to 3 levels
-8. Each subflow has its own `nodes`, `edges`, and `variables` sections
+8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections
+9. Subflow node positions go in the subflow's own `layout.nodes` — NOT in the top-level `layout.nodes`. Each subflow scope is independent.
 
 ## Creating a Subflow
 


### PR DESCRIPTION
## Summary
Documents that each subflow has its own independent `layout.nodes` map alongside its `nodes`/`edges`/`variables`, and that subflow node positions must NOT be placed in the top-level `layout.nodes`. Previously the layout schema guidance didn't call out subflow scoping, which led to agents putting subflow node positions at the wrong level.

This is the skill counterpart to: https://github.com/UiPath/flow-workbench/pull/948

## What Changed
- `references/flow-file-format.md`: Added a callout under the layout section explaining that subflow layout is scoped — each subflow owns its own `layout.nodes`.
- `references/plugins/subflow/impl.md`: Added a `layout` block to the example subflow JSON showing positions for the subflow's internal nodes; added rule 9) stating subflow node positions belong in the subflow's own layout, and updated rule 8) to include `layout` as a per-subflow section.
- `references/flow-editing-operations-json.md`: Updated the "add a subflow" operation to include a `layout.nodes` entry in the new subflow example, and added rule 6) reinforcing the scoping contract.

## Next Steps

Additional updates incoming for other flow file format changes