### PR TITLE
feat(case-management): add direct JSON write for event triggers

### DIFF
--- a/skills/uipath-case-management/references/case-editing-operations.md
+++ b/skills/uipath-case-management/references/case-editing-operations.md
@@ -15,7 +15,7 @@ Default strategy is **CLI**. Plugins opt in to direct JSON when they've been mig
 | `edges` | **JSON** | Migrated after stages. See [plugins/edges/impl-json.md](plugins/edges/impl-json.md). |
 | `triggers/manual` | CLI | Migration queued. |
 | `triggers/timer` | CLI | Migration queued. |
-| `triggers/event` | CLI | Migration queued. |
+| `triggers/event` | **JSON** | CLI fetches metadata, skill writes trigger JSON. See [plugins/triggers/event/impl-json.md](plugins/triggers/event/impl-json.md). |
 | `variables/global-vars` | **JSON** | No CLI exists for variable declaration — always written directly into `caseplan.json`. See [plugins/variables/global-vars/impl-json.md](plugins/variables/global-vars/impl-json.md). |
 | `variables/io-binding` | **JSON** | Direct write to `task.data.inputs[i].value`. No CLI needed. See [plugins/variables/io-binding/impl-json.md](plugins/variables/io-binding/impl-json.md). |
 | `tasks/process` | **JSON** | See [plugins/tasks/process/impl-json.md](plugins/tasks/process/impl-json.md). |

