### PR TITLE
[codex] Enforce UIA readiness before live app automation

### DIFF
--- a/skills/uipath-interact/SKILL.md
+++ b/skills/uipath-interact/SKILL.md
@@ -1,12 +1,25 @@
 ---
 name: uipath-interact
-description: "[PREVIEW] Inspect and interact with live desktop/browser apps -- click buttons, type text, read values, take screenshots, inspect UI state, verify behavior, fill forms, navigate menus, and extract table data from running applications."
+description: "[PREVIEW] Inspect and interact with live desktop/browser apps using uip rpa uia only -- snapshot inspect, click, type, read values, take screenshots, inspect UI state, verify behavior, fill forms, navigate menus, and extract table data. Use for live-app exploration before UiPath RPA authoring and for post-build verification. Never use PowerShell/OS scripts, Playwright, or hand-written selectors as substitutes."
 allowed-tools: Bash(uip:*), Read, Grep
 ---
 
 # UI Interaction via "uip rpa uia"
 
 Drive live desktop applications and browser tabs via the `uip rpa uia` CLI: discover applications and interact with elements using stable refs.
+
+## Mandatory Entry Gate
+
+Before inspecting or interacting with any live app:
+
+1. Resolve `PROJECT_DIR` to the folder containing `project.json`.
+2. Read `../uipath-rpa/references/uia-prerequisites.md`.
+3. Ensure `UiPath.UIAutomation.Activities` is installed at the minimum version from that file. If it is absent or older and the user asked you to build/fix/explore UI automation, upgrade it before continuing unless the user explicitly forbids dependency changes.
+4. Run `uip rpa restore "$PROJECT_DIR" --output json`.
+5. Verify `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md` exists and read it inline.
+6. Verify `uip rpa uia --help` exposes the interaction commands described by the package docs.
+
+If any check fails after the prerequisite version and restore, stop and report the exact blocker. Do not use PowerShell UIAutomation, `Get-Process`, window-title scraping, Playwright, Selenium, browser devtools, or guessed selectors to compensate.
 
 ## When to use
 
@@ -25,5 +38,7 @@ See [uia-prerequisites.md](../uipath-rpa/references/uia-prerequisites.md).
 ## Entry procedure
 
 Read and follow `$PROJECT_DIR/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md` **inline** in the main conversation. Do NOT delegate to a subagent -- the skill drives the live CLI and needs the main conversation's feedback loop (screenshots, captured output, user replies).
+
+The first live-app discovery command must be `uia snapshot inspect`. Use `uia interact` commands only after a UIA snapshot/ref exists. Keep using UIA refs; do not switch to coordinates or OS-level scripts.
 
 > **Trouble?** If something didn't work as expected, use `/uipath-feedback` to send a report.

--- a/skills/uipath-interact/SKILL.md
+++ b/skills/uipath-interact/SKILL.md
@@ -17,9 +17,9 @@ Before inspecting or interacting with any live app:
 3. Ensure `UiPath.UIAutomation.Activities` is installed at the minimum version from that file. If it is absent or older and the user asked you to build/fix/explore UI automation, upgrade it before continuing unless the user explicitly forbids dependency changes.
 4. Run `uip rpa restore "$PROJECT_DIR" --output json`.
 5. Verify `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md` exists and read it inline.
-6. Verify `uip rpa uia --help` exposes the interaction commands described by the package docs.
+6. Verify `uip rpa --project-dir "$PROJECT_DIR" uia --help` exposes the interaction commands described by the package docs. Put `--project-dir` before `uia`; `uip rpa uia --project-dir ...` is the wrong shape.
 
