### PR TITLE
docs(uipath-rpa,uipath-platform): correct RPA CLI snippets

### DIFF
--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -109,12 +109,12 @@ Some operations (creating projects, validating, running workflows, packing) requ
 
 1. **Check for a running instance first:**
    ```bash
-   rpa-tool list-instances --output json
+   uip rpa list-instances --output json
    ```
 
 2. **If no instance is running, try the standard install location:**
    ```bash
-   rpa-tool start-studio --output json
+   uip rpa start-studio --output json
    ```
 
 3. **If that fails (version too old, not found, etc.) — ASK THE USER where their Studio build is located.** Do NOT search the entire filesystem. Common locations include:
@@ -124,7 +124,7 @@ Some operations (creating projects, validating, running workflows, packing) requ
 
 4. **Once you have the path, pass it explicitly:**
    ```bash
-   rpa-tool start-studio --studio-dir "<STUDIO_DIR>" --output json
+   uip rpa start-studio --studio-dir "<STUDIO_DIR>" --output json
    ```
 
 > **Never spend time searching for Studio automatically.** If the default doesn't work, ask immediately — the user knows where their build is.
@@ -217,7 +217,7 @@ The typical deployment workflow for a UiPath automation:
 
 ```
 1. Develop    → Create/edit coded workflows or RPA projects locally
-2. Validate   → uip rpa get-errors --use-studio
+2. Validate   → uip rpa get-errors
 3. Pack       → uip solution pack
 4. Login      → uip login
 5. Publish    → uip solution publish

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -284,7 +284,8 @@ Check `project.json` → `dependencies` for the required package.
 - **If absent** → install:
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output jsonuip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
+uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output json
+uip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
 ```
 
 ### Step 2 — Find activity docs (priority order)

--- a/skills/uipath-rpa/assets/json-template.md
+++ b/skills/uipath-rpa/assets/json-template.md
@@ -2,7 +2,7 @@
 
 Ready-to-use templates for all UiPath coded automation project files. Replace placeholders in `{{PLACEHOLDER}}` format.
 
-> **IMPORTANT: Do NOT use these `project.json` / `project.uiproj` templates to create new projects.** Always use `rpa-tool create-project` which generates correct defaults, metadata directories, and version-matched configuration. These templates are **reference-only** — use them to understand the file structure, or to manually add entry points, dependencies, and fileInfoCollection entries to an existing `project.json` that was scaffolded by `create-project`.
+> **IMPORTANT: Do NOT use these `project.json` / `project.uiproj` templates to create new projects.** Always use `uip rpa create-project` which generates correct defaults, metadata directories, and version-matched configuration. These templates are **reference-only** — use them to understand the file structure, or to manually add entry points, dependencies, and fileInfoCollection entries to an existing `project.json` that was scaffolded by `create-project`.
 
 ---
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AppendRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AppendRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `DestinationRange`, `HasHeaders`, `DestinationHasHeaders`, `PasteOptions`, `Transpose`, `StartingColumnName="{x:Null}"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFillX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFillX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `StartRange` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFitX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFitX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `Columns`, `Rows` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangeDataRangeModification.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangeDataRangeModification.md
@@ -11,4 +11,4 @@ xmlns:ueabc="clr-namespace:UiPath.Excel.Activities.Business.ChartModifications;a
 |---------------|
 | `Range` (nested inside `UpdateChartX` body) |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangePivotTableDataSourceX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangePivotTableDataSourceX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `PivotTable="[Excel.Sheet(&quot;Sheet1&quot;).PivotTable(&quot;PivotName&quot;)]"`, `NewSourceRange` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ClearRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ClearRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `TargetRange`, `HasHeaders` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CopyPasteRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CopyPasteRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `DestinationRange`, `PasteOptions="All"`, `Transpose="False"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreatePivotTableXv2.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreatePivotTableXv2.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `DestinationRange`, `TableName`, `LayoutRowType`, `ValuesMode`; body `ActivityAction` (no type args), child `ueab:PivotTableFieldX` inside |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreateTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreateTableX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `HasHeaders`, `OutTableName`, `TableName="{x:Null}"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteColumnX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `ColumnName`, `HasHeaders` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteRowsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteRowsX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `DeleteRowsOption="Specific"`, `RowPositions`, `HasHeaders` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Sheet="[Excel.Sheet(&quot;SheetName&quot;)]"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DuplicateSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DuplicateSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SheetToDuplicate`, `NewSheetName` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroArgumentX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroArgumentX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `ArgumentValue` (nested inside `ExecuteMacroX` body) |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `MacroName`; `Result` via child `OutArgument`; body contains `ueab:ExecuteMacroArgumentX` children |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExportExcelToCsvX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExportExcelToCsvX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `TargetRange`, `FilePath` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FillRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FillRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `DestinationRange="[Excel.Sheet(s).Range(&quot;B11&quot;)]"`, `Value="[&quot;SUM(B1:B10)&quot;]"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterPivotTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterPivotTableX.md
@@ -11,4 +11,4 @@ xmlns:ueabf="clr-namespace:UiPath.Excel.Activities.Business.Filter;assembly=UiPa
 |---------------|
 | `Table="[Excel.Sheet(...).PivotTable(&quot;Name&quot;)]"`, `ColumnName`, `ClearFilter`; child `FilterArgument` uses `ueabf:FilterArgument` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterX.md
@@ -11,4 +11,4 @@ xmlns:ueabf="clr-namespace:UiPath.Excel.Activities.Business.Filter;assembly=UiPa
 |---------------|
 | `Range`, `ColumnName`, `HasHeaders`, `ClearFilter`; child `FilterX.FilterArgument` uses `ueabf:FilterArgument` or `ueabf:AdvancedFilterArgument` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindFirstLastDataRowX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindFirstLastDataRowX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `ColumnName`, `FirstRowIndex`, `LastRowIndex`, `HasHeaders`, `ConfigureLastRowAs`, `BlankRowsToSkip` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindReplaceValueX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindReplaceValueX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `WhereToSearch="[Excel.Sheet(...)]"`, `ValueToFind`, `ReplaceWith`, `Operation="Replace\|FindOnly"`, `LookIn="Values"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FormatRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FormatRangeX.md
