### PR TITLE
test(maestro-flow): F8 CLI pin bump + F11 connector-trigger doc fix

### DIFF
--- a/skills/uipath-maestro-flow/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector-trigger/impl.md
@@ -119,6 +119,8 @@ uip is resources execute list "<connector-key>" "<reference.objectName>" \
 
 The `<id>` in `--connection-id "<id>"` MUST be the connection bound to **this** flow (the final connection from Step 1c), not any other connection you've used in another flow. Use the resolved IDs — from this very `execute list` call — in the trigger's event parameter configuration.
 
+> **Anti-pattern: do not pass the display name as the ID.** Reference fields take the GUID returned by `execute list` (e.g. the `id` field of an item — typically `"AAMkAD..."` for an Outlook MailFolder), **not** the human-readable folder name like `"Inbox"`. Passing the display name validates fine and may even round-trip through `flow validate`, but the trigger faults silently at runtime because the connector cannot resolve a non-GUID against the live connection. After running `execute list`, parse the response and extract the `id` value from the matching item — never substitute the user-typed name.
+
 > **Paginate when looking up by name.** `execute list` returns one page (up to 1000 items) and surfaces `Data.Pagination.HasMore` + `Data.Pagination.NextPageToken`. If the target isn't on the first page, re-run with `--query "nextPage=<NextPageToken>"` until found or `HasMore` is `"false"`. Short-circuit as soon as the target name matches — don't pull every page.
 
 **Read [/uipath:uipath-platform — Integration Service — resources.md](../../../../uipath-platform/references/integration-service/resources.md) for the full reference resolution workflow**, including pagination, describe failures, and fallback strategies.

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a flow called "CeqlWhereTest" with a manual trigger that lists all sharepoint sites that were created in the last 7 days.
   Add a Decision node to check whether the call succeeded.

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "ComplexArrayTest" with a manual trigger.
   You need a flow that records a sales interaction in Act! 365 and associates it

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "DTLLoadByDefaultFalseTest" with a manual trigger.
   You need a flow that lists WooCommerce products filtered by an attribute term

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "DTLLoadByDefaultTrueTest" with a manual trigger.
   You need a flow that provisions a new Azure resource group in a chosen region.

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "EnhancedEnumTest" with a manual trigger.
   You need a flow that retrieves WooCommerce product reviews sorted either

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "EnumTest" with a manual trigger.
   You need a flow that provisions a new Azure Storage Account and chooses a

--- a/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "FieldActionsTest" with a manual trigger.
   You need a flow that lists products from a WooCommerce store filtered by a

--- a/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/file_picker.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "FilePickerTest" with a manual trigger.
   You need a flow that fires whenever a new folder is created under a designated

--- a/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/filter_builder.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "FilterBuilderTest" with a manual trigger.
   You need a flow that queries SAP S/4HANA Cloud for a set of entity records

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "GenerateSchemaTest" with a manual trigger.
   You need a flow that runs a KQL query against an Azure Application Insights

--- a/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/list_curated.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "ListCuratedTest" with a manual trigger.
   You need a flow that fetches every task from a specific Google Tasks list.

--- a/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "MethodOverrideTest" with a manual trigger.
   You need a flow that retrieves the registration token for an Azure Virtual

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "MultiselectTest" with a manual trigger.
   You need a flow that creates a new contact in Act! 365 and assigns the contact

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "PathParamsTest" with a manual trigger.
   You need a flow that deletes a single task from a specific Google Tasks list.

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "QueryParamsTest" with a manual trigger.
   You need a flow that lists all Google Tasks including hidden ones. Discover

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "RequiredGroupsTest" with a manual trigger.
   You need a flow that replies to a Microsoft Teams channel message with one or

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "SearchableJoinsTest" with a manual trigger.
   You need a flow that queries Salesforce accounts and returns each account

--- a/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/upload.yaml
@@ -18,7 +18,7 @@ sandbox:
   node:
     # Pin shared across all connector_features tasks — bump in lockstep.
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 initial_prompt: |
   Create a new Flow project called "UploadTest" with a manual trigger.
   You need a flow that takes a short audio file and produces a text transcript

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -23,7 +23,7 @@ sandbox:
   python: {}
   node:
     env_packages:
-      - "@uipath/cli@0.1.21"
+      - "@uipath/cli@0.9.0"
 
 initial_prompt: |
   Build a Maestro Flow called "CustomerEscalation" that triggers on new


### PR DESCRIPTION
## Summary

Follow-up to [#434](https://github.com/UiPath/skills/pull/434) addressing two `uipath-maestro-flow` failures from e2e-run `2026-04-27_10-24-13` that #434 had flagged as out-of-scope. Triage doc: [\`2026-04-27-pr434-failure-coverage.md\`](../blob/main/.../2026-04-27-pr434-failure-coverage.md) (failure cluster F8 + F11).

- **F8 — IPE turn-timeout (`complex_array`, `dtl_load_by_default_false`)**: bump the shared CLI pin in 18 \`connector_features/*.yaml\` files from \`@uipath/cli@0.1.21\` → \`@uipath/cli@0.9.0\` (latest, published 2026-04-24). The lockstep comment (\"Pin shared across all connector_features tasks — bump in lockstep\") is honored — all 18 move together. Followed up by also moving \`multi_node/customer_escalation/customer_escalation.yaml\` to \`0.9.0\` for surface uniformity.
- **F11 — `skill-flow-outlook-trigger-inbox`**: add an explicit anti-pattern callout in `connector-trigger/impl.md` Step 3. The agent in the failing run did call `uip is resources execute list ... MailFolder ... --connection-id ...` (PR #348 regression check passed), but then wrote `parentFolderId: "Inbox"` (the human-readable display name) instead of the GUID returned by the call. The new callout names the failure mode and the fix — parse the response and extract the matching item's `id`.

## Test plan

- [x] `validate_yaml.py` — 19/19 affected YAMLs (18 connector_features + customer_escalation) parse against `TaskDefinition`.
- [x] No residual `@uipath/cli@0.1.x` pins left in `tests/tasks/`. Only residual occurrence is in a frozen run-artifact `bun.lock` snapshot under `tests/runs/2026-04-23_15-05-11/`, which is correct to leave untouched.
- [x] Doc edit reviewed against the failing run's `task.json`: agent's `parentFolderId` was `"Inbox"` (the literal name), confirming the anti-pattern hits the actual observed failure mode.
- [ ] Re-run `coder-eval run --experiment skill-tests-e2e` after merge to confirm F8 + F11 recovery (operational follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)