-If any check fails after the prerequisite version and restore, stop and report the exact blocker. Do not use PowerShell UIAutomation, `Get-Process`, window-title scraping, Playwright, Selenium, browser devtools, or guessed selectors to compensate.
+If the UIA command surface is still unavailable after the prerequisite version and restore, stop and report the exact blocker. If package skill docs are missing but the UIA command surface exists, proceed from CLI help and package activity docs and record the missing-docs issue. Do not use PowerShell UIAutomation, `Get-Process`, window-title scraping, Playwright, Selenium, browser devtools, or guessed selectors to compensate.
 
 ## When to use
 

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -32,7 +32,7 @@ High-level view of what each specialist owns. **Do not describe internal flows o
 | `uipath-coded-apps` | Web apps (`.uipath/` dir): build, sync, package, publish, deploy | Yes (`uip login`) | **Yes** — end-to-end |
 | `uipath-maestro-flow` | `.flow` files orchestrating RPA, agents, apps | Yes (`uip login`) | **Partial** — Studio Web by default; `uipath-platform` for Orchestrator |
 | `uipath-platform` | Auth, Orchestrator resources, solution lifecycle (pack/publish/deploy), Integration Service, Test Manager | Yes (auth hub) | **Yes** — the deploy destination |
-| `uipath-interact` | Inspect and interact with live desktop/browser UI: click, type, screenshot, inspect. For app launching, ad-hoc exploration, post-build verification. Does NOT author workflows or generate selectors — that's `uipath-rpa`. | No auth | **No** |
+| `uipath-interact` | Inspect and interact with live desktop/browser UI through `uip rpa uia`: snapshot, click, type, screenshot, inspect. Use for upfront live-app exploration and post-build verification. Does NOT author workflows or register Object Repository selectors - that's `uipath-rpa`. | No auth | **No** |
 
 ## RPA skill routing
 
@@ -171,14 +171,15 @@ Replace steps 2–3 with `uipath-agents` if the missing resource is an agent.
 
 `uipath-maestro-flow` publishes to Studio Web by default; Orchestrator deploy requires `uipath-platform`.
 
-### Build + verify UI automation on the live app
+### UI automation with a live app to inspect
 
-User wants to build a UI automation AND observe it running on the live app.
+User wants to build a UI automation and the app is already open, or asks the agent to inspect/capture/explore the live app.
 
 ```
-1. uipath-rpa      → build the workflow end-to-end
-2. uipath-interact → observe the live app, capture screenshots/snapshots to diagnose issues
-3. uipath-rpa      → apply fixes from findings; repeat 2–3 as needed
+1. uipath-interact → run the UIA prerequisite/readiness gate, inspect the live app with `uip rpa uia`, and record current screens/states without generating workflow code
+2. uipath-rpa      → configure Object Repository targets and build the workflow end-to-end from those findings
+3. uipath-interact → observe the completed workflow against the live app, capture screenshots/snapshots to diagnose issues
+4. uipath-rpa      → apply fixes from findings; repeat 3-4 as needed
 ```
 
 ### Verify or fix existing automation against a running app
