### PR TITLE
docs(uipath-rpa): clarify agent-era routing

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -21,6 +21,14 @@ Full assistant for creating, editing, managing, and running UiPath automation pr
 - User wants to **call an Integration Service connector** (Jira, Salesforce, ServiceNow, Slack, etc.)
 - User wants to **use UI automation** to interact with desktop or web applications
 
+## Agent/LLM-Era Routing
+
+Use this skill when the requested outcome is a **deterministic automation**: interact with applications, move files, process records, call activities/connectors, run Orchestrator jobs, or implement coded/XAML workflow logic.
+
+Do **not** treat RPA as the primary implementation for a conversational agent, RAG assistant, evaluator, planner, tool-selection loop, or other LLM reasoning system. Route that primary agent work to the agent authoring workflow, and use RPA only for deterministic processes or tools the agent needs to call.
+
+When an agent needs RPA, build the RPA side as a stable callable automation with explicit inputs, outputs, validation, and failure modes. Keep nondeterministic LLM reasoning outside the RPA workflow unless the user explicitly requests an activity or connector that calls an AI service.
+
 ## Precondition: Project Context
 
 Before doing any work, check if `.claude/rules/project-context.md` exists in the project directory.
@@ -67,9 +75,12 @@ After establishing `PROJECT_DIR`, determine whether this is a **coded** or **XAM
 
 | Scenario | Mode | Why |
 |----------|------|-----|
+| Conversational agent, RAG, evaluator, planner, or tool-selection loop | **Agent workflow, not RPA** | RPA is the deterministic execution layer; agent reasoning belongs in the agent authoring workflow |
+| Agent needs to click apps, move files, update records, or run a fixed process | **RPA workflow/tool** | Build a stable automation the agent can invoke with explicit inputs/outputs |
 | Standard RPA (Excel, email, file ops) | **XAML** (default) | Direct activity support, no code needed |
 | UI automation | **XAML** (default) | Full activity support; coded also works via `uiAutomation` service |
 | Integration Service connectors (XAML) | **XAML** | IS connector activities use XAML-specific dynamic activity config |
+| API-first automation with pagination, retry, typed JSON, or custom auth flow | **Coded** | C# is clearer and easier to test than nested XAML activities |
 | No matching activity for a subtask | **Coded fallback** | Small .cs invoked from XAML via `Invoke Workflow File` |
 | Complex data transforms, HTTP, parsing | **Coded** | C# is more natural than nested XAML activities |
 | Custom data models / DTOs | **Coded Source File** | XAML cannot define types — plain `.cs`, no `CodedWorkflow` base |
@@ -143,6 +154,7 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 
 | I need to... | Mode | Read these |
 |-------------|------|-----------|
