### PR TITLE
docs(uipath-diagnostics): clarify portable role execution

### DIFF
--- a/skills/uipath-diagnostics/SKILL.md
+++ b/skills/uipath-diagnostics/SKILL.md
@@ -5,18 +5,30 @@ description: Use when diagnosing UiPath platform & process issues - failed jobs,
 
 # UiPath Diagnostic Agent
 
-You orchestrate a hypothesis-driven diagnostic investigation. You manage the loop, delegate to sub-agents, and present findings to the user.
+You orchestrate a hypothesis-driven diagnostic investigation. You manage the loop, delegate work to diagnostic roles, and present findings to the user.
 
-All agents (including you) follow the invariants and confidence-level behavior defined in `agents/shared.md`.
+All diagnostic roles (including you) follow the invariants and confidence-level behavior defined in `agents/shared.md`.
+
+## 0. Execution Adapter
+
+This skill is written as a multi-role investigation. Use the best execution primitive your host provides:
+
+| If your host supports... | Do this |
+|---|---|
+| Background sub-agents / tasks | Spawn the named role file (`agents/triage.md`, `agents/hypothesis-tester.md`, etc.) and pass the working directory plus `.investigation/` path. |
+| Resuming or messaging an existing task | Continue that same role with the user's answer when a role wrote `needs_input.json`. |
+| No sub-agents or no resume primitive | Run the named role sequentially in the current agent context. Read `agents/shared.md` plus the role file, perform only that role's work, write the same `.investigation/` files, then return to the orchestrator loop. |
+
+When the instructions below say **spawn**, **re-spawn**, or **continue**, apply this adapter. Preserve the role boundary either way: the orchestrator decides phase transitions; triage gathers initial data; generators generate; testers test; presenters format the final answer.
 
 ## 1. Critical Rules
 
-1. **You NEVER run uip commands, query endpoints, or read reference docs.** Sub-agents do everything else.
-2. **You NEVER confirm/eliminate hypotheses yourself.** Always spawn a tester.
+1. **As orchestrator, you NEVER run uip commands, query endpoints, or read reference docs.** Delegate to the relevant diagnostic role. In single-agent hosts, enter that role via the Execution Adapter before doing role work.
+2. **You NEVER confirm/eliminate hypotheses in orchestrator mode.** Always delegate to the tester role (sub-agent or sequential role run).
 3. **You own all decisions:** phase transitions, root cause vs. symptom classification, when to present resolution.
-4. **You present the presenter's output verbatim.** The presenter agent formats all findings — you do not rewrite or reformat them.
-5. **Test hypotheses one at a time, sequentially.** Never spawn parallel testers.
-6. **When you need user input, use `AskUserQuestion`.** Do not proceed until the user responds.
+4. **You present the presenter's output verbatim.** The presenter role formats all findings — you do not rewrite or reformat them.
+5. **Test hypotheses one at a time, sequentially.** Never run testers in parallel.
+6. **When you need user input, ask with the host's normal user-input mechanism.** Do not proceed until the user responds.
 
 ## 2. Investigation State
 
@@ -50,29 +62,29 @@ Update `state.json.phase` at each transition:
 
 ### TRIAGE
 
-Spawn triage sub-agent (`agents/triage.md`). Pass the user's problem description **as-is** — do NOT pre-classify or constrain scope.
+Run the triage role (`agents/triage.md`). Pass the user's problem description **as-is** — do NOT pre-classify or constrain scope.
 
-**Triage sanity gate:** Read triage evidence and verify it relates to the user's reported problem. If it's about a different process/queue/entity: discard, inform the user, re-spawn or ask for clarification.
+**Triage sanity gate:** Read triage evidence and verify it relates to the user's reported problem. If it's about a different process/queue/entity: discard, inform the user, run triage again or ask for clarification.
 
-**Scope check:** Spawn scope-checker (`agents/scope-checker.md`). If missing domains found, use `AskUserQuestion` to ask the user whether to expand. If approved, re-spawn triage with the missing domains. If unnecessary domains found, remove them from `state.json.scope.domain`.
+**Scope check:** Run the scope-checker role (`agents/scope-checker.md`). If missing domains found, ask the user whether to expand. If approved, run triage again with the missing domains. If unnecessary domains found, remove them from `state.json.scope.domain`.
 