@@ -196,7 +197,7 @@ User wants to build a UI automation AND observe it running on the live app.
 3. uipath-agents   → create the agent, bind the published processes as tools, deploy
 ```
 
-> **Important:** Single-app UI automation (one project, one live app, one workflow) is **not** a multi-skill pattern — it's a single-skill `uipath-rpa` task. `uipath-rpa` owns UI automation authoring end-to-end. Do not plan a separate "uipath-interact discovery" step.
+> **Important:** `uipath-rpa` owns UI automation authoring and selector registration. `uipath-interact` owns live-app exploration and verification through `uip rpa uia`. For a single-app UI workflow where the app is not open and no live inspection is requested, a single `uipath-rpa` task is enough. When the app is open or the user asks the agent to inspect/capture/explore it, include `uipath-interact` before `uipath-rpa`.
 
 ## Step 3 — Filesystem detection (single-skill requests)
 
@@ -365,7 +366,7 @@ Save as `YYYY-MM-DD-<feature-name>.md`:
 4. **Do not recommend a skill that contradicts the filesystem signals.** `.flow` files → `uipath-maestro-flow`, not `uipath-rpa`.
 5. **Do not skip Step 2.** Check multi-skill patterns before filesystem detection.
 6. **Do not ask the UI-targeting question (Step 4) unless the plan includes a UI automation workflow.** Gate on the presence of UI element targeting, NOT on whether `uipath-interact` is loaded — most UI plans are single-skill `uipath-rpa`.
-7. **Do not route UI automation through `uipath-interact` for element discovery or selector work.** `uipath-rpa` is the sole workflow authoring skill. `uipath-interact` is only for live-app interaction and post-build verification.
+7. **Do not use `uipath-interact` to author workflows or register selectors.** Use it for live-app exploration and post-build verification through `uip rpa uia`; use `uipath-rpa` for Object Repository target configuration and workflow authoring.
 8. **Do not describe specialist-internal flows in the plan** (target-configuration procedures, OR registration, scaffolding/write-agent pipelines, auth steps, pack/publish details). Route to the skill and let it follow its own documentation — inlining those flows creates drift.
 9. **Do not save a plan with placeholders** (TBD, TODO, as needed, similar to Task N).
 10. **Do not ask the user to choose between XAML and C#.** Project type is inferred from the request (see "Project type: infer first, ask only if vague" in Step 1). RPA workflows are XAML by default. Coded mode is only set when the user explicitly says "coded workflow", "C# workflow", or "create a .cs file" — record the choice directly, no question needed.

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -61,10 +61,10 @@ Do this before choosing a UIAutomation package version, before writing XAML/C# U
    - [references/uia-configure-target-workflows.md](references/uia-configure-target-workflows.md)
 2. Check `project.json` for `UiPath.UIAutomation.Activities`. If it is absent or below the minimum in `uia-prerequisites.md`, install or upgrade to that minimum before UIA exploration or selector authoring unless the user explicitly forbids dependency changes.
 3. Run `uip rpa restore "<PROJECT_DIR>" --output json`, then verify the UIA command/docs surface:
-   - `uip rpa uia --help`
+   - `uip rpa --project-dir "<PROJECT_DIR>" uia --help`
    - `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`
    - `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-configure-target/SKILL.md`
-4. If the command/docs surface is missing after the prerequisite version and restore, stop UI exploration and report the exact blocker. Do not substitute PowerShell UIAutomation scripts, Playwright, Selenium, OS process/window scraping, hand-written selectors, or guessed browser selectors.
+4. If the UIA command surface is missing after the prerequisite version and restore, stop UI exploration and report the exact blocker. If generated docs are missing but the `uia` commands are available, proceed from CLI help and package activity docs and record the missing-docs issue. Do not substitute PowerShell UIAutomation scripts, Playwright, Selenium, OS process/window scraping, hand-written selectors, or guessed browser selectors.
 5. For live-app exploration, use the `uip rpa uia` flow from the package docs. The first app-state probe must be `uia snapshot inspect`; subsequent UI advancement must use `uia interact` commands. For target creation, use `uia-configure-target`; do not call its internal selector-building commands directly.
 6. Use `indicate-application` / `indicate-element` only as the documented fallback after the UIA readiness gate has passed or when the user explicitly chooses Studio indication.
 

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -49,6 +49,25 @@ Before creating or modifying anything, determine which project to work with and 
 
 **Quick check:** Find `project.json` to establish `{projectRoot}`, run `uip rpa list-instances --output json` to verify Studio, and `uip rpa open-project` if needed.
 
+## Mandatory UIA Readiness Gate
+
+Apply this gate before any UI automation work: any browser/desktop app automation, selector work, Object Repository target capture, screen scraping, clicking, typing, reading UI text, SAP/WebGUI automation, or live-app inspection.
+
+Do this before choosing a UIAutomation package version, before writing XAML/C# UI activities, and before inspecting a running application:
+
+1. Read these references in this order:
+   - [references/uia-prerequisites.md](references/uia-prerequisites.md)
+   - [references/ui-automation-guide.md](references/ui-automation-guide.md)
+   - [references/uia-configure-target-workflows.md](references/uia-configure-target-workflows.md)
+2. Check `project.json` for `UiPath.UIAutomation.Activities`. If it is absent or below the minimum in `uia-prerequisites.md`, install or upgrade to that minimum before UIA exploration or selector authoring unless the user explicitly forbids dependency changes.
+3. Run `uip rpa restore "<PROJECT_DIR>" --output json`, then verify the UIA command/docs surface:
+   - `uip rpa uia --help`
+   - `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`
+   - `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-configure-target/SKILL.md`
+4. If the command/docs surface is missing after the prerequisite version and restore, stop UI exploration and report the exact blocker. Do not substitute PowerShell UIAutomation scripts, Playwright, Selenium, OS process/window scraping, hand-written selectors, or guessed browser selectors.
+5. For live-app exploration, use the `uip rpa uia` flow from the package docs. The first app-state probe must be `uia snapshot inspect`; subsequent UI advancement must use `uia interact` commands. For target creation, use `uia-configure-target`; do not call its internal selector-building commands directly.
+6. Use `indicate-application` / `indicate-element` only as the documented fallback after the UIA readiness gate has passed or when the user explicitly chooses Studio indication.
+
 ## Project Type Detection
 
 After establishing `PROJECT_DIR`, determine whether this is a **coded** or **XAML** project:
@@ -91,7 +110,7 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 3. **ALWAYS validate files as you go AND verify the project builds before declaring done.** Per-file `get-errors` after every create or edit; project-level `build` (or a passing `run-file` smoke test) before reporting done. See [references/validation-guide.md](references/validation-guide.md).
 4. **Prefer UiPath built-in activities** for Orchestrator integration, UI automation, and document handling. Prefer plain .NET / third-party packages for pure data transforms, HTTP calls, parsing.
 5. **ALWAYS ensure required package dependencies are in `project.json`** before using their activities or services.
-6. **For UI automation workflows**, MUST follow the target configuration workflow in [references/ui-automation-guide.md](references/ui-automation-guide.md). NEVER hand-write selectors — use `uia-configure-target` exclusively.
+6. **For UI automation workflows**, MUST complete the Mandatory UIA Readiness Gate above and follow the target configuration workflow in [references/ui-automation-guide.md](references/ui-automation-guide.md). NEVER hand-write selectors - use `uia-configure-target` exclusively.
 7. **Use `--output json`** on all CLI commands whose output is parsed programmatically.
 
 ### Execution Discipline (Both Modes)
@@ -141,8 +160,8 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 | **Use execution templates** | XAML | [testing-guide.md § Execution Templates](references/testing-guide.md) |
 | **Create/edit XAML workflow** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/xaml-basics-and-rules.md](references/xaml/xaml-basics-and-rules.md) |
 | **Create Flowchart/StateMachine/LRW** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) |
-| **Write UI automation** | Both | [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) |
-| **Build multi-screen UIA XAML workflow** | XAML | [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md § Multi-Step UI Flows](references/uia-configure-target-workflows.md#multi-step-ui-flows) |
+| **Write UI automation** | Both | [uia-prerequisites.md](references/uia-prerequisites.md) → [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) |
+| **Build multi-screen UIA XAML workflow** | XAML | [uia-prerequisites.md](references/uia-prerequisites.md) → [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md § Multi-Step UI Flows](references/uia-configure-target-workflows.md#multi-step-ui-flows) |
 | **Use Excel/Word/Mail/etc.** | Both | Service table below → `.local/docs/packages/{PackageId}/` → fallback: `references/activity-docs/{PackageId}/{closest}/` |
 | **Call an IS connector (coded)** | Coded | [coded/integration-service-guide.md](references/coded/integration-service-guide.md) |
 | **Call an IS connector (XAML)** | XAML | [is-connector-xaml-guide.md](references/is-connector-xaml-guide.md) → [connector-capabilities.md](references/connector-capabilities.md) |
@@ -278,7 +297,7 @@ uip rpa get-versions --package-id <PackageId> --include-prerelease --project-dir
 
 ## UI Automation References
 
-**MUST read [references/ui-automation-guide.md](references/ui-automation-guide.md) before any UI automation work** — mode-specific UIA patterns (coded vs XAML).
+**MUST run the Mandatory UIA Readiness Gate before any UI automation work**. This means reading the prerequisite and UIA guides before package selection, live-app inspection, target capture, or workflow authoring.
 
 Additional UIA procedures and guides:
 - [uia-prerequisites.md](references/uia-prerequisites.md) — Package version requirements

--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -4,7 +4,7 @@ Quick reference for UI automation in UiPath workflows — covers both coded work
 
 ## Prerequisites
 
-Read and apply [uia-prerequisites.md](uia-prerequisites.md) before doing anything else for UI automation. Do not inspect a live app, select a UIAutomation package version, write UIA XAML/C#, or configure targets until the package minimum and generated UIA docs are in place.
+Read and apply [uia-prerequisites.md](uia-prerequisites.md) before doing anything else for UI automation. Do not inspect a live app, select a UIAutomation package version, write UIA XAML/C#, or configure targets until the package minimum is installed and the `uip rpa --project-dir "$PROJECT_DIR" uia` command surface is available. If generated UIA docs are missing but the command surface exists, proceed from CLI help and package activity docs and record the missing-docs issue.
 
 **Required package:** `UiPath.UIAutomation.Activities`
 

--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -4,7 +4,7 @@ Quick reference for UI automation in UiPath workflows — covers both coded work
 
 ## Prerequisites
 
-See [uia-prerequisites.md](uia-prerequisites.md).
+Read and apply [uia-prerequisites.md](uia-prerequisites.md) before doing anything else for UI automation. Do not inspect a live app, select a UIAutomation package version, write UIA XAML/C#, or configure targets until the package minimum and generated UIA docs are in place.
 
 **Required package:** `UiPath.UIAutomation.Activities`
 
@@ -14,14 +14,14 @@ See [uia-prerequisites.md](uia-prerequisites.md).
 
 ## Pre-flight: Window Baseline
 
-Before configuring any target or writing any UIA workflow, list top-level windows **once** via the `uia snapshot inspect` CLI to check whether the target app is open. Two outcomes:
+After prerequisites pass, and before configuring any target or writing any UIA workflow, list top-level windows **once** via the `uia snapshot inspect` CLI to check whether the target app is open. Two outcomes:
 
 - **Target window present** → proceed directly to `uia-configure-target`; it will attach.
 - **Target window absent** → launch the app yourself, then proceed directly to `uia-configure-target`; the skill picks up the new window as part of its own capture.
 
 Do not re-inspect or keep polling after the initial check — subsequent capture and attach are `uia-configure-target`'s job. This single pre-flight exists only to drive the launch decision.
 
-**Never use `Get-Process`, `tasklist`, `ps`, WMI, window-title scraping, or any other OS-level process command** to infer app state. They report processes, not UIA-visible windows; they miss background apps and name-mismatched binaries; and they produce wrong launch decisions.
+**Never use `Get-Process`, `tasklist`, `ps`, WMI, PowerShell UIAutomation scripts, browser automation frameworks, window-title scraping, or any other OS-level process command** to infer app state or explore the app. They report processes, not UIA-visible windows; they miss background apps and name-mismatched binaries; and they produce wrong launch decisions. If `uip rpa uia` is unavailable, fix the prerequisites or stop with a concrete blocker.
 
 ---
 

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -2,11 +2,15 @@
 
 ## Prerequisite Gate
 
-Before following this workflow, complete [uia-prerequisites.md](uia-prerequisites.md). If `UiPath.UIAutomation.Activities` is below the required minimum, upgrade it and restore before capture. If `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-configure-target/SKILL.md` or `uia-interact/SKILL.md` is missing after restore, stop and report the blocker. Do not replace this workflow with hand-written selectors, OS-level UI probing, or PowerShell/browser automation scripts.
+If generated package docs are missing after restore but `uip rpa --project-dir "$PROJECT_DIR" uia --help` exposes `snapshot`, `interact`, `target-app`, `target-anchorable`, `object-repository`, and `selector-intelligence`, proceed from CLI help and package activity docs and record the missing-docs issue. Stop only when the UIA command surface itself is unavailable.
+
+Before following this workflow, complete [uia-prerequisites.md](uia-prerequisites.md). If `UiPath.UIAutomation.Activities` is below the required minimum, upgrade it and restore before capture. If generated docs are missing after restore and the UIA command surface is also unavailable, stop and report the blocker. Do not replace this workflow with hand-written selectors, OS-level UI probing, or PowerShell/browser automation scripts.
 
 **Always use the `uia-configure-target` skill** to create or find targets in the Object Repository. This skill handles the full flow: capturing the application, discovering elements, generating selectors, improving them, and registering them in the OR.
 
 > **Working directory:** run every `uip rpa uia` CLI call from the project directory — the folder containing `project.json`.
+
+> **Project option shape:** when adding an explicit project directory, use `uip rpa --project-dir "$PROJECT_DIR" uia ...`; do not put `--project-dir` after `uia`.
 
 ## Execution Model
 

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -1,5 +1,9 @@
 # Configure Target Workflows
 
+## Prerequisite Gate
+
+Before following this workflow, complete [uia-prerequisites.md](uia-prerequisites.md). If `UiPath.UIAutomation.Activities` is below the required minimum, upgrade it and restore before capture. If `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-configure-target/SKILL.md` or `uia-interact/SKILL.md` is missing after restore, stop and report the blocker. Do not replace this workflow with hand-written selectors, OS-level UI probing, or PowerShell/browser automation scripts.
+
 **Always use the `uia-configure-target` skill** to create or find targets in the Object Repository. This skill handles the full flow: capturing the application, discovering elements, generating selectors, improving them, and registering them in the OR.
 
 > **Working directory:** run every `uip rpa uia` CLI call from the project directory — the folder containing `project.json`.

--- a/skills/uipath-rpa/references/uia-prerequisites.md
+++ b/skills/uipath-rpa/references/uia-prerequisites.md
@@ -3,13 +3,31 @@
 **Required package:** `UiPath.UIAutomation.Activities`
 **Minimum version (`<MIN_VERSION>`):** `26.4.1-beta.11835126`
 
-The `uip rpa uia` CLI used by `uia-configure-target` requires `UiPath.UIAutomation.Activities` at `<MIN_VERSION>` or newer. Before configuring any target, check the installed version in `project.json` under `dependencies`.
+The `uip rpa uia` CLI used by `uia-interact` and `uia-configure-target` requires `UiPath.UIAutomation.Activities` at `<MIN_VERSION>` or newer. Treat this as a hard gate for UI automation work.
 
-If the installed version is below the minimum, ask the user whether to upgrade:
+## Required Sequence
+
+Before any live-app inspection, target capture, selector work, or UIA workflow authoring:
+
+1. Resolve `PROJECT_DIR` and read `project.json`.
+2. Check `dependencies["UiPath.UIAutomation.Activities"]`.
+3. If the package is absent or below `<MIN_VERSION>`, install or upgrade to `<MIN_VERSION>` unless the user explicitly forbids dependency changes.
+4. Restore the project.
+5. Verify the generated UIA docs and CLI surface exist before proceeding.
+
+Do not choose an older stable-looking package when UI exploration or selector capture is needed. The minimum version here is the source of truth.
 
 ```bash
