### PR TITLE
docs(uipath-rpa): fix link-* flag names and document mixed-activity captures

### DIFF
--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -38,7 +38,7 @@ The skill will search the Object Repository for existing matches before creating
 
 `--activity <type>` applies to the **entire batch** — every element in `--elements` is configured for that one activity type (the default is `Click`). When a single screen mixes activity types (e.g., a `TypeInto` target for a text input plus a `Click` target for a button), split into one `uia-configure-target` call per type:
 
-```
+```bash
 # TypeInto targets
 uia-configure-target --window "Todo App" --elements "new todo input" --activity TypeInto
 

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -34,6 +34,20 @@ To configure multiple elements on the same screen in a single invocation, separa
 
 The skill will search the Object Repository for existing matches before creating new entries, generate selectors from the live application tree, and register everything in the OR. After completion, retrieve the target references for your workflow.
 
+### Mixed activity types
+
+`--activity <type>` applies to the **entire batch** — every element in `--elements` is configured for that one activity type (the default is `Click`). When a single screen mixes activity types (e.g., a `TypeInto` target for a text input plus a `Click` target for a button), split into one `uia-configure-target` call per type:
+
+```
+# TypeInto targets
+uia-configure-target --window "Todo App" --elements "new todo input" --activity TypeInto
+
+# Click targets (separate call, same window)
+uia-configure-target --window "Todo App" --elements "Add button" --activity Click
+```
+
+The skill's screen-lookup step is cheap, so the second call reuses the registered screen rather than recreating it. Do **not** use a single `--activity` value (such as the default `Click`) for mixed targets and expect to fix the activity type later — the `ActivityType` baked into each target's definition file feeds selector generation and OR registration, and retrofitting it requires re-running `get-default-selector` per target.
+
 ## Rules
 
 **Do NOT manually call low-level `uip rpa uia` CLI commands** (`snapshot capture`, `snapshot filter`, `selector-intelligence get-default-selector`) to build selectors outside of the skill flow. These are internal tools used *by* the skill — calling them directly skips selector improvement and OR registration, producing fragile selectors that aren't registered in the Object Repository.

--- a/skills/uipath-rpa/references/uia-target-attachment-guide.md
+++ b/skills/uipath-rpa/references/uia-target-attachment-guide.md
@@ -18,8 +18,8 @@ Write plain activities (no `.Target` child element) with unique IdRefs, then att
 
 ```bash
 uip rpa uia object-repository link-screen \
-  --workflow-relative-path "<RELATIVE_XAML_PATH>" \
-  --activity-ref-id "<ACTIVITY_REF_ID>" \
+  --workflow-file-path "<WORKFLOW_FILE_PATH>" \
+  --activity-id "<ACTIVITY_ID>" \
   --reference-id "<SCREEN_REFERENCE_ID>" \
   --project-dir "<PROJECT_DIR>" \
   --output json
@@ -27,8 +27,8 @@ uip rpa uia object-repository link-screen \
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--workflow-relative-path` | Yes | Path to the `.xaml` file, relative to the project directory (e.g., `Workflows/Main.xaml`). |
-| `--activity-ref-id` | Yes | The `sap2010:WorkflowViewState.IdRef` on the target activity — typically `NApplicationCard_1`. |
+| `--workflow-file-path` | Yes | Path to the `.xaml` file — either relative to the project directory (e.g., `Workflows/Main.xaml`) or a full path inside the project directory. |
+| `--activity-id` | Yes | The `sap2010:WorkflowViewState.IdRef` on the target activity — typically `NApplicationCard_1`. |
 | `--reference-id` | Yes | OR screen reference returned by `uia-configure-target` or `indicate-application`. |
 
 ### 2. Link elements to UI activities
