### PR TITLE
fix(uipath-platform): remove direct auth fallback guidance

### DIFF
--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -20,19 +20,11 @@ Comprehensive guide for setting up and managing UiPath development environments,
 - User wants to set up a **CI/CD pipeline** for UiPath automation projects
 - User asks **how to deploy** an automation to Orchestrator
 
-## Auth token location
+## Authentication and Credential Safety
 
-The CLI stores credentials at **`~/.uipath/.auth`** after login:
-```
-UIPATH_URL=https://alpha.uipath.com
-UIPATH_ORG_NAME=my_org
-UIPATH_TENANT_NAME=my_tenant
-UIPATH_ACCESS_TOKEN=eyJ...
-UIPATH_ORGANIZATION_ID=...
-UIPATH_TENANT_ID=...
-```
+Use `uip login` and other supported `uip` commands for all platform operations. The CLI manages its own credential cache after login.
 
-This token can be reused for direct Orchestrator REST API calls when CLI commands don't cover a use case.
+Do **not** read, print, source, parse, copy, or expose cached credential files or access tokens. Do **not** build ad hoc `curl` calls against UiPath backend APIs with cached tokens. If the CLI does not expose an operation, stop and explain the unsupported operation, then ask the user whether they want to use a supported CLI workflow, a product API integration outside this skill, or file feedback for CLI coverage.
 
 ## Quick Start
 
@@ -227,37 +219,7 @@ The typical deployment workflow for a UiPath automation:
 ### Practical Deployment Notes
 
 - **Starting jobs requires runtimes.** If you get error 2818 "no runtimes configured", the target folder needs machine templates with Unattended/Development runtimes assigned.
-- **Fallback: direct REST API.** When CLI tools don't support an operation, use the Orchestrator REST API with the access token from `~/.uipath/.auth`. See [references/orchestrator/orchestrator.md - REST API](references/orchestrator/orchestrator.md).
-
-## Orchestrator REST API (Fallback)
-
-When CLI commands are insufficient, use the Orchestrator REST API directly with the stored access token:
-
-```bash
-source ~/.uipath/.auth
-
-# Upload a .nupkg package
-curl -X POST "${UIPATH_URL}/${UIPATH_ORG_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.UploadPackage" \
-  -H "Authorization: Bearer ${UIPATH_ACCESS_TOKEN}" \
-  -H "X-UIPATH-OrganizationUnitId: <FOLDER_ID>" \
-  -F "file=@./MyProject.1.0.0.nupkg"
-
-# Create a process (release) from an uploaded package
-curl -X POST "${UIPATH_URL}/${UIPATH_ORG_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Releases" \
-  -H "Authorization: Bearer ${UIPATH_ACCESS_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -H "X-UIPATH-OrganizationUnitId: <FOLDER_ID>" \
-  -d '{"Name":"MyProcess","ProcessKey":"MyProject","ProcessVersion":"1.0.0"}'
-
-# Start a job
-curl -X POST "${UIPATH_URL}/${UIPATH_ORG_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Jobs/UiPath.Server.Configuration.OData.StartJobs" \
-  -H "Authorization: Bearer ${UIPATH_ACCESS_TOKEN}" \
-  -H "Content-Type: application/json" \
-  -H "X-UIPATH-OrganizationUnitId: <FOLDER_ID>" \
-  -d '{"startInfo":{"ReleaseKey":"<RELEASE_KEY>","Strategy":"ModernJobsCount","JobsCount":1,"RuntimeType":"Unattended","InputArguments":"{}"}}'
-```
-
-The `X-UIPATH-OrganizationUnitId` header is the **folder ID** (get it from `uip or folders list`).
+- **Unsupported operations.** If a platform operation is not available through `uip`, do not bypass the CLI with direct token or REST calls. Summarize the missing operation, include the `uip --help` / subcommand evidence you checked, and ask the user whether to use a supported CLI path or file feedback for CLI coverage.
 
 ## References
 

--- a/skills/uipath-platform/references/orchestrator/orchestrator.md
+++ b/skills/uipath-platform/references/orchestrator/orchestrator.md
@@ -90,37 +90,16 @@ The CLI uses GUID keys for all entity references. Numeric IDs are never exposed 
 
 ---
 
-## REST API Fallback
+## Unsupported CLI Operations
 
-When the CLI does not cover an operation, use the Orchestrator REST API directly with a stored token from `~/.uipath/.auth`.
+Always check `uip or --help`, `uip resource --help`, and the relevant subcommand help before deciding an operation is unsupported. Most common Orchestrator operations are covered by the CLI.
 
-**Base URL pattern:**
+If the CLI does not cover the operation you need:
 
-```
-${UIPATH_URL}/${UIPATH_ORG_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/
-```
-
-**Auth header:**
-
-```
-Authorization: Bearer <UIPATH_ACCESS_TOKEN>
-X-UIPATH-OrganizationUnitId: <FOLDER_ID>
-```
-
-Always check `uip or --help` and `uip resource --help` first -- most operations are covered by the CLI. Only fall back to REST when there is no CLI command for the operation you need.
-
-**Example -- list triggers (no CLI command yet):**
-
-```bash
-ACCESS_TOKEN=$(cat ~/.uipath/.auth | jq -r '.access_token')
-BASE_URL="https://cloud.uipath.com/myorg/mytenant/orchestrator_/odata"
-
-curl -s -G "${BASE_URL}/ProcessSchedules" \
-  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-  -H "X-UIPATH-OrganizationUnitId: <FOLDER_ID>" | jq .
-```
-
-Token expiry: re-run `uip login` if you get a 401.
+- Do not read, source, print, or parse cached credential files.
+- Do not construct direct `curl` calls with cached access tokens.
+- Summarize the missing command, the help output you checked, and the closest supported CLI alternative.
+- Ask the user whether to use a supported workflow or file feedback for CLI/API coverage.
 
 ---
 


### PR DESCRIPTION
## Summary

- Remove guidance that exposes cached auth file contents or encourages reusing cached access tokens.
- Remove direct Orchestrator REST/curl fallback examples from the platform skill and Orchestrator reference.
- Replace the fallback path with a CLI-first unsupported-operation workflow: check help, summarize the missing command, use a supported workflow, or file feedback for CLI coverage.

## Why

The skill should not instruct agents to source or parse local credential caches, nor should it steer agents toward direct backend calls when validating CLI behavior. Agents should stay on supported `uip` workflows unless the user explicitly chooses a separate API integration path outside this skill.

Fixes #335

## Validation

- `rg -n "~/.uipath/.auth|UIPATH_ACCESS_TOKEN|source ~/.uipath|cat ~/.uipath|Authorization: Bearer" skills/uipath-platform` returns no matches.
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh skills/uipath-platform/SKILL.md`

The full smoke eval suite depends on the repository CI environment and private test secrets, so it is expected to run in GitHub Actions for this PR.
