### PR TITLE
fix(uipath-rpa): document Studio IPC dead ends

### DIFF
--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -64,6 +64,26 @@ Every `uip rpa` invocation accepts these flags:
 
 `--project-dir` defaults to the current working directory. When the project is elsewhere, pass the absolute path to the folder containing `project.json`.
 
+### Studio IPC Compatibility Preflight
+
+At the start of RPA work, record the CLI and Studio versions before running validation or execution commands:
+
+```bash
+uip --version
+uip rpa list-instances --output json
+```
+
+If Studio is running, read the Studio version and project directory from `list-instances`. If the project is not open, run `open-project` once, then list instances again. Keep these versions in mind for every Studio-backed validation, execution, build, and analysis command.
+
+Treat these as compatibility dead ends, not ordinary workflow errors:
+- `"Studio <version> does not support rpa-tool"`
+- `"does not have interop support"` or `"Requires Studio ..."`
+- `"Too many parameters for Task<string> ExecuteCommand"` from an IPC call
+- `get-errors`, `run-file`, `build`, or `analyze` hangs with no output after the configured timeout
+- standalone `build`/`analyze` fails because the project is already open in Studio while the Studio-backed command also fails or hangs
+
+When any of these appears, do **not** retry the same command in a loop and do not switch blindly between Studio-backed and standalone variants. Capture the exact command, `uip` version, Studio version, and error text, then tell the user that CLI/Studio compatibility is blocking automated validation or execution. Continue only with work that can be done safely without that command, and report the verification gap explicitly.
+
 ---
 
 ## Installed Package Activity Documentation
@@ -90,7 +110,8 @@ Located at `{projectRoot}/.local/docs/packages/{PackageId}/`.
 List running Studio Desktop instances and their IPC status. Hidden diagnostic command — does **not** report the auto-launched headless Studio (Helm) instances.
 
 ```bash
-uip rpa list-instances --output json```
+uip rpa list-instances --output json
+```
 
 No command-specific options. An empty `Data` array does NOT mean `uip rpa` won't work — headless Studio starts on demand.
 
@@ -104,7 +125,8 @@ Ensure a **Studio Desktop** instance is running. Only required before invoking `
 3. Start a new instance via `--studio-dir` -- poll until available
 
 ```bash
-uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json```
+uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json
+```
 
 ---
 
@@ -115,7 +137,8 @@ uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json```
 Create a new UiPath project from a template.
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json```
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json
+```
 
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
@@ -156,7 +179,8 @@ Returns `Data[*]` with `packageId`, `version`, `title`, `description`, `authors`
 Open an existing project in Studio. Only needed when explicitly loading a project that isn't already open (e.g. after `create-project`, or when switching projects). Most commands (`validate`, `run-file`) auto-resolve a Studio instance and open the project automatically, so this is rarely required.
 
 ```bash
-uip rpa open-project --project-dir "<PROJECT_DIR>" --output json```
+uip rpa open-project --project-dir "<PROJECT_DIR>" --output json
+```
 
 No command-specific options.
 
@@ -172,7 +196,8 @@ Run or debug a workflow file using Studio.
 # Run (default -- closes app on completion or error):
 uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json
 # Debug (pauses on error -- keeps app open for inspection/repair):
-uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json```
+uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -190,7 +215,8 @@ uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command St
 Return validation errors for a file or project. By default, forces Studio to re-validate before returning errors.
 
 ```bash
-uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json```
+uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -204,7 +230,8 @@ uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json```
 Build (compile) a UiPath project. Compiles all XAML expressions — catches runtime-compile failures that `get-errors` misses. Required before returning a project to the user (see [validation-guide.md § Project Build Verification](validation-guide.md#project-build-verification-required-before-returning-a-project)). Runs independently of Studio IPC; takes the project directory as a positional argument.
 
 ```bash
-uip rpa build "<PROJECT_DIR>" --log-level Warn --output json```
+uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -244,7 +271,8 @@ Each rule returns `severity` (`error` / `warning` / `info`), rule ID (e.g. `ST-D
 Install or update NuGet packages in the project.
 
 ```bash
-uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]' --output json```
+uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]' --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -263,7 +291,9 @@ Omit `version` to automatically resolve the latest compatible version (preferred
 Get available versions for a NuGet package.
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --output jsonuip rpa get-versions --package-id <PackageId> --include-prerelease --output json```
+uip rpa get-versions --package-id <PackageId> --output json
+uip rpa get-versions --package-id <PackageId> --include-prerelease --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -340,7 +370,8 @@ Returns JSON:
 Get unautomated test case IDs from Test Manager.
 
 ```bash
