### PR TITLE
chore: align marketplace.json with Anthropic schema [PILOT-4860]

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,6 +14,25 @@
       "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath diagnostics",
       "source": "./",
       "strict": false,
+      "version": "0.0.19",
+      "author": {
+        "name": "UiPath"
+      },
+      "homepage": "https://github.com/UiPath/skills",
+      "repository": "https://github.com/UiPath/skills",
+      "license": "MIT",
+      "keywords": [
+        "uipath",
+        "automation",
+        "rpa",
+        "code",
+        "workflow",
+        "ui-automation",
+        "ui-testing",
+        "desktop",
+        "browser",
+        "diagnostics"
+      ],
       "skills": [
         "./skills/uipath-agents",
         "./skills/uipath-case-management",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,29 +4,32 @@
     "name": "UiPath",
     "email": "support@uipath.com"
   },
+  "metadata": {
+    "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath diagnostics",
+    "version": "0.0.19"
+  },
   "plugins": [
     {
       "name": "uipath",
-      "source": "./",
       "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath diagnostics",
-      "version": "0.0.19",
-      "author": {
-        "name": "UiPath"
-      },
-      "homepage": "https://github.com/UiPath/skills",
-      "repository": "https://github.com/UiPath/skills",
-      "license": "MIT",
-      "keywords": [
-        "uipath",
-        "automation",
-        "rpa",
-        "code",
-        "workflow",
-        "ui-automation",
-        "ui-testing",
-        "desktop",
-        "browser",
-        "diagnostics"
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./skills/uipath-agents",
+        "./skills/uipath-case-management",
+        "./skills/uipath-coded-apps",
+        "./skills/uipath-data-fabric",
+        "./skills/uipath-diagnostics",
+        "./skills/uipath-feedback",
+        "./skills/uipath-human-in-the-loop",
+        "./skills/uipath-maestro-flow",
+        "./skills/uipath-planner",
+        "./skills/uipath-platform",
+        "./skills/uipath-rpa",
+        "./skills/uipath-rpa-legacy",
+        "./skills/uipath-servo",
+        "./skills/uipath-solution-design",
+        "./skills/uipath-test"
       ]
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "email": "support@uipath.com"
   },
   "metadata": {
-    "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath diagnostics",
+    "description": "UiPath plugin for Claude Code — skills for building RPA (C#, XAML, legacy), agents (coded + low-code), Maestro flows, coded apps, Data Fabric entities, case management, and tests; plus Orchestrator ops, live desktop/browser UI automation, human-in-the-loop, solution design, and diagnostics",
     "version": "0.0.19"
   },
   "plugins": [
     {
       "name": "uipath",
-      "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath diagnostics",
+      "description": "UiPath plugin for Claude Code — skills for building RPA (C#, XAML, legacy), agents (coded + low-code), Maestro flows, coded apps, Data Fabric entities, case management, and tests; plus Orchestrator ops, live desktop/browser UI automation, human-in-the-loop, solution design, and diagnostics",
       "source": "./",
       "strict": false,
       "version": "0.0.19",


### PR DESCRIPTION
**Jira:** [PILOT-4860](https://uipath.atlassian.net/browse/PILOT-4860)

## Summary
- Add top-level `metadata` block (description + version)
- Add `strict: false` to the plugin entry
- Enumerate all 15 skills explicitly under `skills[]`
- Drop fields not present in the reference schema (`author`, `homepage`, `repository`, `license`, `keywords`, per-plugin `version`)

## Context
Aligns `.claude-plugin/marketplace.json` with the shape used by [`anthropics/skills/.claude-plugin/marketplace.json`](https://github.com/anthropics/skills/blob/main/.claude-plugin/marketplace.json).

> **Heads-up:** this drops `repository`, `license`, and `keywords`. If those are load-bearing for the public marketplace listing, re-add them before merging.

## Test plan
- [ ] `jq . .claude-plugin/marketplace.json` parses cleanly
- [ ] Plugin still loadable (install/reload locally and verify skills appear)
- [ ] Daily version-bump automation still works against the new `metadata.version` path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PILOT-4860]: https://uipath.atlassian.net/browse/PILOT-4860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