### PR TITLE
docs(uipath-rpa): clarify UIA selector recovery flow

### DIFF
--- a/skills/uipath-rpa/references/uia-debug-workflow.md
+++ b/skills/uipath-rpa/references/uia-debug-workflow.md
@@ -7,11 +7,13 @@
 1. **Record the window baseline** — list top-level windows via the `uia interact` CLI and note which w-refs and titles are already present. See the skill (`{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`) for the exact command.
 2. **Run the workflow:**
    ```bash
-   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json   ```
-   If the run fails, [`uia-selector-recovery.md`](uia-selector-recovery.md) spawns the `uia-improve-selector` subagent — this is the **only** correct recovery path. Do not hand-edit selectors in the XAML file.
+   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json
+   ```
+   If the run fails with a selector error, follow [`uia-selector-recovery.md`](uia-selector-recovery.md) — this is the **only** correct recovery path. Do not hand-edit selectors in the XAML file.
 3. **When done** (success or failure) — **stop the debug session:**
    ```bash
-   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json   ```
+   uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json
+   ```
 4. **List windows again** via the `uia interact` CLI.
 5. **Diff before vs after.** Any window present now that was NOT in the baseline was opened by the workflow. Close each such window via the `uia interact` CLI's window command (see the skill).
 

--- a/skills/uipath-rpa/references/uia-selector-recovery.md
+++ b/skills/uipath-rpa/references/uia-selector-recovery.md
@@ -7,7 +7,11 @@ When a workflow fails at runtime with a selector error:
 1. **The app is already in the right state.** The debug session paused at the failing activity, so the app's current DOM reflects the state that activity needs to target.
 2. **Identify the failing element** -- read the error to find which descriptor/element failed.
 3. **Read the window selector** -- from the Object Repository files, find the screen's selector that scopes the failing element.
-4. **Run the `uia-improve-selector` skill in recover mode.** Read `<PROJECT_DIR>/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-improve-selector/USAGE.md`, pick the appropriate invocation form for this context, run the staging CLI command from that form, spawn a subagent with the Agent tool to run the skill in recover mode against the staged folder, then run the write-back CLI command from the same form to persist the recovered selector.
-5. **Clean up and re-run** -- follow the [Running UI Automation Workflows](uia-debug-workflow.md) procedure (stop, diff, close leaked windows, re-run).
+4. **Stage selector recovery.** Read `<PROJECT_DIR>/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-improve-selector/USAGE.md`, choose the recover-mode invocation form for this context, and run its staging CLI command exactly as documented.
+5. **Improve the staged selector.** Run the `uia-improve-selector` recover-mode instructions against the staged folder. If the current coding environment supports delegated worker sessions, you may delegate only this staged-folder improvement step; otherwise execute the same recover-mode instructions inline in the current session.
+6. **Write back the recovered selector.** Run the write-back CLI command from the same invocation form to persist the recovered selector into the Object Repository.
+7. **Clean up and re-run** -- follow the [Running UI Automation Workflows](uia-debug-workflow.md) procedure (stop, diff, close leaked windows, re-run).
+
+The required contract is **stage from the paused debug state -> improve the staged selector -> write back through the documented CLI**. Do not hand-edit selector strings or Object Repository files directly.
 
 Repeat until the workflow completes successfully. Each failure advances the app to the next problematic state, making recovery self-correcting.


### PR DESCRIPTION
## Summary
- Replace the tool-specific selector recovery instruction with a portable stage/improve/write-back flow
- Allow a delegated worker only for the staged selector improvement step, with an inline fallback for environments without delegation
- Fix malformed fenced command examples in the UIA debug workflow guide

## Related issues
No directly matching open issue found.

## Validation
- git diff --check
- ruby fence-balance check for changed markdown files
- verified referenced local markdown targets exist
- confirmed changed selector recovery docs no longer mention the old Agent-tool/subagent path