### PR TITLE
test(uipath-case-management): add init/validate and registry discover…

### DIFF
--- a/tests/tasks/uipath-case-management/init_validate.yaml
+++ b/tests/tasks/uipath-case-management/init_validate.yaml
@@ -1,0 +1,95 @@
+task_id: skill-case-init-validate
+description: >
+  Skill-guided evaluation: agent uses the uipath-case-management skill to
+  scaffold a minimal Case Management project inside a solution (manual
+  trigger, one stage) and validate it. Either scaffolding path is accepted
+  — CLI (`uip solution new` + `uip solution project add`) or the JSON
+  strategy (writing project files directly). The test asserts on the
+  resulting artifacts and the validate step, not on the scaffolding method.
+tags: [uipath-case-management, smoke, init, validate]
+
+agent:
+  type: claude-code
+  max_turns: 20
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a new UiPath Case Management project called "OnboardingCase" with
+  a manual trigger and a single stage named "Intake", and make sure the
+  case validates successfully.
+
+  Use this sdd.md as the sole input — write it to sdd.md first, then build
+  from it:
+
+  ```
+  # OnboardingCase
+
+  ## Trigger
+  - Manual trigger — user-initiated start of the case.
+
+  ## Stages
+  - Intake (regular stage) — receives the case after the manual trigger.
+  ```
+
+  Save a summary of what you did to report.json with at minimum:
+    {
+      "project_name": "OnboardingCase",
+      "commands_used": ["<list of uip commands you ran>"],
+      "validation_passed": true
+    }
+
+  Important:
+  - The `uip` CLI is already available in the environment.
+  - Treat the generated plan as pre-approved for this smoke test — do not
+    block on the HARD STOP / AskUserQuestion approval step.
+  - Do not run `uip maestro case debug` — just validate locally.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent validated the case project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+case\s+validate'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "sdd.md fixture was written"
+    path: "sdd.md"
+    weight: 0.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "A caseplan.json was scaffolded somewhere under the working directory (CLI or JSON strategy)"
+    command: "find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1 | grep -q ."
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json has correct structure and values"
+    path: "report.json"
+    assertions:
+      - expression: "project_name"
+        operator: equals
+        expected: "OnboardingCase"
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+      - expression: "length(commands_used)"
+        operator: gte
+        expected: 1
+    weight: 2.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-case-management/init_validate.yaml
+++ b/tests/tasks/uipath-case-management/init_validate.yaml
@@ -10,7 +10,7 @@ tags: [uipath-case-management, smoke, init, validate]
 
 agent:
   type: claude-code
-  max_turns: 20
+  max_turns: 40
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-case-management/registry_discovery.yaml
+++ b/tests/tasks/uipath-case-management/registry_discovery.yaml
@@ -1,0 +1,93 @@
+task_id: skill-case-registry-discovery
+description: >
+  Skill-guided evaluation: agent uses the uipath-case-management skill to
+  explore available case task resources via the registry. Tests whether the
+  skill teaches the correct discovery workflow (pull + direct cache-file
+  inspection at ~/.uipcli/case-resources/, not relying on registry search).
+tags: [uipath-case-management, smoke, registry]
+
+agent:
+  type: claude-code
+  max_turns: 14
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I want to build a UiPath Case Management definition that includes a HITL
+  action-app task and an RPA-style process task. Before planning, explore
+  what resources are available in the case registry to see which task types
+  I can use.
+
+  Save your findings to registry_report.json with at minimum:
+    {
+      "cache_files_inspected": ["<list of <type>-index.json file names you read>"],
+      "commands_used": ["<list of uip commands you ran>"],
+      "action_app_index_file": "<the cache index filename for HITL action-apps>",
+      "process_index_file": "<the cache index filename for processes>"
+    }
+
+  Important:
+  - The `uip` CLI is already available in the environment.
+  - Use `--output json` on uip read commands.
+  - Do not build a case — just explore the registry and report.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent pulled the case registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+case\s+registry\s+pull'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inspected registry cache index files directly"
+    tool_name: "Bash"
+    command_pattern: 'case-resources/.*-index\.json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "registry_report.json exists"
+    path: "registry_report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "registry_report.json is valid JSON"
+    command: "python -c \"import json; json.load(open('registry_report.json'))\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Report contains expected fields"
+    path: "registry_report.json"
+    includes:
+      - "cache_files_inspected"
+      - "commands_used"
+      - "action_app_index_file"
+      - "process_index_file"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Report identifies the correct cache index filenames"
+    path: "registry_report.json"
+    includes:
+      - "action-apps-index.json"
+      - "process-index.json"
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-case-management/registry_discovery.yaml
+++ b/tests/tasks/uipath-case-management/registry_discovery.yaml
@@ -8,7 +8,7 @@ tags: [uipath-case-management, smoke, registry]
 
 agent:
   type: claude-code
-  max_turns: 14
+  max_turns: 20
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-case-management/registry_discovery.yaml
+++ b/tests/tasks/uipath-case-management/registry_discovery.yaml
@@ -22,40 +22,42 @@ initial_prompt: |
 
   Save your findings to registry_report.json with at minimum:
     {
-      "cache_files_inspected": ["<list of <type>-index.json file names you read>"],
-      "commands_used": ["<list of uip commands you ran>"],
+      "cache_files_inspected": ["<list of <type>-index.json file names you read or listed>"],
+      "commands_used": ["<list of uip commands you ran, exactly as invoked>"],
       "action_app_index_file": "<the cache index filename for HITL action-apps>",
-      "process_index_file": "<the cache index filename for processes>"
+      "process_index_file": "<the cache index filename for processes>",
+      "auth_state": "<authenticated | unauthenticated | unknown>",
+      "cache_populated": <true|false>
     }
 
   Important:
   - The `uip` CLI is already available in the environment.
+  - Always run the registry pull yourself with `--output json`, even if a
+    cache appears to exist. The pull command may report per-resource-type
+    "Not logged in. Run 'uip login' first." entries when the environment is
+    unauthenticated — that is expected. Record the auth state and continue.
   - Use `--output json` on uip read commands.
+  - If the cache directory at `~/.uipcli/case-resources/` is missing or the
+    expected `<type>-index.json` files were not populated by the pull, list
+    the directory and still report the expected filenames per the skill
+    reference (do not fabricate sample data).
   - Do not build a case — just explore the registry and report.
 
 success_criteria:
   - type: command_executed
-    description: "Agent pulled the case registry"
+    description: "Agent pulled the case registry with --output json"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+case\s+registry\s+pull'
+    command_pattern: 'uip\s+maestro\s+case\s+registry\s+pull[^\n]*--output\s+json'
     min_count: 1
-    weight: 1.5
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent inspected registry cache index files directly"
+    description: "Agent inspected the registry cache directory or its index files"
     tool_name: "Bash"
-    command_pattern: 'case-resources/.*-index\.json'
+    command_pattern: 'case-resources(/|\b)'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: file_exists
@@ -80,6 +82,8 @@ success_criteria:
       - "commands_used"
       - "action_app_index_file"
       - "process_index_file"
+      - "auth_state"
+      - "cache_populated"
     weight: 1.5
     pass_threshold: 1.0
 


### PR DESCRIPTION
Adds two skill-guided evaluation tasks for uipath-case-management:
- init_validate: agent scaffolds a minimal case project (manual trigger,
  single stage) from an sdd.md fixture and runs `uip maestro case validate`;
  accepts either CLI or JSON scaffolding strategy.
- registry_discovery: agent pulls the case registry and inspects cache
  index files directly under ~/.uipcli/case-resources/, verifying the
  skill teaches the correct discovery workflow.