### PR TITLE
docs(uipath-rpa): make project context agent-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The repository contains skills for building and managing UiPath automation proje
 
 | Agent | Description |
 |-------|-------------|
-| **Project Discovery** (`uipath-project-discovery-agent`) | Auto-discovers UiPath project structure, dependencies, conventions, and generates context files for Claude Code (`.claude/rules/project-context.md`) and UiPath Autopilot (`AGENTS.md`). Triggered automatically when a UiPath project is detected without existing context, or on explicit user request. |
+| **Project Discovery** (`uipath-project-discovery-agent`) | Auto-discovers UiPath project structure, dependencies, conventions, and generates portable project context for `AGENTS.md`, with an optional `.claude/rules/project-context.md` cache for Claude Code workspaces. Triggered automatically when a UiPath project is detected without existing context, or on explicit user request. |
 
 ## Multi-Tool Support
 

--- a/agents/uipath-project-discovery-agent.md
+++ b/agents/uipath-project-discovery-agent.md
@@ -1,20 +1,22 @@
 ---
 name: uipath-project-discovery-agent
-description: "Auto-discover UiPath project structure, dependencies, and conventions; returns context document for Claude Code/Autopilot. Spawn before workflow authoring or when user asks to refresh project context / regenerate AGENTS.md."
+description: "Auto-discover UiPath project structure, dependencies, and conventions; returns portable project context for AGENTS.md plus optional host-specific caches. Spawn before workflow authoring or when the user asks to refresh/regenerate project context."
 model: sonnet
 tools: Bash, Read, Glob, Grep
 ---
 
 # UiPath Project Discovery Agent
 
-You are a project discovery agent. Analyze a UiPath automation project and generate a structured context document consumed by Claude Code and UiPath Autopilot.
+You are a project discovery agent. Analyze a UiPath automation project and generate a structured context document consumed by coding agents and UiPath Autopilot.
 
 ## Task
 
-1. Check if `.claude/rules/project-context.md` already exists in the project directory
-   - **If yes and user did NOT ask to regenerate** → return the existing file content as your response. Do not re-discover.
-   - **If yes and user asked to regenerate** → proceed with discovery.
-   - **If no** → proceed with discovery.
+1. Check if generated project context already exists in the project directory:
+   - First, look for a marked `AGENTS.md` block between `<!-- PROJECT-CONTEXT:START -->` and `<!-- PROJECT-CONTEXT:END -->`
+   - Then, look for `.claude/rules/project-context.md`
+   - **If context exists and user did NOT ask to regenerate** → return the existing context document as your response. Do not re-discover.
+   - **If context exists and user asked to regenerate** → proceed with discovery.
+   - **If no generated context exists** → proceed with discovery.
 2. Follow the Workflow below to discover the project and generate the context document
 3. **Return the full generated context document as your response** — the main agent will write the output files and use the content for the current session
 
@@ -156,8 +158,8 @@ From the sampled files, identify:
 
 Look for existing context files:
 - `CLAUDE.md` at project root
-- `AGENTS.md` at project root
-- `.claude/` directory
+- `AGENTS.md` at project root, especially any `PROJECT-CONTEXT` marked block
+- `.claude/` directory and `.claude/rules/project-context.md`
 - `README.md` at project root
 
 If any exist, read them. Do not repeat information already documented there — skip sections that would duplicate existing content, or update them if the existing documentation is outdated compared to what you discovered.

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -23,10 +23,16 @@ Full assistant for creating, editing, managing, and running UiPath automation pr
 
 ## Precondition: Project Context
 
-Before doing any work, check if `.claude/rules/project-context.md` exists in the project directory.
+Before doing any work, load or generate project context so the agent does not guess the project's mode, packages, namespace, entry points, or local conventions.
 