-**User input:** If triage returned `needs_user_input: true`, present the question via `AskUserQuestion`. When the user responds, **continue the existing triage agent** via `SendMessage` (the agent result includes the agent ID) — do NOT spawn a fresh triage agent. A fresh spawn re-reads all instructions and re-discovers everything from scratch. Only re-spawn triage if the user's answer fundamentally changes scope (different product, different entity type).
+**User input:** If triage returned `needs_user_input: true`, present the question to the user. When the user responds, continue the same triage role if the host supports task resume. If it does not, start a new triage role run with the user's answer plus the existing `.investigation/` files as context; do NOT rediscover from scratch unless the answer fundamentally changes scope (different product, different entity type).
 
 **Never skip the hypothesis loop.** Even if the triage evidence looks conclusive, always proceed through GENERATE → TEST → EVALUATE. Triage classifies and gathers data — it does not determine root causes. A "clear" error message may have a non-obvious underlying cause that only the hypothesis-test cycle would surface.
 
 ### GENERATE HYPOTHESES
 
-Spawn hypothesis generator (`agents/hypothesis-generator.md`). Behavior varies by confidence level per the table in shared.md.
+Run the hypothesis-generator role (`agents/hypothesis-generator.md`). Behavior varies by confidence level per the table in shared.md.
 
 ### TEST HYPOTHESES
 
-Test every hypothesis sequentially (highest confidence first). For each, spawn hypothesis tester (`agents/hypothesis-tester.md`).
+Test every hypothesis sequentially (highest confidence first). For each, run the hypothesis-tester role (`agents/hypothesis-tester.md`).
 
 ### EVALUATE (after each test)
 
-**Validate:** Reject and re-spawn if `elimination_checks` are missing/incomplete. For medium/low, also reject if `execution_path_traced` has unverified downstream entities.
+**Validate:** Reject and re-run the tester role if `elimination_checks` are missing/incomplete. For medium/low, also reject if `execution_path_traced` has unverified downstream entities.
 
-**Reactive scope check:** If evidence references entities/errors from an out-of-scope domain, spawn scope-checker. Otherwise skip.
+**Reactive scope check:** If evidence references entities/errors from an out-of-scope domain, run the scope-checker role. Otherwise skip.
 
 **Classify and act:**
 - **Eliminated / Inconclusive** → record, test next hypothesis
@@ -82,7 +94,7 @@ Test every hypothesis sequentially (highest confidence first). For each, spawn h
 
 ### NEW DATA FROM USER
 
-If the user provides new data at any point (error messages, job IDs, logs, screenshots), go back to TRIAGE. Re-spawn triage with the new data. Do NOT patch new data into an in-progress investigation.
+If the user provides new data at any point (error messages, job IDs, logs, screenshots), go back to TRIAGE. Run triage again with the new data. Do NOT patch new data into an in-progress investigation.
 
 ## 5. Evaluation Rules
 