-uip rpa get-manual-test-cases --project-dir "<PROJECT_DIR>" --output json```
+uip rpa get-manual-test-cases --project-dir "<PROJECT_DIR>" --output json
+```
 
 No command-specific options.
 
@@ -351,7 +382,8 @@ No command-specific options.
 Get steps for specific test cases from Test Manager.
 
 ```bash
-uip rpa get-manual-test-steps --test-case-ids "id1,id2,id3" --project-dir "<PROJECT_DIR>" --output json```
+uip rpa get-manual-test-steps --test-case-ids "id1,id2,id3" --project-dir "<PROJECT_DIR>" --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -524,10 +556,14 @@ When `uip` commands fail, diagnose by error category:
 | Error Pattern | Cause | Recovery |
 |---------------|-------|----------|
 | `"connection refused"`, `"EPIPE"`, `"pipe not found"` | Studio IPC not available. Headless Studio (Helm): NuGet restore failed or process exited. Studio Desktop: not running. | Re-run the command — headless Studio relaunches automatically. If it persists, raise `--timeout` and check the Helm restore output for NuGet errors. Only run `uip rpa start-studio` if the failing command is `diff`/`focus-activity` or `UIPATH_RPA_TOOL_USE_STUDIO=1` is set. |
+| `"does not support rpa-tool"`, `"does not have interop support"`, `"Requires Studio"` | Studio build does not support the CLI IPC protocol needed by the command | Stop retrying; record CLI/Studio versions and tell the user Studio must be updated or the command cannot be used in this environment |
+| `"Too many parameters for Task<string> ExecuteCommand"` | CLI and Studio IPC contract mismatch | Stop retrying; record CLI/Studio versions and report validation/execution as blocked by compatibility |
 | `"timeout"`, `"ETIMEDOUT"` | Command took too long. Cold Helm NuGet restore can take 30–90 s. | Raise the timeout: `uip rpa --timeout 600 <command>`. For `get-errors`, also try `--skip-validation`. |
+| Command produces no output until your shell timeout expires | Possible Studio IPC hang or package restore/build deadlock | Retry once with a larger `--timeout`; if it hangs again, treat as a compatibility/environment blocker and report it |
 | `"not authenticated"`, `401`, `403` | Auth required for cloud features | Run `uip login` and re-try |
 | `"package not found"`, `"version not available"` | Wrong package ID or version | Verify package name via `uip rpa find-activities`; omit `version` to auto-resolve latest |
-| `"project not found"`, `"no project open"` | Wrong project-dir or project not open in Studio | Verify `--project-dir` path, run `uip rpa open-project` |
+| `"project not found"`, `"no project open"` | Wrong project-dir or project not open | Verify `--project-dir` path; run `uip rpa open-project` only if the command needs an already-open project |
+| `"project is already opened in another Studio instance"` | Standalone compiler or wrong Studio instance is competing with an open project | Use the intended `--project-dir`, close idle Studio instances or ask the user to do so, then retry once |
 | `"file not found"` in `get-errors` | Wrong `--file-path` (must be relative to project) | Use path relative to project root, not absolute |
 | `"Studio is busy"`, `"operation in progress"` | Studio is processing a previous request | Wait a few seconds and retry the command |
 | Any unrecognized error | Unknown | Check `--verbose` flag: `uip rpa --verbose <command>` for debug details, inform the user |
@@ -543,7 +579,9 @@ When `uip` commands fail, diagnose by error category:
 Search for activities by keyword. Global search -- not limited to installed packages.
 
 ```bash
-uip rpa find-activities --query "<KEYWORD>" --output jsonuip rpa find-activities --query "<KEYWORD>" --tags "<TAGS>" --limit 20 --output json```
+uip rpa find-activities --query "<KEYWORD>" --output json
+uip rpa find-activities --query "<KEYWORD>" --tags "<TAGS>" --limit 20 --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -561,7 +599,8 @@ Get the default XAML template for an activity. Two modes depending on whether th
 # Non-dynamic activity:
 uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json
 # Dynamic activity (connector-backed):
-uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json```
+uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -576,7 +615,9 @@ uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id
 Search example workflows by service tags.
 
 ```bash
-uip rpa list-workflow-examples --tags "service1,service2" --output jsonuip rpa list-workflow-examples --tags "service1" --prefix "<PREFIX>" --limit 20 --output json```
+uip rpa list-workflow-examples --tags "service1,service2" --output json
+uip rpa list-workflow-examples --tags "service1" --prefix "<PREFIX>" --limit 20 --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -591,7 +632,8 @@ uip rpa list-workflow-examples --tags "service1,service2" --output jsonuip rpa l
 Retrieve the full XAML content of an example workflow.
 
 ```bash