-uip rpa get-versions --package-id UiPath.UIAutomation.Activities --project-dir "$PROJECT_DIR" --output json
-# If user approves the upgrade (substitute <MIN_VERSION> with the value declared above):
-uip rpa install-or-update-packages --packages '[{"id": "UiPath.UIAutomation.Activities", "version": "<MIN_VERSION>"}]' --project-dir "$PROJECT_DIR" --output json```
+uip rpa get-versions --package-id UiPath.UIAutomation.Activities --include-prerelease --project-dir "$PROJECT_DIR" --output json
+uip rpa install-or-update-packages --packages '[{"id":"UiPath.UIAutomation.Activities","version":"26.4.1-beta.11835126"}]' --project-dir "$PROJECT_DIR" --output json
+uip rpa restore "$PROJECT_DIR" --output json
+uip rpa uia --help
+```
 
-If the user declines, warn that `uip rpa uia` commands will fail and fall back to indication (see [uia-configure-target-workflows.md](uia-configure-target-workflows.md) § Indication Fallback).
+Expected docs after restore:
+
+- `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`
+- `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-configure-target/SKILL.md`
+- `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/uia-target-attachment-guide.md`
+
+If the user declines the upgrade, or if the CLI/docs surface is still unavailable after the upgrade and restore, do not use OS-level substitutes. Report the blocker and use indication fallback only if the user accepts that path. See [uia-configure-target-workflows.md](uia-configure-target-workflows.md) Indication Fallback.