--- a/skills/uipath-case-management/references/connector-trigger-common.md
+++ b/skills/uipath-case-management/references/connector-trigger-common.md
@@ -1,0 +1,222 @@
+# Connector Trigger — Shared Pipeline
+
+Shared planning and implementation logic for connector-based triggers. Used by both:
+- [connector-trigger task](plugins/tasks/connector-trigger/planning.md) — in-stage `wait-for-connector`
+- [event trigger](plugins/triggers/event/planning.md) — case-level `Intsvc.EventTrigger`
+
+Both use the same TypeCache (`typecache-triggers-index.json`), same IS CLI commands, same metadata structure, and same enrichment pipeline. Only the target (task vs trigger node), serviceType, and output format differ — see each plugin's own docs for those specifics.
+
+---
+
+## Planning Pipeline
+
+### 1. Find the trigger in TypeCache
+
+Read `~/.uip/case-resources/typecache-triggers-index.json` directly. Match on `displayName`, `connectorKey`, or `eventOperation` from sdd.md. Record `uiPathActivityTypeId`.
+
+### 2. Resolve the connection
+
+```bash
+uip case registry get-connection \
+  --type typecache-triggers \
+  --activity-type-id "<uiPathActivityTypeId>" --output json
+```
+
+Returns `Entry`, `Config`, and `Connections`.
+
+- **Single connection** → use it.
+- **Multiple connections** → **AskUserQuestion** with connection names + "Something else".
+- **Empty `Connections`** → mark `<UNRESOLVED>`. See each plugin's unresolved fallback.
+
+Record `connection-id`, `connector-key`, `object-name`, `eventOperation` from the response.
+
+### 3. Describe the trigger — discover event parameters and filter fields
+
+```bash
+uip is triggers describe "<connector-key>" "<eventOperation>" "<object-name>" \
+  --connection-id "<connection-id>" --output json
+```
+
+Returns:
+- **`eventParameters`** — fields that configure *what* the trigger monitors. May be `required: true` and may have `reference` objects.
+- **`filterFields`** — fields used to narrow *which* events fire the trigger. Optional filter criteria.
+- **`eventMode`** — `"polling"` or `"webhooks"`. Authoritative source for `event-mode`.
+
+**This step is mandatory.** Without it, the agent cannot discover required event parameters or available filter fields.
+
+### 4. Resolve reference fields in event parameters
+
+Check `eventParameters` for fields with a `reference` object. For each, resolve display names from sdd.md to IDs:
+
+```bash
+uip is resources execute list "<connector-key>" "<reference.objectName>" \
+  --connection-id "<connection-id>" --output json
+```
+
+Match the sdd.md value to `displayName`. Use the resolved `id` in `input-values`.
+
+> **Paginate when looking up by name.** If `Pagination.HasMore` is `true`, re-run with `--query "nextPage=<NextPageToken>"` until found.
+
+If a reference cannot be resolved, **AskUserQuestion** with the available options. Do not guess.
+
+### 5. Validate required event parameters
+
+For each `eventParameters` entry with `required: true`:
+1. Check if sdd.md provides a value
+2. If missing, **AskUserQuestion** — list the missing parameter with its `displayName` and description
+3. Only after all required event parameters have values, proceed
+
+### 6. Map SDD inputs to event parameters vs filter fields
+
+SDD input fields don't map 1:1 to the connector's schema. Cross-reference each SDD input against `eventParameters` and `filterFields` from Step 3 to decide where it goes:
+
+- **eventParameters** → configure *what* the trigger monitors. Values must be **static** — resolved to IDs at planning time. Go into `input-values`.
+- **filterFields** → narrow *which* events fire the trigger. Values can be **static** literals or **dynamic** `=vars.X` references resolved at runtime. Go into `filter`.
+
+If an SDD input matches an `eventParameters` field name, it's an event parameter. If it matches a `filterFields` field name, it's a filter. If it matches neither, **AskUserQuestion** — the SDD may use different naming than the connector.
+
+### 7. Build input-values and filter
+
+**input-values** — resolved event parameter values (static IDs only):
+```json
+{"parentFolderId": "AAMkADNm..."}
+```
+
+**filter** — translate SDD filter criteria using `filterFields` from Step 3. Use JMESPath syntax. Supports `=vars.X` for runtime case variable references:
+
+| Pattern | JMESPath |
+|---|---|
+| Exact match (static) | `(fieldName == 'value')` |
+| Exact match (dynamic variable) | `(fieldName == '=vars.variableName')` |
+| Substring match | `(contains(fieldName, 'value'))` |
+| Multiple conditions | `(fieldA == 'x' && fieldB == 'y')` |
+
+Only use field names that appear in `filterFields`. If a filter cannot be translated unambiguously, **AskUserQuestion**.
+
+---
+
+## Implementation — Shared CLI Calls
+
+### Step 1 — Get connection details + Entry
+
+```bash
+uip case registry get-connection \
+  --type typecache-triggers \
+  --activity-type-id "<type-id>" --output json
+```
+
+**Save:**
+
+| Variable | Source | Example |
+|---|---|---|
+| `Entry` | `.Data.Entry` (full object) | `{ displayName: "Email Received", ... }` |
+| `Config` | `.Data.Config` | `{ connectorKey, objectName, eventOperation, eventMode, version, supportsStreaming }` |
+| `folderKey` | `.Data.Connections[selected].folder.key` | `"87fd6cec-..."` |
+| `connectorName` | `.Data.Connections[selected].connector.name` | `"Microsoft Outlook 365"` |
+
+### Step 2 — Get enriched metadata + outputs
+
+```bash
+uip case tasks describe --type connector-trigger \
+  --id "<type-id>" \
+  --connection-id "<connection-id>" --output json
+```
+
+**Save:**
+
+| Variable | Source | Example |
+|---|---|---|
+| `enrichment.operation` | `.Data.enrichment.operation` | `"EMAIL_RECEIVED"` |
+| `enrichment.connectorVersion` | `.Data.enrichment.connectorVersion` | `"1.35.48"` |
+| `outputs` | `.Data.outputs` | Array with response schema + Error |
+
+---
+
+## Implementation — Shared Metadata Construction
+
+### Context array
+
+| `name` | `value` source | Notes |
+|---|---|---|
+| `connectorKey` | `connector-key` (tasks.md) | |
+| `connection` | `=bindings.<connBindingId>` | Reference — not raw UUID |
+| `resourceKey` | `connection-id` (tasks.md) | |
+| `folderKey` | `=bindings.<folderBindingId>` | Reference — not raw UUID |
+| `method` | *(no value)* | Empty placeholder. Do not omit. |
+| `path` | *(no value)* | Empty placeholder. Do not omit. |
+| `objectName` | `object-name` (tasks.md) | |
+| `operation` | `enrichment.operation` (Step 2) | |
+| `metadata` | *(see below)* | `type: "json"` with `body` |
+
+### Metadata body
+
+```json
+{
+  "activityPropertyConfiguration": {
+    "objectName": "<object-name>",
+    "eventType": "<enrichment.operation>",
+    "eventMode": "<event-mode from tasks.md>",
+    "configuration": "=jsonString:<essentialConfiguration>",
+    "uiPathActivityTypeId": "<type-id>",
+    "errorState": { "issues": [] }
+  },
+  "activityMetadata": {
+    "activity": "<Entry from Step 1 — copy full object>"
+  },
+  "inputMetadata": {},
+  "telemetryData": {
+    "connectorKey": "<connector-key>",
+    "connectorName": "<connectorName from Step 1>",
+    "objectName": "<object-name>",
+    "objectDisplayName": "<object-name>",
+    "primaryKeyName": ""
+  }
+}
+```
+
+### essentialConfiguration
+
+```
+=jsonString:{"essentialConfiguration":{"instanceParameters":{"connectorKey":"<connector-key>","objectName":"<object-name>","activityType":"CuratedWaitFor","version":"<Config.version>","eventOperation":"<enrichment.operation>","eventMode":"<event-mode>","supportsStreaming":<Config.supportsStreaming>},"objectName":"<object-name>","packageVersion":"<Config.version>","connectorVersion":"<enrichment.connectorVersion>","executionType":null,"httpMethod":null,"path":null,"filter":null}}
+```
+
+> **Critical:** `activityType` MUST be `"CuratedWaitFor"` — NOT `Config.activityType` (which is `"CuratedTrigger"`).
+
+> `filter` is always `null` in essentialConfiguration. The filter goes in `inputs[].body.filters.expression` only.
+
+### Input body (from tasks.md values)
+
+If `input-values` has event parameters, convert to JMESPath + combine with `filter`:
+
+```json
+{
+  "filters": { "expression": "(parentFolderId == 'AAMkADNm...') && (contains(subject, 'urgent'))" },
+  "queryParams": { "parentFolderId": "AAMkADNm..." }
+}
+```
+
+If no `input-values` and no `filter`: empty body `{}`.
+
+### Root-level bindings
+
+Create 2 entries in `root.data.uipath.bindings[]`:
+
+| Binding | `propertyAttribute` | `default` |
+|---|---|---|
+| ConnectionId | `"ConnectionId"` | `connection-id` |
+| folderKey | `"folderKey"` | `folderKey` (from Step 1) |
+
+Both share `resourceKey` = `connection-id`. Deduplicate against existing root bindings.
+
+---
+
+## What NOT to Do (shared)
+
+- **Do NOT use `CuratedTrigger`** in essentialConfiguration. It MUST be `CuratedWaitFor`.
+- **Do NOT put filter in `essentialConfiguration.filter`.** It stays `null`. Filter goes in `body.filters.expression`.
+- **Do NOT add `body.parameters`.** Only `body.filters.expression` + `body.queryParams`.
+- **Do NOT auto-inject `entryConditions`** (for tasks). Step 10 handles them.
+
+## Known Limitation (shared)
+
+The `activityPropertyConfiguration.configuration` uses `essentialConfiguration` only (from the shared SDK). Works at **runtime** but the FE editor may not render until the user re-configures in the UI.

