### PR TITLE
fix(maestro-case): sync bindings_v2.json, root bindings, and debloat non-connector task docs

### DIFF
--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -34,6 +34,7 @@ Builds UiPath Case Management definitions from `sdd.md`. Generates `tasks.md` pl
 10. **HARD STOP between Phase 2a and Phase 2b — unconditional, every run.** Run informational `validate` (no `--mode`), surface counts, present AskUserQuestion: `Publish for review` / `Skip publish and continue` / `Abort`. Do NOT halt on Phase 2a validate errors — unbound inputs/missing conditions/missing SLA expected. Never skip prompt for auto mode, non-interactive mode, prior approval. If harness forbids prompts, halt with error. **On `Publish for review`: print `DesignerUrl` as plain-text output BEFORE invoking the second AskUserQuestion — never embed URL only inside the question body.** Full contract in [`references/phased-execution.md`](references/phased-execution.md).
 11. **Never run `uip maestro case debug` automatically.** Executes case for real — emails, messages, API calls. Explicit user consent only.
 12. **`caseplan.json` mutations: Read + Write/Edit only.** No `python`, `node`, `jq`, `sed`, `awk`, or scripts that open/parse/modify/save the file. Bash subprocesses OK for stdout-only helpers (e.g., id generation), CLI metadata fetches, validate, debug, and solution scaffold/upload. See [references/case-editing-operations.md § Tool usage](references/case-editing-operations.md#tool-usage--mandatory).
+13. **Always run `uip solution resource refresh` before `uip solution upload` or `uip maestro case debug`** — syncs resources from `bindings_v2.json` so Studio Web can resolve connector dependencies.
 
 ## Workflow
 
@@ -57,7 +58,7 @@ Read [references/implementation.md](references/implementation.md) + [references/
 3. Stages (Step 7), edges (Step 8), triggers
 4. Tasks — shape only (Step 9): non-connector with full `data.inputs[]` schema + empty values; connector with `typeId` + `connectionId` only (no `is describe`); unresolved as skeletons per Rule 7
 5. Informational validate (Step 9.5.1) — do NOT halt on errors/warnings
-6. **HARD STOP** (Step 9.5.2–9.5.5): `Publish for review` / `Skip publish and continue` / `Abort`. On `Publish`: `uip solution upload`, print DesignerUrl, AskUserQuestion: `Continue to phase 2b` / `Abort`. On `Abort`: dump `build-issues.md`, exit (no cleanup).
+6. **HARD STOP** (Step 9.5.2–9.5.5): `Publish for review` / `Skip publish and continue` / `Abort`. On `Publish`: `uip solution resource refresh <SolutionDir> --output json` then `uip solution upload`, print DesignerUrl, AskUserQuestion: `Continue to phase 2b` / `Abort`. On `Abort`: dump `build-issues.md`, exit (no cleanup).
 
 ### Phase 2b — Detail build
 
@@ -85,6 +86,7 @@ Re-read `tasks.md` AND `caseplan.json` (Step 9.6). Then:
 | Wire inputs/outputs + cross-task refs + expression prefixes | [references/bindings-and-expressions.md](references/bindings-and-expressions.md) |
 | Configure connector activity / trigger / event | [references/connector-integration.md](references/connector-integration.md) |
 | Skeleton tasks for unresolved resources | [references/skeleton-tasks.md](references/skeleton-tasks.md) |
+| Sync bindings_v2.json + connection resources | [references/bindings-v2-sync.md](references/bindings-v2-sync.md) |
 
 ### Plugin Index
 

--- a/skills/uipath-maestro-case/references/bindings-v2-sync.md
+++ b/skills/uipath-maestro-case/references/bindings-v2-sync.md
@@ -1,0 +1,130 @@
+# bindings_v2.json Sync
+
+Shared procedure for keeping `bindings_v2.json` in sync after any plugin writes to `root.data.uipath.bindings[]` in `caseplan.json`.
+
+## When to Run
+
+**Batched, not per-task.** `bindings_v2.json` is only consumed by `uip solution resource refresh` (which runs once before upload/debug). No intermediate step reads it. Regenerating after every task wastes Read→convert→Write cycles on a growing file.
+
+Run at these two points only:
+
+1. **End of Phase 2a Step 9** (after all non-connector tasks written) — covers all process/agent/rpa/action/api-workflow/case-management bindings
+2. **End of Phase 2b Step 9.7** (after all connector tasks populated) — adds Connection bindings + populates IS cache
+
+Individual task plugins write root bindings to `caseplan.json` per-task as normal. The batch regeneration reads the full `root.data.uipath.bindings[]` once and converts everything in one pass.
+
+---
+
+## § Regenerate bindings_v2.json
+
+After writing bindings to `root.data.uipath.bindings[]`, regenerate `bindings_v2.json`. This file uses a **different format**: `caseplan.json` stores two entries per resource (one per property), `bindings_v2.json` stores one entry per resource with properties nested under `value`.
+
+### Procedure
+
+1. Read `root.data.uipath.bindings[]` from `caseplan.json`
+2. Group bindings by `resourceKey` — entries sharing the same key belong to one resource
+3. For each group, produce one resource entry using the shapes below
+4. Write the full file (always overwrite, never append) to `<SolutionDir>/<ProjectName>/bindings_v2.json`
+
+### Non-connector resource entry
+
+```json
+{
+  "resource": "<resource>",
+  "key": "<resourceKey>",
+  "value": {
+    "name": { "defaultValue": "<name binding default>" },
+    "folderPath": { "defaultValue": "<folderPath binding default>" }
+  },
+  "metadata": { "subType": "<resourceSubType — omit metadata key if none>" }
+}
+```
+
+### Connector resource entry
+
+```json
+{
+  "resource": "Connection",
+  "key": "<connectionId>",
+  "value": {
+    "connectionId": { "defaultValue": "<connectionId>" },
+    "folderKey": { "defaultValue": "<folderKey>" }
+  },
+  "metadata": { "connector": "<connectorKey>" }
+}
+```
+
+> **Known CLI bug:** `syncConnectionResources` reads `value.connectionId` (lowercase c) but `flow-schema` writes `value.ConnectionId` (uppercase C). Use **lowercase `connectionId`** until fixed.
+
+File envelope: `{ "version": "2.0", "resources": [ /* one entry per resource */ ] }`
+
+---
+
+## § Populate IS connection cache
+
+`uip solution resource refresh` reads a local IS cache that connector plugins must populate after `get-connection`.
+
+**Path:** `~/.uipath/cache/integrationservice/<connectorKey>/connections.json`
+
+**Shape — bare JSON array:**
+
+```json
+[
+    {
+        "id": "<connectionId>",
+        "name": "<connectionName>",
+        "connectorKey": "<connectorKey>",
+        "connectorName": "<connectorName>",
+        "folderKey": "<folderKey>",
+        "folderName": "<folderName>"
+    }
+]
+```
+
+### Field sources
+
+| Field | Source | Plugin step |
+|---|---|---|
+| `id` | `connection-id` from `tasks.md` | Planning |
+| `name` | `.Data.Connections[selected].name` from `get-connection` | Step 1 |
+| `connectorKey` | `connector-key` from `tasks.md` | Planning |
+| `connectorName` | `.Data.Connections[selected].connector.name` from `get-connection` | Step 1 |
+| `folderKey` | `.Data.Connections[selected].folder.key` from `get-connection` | Step 1 |
+| `folderName` | `.Data.Connections[selected].folder.name` from `get-connection` | Step 1 |
+
+### Procedure
+
+After `get-connection` succeeds (Step 1), write or merge the cache:
+
+1. Read existing cache at the path above (may not exist — start with `[]`)
+2. If an entry with the same `id` already exists, skip
+3. Otherwise append the new entry
+4. Write the file as a bare JSON array (NOT wrapped in `{ cachedAt, data }`)
+
+```bash
+mkdir -p ~/.uipath/cache/integrationservice/<connectorKey>
+```
+
+> Workaround for CLI bugs: (1) tenant-ID prefix in cache path, (2) wrapped `{ cachedAt, data }` format. Direct write bypasses both.
+
+---
+
+## What `resource refresh` produces
+
+With `bindings_v2.json` and IS cache in place, `uip solution resource refresh` creates:
+
+| Input | Output | Purpose |
+|---|---|---|
+| Non-connector bindings in `bindings_v2.json` | `resources/solution_folder/process/` files | Resource declarations imported from Orchestrator |
+| Connection binding in `bindings_v2.json` + IS cache | `resources/solution_folder/connection/<connectorKey>/<name>.json` | Connection resource declaration |
+| Both | `userProfile/<userId>/debug_overwrites.json` | Maps abstract resources to Orchestrator instances for debug |
+
+All three required for `uip solution upload` and `uip maestro case debug` to work without "Resource is not configured" warnings.
+
+---
+
+## Cleanup on task removal
+
+When any task is removed and its root bindings are pruned (per [case-editing-operations.md](case-editing-operations.md) § node deletion cascade):
+
+1. After pruning root bindings, regenerate `bindings_v2.json` from the updated array.

--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -10,7 +10,7 @@ All commands output `{ "Result": "Success"|"Failure", "Code": "...", "Data": { .
 
 | Commands | What | Auth |
 |----------|------|------|
-| `solution new`, `solution project add`, `solution upload` | Solution scaffold + Studio Web upload | Yes (for `upload`) |
+| `solution new`, `solution project add`, `solution resource refresh`, `solution upload` | Solution scaffold + resource sync + Studio Web upload | Yes (for `upload`) |
 | `registry pull/list/search`, `get-connector`, `get-connection`, `tasks describe`, `is resources/triggers describe` | Registry + metadata discovery (read-only) | Yes (for `pull`) |
 | `validate` | Validate `caseplan.json` | No |
 | `instance`, `processes`, `incidents`, `process run`, `job traces`, `debug` | Query/manage live Orchestrator state | Yes |
@@ -50,17 +50,32 @@ Adds the project to `.uipx.Projects[]`. Run after the case plugin has scaffolded
 
 ---
 
+## uip solution resource refresh
+
+Re-scan all projects in the solution and sync resource declarations from `bindings_v2.json`. Creates new resources for bindings not yet in the solution, imports from Orchestrator when a matching resource exists.
+
+```bash
+uip solution resource refresh <SolutionDir> --output json
+```
+
+**Always run before `uip solution upload` or `uip maestro case debug`.** Without this step, connection resources may not be registered on Studio Web ("Resource is not configured" warning).
+
+> Requires `bindings_v2.json` to be populated. If still the empty scaffold (`resources: []`), no resources will be synced.
+
+---
+
 ## uip solution upload
 
 Upload a solution directly to Studio Web. **Requires `uip login`.**
 
 ```bash
+uip solution resource refresh <SolutionDir> --output json
 uip solution upload <SolutionDir> --output json
 ```
 
 `uip solution upload` accepts the solution directory (the folder containing the `.uipx` file) directly — no intermediate bundling step. Uploads to Studio Web where the user can visualize, inspect, edit, and publish the case from the browser.
 
-> **This is the default publish path.** When the user asks to "publish" without specifying where, run `uip solution upload <SolutionDir>` to push to Studio Web. Share the resulting URL with the user.
+> **This is the default publish path.** When the user asks to "publish" without specifying where, run `resource refresh` then `uip solution upload <SolutionDir>`. Share the resulting URL with the user.
 
 ---
 
@@ -105,8 +120,11 @@ Output: `{ File, Status: "Valid" }` on success. Errors and warnings are reported
 Debug a Case JSON file via a Studio Web debug session. **Requires `uip login`. Executes the case for real — sends emails, posts messages, calls APIs. Only run on explicit user consent.**
 
 ```bash
+uip solution resource refresh <SolutionDir> --output json
 uip maestro case debug <projectDirectory> --log-level debug --output json
 ```
+
+> **Always run `uip solution resource refresh`** on the solution directory before debug.
 
 | Flag | Description |
 |------|-------------|

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -97,6 +97,8 @@ Only use field names that appear in `filterFields`. If a filter cannot be transl
 
 ## Implementation — Shared Metadata Fetches (read-only CLI)
 
+> **Each connector task runs its own `get-connection`.** Even when two tasks share the same `connection-id`, the Entry and Config objects differ between activity and trigger types. Never reuse another task's CLI output.
+
 ### Step 1 — Get connection details + Entry
 
 ```bash
@@ -112,7 +114,9 @@ uip case registry get-connection \
 | `Entry` | `.Data.Entry` (full object) | `{ displayName: "Email Received", ... }` |
 | `Config` | `.Data.Config` | `{ connectorKey, objectName, eventOperation, eventMode, version, supportsStreaming }` |
 | `folderKey` | `.Data.Connections[selected].folder.key` | `"87fd6cec-..."` |
+| `folderName` | `.Data.Connections[selected].folder.name` | `"57d6e3b0's workspace"` |
 | `connectorName` | `.Data.Connections[selected].connector.name` | `"Microsoft Outlook 365"` |
+| `connectionName` | `.Data.Connections[selected].name` | `"my-outlook-connection"` |
 
 ### Step 2 — Get enriched metadata + outputs
 
@@ -209,6 +213,12 @@ Create 2 entries in `root.data.uipath.bindings[]`:
 | folderKey | `"folderKey"` | `folderKey` (from Step 1) |
 
 Both share `resourceKey` = `connection-id`. Deduplicate against existing root bindings.
+
+### Root-level bindings post-sync
+
+After writing root bindings, populate IS connection cache per [bindings-v2-sync.md § Populate IS connection cache](bindings-v2-sync.md). Skip if `get-connection` failed.
+
+> **`bindings_v2.json` regeneration is deferred** — runs once at end of Step 9.7 (after all connector tasks), not per-task. See [bindings-v2-sync.md § When to Run](bindings-v2-sync.md).
 
 ---
 

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -100,6 +100,10 @@ Skeleton tasks integrate with the rest of the graph:
 - **Stage-exit `selected-tasks-completed`** rules reference skeleton `TaskId`s normally.
 - **Cross-task variable bindings** are deferred — the user binds them after attaching the real resource.
 
+## Step 9.4 — Regenerate bindings_v2.json (batch)
+
+After all non-connector tasks are written (Step 9), regenerate `bindings_v2.json` once per [bindings-v2-sync.md § Regenerate](bindings-v2-sync.md). This single pass converts all root bindings accumulated during Step 9 — no per-task regeneration needed.
+
 ## Step 9.5 — Skeleton-mode validate + HARD STOP
 
 End of Phase 2a. Full contract (summary content, prompt options, publish branch, abort cleanup, continue branch) in [phased-execution.md § Hard stop](phased-execution.md). This section is a bridge — do NOT duplicate that contract here.
@@ -137,10 +141,13 @@ Never trust in-memory maps from Phase 2a without re-reading `caseplan.json` — 
 
 For each connector task (`connector-activity`, `connector-trigger`) in `tasks.md`:
 
-1. Run `is resources describe` (activity) or `is triggers describe` (trigger) per the plugin's `impl-json.md`.
-2. Write `data.inputs[]` / `data.outputs[]` schema into the existing task in `caseplan.json`.
+1. Run `get-connection` (each task runs its own — never reuse) + `is resources describe` (activity) or `is triggers describe` (trigger) per the plugin's `impl-json.md`.
+2. Write root bindings, `data.context[]`, `data.inputs[]` / `data.outputs[]` schema into the existing task in `caseplan.json`.
+3. Populate IS connection cache per [bindings-v2-sync.md § Populate IS connection cache](bindings-v2-sync.md).
 
 Skip connector tasks that are skeletons (unresolved `typeId` / `connectionId`) — they stay bare.
+
+After all connector tasks are done, **regenerate `bindings_v2.json`** once per [bindings-v2-sync.md § Regenerate](bindings-v2-sync.md). This single pass includes both the non-connector bindings from Step 9 and the Connection bindings from this step.
 
 ## Step 9.8 — Bind task input/output values
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -1,12 +1,8 @@
 # action task — Implementation (Direct JSON Write)
 
-> **Phase split.** Runs across both phases. Phase 2a writes shape: `data.taskTitle` + full `data.inputs[]` / `data.outputs[]` schema from `tasks describe`, each `value` empty (`""`). Phase 2b binds values via [`../../variables/io-binding/impl-json.md`](../../variables/io-binding/impl-json.md). See [`../../../phased-execution.md`](../../../phased-execution.md).
-
-Cross check the action (HITL) task metadata via CLI, then write the task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md`.
+> **Phase split.** Phase 2a writes shape with empty input values. Phase 2b binds values per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md). See [phased-execution.md](../../../phased-execution.md).
 
 ## Task JSON Shape
-
-> **ID and elementId format.** Task `id` is `t` + 8 random chars. `elementId` is the composite `${stageId}-${taskId}`.
 
 ```json
 {
@@ -20,86 +16,67 @@ Cross check the action (HITL) task metadata via CLI, then write the task directl
     "taskTitle": "Please review this PO and approve or reject",
     "priority": "High",
     "recipient": "approver@corp.com",
-    "actionCatalogName": "<deploymentTitle from planning>",
-    "labels": "<labels string from tasks.md (captured during planning)>",
-    "inputs": [ /* form-field inputs, from planning enrichment */ ],
-    "outputs": [ /* decision, comments, form outputs, from planning enrichment */ ],
-    "context": { "taskTypeId": "act_app_9876543210" }
+    "actionCatalogName": "<deploymentTitle>",
+    "labels": "<labels string>",
+    "name": "=bindings.bG0SraLpg",
+    "folderPath": "=bindings.bH1iJK2lm",
+    "inputs": [],
+    "outputs": []
   }
 }
 ```
 
-## All Attributes
+- `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
+- `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
-Inherits the full `ProcessTask` shape — see [process/impl-json.md § All Attributes](../process/impl-json.md#all-attributes) for top-level fields and base `data` fields. Action-specific differences:
+## Action-Specific Fields
 
-- `type` is `"action"` (not `"process"`)
-- `data` carries the additional fields below
+| Field | Notes |
+|---|---|
+| `data.taskTitle` | Required, even on skeletons. Validator rejects empty. |
+| `data.priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
+| `data.recipient` | User email string. Omit for group/role assignment. |
+| `data.actionCatalogName` | `deploymentTitle` from tasks.md |
+| `data.labels` | Label set from tasks.md |
 
-`data` — extra fields for `ActionTask`:
-
-| Field | Type | Notes |
-|---|---|---|
-| `data.taskTitle` | string | HITL task title shown to the assignee (required, even on skeletons) |
-| `data.labels` | string | Label set from `tasks.md` (captured during planning) |
-| `data.priority` | string | `"Low"`, `"Medium"` (default), `"High"`, or `"Critical"` |
-| `data.actionCatalogName` | string | `deploymentTitle` from `tasks.md` (captured during planning) |
-| `data.recipient` | string \| `ActionTaskAssignee` | User email string, or assignee object for group/role |
-| `data.startCriteria` | string \| number | Expression/value that starts the action |
-| `data.endCriteria` | string \| number | Expression/value that ends the action |
-| `data.timer` | string \| number | Timer expression/value for the action |
-| `data.actionDataOutcome` | string \| number | Outcome payload selector |
-| `data.actionData` | string | Serialized action data payload |
-
-`ActionTaskAssignee` (when `data.recipient` is an object):
-
-| Field | Type | Notes |
-|---|---|---|
-| `Type` | `0 \| 1 \| 2 \| 3` | Assignee kind (see mapping below) |
-| `Value` | string | Assignee identifier (format depends on `Type`) |
-| `originalEntry` | unknown | Original entry payload |
-
-`Type` / `Value` mapping:
-
-| `Type` | `Value` format | Meaning |
-|---|---|---|
-| `0` | User UUID | Assign by user ID |
-| `1` | Group UUID | Assign to any group member |
-| `2` | Email string | Assign by email address |
-| `3` | `"=vars.<varId>"` | Resolved from variable at runtime |
+`recipient` as object (`ActionTaskAssignee`): `{ Type: 0|1|2|3, Value: "<id-or-email>" }`. Type 3 = `"=vars.<varId>"` for runtime resolution.
 
 ## Procedure
 
-**Step 0 — Get enriched metadata + outputs:**
-
-Run `tasks describe` against the resolved action-app `id` and save the JSON response — this is the source of truth for the form-field `data.inputs[]` / `data.outputs[]` (including standard `decision` / `comments`) in Step 1.
+**Step 0 — Get inputs/outputs schema:**
 
 ```bash
 uip maestro case tasks describe --type action --id "<action-app-id>" --output json
 ```
 
-Capture the response (input/output schema with names, types, and ids). If `tasks describe` fails or returns no schema, fall back to the planning-captured schema from `tasks.md`; if that is also missing, treat the task as skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
+Fallback: planning-captured schema from tasks.md. If unavailable, skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
 
-**Step 1 — Write task with populated data:**
+**Step 1 — Root-level bindings:**
 
-1. Generate task ID: `t` + 8 alphanumeric chars (unique across all tasks)
-2. Generate elementId: `<stageId>-<taskId>`
-3. Set top-level fields (`type: "action"`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) from tasks.md per the Task JSON Shape above
-4. Set `data.taskTitle` from tasks.md `task-title` (always emit — validator requires it; fall back per [planning.md § Task Title Fallback](planning.md))
-5. Set `data.priority` from tasks.md (default `"Medium"`)
-6. Set `data.recipient` from tasks.md only when a user email is supplied. Omit the key entirely for group/role assignment or when the user chose `Skip`
-7. Set `data.context.taskTypeId` to the action-app `id` from `tasks.md` (captured during planning)
-8. Set `data.actionCatalogName` to the action-app `deploymentTitle` and `data.labels` to the label set — both read from `tasks.md` (captured during planning)
-9. Write `data.inputs[]` / `data.outputs[]` using the schema captured in Step 0 (falling back to the planning-captured schema in tasks.md if Step 0 was unavailable). Each input is `{ name, type, id, var, elementId, value: "" }`; each output is `{ name, type, id, var, value, source, target, elementId }`. See [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md) for shape details.
-10. Write the task to the target stage's `tasks[]` array (in its own task set / lane)
+Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
 
-> **Handled elsewhere.** Input value bindings happen in outer-workflow Step 9 — see [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md). Entry conditions are added in Step 10.
+| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
+|---|---|---|---|
+| `"name"` | `"app"` | — | `name` from tasks.md |
+| `"folderPath"` | `"app"` | — | `folder-path` from tasks.md |
+
+Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+
+**Step 2 — Write task:**
+
+1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
+2. Set `data.taskTitle`, `data.priority`, `data.recipient`, `data.actionCatalogName`, `data.labels` from tasks.md
+3. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
+4. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
+5. Append to target stage's `tasks[laneIndex][]`
+
+> Entry conditions added in Step 10. Input value bindings in Phase 2b per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md).
 
 ## Post-Write Verification
 
