### PR TITLE
docs(uipath-maestro-flow): add fast-path flow example

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -40,6 +40,7 @@ Comprehensive guide for creating, editing, validating, debugging, publishing, an
 | I want to...                                                 | Read                                                                                             |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
 | Create a new flow or edit an existing one                    | [references/author/CAPABILITY.md](references/author/CAPABILITY.md)                               |
+| Start from a known-good branching example                    | [references/examples/README.md](references/examples/README.md)                                   |
 | Publish, deploy, debug, or manage a flow's lifecycle         | [references/operate/CAPABILITY.md](references/operate/CAPABILITY.md)                             |
 | Diagnose a failed or misbehaving flow run                    | [references/diagnose/CAPABILITY.md](references/diagnose/CAPABILITY.md)                           |
 | Look up CLI command syntax                                   | [references/shared/cli-commands.md](references/shared/cli-commands.md)                                   |

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-cli.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-cli.md
@@ -31,7 +31,11 @@ uip maestro flow node add <ProjectName>.flow <nodeType> --output json \
 | `--position` | No | `x,y` coordinates. Any value is fine (e.g. `0,0`) — `flow tidy` rewrites positions on save. |
 | `--output json` | Yes (for parsing) | Structured JSON response with the assigned node `id` |
 
-**Shell quoting tip:** If `--input` JSON contains special characters (quotes, braces, `$vars`), write it to a temp file:
+**Shell quoting tip:** There is no `--input-file` flag for `node add` in current
+CLI releases. If `--input` JSON contains special characters (quotes, braces,
+`$vars`), prefer the Direct JSON strategy. If the user explicitly requested CLI,
+write the input to a temp file and pass its contents through command
+substitution:
 
 ```bash
 cat > /tmp/input.json << 'ENDJSON'

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations.md
@@ -6,6 +6,12 @@ Strategy selection and shared concepts for modifying `.flow` files. Two implemen
 
 > **Default to Direct JSON for all `.flow` edits.** Use CLI only when the user explicitly requests CLI, or for connector, connector-trigger, or inline-agent nodes (see carve-out rows in the matrix below).
 
+For common manual-trigger branching flows, use
+[examples/decision-branch.flow](examples/decision-branch.flow) as the starting
+template instead of adding each non-connector node through `node add`. It avoids
+inline JSON shell escaping for `$vars`, backticks, quotes, and multiline scripts
+while preserving a validator-clean topology that can be adapted in-place.
+
 | Strategy | Guide | When to use |
 |----------|-------|-------------|
 | **Direct JSON** (default) | [editing-operations-json.md](editing-operations-json.md) | Default for all `.flow` edits — node/edge CRUD, variables, subflows, output mapping, in-place input updates. |
@@ -73,6 +79,12 @@ These apply regardless of which strategy you use.
 - Do not validate after each individual edit — intermediate states are expected to be invalid
 - Validation checks: JSON schema, definitions coverage, edge references, unique IDs
 - Validation does NOT check: connector configuration, connection health, expression correctness, required field completeness
+- If a validation warning claims a required node input is missing, inspect the
+  actual node `inputs` and the registry definition before changing working JSON.
+  Older CLI versions have reported `REQUIRED_FIELD` warnings for fields that
+  were present, especially after complex inline `--input` values. Prefer direct
+  JSON edits when the input contains `$vars`, quotes, backticks, or multiline
+  script.
 
 ### Expression prefix rules
 

--- a/skills/uipath-maestro-flow/references/examples/README.md
+++ b/skills/uipath-maestro-flow/references/examples/README.md
@@ -1,0 +1,29 @@
+# Flow Examples
+
+This directory contains complete `.flow` files that can be copied into a
+scaffolded Flow project and validated locally. Use them as known-good baselines
+when building common patterns directly in JSON.
+
+## Decision Branch
+
+`decision-branch.flow` demonstrates:
+
+- manual trigger
+- script output captured in `$vars`
+- decision node with `true` and `false` branches
+- two branch-specific script nodes
+- separate End nodes with workflow output mappings
+- registry-derived definitions for every node type
+- horizontal layout entries for every node
+
+Validate the example before using it:
+
+```bash
+uip maestro flow validate skills/uipath-maestro-flow/references/examples/decision-branch.flow --output json
+```
+
+To use it as a starting point, scaffold a Flow project with
+`uip maestro flow init`, replace the generated `<ProjectName>.flow` contents
+with this file, then update the top-level `name` and any node labels or scripts.
+Keep the `.flow` file extension; `uip maestro flow validate` rejects copied
+examples that are renamed with a `.json` suffix.

--- a/skills/uipath-maestro-flow/references/examples/decision-branch.flow
+++ b/skills/uipath-maestro-flow/references/examples/decision-branch.flow
@@ -1,0 +1,950 @@
+{
+  "id": "00000000-0000-4000-8000-000000000114",
+  "version": "1.0.0",
+  "name": "DecisionBranchExample",
+  "nodes": [
+    {
+      "id": "start",
+      "type": "core.trigger.manual",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Manual trigger"
+      },
+      "inputs": {},
+      "outputs": {
+        "output": {
+          "type": "object",
+          "description": "Data passed when manually triggering the workflow.",
+          "source": "null",
+          "var": "output"
+        }
+      },
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": "00000000-0000-4000-8000-000000000001",
+        "isDefaultEntryPoint": true
+      }
+    },
+    {
+      "id": "rollDice",
+      "type": "core.action.script",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Roll Dice"
+      },
+      "inputs": {
+        "script": "const roll = Math.floor(Math.random() * 6) + 1;\nreturn { roll, isHigh: roll >= 4 };"
+      },
+      "outputs": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the dice roll script",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the script fails",
+          "source": "=result.Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "model": {
+        "type": "bpmn:ScriptTask"
+      }
+    },
+    {
+      "id": "checkHighRoll",
+      "type": "core.logic.decision",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "High Roll?"
+      },
+      "inputs": {
+        "expression": "$vars.rollDice.output.isHigh === true",
+        "trueLabel": "High",
+        "falseLabel": "Low"
+      },
+      "model": {
+        "type": "bpmn:InclusiveGateway"
+      }
+    },
+    {
+      "id": "formatHigh",
+      "type": "core.action.script",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Format High"
+      },
+      "inputs": {
+        "script": "return { message: `High roll: ${$vars.rollDice.output.roll}` };"
+      },
+      "outputs": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the high-roll formatter",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the script fails",
+          "source": "=result.Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "model": {
+        "type": "bpmn:ScriptTask"
+      }
+    },
+    {
+      "id": "formatLow",
+      "type": "core.action.script",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Format Low"
+      },
+      "inputs": {
+        "script": "return { message: `Low roll: ${$vars.rollDice.output.roll}` };"
+      },
+      "outputs": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the low-roll formatter",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the script fails",
+          "source": "=result.Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "model": {
+        "type": "bpmn:ScriptTask"
+      }
+    },
+    {
+      "id": "endHigh",
+      "type": "core.control.end",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "High Done"
+      },
+      "inputs": {},
+      "outputs": {
+        "resultMessage": {
+          "source": "=js:$vars.formatHigh.output.message"
+        },
+        "roll": {
+          "source": "=js:$vars.rollDice.output.roll"
+        }
+      },
+      "model": {
+        "type": "bpmn:EndEvent"
+      }
+    },
+    {
+      "id": "endLow",
+      "type": "core.control.end",
+      "typeVersion": "1.0.0",
+      "display": {
+        "label": "Low Done"
+      },
+      "inputs": {},
+      "outputs": {
+        "resultMessage": {
+          "source": "=js:$vars.formatLow.output.message"
+        },
+        "roll": {
+          "source": "=js:$vars.rollDice.output.roll"
+        }
+      },
+      "model": {
+        "type": "bpmn:EndEvent"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "id": "edge-start-rollDice",
+      "sourceNodeId": "start",
+      "sourcePort": "output",
+      "targetNodeId": "rollDice",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-rollDice-checkHighRoll",
+      "sourceNodeId": "rollDice",
+      "sourcePort": "success",
+      "targetNodeId": "checkHighRoll",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-checkHighRoll-formatHigh",
+      "sourceNodeId": "checkHighRoll",
+      "sourcePort": "true",
+      "targetNodeId": "formatHigh",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-checkHighRoll-formatLow",
+      "sourceNodeId": "checkHighRoll",
+      "sourcePort": "false",
+      "targetNodeId": "formatLow",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-formatHigh-endHigh",
+      "sourceNodeId": "formatHigh",
+      "sourcePort": "success",
+      "targetNodeId": "endHigh",
+      "targetPort": "input"
+    },
+    {
+      "id": "edge-formatLow-endLow",
+      "sourceNodeId": "formatLow",
+      "sourcePort": "success",
+      "targetNodeId": "endLow",
+      "targetPort": "input"
+    }
+  ],
+  "definitions": [
+    {
+      "nodeType": "core.trigger.manual",
+      "version": "1.0.0",
+      "category": "trigger",
+      "description": "Start workflow manually",
+      "tags": [
+        "trigger",
+        "start",
+        "manual"
+      ],
+      "sortOrder": 40,
+      "display": {
+        "label": "Manual trigger",
+        "icon": "play",
+        "shape": "circle",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "output",
+              "type": "source",
+              "handleType": "output",
+              "showButton": true,
+              "constraints": {
+                "forbiddenTargetCategories": [
+                  "trigger"
+                ]
+              }
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": true
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "Data passed when manually triggering the workflow.",
+          "source": "null",
+          "var": "output"
+        }
+      },
+      "toolbarExtensions": {
+        "design": {
+          "actions": [
+            {
+              "id": "change-trigger-type",
+              "icon": "replace",
+              "label": "Change trigger type"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "nodeType": "core.action.script",
+      "version": "1.0.0",
+      "category": "data-operations",
+      "description": "Run custom JavaScript code",
+      "tags": [
+        "code",
+        "javascript",
+        "python"
+      ],
+      "sortOrder": 35,
+      "supportsErrorHandling": true,
+      "display": {
+        "label": "Script",
+        "icon": "code",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "success",
+              "type": "source",
+              "handleType": "output"
+            }
+          ]
+        }
+      ],
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:ScriptTask"
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "A script function is required",
+            "validationSeverity": "warning"
+          }
+        },
+        "required": [
+          "script"
+        ]
+      },
+      "inputDefaults": {
+        "script": ""
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the script",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the script fails",
+          "source": "=result.Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "form": {
+        "id": "script-properties",
+        "title": "Script configuration",
+        "sections": [
+          {
+            "id": "script",
+            "title": "Script",
+            "collapsible": true,
+            "defaultExpanded": true,
+            "fields": [
+              {
+                "name": "inputs.script",
+                "type": "custom",
+                "component": "script-editor",
+                "componentProps": {
+                  "language": "javascript",
+                  "returnType": "any",
+                  "validationMode": "script",
+                  "minHeight": 200,
+                  "placeholder": " // Return an object with your result\nreturn {\n  message: \"Web request response\",\n  data: $vars.httpRequest1.output\n                  };"
+                },
+                "label": "Code",
+                "description": "JavaScript expression that returns a result object"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "nodeType": "core.logic.decision",
+      "version": "1.0.0",
+      "category": "control-flow",
+      "description": "Branch based on a true/false condition",
+      "tags": [
+        "control-flow",
+        "if",
+        "loop",
+        "switch"
+      ],
+      "sortOrder": 20,
+      "display": {
+        "label": "Decision",
+        "icon": "trending-up-down",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "true",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.trueLabel}",
+              "constraints": {
+                "minConnections": 1
+              }
+            },
+            {
+              "id": "false",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.falseLabel}",
+              "constraints": {
+                "minConnections": 1
+              }
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:InclusiveGateway"
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "expression": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "A condition expression is required"
+          },
+          "trueLabel": {
+            "type": "string"
+          },
+          "falseLabel": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "expression"
+        ]
+      },
+      "outputDefinition": {
+        "matchedCase": {
+          "type": "string",
+          "description": "The label of the matched branch (true/false label)",
+          "var": "matchedCase"
+        },
+        "matchedCaseId": {
+          "type": "string",
+          "description": "The branch that was taken (true or false)",
+          "var": "matchedCaseId"
+        }
+      },
+      "inputDefaults": {
+        "trueLabel": "True",
+        "falseLabel": "False"
+      },
+      "form": {
+        "id": "decision-properties",
+        "title": "Decision configuration",
+        "sections": [
+          {
+            "id": "condition",
+            "title": "Condition",
+            "fields": [
+              {
+                "name": "inputs.expression",
+                "type": "custom",
+                "component": "script-editor",
+                "componentProps": {
+                  "language": "javascript",
+                  "returnType": "boolean",
+                  "validationMode": "expression",
+                  "minHeight": 100,
+                  "placeholder": "e.g., $vars.data.status === \"approved\" && $vars.data.amount > 1000"
+                },
+                "label": "Expression",
+                "description": "JavaScript expression that evaluates to true or false"
+              },
+              {
+                "name": "inputs.trueLabel",
+                "type": "text",
+                "label": "True branch label",
+                "description": "Label shown when condition is true"
+              },
+              {
+                "name": "inputs.falseLabel",
+                "type": "text",
+                "label": "False branch label",
+                "description": "Label shown when condition is false"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "nodeType": "core.control.end",
+      "version": "1.0.0",
+      "category": "control-flow",
+      "description": "Mark the end of a workflow path",
+      "tags": [
+        "control-flow",
+        "end",
+        "finish",
+        "complete"
+      ],
+      "sortOrder": 20,
+      "display": {
+        "label": "End",
+        "icon": "circle-check",
+        "shape": "circle"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        }
+      ],
+      "model": {
+        "type": "bpmn:EndEvent"
+      },
+      "runtimeConstraints": {
+        "exclude": [
+          "api-function"
+        ]
+      }
+    }
+  ],
+  "bindings": [],
+  "variables": {
+    "globals": [
+      {
+        "id": "resultMessage",
+        "direction": "out",
+        "type": "string",
+        "description": "Message from the branch that completed."
+      },
+      {
+        "id": "roll",
+        "direction": "out",
+        "type": "number",
+        "description": "Dice value from 1 to 6."
+      }
+    ],
+    "nodes": [
+      {
+        "id": "start.output",
+        "type": "object",
+        "binding": {
+          "nodeId": "start",
+          "outputId": "output"
+        },
+        "description": "Data passed when manually triggering the workflow."
+      },
+      {
+        "id": "rollDice.output",
+        "type": "object",
+        "binding": {
+          "nodeId": "rollDice",
+          "outputId": "output"
+        },
+        "description": "The return value of the dice roll script"
+      },
+      {
+        "id": "rollDice.error",
+        "type": "object",
+        "binding": {
+          "nodeId": "rollDice",
+          "outputId": "error"
+        },
+        "description": "Error information if the script fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
+        "id": "formatHigh.output",
+        "type": "object",
+        "binding": {
+          "nodeId": "formatHigh",
+          "outputId": "output"
+        },
+        "description": "The return value of the high-roll formatter"
+      },
+      {
+        "id": "formatHigh.error",
+        "type": "object",
+        "binding": {
+          "nodeId": "formatHigh",
+          "outputId": "error"
+        },
+        "description": "Error information if the script fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      {
+        "id": "formatLow.output",
+        "type": "object",
+        "binding": {
+          "nodeId": "formatLow",
+          "outputId": "output"
+        },
+        "description": "The return value of the low-roll formatter"
+      },
+      {
+        "id": "formatLow.error",
+        "type": "object",
+        "binding": {
+          "nodeId": "formatLow",
+          "outputId": "error"
+        },
+        "description": "Error information if the script fails",
+        "schema": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "required": [
+            "code",
+            "message",
+            "detail",
+            "category",
+            "status"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "description": "Error code as a string"
+            },
+            "message": {
+              "type": "string",
+              "description": "High-level error message"
+            },
+            "detail": {
+              "type": "string",
+              "description": "Detailed error description"
+            },
+            "category": {
+              "type": "string",
+              "description": "Error category"
+            },
+            "status": {
+              "type": "integer",
+              "description": "HTTP status code"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    ],
+    "variableUpdates": {}
+  },
+  "layout": {
+    "nodes": {
+      "start": {
+        "position": {
+          "x": 256,
+          "y": 144
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "rollDice": {
+        "position": {
+          "x": 456,
+          "y": 144
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "checkHighRoll": {
+        "position": {
+          "x": 656,
+          "y": 144
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "formatHigh": {
+        "position": {
+          "x": 856,
+          "y": 44
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "formatLow": {
+        "position": {
+          "x": 856,
+          "y": 244
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "endHigh": {
+        "position": {
+          "x": 1056,
+          "y": 44
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      },
+      "endLow": {
+        "position": {
+          "x": 1056,
+          "y": 244
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        }
+      }
+    }
+  }
+}

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -230,6 +230,16 @@ See the [Diagnose troubleshooting guide](../diagnose/references/troubleshooting-
 
 See the [Author CLI editing strategy](../author/references/editing-operations-cli.md) for complete `node add/delete/list/configure` and `edge add/delete/list` syntax, flags, and auto-managed behaviors.
 
+### CLI input ergonomics
+
+`uip maestro flow node add` accepts inline JSON through `--input <json>`. Current
+CLI releases do not expose an `--input-file` or stdin form for this command.
+When node inputs include `$vars`, nested quotes, template literals, or multiline
+scripts, prefer the Direct JSON workflow or start from
+[examples/decision-branch.flow](examples/decision-branch.flow) and edit the
+node `inputs` in-place. This keeps agents out of shell-escaping loops and makes
+the final `validate` pass the source of truth.
+
 ## uip maestro flow registry
 
 Manage the local node type cache. No auth required for OOTB nodes; login for tenant-specific connector nodes.

--- a/tests/tasks/uipath-maestro-flow/_shared/test_example_flows.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_example_flows.py
@@ -1,0 +1,96 @@
+"""Static checks for committed Flow examples.
+
+These tests keep copy-pasteable example flows aligned with the skill rules
+without requiring a tenant, debug run, or network access.
+"""
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+EXAMPLES_DIR = REPO_ROOT / "skills" / "uipath-maestro-flow" / "references" / "examples"
+
+
+def _load_example(name):
+    return json.loads((EXAMPLES_DIR / name).read_text())
+
+
+def test_decision_branch_example_has_expected_topology():
+    flow = _load_example("decision-branch.flow")
+
+    nodes = {node["id"]: node for node in flow["nodes"]}
+    assert set(nodes) == {
+        "start",
+        "rollDice",
+        "checkHighRoll",
+        "formatHigh",
+        "formatLow",
+        "endHigh",
+        "endLow",
+    }
+
+    assert nodes["start"]["type"] == "core.trigger.manual"
+    assert nodes["rollDice"]["type"] == "core.action.script"
+    assert nodes["checkHighRoll"]["type"] == "core.logic.decision"
+    assert nodes["formatHigh"]["type"] == "core.action.script"
+    assert nodes["formatLow"]["type"] == "core.action.script"
+    assert nodes["endHigh"]["type"] == "core.control.end"
+    assert nodes["endLow"]["type"] == "core.control.end"
+
+    edge_tuples = {
+        (
+            edge["sourceNodeId"],
+            edge["sourcePort"],
+            edge["targetNodeId"],
+            edge["targetPort"],
+        )
+        for edge in flow["edges"]
+    }
+    assert edge_tuples == {
+        ("start", "output", "rollDice", "input"),
+        ("rollDice", "success", "checkHighRoll", "input"),
+        ("checkHighRoll", "true", "formatHigh", "input"),
+        ("checkHighRoll", "false", "formatLow", "input"),
+        ("formatHigh", "success", "endHigh", "input"),
+        ("formatLow", "success", "endLow", "input"),
+    }
+
+
+def test_decision_branch_example_has_agent_safe_runtime_metadata():
+    flow = _load_example("decision-branch.flow")
+    nodes = {node["id"]: node for node in flow["nodes"]}
+
+    assert "return { roll, isHigh: roll >= 4 };" in nodes["rollDice"]["inputs"]["script"]
+    assert nodes["checkHighRoll"]["inputs"]["expression"] == (
+        "$vars.rollDice.output.isHigh === true"
+    )
+
+    for node_id in ("start", "rollDice", "formatHigh", "formatLow"):
+        assert nodes[node_id]["outputs"], f"{node_id} must define node outputs"
+
+    assert nodes["endHigh"]["outputs"] == {
+        "resultMessage": {"source": "=js:$vars.formatHigh.output.message"},
+        "roll": {"source": "=js:$vars.rollDice.output.roll"},
+    }
+    assert nodes["endLow"]["outputs"] == {
+        "resultMessage": {"source": "=js:$vars.formatLow.output.message"},
+        "roll": {"source": "=js:$vars.rollDice.output.roll"},
+    }
+
+    definition_types = {definition["nodeType"] for definition in flow["definitions"]}
+    assert definition_types == {
+        "core.trigger.manual",
+        "core.action.script",
+        "core.logic.decision",
+        "core.control.end",
+    }
+
+    assert set(flow["layout"]["nodes"]) == set(nodes)
+    xs = {
+        node_id: layout["position"]["x"]
+        for node_id, layout in flow["layout"]["nodes"].items()
+    }
+    assert xs["start"] < xs["rollDice"] < xs["checkHighRoll"]
+    assert xs["checkHighRoll"] < xs["formatHigh"] < xs["endHigh"]
+    assert xs["checkHighRoll"] < xs["formatLow"] < xs["endLow"]


### PR DESCRIPTION
## Summary
- Add a validator-clean `decision-branch.flow` example for the common manual trigger -> script -> decision -> branch scripts -> End-node pattern.
- Document the example as the fast path for common branching flows and clarify when agents should avoid inline `node add --input` shell-escaping loops.
- Add helper pytest coverage for the example topology, outputs, definitions, and horizontal layout.

## Why
Agents building Flow projects can lose time fighting inline JSON quoting for `$vars`, template literals, and multiline scripts. A complete `.flow` baseline gives them a copyable, validated starting point for a common branching pattern while preserving the Direct JSON default.

Refs #114

## Validation
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh skills/uipath-maestro-flow/SKILL.md`
- `python3 -m pytest tests/tasks/uipath-maestro-flow/_shared -q`
- `npx -y @uipath/cli@latest maestro flow validate skills/uipath-maestro-flow/references/examples/decision-branch.flow --output json`