--- a/skills/uipath-case-management/references/implementation.md
+++ b/skills/uipath-case-management/references/implementation.md
@@ -20,7 +20,7 @@ Mixing strategies within a single skill run is expected during the migration. Bo
 > - Stages → `plugins/stages/impl-json.md` (pilot) — `plugins/stages/impl-cli.md` is the fallback
 > - Edges → `plugins/edges/impl-json.md` (JSON strategy) — `plugins/edges/impl-cli.md` is the fallback
 > - Tasks → `plugins/tasks/<type>/impl-cli.md` (or `impl-json.md` for connector-activity and connector-trigger)
-> - Triggers → `plugins/triggers/<type>/impl-cli.md`
+> - Triggers → `plugins/triggers/<type>/impl-cli.md` (or `impl-json.md` for event triggers)
 > - Conditions → `plugins/conditions/<scope>/impl-cli.md`
 > - SLA → `plugins/sla/impl-json.md` (primary) — `plugins/sla/impl-cli.md` is the fallback
 > - Global variables & arguments → `plugins/variables/global-vars/impl-json.md`

--- a/skills/uipath-case-management/references/plugins/tasks/connector-trigger/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/tasks/connector-trigger/impl-json.md
@@ -1,62 +1,22 @@
 # connector-trigger task — Implementation (Direct JSON Write)
 