-Confirm the task exists in the correct stage with:
-
 - `type: "action"`
 - `data.taskTitle` non-empty
-- `data.recipient` matches the sdd.md assignee when one is specified (absent when group-assigned)
-- `data.context.taskTypeId` non-empty (unless intentionally skeleton)
+- `data.name` and `data.folderPath` start with `=bindings.`
+- `root.data.uipath.bindings[]` has 2 entries: `resource: "app"`, no `resourceSubType`, `propertyAttribute` = `name` / `folderPath`
+- `data.inputs` and `data.outputs` populated (unless skeleton)
+- `id` captured in `id-map.json`

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -35,11 +35,11 @@
 |---|---|
 | `data.taskTitle` | Required, even on skeletons. Validator rejects empty. |
 | `data.priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
-| `data.recipient` | User email string. Omit for group/role assignment. |
+| `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. Omit for group/role assignment. |
 | `data.actionCatalogName` | `deploymentTitle` from tasks.md |
 | `data.labels` | Label set from tasks.md |
 
-`recipient` as object (`ActionTaskAssignee`): `{ Type: 0|1|2|3, Value: "<id-or-email>" }`. Type 3 = `"=vars.<varId>"` for runtime resolution.
+`recipient.Type` values: `0` = user ID, `1` = group ID, `2` = email address, `3` = `"=vars.<varId>"` for runtime resolution. Email recipients always use Type `2`.
 
 ## Procedure
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/agent/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/agent/impl-json.md
@@ -1,12 +1,8 @@
 # agent task — Implementation (Direct JSON Write)
 
