### PR TITLE
docs(uipath-rpa): add semantic XAML editing guide

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -154,6 +154,7 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 | **Use XAML test activities** | XAML | [testing-guide.md § XAML Test Activities](references/testing-guide.md) |
 | **Use execution templates** | XAML | [testing-guide.md § Execution Templates](references/testing-guide.md) |
 | **Create/edit XAML workflow** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/xaml-basics-and-rules.md](references/xaml/xaml-basics-and-rules.md) |
+| **Perform structural XAML edits** | XAML | [xaml/semantic-editing-guide.md](references/xaml/semantic-editing-guide.md) for activity inserts, arguments, variables, imports, references, and validation checkpoints |
 | **Create Flowchart/StateMachine/LRW** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) |
 | **Write UI automation** | Both | [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) |
 | **Build multi-screen UIA XAML workflow** | XAML | [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md § Multi-Step UI Flows](references/uia-configure-target-workflows.md#multi-step-ui-flows) |
@@ -262,6 +263,7 @@ The XAML file anatomy template (namespace declarations, root Activity element, b
 ### Key References
 
 - [xaml/xaml-basics-and-rules.md](references/xaml/xaml-basics-and-rules.md) — XAML anatomy, safety rules, editing operations (read before any XAML work)
+- [xaml/semantic-editing-guide.md](references/xaml/semantic-editing-guide.md) — Structured edit recipes for safe inserts, arguments, variables, imports, references, and validation
 - [xaml/common-pitfalls.md](references/xaml/common-pitfalls.md) — Activity gotchas, scope requirements, property conflicts
 - [xaml/csharp-activity-binding-guide.md](references/xaml/csharp-activity-binding-guide.md) — Canonical C# binding forms per common activity property (LogMessage, GetText, StartProcess, …) — flat lookup table + recipes
 - [xaml/csharp-expression-pitfalls.md](references/xaml/csharp-expression-pitfalls.md) — C#-specific expression failures (attribute-form VB JIT, ThrowIfNotInTree, OutArgument parse errors)
@@ -284,7 +286,8 @@ Check `project.json` → `dependencies` for the required package.
 - **If absent** → install:
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output jsonuip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
+uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output json
+uip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
 ```
 
 ### Step 2 — Find activity docs (priority order)

--- a/skills/uipath-rpa/references/xaml/semantic-editing-guide.md
+++ b/skills/uipath-rpa/references/xaml/semantic-editing-guide.md
@@ -1,0 +1,175 @@
+# Semantic XAML Editing Guide
+
+Use this guide when modifying an existing `.xaml` workflow by adding or moving
+activities, arguments, variables, namespace imports, or assembly references.
+Treat each change as a structured operation on the workflow tree, then apply the
+smallest possible textual diff to preserve prefixes, designer metadata, and
+surrounding layout.
+
+## Decision Rules
+
+| Task | Preferred path |
+| --- | --- |
+| Add a UI Automation target | Use `uia-configure-target`; do not hand-edit selectors |
+| Add a package activity | Use `find-activities` and `get-default-activity-xaml`, then adapt the returned snippet |
+| Add an Integration Service connector activity | Follow `../is-connector-xaml-guide.md`; schema and connection binding are required |
+| Add workflow arguments, variables, imports, or references | Use the recipes below |
+| Rewrite large control-flow regions | Prefer a new workflow file or ask the user to confirm the restructuring |
+| Edit a Flowchart, State Machine, or ProcessDiagram layout | Read `canvas-layout-guide.md` first and preserve existing ViewState |
+
+## Pre-Edit Checklist
+
+1. Read `project.json` and record `expressionLanguage`, `targetFramework`, and
+   installed package versions.
+2. Run a baseline validation before editing:
+   `uip rpa get-errors --file-path "<relative/path.xaml>" --output json`.
+3. Read the full target `.xaml` file once, then identify a narrow, unique anchor:
+   `DisplayName` plus activity type is safer than `DisplayName` alone.
+4. Collect existing root `xmlns:*` prefixes, `x:Name` values, and
+   `sap2010:WorkflowViewState.IdRef` values.
+5. Decide the exact operation first: `insert-activity`, `add-argument`,
+   `add-variable`, `add-namespace-import`, `add-assembly-reference`, or
+   `validate-and-save`.
+
+If the baseline has errors, separate pre-existing errors from errors introduced
+by your edit. Do not claim the edit caused or fixed unrelated baseline errors.
+
+## Operation Recipes
+
+### Insert Activity
+
+1. Discover the activity class and package:
+   `uip rpa find-activities --query "<task>" --output json`.
+2. Get starter XAML from the installed package:
+   `uip rpa get-default-activity-xaml --activity-class-name "<class>" --output json`.
+3. Read the activity docs from `{PROJECT_DIR}/.local/docs/packages/{PackageId}/`
+   or the bundled fallback under `../activity-docs/{PackageId}/`.
+4. Trim the starter snippet to the activity element and required child elements.
+   Keep package-specific property objects when docs say they are required.
+5. Insert the snippet into the correct parent collection:
+   - `Sequence`: direct child of the sequence, after the anchor activity.
+   - `If.Then` / `If.Else`: inside the branch `Sequence`, not beside the `If`.
+   - Scope activity bodies: inside the body `Sequence`, not beside the scope.
+   - `Flowchart` / `ProcessDiagram`: follow the node-wrapper and `x:Reference`
+     registration rules in `xaml-basics-and-rules.md`.
+6. Give the new activity a unique `DisplayName` and a unique
+   `sap2010:WorkflowViewState.IdRef` when the surrounding file uses IdRefs.
+7. Add only the missing root namespace declarations and imports/references.
+8. Validate immediately with `get-errors`.
+
+### Add Argument
+
+Add arguments only inside the root `<x:Members>` block:
+
+```xml
+<x:Property Name="in_CustomerId" Type="InArgument(x:String)" />
+<x:Property Name="out_Result" Type="OutArgument(x:String)" />
+<x:Property Name="io_Attempts" Type="InOutArgument(x:Int32)" />
+```
+
+Rules:
+
+- Use `in_`, `out_`, and `io_` prefixes.
+- Preserve existing argument order and naming style when the file already has
+  arguments.
+- Use the type aliases already present in the file when possible.
+- Add the required root namespace only when the type is not already resolvable.
+
+### Add Variable
+
+Add variables to the nearest owning activity that needs the state:
+
+```xml
+<Sequence.Variables>
+  <Variable x:TypeArguments="x:String" Name="statusText" />
+</Sequence.Variables>
+```
+
+Rules:
+
+- Put `<Sequence.Variables>` before executable child activities.
+- For `Flowchart`, use `<Flowchart.Variables>`.
+- For `StateMachine`, use the variable collection supported by the surrounding
+  workflow structure.
+- Do not place a variable in a branch if a later sibling activity must read it.
+- Prefer narrower scope when the value is used only inside one branch or loop.
+
+### Add Namespace Import
+
+Namespace imports belong inside the single
+`TextExpression.NamespacesForImplementation` collection:
+
+```xml
+<TextExpression.NamespacesForImplementation>
+  <sco:Collection x:TypeArguments="x:String">
+    <x:String>System</x:String>
+    <x:String>UiPath.Platform.ResourceHandling</x:String>
+  </sco:Collection>
+</TextExpression.NamespacesForImplementation>
+```
+
+Rules:
+
+- Do not create a second `TextExpression.NamespacesForImplementation` block.
+- Do not create a second `<sco:Collection>` child.
+- Insert into the existing collection and keep the existing `sco` prefix.
+- Avoid duplicate `<x:String>` entries.
+
+### Add Assembly Reference
+
+Assembly references belong inside the single
+`TextExpression.ReferencesForImplementation` collection:
+
+```xml
+<TextExpression.ReferencesForImplementation>
+  <sco:Collection x:TypeArguments="AssemblyReference">
+    <AssemblyReference>System.Data</AssemblyReference>
+    <AssemblyReference>UiPath.System.Activities</AssemblyReference>
+  </sco:Collection>
+</TextExpression.ReferencesForImplementation>
+```
+
+Rules:
+
+- Do not duplicate an existing assembly reference.
+- Match the package assembly name from the activity docs or default XAML.
+- Keep the existing collection prefix and type argument form.
+
+## Prefix and ViewState Safety
+
+UiPath XAML uses namespace prefixes as part of the designer contract. XML tools
+that reserialize the whole document may rename prefixes, reorder attributes, or
+collapse nodes in ways Studio can load differently.
+
+Keep these invariants:
+
+- Preserve root `xmlns:*` prefixes exactly unless adding a new prefix.
+- Preserve `mc:Ignorable` prefix names. If you add a designer prefix that must be
+  ignorable, add that literal prefix to `mc:Ignorable`.
+- Preserve every existing `sap2010:WorkflowViewState.IdRef`.
+- Generate unique IdRefs for new nodes only; never renumber existing ones.
+- Preserve existing `x:Name` values and `x:Reference` targets.
+- Avoid reformatting the whole file.
+
+## Validation Loop
+
+After every operation:
+
+1. Run `uip rpa get-errors --file-path "<relative/path.xaml>" --output json`.
+2. If errors appear, fix one category at a time: package, structure, type,
+   activity properties, then logic.
+3. Stop after five failed fix attempts and report the current error output.
+4. Run `uip rpa build --project-dir "<PROJECT_DIR>" --output json` before
+   reporting the workflow as verified, unless a successful `run-file` smoke test
+   already compiled the project.
+
+## Stop Conditions
+
+Stop and ask for help instead of continuing to patch when:
+
+- the anchor activity is not unique;
+- a UI selector or Object Repository target is missing;
+- the edit requires changing project `expressionLanguage` or `targetFramework`;
+- a dynamic connector activity lacks schema or connection metadata;
+- a Flowchart/State Machine/ProcessDiagram edit needs a layout you cannot infer;
+- `get-errors`, `build`, or Studio IPC is unavailable in the environment.

--- a/skills/uipath-rpa/references/xaml/workflow-guide.md
+++ b/skills/uipath-rpa/references/xaml/workflow-guide.md
@@ -94,7 +94,7 @@ Read: file_path="{projectRoot}/ExistingWorkflow.xaml"
 Use when you need to find which activity implements a user-described action:
 
 ```bash
-uip rpa find-activities --query "send mail" --limit 10 --output json```
+uip rpa find-activities --query "send mail" --limit 10 --output json
 ```
 
 - Results are **global** — not limited to installed packages
@@ -123,7 +123,8 @@ Use `uip rpa get-default-activity-xaml` when activity docs are insufficient:
 # Non-dynamic activity:
 uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json
 # Dynamic activity (connector-backed):
-uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json```
+uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json
+```
 
 For JIT custom types: `Read: file_path="{projectRoot}/.project/JitCustomTypesSchema.json"`. See [jit-custom-types-schema.md](jit-custom-types-schema.md).
 
@@ -132,10 +133,11 @@ For JIT custom types: `Read: file_path="{projectRoot}/.project/JitCustomTypesSch
 Use when activity docs, `find-activities`, and `get-default-activity-xaml` don't provide enough context:
 
 ```bash
-uip rpa list-workflow-examples --tags web --limit 10 --output jsonuip rpa get-workflow-example --key "<BLOB_PATH>"```
-
-**Complete tag list:** `adobe-sign`, `asana`, `box`, `concur`, `confluence`, `database`, `document-understanding`, `docusign`, `dropbox`, `email-generic`, `excel`, `excel-online`, `freshbooks`, `freshdesk`, `github`, `gmail`, `google-calendar`, `google-docs`, `google-drive`, `google-sheets`, `gsuite`, `hubspot`, `intacct`, `jira`, `mailchimp`, `marketo`, `microsoft-365`, `onedrive`, `outlook`, `outlook-calendar`, `pdf`, `powerpoint`, `productivity`, `quickbooks`, `salesforce`, `servicenow`, `sharepoint`, `shopify`, `slack`, `smartsheet`, `stripe`, `teams`, `testing`, `trello`, `web`, `webex`, `word`, `workday`, `zendesk`, `zoom`
+uip rpa list-workflow-examples --tags web --limit 10 --output json
+uip rpa get-workflow-example --key "<BLOB_PATH>" --output json
 ```
+
+**Complete tag list:** `adobe-sign`, `asana`, `box`, `concur`, `confluence`, `database`, `document-understanding`, `docusign`, `dropbox`, `email-generic`, `excel`, `excel-online`, `freshbooks`, `freshdesk`, `github`, `gmail`, `google-calendar`, `google-docs`, `google-drive`, `google-sheets`, `gsuite`, `hubspot`, `jira`, `mailchimp`, `marketo`, `microsoft-365`, `onedrive`, `outlook`, `outlook-calendar`, `pdf`, `powerpoint`, `productivity`, `quickbooks`, `salesforce`, `servicenow`, `sharepoint`, `shopify`, `slack`, `smartsheet`, `stripe`, `teams`, `testing`, `trello`, `web`, `webex`, `word`, `workday`, `zendesk`, `zoom`
 
 ### Step 1.8: Get Current Context (As Needed)
 
@@ -191,6 +193,12 @@ Edit: file_path=... old_string=<exact text> new_string=<modified text>
 
 **Critical:** `old_string` must match exactly and be unique. Include surrounding context if needed.
 
+For structural edits (activity insertions, arguments, variables, namespace
+imports, assembly references, or anchor-based changes), follow
+[semantic-editing-guide.md](semantic-editing-guide.md) before applying the diff.
+Choose the operation first, collect existing prefixes/IdRefs/anchors, apply the
+smallest targeted replacement, then validate.
+
 ---
 
 ## Phase 3: Validate & Fix Loop
@@ -200,7 +208,8 @@ Edit: file_path=... old_string=<exact text> new_string=<modified text>
 ### Step 3.1: Check for Errors
 
 ```bash
-uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --output json```
+uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --output json
+```
 
 `--file-path` must be **relative to the project directory**. Use `--skip-validation` only for quick cached-error checks.
 
@@ -247,3 +256,4 @@ For detailed procedures, see [../validation-guide.md](../validation-guide.md).
 - **NEVER** use connector activities without checking connection existence
 - **NEVER** ignore activity doc conditional property groups (OverloadGroup conflicts cause validation errors)
 - **NEVER** generate full XAML from scratch without using `get-default-activity-xaml` as a starting point
+- **NEVER** perform broad text rewrites for structural edits; use the semantic editing guide and preserve prefixes, IdRefs, and anchors

--- a/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
@@ -260,6 +260,10 @@ When editing XAML:
 - Do not reformat or re-indent the entire file
 - Only modify the specific section you need to change
 - Use the `Edit` tool for targeted replacements (match exact `old_string`, replace with `new_string`)
+- For structural edits such as activity insertion, arguments, variables,
+  namespace imports, or assembly references, follow
+  [semantic-editing-guide.md](semantic-editing-guide.md) before applying the
+  targeted replacement.
 
 ### Validate After Every Change
 Run `uip rpa get-errors` after every XAML modification. Do not batch multiple edits without validation — catching errors early is much easier than debugging compound issues.


### PR DESCRIPTION
## Summary
- Add a semantic XAML editing guide for structured activity inserts, arguments, variables, namespace imports, assembly references, and validation checkpoints.
- Route structural XAML edits from the RPA skill and XAML workflow docs to the new guide.
- Document prefix, IdRef, anchor, ViewState, and baseline-validation guardrails so agents avoid broad text rewrites of workflow files.

## Why
LLM agents editing UiPath workflows need a reliable workflow-tree mental model even before a dedicated WF-aware companion tool exists. This gives agents an immediate skill-side checklist for the common operations described in the feature request while preserving the existing Direct XAML and CLI validation flow.

Refs #76

## Validation
- `git diff --check`
- `git diff --cached --check`
- `bash hooks/validate-skill-descriptions.sh skills/uipath-rpa/SKILL.md`
- semantic guide link-target check for the new references