@@ -4,6 +4,6 @@
 
 | Key Attributes |
 |---------------|
-| `Range` + child elements `Alignment`, `Font`, `Format`, `NumberFormat` (use `uip rpa get-default-activity-xaml --use-studio` for child structure) |
+| `Range` + child elements `Alignment`, `Font`, `Format`, `NumberFormat` (use `uip rpa get-default-activity-xaml` for child structure) |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertColumnX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range="[Excel.Sheet(...)]"`, `NewColumnName`, `RelativeColumnName`, `RelativePosition="After\|Before"`, `HasHeaders="True"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertExcelChartX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertExcelChartX.md
@@ -11,4 +11,4 @@ xmlns:ueabc="clr-namespace:UiPath.Excel.Activities.Business.ChartModifications;a
 |---------------|
 | `Range`, `InsertIntoSheet`, `InsertedChart` (output, type `ue:IChartRef`), `ChartCategory`, `ChartType`, `ChartHeight`, `ChartWidth`, `Left`, `Top` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertRowsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertRowsX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range="[Excel.Sheet(...)]"`, `InsertPosition="End\|Beginning"`, `NbOfRows`, `HasHeaders="True"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `Name="NewSheet"`, `ReferenceNewSheetAs="[outNewSheet]"` — variable type `ue:ISheetRef` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAArgumentX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAArgumentX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `ArgumentValue` (nested inside `InvokeVBAX` body) |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `CodeFilePath`, `EntryMethodName`, `Result="{x:Null}"`; body contains `ueab:InvokeVBAArgumentX` children |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/LookupX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/LookupX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `Label`, `ResultRange="{x:Null}"`, output via `Value` child `OutArgument` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/PivotTableFieldX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/PivotTableFieldX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `FieldName`, `Function="Sum"`, `Type="Row"` (nested inside `CreatePivotTableXv2` body) |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ProtectSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ProtectSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Sheet="[Excel.Sheet(...)]"`, `Password`, `SecurePassword="{x:Null}"`, `AdditionalPermissions` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellFormulaX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellFormulaX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Cell`, `SaveTo="[outFormula]"` (direct attribute) |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellValueX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellValueX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Cell="[CurrentRow.ByIndex(0)]"`, `GetFormattedText`, output via `SaveTo` child `OutArgument` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RefreshPivotTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RefreshPivotTableX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Table="[Excel.Sheet(...).PivotTable(...)]"`, `LayoutRowType="{x:Null}"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RemoveDuplicatesX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RemoveDuplicatesX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `ColumnsCompareMode="AllColumns"`, `Columns` child list |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RenameSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RenameSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `From="[Excel.Sheet(&quot;OldName&quot;)]"`, `To="NewName"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveAsPdfX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveAsPdfX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `DestinationPdfPath`, `SaveQuality="StandardQuality"`, `EndPage="{x:Null}"`, `StartPage="{x:Null}"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveExcelFileX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveExcelFileX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortColumnX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `ColumnName`, `SortDirection="Ascending"` (nested inside `SortX` body) |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `HasHeaders`; body `ActivityAction` (no type args), child `ueab:SortColumnX` inside |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UnprotectSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UnprotectSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Sheet`, `Password`, `SecurePassword="{x:Null}"` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UpdateChartX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UpdateChartX.md