-> **Phase split.** Runs across both phases. Phase 2a writes shape: full `data.inputs[]` schema from `tasks describe`, each `value` empty (`""`). Phase 2b binds values via [`../../variables/io-binding/impl-json.md`](../../variables/io-binding/impl-json.md). See [`../../../phased-execution.md`](../../../phased-execution.md).
-
-Cross check the agent task metadata via CLI, then write the task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md`.
+> **Phase split.** Phase 2a writes shape with empty input values. Phase 2b binds values per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md). See [phased-execution.md](../../../phased-execution.md).
 
 ## Task JSON Shape
-
-> **ID and elementId format.** Task `id` is `t` + 8 random chars. `elementId` is the composite `${stageId}-${taskId}`.
 
 ```json
 {
@@ -17,27 +13,20 @@ Cross check the agent task metadata via CLI, then write the task directly into `
   "isRequired": true,
   "shouldRunOnlyOnce": true,
   "data": {
-    "name": "PO Classifier",
-    "folderPath": "Shared",
-    "inputs": [ /* from planning enrichment */ ],
-    "outputs": [ /* from planning enrichment */ ],
-    "context": { "taskTypeId": "a1b2c3d4-5678-90ab-cdef-1234567890ab" }
+    "name": "=bindings.bG0SraLpg",
+    "folderPath": "=bindings.bH1iJK2lm",
+    "inputs": [],
+    "outputs": []
   }
 }
 ```
 
-## All Attributes
-
-Same shape as `ProcessTask` — see [process/impl-json.md § All Attributes](../process/impl-json.md#all-attributes). Only differences:
-
-- `type` is `"agent"` (not `"process"`)
-- `data.name` resolves from the agent registry (captured in `tasks.md` during planning), not the process registry
+- `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
+- `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure
 
-**Step 0 — Get enriched metadata + outputs:**
-
-Run `tasks describe` against the resolved `entityKey` and save the JSON response — this is the source of truth for `data.inputs[]` / `data.outputs[]` in Step 1. For agents with multiple element bindings, also pass `--element-id`.
+**Step 0 — Get inputs/outputs schema:**
 
 ```bash
 uip maestro case tasks describe --type agent --id "<entityKey>" --output json
@@ -45,25 +34,32 @@ uip maestro case tasks describe --type agent --id "<entityKey>" --output json
 uip maestro case tasks describe --type agent --id "<entityKey>" --element-id "<elementId>" --output json
 ```
 
-Capture the response (input/output schema with names, types, and ids). If `tasks describe` fails or returns no schema, fall back to the planning-captured schema from `tasks.md`; if that is also missing, treat the task as skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
+Fallback: planning-captured schema from tasks.md. If unavailable, skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
 
-**Step 1 — Write task with populated data:**
+**Step 1 — Root-level bindings:**
 
-1. Generate task ID: `t` + 8 alphanumeric chars (unique across all tasks)
-2. Generate elementId: `<stageId>-<taskId>`
-3. Set top-level fields (`type: "agent"`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) from tasks.md per the Task JSON Shape above
-4. Set `data.name` from tasks.md `name`
-5. Set `data.folderPath` from tasks.md `folder-path`
-6. Set `data.context.taskTypeId` to the agent `entityKey` from `tasks.md` (captured during planning per [planning.md § Registry Resolution](planning.md))
-7. Write `data.inputs[]` / `data.outputs[]` using the schema captured in Step 0 (falling back to the planning-captured schema in tasks.md if Step 0 was unavailable). Each input is `{ name, type, id, var, elementId, value: "" }`; each output is `{ name, type, id, var, value, source, target, elementId }`. See [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md) for shape details.
-8. Write the task to the target stage's `tasks[]` array (in its own task set / lane)
+Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
 
-> **Handled elsewhere.** Input value bindings happen in outer-workflow Step 9 — see [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md). Entry conditions are added in Step 10.
+| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
+|---|---|---|---|
+| `"name"` | `"process"` | `"Agent"` | `name` from tasks.md |
+| `"folderPath"` | `"process"` | `"Agent"` | `folder-path` from tasks.md |
+
+Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+
+**Step 2 — Write task:**
+
+1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
+2. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
+3. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
+4. Append to target stage's `tasks[laneIndex][]`
+
+> Entry conditions added in Step 10. Input value bindings in Phase 2b per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md).
 
 ## Post-Write Verification
 
-Confirm the task exists in the correct stage with:
-
 - `type: "agent"`
-- `data.context.taskTypeId` non-empty (unless intentionally skeleton)
-- `data.inputs` and `data.outputs` populated from the planning-captured schema (if empty, planning enrichment is missing — return to planning to re-run discovery)
+- `data.name` and `data.folderPath` start with `=bindings.`
+- `root.data.uipath.bindings[]` has 2 entries: `resource: "process"`, `resourceSubType: "Agent"`, `propertyAttribute` = `name` / `folderPath`
+- `data.inputs` and `data.outputs` populated (unless skeleton)
+- `id` captured in `id-map.json`

--- a/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/impl-json.md
@@ -1,12 +1,8 @@
 # api-workflow task — Implementation (Direct JSON Write)
 
-> **Phase split.** Runs across both phases. Phase 2a writes shape: full `data.inputs[]` schema from `tasks describe`, each `value` empty (`""`). Phase 2b binds values via [`../../variables/io-binding/impl-json.md`](../../variables/io-binding/impl-json.md). See [`../../../phased-execution.md`](../../../phased-execution.md).
-
-Cross check the api-workflow (Coded Workflow) task metadata via CLI, then write the task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md`.
+> **Phase split.** Phase 2a writes shape with empty input values. Phase 2b binds values per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md). See [phased-execution.md](../../../phased-execution.md).
 
 ## Task JSON Shape
-
-> **ID and elementId format.** Task `id` is `t` + 8 random chars. `elementId` is the composite `${stageId}-${taskId}`.
 
 ```json
 {
@@ -17,51 +13,51 @@ Cross check the api-workflow (Coded Workflow) task metadata via CLI, then write 
   "isRequired": true,
   "shouldRunOnlyOnce": true,
   "data": {
-    "name": "OrderInboxWatcher",
-    "folderPath": "Shared",
-    "inputs": [ /* from planning enrichment */ ],
-    "outputs": [ /* from planning enrichment */ ],
-    "context": { "taskTypeId": "c3d4e5f6-7890-1234-abcd-345678901234" }
+    "name": "=bindings.bG0SraLpg",
+    "folderPath": "=bindings.bH1iJK2lm",
+    "inputs": [],
+    "outputs": []
   }
 }
 ```
 
-## All Attributes
-
-Same shape as `ProcessTask` — see [process/impl-json.md § All Attributes](../process/impl-json.md#all-attributes). Only differences:
-
-- `type` is `"api-workflow"` (not `"process"`)
-- `data.name` resolves from the api-workflow registry (captured in `tasks.md` during planning), not the process registry
+- `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
+- `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure
 
-**Step 0 — Get enriched metadata + outputs:**
-
-Run `tasks describe` against the resolved `entityKey` and save the JSON response — this is the source of truth for `data.inputs[]` / `data.outputs[]` in Step 1.
+**Step 0 — Get inputs/outputs schema:**
 
 ```bash
 uip maestro case tasks describe --type api-workflow --id "<entityKey>" --output json
 ```
 
-Capture the response (input/output schema with names, types, and ids). If `tasks describe` fails or returns no schema, fall back to the planning-captured schema from `tasks.md`; if that is also missing, treat the task as skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
+Fallback: planning-captured schema from tasks.md. If unavailable, skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
 
-**Step 1 — Write task with populated data:**
+**Step 1 — Root-level bindings:**
 
-1. Generate task ID: `t` + 8 alphanumeric chars (unique across all tasks)
-2. Generate elementId: `<stageId>-<taskId>`
-3. Set top-level fields (`type: "api-workflow"`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) from tasks.md per the Task JSON Shape above
-4. Set `data.name` from tasks.md `name`
-5. Set `data.folderPath` from tasks.md `folder-path`
-6. Set `data.context.taskTypeId` to the API-workflow `entityKey` from `tasks.md` (captured during planning per [planning.md § Registry Resolution](planning.md))
-7. Write `data.inputs[]` / `data.outputs[]` using the schema captured in Step 0 (falling back to the planning-captured schema in tasks.md if Step 0 was unavailable). Each input is `{ name, type, id, var, elementId, value: "" }`; each output is `{ name, type, id, var, value, source, target, elementId }`. See [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md) for shape details.
-8. Write the task to the target stage's `tasks[]` array (in its own task set / lane)
+Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
 
-> **Handled elsewhere.** Input value bindings happen in outer-workflow Step 9 — see [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md). Entry conditions are added in Step 10.
+| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
+|---|---|---|---|
+| `"name"` | `"process"` | `"Api"` | `name` from tasks.md |
+| `"folderPath"` | `"process"` | `"Api"` | `folder-path` from tasks.md |
+
+Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+
+**Step 2 — Write task:**
+
+1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
+2. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
+3. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
+4. Append to target stage's `tasks[laneIndex][]`
+
+> Entry conditions added in Step 10. Input value bindings in Phase 2b per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md).
 
 ## Post-Write Verification
 
-Confirm the task exists in the correct stage with:
-
 - `type: "api-workflow"`
-- `data.context.taskTypeId` non-empty (unless intentionally skeleton)
-- `data.inputs` and `data.outputs` populated from the planning-captured schema
+- `data.name` and `data.folderPath` start with `=bindings.`
+- `root.data.uipath.bindings[]` has 2 entries: `resource: "process"`, `resourceSubType: "Api"`, `propertyAttribute` = `name` / `folderPath`
+- `data.inputs` and `data.outputs` populated (unless skeleton)
+- `id` captured in `id-map.json`

--- a/skills/uipath-maestro-case/references/plugins/tasks/case-management/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/case-management/impl-json.md
@@ -1,12 +1,8 @@
 # case-management task — Implementation (Direct JSON Write)
 
-> **Phase split.** Runs across both phases. Phase 2a writes shape: full `data.inputs[]` schema from `tasks describe`, each `value` empty (`""`). Phase 2b binds values via [`../../variables/io-binding/impl-json.md`](../../variables/io-binding/impl-json.md). See [`../../../phased-execution.md`](../../../phased-execution.md).
-
-Cross check the case-management (sub-case) task metadata via CLI, then write the task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md`.
+> **Phase split.** Phase 2a writes shape with empty input values. Phase 2b binds values per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md). See [phased-execution.md](../../../phased-execution.md).
 
 ## Task JSON Shape