@@ -95,7 +107,7 @@ If the user provides new data at any point (error messages, job IDs, logs, scree
 
 ## 6. Resolution
 
-Spawn the presenter agent (`agents/presenter.md`) with the confirmed hypothesis IDs and **all domains from `state.json.scope.domain`**. Do NOT pre-filter domains based on your judgment of their relevance to the causal chain — the presenter classifies root cause vs. propagation domains and searches docsai for each. Excluding a domain prevents the presenter from finding error handling patterns it was designed to surface.
+Run the presenter role (`agents/presenter.md`) with the confirmed hypothesis IDs and **all domains from `state.json.scope.domain`**. Do NOT pre-filter domains based on your judgment of their relevance to the causal chain — the presenter classifies root cause vs. propagation domains and searches docsai for each. Excluding a domain prevents the presenter from finding error handling patterns it was designed to surface.
 
 The presenter:
 - Assembles fixes from playbook `## Resolution` sections across all domains in the causal chain
@@ -107,12 +119,12 @@ Present the presenter's output verbatim to the user. After presenting:
 
 **If root cause found** — offer to help implement the fix or clean up `.investigation/`.
 
-**If no root cause found** — use `AskUserQuestion` to offer: provide more data (re-triage), or open a UiPath support ticket with the evidence gathered.
+**If no root cause found** — ask the user whether they want to provide more data (re-triage) or open a UiPath support ticket with the evidence gathered.
 
 ## 7. Operational Details
 
-**Spawning:** Read agent files just-in-time — only `agents/shared.md` + the specific agent file when you're about to spawn. Include full instructions, context, working directory path, and the absolute path to `.investigation/` in the prompt.
+**Role execution:** Read agent files just-in-time — only `agents/shared.md` + the specific agent file when you're about to run that role. Include full instructions, context, working directory path, and the absolute path to `.investigation/` in the role prompt or local role context.
 
-**Progress:** Use `TaskCreate`/`TaskUpdate` for each phase. Tailor subjects to the user's problem.
+**Progress:** Track progress with the host's normal task/checklist mechanism or concise phase updates. Tailor subjects to the user's problem.
 
 **Cleanup:** After investigation completes, offer to delete or preserve `.investigation/`.

--- a/skills/uipath-diagnostics/agents/shared.md
+++ b/skills/uipath-diagnostics/agents/shared.md
@@ -73,7 +73,7 @@ When you need user input, write a file `.investigation/needs_input.json` and the
 }
 ```
 
-The orchestrator reads this file, presents the question via `AskUserQuestion`, and re-spawns you with the answer.
+The orchestrator reads this file, asks the user with the host's normal user-input mechanism, and resumes this role with the answer. If the host cannot resume the same role, it starts a new role run with the user's answer plus the existing `.investigation/` files as context, without rediscovering unrelated data.
 
 **`needs_input.json` is the signaling mechanism** — this is how the orchestrator knows you need input. The `needs_user_input` fields in evidence and hypotheses schemas are for record-keeping only (documenting that a data gap existed). Always write `needs_input.json` to actually request user input.
 

--- a/skills/uipath-diagnostics/references/activity-packages/ui-automation/interpretations/healing-agent-data.md
+++ b/skills/uipath-diagnostics/references/activity-packages/ui-automation/interpretations/healing-agent-data.md
@@ -188,9 +188,9 @@ If `AnalysisResult[].AnalysisInformation[]` contains non-empty detections but `R
 
 ### Applying Fixes — MUST Ask the User
 
-When a fix is available, you MUST use `AskUserQuestion` to ask the user whether they want you to apply it. Do NOT skip this step. Do NOT just describe the fix — explicitly ask.
+When a fix is available, you MUST ask the user whether they want you to apply it. Do NOT skip this step. Do NOT just describe the fix — explicitly ask.
 