@@ -11,4 +11,4 @@ xmlns:ueabc="clr-namespace:UiPath.Excel.Activities.Business.ChartModifications;a
 |---------------|
 | `Chart`; body `ActivityAction` (no type args), child `ueabc:ChangeDataRangeModification` inside |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/VLookupX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/VLookupX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `Label`, `ExactMatch`, `ColumnIndex="{x:Null}"`, output via `Value` child `OutArgument` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/WriteCellX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/WriteCellX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Cell="[Excel.Sheet(&quot;Sheet1&quot;).Cell(&quot;A1&quot;)]"`, `Value` |
 
-Use `uip rpa get-default-activity-xaml --use-studio` for full XAML.
+Use `uip rpa get-default-activity-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Excel Activities
 
-Excel activity patterns for `UiPath.Excel.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+Excel activity patterns for `UiPath.Excel.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml` — this file covers confirmed patterns from real workflows only.
 
 ## Package
 
@@ -46,7 +46,7 @@ Namespace imports needed in `TextExpression.NamespacesForImplementation`:
 | Handle variable types | `ue:ISheetRef` (InsertSheetX output), `ue:IChartRef` (InsertExcelChartX output) |
 | Classic standalone | No scope — `WorkbookPath` on each activity; set `WorkbookPathResource="{x:Null}"` |
 | `ForEachRow` (classic) | One arg: `DelegateInArgument x:TypeArguments="sd:DataRow" Name="CurrentRow"` |
-| Full XAML | Always use `uip rpa get-default-activity-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa get-default-activity-xaml` for complete activity XAML |
 
 ## Common Pitfalls
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.GSuite.Activities/3.8/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.GSuite.Activities/3.8/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML GSuite Activities
 
-Google Suite activity patterns for `UiPath.GSuite.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+Google Suite activity patterns for `UiPath.GSuite.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml` — this file covers confirmed patterns from real workflows only.
 
 ## Package + Connection Pattern
 
@@ -42,4 +42,4 @@ Use `uip is connections list --output json` to obtain the connection GUID. If no
 | `ForEachEmailConnections` | Three-arg body: `Argument1` (`GmailMessage` `"CurrentEmail"`), `Argument2` (`Int32` `"CurrentEmailIndex"`) |
 | `ForEachFileFolderConnections` | One-arg body: `CurrentItem` as `GDriveRemoteItem` |
 | `RowAddedToSheetBottom` | Generic type param `System.Data.DataRow`; output `AddedRow: DataRow` |
-| Full XAML | Always use `uip rpa get-default-activity-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa get-default-activity-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Mail.Activities/2.8/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Mail.Activities/2.8/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Outlook Mail Activities (UiPath.Mail.Activities)
 
-Classic Outlook mail activity patterns for `UiPath.Mail.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml --use-studio` — this file covers confirmed namespace and attribute patterns from real workflows only. **Not for `UiPath.MicrosoftOffice365.Activities`** — see `msoffice365-outlook-activities.md` for O365.
+Classic Outlook mail activity patterns for `UiPath.Mail.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml` — this file covers confirmed namespace and attribute patterns from real workflows only. **Not for `UiPath.MicrosoftOffice365.Activities`** — see `msoffice365-outlook-activities.md` for O365.
 
 ## Package
 
@@ -68,4 +68,4 @@ Without IS connection, omit `UseISConnection` and the child element entirely.
 | `ForEachEmailX` | Two args: `Argument1` (`snm:MailMessage` `"CurrentMail"`) + `Argument2` (`x:Int32` `"CurrentIndex"`) |
 | `SaveMailAttachments` | Uses `ui:` prefix even inside modern scope — it's a classic activity |
 | Email properties | `CurrentMail.Subject`, `CurrentMail.SenderEmailAddress()`, `CurrentMail.Date()`, `CurrentMail.Priority.AsText()`, `CurrentMail.Attachments.Count` |
-| Full XAML | Always use `uip rpa get-default-activity-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa get-default-activity-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/SendMailConnections.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/SendMailConnections.md
@@ -40,6 +40,6 @@ Null attributes: `ArgumentAttachmentPaths`, `AttachmentList`, `Bcc`, `Cc`, `Conn
 </umam:SendMailConnections>
 ```
 
-Additional BackupSlot children (get full structure from `uip rpa get-default-activity-xaml --use-studio`):
+Additional BackupSlot children (get full structure from `uip rpa get-default-activity-xaml`):
 - `AttachmentsArg` — type `umame:AttachmentInputMode`
 - `InputTypeArg` — type `umame:BodyInputType`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Outlook Mail Activities
 