-
-> **ID and elementId format.** Task `id` is `t` + 8 random chars. `elementId` is the composite `${stageId}-${taskId}`.
 
 ```json
 {
@@ -17,53 +13,53 @@ Cross check the case-management (sub-case) task metadata via CLI, then write the
   "isRequired": true,
   "shouldRunOnlyOnce": true,
   "data": {
-    "name": "VendorOnboarding",
-    "folderPath": "Shared/Procurement",
-    "inputs": [ /* from planning enrichment */ ],
-    "outputs": [ /* from planning enrichment */ ],
-    "context": { "taskTypeId": "d4e5f6g7-8901-2345-abcd-456789012345" }
+    "name": "=bindings.bG0SraLpg",
+    "folderPath": "=bindings.bH1iJK2lm",
+    "inputs": [],
+    "outputs": []
   }
 }
 ```
 
-## All Attributes
-
-Same shape as `ProcessTask` — see [process/impl-json.md § All Attributes](../process/impl-json.md#all-attributes). Only differences:
-
-- `type` is `"case-management"` (not `"process"`)
-- `data.name` resolves from the case-management registry (captured in `tasks.md` during planning), not the process registry
+- `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
+- `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure
 
-**Step 0 — Get enriched metadata + outputs:**
-
-Run `tasks describe` against the resolved `entityKey` and save the JSON response — this is the source of truth for `data.inputs[]` / `data.outputs[]` in Step 1.
+**Step 0 — Get inputs/outputs schema:**
 
 ```bash
 uip maestro case tasks describe --type case-management --id "<entityKey>" --output json
 ```
 
-Capture the response (input/output schema with names, types, and ids). If `tasks describe` fails or returns no schema, fall back to the planning-captured schema from `tasks.md`; if that is also missing, treat the task as skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
+Fallback: planning-captured schema from tasks.md. If unavailable, skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
 
-**Step 1 — Write task with populated data:**
+**Step 1 — Root-level bindings:**
 
-1. Generate task ID: `t` + 8 alphanumeric chars (unique across all tasks)
-2. Generate elementId: `<stageId>-<taskId>`
-3. Set top-level fields (`type: "case-management"`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) from tasks.md per the Task JSON Shape above
-4. Set `data.name` from tasks.md `name`
-5. Set `data.folderPath` from tasks.md `folder-path`
-6. Set `data.context.taskTypeId` to the sub-case `entityKey` from `tasks.md` (captured during planning per [planning.md § Registry Resolution](planning.md))
-7. Write `data.inputs[]` / `data.outputs[]` using the schema captured in Step 0 (falling back to the planning-captured schema in tasks.md if Step 0 was unavailable). Each input is `{ name, type, id, var, elementId, value: "" }`; each output is `{ name, type, id, var, value, source, target, elementId }`. See [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md) for shape details.
-8. **Recursion guard** — before writing, confirm `data.context.taskTypeId` does NOT match the current case's own entityKey (direct recursion) and does not appear as an ancestor in any already-written `case-management` task on the current case (transitive recursion). If either check fails, flag for user review before continuing.
-9. Write the task to the target stage's `tasks[]` array (in its own task set / lane)
+Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
 
-> **Handled elsewhere.** Input value bindings happen in outer-workflow Step 9 — see [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md). Entry conditions are added in Step 10.
+| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
+|---|---|---|---|
+| `"name"` | `"process"` | `"CaseManagement"` | `name` from tasks.md |
+| `"folderPath"` | `"process"` | `"CaseManagement"` | `folder-path` from tasks.md |
+
+Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+
+**Step 2 — Write task:**
+
+1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
+2. **Recursion guard** — confirm the sub-case `entityKey` from tasks.md does NOT match the current case's own entityKey (direct recursion) and does not appear as an ancestor in already-written `case-management` tasks (transitive recursion). If either check fails, flag for user review.
+3. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
+4. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
+5. Append to target stage's `tasks[laneIndex][]`
+
+> Entry conditions added in Step 10. Input value bindings in Phase 2b per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md).
 
 ## Post-Write Verification
 