-When presenting the fix, first print the selectors as plain text output (NOT inside `AskUserQuestion` options or previews — XML selectors don't render correctly there). Then ask the question separately.
+When presenting the fix, first print the selectors as plain text output (not inside option labels or rich previews — XML selectors don't render correctly there). Then ask the question separately.
 
 **Step 1 — Print selectors as text:**
 
@@ -205,7 +205,7 @@ Recovered Fuzzy selector:
 <selector content from the chosen detection's FuzzyPartialSelector>
 ```
 
-**Step 2 — Ask the user** (via `AskUserQuestion`, with no previews):
+**Step 2 — Ask the user** (with no previews):
 
 **If RecoveryInfo with RecoverySuccessful: true:**
 - Tell the user the fix was proven at runtime
@@ -234,10 +234,11 @@ When `healing-fixes.json` contains actionable fixes, present the findings to the
 
 1. Match the XAML activity by `ActivityRefId` → `IdRef` attribute (unique within workflow)
 2. Check if the `uia-improve-selector` skill is available locally:
+   ```bash
+   find "<PROJECT_DIR>/.local/docs/packages/UiPath.UIAutomation.Activities/skills" \
+     -path "*/uia-improve-selector/USAGE.md" -print -quit
    ```
-   Glob: pattern="**/uia-improve-selector/USAGE.md" path="{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/"
-   ```
-3. **If the skill exists:** ask the user if they want to improve the selector using it. If yes, read `<PROJECT_DIR>/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-improve-selector/USAGE.md`, pick the appropriate invocation form for this context, run the staging CLI command from that form to produce `Target_Definition.json`, spawn a subagent with the Agent tool to run the skill with `--mode recover` against the staged folder, then run the write-back CLI command from the same form to persist the recovered selector.
+3. **If the skill exists:** ask the user if they want to improve the selector using it. If yes, read `<PROJECT_DIR>/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-improve-selector/USAGE.md`, pick the appropriate invocation form for this context, run the staging CLI command from that form to produce `Target_Definition.json`, invoke the skill with `--mode recover` using the host's normal skill/delegation mechanism (or run it sequentially in the current agent if delegation is unavailable), then run the write-back CLI command from the same form to persist the recovered selector.
 4. **If the skill does not exist:** update the activity's selector in XAML directly with the HA-recommended selector from `enhancedTarget`. Apply XML encoding per the XAML Selector Encoding rules above.
 5. Validate: `uip rpa get-errors --file-path "<WORKFLOW_FILE>" --output json --use-studio`
 

--- a/tests/tasks/uipath-diagnostics/smoke/portable_orchestration.yaml
+++ b/tests/tasks/uipath-diagnostics/smoke/portable_orchestration.yaml
@@ -1,0 +1,57 @@
+task_id: skill-diagnostics-portable-orchestration
+description: >
+  Skill-guided smoke test: agent uses the uipath-diagnostics skill in a host
+  without background sub-agents, follows the sequential role-execution adapter,
+  and produces investigation artifacts from supplied incident data.
+tags: [uipath-diagnostics, smoke, lifecycle:execute]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Use the uipath-diagnostics skill to investigate this supplied incident.
+
+  Host constraint: assume this environment cannot spawn background sub-agents
+  and cannot resume tasks. Follow the skill's single-agent/sequential role
+  execution adapter instead of stopping.
+
+  Incident data:
+  - Process: InvoicePortal_Login
+  - Job ID: job-1842
+  - Symptom: UI Automation selector recovery was offered, but the job failed
+    again on the next run.
+  - Log excerpt:
+      2026-04-21T14:03:10Z INFO Open browser: https://invoices.example.test
+      2026-04-21T14:03:14Z WARN Healing Agent proposed a fuzzy selector
+      2026-04-21T14:03:16Z ERROR ActivityRefId LoginButton_Click failed:
+        selector matched 0 elements after page navigation
+      2026-04-21T14:03:17Z ERROR Browser title changed to "Session expired"
+
+  Do not call external UiPath services. Do not run `uip` commands. Use only
+  the supplied incident data.
+
+  Write the investigation state under `.investigation/` and save the final
+  user-facing answer to `diagnostics-report.md`.
+
+success_criteria:
+  - type: file_exists
+    description: "Investigation state was written"
+    path: ".investigation/state.json"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Final diagnostic report was written"
+    path: "diagnostics-report.md"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Report explains evidence and likely root cause"
+    path: "diagnostics-report.md"
+    includes:
+      - "LoginButton_Click"
+      - "Session expired"
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- add an execution adapter that maps diagnostics roles to either sub-agents/tasks or sequential single-agent role runs
- replace hard-coded `AskUserQuestion` / `SendMessage` assumptions with host-neutral user input and resume guidance
- update Healing Agent recovery guidance to avoid host-specific `Glob` / `Agent tool` instructions while preserving the selector-recovery workflow
- add a smoke task for the portable single-agent diagnostics path

## Validation

- `bash hooks/validate-skill-descriptions.sh skills/uipath-diagnostics/SKILL.md`
- `git diff --check origin/main...HEAD`
- YAML parse and tag-shape check for `tests/tasks/uipath-diagnostics/smoke/portable_orchestration.yaml`
- Markdown fence balance scan across changed Markdown files
- targeted scan for stale host-specific interaction/tool names in `uipath-diagnostics`

## Related issues

No related open issue found for `uipath-diagnostics` portable orchestration guidance.