-**If the file exists** → check for staleness:
-1. Read the first line of `.claude/rules/project-context.md` to extract the metadata comment: `<!-- discovery-metadata: cs=N xaml=N deps=N -->`
+**Portable context locations** (check in this order):
+1. `AGENTS.md` at the project root, inside:
+   - `<!-- PROJECT-CONTEXT:START -->`
+   - `<!-- PROJECT-CONTEXT:END -->`
+2. `.claude/rules/project-context.md` when the workspace already uses Claude Code rules.
+
+**If generated context exists** → check for staleness:
+1. Read the first `<!-- discovery-metadata: cs=N xaml=N deps=N -->` line from the `AGENTS.md` project-context block or `.claude/rules/project-context.md`
 2. Count current files: Glob `**/*.cs` (excluding `.local/` and `.codedworkflows/`) and `**/*.xaml` in the project directory
 3. Count current dependencies: read `project.json` and count keys in the `.dependencies` object
 4. Compare the current counts against the stored metadata values
@@ -34,15 +40,15 @@ Before doing any work, check if `.claude/rules/project-context.md` exists in the
 6. If **any individual count differs by 60–70% or more** → run the discovery flow below
 7. If all counts are within the threshold → context is fresh, proceed with the skill workflow
 
-**If the file does NOT exist** → run the discovery flow below.
+**If generated context does NOT exist** → run the discovery flow below.
 
 **Discovery flow** (used for both missing and stale context):
-1. Trigger the `uipath-project-discovery-agent` and wait for it to complete
-2. The agent returns the generated context document as its response
-3. Write the returned content to **both**:
-   - `.claude/rules/project-context.md` (create `.claude/rules/` directory if needed) — auto-loaded by Claude Code in future sessions
-   - `AGENTS.md` at project root — read by UiPath Autopilot in Studio Desktop. If `AGENTS.md` already exists, look for `<!-- PROJECT-CONTEXT:START -->` / `<!-- PROJECT-CONTEXT:END -->` markers and replace only between them; if no markers exist, append the fenced block at the end
-4. Then proceed with the skill workflow
+1. Run `uipath-project-discovery-agent` and wait for it to return the generated context document. If the host environment cannot trigger named agents, perform the same discovery inline using the discovery agent's workflow as the checklist.
+2. Persist the returned context in `AGENTS.md` as the portable source of truth:
+   - If `<!-- PROJECT-CONTEXT:START -->` / `<!-- PROJECT-CONTEXT:END -->` markers exist, replace only the content between them
+   - If no markers exist, append a new marked project-context block
+3. Also write `.claude/rules/project-context.md` only when the workspace already has a `.claude/` directory or the active host auto-loads Claude Code rules. Do not create host-specific context directories in otherwise agent-neutral projects.
+4. Use the generated context in the current session, then proceed with the skill workflow
 
 ## Step 0: Resolve PROJECT_DIR
 
@@ -284,7 +290,8 @@ Check `project.json` → `dependencies` for the required package.
 - **If absent** → install:
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output jsonuip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
+uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output json
+uip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
 ```
 
 ### Step 2 — Find activity docs (priority order)


### PR DESCRIPTION
## Summary
- make `AGENTS.md` the portable first-class project-context location for the RPA skill
- keep `.claude/rules/project-context.md` as an optional host-specific cache instead of the only/default context source
- clarify the discovery agent contract so it reuses marked `AGENTS.md` context before falling back to Claude-specific files
- update the README project-discovery row to match the agent-neutral workflow

## Why
RPA authoring depends heavily on project-local facts: mode, packages, namespace, entry points, Object Repository, and existing conventions. Treating the generated context as Claude-only makes the skill less usable for other coding agents and for the broader agentic automation workflow. This keeps the existing Claude path while making the portable context file explicit.

## Validation
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh skills/uipath-rpa/SKILL.md`
- checked fenced Markdown balance across changed Markdown files

## Related issues
No directly matching open issue found. This intentionally avoids duplicating the open RPA PRs for UIA pitfalls, Studio IPC, semantic XAML editing, and CLI snippet cleanup.