-Confirm the task exists in the correct stage with:
-
 - `type: "case-management"`
-- `data.context.taskTypeId` non-empty (unless intentionally skeleton)
-- `data.inputs` and `data.outputs` populated from the planning-captured schema
+- `data.name` and `data.folderPath` start with `=bindings.`
+- `root.data.uipath.bindings[]` has 2 entries: `resource: "process"`, `resourceSubType: "CaseManagement"`, `propertyAttribute` = `name` / `folderPath`
+- `data.inputs` and `data.outputs` populated (unless skeleton)
 - No circular self-reference
+- `id` captured in `id-map.json`

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
@@ -20,6 +20,8 @@ The `tasks.md` entry provides:
 
 ## Configuration Workflow
 
+> **Each connector task runs its own `get-connection`.** Even when two tasks share the same `connection-id`, the Entry and Config objects differ between activity and trigger types (`httpMethod`, `activityType`, `inputMetadata`, etc.). Never reuse another task's CLI output.
+
 ### Step 1 — Get connection details + Entry
 
 ```bash
@@ -35,7 +37,9 @@ uip case registry get-connection \
 | `Entry` | `.Data.Entry` (full object) | `{ displayName: "Send Email", svgIconUrl: "icons/...", ... }` |
 | `Config` | `.Data.Config` | `{ connectorKey, objectName, httpMethod, activityType, version }` |
 | `folderKey` | `.Data.Connections[selected].folder.key` | `"87fd6cec-..."` |
+| `folderName` | `.Data.Connections[selected].folder.name` | `"57d6e3b0's workspace"` |
 | `connectorName` | `.Data.Connections[selected].connector.name` | `"Microsoft Outlook 365"` |
+| `connectionName` | `.Data.Connections[selected].name` | `"song.zhao@uipath.com #1"` |
 
 ### Step 2 — Get enriched metadata + outputs
 
@@ -90,6 +94,12 @@ Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](..
 | folderKey | `"folderKey"` | `folderKey` (from Step 1) |
 
 Both share `resourceKey` = `connection-id`. ID generation: `b` + 8 alphanumeric chars.
+
+### 3a-post. IS connection cache
+
+After writing root bindings in § 3a, populate IS connection cache per [bindings-v2-sync.md § Populate IS connection cache](../../../bindings-v2-sync.md). Skip if `get-connection` failed.
+
+> **`bindings_v2.json` regeneration is deferred** — runs once at end of Step 9.7 (after all connector tasks), not per-task. See [bindings-v2-sync.md § When to Run](../../../bindings-v2-sync.md).
 
 ### 3b. `data.context[]`
 
@@ -235,9 +245,9 @@ Append the task to the target stage's `tasks[]` array in its own task set (one t
 
 | Step failed | What gets populated | Log |
 |---|---|---|
-| get-connection | Context from tasks.md values only. No bindings — folderKey unknown | `[SKIPPED] get-connection failed — bindings/folderKey omitted` |
-| tasks describe | Context + bindings. No outputs/enrichment. Use Config fallbacks | `[SKIPPED] tasks describe failed — outputs/enrichment omitted` |
-| All succeed | Full population per §3a-3h | — |
+| get-connection | Context from tasks.md values only. No bindings, no bindings_v2 sync — folderKey unknown | `[SKIPPED] get-connection failed — bindings/folderKey omitted` |
+| tasks describe | Context + bindings + bindings_v2. No outputs/enrichment. Use Config fallbacks | `[SKIPPED] tasks describe failed — outputs/enrichment omitted` |
+| All succeed | Full population per §3a-3h including bindings_v2 sync | — |
 
 All issues appended to the shared issue list per [logging/impl-json.md](../../logging/impl-json.md).
 
@@ -253,6 +263,7 @@ All issues appended to the shared issue list per [logging/impl-json.md](../../lo
 8. `data.bindings[]` is empty `[]`
 9. `data.outputs[]` copied verbatim with `elementId` set
 10. `data.inputs[]` includes `pathParameters` (always), `queryParameters` (when applicable), `file` (when multipart has file), `body`
+11. `bindings_v2.json` `resources` array matches `root.data.uipath.bindings` (unless get-connection failed)
 
 ## What NOT to Do
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/process/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/process/impl-json.md
@@ -1,12 +1,8 @@
 # process task — Implementation (Direct JSON Write)
 
-> **Phase split.** Runs across both phases. Phase 2a writes shape: full `data.inputs[]` schema from `tasks describe`, each `value` empty (`""`). Phase 2b binds values via [`../../variables/io-binding/impl-json.md`](../../variables/io-binding/impl-json.md). See [`../../../phased-execution.md`](../../../phased-execution.md).
-
-Cross check the process task metadata via CLI, then write the task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md`.
+> **Phase split.** Phase 2a writes shape with empty input values. Phase 2b binds values per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md). See [phased-execution.md](../../../phased-execution.md).
 
 ## Task JSON Shape
