### PR TITLE
docs(uipath-rpa): align UIA window preflight docs

### DIFF
--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -14,12 +14,14 @@ See [uia-prerequisites.md](uia-prerequisites.md).
 
 ## Pre-flight: Window Baseline
 
-Before configuring any target or writing any UIA workflow, list top-level windows **once** via the `uia snapshot inspect` CLI to check whether the target app is open. Two outcomes:
+Before configuring any target or writing any UIA workflow, list top-level windows **once** using the installed UIA package's `uia-interact` window-listing procedure at `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`. Use the exact command syntax from that installed file. Two outcomes:
 
 - **Target window present** → proceed directly to `uia-configure-target`; it will attach.
 - **Target window absent** → launch the app yourself, then proceed directly to `uia-configure-target`; the skill picks up the new window as part of its own capture.
 
 Do not re-inspect or keep polling after the initial check — subsequent capture and attach are `uia-configure-target`'s job. This single pre-flight exists only to drive the launch decision.
+
+Do not call low-level UIA snapshot commands from memory for this pre-flight. UIA command syntax lives in the installed `UiPath.UIAutomation.Activities` docs and can change with the package version.
 
 **Never use `Get-Process`, `tasklist`, `ps`, WMI, window-title scraping, or any other OS-level process command** to infer app state. They report processes, not UIA-visible windows; they miss background apps and name-mismatched binaries; and they produce wrong launch decisions.
 


### PR DESCRIPTION
## Summary
- Route the UIA window pre-flight check to the installed `uia-interact` package docs instead of naming a low-level snapshot command
- Keep the launch decision behavior unchanged: list windows once, then proceed to `uia-configure-target`
- Reinforce that UIA command syntax should come from the installed `UiPath.UIAutomation.Activities` docs

## Related issues
No directly matching open issue found.

## Validation
- git diff --check
- ruby fence-balance check for changed markdown file
- scanned changed file for forbidden UIA subcommand/flag/artifact patterns from `skills/uipath-rpa/CLAUDE.md`