--- a/skills/uipath-rpa/references/uia-prerequisites.md
+++ b/skills/uipath-rpa/references/uia-prerequisites.md
@@ -17,11 +17,19 @@ Before any live-app inspection, target capture, selector work, or UIA workflow a
 
 Do not choose an older stable-looking package when UI exploration or selector capture is needed. The minimum version here is the source of truth.
 
+`--project-dir` is an option on `uip rpa`, not on the nested `uia` command. When a project directory is needed, put it before `uia`:
+
 ```bash
 uip rpa get-versions --package-id UiPath.UIAutomation.Activities --include-prerelease --project-dir "$PROJECT_DIR" --output json
 uip rpa install-or-update-packages --packages '[{"id":"UiPath.UIAutomation.Activities","version":"26.4.1-beta.11835126"}]' --project-dir "$PROJECT_DIR" --output json
 uip rpa restore "$PROJECT_DIR" --output json
-uip rpa uia --help
+uip rpa --project-dir "$PROJECT_DIR" uia --help
+```
+
+With `@uipath/rpa-tool` 0.9.x, restore may try to resolve `UiPath.Studio.Helm.Windows` 0.9.0 even when only a newer `1.0.0-alpha.*` package exists on the feed. If the restore error reports a nearest available Helm version, set `HELM_NUGET_VERSION` to that exact version and rerun restore, for example:
+
+```bash
+HELM_NUGET_VERSION=1.0.0-alpha.20260422.11 uip rpa restore "$PROJECT_DIR" --output json
 ```
 
 Expected docs after restore:
@@ -30,4 +38,4 @@ Expected docs after restore:
 - `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-configure-target/SKILL.md`
 - `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/uia-target-attachment-guide.md`
 
-If the user declines the upgrade, or if the CLI/docs surface is still unavailable after the upgrade and restore, do not use OS-level substitutes. Report the blocker and use indication fallback only if the user accepts that path. See [uia-configure-target-workflows.md](uia-configure-target-workflows.md) Indication Fallback.
+If the user declines the upgrade, or if the CLI surface is still unavailable after the upgrade and restore, do not use OS-level substitutes. If docs are missing but `uip rpa --project-dir "$PROJECT_DIR" uia --help` exposes `snapshot`, `interact`, `target-app`, `target-anchorable`, `object-repository`, and `selector-intelligence`, proceed from CLI help and package activity docs, then record the missing-docs issue. Report the blocker and use indication fallback only if the UIA command surface itself is unavailable. See [uia-configure-target-workflows.md](uia-configure-target-workflows.md) Indication Fallback.


### PR DESCRIPTION
## Summary

- Add a mandatory UIA readiness gate to the `uipath-rpa` skill before any live app inspection, selector capture, or UI automation authoring.
- Harden UIA prerequisites so `UiPath.UIAutomation.Activities >= 26.4.1-beta.11835126` is treated as the source-of-truth minimum for `uip rpa uia`, `uia-interact`, and `uia-configure-target`.
- Update planner and interact guidance so live app exploration uses `uip rpa uia` first, and explicitly blocks PowerShell/OS probing, Playwright, guessed selectors, and hand-written selector substitutes.

## Why

The previous flow allowed agents to miss `uia-prerequisites.md`, choose an older UIAutomation package, and fall back to non-UiPath live-app probing when `uip rpa uia` was unavailable. This change makes the prerequisite and generated UIA docs part of the mandatory path.

## Validation

- Ran `git diff --check`.
- Verified changed skill frontmatter still includes `name` and `description`.
- Reviewed staged diff scope before commit.