-
-> **ID and elementId format.** Task `id` is `t` + 8 random chars (e.g. `t8GQTYo8O`). `elementId` is the composite `${stageId}-${taskId}` (e.g. `Stage_aB3kL9-t8GQTYo8O`).
 
 ```json
 {
@@ -17,73 +13,51 @@ Cross check the process task metadata via CLI, then write the task directly into
   "isRequired": true,
   "shouldRunOnlyOnce": true,
   "data": {
-    "name": "KYC",
-    "folderPath": "Shared",
-    "inputs": [ /* from planning enrichment */ ],
-    "outputs": [ /* from planning enrichment */ ],
-    "context": { "taskTypeId": "f1b2c3d4-1234-5678-abcd-ef1234567890" }
+    "name": "=bindings.bG0SraLpg",
+    "folderPath": "=bindings.bH1iJK2lm",
+    "inputs": [],
+    "outputs": []
   }
 }
 ```
 
-## All Attributes
-
-Top-level fields:
-
-| Field | Type | Notes |
-|---|---|---|
-| `id` | string | `t` + 8 alphanumeric chars (unique across all tasks) |
-| `elementId` | string | Composite `${stageId}-${taskId}` |
-| `type` | `"process"` | Discriminator — always `"process"` |
-| `displayName` | string | Human-readable task name |
-| `description` | string | Free-form task description |
-| `isRequired` | boolean | Marks task as required for stage completion |
-| `shouldRunOnlyOnce` | boolean | Prevents re-execution on stage re-entry |
-| `skipCondition` | string | Expression that causes the task to be skipped |
-| `entryConditions` | `TaskEntryCondition[]` | Entry condition rules (populated in Step 10) |
-| `data` | object | Process-specific data (see below) |
-
-`data` fields:
-
-| Field | Type | Notes |
-|---|---|---|
-| `data.name` | string | Registry-resolved process name |
-| `data.folderPath` | string | Orchestrator folder path |
-| `data.inputs` | `UiPathVariable[]` | Populated from planning enrichment |
-| `data.outputs` | `UiPathVariable[]` | Populated from planning enrichment |
-| `data.context` | `UiPathVariable[]` | Carries the resolved `taskTypeId` |
+- `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
+- `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
 
 ## Procedure
 
-**Step 0 — Get enriched metadata + outputs:**
-
-Run `tasks describe` against the resolved `entityKey` and save the JSON response — this is the source of truth for `data.inputs[]` / `data.outputs[]` in Step 1. Use `processOrchestration` as the `--type` for `AGENTIC_PROCESS`; otherwise use `process`.
+**Step 0 — Get inputs/outputs schema:**
 
 ```bash
 uip maestro case tasks describe --type process --id "<entityKey>" --output json
 ```
 
-Capture the response (input/output schema with names, types, and ids). If `tasks describe` fails or returns no schema, fall back to the planning-captured schema from `tasks.md`; if that is also missing, treat the task as skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
+Fallback: planning-captured schema from tasks.md. If unavailable, skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
 
-**Step 1 — Write task with populated data:**
+**Step 1 — Root-level bindings:**
 
-1. Generate task ID: `t` + 8 alphanumeric chars (unique across all tasks)
-2. Generate elementId: `<stageId>-<taskId>`
-3. Set top-level fields (`type: "process"`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) from tasks.md per the Task JSON Shape above
-4. Set `data.name` from tasks.md `name`
-5. Set `data.folderPath` from tasks.md `folder-path`
-6. Set `data.context.taskTypeId` to the process `entityKey` from `tasks.md` (captured during planning per [planning.md § Registry Resolution](planning.md) — includes `AGENTIC_PROCESS` entries)
-7. Write `data.inputs[]` / `data.outputs[]` using the schema captured in Step 0 (falling back to the planning-captured schema in tasks.md if Step 0 was unavailable). Each input is `{ name, type, id, var, elementId, value: "" }`; each output is `{ name, type, id, var, value, source, target, elementId }`. See [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md) for shape details.
-8. Write the task to the target stage's `tasks[]` array (in its own task set / lane)
+Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
 
-> **Handled elsewhere.** Input value bindings happen in outer-workflow Step 9 — see [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md). Entry conditions are added in Step 10.
+| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
+|---|---|---|---|
+| `"name"` | `"process"` | `"ProcessOrchestration"` | `name` from tasks.md |
+| `"folderPath"` | `"process"` | `"ProcessOrchestration"` | `folder-path` from tasks.md |
+
+Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+
+**Step 2 — Write task:**
+
+1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
+2. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
+3. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
+4. Append to target stage's `tasks[laneIndex][]`
+
+> Entry conditions added in Step 10. Input value bindings in Phase 2b per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md).
 
 ## Post-Write Verification
 
-Confirm the task exists in the correct stage with:
-
 - `type: "process"`
-- `data.context.taskTypeId` non-empty (unless intentionally skeleton)
-- `data.inputs` and `data.outputs` populated from the planning-captured schema
-
-Capture the generated `id` in `id-map.json` so downstream cross-task references can resolve.
+- `data.name` and `data.folderPath` start with `=bindings.`
+- `root.data.uipath.bindings[]` has 2 entries: `resource: "process"`, `resourceSubType: "ProcessOrchestration"`, `propertyAttribute` = `name` / `folderPath`
+- `data.inputs` and `data.outputs` populated (unless skeleton)
+- `id` captured in `id-map.json`

--- a/skills/uipath-maestro-case/references/plugins/tasks/rpa/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/rpa/impl-json.md
@@ -1,12 +1,8 @@
 # rpa task — Implementation (Direct JSON Write)
 
-> **Phase split.** Runs across both phases. Phase 2a writes shape: full `data.inputs[]` schema from `tasks describe`, each `value` empty (`""`). Phase 2b binds values via [`../../variables/io-binding/impl-json.md`](../../variables/io-binding/impl-json.md). See [`../../../phased-execution.md`](../../../phased-execution.md).
-
-Cross check the RPA task metadata via CLI, then write the task directly into `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md`. Shape is identical to `process` except `type: "rpa"`.
+> **Phase split.** Phase 2a writes shape with empty input values. Phase 2b binds values per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md). See [phased-execution.md](../../../phased-execution.md).
 
 ## Task JSON Shape
