### PR TITLE
fix(uipath-gov-access-policy): harden auth context guidance

### DIFF
--- a/skills/uipath-gov-access-policy/SKILL.md
+++ b/skills/uipath-gov-access-policy/SKILL.md
@@ -68,13 +68,13 @@ Map intent phrases to the three policy blocks. These priors feed directly into P
 2. **`policyType` is always `"ToolUsePolicy"`; `enforcement` is always `"Allow"`. Never emit `"Deny"`.**
     - **Why:** the API rejects `enforcement: "Deny"`; Deny is the runtime default when no Allow policy matches, so blocking is expressed as the complement of an Allow set.
     - **Applies to:** every create / update payload. When the user expresses Deny intent, silently translate to an Allow shape and never surface the mechanic (no "Deny→Allow flip" jargon, no `(flipped)` badge, no "enforcement: Deny is not authorable" caveat). See [plugins/tags/planning.md — Deny-to-Allow flip](./references/plugins/tags/planning.md#deny-to-allow-flip) for the decision logic.
-3. Read `organizationId` and `tenantId` from `~/.uipath/.auth` (see [planning-impl.md — Step 1](./references/planning-impl.md#step-1--gather-identity)). Never hardcode tenant or organization UUIDs.
+3. Gather the active organization / tenant context with the safe auth-context workflow in [access-policy-commands.md — Auth context for policy payloads](./references/access-policy-commands.md#auth-context-for-policy-payloads). Use `uip login status --output json` for names and extract only the non-secret org / tenant UUID fields when the CLI status output does not expose them. Never hardcode UUIDs, never print or source the full auth file, and never expose tokens in chat, logs, files, or review gates.
 4. **Three rule blocks; `actorRule` is optional.** A `ToolUsePolicy` access policy is composed of **Selection Rule** (`selectors[]`), **Actor Process Rule** (`executableRule`), and **Actor Identity Rule** (`actorRule`). The first two are mandatory; `actorRule` is emitted only when the user expressed actor-shaped intent — its absence means "any identity passes".
 5. **`values` is required on every entry; `tags` only on `selectors[]` / `executableRule`.**
     - **Why:** missing `values` returns `400 Bad Request`; `actorRule` does not accept a `tags` block today (the API rejects `actorRule.tags`).
     - **Applies to:** every entry under `selectors[]`, `executableRule.values[]`, and `actorRule.values[]` — use `["*"]` for "all of this type" even when `tags` narrow the scope. Never emit `actorRule.tags`.
 6. **Two-phase authoring is mandatory.** Never construct policy JSON from scratch. Author and approve a **Policy Spec** (natural-language narrative + Spec Components Table) via [planning-arch.md](./references/planning-arch.md) (Phase 1), then compose the concrete JSON via [planning-impl.md](./references/planning-impl.md) (Phase 2), which walks the approved Spec and delegates to each plugin's `impl.md` for block-level JSON.
-7. **Single confirmation gate per mutation.** Exactly one `yes / no` review precedes each `create`, `update`, or `delete` call. The gate must show: (a) the **Scope** — the organization name / tenant name plus their UUIDs, read from `~/.uipath/.auth` — so the user sees which environment is about to be mutated; (b) the complete policy JSON in chat; (c) clickable markdown links to **both** the Spec file (`/tmp/access-policy-<slug>.spec.md`, written by Phase 1) and the JSON working file (`/tmp/access-policy-<slug>.json`, written by Phase 2) using their **resolved absolute paths** (run `realpath` — never a relative path, a `<WORKING_FILE>` placeholder, or a `~/` path). For update flows the Spec file does not exist (Critical Rule #8) — show the Scope, the diff, and the JSON working file only. See [Confirmation-gate wording](#confirmation-gate-wording).
+7. **Single confirmation gate per mutation.** Exactly one `yes / no` review precedes each `create`, `update`, or `delete` call. The gate must show: (a) the **Scope** — the organization name / tenant name plus their UUIDs from the safe auth-context workflow — so the user sees which environment is about to be mutated; (b) the complete policy JSON in chat; (c) clickable markdown links to **both** the Spec file (`/tmp/access-policy-<slug>.spec.md`, written by Phase 1) and the JSON working file (`/tmp/access-policy-<slug>.json`, written by Phase 2) using their **resolved absolute paths** (run `realpath` — never a relative path, a `<WORKING_FILE>` placeholder, or a `~/` path). For update flows the Spec file does not exist (Critical Rule #8) — show the Scope, the diff, and the JSON working file only. See [Confirmation-gate wording](#confirmation-gate-wording).
 8. **For `update`: always `get` first and start from `Data` verbatim. Update is a full replacement.**
     - **Why:** any field you omit from the file is cleared on the server (including the whole `actorRule` block); a fresh Phase 1 Spec would silently wipe fields the user did not re-specify.
     - **Applies to:** every update flow. Use the returned `Data` object verbatim as the starting state, then strip audit fields (`isBuiltIn`, `isTemplate`, `createdBy`, `createdOn`, `modifiedBy`, `modifiedOn`, `deletedBy`, `deletedOn`).
@@ -127,7 +127,7 @@ The user reviews the pre-filled Spec and changes any row they want; the agent re
 
 ### Step 3 — Phase 2: compose the JSON via plugins
 
-Hand off to [planning-impl.md](./references/planning-impl.md). It reads `organizationId` and `tenantId` from `~/.uipath/.auth`, then walks each row of the approved **Spec Components Table** and reads the matching plugin's `impl.md`:
+Hand off to [planning-impl.md](./references/planning-impl.md). It gathers the active auth context, then walks each row of the approved **Spec Components Table** and reads the matching plugin's `impl.md`:
 
 - Each Resource entry (Spec rows 5–7 — type, scope, optional tag filter) → one `selectors[]` entry via [plugins/selector/impl.md](./references/plugins/selector/impl.md)
 - Each Actor Process entry (Spec rows 8–10 — type, scope, optional tag filter) → one `executableRule.values[]` entry via [plugins/executable/impl.md](./references/plugins/executable/impl.md)
@@ -139,14 +139,14 @@ Phase 2 reuses the slug Phase 1 used for the Spec file and writes the assembled 
 ### Step 4 — Single review gate
 
 Show a **short human-readable summary** that includes:
-- A **Scope** line on top — `Organization "<NAME>" / Tenant "<NAME>"` plus the matching `organizationId` / `tenantId` UUIDs read from `~/.uipath/.auth` — so the user always sees which environment they are about to mutate before approving.
+- A **Scope** line on top — `Organization "<NAME>" / Tenant "<NAME>"` plus the matching `organizationId` / `tenantId` UUIDs from the safe auth-context workflow — so the user always sees which environment they are about to mutate before approving.
 - One plain-English line per block — `Resources`, `Actor Process`, `Actor Identity` — with the per-entry technical breakdown tucked inside a collapsible `<details>` section.
 
 Then output the complete JSON as a ```json code block in the chat (do not rely on the file links alone — the user may not be able to open them), plus clickable markdown links to **both** files using their **resolved absolute paths** (Critical Rule #7):
 - `/tmp/access-policy-<slug>.spec.md` — the human-readable Policy Spec from Phase 1
 - `/tmp/access-policy-<slug>.json` — the JSON payload Phase 2 will submit
 
-See [policy-manage-guide.md — Create Step 4](./references/policy-manage-guide.md#step-4--single-review-gate) for the exact layout, the `~/.uipath/.auth` source-mapping for the Scope line, and the phrasing rules. Use the canonical wording from [Confirmation-gate wording](#confirmation-gate-wording) below. This is the only confirmation gate in the create flow.
+See [policy-manage-guide.md — Create Step 4](./references/policy-manage-guide.md#step-4--single-review-gate) for the exact layout, the auth-context source mapping for the Scope line, and the phrasing rules. Use the canonical wording from [Confirmation-gate wording](#confirmation-gate-wording) below. This is the only confirmation gate in the create flow.
 
 ### Step 5 — Create
 
@@ -195,7 +195,7 @@ Non-obvious mistakes the Critical Rules don't already cover by name. (Restatemen
 | **List policies** | [policy-manage-guide.md — List](./references/policy-manage-guide.md#list-policies) |
 | **Get a single policy by UUID** | [policy-manage-guide.md — Get](./references/policy-manage-guide.md#get-a-policy) |
 | **Evaluate a policy against a request context** | [access-policy-commands.md — evaluate](./references/access-policy-commands.md#uip-gov-access-policy-evaluate) — user-initiated only (Rule #13) |
-| **Resolve a process / agent / flow / user / robot name to a UUID** | [resource-lookup-guide.md](./references/resource-lookup-guide.md) — `uip or processes list` / `uip or folders list` / `uip or users list`; robot lookups use the REST fallback then resolve to a User UUID |
+| **Resolve a process / agent / flow / user / robot name to a UUID** | [resource-lookup-guide.md](./references/resource-lookup-guide.md) — `uip or processes list` / `uip or folders list` / `uip or users list`; robot intent resolves to the linked User UUID without exposing auth tokens |
 | **Compose a `selectors[]` entry (Selection Rule)** | [plugins/selector/planning.md](./references/plugins/selector/planning.md) + [plugins/selector/impl.md](./references/plugins/selector/impl.md) |
 | **Compose the `executableRule` block (Actor Process Rule)** | [plugins/executable/planning.md](./references/plugins/executable/planning.md) + [plugins/executable/impl.md](./references/plugins/executable/impl.md) |
 | **Compose the `actorRule` block (Actor Identity Rule)** | [plugins/actor/planning.md](./references/plugins/actor/planning.md) + [plugins/actor/impl.md](./references/plugins/actor/impl.md) |
@@ -340,7 +340,7 @@ Do not run any of these actions automatically. Wait for the user's selection.
 - **[resource-lookup-guide.md](./references/resource-lookup-guide.md)** — `uip or processes list` / `uip or folders list` / `uip or users list` lookups to resolve human-readable names to the UUIDs required by `selectors[].values`, `executableRule.values[].values`, and `actorRule.values[].values`. Route here whenever the user names a process, folder, or user without supplying a UUID.
 - **[planning-arch.md](./references/planning-arch.md)** — Phase 1: author a **Policy Spec** (narrative paragraph + Spec Components Table covering name, description, status, enforcement, resource selection, actor process, actor identity, tags, operators). The agent pre-fills every row; the user reviews and edits before approving, and approval is required before any JSON is composed.
 - **[sample-policy-guide.md](./references/sample-policy-guide.md)** — canonical Spec narrative + JSON (Production Agent + one Maestro + one User, Allow, Simulated). Phase 1 routes here when the user has no concrete intent or has gaps; surfaces a 3-option picker so the user can adopt, adapt, or replace the sample.
-- **[planning-impl.md](./references/planning-impl.md)** — Phase 2: walk the approved Spec Components Table and assemble the concrete `PolicyDefinition` JSON by reading `~/.uipath/.auth` for identity and each plugin's `impl.md` for block-level JSON.
+- **[planning-impl.md](./references/planning-impl.md)** — Phase 2: walk the approved Spec Components Table and assemble the concrete `PolicyDefinition` JSON by gathering the safe auth context and reading each plugin's `impl.md` for block-level JSON.
 - **[policy-manage-guide.md](./references/policy-manage-guide.md)** — Full CRUD lifecycle (list / get / create / update / delete). Owns the single final-review gate before every mutation.
 - **[plugins/selector/](./references/plugins/selector/)** — `selectors[]` (Selection Rule): resource/tool types (`Agent`, `AgenticProcess`, `RPAWorkflow`, `APIWorkflow`, `CaseManagement`, `Flow`), targeting modes, tag filters.
 - **[plugins/executable/](./references/plugins/executable/)** — `executableRule` (Actor Process Rule): executable types (`Agent`, `AgenticProcess`, `CaseManagement`, `Flow`), targeting modes, shared tag filter.

--- a/skills/uipath-gov-access-policy/references/access-policy-commands.md
+++ b/skills/uipath-gov-access-policy/references/access-policy-commands.md
@@ -41,22 +41,36 @@ uip login --authority https://alpha.uipath.com     # non-production environments
 
 For `evaluate`, login must target a specific tenant (not just an organization).
 
-### Reading `organizationId` and `tenantId`
+### Auth context for policy payloads
 
-The org and tenant UUIDs required in every `PolicyDefinition` live in `~/.uipath/.auth`:
+Every `PolicyDefinition` needs `organizationId` and `tenantId`, and every review gate must show the matching organization / tenant names. Treat this as auth context, not as general credential access.
 
 ```bash
-grep -E "UIPATH_ORGANIZATION_ID|UIPATH_TENANT_ID" ~/.uipath/.auth
+uip login status --output json
 ```
 
-Expected output:
+Use `Data.Organization` and `Data.Tenant` from the status response for display names. If the CLI status output does not include the UUIDs, extract only the non-secret scope fields from the local auth cache:
 
+```bash
+awk -F= '$1 ~ /^UIPATH_(ORGANIZATION|TENANT)_(ID|NAME)$/ {print $1 "=" substr($0, index($0, "=") + 1)}' "$HOME/.uipath/.auth"
 ```
+
+Expected scope fields:
+
+```text
+UIPATH_ORGANIZATION_NAME=<ORG_NAME>
+UIPATH_TENANT_NAME=<TENANT_NAME>
 UIPATH_ORGANIZATION_ID=<ORG_UUID>
 UIPATH_TENANT_ID=<TENANT_UUID>
 ```
 
-Copy these into `organizationId` and `tenantId` when composing a policy (see [planning-impl.md — Step 1](./planning-impl.md#step-1--gather-identity)). Never hardcode.
+Copy only the two UUIDs into `organizationId` and `tenantId` when composing a policy (see [planning-impl.md — Step 1](./planning-impl.md#step-1--gather-identity)). Use the names only in Spec scope rows and review gates.
+
+**Safety rules:**
+
+- Do not run `cat ~/.uipath/.auth`, `env`, `source ~/.uipath/.auth`, or broad `grep = ~/.uipath/.auth` in chat-visible workflows.
+- Do not print, store, or include `UIPATH_ACCESS_TOKEN` in any file, command output, PR, issue, or review gate.
+- If the auth cache is missing or lacks org / tenant UUIDs, stop and ask the user to re-run `uip login` or tenant selection. Do not invent IDs or continue with placeholders.
 
 ---
 

--- a/skills/uipath-gov-access-policy/references/planning-arch.md
+++ b/skills/uipath-gov-access-policy/references/planning-arch.md
@@ -24,7 +24,7 @@ Both parts are kept in sync: every change to the table updates the narrative, an
 1. **Read the user's request.** Extract resource phrases, actor process phrases, tag phrases, and actor-identity phrases (user, robot user, or group — Critical Rule #16). Use the [Intent analysis](#intent-analysis) heuristics below.
 2. **If the user has no concrete intent or named ≤ 1 of the four phrase categories** (Resource / Actor Process / Actor Identity / Tag), route through [Sample-policy starter (when intent is missing or sparse)](#sample-policy-starter-when-intent-is-missing-or-sparse) BEFORE generating the Spec — show the canonical sample, let the user pick a path, and seed the Spec from the user's choice.
 3. **Generate the initial Spec — fully pre-filled.** Build the narrative paragraph and Spec Components Table with **a concrete value in every row** (don't leave rows empty for the user to fill in). For values the user explicitly supplied, use those. For values they didn't, apply sensible defaults (Critical Rule #11 — don't ask, just do):
-    - **Scope rows (Org / Tenant — read-only):** capture both rows from the active auth context BEFORE generating the rest of the Spec. Read **names** via `uip login status --output json` (`Data.Organization`, `Data.Tenant`) and **UUIDs** from `~/.uipath/.auth` (`organizationId`, `tenantId`). Render each row as `<NAME> (UUID <UUID>)`. Mark these rows as read-only — the user changes them by re-running `uip login` (Critical Rule #1), not by editing the Spec. They appear above the numbered rows so the user always sees which environment the policy will be authored against.
+    - **Scope rows (Org / Tenant — read-only):** capture both rows from the active auth context BEFORE generating the rest of the Spec. Read **names** via `uip login status --output json` (`Data.Organization`, `Data.Tenant`) and gather UUIDs with [access-policy-commands.md — Auth context for policy payloads](./access-policy-commands.md#auth-context-for-policy-payloads). Render each row as `<NAME> (UUID <UUID>)`. Mark these rows as read-only — the user changes them by re-running `uip login` (Critical Rule #1), not by editing the Spec. They appear above the numbered rows so the user always sees which environment the policy will be authored against.
     - **Row 1 (Name):** ALWAYS suggest a name derived from intent — never `(missing)`. Pattern: `"Allow <ResourceSummary> in <ActorProcessSummary>"` (e.g. `"Allow Production Agents in Maestro"`). Use user-facing names (`Maestro` for `AgenticProcess` — Critical Rule #14).
     - **Row 2 (Description):** auto-derive from the narrative paragraph.
     - **Row 3 (Status):** `Simulated` (Critical Rule #13).
@@ -157,8 +157,8 @@ Present the Spec as **structured narrative + Spec Components Table** every time.
 
 | # | Component | Allowed values | Current value | Required? |
 |---|-----------|---------------|--------------|-----------|
-| — | Organization (read-only)      | sourced from `uip login status` + `~/.uipath/.auth` — change via `uip login`     | <ORG_NAME> (UUID `<ORG_ID>`)                   | Scope (read-only) |
-| — | Tenant (read-only)            | sourced from `uip login status` + `~/.uipath/.auth` — change via `uip login`     | <TENANT_NAME> (UUID `<TENANT_ID>`)             | Scope (read-only) |
+| — | Organization (read-only)      | sourced from active auth context — change via `uip login`                       | <ORG_NAME> (UUID `<ORG_ID>`)                   | Scope (read-only) |
+| — | Tenant (read-only)            | sourced from active auth context — change via `uip login`                       | <TENANT_NAME> (UUID `<TENANT_ID>`)             | Scope (read-only) |
 | 1 | Policy name                   | string — always pre-filled                                                       | <suggested name>                               | Required |
 | 2 | Description                   | one sentence — auto-derived from the narrative above                             | <description>                                  | Required |
 | 3 | Status                        | `Simulated` (default) / `Active`                                                 | `Simulated`                                    | Required |
@@ -187,8 +187,8 @@ Every row gets a concrete value in the initial Spec (Critical Rule #11 — don't
 
 | Row | Required? | Default when not specified |
 |---|---|---|
-| — Organization (read-only) | Scope | Name from `uip login status` (`Data.Organization`); UUID from `~/.uipath/.auth` (`organizationId`). Not user-editable in the Spec. |
-| — Tenant (read-only) | Scope | Name from `uip login status` (`Data.Tenant`); UUID from `~/.uipath/.auth` (`tenantId`). Not user-editable in the Spec. |
+| — Organization (read-only) | Scope | Name from `uip login status` (`Data.Organization`); UUID from the safe auth-context workflow. Not user-editable in the Spec. |
+| — Tenant (read-only) | Scope | Name from `uip login status` (`Data.Tenant`); UUID from the safe auth-context workflow. Not user-editable in the Spec. |
 | 1 — Policy name | Required | Suggested from intent: `"Allow <ResourceSummary> in <ActorProcessSummary>"` |
 | 2 — Description | Required | Auto-derived from the narrative |
 | 3 — Status | Required | `Simulated` (Critical Rule #13) |
@@ -224,7 +224,7 @@ Spec row 2 (`Description`) is the **one-sentence summary** that the policy carri
 
 ### Spec rules
 
-- **Org / Tenant rows are read-only scope.** The two un-numbered rows at the top of the table show the active auth context — `<NAME> (UUID <UUID>)` for both Organization and Tenant. They are sourced from `uip login status --output json` (names) and `~/.uipath/.auth` (UUIDs) and are NOT user-editable in the Spec; if the user wants to author against a different org or tenant, route them to re-run `uip login` (Critical Rule #1) and regenerate the Spec. The same Scope is shown again at the Phase 2 review gate (Critical Rule #7).
+- **Org / Tenant rows are read-only scope.** The two un-numbered rows at the top of the table show the active auth context — `<NAME> (UUID <UUID>)` for both Organization and Tenant. They are sourced from `uip login status --output json` plus the safe auth-context workflow and are NOT user-editable in the Spec; if the user wants to author against a different org or tenant, route them to re-run `uip login` (Critical Rule #1) and regenerate the Spec. The same Scope is shown again at the Phase 2 review gate (Critical Rule #7).
 - **Narrative and table are kept in sync.** When the user changes a row, re-derive the narrative; when the user changes the narrative ("make it match this description"), re-derive the table by re-running [Intent analysis](#intent-analysis) on the new narrative. Both must reflect the same policy.
 - **Terminology (user-facing — Critical Rule #14):** say "Resource", "Actor Process", "Actor Identity", "tag filter", "Allow", "Simulated / Active" in the Spec. Never use the JSON field names (`selectors`, `executableRule`, `actorRule`, `operator: Or/And/None`) in the Spec. JSON terms appear only in Phase 2.
 - **Multi-type rows.** If the user names two resource types ("Agents and Flows"), each type gets its own row group — duplicate rows 5/6/7 once per type and label them `5a / 6a / 7a` for the first type, `5b / 6b / 7b` for the second, etc. Do the same for Actor Process rows (8/9/10) when multiple Actor Process types are named. The Spec table grows row-wise; it never collapses two types into one row.

--- a/skills/uipath-gov-access-policy/references/planning-impl.md
+++ b/skills/uipath-gov-access-policy/references/planning-impl.md
@@ -8,9 +8,9 @@ Compose the concrete `PolicyDefinition` JSON from an **approved Phase 1 Spec** (
 
 ## Step 1 — Gather identity
 
-Every `PolicyDefinition` requires `organizationId` and `tenantId` at the top level. Read them from `~/.uipath/.auth` — see [access-policy-commands.md — Reading `organizationId` and `tenantId`](./access-policy-commands.md#reading-organizationid-and-tenantid) for the exact command. Use the two UUIDs verbatim in the assembled JSON; never hardcode (Critical Rule #3).
+Every `PolicyDefinition` requires `organizationId` and `tenantId` at the top level. Gather them with [access-policy-commands.md — Auth context for policy payloads](./access-policy-commands.md#auth-context-for-policy-payloads): verify `uip login status --output json`, use that response for display names, and extract only the non-secret org / tenant UUID fields if the CLI does not expose them. Use the two UUIDs verbatim in the assembled JSON; never hardcode and never keep placeholders (Critical Rule #3).
 
-If the file is missing or the IDs are not present, the user is not logged in — stop and route them to [access-policy-commands.md — Authentication](./access-policy-commands.md#authentication).
+If the auth context is missing, tenant-less, or does not expose both UUIDs, stop and route the user to [access-policy-commands.md — Authentication](./access-policy-commands.md#authentication). Do not source or print the full auth file and do not expose tokens while troubleshooting.
 
 ---
 

--- a/skills/uipath-gov-access-policy/references/plugins/actor/impl.md
+++ b/skills/uipath-gov-access-policy/references/plugins/actor/impl.md
@@ -138,8 +138,8 @@ This allows every User **except** `alice-uuid`. (See [../tags/planning.md — De
 **Intent:** "Only the unattended robot `build-bot` can trigger this".
 
 Resolution flow (see [planning.md — Robot intent](./planning.md#robot-intent-resolves-to-user)):
-1. `GET /orchestrator_/odata/Robots` → match `build-bot` → read `Username`.
-2. `uip or users list` filtered on that `UserName` → get the User UUID `bot-user-uuid`.
+1. Ask the user for the linked username / email shown for `build-bot` in Orchestrator or Admin.
+2. `uip or users list --output json` filtered on that username / email → get the User UUID `bot-user-uuid`.
 3. Emit:
 
 ```json

--- a/skills/uipath-gov-access-policy/references/plugins/actor/planning.md
+++ b/skills/uipath-gov-access-policy/references/plugins/actor/planning.md
@@ -4,7 +4,7 @@
 
 The `actorRule` block is the policy's **Actor Identity Rule** — it identifies **who** (which user or group) is allowed (or blocked) from triggering the Actor Process that invokes the Resource. The access policy has at most one `actorRule` block, which can hold at most two entries — one `User` and one `Group` (Critical Rule #16).
 
-> **Supported types: `User` and `Group` only** (Critical Rule #16). `ExternalApplication` is **not supported** today; reject any intent that names a service principal / registered app and route the user to use a User or Group instead, or to omit Actor Identity entirely. **Robot intent maps to `User`** — look up the robot via [resource-lookup-guide.md § Robots](../../resource-lookup-guide.md#robots-resolve-to-type-user) (REST → `Username` → `uip or users list`), resolve to its linked User UUID, and emit a `User`-typed entry. Never emit `type: "Robot"` or `type: "ExternalApplication"`.
+> **Supported types: `User` and `Group` only** (Critical Rule #16). `ExternalApplication` is **not supported** today; reject any intent that names a service principal / registered app and route the user to use a User or Group instead, or to omit Actor Identity entirely. **Robot intent maps to `User`** — ask for the robot's linked username / email from Orchestrator or Admin, resolve it with `uip or users list --output json`, and emit a `User`-typed entry. Never emit `type: "Robot"` or `type: "ExternalApplication"`.
 
 > **Terminology recap.** The access policy has three rule parts:
 > - **Selection Rule** → `selectors[]` — which Resource/Tool the policy applies to.
@@ -86,12 +86,11 @@ Present matched users as a numbered picker (see [resource-lookup-guide.md § 3](
 
 A robot in UiPath identity is **a kind of user** (Critical Rule #16). When the user says "robot R can trigger…":
 
-1. Look up the robot via the REST fallback `GET /orchestrator_/odata/Robots` — see [resource-lookup-guide.md § Robots](../../resource-lookup-guide.md#robots-resolve-to-type-user) for the secure token-sourcing pattern.
-2. Read the `Username` field on the matched robot record.
-3. Resolve that username to a User UUID with `uip or users list --output json` filtered on `UserName`.
-4. Emit `{ "type": "User", "values": ["<USER_UUID>"], "operator": "Or" }` — never `type: "Robot"`.
+1. Ask the user for the robot's linked username, email, or user display name from Orchestrator / Admin — see [resource-lookup-guide.md § 5](../../resource-lookup-guide.md#5-robot-lookups-resolve-to-user-identity). Do not bypass the CLI by sourcing auth tokens into direct REST calls.
+2. Resolve that username / email to a User UUID with `uip or users list --output json`.
+3. Emit `{ "type": "User", "values": ["<USER_UUID>"], "operator": "Or" }` — never `type: "Robot"`.
 
-If the robot has no linked user (rare), surface as an Open question and stop — do not invent a UUID.
+If the robot has no linked user or the user cannot identify it, surface as an Open question and stop — do not invent a UUID.
 
 ## Multi-type actor rules
 

--- a/skills/uipath-gov-access-policy/references/plugins/tags/planning.md
+++ b/skills/uipath-gov-access-policy/references/plugins/tags/planning.md
@@ -42,7 +42,7 @@ The Resource Catalog tag set is tenant-specific, but these names recur across Ui
 - **Team / org:** `Finance`, `Marketing`, `HR`, `Platform`
 - **Product / domain:** user-specific product names
 
-> Tags the user mentions must actually exist in the Resource Catalog of the **policy's own tenant** (the tenant in `~/.uipath/.auth`). A policy that references `DoesNotExist` silently matches nothing. **Confirm tag names during Phase 1** before approving the Spec by running `uip admin rcs tag list --output json` (no `--tenant` — the default targets the policy's tenant; see [resource-lookup-guide.md § 4](../../resource-lookup-guide.md#4-resource-catalog-tags)). If the tag is missing, surface it as an Open question and ask the user to either pick a returned tag or add the missing one to the Resource Catalog before the JSON is composed.
+> Tags the user mentions must actually exist in the Resource Catalog of the **policy's own tenant** (the active tenant from the safe auth-context workflow). A policy that references `DoesNotExist` silently matches nothing. **Confirm tag names during Phase 1** before approving the Spec by running `uip admin rcs tag list --output json` (no `--tenant` — the default targets the policy's tenant; see [resource-lookup-guide.md § 4](../../resource-lookup-guide.md#4-resource-catalog-tags)). If the tag is missing, surface it as an Open question and ask the user to either pick a returned tag or add the missing one to the Resource Catalog before the JSON is composed.
 
 ## Deny-to-Allow flip
 

--- a/skills/uipath-gov-access-policy/references/policy-manage-guide.md
+++ b/skills/uipath-gov-access-policy/references/policy-manage-guide.md
@@ -125,18 +125,19 @@ Review the access policy to be created:
 </details>
 ```
 
-**Scope line — what to fill in.** The Scope line tells the user which organization + tenant the policy will be created in. Read all four values from `~/.uipath/.auth`:
+**Scope line — what to fill in.** The Scope line tells the user which organization + tenant the policy will be created in. Use [access-policy-commands.md — Auth context for policy payloads](./access-policy-commands.md#auth-context-for-policy-payloads):
 
 ```bash
-grep -E "UIPATH_ORGANIZATION_NAME|UIPATH_TENANT_NAME|UIPATH_ORGANIZATION_ID|UIPATH_TENANT_ID" ~/.uipath/.auth
+uip login status --output json
+awk -F= '$1 ~ /^UIPATH_(ORGANIZATION|TENANT)_(ID|NAME)$/ {print $1 "=" substr($0, index($0, "=") + 1)}' "$HOME/.uipath/.auth"
 ```
 
-- `UIPATH_ORGANIZATION_NAME` → `<ORG_NAME>`
-- `UIPATH_TENANT_NAME` → `<TENANT_NAME>`
+- `Data.Organization` (preferred) or `UIPATH_ORGANIZATION_NAME` → `<ORG_NAME>`
+- `Data.Tenant` (preferred) or `UIPATH_TENANT_NAME` → `<TENANT_NAME>`
 - `UIPATH_ORGANIZATION_ID` → `<ORG_UUID>` (matches `organizationId` in the JSON payload)
 - `UIPATH_TENANT_ID` → `<TENANT_UUID>` (matches `tenantId` in the JSON payload)
 
-If the org / tenant names are missing from `~/.uipath/.auth`, show only the UUIDs on the second line and note "(name unavailable)". Do **not** skip the Scope line — the user must always see which environment is about to be mutated. If the user expected a different org / tenant, they should `cancel` and re-login (`uip login --authority …` or `uip login --tenant …`).
+If the org / tenant names are unavailable, show only the UUIDs on the second line and note "(name unavailable)". Do **not** skip the Scope line — the user must always see which environment is about to be mutated. If the user expected a different org / tenant, they should `cancel` and re-login (`uip login --authority …` or tenant selection). Never print `UIPATH_ACCESS_TOKEN` or the full auth file while filling this line.
 
 Then output the full JSON as a ```json code block in the chat (do NOT rely on the file link alone — the user may not be able to open it).
 
@@ -265,7 +266,7 @@ Review access-policy update:
   Working file: [access-policy-<id>-working.json](/tmp/access-policy-<id>-working.json)
 ```
 
-The Scope line uses the same source as the create gate — read from `~/.uipath/.auth` (see [Step 4 — Single review gate](#step-4--single-review-gate) above for the full source-mapping). For an update, the values come from the policy's stored `organizationId` / `tenantId` (which must match the logged-in tenant — if they do not, the update will fail at the API).
+The Scope line uses the same safe auth-context workflow as the create gate (see [Step 4 — Single review gate](#step-4--single-review-gate) above for the full source mapping). For an update, display the stored `organizationId` / `tenantId` from the working file and the current login names from `uip login status --output json` when available. If the stored IDs do not match the active login context, stop before `update` and ask the user to switch tenants; otherwise the API will reject the mutation or target the wrong environment.
 
 For each row, show `(unchanged)` if the field was not modified. Output the full updated JSON as a ```json code block in the chat as well.
 

--- a/skills/uipath-gov-access-policy/references/resource-lookup-guide.md
+++ b/skills/uipath-gov-access-policy/references/resource-lookup-guide.md
@@ -181,8 +181,8 @@ uip or users current --output json
 
 A robot is a kind of user in the UiPath identity model (Critical Rule #16). To use a robot in `actorRule`, the policy emits `type: "User"` with the robot's **linked user UUID**, never `type: "Robot"`. Resolve the robot to its user identity in three steps:
 
-1. **Find the robot** via the [REST API fallback](#5-rest-api-fallback-for-robot-lookups) below — read the `Username` field from the matching robot record.
-2. **Resolve the username to a User UUID** with `uip or users list --output json --output-filter "Data[?UserName == '<USERNAME>']"`. The user `Key` is the UUID to use in the policy.
+1. **Ask for the robot's linked username / email** from Orchestrator or Admin. Do not bypass the CLI by sourcing auth tokens into direct REST calls.
+2. **Resolve the username / email to a User UUID** with `uip or users list --output json --output-filter "Data[?UserName == '<USERNAME>']"`. The user `Key` is the UUID to use in the policy.
 3. **Emit `type: "User"`** in the policy JSON — see [plugins/actor/impl.md — Example E](./plugins/actor/impl.md#e-robot-only-trigger-resolves-to-user).
 
 If the robot has no linked user (rare for modern Orchestrator deployments), surface this as an Open question on the Phase 1 Spec and stop — do not invent a UUID.
@@ -210,7 +210,7 @@ Resource Catalog tags are tenant-scoped labels that feed `selectors[].tags.value
 uip admin rcs tag list --output json
 ```
 
-With no `--tenant`, the command targets the tenant in the current `uip login` context — and that is **also** the tenant the access policy will be authored in (the policy's `tenantId` is read from `~/.uipath/.auth`). This default is the only mode that proves a tag will resolve at evaluation time. Run it before approving any Spec or update that introduces a tag the user named; if the tag is missing from `Data.value[].displayName`, prompt the user to pick a returned tag, or to add the missing one to the Resource Catalog of the policy's tenant before retrying. Never invent a tag, and never silently substitute a near-match.
+With no `--tenant`, the command targets the tenant in the current `uip login` context — and that is **also** the tenant the access policy will be authored in (the policy's `tenantId` comes from the safe auth-context workflow). This default is the only mode that proves a tag will resolve at evaluation time. Run it before approving any Spec or update that introduces a tag the user named; if the tag is missing from `Data.value[].displayName`, prompt the user to pick a returned tag, or to add the missing one to the Resource Catalog of the policy's tenant before retrying. Never invent a tag, and never silently substitute a near-match.
 
 | Flag | Required? | Purpose |
 |------|-----------|---------|
@@ -240,40 +240,34 @@ With no `--tenant`, the command targets the tenant in the current `uip login` co
 
 ### Tenant alignment
 
-The access-policy `tenantId` is read from `~/.uipath/.auth` (`UIPATH_TENANT_ID`) and pinned at `create` time — the policy can only ever resolve tags from **that** tenant at evaluation.
+The access-policy `tenantId` is gathered from the safe auth-context workflow and pinned at `create` time — the policy can only ever resolve tags from **that** tenant at evaluation.
 
 - **Default (no `--tenant`)** — verify tags for the in-flight policy. Use this for every Phase 1 / Phase 2 confirmation prompt.
 - **`--tenant <OTHER_NAME>`** — comparison only (e.g. "do these tag names also exist in our staging tenant?"). Never use a result from another tenant as evidence that a tag will work in the policy's tenant. If the user explicitly asks to check a different tenant, run the call but surface a one-line warning: `Tags from <OTHER_NAME> do not affect a policy authored in <POLICY_TENANT>; copy the tag in the Resource Catalog of <POLICY_TENANT> if it is missing there.`
 
-To recover the policy's tenant name (for the warning above) without echoing the bearer token:
+To recover the policy's tenant name for the warning above, prefer login status:
 
 ```bash
-grep "^UIPATH_TENANT_NAME=" ~/.uipath/.auth | cut -d= -f2
+uip login status --output json
 ```
 
 ---
 
-## 5. REST API fallback (for Robot lookups)
+## 5. Robot lookups resolve to User identity
 
-`Robot` lookups are not wrapped by `uip or`. Fall back to Orchestrator REST directly to find the robot's `Username`, which then feeds a `uip or users list` call (see [Robots resolve to `type: User`](#robots-resolve-to-type-user) above). **Never `cat ~/.uipath/.auth` into the transcript** — the file contains the bearer token. Instead, source it into environment variables inside a sub-shell so the token stays out of logs:
+`Robot` lookups are not wrapped by `uip or` in all CLI versions. Do **not** bypass the CLI by sourcing auth tokens into direct REST calls from this skill. Instead, resolve robot intent through the linked user identity:
 
-```bash
-# SECURITY: sources the auth env into a sub-shell only; the token never prints.
-bash -c 'source <(grep = ~/.uipath/.auth) && curl -s \
-  "${UIPATH_URL}/${UIPATH_ORGANIZATION_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Robots?\$top=50&\$select=Id,Key,Name,Username,Type" \
-  -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
-  -H "Accept: application/json"' \
-  | jq '.value[] | {Key, Name, Username, Type}'
-```
-
-The `Username` field is what you feed to `uip or users list` to get the User UUID for the policy.
+1. Ask the user for the robot's linked username, email, or user display name as shown in Orchestrator / Admin.
+2. Run `uip or users list --output json` with the broadest safe filter the CLI supports, then match the returned user record.
+3. Use the User UUID in `actorRule.values[]` with `type: "User"`.
+4. If the user cannot identify the linked user, treat the robot identity as a blocking Open question in the Phase 1 Spec. Do not fabricate a UUID and do not print auth tokens while troubleshooting.
 
 | Identity type | Endpoint / source | What to do with it |
 |---------------|------------------|--------------------|
-| **Robot** (intermediate lookup) | `orchestrator_/odata/Robots` — read `Username` | Resolve `Username` → User UUID via `uip or users list`, then emit `type: "User"`. |
+| **Robot** (intermediate lookup) | User-supplied linked username / email from Orchestrator or Admin | Resolve username / email → User UUID via `uip or users list`, then emit `type: "User"`. |
 | **Group** | Identity service — ask the user to paste the UUID from Admin portal | Use directly as `type: "Group"`. |
 
-If the call returns `401 Unauthorized`, the token expired — ask the user to `uip login` and retry. Never commit or echo the token.
+If `uip or users list` returns an authorization error, ask the user to `uip login` and retry. Never commit or echo tokens.
 
 ---
 
@@ -298,6 +292,6 @@ If the call returns `401 Unauthorized`, the token expired — ask the user to `u
 | A user UUID by username / display name | `uip or users list --output json` → filter on `UserName` or `Name` |
 | The currently authenticated user's UUID | `uip or users current --output json` |
 | A Resource Catalog tag name (for `tags.values[]`) | `uip admin rcs tag list --output json` — paste each row's `displayName` into `tags.values[]`. Do NOT pass `--tenant` when verifying tags for the policy under construction (see [§ 4 Tenant alignment](#tenant-alignment)). |
-| A robot's User UUID (for `actorRule`) | REST `GET /orchestrator_/odata/Robots` to find `Username` (see [§ 5](#5-rest-api-fallback-for-robot-lookups)), then `uip or users list` to resolve `Username` → User UUID |
+| A robot's User UUID (for `actorRule`) | Ask for the robot's linked username / email from Orchestrator or Admin (see [§ 5](#5-robot-lookups-resolve-to-user-identity)), then `uip or users list --output json` to resolve that identity → User UUID |
 | A group UUID | Admin portal — paste into the Phase 1 Spec as an Open question |
 | An external application UUID | **Not supported** by access policies today (Critical Rule #16) — route to a `User` or `Group` workaround |

--- a/skills/uipath-gov-access-policy/references/sample-policy-guide.md
+++ b/skills/uipath-gov-access-policy/references/sample-policy-guide.md
@@ -64,7 +64,7 @@ Use this canonical sample when the user has **no concrete intent** ("I want to c
 }
 ```
 
-> Replace `<ORG_UUID>` and `<TENANT_UUID>` from `~/.uipath/.auth` (Critical Rule #3). Replace `<AGENTIC_PROCESS_UUID>` and `<USER_UUID>` via [resource-lookup-guide.md](./resource-lookup-guide.md) once the user names a real process and user (Critical Rule #15). Resolve every `<…_UUID>` during Phase 1 — before the Spec is approved and Phase 2 composes the JSON. Never let a placeholder flow into the working file.
+> Replace `<ORG_UUID>` and `<TENANT_UUID>` from the safe auth-context workflow in [access-policy-commands.md](./access-policy-commands.md#auth-context-for-policy-payloads) (Critical Rule #3). Replace `<AGENTIC_PROCESS_UUID>` and `<USER_UUID>` via [resource-lookup-guide.md](./resource-lookup-guide.md) once the user names a real process and user (Critical Rule #15). Resolve every `<…_UUID>` during Phase 1 — before the Spec is approved and Phase 2 composes the JSON. Never let a placeholder flow into the working file.
 
 ---
 
@@ -104,7 +104,7 @@ Pick one to continue:
 
 Map the user's reply:
 
-- **Option 1** → seed the Spec Components Table from the [mapping table above](#how-the-sample-seeds-the-spec-components-table) — every row pre-filled. Run [resource-lookup-guide.md](./resource-lookup-guide.md) to resolve the Maestro and User UUIDs (do NOT keep `<…_UUID>` placeholders). Read `~/.uipath/.auth` for `organizationId` / `tenantId` (Critical Rule #3). Continue to the [planning-arch.md](./planning-arch.md) Review gate — explicit `yes` is still required.
+- **Option 1** → seed the Spec Components Table from the [mapping table above](#how-the-sample-seeds-the-spec-components-table) — every row pre-filled. Run [resource-lookup-guide.md](./resource-lookup-guide.md) to resolve the Maestro and User UUIDs (do NOT keep `<…_UUID>` placeholders). Gather `organizationId` / `tenantId` from the safe auth-context workflow (Critical Rule #3). Continue to the [planning-arch.md](./planning-arch.md) Review gate — explicit `yes` is still required.
 - **Option 2** → seed the Spec Components Table from the sample for rows the user did NOT change; mark the rows they want to change as `(missing)` and re-enter the [planning-arch.md](./planning-arch.md) iteration loop on those rows only.
 - **Option 3** → drop the sample, return to [planning-arch.md](./planning-arch.md) intent analysis with the user's full description and build the Spec from scratch.
 


### PR DESCRIPTION
## Summary

- centralize access-policy org / tenant context guidance around `uip login status --output json` plus a narrow non-secret scope-field fallback
- remove normal-flow direct token sourcing and robot REST fallback guidance from access-policy references
- align Phase 1, Phase 2, review-gate, sample, tag, and actor identity docs with the safer auth-context workflow

## Validation

- `bash hooks/validate-skill-descriptions.sh skills/uipath-gov-access-policy/SKILL.md`
- `git diff --check`
- Markdown fence balance scan across changed Markdown files
- targeted scan for stale direct-token / robot REST fallback patterns

## Related issues

No related open issue found for `uipath-gov-access-policy` auth-context hardening.
