### PR TITLE
feat(maestro-flow): add troubleshooting workflow for failed flows

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -286,53 +286,18 @@ The argument to `resource refresh` is the **solution directory** (containing the
 
 ### Step 7a — Troubleshoot failed flows
 
-When a debug run or a deployed process run fails, use the following diagnostic workflow. All commands require `uip login`.
+When a debug or process run fails, diagnose in this order. All commands require `uip login`. Get the instance ID from debug output (`Data.instanceId`) or from `uip maestro flow job status <JOB_KEY> --output json`.
 
-**1. Get the instance ID.** The debug output (`Data.instanceId`) or `job status` response contains the instance ID. If you only have a job key:
+1. **Incidents first** — failed flows always have an incident. This gives the error message and faulting element:
+   `uip maestro flow instance incidents <INSTANCE_ID> --output json`
+   Drill into a specific incident: `uip maestro flow incident get <INCIDENT_ID> --output json`
+2. **Runtime variables** — inspect variable state at time of failure:
+   `uip maestro flow instance variables <INSTANCE_ID> --output json`
+   Scope to an element: `uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json`
+3. **Correlate with the .flow file** — map the faulting element ID to its node, check `inputs`, upstream edges, and variable values. If the local file may differ from what ran, fetch the deployed definition: `uip maestro flow instance asset <INSTANCE_ID> --output json`
+4. **Traces (last resort)** — verbose full execution timeline: `uip maestro flow job traces <JOB_KEY> --output json`
 
-```bash
-uip maestro flow job status <JOB_KEY> --output json
-```
-
-Parse the instance ID from the response.
-
-**2. Fetch incidents for the instance.** Failed flows always have an incident associated with them. Start here — incidents give you the error category, message, and the faulting element:
-
-```bash
-uip maestro flow instance incidents <INSTANCE_ID> --output json
-```
-
-If you need more detail on a specific incident:
-
-```bash
-uip maestro flow incident get <INCIDENT_ID> --output json
-```
-
-**3. Fetch runtime variable state.** Get the variable values at the time of failure to understand what data each node was working with:
-
-```bash
-uip maestro flow instance variables <INSTANCE_ID> --output json
-```
-
-To scope variables to a specific element (node/subflow):
-
-```bash
-uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json
-```
-
-**4. Correlate with the flow definition.** Use the incident's faulting element ID and the variable state to locate the failure point in the `.flow` file. Map the element ID to the corresponding node, check its `inputs`, upstream edges, and the variable values flowing into it. If the local `.flow` file may differ from what was deployed, fetch the deployed BPMN definition:
-
-```bash
-uip maestro flow instance asset <INSTANCE_ID> --output json
-```
-
-**5. (Last resort) Fetch execution traces.** Traces are verbose but contain the full execution timeline. Use them only when incidents and variables are insufficient:
-
-```bash
-uip maestro flow job traces <JOB_KEY> --output json
-```
-
-> **Always use CLI commands for troubleshooting — never call the underlying APIs directly.**
+Always use CLI commands — never call the underlying APIs directly. See [flow-commands.md — instance / incident](references/flow-commands.md#uip-maestro-flow-instance) for full command reference.
 
 ### Step 8 — Publish to Studio Web
 

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -286,18 +286,7 @@ The argument to `resource refresh` is the **solution directory** (containing the
 
 ### Step 7a — Troubleshoot failed flows
 
-When a debug or process run fails, diagnose in this order. All commands require `uip login`. Get the instance ID from debug output (`Data.instanceId`) or from `uip maestro flow job status <JOB_KEY> --output json`.
-
-1. **Incidents first** — failed flows always have an incident. This gives the error message and faulting element:
-   `uip maestro flow instance incidents <INSTANCE_ID> --output json`
-   Drill into a specific incident: `uip maestro flow incident get <INCIDENT_ID> --output json`
-2. **Runtime variables** — inspect variable state at time of failure:
-   `uip maestro flow instance variables <INSTANCE_ID> --output json`
-   Scope to an element: `uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json`
-3. **Correlate with the .flow file** — map the faulting element ID to its node, check `inputs`, upstream edges, and variable values. If the local file may differ from what ran, fetch the deployed definition: `uip maestro flow instance asset <INSTANCE_ID> --output json`
-4. **Traces (last resort)** — verbose full execution timeline: `uip maestro flow job traces <JOB_KEY> --output json`
-
-Always use CLI commands — never call the underlying APIs directly. See [flow-commands.md — instance / incident](references/flow-commands.md#uip-maestro-flow-instance) for full command reference.
+When a debug or process run fails, read **[references/troubleshooting-guide.md](references/troubleshooting-guide.md)**. Diagnostic priority: incidents → runtime variables → .flow correlation → traces (last resort).
 
 ### Step 8 — Publish to Studio Web
 
@@ -369,7 +358,7 @@ When the build completes, present the next-step dropdown described in the [Compl
 | **Create a subflow** | [references/plugins/subflow/impl.md](references/plugins/subflow/impl.md) + [JSON: Create a subflow](references/flow-editing-operations-json.md#create-a-subflow) |
 | **Add a delay or scheduled trigger** | [references/plugins/delay/](references/plugins/delay/) or [references/plugins/scheduled-trigger/](references/plugins/scheduled-trigger/) |
 | **Use queue nodes** | [references/plugins/queue/impl.md](references/plugins/queue/impl.md) |
-| **Troubleshoot a failed flow** | Step 7a + [references/flow-commands.md — instance / incident](references/flow-commands.md#uip-maestro-flow-instance) |
+| **Troubleshoot a failed flow** | [references/troubleshooting-guide.md](references/troubleshooting-guide.md) |
 
 ## Key Concepts
 
@@ -422,6 +411,7 @@ When you finish building or editing a flow, report to the user:
 - **[Planning: Implementation Resolution](references/planning-impl.md)** — Registry lookups, connection binding, reference field resolution, wiring rules, and flow patterns.
 - **[.flow File Format](references/flow-file-format.md)** — JSON schema, node/edge structure, definition requirements, and minimal working example
 - **[CLI Command Reference](references/flow-commands.md)** — All `uip flow` subcommands with flags and options
+- **[Troubleshooting Guide](references/troubleshooting-guide.md)** — Diagnostic workflow for failed flows: incidents, runtime variables, definition correlation, traces, and `instance`/`incident` CLI reference
 - **[Variables and Expressions](references/variables-and-expressions.md)** — Variable declaration (in/out/inout), type system, `=js:` Jint expressions, template syntax, scoping rules, output mapping, and variable updates
 - **[Node Plugins](references/plugins/)** — Each node type has its own plugin folder with `planning.md` (selection heuristics, ports, key inputs) and `impl.md` (registry validation, JSON structure, configuration, debug):
   - [connector](references/plugins/connector/) — IS connector nodes: connection binding, enriched metadata, reference resolution, `bindings_v2.json`

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -284,6 +284,56 @@ The argument to `resource refresh` is the **solution directory** (containing the
 
 **Debug summary format:** Start the report with `Studio Web URL: <url>` and `Instance ID: <instanceId>` on the first two lines (parse `Data.studioWebUrl` / `Data.instanceId` from the JSON output). Use `<not returned by CLI>` if missing — never omit the line. See [flow-commands.md — uip maestro flow debug](references/flow-commands.md#uip-maestro-flow-debug).
 
+### Step 7a — Troubleshoot failed flows
+
+When a debug run or a deployed process run fails, use the following diagnostic workflow. All commands require `uip login`.
+
+**1. Get the instance ID.** The debug output (`Data.instanceId`) or `job status` response contains the instance ID. If you only have a job key:
+
+```bash
+uip maestro flow job status <JOB_KEY> --output json
+```
+
+Parse the instance ID from the response.
+
+**2. Fetch incidents for the instance.** Failed flows always have an incident associated with them. Start here — incidents give you the error category, message, and the faulting element:
+
+```bash
+uip maestro flow instance incidents <INSTANCE_ID> --output json
+```
+
+If you need more detail on a specific incident:
+
+```bash
+uip maestro flow incident get <INCIDENT_ID> --output json
+```
+
+**3. Fetch runtime variable state.** Get the variable values at the time of failure to understand what data each node was working with:
+
+```bash
+uip maestro flow instance variables <INSTANCE_ID> --output json
+```
+
+To scope variables to a specific element (node/subflow):
+
+```bash
+uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json
+```
+
+**4. Correlate with the flow definition.** Use the incident's faulting element ID and the variable state to locate the failure point in the `.flow` file. Map the element ID to the corresponding node, check its `inputs`, upstream edges, and the variable values flowing into it. If the local `.flow` file may differ from what was deployed, fetch the deployed BPMN definition:
+
+```bash
+uip maestro flow instance asset <INSTANCE_ID> --output json
+```
+
+**5. (Last resort) Fetch execution traces.** Traces are verbose but contain the full execution timeline. Use them only when incidents and variables are insufficient:
+
+```bash
+uip maestro flow job traces <JOB_KEY> --output json
+```
+
+> **Always use CLI commands for troubleshooting — never call the underlying APIs directly.**
+
 ### Step 8 — Publish to Studio Web
 
 **This is the default publish target.** After tidy (Step 6), when the user wants to publish, view, or share the flow, **refresh solution resources first**, then upload:
@@ -354,6 +404,7 @@ When the build completes, present the next-step dropdown described in the [Compl
 | **Create a subflow** | [references/plugins/subflow/impl.md](references/plugins/subflow/impl.md) + [JSON: Create a subflow](references/flow-editing-operations-json.md#create-a-subflow) |
 | **Add a delay or scheduled trigger** | [references/plugins/delay/](references/plugins/delay/) or [references/plugins/scheduled-trigger/](references/plugins/scheduled-trigger/) |
 | **Use queue nodes** | [references/plugins/queue/impl.md](references/plugins/queue/impl.md) |
+| **Troubleshoot a failed flow** | Step 7a + [references/flow-commands.md — instance / incident](references/flow-commands.md#uip-maestro-flow-instance) |
 
 ## Key Concepts
 

--- a/skills/uipath-maestro-flow/references/flow-commands.md
+++ b/skills/uipath-maestro-flow/references/flow-commands.md
@@ -148,40 +148,9 @@ uip maestro flow job status <job-key> --output json
 uip maestro flow job traces <job-key> --output json
 ```
 
-## uip maestro flow instance
+## uip maestro flow instance / uip maestro flow incident
 
-Inspect and manage Flow process instances. **Requires `uip login`.**
-
-```bash
-uip maestro flow instance list --output json                              # list all instances
-uip maestro flow instance get <INSTANCE_ID> --output json                 # get instance details (status, timestamps, process info)
-uip maestro flow instance incidents <INSTANCE_ID> --output json           # get incidents for a failed instance
-uip maestro flow instance variables <INSTANCE_ID> --output json           # get runtime variable values
-uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json  # scope to a specific element
-uip maestro flow instance element-executions <INSTANCE_ID> --output json  # get per-element execution details
-uip maestro flow instance asset <INSTANCE_ID> --output json               # get the deployed BPMN definition
-uip maestro flow instance cursors <INSTANCE_ID> --output json             # get current execution cursor positions
-```
-
-Additional instance lifecycle commands:
-
-```bash
-uip maestro flow instance pause <INSTANCE_ID> --output json               # pause a running instance
-uip maestro flow instance resume <INSTANCE_ID> --output json              # resume a paused instance
-uip maestro flow instance cancel <INSTANCE_ID> --output json              # cancel an instance
-uip maestro flow instance retry <INSTANCE_ID> --output json               # retry a faulted instance
-```
-
-## uip maestro flow incident
-
-Get incident details for failed flows. **Requires `uip login`.**
-
-```bash
-uip maestro flow incident summary --output json                # get incident summaries across all processes
-uip maestro flow incident get <INCIDENT_ID> --output json      # get full details for a specific incident
-```
-
-Use `instance incidents <INSTANCE_ID>` to get incidents scoped to a specific run, then `incident get <INCIDENT_ID>` for full detail on a specific incident.
+See [troubleshooting-guide.md](troubleshooting-guide.md) for the full diagnostic workflow and command reference for `instance` and `incident` subcommands.
 
 ## uip maestro flow node / uip maestro flow edge
 

--- a/skills/uipath-maestro-flow/references/flow-commands.md
+++ b/skills/uipath-maestro-flow/references/flow-commands.md
@@ -148,6 +148,41 @@ uip maestro flow job status <job-key> --output json
 uip maestro flow job traces <job-key> --output json
 ```
 
+## uip maestro flow instance
+
+Inspect and manage Flow process instances. **Requires `uip login`.**
+
+```bash
+uip maestro flow instance list --output json                              # list all instances
+uip maestro flow instance get <INSTANCE_ID> --output json                 # get instance details (status, timestamps, process info)
+uip maestro flow instance incidents <INSTANCE_ID> --output json           # get incidents for a failed instance
+uip maestro flow instance variables <INSTANCE_ID> --output json           # get runtime variable values
+uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json  # scope to a specific element
+uip maestro flow instance element-executions <INSTANCE_ID> --output json  # get per-element execution details
+uip maestro flow instance asset <INSTANCE_ID> --output json               # get the deployed BPMN definition
+uip maestro flow instance cursors <INSTANCE_ID> --output json             # get current execution cursor positions
+```
+
+Additional instance lifecycle commands:
+
+```bash
+uip maestro flow instance pause <INSTANCE_ID> --output json               # pause a running instance
+uip maestro flow instance resume <INSTANCE_ID> --output json              # resume a paused instance
+uip maestro flow instance cancel <INSTANCE_ID> --output json              # cancel an instance
+uip maestro flow instance retry <INSTANCE_ID> --output json               # retry a faulted instance
+```
+
+## uip maestro flow incident
+
+Get incident details for failed flows. **Requires `uip login`.**
+
+```bash
+uip maestro flow incident summary --output json                # get incident summaries across all processes
+uip maestro flow incident get <INCIDENT_ID> --output json      # get full details for a specific incident
+```
+
+Use `instance incidents <INSTANCE_ID>` to get incidents scoped to a specific run, then `incident get <INCIDENT_ID>` for full detail on a specific incident.
+
 ## uip maestro flow node / uip maestro flow edge
 
 See [flow-editing-operations-cli.md](flow-editing-operations-cli.md) for complete `node add/delete/list/configure` and `edge add/delete/list` syntax, flags, and auto-managed behaviors.

--- a/skills/uipath-maestro-flow/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-flow/references/troubleshooting-guide.md
@@ -2,6 +2,8 @@
 
 Diagnostic workflow for failed debug runs and deployed process runs. All commands require `uip login`.
 
+> **`--folder-key` is required.** All `instance` and `incident get` commands require `--folder-key <FOLDER_KEY>`. Get the folder key from `uip orchestrator folder list --output json` or from the job/process context.
+
 ## Diagnostic priority
 
 Investigate in this order — each step adds context, stop when you have enough to diagnose the root cause:
@@ -19,20 +21,20 @@ The debug output (`Data.instanceId`) or `job status` response contains the insta
 uip maestro flow job status <JOB_KEY> --output json
 ```
 
-Parse the instance ID from the response.
+Parse the instance ID and folder key from the response.
 
 ## Step 2 — Fetch incidents
 
 Failed flows always have an incident. Start here — incidents give you the error category, message, and the faulting element.
 
 ```bash
-uip maestro flow instance incidents <INSTANCE_ID> --output json
+uip maestro flow instance incidents <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json
 ```
 
 Drill into a specific incident for full detail:
 
 ```bash
-uip maestro flow incident get <INCIDENT_ID> --output json
+uip maestro flow incident get <INCIDENT_ID> --folder-key <FOLDER_KEY> --output json
 ```
 
 To get a cross-process incident overview:
@@ -46,13 +48,13 @@ uip maestro flow incident summary --output json
 Get the variable values at the time of failure to understand what data each node was working with:
 
 ```bash
-uip maestro flow instance variables <INSTANCE_ID> --output json
+uip maestro flow instance variables <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json
 ```
 
 Scope to a specific element (node or subflow):
 
 ```bash
-uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json
+uip maestro flow instance variables <INSTANCE_ID> --folder-key <FOLDER_KEY> --parent-element-id <ELEMENT_ID> --output json
 ```
 
 ## Step 4 — Correlate with the flow definition
@@ -62,14 +64,14 @@ Use the incident's faulting element ID and the variable state to locate the fail
 If the local `.flow` file may differ from what was deployed, fetch the deployed BPMN definition:
 
 ```bash
-uip maestro flow instance asset <INSTANCE_ID> --output json
+uip maestro flow instance asset <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json
 ```
 
 Additional instance inspection commands:
 
 ```bash
-uip maestro flow instance element-executions <INSTANCE_ID> --output json  # per-element execution details
-uip maestro flow instance cursors <INSTANCE_ID> --output json             # current execution cursor positions
+uip maestro flow instance element-executions <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json  # per-element execution details
+uip maestro flow instance cursors <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json             # current execution cursor positions
 ```
 
 ## Step 5 — Traces (last resort)
@@ -86,26 +88,26 @@ uip maestro flow job traces <JOB_KEY> --output json
 
 ### uip maestro flow instance
 
-Inspect and manage Flow process instances. **Requires `uip login`.**
+Inspect and manage Flow process instances. **Requires `uip login`.** All subcommands require `--folder-key <FOLDER_KEY>` (`-f` shorthand).
 
 ```bash
-uip maestro flow instance list --output json                              # list all instances
-uip maestro flow instance get <INSTANCE_ID> --output json                 # get instance details (status, timestamps, process info)
-uip maestro flow instance incidents <INSTANCE_ID> --output json           # get incidents for a failed instance
-uip maestro flow instance variables <INSTANCE_ID> --output json           # get runtime variable values
-uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json  # scope to a specific element
-uip maestro flow instance element-executions <INSTANCE_ID> --output json  # get per-element execution details
-uip maestro flow instance asset <INSTANCE_ID> --output json               # get the deployed BPMN definition
-uip maestro flow instance cursors <INSTANCE_ID> --output json             # get current execution cursor positions
+uip maestro flow instance list --output json                                                        # list all instances
+uip maestro flow instance get <INSTANCE_ID> -f <FOLDER_KEY> --output json                           # get instance details
+uip maestro flow instance incidents <INSTANCE_ID> -f <FOLDER_KEY> --output json                     # get incidents for a failed instance
+uip maestro flow instance variables <INSTANCE_ID> -f <FOLDER_KEY> --output json                     # get runtime variable values
+uip maestro flow instance variables <INSTANCE_ID> -f <FOLDER_KEY> --parent-element-id <ELEMENT_ID> --output json  # scope to a specific element
+uip maestro flow instance element-executions <INSTANCE_ID> -f <FOLDER_KEY> --output json            # get per-element execution details
+uip maestro flow instance asset <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # get the deployed BPMN definition
+uip maestro flow instance cursors <INSTANCE_ID> -f <FOLDER_KEY> --output json                       # get current execution cursor positions
 ```
 
 Instance lifecycle commands:
 
 ```bash
-uip maestro flow instance pause <INSTANCE_ID> --output json               # pause a running instance
-uip maestro flow instance resume <INSTANCE_ID> --output json              # resume a paused instance
-uip maestro flow instance cancel <INSTANCE_ID> --output json              # cancel an instance
-uip maestro flow instance retry <INSTANCE_ID> --output json               # retry a faulted instance
+uip maestro flow instance pause <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # pause a running instance
+uip maestro flow instance resume <INSTANCE_ID> -f <FOLDER_KEY> --output json                        # resume a paused instance
+uip maestro flow instance cancel <INSTANCE_ID> -f <FOLDER_KEY> --output json                        # cancel an instance
+uip maestro flow instance retry <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # retry a faulted instance
 ```
 
 ### uip maestro flow incident
@@ -113,8 +115,8 @@ uip maestro flow instance retry <INSTANCE_ID> --output json               # retr
 Get incident details for failed flows. **Requires `uip login`.**
 
 ```bash
-uip maestro flow incident summary --output json                # get incident summaries across all processes
-uip maestro flow incident get <INCIDENT_ID> --output json      # get full details for a specific incident
+uip maestro flow incident summary --output json                                    # get incident summaries across all processes
+uip maestro flow incident get <INCIDENT_ID> --folder-key <FOLDER_KEY> --output json # get full details for a specific incident
 ```
 
 Use `instance incidents <INSTANCE_ID>` to get incidents scoped to a specific run, then `incident get <INCIDENT_ID>` for full detail on a specific incident.

--- a/skills/uipath-maestro-flow/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-flow/references/troubleshooting-guide.md
@@ -1,0 +1,120 @@
+# Troubleshooting Failed Flows
+
+Diagnostic workflow for failed debug runs and deployed process runs. All commands require `uip login`.
+
+## Diagnostic priority
+
+Investigate in this order — each step adds context, stop when you have enough to diagnose the root cause:
+
+1. Incidents (error message + faulting element)
+2. Runtime variables (data state at failure)
+3. Flow definition correlation (map element to `.flow` node)
+4. Traces (last resort — verbose full timeline)
+
+## Step 1 — Get the instance ID
+
+The debug output (`Data.instanceId`) or `job status` response contains the instance ID. If you only have a job key:
+
+```bash
+uip maestro flow job status <JOB_KEY> --output json
+```
+
+Parse the instance ID from the response.
+
+## Step 2 — Fetch incidents
+
+Failed flows always have an incident. Start here — incidents give you the error category, message, and the faulting element.
+
+```bash
+uip maestro flow instance incidents <INSTANCE_ID> --output json
+```
+
+Drill into a specific incident for full detail:
+
+```bash
+uip maestro flow incident get <INCIDENT_ID> --output json
+```
+
+To get a cross-process incident overview:
+
+```bash
+uip maestro flow incident summary --output json
+```
+
+## Step 3 — Fetch runtime variable state
+
+Get the variable values at the time of failure to understand what data each node was working with:
+
+```bash
+uip maestro flow instance variables <INSTANCE_ID> --output json
+```
+
+Scope to a specific element (node or subflow):
+
+```bash
+uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json
+```
+
+## Step 4 — Correlate with the flow definition
+
+Use the incident's faulting element ID and the variable state to locate the failure point in the `.flow` file. Map the element ID to the corresponding node, check its `inputs`, upstream edges, and the variable values flowing into it.
+
+If the local `.flow` file may differ from what was deployed, fetch the deployed BPMN definition:
+
+```bash
+uip maestro flow instance asset <INSTANCE_ID> --output json
+```
+
+Additional instance inspection commands:
+
+```bash
+uip maestro flow instance element-executions <INSTANCE_ID> --output json  # per-element execution details
+uip maestro flow instance cursors <INSTANCE_ID> --output json             # current execution cursor positions
+```
+
+## Step 5 — Traces (last resort)
+
+Traces are verbose but contain the full execution timeline. Use them only when incidents and variables are insufficient:
+
+```bash
+uip maestro flow job traces <JOB_KEY> --output json
+```
+
+> **Always use CLI commands for troubleshooting — never call the underlying APIs directly.**
+
+## CLI command reference
+
+### uip maestro flow instance
+
+Inspect and manage Flow process instances. **Requires `uip login`.**
+
+```bash
+uip maestro flow instance list --output json                              # list all instances
+uip maestro flow instance get <INSTANCE_ID> --output json                 # get instance details (status, timestamps, process info)
+uip maestro flow instance incidents <INSTANCE_ID> --output json           # get incidents for a failed instance
+uip maestro flow instance variables <INSTANCE_ID> --output json           # get runtime variable values
+uip maestro flow instance variables <INSTANCE_ID> --parent-element-id <ELEMENT_ID> --output json  # scope to a specific element
+uip maestro flow instance element-executions <INSTANCE_ID> --output json  # get per-element execution details
+uip maestro flow instance asset <INSTANCE_ID> --output json               # get the deployed BPMN definition
+uip maestro flow instance cursors <INSTANCE_ID> --output json             # get current execution cursor positions
+```
+
+Instance lifecycle commands:
+
+```bash
+uip maestro flow instance pause <INSTANCE_ID> --output json               # pause a running instance
+uip maestro flow instance resume <INSTANCE_ID> --output json              # resume a paused instance
+uip maestro flow instance cancel <INSTANCE_ID> --output json              # cancel an instance
+uip maestro flow instance retry <INSTANCE_ID> --output json               # retry a faulted instance
+```
+
+### uip maestro flow incident
+
+Get incident details for failed flows. **Requires `uip login`.**
+
+```bash
+uip maestro flow incident summary --output json                # get incident summaries across all processes
+uip maestro flow incident get <INCIDENT_ID> --output json      # get full details for a specific incident
+```
+
+Use `instance incidents <INSTANCE_ID>` to get incidents scoped to a specific run, then `incident get <INCIDENT_ID>` for full detail on a specific incident.


### PR DESCRIPTION
## Summary
- Add **Step 7a — Troubleshoot failed flows** to SKILL.md with a prioritized 5-step diagnostic workflow: get instance ID → fetch incidents → fetch runtime variables → correlate with .flow/BPMN definition → traces as last resort
- Document `uip maestro flow instance` commands (list, get, incidents, variables, element-executions, asset, cursors, pause/resume/cancel/retry) in flow-commands.md
- Document `uip maestro flow incident` commands (summary, get) in flow-commands.md
- Add troubleshooting entry to the reference navigation table

## Test plan
- [ ] Verify `uip maestro flow instance --help` matches documented subcommands
- [ ] Verify `uip maestro flow incident --help` matches documented subcommands
- [ ] Run `hooks/validate-skill-descriptions.sh` to confirm SKILL.md frontmatter is valid
- [ ] Trigger a debug run, let it fail, and walk through the Step 7a workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)