-
-> **ID and elementId format.** Task `id` is `t` + 8 random chars. `elementId` is the composite `${stageId}-${taskId}`.
 
 ```json
 {
@@ -17,52 +13,52 @@ Cross check the RPA task metadata via CLI, then write the task directly into `ca
   "isRequired": true,
   "shouldRunOnlyOnce": true,
   "data": {
-    "name": "InvoiceExtractor",
-    "folderPath": "Finance",
-    "inputs": [ /* from planning enrichment */ ],
-    "outputs": [ /* from planning enrichment */ ],
-    "context": { "taskTypeId": "b2c3d4e5-6789-01ab-cdef-234567890abc" }
+    "name": "=bindings.bG0SraLpg",
+    "folderPath": "=bindings.bH1iJK2lm",
+    "inputs": [],
+    "outputs": []
   }
 }
 ```
 
-## All Attributes
-
-Same shape as `ProcessTask` — see [process/impl-json.md § All Attributes](../process/impl-json.md#all-attributes). Only difference:
-
-- `type` is `"rpa"` (never `"process"`, even though the registry entry shares the process registry)
+- `id`: `t` + 8 alphanumeric chars. `elementId`: `${stageId}-${taskId}`.
+- `data.name` / `data.folderPath` MUST be `=bindings.<id>` references — never literals.
+- **Do not flip to `type: "process"`** based on registry. The `rpa` vs `process` distinction comes from sdd.md intent.
 
 ## Procedure
 
-**Step 0 — Get enriched metadata + outputs:**
-
-Run `tasks describe` against the resolved `entityKey` and save the JSON response — this is the source of truth for `data.inputs[]` / `data.outputs[]` in Step 1. Use `--type rpa` even though the registry entry shares the process registry.
+**Step 0 — Get inputs/outputs schema:**
 
 ```bash
 uip maestro case tasks describe --type rpa --id "<entityKey>" --output json
 ```
 
-Capture the response (input/output schema with names, types, and ids). If `tasks describe` fails or returns no schema, fall back to the planning-captured schema from `tasks.md`; if that is also missing, treat the task as skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
+Fallback: planning-captured schema from tasks.md. If unavailable, skeleton per [skeleton-tasks.md](../../../skeleton-tasks.md).
 
-**Step 1 — Write task with populated data:**
+**Step 1 — Root-level bindings:**
 
-1. Generate task ID: `t` + 8 alphanumeric chars (unique across all tasks)
-2. Generate elementId: `<stageId>-<taskId>`
-3. Set top-level fields (`type: "rpa"`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) from tasks.md per the Task JSON Shape above
-4. Set `data.name` from tasks.md `name`
-5. Set `data.folderPath` from tasks.md `folder-path`
-6. Set `data.context.taskTypeId` to the `entityKey` from `tasks.md` (captured during planning — RPA tasks share the process registry per [planning.md § Registry Resolution](planning.md))
-7. Write `data.inputs[]` / `data.outputs[]` using the schema captured in Step 0 (falling back to the planning-captured schema in tasks.md if Step 0 was unavailable). Each input is `{ name, type, id, var, elementId, value: "" }`; each output is `{ name, type, id, var, value, source, target, elementId }`. See [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md) for shape details.
-8. Write the task to the target stage's `tasks[]` array (in its own task set / lane)
+Create 2 entries in `root.data.uipath.bindings[]` per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
 
-> **Handled elsewhere.** Input value bindings happen in outer-workflow Step 9 — see [variables/io-binding/impl-json.md](../../variables/io-binding/impl-json.md). Entry conditions are added in Step 10.
+| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
+|---|---|---|---|
+| `"name"` | `"process"` | — | `name` from tasks.md |
+| `"folderPath"` | `"process"` | — | `folder-path` from tasks.md |
 
-> **Do not flip to `type: "process"`** based on where the `entityKey` was found. The `rpa` vs `process` distinction comes from the sdd.md intent, not from the registry.
+Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+
+**Step 2 — Write task:**
+
+1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
+2. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
+3. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
+4. Append to target stage's `tasks[laneIndex][]`
+
+> Entry conditions added in Step 10. Input value bindings in Phase 2b per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md).
 
 ## Post-Write Verification
 
-Confirm the task exists in the correct stage with:
-
 - `type: "rpa"` (NOT `"process"`)
-- `data.context.taskTypeId` non-empty (unless intentionally skeleton)
-- `data.inputs` and `data.outputs` populated from the planning-captured schema
+- `data.name` and `data.folderPath` start with `=bindings.`
+- `root.data.uipath.bindings[]` has 2 entries: `resource: "process"`, no `resourceSubType`, `propertyAttribute` = `name` / `folderPath`
+- `data.inputs` and `data.outputs` populated (unless skeleton)
+- `id` captured in `id-map.json`

--- a/skills/uipath-maestro-case/references/plugins/variables/bindings/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/bindings/impl-json.md
@@ -1,24 +1,10 @@
 # Resource Bindings — Implementation
 
-Root-level binding creation for `root.data.uipath.bindings[]`. Referenced by connector task plugins for ConnectionId + folderKey bindings.
+Root-level binding creation for `root.data.uipath.bindings[]`. Referenced by **all** task plugins — non-connector tasks for name + folderPath bindings, connector tasks for ConnectionId + folderKey bindings. Every task type MUST create root bindings; see each task plugin's §Root-level bindings section.
 
 ## What Bindings Are
 
 `root.data.uipath.bindings[]` stores resource metadata for tasks — process names, folder paths, connection IDs. Tasks reference these indirectly via `=bindings.<id>` instead of storing literal values.
-
-```json
-// root.data.uipath.bindings[]
-{
-  "id": "bG0SraLpg",
-  "name": "name",
-  "type": "string",
-  "resource": "process",
-  "resourceSubType": "ProcessOrchestration",
-  "resourceKey": "Shared.MyProcess",
-  "default": "MyProcess",
-  "propertyAttribute": "name"
-}
-```
 
 ## Per Task Type
 
@@ -30,28 +16,69 @@ Root-level binding creation for `root.data.uipath.bindings[]`. Referenced by con
 | rpa | `"process"` | — | name + folderPath |
 | api-workflow | `"process"` | `"Api"` | name + folderPath |
 | case-management | `"process"` | `"CaseManagement"` | name + folderPath |
-| connector (event trigger) | `"Connection"` | — | ConnectionId + folderKey |
+| connector (activity/trigger) | `"Connection"` | — | ConnectionId + folderKey |
 
-## Task References Bindings
+## Non-Connector Binding Creation (name + folderPath)
+
+For every non-connector task (process, action, agent, rpa, api-workflow, case-management), create **two** binding entries in `root.data.uipath.bindings[]`. Both bindings share the same `resourceKey`.
+
+### Data sources
+
+| Field | Source |
+|---|---|
+| `name` | `tasks.md` `name` field (captured from registry during planning: `entry.name` for process types, `entry.deploymentTitle` for action) |
+| `folderPath` | `tasks.md` `folder-path` field (captured from registry during planning: `entry.folders[0].fullyQualifiedName` for process types, `entry.deploymentFolder.fullyQualifiedName` for action) |
+
+### resourceKey construction
+
+```
+resourceKey = "<folderPath>.<name>"
+```
+
+Examples:
+- folderPath `"Shared"`, name `"KYC"` → `"Shared.KYC"`
+- folderPath `"Shared/Finance"`, name `"InvoiceProcess"` → `"Shared/Finance.InvoiceProcess"`
+- folderPath `""` (empty), name `"ReviewHITL"` → `".ReviewHITL"`
+
+### Full binding shape (two entries per task)
 
 ```json
-// task.data
-{
-  "name": "=bindings.bG0SraLpg",
-  "folderPath": "=bindings.bH1iJK2lm"
-}
+[
+  {
+    "id": "<b + 8 alphanumeric chars>",
+    "name": "name",
+    "type": "string",
+    "resource": "<see Per Task Type table>",
+    "resourceSubType": "<see Per Task Type table, omit key if none>",
+    "resourceKey": "<folderPath>.<name>",
+    "default": "<name>",
+    "propertyAttribute": "name"
+  },
+  {
+    "id": "<b + 8 alphanumeric chars>",
+    "name": "folderPath",
+    "type": "string",
+    "resource": "<same as above>",
+    "resourceSubType": "<same as above>",
+    "resourceKey": "<folderPath>.<name>",
+    "default": "<folderPath>",
+    "propertyAttribute": "folderPath"
+  }
+]
 ```
+
+### Task references
+
+After creating bindings, set `data.name` to `=bindings.<nameBindingId>` and `data.folderPath` to `=bindings.<folderPathBindingId>`. Do NOT use literal strings.
 
 ## Deduplication
 
-Multiple tasks referencing the same resource share one binding. Deduped by `default + resource + resourceKey`. The FE checks before creating a new binding.
+Multiple tasks referencing the same resource share one binding pair. Deduped by `default + resource + resourceKey`. Before creating a new binding, check if an existing entry in `root.data.uipath.bindings[]` matches on all three fields. If found, reuse the existing binding's `id` instead of creating a new one.
 
 ## Binding ID Generation
 
-IDs use `b` prefix + 8 alphanumeric chars (e.g., `bG0SraLpg`). Generated via `createBinding()` in `FPSFormControlUtils.ts`.
+IDs use `b` prefix + 8 alphanumeric chars (e.g., `bG0SraLpg`).
 
-## Usage
+## bindings_v2.json Sync
 
-1. Create binding entries in `root.data.uipath.bindings[]` before or during task creation
-2. Reference from task data via `=bindings.<id>` (e.g., `data.context[].value` for connectors, `data.name` / `data.folderPath` for process tasks)
-3. Apply deduplication check before creating new bindings
+`bindings_v2.json` must mirror `root.data.uipath.bindings[]` in SDK format. Regenerated in batch (not per-task) at end of Step 9 and Step 9.7. See [bindings-v2-sync.md](../../../bindings-v2-sync.md).

--- a/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
@@ -79,7 +79,7 @@ Combines In + Out. Creates input + **one** shared companion IO + trigger mapping
 
 The FE's `CaseManagementVariablesProvider` collects task outputs directly from `task.data.outputs[]` and makes them referenceable via `=vars.<var>`. A separate `root.data.uipath.variables.inputOutputs[]` entry is **not required** for cross-task variable resolution — the FE resolves from task outputs directly.
 
-The FE does write a root `inputOutputs` copy as a sync convention. To match FE behavior, optionally append a companion entry:
+Write the companion entry to match FE behavior. Safe to omit — resolution works without it:
 
 ```json
 // Task output on the task node (required)

