### PR TITLE
tests(case): add registry discovery task

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,6 +43,7 @@
 
 # Case Management skill
 /skills/uipath-maestro-case/ @charlesliu9 @song-zhao-25 @jundayin
+/tests/tasks/uipath-maestro-case/ @charlesliu9 @song-zhao-25 @jundayin
 
 # Coded Apps skill
 /skills/uipath-coded-apps/ @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354

--- a/tests/tasks/uipath-maestro-case/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-case/init_validate.yaml
@@ -1,12 +1,12 @@
 task_id: skill-case-init-validate
 description: >
-  Skill-guided evaluation: agent uses the uipath-maestro-case skill to
+  Integration evaluation: agent uses the uipath-maestro-case skill to
   scaffold a minimal Case Management project inside a solution (manual
   trigger, one stage) and validate it. Either scaffolding path is accepted
   — CLI (`uip solution new` + `uip solution project add`) or the JSON
   strategy (writing project files directly). The test asserts on the
   resulting artifacts and the validate step, not on the scaffolding method.
-tags: [uipath-maestro-case, smoke, init, validate]
+tags: [uipath-maestro-case, integration, init, validate]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-case/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_discovery.yaml
@@ -1,10 +1,10 @@
 task_id: skill-case-registry-discovery
 description: >
-  Skill-guided evaluation: agent uses the uipath-maestro-case skill to
+  Integration evaluation: agent uses the uipath-maestro-case skill to
   explore available case task resources via the registry. Tests whether the
   skill teaches the correct discovery workflow (pull + direct cache-file
   inspection at ~/.uipcli/case-resources/, not relying on registry search).
-tags: [uipath-maestro-case, smoke, registry]
+tags: [uipath-maestro-case, integration, registry]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-case/registry_help_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_help_discovery.yaml
@@ -17,6 +17,8 @@ initial_prompt: |
   - do not authenticate
   - do not create remote resources
   - do not run the actual registry pull
+  - if you parse any structured `uip` output, use `--output json`
+  - plain `--help` output is sufficient for this task
 
   Save a summary to case_registry_report.json with at minimum:
     {

--- a/tests/tasks/uipath-maestro-case/registry_help_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_help_discovery.yaml
@@ -1,0 +1,63 @@
+task_id: skill-case-registry-help-discovery
+description: >
+  Skill-guided evaluation: `uipath-maestro-case` should direct the agent to
+  the `uip maestro case` registry surface when discovering how Case Management
+  definitions are built.
+tags: [uipath-maestro-case, smoke, registry]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Using the `uipath-maestro-case` skill, determine the correct CLI command
+  to inspect the Case Management registry and check its help output.
+
+  Stay at the help/discovery layer only:
+  - do not authenticate
+  - do not create remote resources
+  - do not run the actual registry pull
+
+  Save a summary to case_registry_report.json with at minimum:
+    {
+      "registry_pull_command": "uip maestro case registry pull",
+      "help_checked": true,
+      "auth_required_for_this_task": false
+    }
+
+success_criteria:
+  - type: command_executed
+    description: "Agent checked the maestro case registry pull help"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+case\s+registry\s+pull\s+--help'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Registry pull help uses the maestro namespace"
+    command: 'uip maestro case registry pull --help'
+    expected_stdout: 'uip maestro case registry pull'
+    stdout_match: contains
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "case_registry_report.json records the correct discovery result"
+    command: |
+      python3 - <<'PY'
+      import json
+      from pathlib import Path
+
+      report = json.loads(Path("case_registry_report.json").read_text())
+      ok = (
+          report.get("registry_pull_command") == "uip maestro case registry pull"
+          and report.get("help_checked") is True
+          and report.get("auth_required_for_this_task") is False
+      )
+      print("OK" if ok else "FAIL")
+      PY
+    expected_stdout: "OK"
+    stdout_match: contains
+    weight: 1.5
+    pass_threshold: 1.0


### PR DESCRIPTION
## Why
Adds a focused `uipath-case-management` smoke task that verifies the skill directs the agent to the `uip maestro case` registry surface instead of stale `uip case` forms.

## What
- adds `tests/tasks/uipath-case-management/registry_discovery.yaml`
- routes new case-management test paths to the case-management CODEOWNERS

## Validation
- `ruby -e 'require "yaml"; YAML.load_file("tests/tasks/uipath-case-management/registry_discovery.yaml"); puts "yaml-ok"'`
- `git diff --check`
- executed `coder-eval plan` locally against this PR branch via a real `UiPath/skills` checkout and `SKILLS_REPO_PATH`
- executed `coder-eval run` locally against this PR branch via the same setup
- both steps passed
