### PR TITLE
fix(uipath-maestro-flow): clarify nested subflow shape

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-cli.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-cli.md
@@ -305,4 +305,4 @@ These operations require direct `.flow` JSON editing. Use the [JSON strategy gui
 1. **Workflow variables** — add/remove/update `variables.globals`
 2. **Variable updates** — add/modify `variables.variableUpdates` entries
 3. **Output mapping on End nodes** — add `outputs` object with `source` expressions
-4. **Subflows** — create `subflows.{nodeId}` with nested nodes, edges, variables
+4. **Subflows** — create `subflows.{nodeId}` with child nodes, edges, variables; nested subflow definitions remain flat top-level peers in the root `subflows` map

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -353,10 +353,24 @@ Edit the start node in-place (no delete/re-add needed):
    }
    ```
 
+   **Nested subflows stay flat.** If a node inside `<SUBFLOW_NODE_ID>` is another `core.subflow`, add that child definition as another top-level peer in the root `subflows` object:
+
+   ```json
+   {
+     "subflows": {
+       "outerSubflow": { "nodes": [ { "id": "innerSubflow", "type": "core.subflow" } ], "edges": [], "variables": {}, "layout": {} },
+       "innerSubflow": { "nodes": [ ... ], "edges": [ ... ], "variables": { ... }, "layout": { ... } }
+     }
+   }
+   ```
+
+   Do **not** create `subflows.outerSubflow.subflows.innerSubflow`. Real `.flow` files keep every subflow definition at the root `subflows` level, even when the execution nesting is multiple levels deep.
+
 3. Subflow's `in` variables must match the parent node's `inputs` keys
 4. Map all `out` variables on the subflow's End node `outputs`
 5. Parent-scope `$vars` are NOT visible inside the subflow — pass values via inputs
 6. Subflow node positions go in the **subflow's own** `layout.nodes` — not in the top-level `layout.nodes`. Each subflow has an independent layout scope.
+7. Each nested subflow still has its own `nodes`, `edges`, `variables`, and `layout` sections under its top-level `subflows.<nodeId>` entry.
 
 See [subflow/impl.md](plugins/subflow/impl.md) for the full JSON structure and rules.
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/subflow/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/subflow/impl.md
@@ -43,7 +43,7 @@ Confirm: input port `input`, output ports `output` and `error`.
 
 ## Subflow Definition
 
-Subflow contents are stored in a top-level `subflows` object keyed by the parent node's ID:
+Subflow contents are stored in the root-level `subflows` object keyed by the corresponding `core.subflow` node ID:
 
 ```json
 {
@@ -182,6 +182,57 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
 }
 ```
 
+### Nested subflows use a flat `subflows` map
+
+Subflows can contain `core.subflow` nodes, but their definitions are **not** nested inside the parent subflow definition. Every subflow definition, at every nesting depth, is a top-level peer under the root `subflows` object.
+
+Correct:
+
+```json
+{
+  "subflows": {
+    "outerSubflow": {
+      "nodes": [
+        { "id": "outerStart", "type": "core.trigger.manual" },
+        { "id": "innerSubflow", "type": "core.subflow" },
+        { "id": "outerEnd", "type": "core.control.end" }
+      ],
+      "edges": [],
+      "variables": { "globals": [], "nodes": [] },
+      "layout": { "nodes": {} }
+    },
+    "innerSubflow": {
+      "nodes": [
+        { "id": "innerStart", "type": "core.trigger.manual" },
+        { "id": "innerEnd", "type": "core.control.end" }
+      ],
+      "edges": [],
+      "variables": { "globals": [], "nodes": [] },
+      "layout": { "nodes": {} }
+    }
+  }
+}
+```
+
+Wrong:
+
+```json
+{
+  "subflows": {
+    "outerSubflow": {
+      "nodes": [
+        { "id": "innerSubflow", "type": "core.subflow" }
+      ],
+      "subflows": {
+        "innerSubflow": { "nodes": [] }
+      }
+    }
+  }
+}
+```
+
+The nesting relationship comes from the `core.subflow` node placed inside `outerSubflow.nodes`; the JSON definition for `innerSubflow` still lives at `subflows.innerSubflow`.
+
 ## Subflow Rules
 
 1. Every subflow **must** have its own Start node (`core.trigger.manual`) and End node (`core.control.end`)
@@ -191,8 +242,9 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
 5. Parent-scope `$vars` are **not** visible inside the subflow — pass values explicitly via inputs
 6. Subflow nodes must have inline `outputs` defined on them (Start node needs `outputs.output`, Script nodes need `outputs.output` and `outputs.error`)
 7. Subflows can be nested (subflow inside subflow), up to 3 levels
-8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections
-9. Subflow node positions go in the subflow's own `layout.nodes` — NOT in the top-level `layout.nodes`. Each subflow scope is independent.
+8. Nested subflow definitions remain flat top-level peers in the root `subflows` map; never add a `subflows` object inside another subflow definition
+9. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections
+10. Subflow node positions go in the subflow's own `layout.nodes` — NOT in the top-level `layout.nodes`. Each subflow scope is independent.
 
 ## Creating a Subflow
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/subflow/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/subflow/planning.md
@@ -28,6 +28,7 @@ The `error` port is the implicit error port shared with all action nodes — see
 ## Key Properties
 
 - Subflows have their own `nodes`, `edges`, and `variables` stored in `subflows.{nodeId}`
+- Nested subflows are represented by additional top-level entries in the root `subflows` map; do not nest a `subflows` object inside another subflow definition
 - Parent-scope `$vars` are **not** visible inside the subflow — pass values explicitly via inputs
 - Subflow inputs map to `direction: "in"` variables; outputs map to `direction: "out"` variables
 - Nesting supported up to 3 levels deep

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -176,7 +176,7 @@ Each key in `layout.nodes` is a node `id`. `flow tidy` creates an entry for ever
 - Skips `stickyNote` nodes from layout (they keep their custom position and size)
 - Recurses into every subflow and rewrites its `subflows[<id>].layout` map
 
-**Subflow layout is scoped.** Each subflow entry in `subflows[<id>]` has its **own** `layout.nodes` map for the nodes inside that subflow — they do NOT live in the top-level `layout.nodes`. Tidy handles both passes. See the [Author subflow plugin reference](../author/references/plugins/subflow/impl.md).
+**Subflow layout is scoped.** Each subflow entry in `subflows[<id>]` has its **own** `layout.nodes` map for the nodes inside that subflow — they do NOT live in the top-level `layout.nodes`. Nested subflow definitions are still top-level peers in the root `subflows` map; do NOT place `subflows` inside another subflow definition. Tidy handles each subflow layout pass. See the [Author subflow plugin reference](../author/references/plugins/subflow/impl.md).
 
 ## Edge — both ports required
 


### PR DESCRIPTION
## Summary
- Clarify that nested subflows are represented as flat top-level peers in the root `subflows` map.
- Add correct and incorrect nested-subflow examples to the subflow implementation guide.
- Update the main skill table, JSON editing flow, file-format reference, CLI limitation note, and planning guide so agents do not create `subflows.outer.subflows.inner`.

Fixes #116

## Validation
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh skills/uipath-maestro-flow/SKILL.md`
- `python3 -m pytest tests/tasks/uipath-maestro-flow/_shared -q`
- `rg -n 'subflows\..*subflows|nested subflows|flat top-level|root `subflows`|top-level peers|subflows object inside' skills/uipath-maestro-flow`