+| **Decide RPA vs agent/coded workflow** | Both | [coded-vs-xaml-guide.md § RPA vs UiPath Agents](references/coded-vs-xaml-guide.md#rpa-vs-uipath-agents) |
 | **Choose coded vs XAML** | Both | [coded-vs-xaml-guide.md](references/coded-vs-xaml-guide.md) |
 | **Work in a hybrid project** | Hybrid | [coded-vs-xaml-guide.md](references/coded-vs-xaml-guide.md) → [project-structure.md](references/project-structure.md) |
 | **Create a new project** | Both | [environment-setup.md](references/environment-setup.md) |
@@ -284,7 +296,8 @@ Check `project.json` → `dependencies` for the required package.
 - **If absent** → install:
 
 ```bash
-uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output jsonuip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
+uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir "<PROJECT_DIR>" --output json
+uip rpa install-or-update-packages --packages '[{"id":"<PackageId>"}]' --project-dir "<PROJECT_DIR>" --output json
 ```
 
 ### Step 2 — Find activity docs (priority order)

--- a/skills/uipath-rpa/references/coded-vs-xaml-guide.md
+++ b/skills/uipath-rpa/references/coded-vs-xaml-guide.md
@@ -7,20 +7,36 @@ When to use coded workflows (C#), XAML workflows (low-code), Coded Source Files,
 Follow top-down. Stop at the first match.
 
 0. **Did the user specify a mode?** ("coded workflow", "XAML workflow", "create a .cs file", "low-code") → **Use what they asked for. Do not second-guess.**
-1. **Check the project's existing mode.** Match it unless there is a clear reason not to:
-   - **XAML-only project** → default to XAML. Only go coded if steps 3-6 below apply.
+1. **Is the request primarily agentic or LLM reasoning?** (chat assistant, RAG, evaluator, planner, tool-selection loop, multi-agent state machine) → **Use the agent authoring workflow for the primary implementation.** Build RPA only for deterministic app/process tools the agent will call.
+2. **Check the project's existing mode.** Match it unless there is a clear reason not to:
+   - **XAML-only project** → default to XAML. Only go coded if steps 4-7 below apply.
    - **Coded-only project** → default to coded. Activities (Excel, Mail, UI automation) are available via services on `CodedWorkflow`.
-   - **Hybrid project** → either mode is fine; pick the one that fits the task best using steps 2-8.
-   - **New project** → continue to step 2.
-2. **Can existing activities handle the task directly?** (read Excel, send email, move file, UI click/type, queue processing, connector calls) → **Use the project's current mode.** Both XAML activities and coded services can do these. No mode switch needed.
-3. **Does it define data models, DTOs, enums, or custom classes?** → **Coded Source File** (plain `.cs`, no `CodedWorkflow` base). XAML cannot define types — this is the one case where going hybrid is always justified.
-4. **Does it involve complex logic?** (5+ branches, LINQ queries, regex, algorithms, REST API calls with pagination/retry) → **Coded Workflow**. Both modes can handle logic, but coded is significantly clearer past 3-4 decision nodes.
-5. **Does it need unit tests or assertions on business logic?** → **Coded Workflow** + **Coded Test Case**.
-6. **Is it reusable utility code?** (helpers, formatters, validators, extension methods) → **Coded Source File**.
-7. **Is it a new project and still ambiguous?** → Ask the user. If they have no preference, default to XAML — it is the more common mode in UiPath projects.
-8. **Default** → match the project's dominant mode.
+   - **Hybrid project** → either mode is fine; pick the one that fits the task best using steps 3-9.
+   - **New project** → continue to step 3.
+3. **Can existing activities handle the task directly?** (read Excel, send email, move file, UI click/type, queue processing, connector calls) → **Use the project's current mode.** Both XAML activities and coded services can do these. No mode switch needed.
+4. **Does it define data models, DTOs, enums, or custom classes?** → **Coded Source File** (plain `.cs`, no `CodedWorkflow` base). XAML cannot define types — this is the one case where going hybrid is always justified.
+5. **Does it involve complex logic?** (5+ branches, LINQ queries, regex, algorithms, REST API calls with pagination/retry) → **Coded Workflow**. Both modes can handle logic, but coded is significantly clearer past 3-4 decision nodes.
+6. **Does it need unit tests or assertions on business logic?** → **Coded Workflow** + **Coded Test Case**.
+7. **Is it reusable utility code?** (helpers, formatters, validators, extension methods) → **Coded Source File**.
+8. **Is it a new project and still ambiguous?** → Ask the user. If they have no preference, default to XAML — it is the more common mode in UiPath projects.
+9. **Default** → match the project's dominant mode.
 
 ---
+
+## RPA vs UiPath Agents
+
+Use RPA when the work has a concrete, repeatable execution path: desktop/web UI automation, Excel/email/file processing, queue transactions, Integration Service connector calls, Orchestrator jobs, or deterministic coded/XAML workflow logic.
+
+Use a UiPath Agent when the primary work is natural-language reasoning, RAG, multi-step planning, tool selection, evaluation, conversation state, or choosing among multiple automations based on ambiguous user intent.
+
+When combining them, keep the boundary explicit:
+
+1. **Agent decides** — The agent interprets intent, plans, retrieves context, selects tools, and handles natural-language interaction.
+2. **RPA executes** — The RPA workflow performs a deterministic task with typed inputs, typed outputs, validation, logging, and predictable failure behavior.
+3. **Contract stays small** — Prefer a small number of stable arguments over broad free-form prompts. Return structured results an agent can inspect.
+4. **Mode follows the tool** — Use XAML when the callable tool is UI/activity-heavy; use coded workflows when it is API-first, data-transform-heavy, or needs typed models/tests.
+
+Avoid building an "agent" as a large RPA workflow filled with prompt strings and branching around LLM responses. That makes the automation hard to test and gives the agent fewer reliable execution tools.
 
 ## Use Coded Workflows When
 


### PR DESCRIPTION
## Summary
- Add early RPA-vs-agent routing guidance for deterministic automation versus LLM reasoning work
- Extend the coded/XAML decision guide with agent-era routing and callable RPA tool boundaries
- Add task navigation for deciding between RPA, agent, and coded workflow approaches

## Related issues
No directly matching open issue found.

## Validation
- git diff --check
- bash hooks/validate-skill-descriptions.sh skills/uipath-rpa/SKILL.md
- ruby fence-balance check for changed markdown files
- verified the new local reference link target exists