--- a/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
@@ -77,21 +77,23 @@ Combines In + Out. Creates input + **one** shared companion IO + trigger mapping
 
 ## Task Output → inputOutputs Wiring
 
-For every task output written, also append to `root.data.uipath.variables.inputOutputs[]`:
+The FE's `CaseManagementVariablesProvider` collects task outputs directly from `task.data.outputs[]` and makes them referenceable via `=vars.<var>`. A separate `root.data.uipath.variables.inputOutputs[]` entry is **not required** for cross-task variable resolution — the FE resolves from task outputs directly.
+
+The FE does write a root `inputOutputs` copy as a sync convention. To match FE behavior, optionally append a companion entry:
 
 ```json
-// Task output on the task node
+// Task output on the task node (required)
 { "name": "AnomalyCheck", "var": "anomalyCheck", "id": "anomalyCheck",
   "value": "anomalyCheck", "type": "string",
   "source": "=AnomalyCheck", "target": "=anomalyCheck",
   "elementId": "Stage_intake-tAnomalyXX" }
 
-// Corresponding inputOutputs entry on root
+// Optional root inputOutputs companion (FE sync convention, not required for resolution)
 { "id": "anomalyCheck", "name": "AnomalyCheck",
   "type": "string", "elementId": "Stage_intake-tAnomalyXX" }
 ```
 
-Skip when a `custom: true` output reuses an existing variable from another element.
+Skip the root companion when a `custom: true` output reuses an existing variable from another element.
 
 ## Custom Outputs (`custom: true`)
 

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -51,7 +51,7 @@ src_output = find_output_by_name(src_task, "outputName")
 target_input["value"] = f"=vars.{src_output['var']}"
 ```
 
-After all bindings, verify every bound input has a non-empty `value` and every `=vars.X` points to an existing variable ID.
+After all bindings, verify every bound input has a non-empty `value` and every `=vars.X` resolves to an existing ID in: any task `data.outputs[].var`, `root.data.uipath.variables.inputOutputs[].id`, or `root.data.uipath.variables.inputs[].id`.
 
 ## Connector Tasks
 
@@ -79,7 +79,7 @@ Use `=js:()` only for expressions with operators (e.g., `=js:(vars.amount > 5000
   "elementId": "Stage_submit-tEnrich02" }
 ```
 
-Two things must exist: output on Task A with a `var` field, and bound input on Task B referencing `=vars.<var>`. The FE's `CaseManagementVariablesProvider` collects task outputs directly from `task.data.outputs[]` and makes them referenceable — it does not require a separate `root.data.uipath.variables.inputOutputs[]` entry to resolve `=vars.<id>`. Root `inputOutputs` entries for task outputs are a FE sync convention (the FE writes them), not a hard requirement for variable resolution.
+Two things must exist: output on Task A with a `var` field, and bound input on Task B referencing `=vars.<var>`. Root `inputOutputs` companion entries for task outputs are optional — see [global-vars/impl-json.md § Task Output → inputOutputs Wiring](../global-vars/impl-json.md#task-output--inputoutputs-wiring).
 
 ## Error Handling
 

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -73,17 +73,13 @@ Use `=js:()` only for expressions with operators (e.g., `=js:(vars.amount > 5000
   "value": "validationResult", "source": "=ValidationResult", "target": "=validationResult",
   "type": "string", "elementId": "Stage_submit-tValidate01" }
 
-// 2. Root inputOutputs entry (per global-vars output wiring)
-{ "id": "validationResult", "name": "ValidationResult",
-  "type": "string", "elementId": "Stage_submit-tValidate01" }
-
-// 3. Task B input after binding — value set to =vars.<output.var>
+// 2. Task B input after binding — value set to =vars.<output.var>
 { "name": "in_ValidationResult", "value": "=vars.validationResult",
   "type": "string", "id": "vXr9pQ2mK", "var": "vXr9pQ2mK",
   "elementId": "Stage_submit-tEnrich02" }
 ```
 
-All three must exist: output on Task A, inputOutputs entry on root, bound input on Task B. If any is missing, the error handling below will catch it.
+Two things must exist: output on Task A with a `var` field, and bound input on Task B referencing `=vars.<var>`. The FE's `CaseManagementVariablesProvider` collects task outputs directly from `task.data.outputs[]` and makes them referenceable — it does not require a separate `root.data.uipath.variables.inputOutputs[]` entry to resolve `=vars.<id>`. Root `inputOutputs` entries for task outputs are a FE sync convention (the FE writes them), not a hard requirement for variable resolution.
 
 ## Error Handling
 
@@ -94,7 +90,7 @@ All issues go to the shared issue list per [logging/impl-json.md](../../logging/
 | Skeleton task (no `data.inputs[]`) | `SKIPPED` | Skip all bindings |
 | Input name not found (exact match) | `ERROR` | Skip binding — log available inputs |
 | Source output not found (exact match) | `ERROR` | Skip binding — log available outputs |
-| `=vars.X` not in `inputs[]`/`outputs[]`/`inputOutputs[]` | `ERROR` | Skip binding |
+| `=vars.X` not in any task `outputs[]` or root `inputOutputs[]` | `ERROR` | Skip binding |
 | Type mismatch (input vs variable) | `WARNING` | Proceed |
 
 Example log entry (pseudocode — record in-reasoning, not via subprocess):

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -55,10 +55,10 @@ After all bindings, verify every bound input has a non-empty `value` and every `
 
 ## Connector Tasks
 
-Connector inputs are set at creation time via `--input-values`, not post-creation. Plain prefixes work directly. Resolve cross-task `var` IDs **before** constructing the JSON:
+Connector task input values are written during Step 9.7 (connector detail), not during this I/O binding step. Resolve cross-task `var` IDs before constructing the `input-values` body from `tasks.md`:
 
-```bash
---input-values '{"body":{"email":"=vars.employeeEmail","caseRef":"=metadata.ExternalId"}}'
+```json
+{ "body": { "email": "=vars.employeeEmail", "caseRef": "=metadata.ExternalId" } }
 ```
 
 Use `=js:()` only for expressions with operators (e.g., `=js:(vars.amount > 5000)`). See [connector-activity/impl-json.md](../../../plugins/tasks/connector-activity/impl-json.md).


### PR DESCRIPTION
## Summary

- Add `bindings-v2-sync.md`: bindings_v2.json regeneration + connection resource file creation for connector tasks
- Add `resource refresh` step to SKILL.md, case-commands.md, implementation.md
- Add §Root-level bindings to all 6 non-connector task plugins (process, agent, rpa, api-workflow, case-management, action) with correct `resource`/`resourceSubType` per type; `data.name` and `data.folderPath` use `=bindings.<id>` references
- Remove `data.context`/`taskTypeId` from non-connector tasks — FE does not produce these fields (confirmed via CLI `tasks add`)
- Debloat non-connector task `impl-json.md` files: remove duplicate All Attributes tables, verbose prose, redundant procedure steps
- Add `get-connection` isolation warning to connector plugins
- Update `bindings/impl-json.md`: all task types must create root bindings
- Fix action task `recipient` field: must be `ActionTaskAssignee` object `{ "Type": int, "Value": string }`, not plain email string
- Fix io-binding/global-vars: root `inputOutputs` entries for task outputs are optional (FE sync convention, not required for `=vars.<id>` resolution — FE's `CaseManagementVariablesProvider` collects from `task.data.outputs[]` directly)
- Dedup FE resolution explanation: authoritative in global-vars, io-binding links to it
- Clarify `=vars.X` verification scope: explicit lookup locations (task outputs, root inputOutputs, root inputs)
- Reframe connector task I/O binding section from stale CLI `--input-values` flag to direct-JSON Step 9.7

## Test plan

- [ ] Run existing case skill e2e tests
- [ ] Build a case with mixed connector + non-connector tasks; verify root bindings created for all task types
- [ ] Verify `uip solution resource refresh` + `uip solution upload` succeeds with connector tasks
- [ ] Confirm non-connector tasks have no `taskTypeId`/`context` field in caseplan.json
- [ ] Verify cross-task I/O binding works without root `inputOutputs` companion entries
- [ ] Verify action task recipient renders correctly in Studio Web as object format

🤖 Generated with [Claude Code](https://claude.com/claude-code)