### PR TITLE
test(uipath-solution-design): unblock smoke tests, tolerate heading variants

### DIFF
--- a/tests/tasks/uipath-solution-design/e2e_rpa_sdd/check_sdd.py
+++ b/tests/tasks/uipath-solution-design/e2e_rpa_sdd/check_sdd.py
@@ -52,14 +52,36 @@ def load_sdd() -> str:
 
 
 def check_sections(content: str) -> list[str]:
-    """Verify required sections exist as headings."""
+    """Verify required sections exist as headings.
+
+    Tolerates common heading variants the model may emit:
+      - `## 1. Process Overview`           (canonical template form)
+      - `## §1. Process Overview`          (§N copied from cross-refs)
+      - `## 1. **Process Overview**`       (bold inside heading)
+      - `## **1. Process Overview**`       (bold wrapping the whole title)
+      - `## 1 — Process Overview`          (em-dash / en-dash separator)
+      - `## 1) Process Overview`           (paren separator)
+      - `## 11.1 Process Overview`         (sub-numbered, e.g. Master Project)
+      - `### Process Overview`             (no number at all)
+    """
     failures = []
     for section in REQUIRED_SECTIONS:
-        # Match ## N. Section or # N. Section (with optional number)
-        pattern = rf"^#{1,3}\s+(\d+\.\s+)?{re.escape(section)}"
+        pattern = (
+            rf"^#{{1,4}}\s+"                       # heading marker (h1-h4)
+            rf"\**\s*"                             # optional opening bold
+            rf"(?:§\s*)?"                          # optional § prefix
+            rf"(?:\d+(?:\.\d+)*\s*[.\):—–-]?\s+)?" # optional 1. / 1.1 / 1) / 1 — etc.
+            rf"\**\s*"                             # optional bold before the title
+            rf"{re.escape(section)}"
+        )
         if not re.search(pattern, content, re.MULTILINE | re.IGNORECASE):
             failures.append(f"Missing section: {section}")
     return failures
+
+
+def collect_headings(content: str) -> list[str]:
+    """Return every markdown heading line — used for diagnostics on failure."""
+    return re.findall(r"^#{1,4}\s+.*$", content, re.MULTILINE)
 
 
 def check_line_count(content: str) -> list[str]:
@@ -203,6 +225,10 @@ def main():
         print(f"FAIL: {len(all_failures)} check(s) failed:")
         for f in all_failures:
             print(f"  - {f}")
+        if any(f.startswith("Missing section:") for f in all_failures):
+            print("\nHeadings actually present in the SDD:")
+            for h in collect_headings(content):
+                print(f"  {h}")
         sys.exit(1)
     else:
         print("PASS: All SDD structure checks passed")

--- a/tests/tasks/uipath-solution-design/gap_detection.yaml
+++ b/tests/tasks/uipath-solution-design/gap_detection.yaml
@@ -6,6 +6,12 @@ description: >
   business-knowledge gaps, per Critical Rules 4 and the Gap Detection Checklist.
 tags: [uipath-solution-design, smoke, gap-detection]
 
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
 sandbox:
   driver: tempdir
   python: {}

--- a/tests/tasks/uipath-solution-design/pdd_to_sdd.yaml
+++ b/tests/tasks/uipath-solution-design/pdd_to_sdd.yaml
@@ -5,6 +5,12 @@ description: >
   skill teaches correct PDD extraction, product selection, and SDD structure.
 tags: [uipath-solution-design, smoke, pdd, sdd]
 
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
 sandbox:
   driver: tempdir
   python: {}


### PR DESCRIPTION
## Summary

Triage of the 2026-04-27 eval run for `uipath-solution-design` — three failing tests, two distinct root causes, both fixable on the test side.

- **`skill-sdd-pdd-to-sdd`** and **`skill-sdd-gap-detection`** errored at exactly 301.7s with score 0.00. Tool timeline shows the agent only got as far as `Skill` + 4 reference reads (~96 KB combined) before the default 300s `turn_timeout` expired — `Write` was never called, so every success criterion failed against a missing file. Bumping `agent.turn_timeout` to 1200s (matching the e2e task) gives the agent the headroom it needs to finish Phase 1 → 2 → 3 and write the SDD.
- **`skill-sdd-e2e-rpa-process`** finished and produced a 727-line SDD that passed every `file_contains` assertion (PDD content, exception IDs, value mappings, implementation plan structure) — but `check_sdd.py` reported all 13 required sections missing. Cause: the regex `^#{1,3}\s+(\d+\.\s+)?<section>` only accepts the canonical `## 1. Process Overview` form and rejects the variants the model regularly emits (`## §1.`, `## 1. **Process Overview**`, `## 1 — `, `## 11.1`, etc.). Loosened the pattern to tolerate those variants, kept the negative cases working, and added a diagnostic that dumps the headings actually present so future regressions are debuggable instead of opaque.

## Changes

- `tests/tasks/uipath-solution-design/pdd_to_sdd.yaml` — add `agent` block with `turn_timeout: 1200`.
- `tests/tasks/uipath-solution-design/gap_detection.yaml` — same.
- `tests/tasks/uipath-solution-design/e2e_rpa_sdd/check_sdd.py` — loosen section regex; print headings on failure.

## Test plan

- [ ] Re-run the three eval tasks (`skill-sdd-pdd-to-sdd`, `skill-sdd-gap-detection`, `skill-sdd-e2e-rpa-process`) — confirm timeouts no longer hit and the e2e structure check passes.
- [ ] Spot-check that `check_sdd.py` still fails when a section is genuinely missing (no false-positive PASS) — the diagnostic block makes the failure mode obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)