### PR TITLE
feat(uipath-case-management): upgrade schema to v19 and add runs-sequ…

### DIFF
--- a/skills/uipath-case-management/references/case-commands.md
+++ b/skills/uipath-case-management/references/case-commands.md
@@ -621,7 +621,7 @@ Options for `add`:
 | `<stage-id>` | **(required)** ID of the stage node |
 | `<task-id>` | **(required)** ID of the task |
 | `-d, --display-name <name>` | Display name for the condition |
-| `--rule-type <type>` | Initial rule type: `current-stage-entered`, `selected-tasks-completed`, `wait-for-connector`, `adhoc` |
+| `--rule-type <type>` | Initial rule type: `current-stage-entered`, `selected-tasks-completed`, `wait-for-connector`, `adhoc`, `runs-sequentially` |
 | `--condition-expression <expr>` | Condition expression for the initial rule |
 | `--selected-tasks-ids <ids>` | Comma-separated task IDs. **Required** when `--rule-type` is `selected-tasks-completed` |
 

--- a/skills/uipath-case-management/references/case-schema.md
+++ b/skills/uipath-case-management/references/case-schema.md
@@ -44,7 +44,7 @@ Metadata and configuration for the case definition.
   "caseIdentifier": "LOAN",
   "caseAppEnabled": false,
   "caseIdentifierType": "constant",
-  "version": "v17",
+  "version": "v19",
   "publishVersion": 2,
   "data": {
     "slaRules": [
@@ -69,7 +69,7 @@ Metadata and configuration for the case definition.
 | `caseIdentifier` | string | Identifier used at runtime |
 | `caseIdentifierType` | `"constant"` \| `"external"` | How the identifier is resolved |
 | `caseAppEnabled` | boolean | Whether the Case App UI is enabled |
-| `version` | string | Schema version — `"v17"` for current schema. Emitted by `uip maestro case cases add`. |
+| `version` | string | Schema version — `"v19"` for current schema. Emitted by `uip maestro case cases add`. |
 | `publishVersion` | number? | Publish version — `2` for current schema |
 | `data.slaRules` | SlaRuleEntry[]? | Conditional + default SLA rules for the case. Default SLA lives here as the trailing entry with `expression: "=js:true"`. Escalations attach inside each rule's `escalationRule[]`. See §6. |
 | `data.intsvcActivityConfig` | string? | Integration-service activity configuration payload |
@@ -314,6 +314,7 @@ Rules = Rule[][]
 | `current-stage-entered` | `id?`, `conditionExpression?` | The current stage was just entered |
 | `user-selected-stage` | `id?`, `conditionExpression?` | Fires when a user manually selects/routes to this stage |
 | `adhoc` | `id?`, `conditionExpression?` | Ad-hoc expression-based condition |
+| `runs-sequentially` | `id?`, `conditionExpression?` | Sequential tasks run in the order they appear in the stage from top to bottom | 
 
 Not every rule type is valid at every level — see each condition plugin's `impl-cli.md` / `impl-json.md` for the allowed subset per location.
 
@@ -437,7 +438,7 @@ All tasks inside a stage share this envelope. Per-type `data` fields live in eac
     "caseIdentifier": "Simple Case",
     "caseAppEnabled": false,
     "caseIdentifierType": "constant",
-    "version": "v17",
+    "version": "v19",
     "publishVersion": 2,
     "data": {
       "intsvcActivityConfig": "v2",

--- a/skills/uipath-case-management/references/plugins/case/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/case/impl-cli.md
@@ -66,7 +66,7 @@ After the command runs, `caseplan.json` contains (CLI 0.3.4):
         "caseIdentifier": "LOAN",
         "caseAppEnabled": true,
         "caseIdentifierType": "constant",
-        "version": "v17",
+        "version": "v19",
         "publishVersion": 2,
         "data": {
             "intsvcActivityConfig": "v2",
@@ -103,7 +103,7 @@ Capture from `--output json`:
 
 - **File path** — confirm the file exists on disk.
 - **Initial Trigger ID** — the literal string `"trigger_1"`. Use as the source for the first edge (Trigger → first stage).
-- Confirm `root.type == "case-management:root"` and `root.version == "v17"`.
+- Confirm `root.type == "case-management:root"` and `root.version == "v19"`.
 
 ## Editing the Root Case
 

--- a/skills/uipath-case-management/references/plugins/case/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/case/impl-json.md
@@ -64,7 +64,7 @@ When `description` is absent in the T01 input, emit `description: ""` (always-em
         "caseIdentifier": "<case-identifier — defaults to <name>>",
         "caseAppEnabled": <true|false — defaults to false>,
         "caseIdentifierType": "<constant|external — defaults to constant>",
-        "version": "v17",
+        "version": "v19",
         "publishVersion": 2,
         "data": {
             "intsvcActivityConfig": "v2",
@@ -95,7 +95,7 @@ Same as above with `description` value populated from sdd.md:
         "caseIdentifier": "<case-identifier>",
         "caseAppEnabled": <true|false>,
         "caseIdentifierType": "<constant|external>",
-        "version": "v17",
+        "version": "v19",
         "publishVersion": 2,
         "data": {
             "intsvcActivityConfig": "v2",
@@ -129,7 +129,7 @@ Cheap sanity checks only — full validation runs after all plugins are done, pe
 2. **Root shape.**
    - `root.id === "root"`
    - `root.type === "case-management:root"`
-   - `root.version === "v17"`
+   - `root.version === "v19"`
    - `root.publishVersion === 2`
    - `root.data.intsvcActivityConfig === "v2"`
    - `root.data.uipath.variables.inputOutputs` is an array (empty at T01)

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-cli.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-cli.md
@@ -21,6 +21,7 @@ uip maestro case task-entry-conditions add <file> <stage-id> <task-id> \
 | `selected-tasks-completed` | `--selected-tasks-ids "<comma-separated task IDs>"` |
 | `wait-for-connector` | `--condition-expression` |
 | `adhoc` | `--condition-expression` |
+| `runs-sequentially` | `--condition-expression` |
 
 ## Translation from tasks.md
 

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -94,6 +94,7 @@ Expression syntax per [`../../../bindings-and-expressions.md`](../../../bindings
 | `selected-tasks-completed` | `selectedTasksIds` (array) |
 | `wait-for-connector` | — |
 | `adhoc` | — |
+| `runs-sequentially` | — |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
 

--- a/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-case-management/references/plugins/conditions/task-entry-conditions/planning.md
@@ -30,6 +30,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `selected-tasks-completed` | Fires when specific sibling tasks in the same stage complete | `--selected-tasks-ids` |
 | `wait-for-connector` | Waits for a connector event | `--condition-expression` |
 | `adhoc` | Ad hoc tasks run only when a user triggers them from the case app. | `--condition-expression` (optional) |
+| `runs-sequentially` | Sequential tasks run in the order they appear in the stage from top to bottom. | `--condition-expression` (optional) |
 
 ## Ordering
 


### PR DESCRIPTION
Bump case schema version from v17 to v19 across references and plugin
docs, and document the new `runs-sequentially` task-entry rule type
for sequential tasks that execute top-to-bottom within a stage.