### PR TITLE
fix(hooks): raise SKILL.md description limit from 250 to 1024 chars

### DIFF
--- a/.claude/rules/pr-review.md
+++ b/.claude/rules/pr-review.md
@@ -9,7 +9,7 @@ When reviewing or creating pull requests for this repository, enforce these rule
 - [ ] Folder is under `skills/` and named `uipath-<kebab-case>`
 - [ ] `SKILL.md` exists with valid YAML frontmatter
 - [ ] `name` field matches the folder name exactly
-- [ ] `description` has under 250 characters and is concise
+- [ ] `description` has under 1024 characters and is concise
 - [ ] Critical Rules section exists with numbered rules
 - [ ] No cross-skill references (skill is fully self-contained)
 - [ ] Reference files use kebab-case naming

--- a/.claude/rules/skill-review.md
+++ b/.claude/rules/skill-review.md
@@ -17,7 +17,7 @@ Does the skill follow the canonical layout and conventions?
 
 - SKILL.md has valid YAML frontmatter with `name` and `description`
 - `name` matches the folder name exactly
-- `description` is under 250 characters (Claude Code truncates non-bundled skill descriptions at 250 chars — run `hooks/validate-skill-descriptions.sh` to verify)
+- `description` is under 1024 characters (repo cap; Claude Code's hard truncation for `description` + `when_to_use` is 1,536 chars — run `hooks/validate-skill-descriptions.sh` to verify)
 - `description` front-loads the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters
 - `description` includes compact `→` redirects for commonly confused sibling skills (e.g., `For XAML→uipath-rpa`)
 - `description` starts with `[PREVIEW]` for new/unstable skills
@@ -26,7 +26,7 @@ Does the skill follow the canonical layout and conventions?
 - Folder organization is logical (references/, assets/, scripts/)
 - No orphaned files (every file is reachable from SKILL.md)
 
-**Red flags:** missing frontmatter fields, name mismatch, description over 250 chars, verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files.
+**Red flags:** missing frontmatter fields, name mismatch, description over 1024 chars, verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files.
 
 ### 2. Consistency (1-5)
 
@@ -89,13 +89,13 @@ Is the skill ready for public use as a plugin?
 
 - `description` in frontmatter is detailed enough for the plugin system to match it correctly — not too broad (false triggers on unrelated requests), not too narrow (misses valid use cases)
 - `description` uses compact `→` redirects to prevent conflicts with commonly confused sibling skills (e.g., `For XAML→uipath-rpa`)
-- `description` passes the 250-character validation hook (`hooks/validate-skill-descriptions.sh`)
+- `description` passes the 1024-character validation hook (`hooks/validate-skill-descriptions.sh`)
 - The skill does not assume any state that the plugin's SessionStart hook doesn't guarantee
 - No hardcoded paths, tokens, or environment-specific assumptions
 - Works on all platforms the skill claims to support
 - CODEOWNERS entry exists
 
-**Red flags:** description that triggers on generic terms, missing `→` redirects for sibling skills, description over 250 chars, hardcoded localhost URLs or personal paths, no CODEOWNERS entry.
+**Red flags:** description that triggers on generic terms, missing `→` redirects for sibling skills, description over 1024 chars, hardcoded localhost URLs or personal paths, no CODEOWNERS entry.
 
 ## Output Format
 

--- a/.claude/rules/skill-structure.md
+++ b/.claude/rules/skill-structure.md
@@ -29,7 +29,7 @@ description: "<identity> (<unique signal>). <core actions>. For <confusing-case>
 ### Validation Rules
 
 - `name` MUST exactly match the parent folder name
-- `description` MUST be under 250 characters. Claude Code truncates non-bundled skill descriptions at 250 chars in the system prompt — anything beyond is invisible to the model
+- `description` MUST be under 1024 characters. Claude Code truncates `description` + `when_to_use` at 1,536 chars in the skill listing ([source](https://code.claude.com/docs/en/skills.md)); 1024 is the repo cap to keep descriptions focused and leave headroom
 - `description` MUST start with `[PREVIEW]` when the skill is first created. Remove the tag only when the skill is considered stable
 - `description` MUST front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters
 - `description` MUST include compact redirects for commonly confused sibling skills using `→` notation (e.g., `For XAML→uipath-rpa`)

--- a/.cursor/rules/pr-review.mdc
+++ b/.cursor/rules/pr-review.mdc
@@ -2,7 +2,7 @@
 description: Pull request review checklist for new skills, skill modifications, and hook changes — invoke when reviewing or creating a PR
 ---
 
-**New skill checklist:** folder under `skills/uipath-<kebab-case>/`; `SKILL.md` present with valid YAML frontmatter; `name` matches folder name; `description` under 250 chars; Critical Rules numbered; no cross-skill references; reference files kebab-case; all relative links resolve; CODEOWNERS updated; no secrets or personal paths committed.
+**New skill checklist:** folder under `skills/uipath-<kebab-case>/`; `SKILL.md` present with valid YAML frontmatter; `name` matches folder name; `description` under 1024 chars; Critical Rules numbered; no cross-skill references; reference files kebab-case; all relative links resolve; CODEOWNERS updated; no secrets or personal paths committed.
 
 **Existing skill modification checklist:** frontmatter still valid; Critical Rules not removed without justification in PR description; no new cross-skill dependencies; reference naming preserved; changes scoped to the skill being modified (no unrelated edits).
 

--- a/.cursor/rules/skill-review.mdc
+++ b/.cursor/rules/skill-review.mdc
@@ -4,7 +4,7 @@ description: Strict skill audit/review framework — use when user asks to revie
 
 Score each skill on six dimensions (1–5 scale, 1 = failing, 3 = acceptable, 5 = excellent):
 
-1. **Structure** — SKILL.md frontmatter valid; `name` matches folder; `description` under 250 chars, front-loads identity, includes `→` redirects; `[PREVIEW]` tag for unstable skills; body follows Title → When to Use → Critical Rules → Workflow → Reference Navigation → Anti-patterns; references use kebab-case + `-guide.md` / `-template.md` suffix; no orphaned files.
+1. **Structure** — SKILL.md frontmatter valid; `name` matches folder; `description` under 1024 chars, front-loads identity, includes `→` redirects; `[PREVIEW]` tag for unstable skills; body follows Title → When to Use → Critical Rules → Workflow → Reference Navigation → Anti-patterns; references use kebab-case + `-guide.md` / `-template.md` suffix; no orphaned files.
 2. **Consistency** — CLI uses `--output json` uniformly; `<UPPER_SNAKE_CASE>` placeholders; heading hierarchy doesn't skip; code blocks have language identifiers; terminology matches other skills.
 3. **Logic & Completeness** — workflows cover full lifecycle; error handling specified; edge cases addressed; CLI commands correct; steps in order; validation loops present; anti-patterns section covers real mistakes.
 4. **Duplication** — no copy-paste between SKILL.md and references; no redundant reference files; SKILL.md links to references instead of inlining; no instructions repeated verbatim in Critical Rules and workflow.

--- a/.cursor/rules/skill-structure.mdc
+++ b/.cursor/rules/skill-structure.mdc
@@ -3,7 +3,7 @@ description: Skill folder layout, SKILL.md frontmatter, and naming conventions
 globs: ["skills/**/SKILL.md", "skills/**/references/**/*.md", "skills/**/assets/**/*"]
 ---
 
-Every skill under `skills/uipath-<kebab-case>/` must have a `SKILL.md` with valid YAML frontmatter: `name` (matching folder name exactly) and `description` (under 250 characters — Claude Code truncates non-bundled descriptions at 250 chars).
+Every skill under `skills/uipath-<kebab-case>/` must have a `SKILL.md` with valid YAML frontmatter: `name` (matching folder name exactly) and `description` (under 1024 characters — repo cap; Claude Code's hard truncation for `description` + `when_to_use` is 1,536 chars).
 
 The `description` must front-load skill identity and unique file/domain signals (e.g. `.cs`, `.xaml`, `.flow`, `servo`) within the first ~100 characters. Use compact `→` redirects for commonly confused sibling skills (e.g. `For XAML→uipath-rpa`). Start with `[PREVIEW]` for unstable skills. Do NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses or nest fields under `metadata:` — both cause Claude Code to drop the field.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -123,14 +123,14 @@ description: "<identity> (<unique signal>). <core actions>. For <confusing-case>
 ---
 ```
 
-> **250-character limit.** Claude Code truncates non-bundled skill descriptions at 250 characters in the system prompt — anything beyond is invisible to the model. The pre-commit hook enforces this. Front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters.
+> **1024-character limit.** Claude Code truncates the combined `description` + `when_to_use` at 1,536 characters in the skill listing ([source](https://code.claude.com/docs/en/skills.md)). This repo caps `description` at 1024 chars to leave headroom and keep descriptions focused; the pre-commit hook enforces it. Front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters.
 
 **Required frontmatter fields:**
 
 | Field | Description |
 |-------|-------------|
 | `name` | Exact skill identifier, must match the folder name |
-| `description` | Under 250 chars. Front-load identity and unique signals, then core actions, then compact `→` redirects for commonly confused sibling skills. Do NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — they waste characters. |
+| `description` | Under 1024 chars. Front-load identity and unique signals, then core actions, then compact `→` redirects for commonly confused sibling skills. Do NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — they waste characters. |
 
 **Optional frontmatter fields:**
 
@@ -213,7 +213,7 @@ Hooks are defined in `hooks/hooks.json` and run during plugin lifecycle events (
 
 ### Git Hooks
 
-This repository uses pre-commit hooks to validate skill descriptions (250-character limit). To enable them:
+This repository uses pre-commit hooks to validate skill descriptions (1024-character limit). To enable them:
 
 ```bash
 bash scripts/setup-hooks.sh
@@ -283,7 +283,7 @@ Before submitting your PR, verify:
 
 ### SKILL.md
 - [ ] Frontmatter has `name` matching the folder name
-- [ ] Frontmatter `description` is under 250 characters (enforced by pre-commit hook)
+- [ ] Frontmatter `description` is under 1024 characters (enforced by pre-commit hook)
 - [ ] Frontmatter `description` front-loads identity and unique signals, uses `→` redirects (not verbose TRIGGER/DO NOT TRIGGER)
 - [ ] Critical Rules section exists with numbered, actionable rules
 - [ ] CLI commands include exact flags and `--output json` where appropriate

--- a/hooks/validate-skill-descriptions.sh
+++ b/hooks/validate-skill-descriptions.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 # Validate skill description lengths
-# Enforces 250-character limit on all SKILL.md descriptions
-# (Claude Code truncates non-bundled skill descriptions at 250 chars in the system prompt)
+# Enforces a 1024-character limit on all SKILL.md descriptions.
+# Claude Code truncates the combined `description` + `when_to_use` at 1,536 chars
+# in the skill listing (https://code.claude.com/docs/en/skills.md). 1024 keeps
+# us comfortably under that cap while leaving headroom for `when_to_use`.
 #
 # Usage:
 #   validate-skill-descriptions.sh [file1 file2 ...]
@@ -9,7 +11,7 @@
 
 set -e
 
-LIMIT=250
+LIMIT=1024
 FAILED=0
 
 # Determine which files to check
@@ -47,7 +49,8 @@ done
 if [ "$FAILED" -eq 1 ]; then
   echo ""
   echo "Skill description validation failed. Descriptions must be ≤ $LIMIT characters."
-  echo "Claude Code truncates plugin skill descriptions at 250 chars in the system prompt."
+  echo "Claude Code truncates description + when_to_use at 1,536 chars in the skill listing;"
+  echo "this repo caps at $LIMIT to leave headroom and keep descriptions focused."
   echo "Edit the 'description' field in SKILL.md frontmatter and try again."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- Raises the `hooks/validate-skill-descriptions.sh` `LIMIT` from **250 → 1024** chars.
- Corrects the misleading framing in repo docs that called 250 chars Claude Code's truncation point — the actual cap is **1,536 chars** for combined `description` + `when_to_use` ([source](https://code.claude.com/docs/en/skills.md)). 1024 leaves headroom under that cap and is a repo style choice, not a platform limit.
- Updates `.claude/rules/`, `.cursor/rules/`, and `CONTRIBUTING.md` so the wording matches.

## Why
250 was too narrow — it was forcing descriptions to drop useful disambiguation signals (`→` redirects, file/domain hints) that the matcher relies on. All 17 existing skills are well under 250 today (max: 247), so this change adds room without breaking anything.

## Test plan
- [x] `bash hooks/validate-skill-descriptions.sh skills/*/SKILL.md` passes for all 17 skills
- [x] `grep -rn "250" hooks/ .claude/rules/ .cursor/rules/ CONTRIBUTING.md` returns nothing
- [ ] CI hook check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)