-Office 365 Outlook mail activity patterns for `UiPath.MicrosoftOffice365.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml --use-studio` — this file covers confirmed namespace and attribute patterns from real workflows only.
+Office 365 Outlook mail activity patterns for `UiPath.MicrosoftOffice365.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml` — this file covers confirmed namespace and attribute patterns from real workflows only.
 
 ## Package
 
@@ -35,5 +35,5 @@ Use `uip is connections list --output json` to obtain the connection GUID. If no
 | Recipients | `<CSharpValue x:TypeArguments="scg:IEnumerable(x:String)">new string[]{"a@b.com"}</CSharpValue>` |
 | FilterExpression booleans | Backtick-quoted: `` `true` ``, `` `false` `` |
 | FilterExpression AND | `&amp;&amp;` (XML-escaped `&&`) |
-| BackupSlot (SendMail) | `MailboxArg` child required; `AttachmentsArg` and `InputTypeArg` also needed — use `uip rpa get-default-activity-xaml --use-studio` for full structure |
-| Full XAML | Always use `uip rpa get-default-activity-xaml --use-studio` for complete activity XAML |
+| BackupSlot (SendMail) | `MailboxArg` child required; `AttachmentsArg` and `InputTypeArg` also needed — use `uip rpa get-default-activity-xaml` for full structure |
+| Full XAML | Always use `uip rpa get-default-activity-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.5/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.5/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML PowerPoint Presentation Activities
 
-PowerPoint activity patterns for `UiPath.Presentations.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+PowerPoint activity patterns for `UiPath.Presentations.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml` — this file covers confirmed patterns from real workflows only.
 
 **Target:** Windows only (not Cross-platform / Studio Web Portable).
 
