### PR TITLE
fix(uipath-agents): remove nonexistent codedagent setup

### DIFF
--- a/skills/uipath-agents/references/coded/lifecycle/setup.md
+++ b/skills/uipath-agents/references/coded/lifecycle/setup.md
@@ -10,7 +10,7 @@ mkdir my-agent && cd my-agent
 # Copy pyproject.toml template, add framework dep if needed, then:
 uv sync
 source .venv/bin/activate           # activate venv BEFORE uip codedagent commands
-uip codedagent setup --output json # configure Python backend (once per env)
+uip codedagent --help               # verify wrapper can reach the Python CLI
 uip codedagent new my-agent        # name is REQUIRED
 uip codedagent init
 
@@ -40,6 +40,7 @@ A `pyproject.toml` template is available in [assets/templates/pyproject.toml](..
 | `NameError: name 'StateGraph' is not defined` | `uip codedagent init` imports `main.py` but `langgraph` not installed | Run `uv sync` to install all dependencies before `uip codedagent init` |
 | `No solution found` for Python 3.10 | `requires-python` set too low | Set `requires-python = ">=3.11"` — UiPath SDK requires Python 3.11+ |
 | `Project authors cannot be empty` | Missing `authors` in `pyproject.toml` | Add `authors = [{ name = "Your Name" }]` to `[project]` section |
+| `error: unknown command 'setup'` or stale guidance says to run `uip codedagent setup` | There is no coded-agent setup subcommand | Run `uv sync`, activate `.venv`, then retry the intended `uip codedagent ...` command |
 
 ## Additional Instructions
 
@@ -136,6 +137,8 @@ uv sync
 ```bash
 uip codedagent --version
 ```
+
+Do not run `uip codedagent setup`; setup is handled by `uv sync` plus the activated virtual environment.
 
 ### 5. Authenticate
 

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -1,6 +1,6 @@
 # UiPath Coded Agents — Quickstart
 
-## CLI Setup (run once at start)
+## Environment Setup (run once at start)
 
 Before running any `uip codedagent` commands, ensure the environment is ready:
 
@@ -8,22 +8,25 @@ Before running any `uip codedagent` commands, ensure the environment is ready:
 # 1. Check uip is installed
 which uip > /dev/null 2>&1 && echo "uip found" || echo "uip NOT found — run: npm install -g @uipath/cli"
 
-# 2. Activate the virtual environment (required if .venv exists)
-if [ -d ".venv" ]; then source .venv/bin/activate; fi
+# 2. Install/sync Python dependencies from pyproject.toml
+uv sync
 
-# 3. Set up the Python environment (detects Python, installs uipath package if needed)
-uip codedagent setup --output json
+# 3. Activate the virtual environment
+source .venv/bin/activate
+
+# 4. Confirm coded-agent commands route to the Python CLI
+uip codedagent --help
 ```
 
 **Steps 2 and 3 are required.** Common errors if skipped:
-- `"uipath executable not found"` → run `uip codedagent setup` first
-- `"Found .venv but no virtual environment is activated"` → run `source .venv/bin/activate` before setup
+- `"uipath executable not found"` → run `uv sync`, then activate `.venv` and retry
+- `"Found .venv but no virtual environment is activated"` → run `source .venv/bin/activate` before `uip codedagent ...`
 
-Run these once per project environment. After setup succeeds, all `uip codedagent` commands will work.
+Run these once per project environment. There is no `uip codedagent setup` command; if an older note or error message suggests it, sync dependencies and activate the virtual environment instead.
 
 If `uip` is not found, install it with `npm install -g @uipath/cli`. If `npm` is missing, ask the user to install Node.js first. All commands in this skill use `uip codedagent <cmd>` — do **not** substitute with `uv run uipath`.
 
-**Do NOT add `--output json` to `uip codedagent` commands.** The `--output` flag is only valid for native `uip` commands (like `uip login`, `uip codedagent setup`). Commands forwarded to the Python CLI (`uip codedagent new`, `init`, `run`, `eval`, `deploy`, `push`, `pull`, `pack`, `publish`, `invoke`) do **not** accept `--output json` and will error.
+**Do NOT add `--output json` to `uip codedagent` commands.** The `--output` flag is only valid for native `uip` commands (like `uip login`). Commands forwarded to the Python CLI (`uip codedagent --help`, `new`, `init`, `run`, `eval`, `deploy`, `push`, `pull`, `pack`, `publish`, `invoke`) do **not** accept `--output json` and will error.
 
 ## Critical Rules
 


### PR DESCRIPTION
## Summary
- remove the nonexistent `uip codedagent setup --output json` setup step from coded-agent docs
- clarify that coded-agent setup is `uv sync` plus virtual environment activation
- keep `--output json` guidance limited to native `uip` commands, not forwarded coded-agent Python CLI commands

## Why
Agents following the current setup docs can run into a dead end because `setup` is not a coded-agent subcommand. The docs should steer them to the dependency/venv prep path before invoking `uip codedagent new`, `init`, or other lifecycle commands.

Fixes #113

## Validation
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh skills/uipath-agents/SKILL.md`
- `uip codedagent --version`
- `uip codedagent --help`