-uip rpa get-workflow-example --key "<BLOB_PATH>" --output json```
+uip rpa get-workflow-example --key "<BLOB_PATH>" --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -604,7 +646,9 @@ uip rpa get-workflow-example --key "<BLOB_PATH>" --output json```
 Focus an activity in the Studio Desktop designer view. **Requires a running Studio Desktop instance** — does not work against headless Studio. Run `uip rpa start-studio --project-dir "<PROJECT_DIR>"` first if Studio Desktop is not already up.
 
 ```bash
-uip rpa focus-activity --activity-id "<IDREF>" --output jsonuip rpa focus-activity --output json```
+uip rpa focus-activity --activity-id "<IDREF>" --output json
+uip rpa focus-activity --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -638,7 +682,8 @@ Use the `packageId` and `version` from results with `uip rpa create-project --te
 Close the current project in Studio.
 
 ```bash
-uip rpa close-project --output json```
+uip rpa close-project --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -56,6 +56,17 @@ REPEAT:
 
 See [cli-reference.md](cli-reference.md) for full `get-errors` and `run-file` command documentation.
 
+### When Validation Is Blocked by Studio IPC Compatibility
+
+The requirement to validate does not permit indefinite retries. Before the validation loop, record `uip --version` and `uip rpa list-instances --output json` so you know the CLI and Studio versions involved.
+
+If `get-errors`, `run-file`, `build`, or `analyze` reports a Studio/rpa-tool compatibility error, an IPC contract mismatch such as `Too many parameters for Task<string> ExecuteCommand`, or hangs with no output after the configured timeout, follow [cli-reference.md § Studio IPC Compatibility Preflight](cli-reference.md#studio-ipc-compatibility-preflight):
+
+1. Stop retrying the same command after one diagnostic retry.
+2. Do not claim the workflow is validated or runnable.
+3. Continue only with edits that can be made safely without that command.
+4. In the final response, state the exact command that was blocked, the CLI/Studio versions, and that validation or execution could not be completed in this environment.
+
 ## Project Build Verification (Required Before Returning a Project)
 
 Every project returned to the user must compile. After all files pass `get-errors`, run:
@@ -78,7 +89,8 @@ uip rpa run-file --file-path "<FILE>" --output json
 # Run with input arguments:
 uip rpa run-file --file-path "<FILE>" --input-arguments '{"key": "value"}' --output json
 # Run with verbose logging for debugging:
-uip rpa run-file --file-path "<FILE>" --log-level Verbose --output json```
+uip rpa run-file --file-path "<FILE>" --log-level Verbose --output json
+```
 
 **When to run:**
 1. Workflow has no compilation errors but you want to verify runtime behavior
@@ -112,7 +124,8 @@ C) <user-driven approach>
 ```
 Read: file_path="{projectRoot}/project.json"     -> check current dependencies
 
-Bash: uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]'```
+Bash: uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]'
+```
 
 Omit `version` to automatically resolve the latest compatible version (preferred — gets newest docs and features). Only pin a specific version when you have a reason to (e.g., known compatibility constraint).
 
@@ -138,7 +151,8 @@ When `get-errors` returns an error referencing a specific activity (by IdRef or 
 # Focus a specific activity by its IdRef (from the error output):
 uip rpa focus-activity --activity-id "Assign_1"
 # Focus all activities sequentially (useful for walkthrough):
-uip rpa focus-activity```
+uip rpa focus-activity
+```
 
 This is especially useful when:
 - An error references an activity and you want the user to confirm the context


### PR DESCRIPTION
## Summary
- add an RPA Studio IPC compatibility preflight for recording CLI and Studio versions
- document known compatibility dead-end signatures such as unsupported `rpa-tool`, IPC contract mismatch, silent command hangs, and Studio DB lock conflicts
- update validation guidance so agents stop retry loops and report validation/execution as blocked when the environment cannot run the required command
- keep guidance host-neutral by avoiding stale Studio-targeting flag examples

## Why
When the CLI and Studio IPC protocol are incompatible, agents can waste many iterations retrying `get-errors`, `run-file`, `build`, or `analyze` as if they were workflow errors. This change gives the skill a clear stop condition and a better user-facing report path for those environments.

Refs #241
Refs #261

## Validation
- `git diff --check origin/main...HEAD`
- synthetic merge check against `origin/main`
- added-line scan for stale or malformed RPA snippets, including stale Studio-targeting flags and same-line code-fence hazards
- RPA UIA boundary added-line scan