@@ -72,4 +72,4 @@ The scope body passes an `IPresentationQuickHandle` as a delegate argument (conv
 | Save vs SaveAs | `AutoSave="True"` on scope saves on close; use `SavePresentationFileAs` to save to a different path/format |
 | Macros | Use `RunMacro` with nested `RunMacroArgument` children for each argument |
 | Windows only | `UiPath.Presentations.Activities` does not support Cross-platform / Studio Web Portable target |
-| Full XAML | Always use `uip rpa get-default-activity-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa get-default-activity-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/25.10/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/25.10/activities/overview.md
@@ -90,4 +90,4 @@ xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 - **Direction:** IN (read-only), OUT (write-only), IN/OUT (read-write)
 - **Case Sensitive:** Argument names are case-sensitive
 
-These activities are part of `UiPath.System.Activities` (always installed). You can write them directly **without** calling `uip rpa get-default-activity-xaml --use-studio`. Use the templates as-is — just replace the placeholder expressions with your actual logic.
+These activities are part of `UiPath.System.Activities` (always installed). You can write them directly **without** calling `uip rpa get-default-activity-xaml`. Use the templates as-is — just replace the placeholder expressions with your actual logic.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.5/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.5/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Word Document Activities
 
-Word document activity patterns for `UiPath.Word.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+Word document activity patterns for `UiPath.Word.Activities`. Always get full XAML from `uip rpa get-default-activity-xaml` — this file covers confirmed patterns from real workflows only.
 
 **Target:** Windows only (not Cross-platform / Studio Web Portable).
 
@@ -106,4 +106,4 @@ xmlns:ui="http://schemas.uipath.com/workflow/activities"
 | Export to PDF | Use `WordExportToPdf` inside scope; set `ReplaceExisting="True"` to overwrite |
 | Save vs SaveAs | `AutoSave="True"` on scope saves on close; use `WordSaveAs` to save to a different path |
 | Windows only | `UiPath.Word.Activities` does not support Cross-platform / Studio Web Portable target |
-| Full XAML | Always use `uip rpa get-default-activity-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa get-default-activity-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -90,7 +90,8 @@ Located at `{projectRoot}/.local/docs/packages/{PackageId}/`.
 List running Studio Desktop instances and their IPC status. Hidden diagnostic command — does **not** report the auto-launched headless Studio (Helm) instances.
 
 ```bash
-uip rpa list-instances --output json```
+uip rpa list-instances --output json
+```
 
 No command-specific options. An empty `Data` array does NOT mean `uip rpa` won't work — headless Studio starts on demand.
 
@@ -104,7 +105,8 @@ Ensure a **Studio Desktop** instance is running. Only required before invoking `
 3. Start a new instance via `--studio-dir` -- poll until available
 
 ```bash
-uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json```
+uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json
+```
 
 ---
 
@@ -115,7 +117,8 @@ uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json```
 Create a new UiPath project from a template.
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json```
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json
+```
 
 > **Flag names are non-standard.** Most `uip rpa` commands take `--project-dir` to identify the project. `create-project` instead uses `--name` (project name) + `--location` (parent directory). Do NOT use `--project-name` or `--project-dir` here — both fail with `error: required option '--name <string>' not specified`.
 
@@ -158,7 +161,8 @@ Returns `Data[*]` with `packageId`, `version`, `title`, `description`, `authors`
 Open an existing project in Studio. Only needed when explicitly loading a project that isn't already open (e.g. after `create-project`, or when switching projects). Most commands (`validate`, `run-file`) auto-resolve a Studio instance and open the project automatically, so this is rarely required.
 
 ```bash
-uip rpa open-project --project-dir "<PROJECT_DIR>" --output json```
+uip rpa open-project --project-dir "<PROJECT_DIR>" --output json
+```
 
 No command-specific options.
 
@@ -174,7 +178,8 @@ Run or debug a workflow file using Studio.
 # Run (default -- closes app on completion or error):
 uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json
 # Debug (pauses on error -- keeps app open for inspection/repair):
-uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json```
+uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -192,7 +197,8 @@ uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command St
 Return validation errors for a file or project. By default, forces Studio to re-validate before returning errors.
 
 ```bash
-uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json```
+uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -208,7 +214,8 @@ uip rpa get-errors [--file-path "<FILE>"] [--skip-validation] --output json```
 Build (compile) a UiPath project. Compiles all XAML expressions — catches runtime-compile failures that `get-errors` misses. Required before returning a project to the user (see [validation-guide.md § Project Build Verification](validation-guide.md#project-build-verification-required-before-returning-a-project)). Runs independently of Studio IPC; takes the project directory as a positional argument.
 
 ```bash
-uip rpa build "<PROJECT_DIR>" --log-level Warn --output json```
+uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -248,7 +255,8 @@ Each rule returns `severity` (`error` / `warning` / `info`), rule ID (e.g. `ST-D
 Install or update NuGet packages in the project.
 
 ```bash
-uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]' --output json```
+uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]' --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -267,7 +275,9 @@ Omit `version` to automatically resolve the latest compatible version (preferred
 Get available versions for a NuGet package.
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --output jsonuip rpa get-versions --package-id <PackageId> --include-prerelease --output json```
+uip rpa get-versions --package-id <PackageId> --output json
+uip rpa get-versions --package-id <PackageId> --include-prerelease --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -344,7 +354,8 @@ Returns JSON:
 Get unautomated test case IDs from Test Manager.
 
 ```bash
-uip rpa get-manual-test-cases --project-dir "<PROJECT_DIR>" --output json```
+uip rpa get-manual-test-cases --project-dir "<PROJECT_DIR>" --output json
+```
 
 No command-specific options.
 
@@ -355,7 +366,8 @@ No command-specific options.
 Get steps for specific test cases from Test Manager.
 
 ```bash
-uip rpa get-manual-test-steps --test-case-ids "id1,id2,id3" --project-dir "<PROJECT_DIR>" --output json```
+uip rpa get-manual-test-steps --test-case-ids "id1,id2,id3" --project-dir "<PROJECT_DIR>" --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -547,7 +559,9 @@ When `uip` commands fail, diagnose by error category:
 Search for activities by keyword. Global search -- not limited to installed packages.
 
 ```bash
-uip rpa find-activities --query "<KEYWORD>" --output jsonuip rpa find-activities --query "<KEYWORD>" --tags "<TAGS>" --limit 20 --output json```
+uip rpa find-activities --query "<KEYWORD>" --output json
+uip rpa find-activities --query "<KEYWORD>" --tags "<TAGS>" --limit 20 --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -565,7 +579,8 @@ Get the default XAML template for an activity. Two modes depending on whether th
 # Non-dynamic activity:
 uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json
 # Dynamic activity (connector-backed):
-uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json```
+uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -580,7 +595,9 @@ uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id
 Search example workflows by service tags.
 
 ```bash
-uip rpa list-workflow-examples --tags "service1,service2" --output jsonuip rpa list-workflow-examples --tags "service1" --prefix "<PREFIX>" --limit 20 --output json```
+uip rpa list-workflow-examples --tags "service1,service2" --output json
+uip rpa list-workflow-examples --tags "service1" --prefix "<PREFIX>" --limit 20 --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -595,7 +612,8 @@ uip rpa list-workflow-examples --tags "service1,service2" --output jsonuip rpa l
 Retrieve the full XAML content of an example workflow.
 
 ```bash
-uip rpa get-workflow-example --key "<BLOB_PATH>" --output json```
+uip rpa get-workflow-example --key "<BLOB_PATH>" --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -608,7 +626,9 @@ uip rpa get-workflow-example --key "<BLOB_PATH>" --output json```
 Focus an activity in the Studio Desktop designer view. **Requires a running Studio Desktop instance** — does not work against headless Studio. Run `uip rpa start-studio --project-dir "<PROJECT_DIR>"` first if Studio Desktop is not already up.
 
 ```bash
-uip rpa focus-activity --activity-id "<IDREF>" --output jsonuip rpa focus-activity --output json```
+uip rpa focus-activity --activity-id "<IDREF>" --output json
+uip rpa focus-activity --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -642,7 +662,8 @@ Use the `packageId` and `version` from results with `uip rpa create-project --te
 Close the current project in Studio.
 
 ```bash
-uip rpa close-project --output json```
+uip rpa close-project --output json
+```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|

--- a/skills/uipath-rpa/references/coded/inspect-package-guide.md
+++ b/skills/uipath-rpa/references/coded/inspect-package-guide.md
@@ -8,13 +8,15 @@ The inspect-package tool is built into the UiPath CLI. No separate build step is
 
 ### Inspect a package from a NuGet feed
 ```bash
-uip rpa inspect-package --package-name <PackageName> --package-version <Version> [--feed-url <NuGetV3FeedUrl>]```
+uip rpa inspect-package --package-name <PackageName> --package-version <Version> [--feed-url <NuGetV3FeedUrl>]
+```
 
 When `--feed-url` is omitted, the tool downloads from the UiPath Official feed first and falls back to nuget.org.
 
 ### Inspect a local .nupkg file
 ```bash
-uip rpa inspect-package --nupkg-path <path/to/package.nupkg>```
+uip rpa inspect-package --nupkg-path <path/to/package.nupkg>
+```
 
 Use this when the package is already cached locally (e.g. from a private feed) or when you have a `.nupkg` file on disk.
 
@@ -30,7 +32,8 @@ uip rpa inspect-package --package-name MyPackage --package-version 1.0.0 --feed-
 # Inspect third-party package from nuget.org
 uip rpa inspect-package --package-name CsvHelper --package-version 33.0.1
 # Inspect a local .nupkg file directly
-uip rpa inspect-package --nupkg-path ~/.nuget/packages/csvhelper/33.0.1/csvhelper.33.0.1.nupkg```
+uip rpa inspect-package --nupkg-path ~/.nuget/packages/csvhelper/33.0.1/csvhelper.33.0.1.nupkg
+```
 
 ## Finding the Latest Stable Version
 

--- a/skills/uipath-rpa/references/coded/integration-service-guide.md
+++ b/skills/uipath-rpa/references/coded/integration-service-guide.md
@@ -256,7 +256,8 @@ var response = await conn.ExecuteAsync(config, request);
 Run `uip rpa get-errors` on the written workflow file until 0 errors. Cap at 5 fix attempts.
 
 ```bash
-uip rpa get-errors --file-path "<WORKFLOW_FILE>" --project-dir "<PROJECT_DIR>" --output json```
+uip rpa get-errors --file-path "<WORKFLOW_FILE>" --project-dir "<PROJECT_DIR>" --output json
+```
 
 ---
 

--- a/skills/uipath-rpa/references/coded/operations-guide.md
+++ b/skills/uipath-rpa/references/coded/operations-guide.md
@@ -11,7 +11,8 @@ Creates a complete UiPath coded automation project from scratch. **ALWAYS use `u
 **1. Create the project with `uip rpa create-project`:**
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json```
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json
+```
 
 **Template options:**
 - `--template-id BlankTemplate` (default) — standard process project

--- a/skills/uipath-rpa/references/testing-guide.md
+++ b/skills/uipath-rpa/references/testing-guide.md
@@ -115,7 +115,6 @@ Register XAML test cases in `fileInfoCollection`. Add `entryPoints` only for **P
 > **Note:** The `entryPoints` block above applies to Process projects only. For Tests and Library projects, only `fileInfoCollection` is needed.
 
 > **`editingStatus` lifecycle:** Set to `"InProgress"` when creating a new test case. Update to `"Publishable"` only when the user explicitly asks to mark the test case as ready.
-```
 
 ### What NOT to Do
 
@@ -159,7 +158,7 @@ Three commands attach different data source types to a test case. All three regi
 #### `add-test-data-variation` — File-based (JSON)
 
 ```bash
-uip rpa add-test-data-variation --test-case-path "<TEST_CASE_FILE>" --data-variation-path "<DATA_FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa add-test-data-variation --test-case-path "<TEST_CASE_FILE>" --data-variation-path "<DATA_FILE>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 | Parameter | Required | Description |
@@ -171,7 +170,7 @@ Parses fields from the JSON file and creates one argument per field with matchin
 
 **Example:**
 ```bash
-uip rpa add-test-data-variation --test-case-path "TestProcessInvoice.cs" --data-variation-path ".variations/InvoiceData.json" --project-dir "C:\MyProject" --output json --use-studio
+uip rpa add-test-data-variation --test-case-path "TestProcessInvoice.cs" --data-variation-path ".variations/InvoiceData.json" --project-dir "C:\MyProject" --output json
 ```
 
 #### `add-test-data-queue` — Orchestrator Test Data Queue
@@ -179,7 +178,7 @@ uip rpa add-test-data-variation --test-case-path "TestProcessInvoice.cs" --data-
 > **Prerequisite:** Use the **uipath-platform** skill to discover queue details (name, ID, folder) before calling this command.
 
 ```bash
-uip rpa add-test-data-queue --test-case-path "<TEST_CASE_FILE>" --queue-name "<QUEUE_NAME>" --folder-path "<FOLDER>" --queue-id <ID> --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa add-test-data-queue --test-case-path "<TEST_CASE_FILE>" --queue-name "<QUEUE_NAME>" --folder-path "<FOLDER>" --queue-id <ID> --project-dir "<PROJECT_DIR>" --output json
 ```
 
 | Parameter | Required | Description |
@@ -193,7 +192,7 @@ Creates an `IDictionary<string, object>` argument named after the queue (camelCa
 
 **Example:**
 ```bash
-uip rpa add-test-data-queue --test-case-path "TestLoanApproval.cs" --queue-name "loan_applications" --folder-path "Shared" --queue-id 123 --project-dir "C:\MyProject" --output json --use-studio
+uip rpa add-test-data-queue --test-case-path "TestLoanApproval.cs" --queue-name "loan_applications" --folder-path "Shared" --queue-id 123 --project-dir "C:\MyProject" --output json
 ```
 
 > **Critical:** Do NOT rename the auto-generated test data queue argument. If you change its name, data retrieval silently fails.
@@ -205,7 +204,7 @@ uip rpa add-test-data-queue --test-case-path "TestLoanApproval.cs" --queue-name 
 > 2. **Install the target entity into the project** if not already installed — `uip rpa install-data-fabric-entities --add "<ENTITY_NAME>" --project-dir "<PROJECT_DIR>" --output json`. `add-test-data-entity` requires the entity's generated type to exist in the project. See [cli-reference.md § Data Fabric Entities](cli-reference.md#commands----data-fabric-entities).
 
 ```bash
-uip rpa add-test-data-entity --test-case-path "<TEST_CASE_FILE>" --entity-name "<ENTITY_NAME>" --entity-type-name "<ENTITY_TYPE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa add-test-data-entity --test-case-path "<TEST_CASE_FILE>" --entity-name "<ENTITY_NAME>" --entity-type-name "<ENTITY_TYPE>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 | Parameter | Required | Description |
@@ -218,7 +217,7 @@ Creates an argument of the entity type named after the entity (camelCase). Requi
 
 **Example:**
 ```bash
-uip rpa add-test-data-entity --test-case-path "TestLoanApproval.cs" --entity-name "LoanApplication" --entity-type-name "LoanApplication" --project-dir "C:\MyProject" --output json --use-studio
+uip rpa add-test-data-entity --test-case-path "TestLoanApproval.cs" --entity-name "LoanApplication" --entity-type-name "LoanApplication" --project-dir "C:\MyProject" --output json
 ```
 
 ### Data-Driven Testing Best Practices

--- a/skills/uipath-rpa/references/uia-debug-workflow.md
+++ b/skills/uipath-rpa/references/uia-debug-workflow.md
@@ -7,11 +7,13 @@
 1. **Record the window baseline** — list top-level windows via the `uia interact` CLI and note which w-refs and titles are already present. See the skill (`{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`) for the exact command.
 2. **Run the workflow:**
    ```bash
-   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json   ```
+   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json
+   ```
    If the run fails, [`uia-selector-recovery.md`](uia-selector-recovery.md) spawns the `uia-improve-selector` subagent — this is the **only** correct recovery path. Do not hand-edit selectors in the XAML file.
 3. **When done** (success or failure) — **stop the debug session:**
    ```bash
-   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json   ```
+   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json
+   ```
 4. **List windows again** via the `uia interact` CLI.
 5. **Diff before vs after.** Any window present now that was NOT in the baseline was opened by the workflow. Close each such window via the `uia interact` CLI's window command (see the skill).
 

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -78,7 +78,8 @@ uip rpa run-file --file-path "<FILE>" --output json
 # Run with input arguments:
 uip rpa run-file --file-path "<FILE>" --input-arguments '{"key": "value"}' --output json
 # Run with verbose logging for debugging:
-uip rpa run-file --file-path "<FILE>" --log-level Verbose --output json```
+uip rpa run-file --file-path "<FILE>" --log-level Verbose --output json
+```
 
 **When to run:**
 1. Workflow has no compilation errors but you want to verify runtime behavior
@@ -112,7 +113,8 @@ C) <user-driven approach>
 ```
 Read: file_path="{projectRoot}/project.json"     -> check current dependencies
 
-Bash: uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]'```
+Bash: uip rpa install-or-update-packages --packages '[{"id": "UiPath.Excel.Activities"}]'
+```
 
 Omit `version` to automatically resolve the latest compatible version (preferred — gets newest docs and features). Only pin a specific version when you have a reason to (e.g., known compatibility constraint).
 
@@ -138,7 +140,8 @@ When `get-errors` returns an error referencing a specific activity (by IdRef or 
 # Focus a specific activity by its IdRef (from the error output):
 uip rpa focus-activity --activity-id "Assign_1"
 # Focus all activities sequentially (useful for walkthrough):
-uip rpa focus-activity```
+uip rpa focus-activity
+```
 
 This is especially useful when:
 - An error references an activity and you want the user to confirm the context

--- a/skills/uipath-rpa/references/xaml/workflow-guide.md
+++ b/skills/uipath-rpa/references/xaml/workflow-guide.md
@@ -94,7 +94,7 @@ Read: file_path="{projectRoot}/ExistingWorkflow.xaml"
 Use when you need to find which activity implements a user-described action:
 
 ```bash
-uip rpa find-activities --query "send mail" --limit 10 --output json```
+uip rpa find-activities --query "send mail" --limit 10 --output json
 ```
 
 - Results are **global** — not limited to installed packages
@@ -123,7 +123,8 @@ Use `uip rpa get-default-activity-xaml` when activity docs are insufficient:
 # Non-dynamic activity:
 uip rpa get-default-activity-xaml --activity-class-name "<FULLY_QUALIFIED_CLASS>" --output json
 # Dynamic activity (connector-backed):
-uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json```
+uip rpa get-default-activity-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN_ID>" --output json
+```
 
 For JIT custom types: `Read: file_path="{projectRoot}/.project/JitCustomTypesSchema.json"`. See [jit-custom-types-schema.md](jit-custom-types-schema.md).
 
@@ -132,10 +133,11 @@ For JIT custom types: `Read: file_path="{projectRoot}/.project/JitCustomTypesSch
 Use when activity docs, `find-activities`, and `get-default-activity-xaml` don't provide enough context:
 
 ```bash
-uip rpa list-workflow-examples --tags web --limit 10 --output jsonuip rpa get-workflow-example --key "<BLOB_PATH>"```
+uip rpa list-workflow-examples --tags web --limit 10 --output json
+uip rpa get-workflow-example --key "<BLOB_PATH>" --output json
+```
 
 **Complete tag list:** `adobe-sign`, `asana`, `box`, `concur`, `confluence`, `database`, `document-understanding`, `docusign`, `dropbox`, `email-generic`, `excel`, `excel-online`, `freshbooks`, `freshdesk`, `github`, `gmail`, `google-calendar`, `google-docs`, `google-drive`, `google-sheets`, `gsuite`, `hubspot`, `intacct`, `jira`, `mailchimp`, `marketo`, `microsoft-365`, `onedrive`, `outlook`, `outlook-calendar`, `pdf`, `powerpoint`, `productivity`, `quickbooks`, `salesforce`, `servicenow`, `sharepoint`, `shopify`, `slack`, `smartsheet`, `stripe`, `teams`, `testing`, `trello`, `web`, `webex`, `word`, `workday`, `zendesk`, `zoom`
-```
 
 ### Step 1.8: Get Current Context (As Needed)
 
@@ -200,7 +202,8 @@ Edit: file_path=... old_string=<exact text> new_string=<modified text>
 ### Step 3.1: Check for Errors
 
 ```bash
-uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --output json```
+uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --output json
+```
 
 `--file-path` must be **relative to the project directory**. Use `--skip-validation` only for quick cached-error checks.
 


### PR DESCRIPTION
## Summary
- replace stale `rpa-tool` references with current `uip rpa` commands
- remove legacy `--use-studio` flags from RPA/platform examples and activity docs
- repair malformed fenced command snippets that concatenated commands or swallowed following prose

## Validation
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh skills/uipath-rpa/SKILL.md skills/uipath-platform/SKILL.md`
- scanned changed RPA/platform docs for stale `--use-studio`, `rpa-tool`, concatenated `--output jsonuip`, and malformed same-line fences
- checked fenced code block balance across changed Markdown files
- validated current `uip rpa` help for the affected command families

Refs #241
Refs #261