### PR TITLE
fix(tests): raise max_turns for 4 maestro-flow smoke tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -8,7 +8,7 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:h
 agent:
   type: claude-code
   permission_mode: acceptEdits
-  max_turns: 30
+  max_turns: 80
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -8,7 +8,7 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:hi
 agent:
   type: claude-code
   permission_mode: acceptEdits
-  max_turns: 40
+  max_turns: 80
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -8,7 +8,7 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:hi
 agent:
   type: claude-code
   permission_mode: acceptEdits
-  max_turns: 20
+  max_turns: 40
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -8,7 +8,7 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:hi
 agent:
   type: claude-code
   permission_mode: acceptEdits
-  max_turns: 20
+  max_turns: 80
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -7,7 +7,7 @@ tags: [uipath-maestro-flow, smoke, lifecycle:discover, feature:registry]
 
 agent:
   type: claude-code
-  max_turns: 14
+  max_turns: 28
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
## Summary

Raises `max_turns` on four `uipath-maestro-flow` smoke tasks that hit `MAX_TURNS_EXHAUSTED` (in coder_eval e2e run `2026-04-24_12-06-40` and/or in this PR's smoke-test CI). Values are data-driven from combined production (blob) + local samples, applying #368's methodology (max-observed + ~5% headroom on right-censored-excluded distributions).

| Task | Old | New | Combined SUCCESS samples | min/max/stdev | Methodology |
|---|---:|---:|---|---|---|
| `skill-flow-hitl-smoke-completed-port` | 20 | **80** | `[35, 50, 67, 74]` (1 prod / 3 local) | 35 / 74 / 17.5 | max + ~5% = 78 → 80 |
| `skill-flow-hitl-smoke-node-placed` | 30 | **80** | `[36, 45, 72, 76]` (2 prod / 2 local) | 36 / 76 / 19.8 | max + ~5% = 80 |
| `skill-flow-hitl-smoke-multi-outcome-routing` | 20 | **80** | `[52, 58, 72]` (0 prod / 3 local) | 52 / 72 / 10.3 | max + ~5% = 76 → 80 |
| `skill-flow-registry-discovery` | 14 | **28** | `[17, 17, 18, 20, 20, 24]` (2 prod / 4 local) | 17 / 24 / 2.7 | max + ~17% = 28 |

Production samples come from `coderevaltests/runs/<run_id>/.../task.json` blobs; local samples come from 3 fresh runs of each task at `--max-turns 150` (so nothing is right-censored). Right-censored samples (`MAX_TURNS_EXHAUSTED` / `TIMEOUT`) are **excluded** from the distribution — they tell us only "≥budget", not actual work needed.

Routing nuance: production runs `aws_bedrock`, local default is `anthropic_direct`. Same HITL tasks show ~2× turn-count difference between routings (production 35–45 vs local 50–76). Setting budget at the production-only max trips if anyone switches routing; setting at combined max + headroom absorbs both.

The three HITL smoke tasks land at the same value (**80**) because their combined distributions are very similar (max in 72–76, mean in 57–61). Aligning them simplifies reasoning across the suite.

Commit history:
- 8dcafe6 — initial reactive bumps (40 / 28) based on the run's single-sample observation
- 03b6692 — re-tunes smoke_02 (`completed_port`) to 80 from the full distribution
- d4c63c7 — adds smoke_01 (`node_placed`) at 80 after PR-CI surfaced it
- 9c01152 — adds smoke_03 (`multi_outcome_routing`) at 80 after the next PR-CI iteration surfaced it

## Out-of-scope from the same run (verified, not in this PR)

The triage of `2026-04-24_12-06-40` surfaced 17 non-passing tasks. The remaining 13 are either already addressed upstream or require non-code action:

- **Pattern A** (3 inline-external-tool tasks @ 0.697): doc/checker conflict — `agent-json-format.md` (commit 474bf70, post-run) reinforces the `solution_folder` placeholder workflow, while `check_inline_external_*.py` deliberately rejects `solution_folder` for `external` and demands a real path. Flagged for UiPath agents team review.
- **Pattern B** (5 ERROR tasks): all `agent_turn_timeout` at iteration 1 with 0 turns completed. No code-level pattern. Flagged for staging-tenant / Claude API health check (2026-04-24 12:06–14:05 UTC).
- **Pattern D** (2 flow-debug tasks): Slack `SendTask` failed; `weatherLoop` subprocess hung. Connector/runtime-shaped. Flagged.
- **Already addressed upstream**: `e2e_07_apptask_brownfield` is `skip:true` since #368; `smoke_05_compliance` was broadened to `json_check` threshold 0.25 by #368; `init_validate` got `max_turns: 30` in #381.
- **Plus**: `sdd-product-selection` template-section coverage (4/7 vs threshold 6/7) — flagged for SDD-skill author review.

## Side-finding — coder_eval framework `max_turns` enforcement (resolved: not a regression)

Investigation in [UiPath/coder_eval#190](https://github.com/UiPath/coder_eval/issues/190) (closed as not-a-framework-bug) showed the framework enforcement did *not* change between the 4-22/4-23 SHAs and the 4-24 SHA. The two 4-24 SHAs (`a895261`, `93ebef2`) lived on `origin/pr/184` at run time — since merged as `bc45021` (evalboard Easy Auth + dashboard `--skip-login`/parallelism flags), unrelated to agent enforcement. Across the full window `260a17d..93ebef2`, the strict-comparison block in `src/coder_eval/agents/claude_code_agent.py` is byte-identical (file sha256 froze at `0a00c357…dba23` from `2b457c9` onward). Two earlier commits did touch the file (#174 SDK settings, #177 error/session-id retention) — neither related to turn counting.

This run-to-run variance was visible in this PR's own CI: `multi_outcome_routing` reported SUCCESS at 42 asst turns on run 25006527079, then MAX_TURNS_EXHAUSTED at 39 asst turns on run 25017004034 — same task, same `max_turns: 20`, opposite verdicts. So the same-task different-verdict pattern across SHAs is run-to-run variance in SDK-reported `num_turns`, not a strictness change. This *strengthens* the case for this PR's data-driven budgets: a right-censored-excluded distribution with headroom is exactly the right shape of fix, since the underlying turn-count signal is genuinely variable.

Full triage log: `~/root/workspace/uipath-skills/triaged/2026-04-24_12-06-40.md`.

## Test plan

- [x] All four YAMLs parse + `TaskDefinition.model_validate` after each commit
- [x] 3 local samples per task at `--max-turns 150` — all SUCCESS at score 1.0, max turn count well below 150
- [x] Smoke-test CI on commit 03b6692 (run 25006527079) reproduced `node_placed` exhaustion → fixed by d4c63c7
- [x] Smoke-test CI on commit d4c63c7 (run 25017004034) confirmed `node_placed`/`completed_port`/`registry_discovery` SUCCESS, surfaced `multi_outcome_routing` exhaustion → fixed by 9c01152
- [x] Smoke-test CI on commit 9c01152 (run 25019250951) — all five smoke tasks SUCCESS, full check suite green
- [ ] Re-run the 4 affected tasks against staging tenant via dashboard pipeline — expect SUCCESS at the new budgets
- [ ] (Reviewer) sanity-check the methodology: combined-distribution + 5% headroom + right-censored exclusion is consistent with #368's approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)