-Fetch connector metadata via CLI, then write the task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md`.
+Write a `wait-for-connector` task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md).
+
+For shared CLI calls, metadata construction, and anti-patterns, see [connector-trigger-common.md](../../../connector-trigger-common.md#implementation--shared-cli-calls). This doc covers only the **task-specific** parts.
 
 ## Prerequisites from Planning
 
-The `tasks.md` entry provides:
+The `tasks.md` entry provides: `type-id`, `connection-id`, `connector-key`, `object-name`, `event-operation`, `event-mode`, `input-values`, `filter`, `isRequired`, `runOnlyOnce`.
 
-| Field | Example |
-|---|---|
-| `type-id` | `"7dc57f24-894c-5ae2-a902-66056fa40609"` |
-| `connection-id` | `"bc095c1f-671f-4669-8634-b7164fa46aa0"` |
-| `connector-key` | `"uipath-microsoft-outlook365"` |
-| `object-name` | `"Message"` |
-| `event-operation` | `"EMAIL_RECEIVED"` |
-| `event-mode` | `"polling"` |
-| `input-values` | `{"parentFolderId": "AAMkADNm..."}` (already resolved IDs) |
-| `filter` | `"(contains(subject, 'urgent'))"` (already JMESPath) |
-| `isRequired` | `true` |
-| `runOnlyOnce` | `false` |
+## Steps 1-2 — Shared CLI calls
 
-## Configuration Workflow
+Follow [connector-trigger-common.md § Implementation — Shared CLI Calls](../../../connector-trigger-common.md#implementation--shared-cli-calls): `get-connection` (Step 1) + `tasks describe` (Step 2).
 
-### Step 1 — Get connection details + Entry
+## Step 3 — Build task and write to caseplan.json
 
-```bash
-uip case registry get-connection \
-  --type typecache-triggers \
-  --activity-type-id "<type-id>" --output json
-```
+Generate task ID (`t` + 8 alphanumeric chars) and elementId (`<stageId>-<taskId>`).
 
-**Save:**
-
-| Variable | Source | Example |
-|---|---|---|
-| `Entry` | `.Data.Entry` (full object) | `{ displayName: "Email Received", ... }` |
-| `Config` | `.Data.Config` | `{ connectorKey, objectName, eventOperation, eventMode, version, supportsStreaming }` |
-| `folderKey` | `.Data.Connections[selected].folder.key` | `"87fd6cec-..."` |
-| `connectorName` | `.Data.Connections[selected].connector.name` | `"Microsoft Outlook 365"` |
-
-### Step 2 — Get enriched metadata + outputs
-
-```bash
-uip case tasks describe --type connector-trigger \
-  --id "<type-id>" \
-  --connection-id "<connection-id>" --output json
-```
-
-**Save:**
-
-| Variable | Source | Example |
-|---|---|---|
-| `enrichment.operation` | `.Data.enrichment.operation` | `"EMAIL_RECEIVED"` |
-| `enrichment.connectorVersion` | `.Data.enrichment.connectorVersion` | `"1.35.48"` |
-| `outputs` | `.Data.outputs` | Array with response schema + Error |
-
-## Step 3 — Build `data` and write to caseplan.json
-
-Generate task ID (`t` + 8 alphanumeric chars) and elementId (`<stageId>-<taskId>`). Create the task skeleton:
+### Task skeleton
 
 ```json
 {
@@ -72,126 +32,15 @@ Generate task ID (`t` + 8 alphanumeric chars) and elementId (`<stageId>-<taskId>
 }
 ```
 
-Then populate each section:
+### `data` population
 
-### 3a. Root-level bindings
-
-Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](../../variables/bindings/impl-json.md). Connector tasks use `resource: "Connection"`:
-
-| Binding | `propertyAttribute` | `default` |
-|---|---|---|
-| ConnectionId | `"ConnectionId"` | `connection-id` (from tasks.md) |
-| folderKey | `"folderKey"` | `folderKey` (from Step 1) |
-
-Both share `resourceKey` = `connection-id`. ID generation: `b` + 8 alphanumeric chars.
-
-### 3b. `data.context[]`
-
-| `name` | `value` source | Notes |
-|---|---|---|
-| `connectorKey` | `connector-key` (tasks.md) | |
-| `connection` | `=bindings.<connBindingId>` | Reference — not raw UUID |
-| `resourceKey` | `connection-id` (tasks.md) | |
-| `folderKey` | `=bindings.<folderBindingId>` | Reference — not raw UUID |
-| `method` | *(no value)* | Empty placeholder. Do not omit. |
-| `path` | *(no value)* | Empty placeholder. Do not omit. |
-| `objectName` | `object-name` (tasks.md) | |
-| `operation` | `enrichment.operation` (Step 2) | |
-| `metadata` | *(see §3c)* | `type: "json"` with `body` |
-
-### 3c. `metadata` context entry body
-
-```json
-{
-  "activityPropertyConfiguration": {
-    "objectName": "<object-name>",
-    "eventType": "<enrichment.operation>",
-    "eventMode": "<event-mode from tasks.md>",
-    "configuration": "=jsonString:<see §3d>",
-    "uiPathActivityTypeId": "<type-id>",
-    "errorState": { "issues": [] }
-  },
-  "activityMetadata": {
-    "activity": "<Entry from Step 1 — copy full object>"
-  },
-  "inputMetadata": {},
-  "telemetryData": {
-    "connectorKey": "<connector-key>",
-    "connectorName": "<connectorName from Step 1>",
-    "objectName": "<object-name>",
-    "objectDisplayName": "<object-name>",
-    "primaryKeyName": ""
-  }
-}
-```
-
-**Differences from connector-activity metadata:**
-
-| Field | Activity | Trigger |
-|---|---|---|
-| `activityPropertyConfiguration` top-level fields | only `configuration`, `uiPathActivityTypeId`, `errorState` | adds `objectName`, `eventType`, `eventMode` |
-| `designTimeMetadata` | present | absent |
-| `telemetryData.operationType` | present (derived from httpMethod) | absent |
-| `errorState` (metadata level) | `{ hasError: false }` | absent |
-
-### 3d. `activityPropertyConfiguration.configuration`
-
-A `=jsonString:` prefixed JSON string. Use `Config` from Step 1:
-
-```
-=jsonString:{"essentialConfiguration":{"instanceParameters":{"connectorKey":"<connector-key>","objectName":"<object-name>","activityType":"CuratedWaitFor","version":"<Config.version>","eventOperation":"<enrichment.operation>","eventMode":"<event-mode>","supportsStreaming":<Config.supportsStreaming>},"objectName":"<object-name>","packageVersion":"<Config.version>","connectorVersion":"<enrichment.connectorVersion>","executionType":null,"httpMethod":null,"path":null,"filter":null}}
-```
-
-> **Critical:** `activityType` MUST be `"CuratedWaitFor"` — NOT `Config.activityType` (which is `"CuratedTrigger"`).
-
-> `Config.version`, `Config.supportsStreaming` — from `Config` returned by Step 1.
-
-> `filter` is always `null` in essentialConfiguration. The user's filter expression goes in `body.filters.expression` only (§3e).
-
-### 3e. `data.inputs[]`
-
-Build the input body from `input-values` and `filter` in the `tasks.md` entry. Planning already resolved all IDs and translated filters to JMESPath — implementation just assembles the body.
-
-**If `input-values` has event parameters:**
-
-Convert each key-value pair to JMESPath equality (`key == 'value'`), join with `&&`. If `filter` is also present, combine with `&&`:
-
-```json
-{
-  "name": "body",
-  "type": "json",
-  "target": "body",
-  "body": {
-    "filters": {
-      "expression": "(parentFolderId == 'AAMkADNm...')"
-    },
-    "queryParams": {
-      "parentFolderId": "AAMkADNm..."
-    }
-  },
-  "var": "<v + 8 chars>",
-  "id": "<same as var>",
-  "elementId": "<elementId>"
-}
-```
-
-`queryParams` preserves raw event parameter values for FE round-trip.
-
-**If no `input-values` and no `filter`:** write empty body `{}`.
-
-### 3f. `data.outputs[]`
-
-Copy verbatim from `tasks describe` (Step 2). Set `elementId` to the task's elementId on each output. Copy `_jsonSchema` from Error output if present.
-
-### 3g. `data.bindings[]`
-
-Leave as empty array `[]`. The FE does not expect task-level binding copies for triggers.
-
-### 3h. `entryConditions`
-
-Do NOT auto-inject. Step 10 handles all task entry conditions.
-
-### Write to caseplan.json
+- **Root bindings** — per [common §Root-level bindings](../../../connector-trigger-common.md#root-level-bindings)
+- **`data.context[]`** — per [common §Context array](../../../connector-trigger-common.md#context-array)
+- **`data.context[].metadata`** — per [common §Metadata body](../../../connector-trigger-common.md#metadata-body) + [common §essentialConfiguration](../../../connector-trigger-common.md#essentialconfiguration)
+- **`data.inputs[]`** — per [common §Input body](../../../connector-trigger-common.md#input-body-from-tasksmd-values). **Include `elementId`** on each input.
+- **`data.outputs[]`** — copy verbatim from `tasks describe` (Step 2). Set `elementId` to the task's elementId. Copy `_jsonSchema` from Error output if present.
+- **`data.bindings[]`** — empty array `[]`
+- **`entryConditions`** — do NOT auto-inject. Step 10 handles them.
 
 Append the task to the target stage's `tasks[]` array in its own task set (one task per lane).
 
@@ -201,34 +50,16 @@ Append the task to the target stage's `tasks[]` array in its own task set (one t
 
 | Step failed | What gets populated | Log |
 |---|---|---|
-| get-connection | Context from tasks.md values only. No bindings — folderKey unknown | `[SKIPPED] get-connection failed — bindings/folderKey omitted` |
-| tasks describe | Context + bindings. No outputs/enrichment | `[SKIPPED] tasks describe failed — outputs/enrichment omitted` |
-| All succeed | Full population per §3a-3h | — |
+| get-connection | Context from tasks.md values only. No bindings | `[SKIPPED] get-connection failed — bindings omitted` |
+| tasks describe | Context + bindings. No outputs/enrichment | `[SKIPPED] tasks describe failed — outputs omitted` |
+| All succeed | Full population | — |
 
 All issues appended to the shared issue list per [logging/impl-json.md](../../logging/impl-json.md).
 
 ## Post-Write Verification
 
-1. `type` is `"wait-for-connector"`
-2. `data.serviceType` is `"Intsvc.WaitForEvent"`
-3. `data.context[]` has: `connectorKey`, `connection`, `resourceKey`, `folderKey`, `method`, `path`, `objectName`, `operation`, `metadata`
-4. `metadata.body.activityPropertyConfiguration.configuration` starts with `=jsonString:` and contains `"activityType":"CuratedWaitFor"`
-5. `metadata.body.activityPropertyConfiguration.configuration` contains `enrichment.connectorVersion`
-6. Root bindings exist for ConnectionId + folderKey
-7. `data.bindings[]` is empty `[]`
-8. `data.outputs[]` copied verbatim with `elementId` set
-9. If `input-values` present: `body.filters.expression` has JMESPath + `body.queryParams` has raw values (no `body.parameters`)
-
-## What NOT to Do
-
-- **Do NOT use `CuratedTrigger`** in `essentialConfiguration.instanceParameters.activityType`. It MUST be `CuratedWaitFor` for in-stage wait-for-connector tasks.
-- **Do NOT copy root bindings into `data.bindings[]`.** Leave it as `[]`. The FE does not expect task-level copies for triggers.
-- **Do NOT add `body.parameters`.** The FE only uses `body.filters.expression` + `body.queryParams`. No `body.parameters`.
-- **Do NOT put the filter expression in `essentialConfiguration.filter`.** It stays `null`. The filter goes in `body.filters.expression` only.
-- **Do NOT add `data.name`.** The FE does not use it for connector tasks.
-- **Do NOT auto-inject `entryConditions`.** Step 10 handles them — injecting here creates duplicates.
-- **Do NOT omit `method` and `path` context entries.** They must be present as empty placeholders (no `value` field) — the runtime expects the keys to exist.
-
-## Known Limitation
-
-The `activityPropertyConfiguration.configuration` uses `essentialConfiguration` only (from the shared SDK). Tasks work at **runtime** (debug/publish) but the FE editor may not render them until the user re-configures the task in the UI.
+1. `type` is `"wait-for-connector"`, `data.serviceType` is `"Intsvc.WaitForEvent"`
+2. Context, metadata, essentialConfiguration per [common §What NOT to Do](../../../connector-trigger-common.md#what-not-to-do-shared)
+3. `data.bindings[]` is empty `[]`
+4. `data.outputs[]` copied verbatim with `elementId` set
+5. If `input-values` present: `body.filters.expression` + `body.queryParams` (no `body.parameters`)

--- a/skills/uipath-case-management/references/plugins/tasks/connector-trigger/planning.md
+++ b/skills/uipath-case-management/references/plugins/tasks/connector-trigger/planning.md
@@ -1,12 +1,12 @@
 # connector-trigger task — Planning
 
-A connector-based trigger **inside a stage** — waits for an external event (e.g., "issue created in Jira", "email received in Outlook") before continuing.
+A connector-based trigger **inside a stage** — waits for an external event before continuing.
 
-This plugin is **schema-data-driven** — one plugin covers every connector trigger. Per-connector event parameters and filter fields are discovered via IS CLI commands.
+The planning pipeline is shared with the [event trigger](../../triggers/event/planning.md) — see [connector-trigger-common.md](../../../connector-trigger-common.md) for the full 7-step resolution pipeline.
 
 ## When to Use
 
-Pick this plugin when the sdd.md describes a task that **suspends the stage until an external event fires**. Typical patterns:
+Pick this plugin when the sdd.md describes a task that **suspends the stage until an external event fires**:
 
 - "Wait until a new row appears in Salesforce"
 - "Continue when a Slack reaction is added"
@@ -20,100 +20,7 @@ Distinguish from:
 
 ## Resolution Pipeline
 
-Run these steps during planning. Each step feeds into the `tasks.md` entry.
-
-### 1. Find the trigger in TypeCache
-
-Read `~/.uip/case-resources/typecache-triggers-index.json` directly. Match on `displayName`, `connectorKey`, or `eventOperation` from sdd.md. Record `uiPathActivityTypeId`.
-
-### 2. Resolve the connection
-
-```bash
-uip case registry get-connection \
-  --type typecache-triggers \
-  --activity-type-id "<uiPathActivityTypeId>" --output json
-```
-
-Returns `Entry`, `Config`, and `Connections`.
-
-- **Single connection** → use it.
-- **Multiple connections** → **AskUserQuestion** with connection names + "Something else".
-- **Empty `Connections`** → mark `<UNRESOLVED: no IS connection for <connectorKey>>`. Execution creates a skeleton task.
-
-Record `connection-id`, `connector-key`, `object-name`, `eventOperation`, `eventMode` from the response.
-
-### 3. Describe the trigger — discover event parameters and filter fields
-
-```bash
-uip is triggers describe "<connector-key>" "<eventOperation>" "<object-name>" \
-  --connection-id "<connection-id>" --output json
-```
-
-Returns:
-- **`eventParameters`** — fields that configure *what* the trigger watches (e.g., which email folder, which Jira project). May be `required: true` and may have `reference` objects.
-- **`filterFields`** — fields used to narrow *which* events fire the trigger (e.g., only emails from a specific sender). These are optional filter criteria.
-- **`eventMode`** — `"polling"` or `"webhooks"`.
-
-**This step is mandatory** — not optional. Without it, the agent cannot:
-- Know which event parameters are required (e.g., `parentFolderId` for Email Received)
-- Discover reference fields that need ID resolution
-- Know which fields are available for filtering
-
-### 4. Resolve reference fields in event parameters
-
-Check `eventParameters` for fields with a `reference` object. For each, resolve display names from sdd.md to IDs:
-
-```bash
-uip is resources execute list "<connector-key>" "<reference.objectName>" \
-  --connection-id "<connection-id>" --output json
-```
-
-Example — resolve folder "Inbox" to its ID:
-```bash
-uip is resources execute list "uipath-microsoft-outlook365" "MailFolder" \
-  --connection-id "<connection-id>" --output json
-# → items: [{ "id": "AAMkADNm...", "displayName": "Inbox" }, ...]
-```
-
-Match the sdd.md value to `displayName`. Use the resolved `id` in `input-values`.
-
-> **Paginate when looking up by name.** If `Pagination.HasMore` is `true`, re-run with `--query "nextPage=<NextPageToken>"` until found.
-
-If a reference cannot be resolved, **AskUserQuestion** with the available options. Do not guess.
-
-### 5. Validate required event parameters
-
-For each `eventParameters` entry with `required: true`:
-1. Check if sdd.md provides a value
-2. If missing, **AskUserQuestion** — list the missing parameter with its `displayName` and description
-3. Only after all required event parameters have values, proceed
-
-### 6. Map SDD inputs to event parameters vs filter fields
-
-SDD input fields don't map 1:1 to the connector's schema. Cross-reference each SDD input against `eventParameters` and `filterFields` from Step 3 to decide where it goes:
-
-- **eventParameters** → configure *what* the trigger monitors. Values must be **static** — resolved to IDs at planning time. Go into `input-values`.
-- **filterFields** → narrow *which* events fire the trigger. Values can be **static** literals or **dynamic** `=vars.X` references resolved at runtime. Go into `filter`.
-
-If an SDD input matches an `eventParameters` field name, it's an event parameter. If it matches a `filterFields` field name, it's a filter. If it matches neither, **AskUserQuestion** — the SDD may use different naming than the connector.
-
-### 7. Build input-values and filter
-
-**input-values** — resolved event parameter values (static IDs only):
-```json
-{"parentFolderId": "AAMkADNm..."}
-```
-
-**filter** — translate SDD filter criteria using `filterFields` from Step 3. Use JMESPath syntax. Supports `=vars.X` for runtime case variable references:
-
-| Pattern | JMESPath |
-|---|---|
-| Exact match (static) | `(fieldName == 'value')` |
-| Exact match (dynamic variable) | `(fieldName == '=vars.variableName')` |
-| Substring match | `(contains(fieldName, 'value'))` |
-| Multiple conditions | `(fieldA == 'x' && fieldB == 'y')` |
-
-Only use field names that appear in `filterFields`. If a filter cannot be translated unambiguously, **AskUserQuestion**.
+Follow the 7-step pipeline in [connector-trigger-common.md](../../../connector-trigger-common.md#planning-pipeline). All steps are identical for both in-stage triggers and case-level event triggers.
 
 ## tasks.md Entry Format
 
@@ -138,5 +45,5 @@ Only use field names that appear in `filterFields`. If a filter cannot be transl
 
 If the connector or connection cannot be resolved:
 - Mark `type-id` or `connection-id` with `<UNRESOLVED: reason>`
-- Omit `input-values:` and `filter:` — no schema to wire against
+- Omit `input-values:` and `filter:`
 - Execution creates a skeleton task (display-name + type only) per [skeleton-tasks.md](../../../skeleton-tasks.md)

--- a/skills/uipath-case-management/references/plugins/triggers/event/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/triggers/event/impl-json.md
@@ -1,0 +1,96 @@
+# event trigger — Implementation (Direct JSON Write)
+
+Configure the case-level event trigger by writing directly into the trigger node in `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md).
+
+For shared CLI calls, metadata construction, and anti-patterns, see [connector-trigger-common.md](../../../connector-trigger-common.md#implementation--shared-cli-calls). This doc covers only the **trigger-node-specific** parts.
+
+## Prerequisites from Planning
+
+The `tasks.md` entry provides: `type-id`, `connection-id`, `connector-key`, `object-name`, `event-operation`, `event-mode`, `input-values`, `filter`.
+
+## Steps 1-2 — Shared CLI calls
+
+Follow [connector-trigger-common.md § Implementation — Shared CLI Calls](../../../connector-trigger-common.md#implementation--shared-cli-calls): `get-connection` (Step 1) + `tasks describe` (Step 2).
+
+## Step 3 — Build trigger node and write to caseplan.json
+
+### 3a. Identify or create the trigger node
+
+For a **single-trigger case**, configure the existing `trigger_1` node. For **multi-trigger cases**, create a new node:
+- ID: `trigger_` + 6 alphanumeric chars
+- Position: `{ x: -100, y: 620 }` (auto-stack below existing triggers)
+
+Set the trigger's display name from `tasks.md`.
+
+### 3b. `data` structure
+
+```json
+{
+  "label": "<display-name>",
+  "uipath": {
+    "serviceType": "Intsvc.EventTrigger",
+    "context": [],
+    "inputs": [],
+    "outputs": [],
+    "bindings": []
+  }
+}
+```
+
+### 3c. Populate `data.uipath`
+
+- **Root bindings** — per [common §Root-level bindings](../../../connector-trigger-common.md#root-level-bindings). Deduplicate against existing root bindings.
+- **`context[]`** — per [common §Context array](../../../connector-trigger-common.md#context-array)
+- **`context[].metadata`** — per [common §Metadata body](../../../connector-trigger-common.md#metadata-body) + [common §essentialConfiguration](../../../connector-trigger-common.md#essentialconfiguration)
+- **`inputs[]`** — per [common §Input body](../../../connector-trigger-common.md#input-body-from-tasksmd-values). **No `elementId`** on trigger inputs (unlike task inputs).
+- **`outputs[]`** — **simplified** from `tasks describe`. Strip `body`, `id`, `target`, `elementId`. Set `_jsonSchema: null`:
+
+```json
+[
+  { "name": "response", "displayName": "Email Received", "type": "jsonSchema",
+    "source": "=response", "_jsonSchema": null, "var": "response", "value": "response" },
+  { "name": "Error", "displayName": "Error", "type": "jsonSchema",
+    "source": "=Error", "_jsonSchema": null, "var": "error", "value": "error" }
+]
+```
+
+> For `Error` output, `var` and `value` are always `"error"`.
+
+- **`bindings[]`** — empty array `[]`
+
+### 3d. Register trigger outputs as root inputOutputs
+
+Add each trigger output to `root.data.uipath.variables.inputOutputs[]`:
+
+```json
+{
+  "id": "<output.var>",
+  "name": "<output.name>",
+  "type": "<output.type>",
+  "elementId": "<triggerId>",
+  "body": "<output.body from tasks describe — full schema>"
+}
+```
+
+Use **original** outputs from `tasks describe` (before simplification) for `body`. The `elementId` is the trigger node's ID.
+
+## Graceful degradation
+
+**If both CLI calls fail**, leave the trigger node unchanged — the default `trigger_1` with no connector configuration remains.
+
+| Step failed | What happens | Log |
+|---|---|---|
+| get-connection | Trigger left as default | `[SKIPPED] get-connection failed — event trigger not configured` |
+| tasks describe | Context populated, but no outputs | `[SKIPPED] tasks describe failed — trigger outputs omitted` |
+| All succeed | Full configuration per §3a-3d | — |
+
+All issues appended to the shared issue list per [logging/impl-json.md](../../logging/impl-json.md).
+
+## Post-Write Verification
+
+1. `data.uipath.serviceType` is `"Intsvc.EventTrigger"` (not `WaitForEvent`)
+2. Context, metadata, essentialConfiguration per [common §What NOT to Do](../../../connector-trigger-common.md#what-not-to-do-shared)
+3. `data.uipath.outputs[]` simplified (no body/id/target/elementId, `_jsonSchema: null`)
+4. `data.uipath.inputs[]` has no `elementId`
+5. `root.data.uipath.variables.inputOutputs[]` has entries for each trigger output
+6. Trigger node wired as `--source` in an edge to the first stage

--- a/skills/uipath-case-management/references/plugins/triggers/event/planning.md
+++ b/skills/uipath-case-management/references/plugins/triggers/event/planning.md
@@ -1,14 +1,14 @@
 # event trigger — Planning
 
-A case-level trigger that fires on an external connector event (e.g., "new Salesforce opportunity created", "Jira issue transitioned"). Starts the case when the event matches a filter.
+A case-level trigger that fires on an external connector event. Starts the case when the event matches a filter.
 
-This plugin is **schema-data-driven** — one plugin covers every connector. The resolution pipeline is shared with the `connector-trigger` task plugin. See [connector-integration.md](../../../connector-integration.md).
+The planning pipeline is shared with the [connector-trigger task](../../tasks/connector-trigger/planning.md) — see [connector-trigger-common.md](../../../connector-trigger-common.md) for the full 7-step resolution pipeline.
 
 ## When to Use
 
 Pick this plugin when the sdd.md describes the case as starting in response to an external event:
 
-- "When a new row is added in Salesforce"
+- "When a new email arrives in Inbox"
 - "On each new Jira issue with priority High"
 - "When a file is uploaded to SharePoint"
 
@@ -18,30 +18,9 @@ Distinguish from:
 - **Scheduled start** → [timer](../timer/planning.md)
 - **In-stage event wait** → [connector-trigger task](../../tasks/connector-trigger/planning.md)
 
-## Required Fields from sdd.md
-
-| Field | Source | Notes |
-|-------|--------|-------|
-| `display-name` | sdd.md (optional) | Defaults to `Trigger N` |
-| `type-id` | `uiPathActivityTypeId` from TypeCache triggers | |
-| `connection-id` | Connection UUID from `get-connection` | |
-| `connector-key` | `Config.connectorKey` | Recorded for debugging |
-| `object-name` | `Config.objectName` | Recorded for debugging |
-| `event-params` | sdd.md event parameters | JSON object |
-| `filter` | sdd.md filter description | Translated to connector's filter DSL |
-
 ## Resolution Pipeline
 
-Follow the full procedure in [connector-integration.md](../../../connector-integration.md) using the **trigger** TypeCache (`typecache-triggers-index.json`):
-
-1. **Find `uiPathActivityTypeId`** by reading the cache file directly.
-2. **Resolve connector metadata** (`connectorKey`, `objectName`).
-3. **Resolve the connection** — if `Connections` is empty, mark `<UNRESOLVED: no IS connection for <connectorKey>>` in `tasks.md`. **Event triggers do not support the skeleton pattern** — without a connector there is no trigger configuration, and a bare trigger node has no entry semantics. The implementation phase skips `triggers add-event` and falls back to the auto-created Trigger node (from `cases add` in T01) as the case entry point. Document the missing event trigger in the completion report so the user adds it after registering the connector + connection.
-4. **(Optional) Describe trigger schema** when the event needs specific field wiring.
-
-## Filter Translation
-
-Convert sdd.md natural language to the connector's filter DSL. See [connector-integration.md](../../../connector-integration.md#filter-expression-syntax) for syntax.
+Follow the 7-step pipeline in [connector-trigger-common.md](../../../connector-trigger-common.md#planning-pipeline). All steps are identical for both event triggers and in-stage connector-trigger tasks.
 
 ## tasks.md Entry Format
 
@@ -51,8 +30,18 @@ Convert sdd.md natural language to the connector's filter DSL. See [connector-in
 - connection-id: <connection-uuid>
 - connector-key: <connectorKey>
 - object-name: <objectName>
-- event-params: {"project":"PROJ"}
-- filter: "((fields.status=`Open`))"
+- event-operation: <eventOperation>
+- event-mode: <polling|webhooks>
+- input-values: {"parentFolderId": "AAMkADNm..."}
+- filter: "(contains(subject, 'urgent'))"
 - order: after T01
-- verify: Confirm Result: Success, capture TriggerId
+- verify: Confirm trigger configured with correct event parameters
 ```
+
+## Unresolved Fallback
+
+If the connector or connection cannot be resolved:
+- Mark `type-id` or `connection-id` with `<UNRESOLVED: reason>`
+- Omit `input-values:` and `filter:`
+- **Event triggers do not support the skeleton pattern** — implementation skips the trigger, and the default `trigger_1` node remains as the case entry point
+- Document the missing trigger in the completion report


### PR DESCRIPTION
## Summary
- Add `impl-json.md` for case-level event trigger (`triggers/event`) with full direct JSON write
- Rewrite `planning.md` with 7-step pipeline matching connector-trigger tasks
- Update strategy matrix and implementation.md references

## Implementation approach

Same enrichment pipeline as connector-trigger tasks (`get-connection` + `tasks describe`), with trigger-specific differences:

- `serviceType: "Intsvc.EventTrigger"` (not `WaitForEvent`)
- Outputs simplified (no body/id/target/elementId, `_jsonSchema: null`)
- Inputs stripped of `elementId`
- Trigger outputs registered in `root.data.uipath.variables.inputOutputs[]`

Planning uses `is triggers describe` for event parameters + filter fields, `is resources execute list` for reference resolution — identical to connector-trigger task planning.

## Tested with
- Outlook Email Received trigger + Send Email activity case
- Event parameter `parentFolderId` resolved to Inbox folder ID
- Validated on `popoc/CaseManagement` environment

## Test plan
- [ ] Validate generated caseplan.json
- [ ] Debug run with email trigger + send email
- [ ] Verify trigger fires on incoming email
- [ ] Verify FE can open case (known essentialConfiguration limitation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)