### PR TITLE
fix(maestro-case): add type field to connector context array docs

### DIFF
--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -136,17 +136,19 @@ uip case tasks describe --type connector-trigger \
 
 ### Context array
 
-| `name` | `value` source | Notes |
-|---|---|---|
-| `connectorKey` | `connector-key` (tasks.md) | |
-| `connection` | `=bindings.<connBindingId>` | Reference — not raw UUID |
-| `resourceKey` | `connection-id` (tasks.md) | |
-| `folderKey` | `=bindings.<folderBindingId>` | Reference — not raw UUID |
-| `method` | *(no value)* | Empty placeholder. Do not omit. |
-| `path` | *(no value)* | Empty placeholder. Do not omit. |
-| `objectName` | `object-name` (tasks.md) | |
-| `operation` | `enrichment.operation` (Step 2) | |
-| `metadata` | *(see below)* | `type: "json"` with `body` |
+Every context entry MUST include `"type": "string"` (or `"type": "json"` for metadata). Omitting `type` causes Studio Web to fail to render the case.
+
+| `name` | `type` | `value` source | Notes |
+|---|---|---|---|
+| `connectorKey` | `"string"` | `connector-key` (tasks.md) | |
+| `connection` | `"string"` | `=bindings.<connBindingId>` | Reference — not raw UUID |
+| `resourceKey` | `"string"` | `connection-id` (tasks.md) | |
+| `folderKey` | `"string"` | `=bindings.<folderBindingId>` | Reference — not raw UUID |
+| `method` | `"string"` | *(no value)* | Empty placeholder. Do not omit entry. |
+| `path` | `"string"` | *(no value)* | Empty placeholder. Do not omit entry. |
+| `objectName` | `"string"` | `object-name` (tasks.md) | |
+| `operation` | `"string"` | `enrichment.operation` (Step 2) | |
+| `metadata` | `"json"` | *(see below)* | Uses `body` not `value` |
 
 ### Metadata body
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
@@ -95,16 +95,18 @@ Both share `resourceKey` = `connection-id`. ID generation: `b` + 8 alphanumeric 
 
 No `operation`, `_label`, or `designTimeMetadata` for activities — the FE only adds `operation` to context for triggers. Activity tasks use `enrichment.operation` inside `essentialConfiguration` only.
 
-| `name` | `value` source | Notes |
-|---|---|---|
-| `connectorKey` | `connector-key` (tasks.md) | |
-| `connection` | `=bindings.<connBindingId>` | Reference — not raw UUID |
-| `resourceKey` | `connection-id` (tasks.md) | |
-| `folderKey` | `=bindings.<folderBindingId>` | Reference — not raw UUID |
-| `objectName` | `object-name` (tasks.md) | |
-| `method` | `Config.httpMethod` (Step 1) | |
-| `path` | `enrichment.path` (Step 2) | From Swagger — includes hub prefix |
-| `metadata` | *(see §3c)* | `type: "json"` with `body` |
+Every context entry MUST include `"type": "string"` (or `"type": "json"` for metadata). Omitting `type` causes Studio Web to fail to render the case.
+
+| `name` | `type` | `value` source | Notes |
+|---|---|---|---|
+| `connectorKey` | `"string"` | `connector-key` (tasks.md) | |
+| `connection` | `"string"` | `=bindings.<connBindingId>` | Reference — not raw UUID |
+| `resourceKey` | `"string"` | `connection-id` (tasks.md) | |
+| `folderKey` | `"string"` | `=bindings.<folderBindingId>` | Reference — not raw UUID |
+| `objectName` | `"string"` | `object-name` (tasks.md) | |
+| `method` | `"string"` | `Config.httpMethod` (Step 1) | |
+| `path` | `"string"` | `enrichment.path` (Step 2) | From Swagger — includes hub prefix |
+| `metadata` | `"json"` | *(see §3c)* | Uses `body` not `value` |
 
 ### 3c. `metadata` context entry body
 


### PR DESCRIPTION
## Summary

- Add `type` column to context array tables in connector-trigger-common.md and connector-activity/impl-json.md
- Every context entry must include `"type": "string"` (or `"type": "json"` for metadata) — omitting causes Studio Web render failure
- Clarify that trigger `method`/`path` entries must omit `value` key when empty (not `value: ""`)

## Root cause

The BPMN converter (`convertCaseToBpmn`) succeeds regardless, but Studio Web's FE renderer requires the `type` field on context entries. Without it, the case shows as "invalid" in the designer.

The skill docs only documented `name` and `value` columns in context tables — `type` was never mentioned.

## Test plan

- [x] Verified case with missing `type` fails to render in Studio Web
- [x] Verified case with `type: "string"` on all context entries renders correctly
- [x] Verified `method`/`path` with no `value` key (just `name` + `type`) matches reference fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)