@@ -37,8 +37,8 @@ One call per (activity, element) pair. The CLI does not batch.
 
 ```bash
 uip rpa uia object-repository link-element \
-  --workflow-relative-path "<RELATIVE_XAML_PATH>" \
-  --activity-ref-id "<ACTIVITY_REF_ID>" \
+  --workflow-file-path "<WORKFLOW_FILE_PATH>" \
+  --activity-id "<ACTIVITY_ID>" \
   --reference-id "<ELEMENT_REFERENCE_ID>" \
   --project-dir "<PROJECT_DIR>" \
   --output json
@@ -46,14 +46,14 @@ uip rpa uia object-repository link-element \
 
 | Flag | Required | Description |
 |------|----------|-------------|
-| `--workflow-relative-path` | Yes | Path to the `.xaml` file, relative to the project directory. |
-| `--activity-ref-id` | Yes | The `sap2010:WorkflowViewState.IdRef` on the target activity (e.g., `NClick_3`). |
+| `--workflow-file-path` | Yes | Path to the `.xaml` file — either relative to the project directory or a full path inside the project directory. |
+| `--activity-id` | Yes | The `sap2010:WorkflowViewState.IdRef` on the target activity (e.g., `NClick_3`). |
 | `--reference-id` | Yes | OR element reference returned by `uia-configure-target` or `indicate-element`. |
 | `--target-property` | No | Activity property to attach the target to. Supports dotted paths for nested properties (e.g., `SearchedElement.Target`). Defaults to `Target`. |
 
 **When to use `--target-property`:** most UI activities (`NClick`, `NTypeInto`, `NGetText`) attach the target at `.Target`, so the default is correct. Some activities expose the target at a nested property (e.g., anchor-based activities use `SearchedElement.Target`). When the target sits anywhere other than `.Target`, pass `--target-property` explicitly.
 
-**Element reuse:** when the same element is referenced by multiple activities (e.g., the same field clicked and then typed into), call `link-element` once per activity with each activity's own `--activity-ref-id`.
+**Element reuse:** when the same element is referenced by multiple activities (e.g., the same field clicked and then typed into), call `link-element` once per activity with each activity's own `--activity-id`.
 
 ## Fallback: Embedding OR Entries When Linking Fails
 


### PR DESCRIPTION
## Summary

Two small docs fixes to the `uipath-rpa` skill, each in its own commit:

- **`docs(uipath-rpa): correct link-screen/link-element flag names`** — the target-attachment guide used `--workflow-relative-path` and `--activity-ref-id`, but the installed CLI requires `--workflow-file-path` and `--activity-id`. Following the guide verbatim produces `ValidationError: required option not specified` on every link call. Renamed both flags across the `link-screen` and `link-element` examples, tables, and the element-reuse paragraph; updated the `--workflow-file-path` description to match the CLI's `--help` text.
- **`docs(uipath-rpa): document mixed-activity-type captures`** — `uia-configure-target --activity <type>` applies to the whole batch of elements passed via `--elements`. Screens that mix target types (e.g., TypeInto input + Click button) need one invocation per type, but the guide didn't say so — callers default to `Click` for everything and then have to re-run `get-default-selector` per target to fix the `ActivityType`. Added a "Mixed activity types" subsection showing the split-per-type pattern.

Both issues surfaced during a live session building a TodoApp web automation; the CLI-flag drift was a hard blocker until the user ran `--help`, and the mixed-activity gotcha cost one extra round-trip of `get-default-selector` calls.

## Test plan

- [ ] Re-read the updated `link-screen` / `link-element` examples in `uia-target-attachment-guide.md`; every flag in them should appear in `uip rpa uia object-repository link-screen --help` and `... link-element --help`.
- [ ] Run the documented `link-screen` and `link-element` commands literally against a real project (filling in placeholders) — each should print `Successfully linked Object Repository …` instead of `ValidationError`.
- [ ] Re-read the new "Mixed activity types" subsection in `uia-configure-target-workflows.md`; confirm it reads as a natural extension of the existing Invocation section and the example's two-call pattern is copy-pasteable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)