### PR TITLE
docs(uipath-rpa): make headless Studio the default in skill docs [PILOT-4918]

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -43,11 +43,11 @@ Before doing any work, check if `.claude/rules/project-context.md` exists in the
    - `AGENTS.md` at project root — read by UiPath Autopilot in Studio Desktop. If `AGENTS.md` already exists, look for `<!-- PROJECT-CONTEXT:START -->` / `<!-- PROJECT-CONTEXT:END -->` markers and replace only between them; if no markers exist, append the fenced block at the end
 4. Then proceed with the skill workflow
 
-## Step 0: Resolve PROJECT_DIR and Environment
+## Step 0: Resolve PROJECT_DIR
 
-Before creating or modifying anything, determine which project to work with and ensure Studio is running. See [references/environment-setup.md](references/environment-setup.md) for the full procedure.
+Before creating or modifying anything, determine which project to work with. See [references/environment-setup.md](references/environment-setup.md) for the full procedure.
 
-**Quick check:** Find `project.json` to establish `{projectRoot}`, run `uip rpa list-instances --output json` to verify Studio, and `uip rpa open-project` if needed.
+**Quick check:** Find `project.json` to establish `{projectRoot}`. That's it — no Studio Desktop check needed. `uip rpa` auto-launches a headless Studio (UiPath.Studio.Helm NuGet) on first call. Studio Desktop is required only for `diff` and `focus-activity`.
 
 ## Project Type Detection
 
@@ -86,7 +86,7 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 
 ### Common Rules (Both Modes)
 
-1. **NEVER create a project without confirming none exists.** Follow Step 0 resolution: check explicit path, project name, running Studio instances, then CWD. Only create when confirmed no project matches AND user explicitly requests creation.
+1. **NEVER create a project without confirming none exists.** Follow Step 0 resolution: check explicit path, project name, then CWD for `project.json`. Only create when confirmed no project matches AND user explicitly requests creation.
 2. **ALWAYS use `uip rpa create-project`** to create new projects — never write `project.json` or scaffolding manually.
 3. **ALWAYS list project analyzer rules before generating workflows, validate files as you go, AND verify the project builds before declaring done.** Three-phase validation:
    - **Pre-generation** (before creating or editing any workflow file — `.cs` with `[Workflow]`/`[TestCase]`, or `.xaml`): `uip rpa get-analyzer-rules --project-dir "<PROJECT_DIR>" --output json` to list the enabled Workflow Analyzer rules. Apply every `error` and `warning` rule during authoring so generated code passes `analyze` and `build` on the first attempt. Run once at the start of the task; re-run only when project dependencies change (a newly added package can ship its own `MA-*` rules).

--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -4,6 +4,28 @@ CLI reference for `uip rpa` -- communicates with UiPath Studio over named pipes 
 
 > **Installation is automatic.** Do NOT attempt to install `uip` manually or instruct the user to install it.
 
+## Studio Desktop vs headless Studio (Helm)
+
+`uip rpa` connects to one of two flavors of Studio behind the same IPC contract:
+
+- **Headless Studio (Helm) — default.** Ships as a NuGet package (`UiPath.Studio.Helm.{Platform}`) and auto-launches on first use. **No Studio Desktop install needed.** First call on a cold NuGet cache may sit near-silent for 30–90 s while `dotnet restore` runs; raise `--timeout` to ≥ 180 for that call.
+- **Studio Desktop.** The interactive UI. Used automatically only by commands with UI side effects.
+
+### Which commands need Studio Desktop
+
+Only these two — they do not work headless:
+
+| Command | Why |
+|---------|-----|
+| `uip rpa diff` | Opens an interactive diff window in Studio's UI |
+| `uip rpa focus-activity` | Highlights an activity in Studio's active workflow designer |
+
+For these, run `uip rpa start-studio --project-dir "<PROJECT_DIR>"` first if Studio Desktop is not already up.
+
+Everything else — `create-project`, `open-project`, `close-project`, `run-file`, `stop-execution`, `get-errors`, `build`, `get-analyzer-rules`, `find-activities`, `get-default-activity-xaml`, `get-versions`, `inspect-package`, `install-or-update-packages`, `list-data-fabric-entities`, `install-data-fabric-entities`, `search-templates`, `indicate-application`, `indicate-element`, all `uia` subcommands, all `uip is` subcommands — runs headless with no Studio Desktop required.
+
+To force Studio Desktop for any command, set `UIPATH_RPA_TOOL_USE_STUDIO=1`. Not recommended for the standard authoring loop.
+
 > **This guide may not list every available command.** The CLI is self-documenting -- append `--help` at any level to progressively discover commands, subcommands, and parameters:
 
 ```bash
@@ -21,8 +43,8 @@ Every `uip rpa` invocation accepts these flags:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--project-dir <path>` | Project directory to match against running Studio instances | Current working directory |
-| `--studio-dir <path>` | Path to Studio installation directory | Auto-detected (see below) |
-| `--timeout <seconds>` | Timeout in seconds for Studio resolution | `300` |
+| `--studio-dir <path>` | Path to Studio Desktop installation (only used when Studio Desktop is in use) | Auto-detected (see below) |
+| `--timeout <seconds>` | Timeout in seconds for Studio resolution (raise to ≥ 180 on a cold Helm NuGet cache) | `300` |
 | `--verbose` | Enable verbose/debug logging | Off |
 | `--output <format>` | Output format: `json`, `table`, `yaml`, `plain` | `table` |
 
@@ -30,13 +52,13 @@ Every `uip rpa` invocation accepts these flags:
 
 ### STUDIO_DIR Resolution
 
-`--studio-dir` is optional -- omit it by default and let `uip` auto-detect Studio. Only provide it explicitly if auto-detection fails, using the first match:
+`--studio-dir` is **only consulted when Studio Desktop is in use** (i.e. you ran `start-studio`, called `diff`/`focus-activity`, or set `UIPATH_RPA_TOOL_USE_STUDIO=1`). Headless Studio (Helm) ignores it. When Studio Desktop is needed and auto-detection fails, the resolution waterfall is:
 
 1. Environment variable `UIPATH_STUDIO_DIR` if set.
 2. Default install: `C:\Program Files\UiPath\Studio` (or `x86` variant) if `UiPathStudio.exe` exists there.
 3. Dev build: Studio source tree build output (e.g. `<repo-root>\Output\bin\Debug`).
 
-> **Error `"Studio X.X.X does not have interop support"` or `"Requires Studio 26.2+"`** means the detected Studio is too old. Stop calling `uip rpa` commands and inform the user to update Studio.
+> **Error `"Studio X.X.X does not have interop support"` or `"Requires Studio 26.2+"`** means the detected Studio Desktop is too old. This affects only the two Studio-only tools (`diff`, `focus-activity`) and any explicitly forced Studio runs. Inform the user to update Studio Desktop.
 
 ### PROJECT_DIR Resolution
 
@@ -59,22 +81,24 @@ Located at `{projectRoot}/.local/docs/packages/{PackageId}/`.
 
 ---
 
-## Commands -- Studio Management
+## Commands -- Studio Desktop Management (edge cases only)
+
+> Skip this section unless you need to invoke `diff` or `focus-activity`. Every other command auto-launches headless Studio (Helm) when needed.
 
 ### list-instances
 
-List running UiPath Studio instances and their IPC status.
+List running Studio Desktop instances and their IPC status. Hidden diagnostic command — does **not** report the auto-launched headless Studio (Helm) instances.
 
 ```bash
 uip rpa list-instances --output json```
 
-No command-specific options.
+No command-specific options. An empty `Data` array does NOT mean `uip rpa` won't work — headless Studio starts on demand.
 
 ---
 
 ### start-studio
 
-Ensure a Studio instance is running. Resolution waterfall:
+Ensure a **Studio Desktop** instance is running. Only required before invoking `diff` or `focus-activity`, or when forcing Studio Desktop with `UIPATH_RPA_TOOL_USE_STUDIO=1`. Resolution waterfall:
 1. Match by `--project-dir` -- reuse if available, wait if busy
 2. Use an idle instance (no project loaded)
 3. Start a new instance via `--studio-dir` -- poll until available
@@ -106,7 +130,7 @@ uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json``
 
 ### open-project
 
-Open an existing project in Studio. Only needed when explicitly loading a project that isn't already open (e.g. after `create-project`, or when switching projects). Most commands (`validate`, `run-file`) auto-resolve a Studio instance, so this is rarely required.
+Open an existing project in Studio. Only needed when explicitly loading a project that isn't already open (e.g. after `create-project`, or when switching projects). Most commands (`validate`, `run-file`) auto-resolve a Studio instance and open the project automatically, so this is rarely required.
 
 ```bash
 uip rpa open-project --project-dir "<PROJECT_DIR>" --output json```
@@ -476,11 +500,11 @@ When `uip` commands fail, diagnose by error category:
 
 | Error Pattern | Cause | Recovery |
 |---------------|-------|----------|
-| `"connection refused"`, `"EPIPE"`, `"pipe not found"` | Studio IPC not available | Run `uip rpa start-studio`, then `uip rpa open-project --project-dir "..."` |
-| `"timeout"`, `"ETIMEDOUT"` | Command took too long | Increase timeout: `uip rpa --timeout 600 <command>`, or use `--skip-validation` for `get-errors` |
+| `"connection refused"`, `"EPIPE"`, `"pipe not found"` | Studio IPC not available. Headless Studio (Helm): NuGet restore failed or process exited. Studio Desktop: not running. | Re-run the command — headless Studio relaunches automatically. If it persists, raise `--timeout` and check the Helm restore output for NuGet errors. Only run `uip rpa start-studio` if the failing command is `diff`/`focus-activity` or `UIPATH_RPA_TOOL_USE_STUDIO=1` is set. |
+| `"timeout"`, `"ETIMEDOUT"` | Command took too long. Cold Helm NuGet restore can take 30–90 s. | Raise the timeout: `uip rpa --timeout 600 <command>`. For `get-errors`, also try `--skip-validation`. |
 | `"not authenticated"`, `401`, `403` | Auth required for cloud features | Run `uip login` and re-try |
 | `"package not found"`, `"version not available"` | Wrong package ID or version | Verify package name via `uip rpa find-activities`; omit `version` to auto-resolve latest |
-| `"project not found"`, `"no project open"` | Wrong project-dir or project not open | Verify `--project-dir` path, run `uip rpa open-project` |
+| `"project not found"`, `"no project open"` | Wrong project-dir or project not open in Studio | Verify `--project-dir` path, run `uip rpa open-project` |
 | `"file not found"` in `get-errors` | Wrong `--file-path` (must be relative to project) | Use path relative to project root, not absolute |
 | `"Studio is busy"`, `"operation in progress"` | Studio is processing a previous request | Wait a few seconds and retry the command |
 | Any unrecognized error | Unknown | Check `--verbose` flag: `uip rpa --verbose <command>` for debug details, inform the user |
@@ -554,7 +578,7 @@ uip rpa get-workflow-example --key "<BLOB_PATH>" --output json```
 
 ### focus-activity
 
-Focus an activity in the Studio designer view.
+Focus an activity in the Studio Desktop designer view. **Requires a running Studio Desktop instance** — does not work against headless Studio. Run `uip rpa start-studio --project-dir "<PROJECT_DIR>"` first if Studio Desktop is not already up.
 
 ```bash
 uip rpa focus-activity --activity-id "<IDREF>" --output jsonuip rpa focus-activity --output json```

--- a/skills/uipath-rpa/references/coded/coding-guidelines.md
+++ b/skills/uipath-rpa/references/coded/coding-guidelines.md
@@ -120,7 +120,7 @@ if (system.PathExists(@"C:\Reports\report.pdf", PathType.File, out ILocalResourc
 - **Escape backslashes in paths** — Use `C:\\path\\file.txt` not `C:\path\file.txt` in input arguments
 
 ### Validation Loop (Critical Rule #14)
-uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>" --output json
+uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json
 @../validation-guide.md
 
 ### Error Handling
@@ -197,12 +197,12 @@ C) <user-driven approach>
 
 | Issue | Cause | Fix |
 |-------|-------|-----|
-| **"Studio X.X.X does not have interop support"** | Auto-detected Studio is too old (< 26.2) | Always pass `--studio-dir "<STUDIO_DIR>"` pointing to the dev build |
-| **No Studio instances found** | Studio is not running | Run `uip rpa start-studio --project-dir "<PROJECT_DIR>" --studio-dir "<STUDIO_DIR>"` |
-| **Stale pipe / ENOENT** | Studio instance crashed or was closed | The tool retries automatically; if persistent, restart Studio |
+| **"Studio X.X.X does not have interop support"** | Surfaces only when running against Studio Desktop and the auto-detected install is too old (< 26.2). Headless Studio is unaffected. | Pass `--studio-dir "<STUDIO_DIR>"` pointing to a 26.2+ build, or drop the Studio Desktop override and let the command run headless |
+| **No Studio instances found** | Only relevant for `diff` / `focus-activity` — they need Studio Desktop. Every other command runs headless and doesn't need a Desktop instance. | Run `uip rpa start-studio --project-dir "<PROJECT_DIR>"` if you actually need Studio Desktop; otherwise re-run the command — headless Studio relaunches automatically |
+| **Stale pipe / ENOENT** | Studio instance crashed or was closed | The tool retries automatically; if persistent, re-run the command (headless) or restart Studio Desktop |
 | **Workflow cannot be found** | Entrypoint not in project.json | Verify project.json entrypoint has the file listed (Process projects only — Tests and Library projects do not use `entryPoints`) |
 | **Service property not available** | Missing package dependency | Add required package to project.json dependencies |
-| **Timeout** | Studio took too long to start | Increase timeout: `--timeout 600` |
+| **Timeout** | Studio took too long to start. First headless call on a cold NuGet cache can take 30–90 s. | Increase timeout: `--timeout 600` |
 | **"Target name 'X' is not part of the current screen"** | Element descriptor used on wrong screen handle | Use the `UiTargetApp` handle from `Open`/`Attach` for the screen that owns the element |
 | **"Cannot select item. It was not found among existing items"** | `SelectItem` fails on web dropdowns | Use `TypeInto` instead of `SelectItem` for web `<select>` elements |
 | **inspect-package cannot find UILibrary package** | Package is on a private/local NuGet feed | Use `--nupkg-path` to inspect the local `.nupkg` directly, or read `.metadata` files manually from `~/.nuget/packages/<name>/<version>/contentFiles/any/any/.objects/` |

--- a/skills/uipath-rpa/references/coded/operations-guide.md
+++ b/skills/uipath-rpa/references/coded/operations-guide.md
@@ -11,7 +11,7 @@ Creates a complete UiPath coded automation project from scratch. **ALWAYS use `u
 **1. Create the project with `uip rpa create-project`:**
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --studio-dir "<STUDIO_DIR>" --output json```
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json```
 
 **Template options:**
 - `--template-id BlankTemplate` (default) — standard process project

--- a/skills/uipath-rpa/references/debugging.md
+++ b/skills/uipath-rpa/references/debugging.md
@@ -4,6 +4,20 @@ The `uip rpa run-file` command provides full interactive debugging capabilities 
 
 This is a powerful complement to `get-errors` (static validation). While `get-errors` catches structural and type issues at design time, the debugger catches runtime problems: wrong API responses, null references, logic errors, failed deserialization, and more. Use both together for comprehensive workflow validation.
 
+## Studio Desktop vs headless
+
+Most debugging works on **headless Studio** with no Studio Desktop install: `StartExecution`, `StartDebugging` (with workflow-level breakpoint), all stepping commands (`StepOver`, `StepInto`, `StepOut`), `Continue`, `Break`, `Resume`, `ContinueRetry`, `ContinueIgnore`, `Stop`, `RestartFromTop`, `ForceSessionEnded`.
+
+**Studio Desktop is required** for any flow that targets a specific activity, because activity targeting goes through `uip rpa focus-activity` and that tool only runs against Studio Desktop:
+
+| Command | Why it needs Studio Desktop |
+|---------|------------------------------|
+| `TestActivity` | Operates on the focused activity — requires `focus-activity` first |
+| `StartDebuggingFromHere` | Operates on the focused activity — requires `focus-activity` first |
+| `ToggleBreakpoint` *targeted to a specific activity* | Targeting requires `focus-activity` first. Without focusing, the breakpoint toggles on the whole workflow (still works headless) |
+
+Before invoking any of the above, run `uip rpa start-studio --project-dir "<PROJECT_DIR>" --output json` and ensure the project is open in Studio Desktop. See [environment-setup.md § Edge case: requiring Studio Desktop](environment-setup.md#edge-case-requiring-studio-desktop).
+
 ---
 
 ## Command Reference
@@ -29,9 +43,9 @@ uip rpa run-file --file-path <relative-path> --command <Command> [--input-argume
 |---------|-------------|--------------|
 | `StartExecution` | Run without debugging | Executes the workflow to completion. Default if `--command` is omitted |
 | `StartDebugging` | Begin a debug session | Starts execution in debug mode. Pauses at the first breakpoint (or at the first activity if a breakpoint is set on the workflow itself). Returns current execution state |
-| `TestActivity` | Test one activity in isolation | Isolates the currently focused activity and executes it in a temporary test workflow. **Requires `focus-activity` first.** Use `--input-variables` to set variable values and `--input-arguments` to set argument values |
-| `StartDebuggingFromHere` | Debug from a specific activity | Starts a debugging session from the currently focused activity, skipping all preceding activities. **Requires `focus-activity` first.** Use `--input-variables` to set variable values and `--input-arguments` to set argument values |
-| `ToggleBreakpoint` | Set/remove breakpoints | Toggles a breakpoint on the currently focused activity (XAML) or line (.cs). Use `uip rpa focus-activity` to focus beforehand. For XAML, cycles through 3 states: **enabled → disabled → no breakpoint**. For .cs, cycles through 2 states: **breakpoint → no breakpoint**. If no activity/line is focused, toggles on the entire workflow |
+| `TestActivity` | Test one activity in isolation | Isolates the currently focused activity and executes it in a temporary test workflow. **Requires `focus-activity` first → Studio Desktop required** (see [Studio Desktop vs headless](#studio-desktop-vs-headless)). Use `--input-variables` to set variable values and `--input-arguments` to set argument values |
+| `StartDebuggingFromHere` | Debug from a specific activity | Starts a debugging session from the currently focused activity, skipping all preceding activities. **Requires `focus-activity` first → Studio Desktop required** (see [Studio Desktop vs headless](#studio-desktop-vs-headless)). Use `--input-variables` to set variable values and `--input-arguments` to set argument values |
+| `ToggleBreakpoint` | Set/remove breakpoints | Toggles a breakpoint on the currently focused activity (XAML) or line (.cs). Use `uip rpa focus-activity` to focus beforehand — **activity-targeted toggling requires Studio Desktop**. For XAML, cycles through 3 states: **enabled → disabled → no breakpoint**. For .cs, cycles through 2 states: **breakpoint → no breakpoint**. If no activity/line is focused, toggles on the entire workflow (works on Helm) |
 | `StepOver` | Execute one activity and pause | Executes the current activity, then pauses at the next sibling activity. Does not enter child scopes (e.g., stays at the For Each level, doesn't step into its body) |
 | `StepInto` | Drill into child activities | Executes and pauses at the first child activity inside the current scope. Use to enter loops, sequences, Try-Catch blocks, etc. |
 | `StepOut` | Exit the current scope | Continues execution until the current scope completes, then pauses at the parent level. Use to leave a loop body or nested sequence |
@@ -206,8 +220,10 @@ For `StartExecution` (non-debug run), `TestActivity` (when no breakpoints are hi
 
 The most common pattern: set a breakpoint on the focused activity, start debugging, inspect state, then continue or step through.
 
+> **Studio Desktop required** for activity-targeted breakpoints (the `focus-activity` step). Skip step 1 to set a workflow-level breakpoint instead — that path runs headless.
+
 ```bash
-# 1. Focus the activity you want to break at (optional — skip if you want to break at the workflow level)
+# 1. Focus the activity you want to break at (Studio Desktop only — skip to break at the workflow level)
 uip rpa focus-activity --activity-id "Assign_1"
 
 # 2. Toggle a breakpoint on the focused activity
@@ -228,8 +244,10 @@ uip rpa run-file --file-path "GetStockPrices.xaml" --command Stop --output json
 
 Use `TestActivity` to run just the currently focused activity without executing the entire workflow. Useful for verifying an activity works with specific inputs.
 
+> **Studio Desktop required** — `focus-activity` and `TestActivity` both rely on it. On a headless-only setup, fall back to a workflow-level `StartDebugging` with a breakpoint placed earlier in the file.
+
 ```bash
-# 1. Focus the activity to test
+# 1. Focus the activity to test (Studio Desktop required)
 uip rpa focus-activity --activity-id "DeserializeJson_1"
 
 # 2. Run it in isolation, pre-setting any variables it reads from
@@ -248,8 +266,10 @@ uip rpa run-file --file-path "GetBucharestTemperature.xaml" \
 
 Use `StartDebuggingFromHere` to skip straight to the activity you care about, avoiding stepping through earlier activities.
 
+> **Studio Desktop required** — `focus-activity` and `StartDebuggingFromHere` both rely on it. On a headless-only setup, use plain `StartDebugging` with a workflow-level breakpoint near the activity instead.
+
 ```bash
-# 1. Focus the activity to start from
+# 1. Focus the activity to start from (Studio Desktop required)
 uip rpa focus-activity --activity-id "HttpRequest_1"
 
 # 2. Start debugging from that point, pre-setting variables
@@ -351,9 +371,9 @@ A practical example — a workflow makes an HTTP request and tries to deserializ
 
 - **Always use `--output json`** for debug commands when you need to parse the output programmatically. The structured output makes it easy to inspect variables and identify exceptions.
 - **Set breakpoints strategically** — place them just before the activity you suspect is failing, not at the very start. This avoids stepping through dozens of unrelated activities.
-- **Use `focus-activity` before `ToggleBreakpoint`** to target a specific activity by its IdRef. Without focusing first, the breakpoint is set on whatever activity or workflow is currently focused in Studio.
-- **Use `TestActivity` for quick feedback** — it runs a single activity in isolation, which is faster than debugging the entire workflow. Pre-set variables with `--input-variables` so the activity has the data it needs.
-- **Use `StartDebuggingFromHere` to skip setup** — when the bug is deep in the workflow, skip straight to the relevant activity instead of stepping through the entire flow. Pre-set variables with `--input-variables` to simulate the state the activity would have received from preceding activities.
+- **Use `focus-activity` before `ToggleBreakpoint`** to target a specific activity by its IdRef — Studio Desktop required. Without focusing first, the breakpoint is set on whatever activity or workflow is currently focused, which on a headless-only run means the entire workflow.
+- **Use `TestActivity` for quick feedback** — it runs a single activity in isolation, which is faster than debugging the entire workflow. Studio Desktop required (depends on `focus-activity`). Pre-set variables with `--input-variables` so the activity has the data it needs.
+- **Use `StartDebuggingFromHere` to skip setup** — when the bug is deep in the workflow, skip straight to the relevant activity instead of stepping through the entire flow. Studio Desktop required (depends on `focus-activity`). Pre-set variables with `--input-variables` to simulate the state the activity would have received from preceding activities.
 - **Prefer `StepOver` for quick inspection** — it moves one activity at a time without descending into scopes. Use `StepInto` only when you need to examine what happens inside a loop iteration or nested sequence.
 - **Check variables after each step** — inspect the Output entries after each step to see the current state of in-scope variables. This is the most direct way to verify that each activity produced the expected result.
 - **Use `ContinueRetry` for transient errors** — if the exception is a network timeout or rate limit, retrying may succeed without any code changes.

--- a/skills/uipath-rpa/references/environment-setup.md
+++ b/skills/uipath-rpa/references/environment-setup.md
@@ -1,6 +1,18 @@
 # Environment Setup
 
-**Goal:** Ensure Studio Desktop is running, connected, and targeting the correct project before any other operations.
+**Goal:** Resolve the project root before any other operations.
+
+## Studio Desktop vs headless Studio
+
+`uip rpa` runs against a **headless Studio** by default (codename Helm — ships as the `UiPath.Studio.Helm.{Platform}` NuGet package, auto-launched the first time a command needs it). **Studio Desktop is not required** for the standard authoring loop — create-project, open-project, run-file, get-errors, build, find-activities, install-or-update-packages, indicate-application/element, the `uia` group, etc. all work headless.
+
+Studio Desktop is only required for two interactive UI tools:
+- `uip rpa diff` — opens an interactive diff window in Studio's UI.
+- `uip rpa focus-activity` — selects an activity in Studio's active workflow designer.
+
+For these two, see [§ Edge case: requiring Studio Desktop](#edge-case-requiring-studio-desktop) below.
+
+> **First call is slow.** On a cold NuGet cache, the very first `uip rpa` invocation triggers a silent `dotnet restore` of the headless Studio package and may sit near-silent for 30–90 seconds (longer behind a slow feed). A heartbeat line every 15s confirms it's still working. Bump the per-call timeout to ≥ 180s for the first invocation.
 
 ## Step 0.1: Establish Project Root
 
@@ -9,42 +21,14 @@ The `uip rpa` commands use `--project-dir` to target a specific project (default
 **Resolution order** (use the first rule that matches):
 1. **Explicit path** — The user provided a directory path → use it as-is.
 2. **Project name reference** — The user mentioned a project by name → search for a folder with that name containing `project.json`.
-3. **Detect from running Studio** — No path or name given → run:
-   ```bash
-   uip rpa list-instances --output json   ```
-   Parse the JSON response. If `Data` is a non-empty array, each entry has a `ProjectDirectory` field. Use it:
-   - **One instance** → use its `ProjectDirectory`.
-   - **Multiple instances** → pick the best match or ask the user.
-4. **Fall back to current working directory** — If `Data` is an empty array.
+3. **Fall back to current working directory** — If neither is given.
 
 If the CWD is not the project root:
 - Locate the project root by finding `project.json`: `Glob: pattern="**/project.json"`
 - **Pass `--project-dir` explicitly** to every `uip rpa` command
 - Store the project root path and use it consistently as `{projectRoot}`
 
-## Step 0.2: Verify Studio is Running
-
-```bash
-uip rpa list-instances --output json```
-
-**If no instances are found or Studio is not running:**
-```bash
-uip rpa start-studio
-```
-
-**If Studio is running but the project is not open:**
-```bash
-uip rpa open-project --project-dir "{projectRoot}"```
-
-**If Studio IPC connection fails** (error messages about connection refused, timeout, or pipe not found):
-1. Check if Studio Desktop is actually installed on the machine
-2. Try `uip rpa start-studio` to launch a fresh instance
-3. If Studio is running but IPC fails, the user may need to restart Studio
-4. Inform the user and ask them to ensure Studio Desktop is open and responsive
-
-**Note:** If `start-studio` fails with a registry key error, pass `--studio-dir` explicitly pointing to the Studio installation directory.
-
-## Step 0.3: Authentication (If Needed)
+## Step 0.2: Authentication (If Needed)
 
 Some commands (IS connections, workflow examples, cloud features) require authentication:
 
@@ -54,7 +38,7 @@ uip login
 
 If you encounter auth errors (401, 403, "not authenticated") during any phase, prompt the user to run `uip login` to authenticate against their UiPath Cloud tenant.
 
-## Step 0.4: Creating a New Project
+## Step 0.3: Creating a New Project
 
 **ALWAYS use `uip rpa create-project`** — never write `project.json`, `project.uiproj`, or other scaffolding files manually.
 
@@ -68,18 +52,17 @@ uip rpa create-project \
   --expression-language "VisualBasic" \
   --target-framework "Windows" \
   --description "Automates invoice processing" \
-  --studio-dir "<STUDIO_DIR>" \
   --output json
 ```
 
 **Expression language for XAML projects:** Prefer `VisualBasic` for Windows target framework projects.
 
-**`--studio-dir`:** Pass the Studio installation directory explicitly (e.g. `C:\Program Files\UiPathPlatform\Studio\<version>`) if the CLI fails to resolve it from the registry. Resolve it once per session and reuse for every subsequent `uip rpa` command.
+**`--studio-dir`:** Optional. Headless Studio does not need it. Pass it only when you have explicitly forced Studio Desktop (`UIPATH_RPA_TOOL_USE_STUDIO=1`, or invoking `diff`/`focus-activity`) and Studio's auto-detection from the registry fails.
 
 ### For Coded Projects
 
 ```bash
-uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --studio-dir "<STUDIO_DIR>" --output json
+uip rpa create-project --name "<NAME>" --location "<PARENT_DIR>" --output json
 ```
 
 Use `--template-id TestAutomationProjectTemplate` for test projects, or `--template-id LibraryProcessTemplate` for libraries.
@@ -137,7 +120,6 @@ uip rpa create-project \
   --location "/path/to/parent/directory" \
   --template-package-id "<PACKAGE_ID>" \
   --template-package-version "<VERSION>" \
-  --studio-dir "<STUDIO_DIR>" \
   --output json
 ```
 
@@ -151,3 +133,23 @@ uip rpa create-project \
 1. Open the project in Studio: `uip rpa open-project --project-dir "/path/to/MyAutomation"`
 2. **Read the scaffolded files** — the command generates starter files. Read them before making changes so you build on valid defaults
 3. Proceed with the skill workflow using the new project root
+
+## Edge case: requiring Studio Desktop
+
+Two `uip rpa` commands need a running Studio Desktop instance — they have UI side effects that Helm cannot render:
+
+| Command | Why it needs Studio |
+|---------|---------------------|
+| `uip rpa diff` | Opens an interactive diff window in Studio's UI; finishes when the user closes the window. |
+| `uip rpa focus-activity` | Selects/highlights an activity in Studio's active workflow designer. |
+
+When (and only when) you need to run one of these, ensure Studio Desktop is up:
+
+```bash
+uip rpa list-instances --output json   # hidden diagnostic — confirms a Studio Desktop instance is running
+uip rpa start-studio --project-dir "{projectRoot}" --output json   # launches Studio Desktop if none is running
+```
+
+If `start-studio` cannot resolve Studio's install directory from the registry, pass `--studio-dir` pointing to the Studio installation root.
+
+You can also force Studio Desktop for any other command by setting `UIPATH_RPA_TOOL_USE_STUDIO=1`, but this is not needed for the standard authoring loop and gives up the headless benefits.

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -130,7 +130,9 @@ Read: file_path="{projectRoot}/.project/JitCustomTypesSchema.json"
 
 ### Focus Activity for Debugging
 
-When `get-errors` returns an error referencing a specific activity (by IdRef or DisplayName), use `focus-activity` to highlight it in the Studio designer. This helps the user see the problematic activity in context and verify fixes visually:
+When `get-errors` returns an error referencing a specific activity (by IdRef or DisplayName), use `focus-activity` to highlight it in the Studio Desktop designer. This helps the user see the problematic activity in context and verify fixes visually.
+
+> **Studio Desktop required.** `focus-activity` does not run against headless Studio — it manipulates the Studio Desktop designer UI. Before invoking it, ensure Studio Desktop is up via `uip rpa start-studio --project-dir "<PROJECT_DIR>"` (see [environment-setup.md § Edge case: requiring Studio Desktop](environment-setup.md#edge-case-requiring-studio-desktop)). Skip this step entirely on headless-only setups — `get-errors` already includes the IdRef and file:line in its output, which is enough to locate the activity.
 
 ```bash
 # Focus a specific activity by its IdRef (from the error output):

--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -717,11 +717,12 @@ All `uip rpa` commands default to the current working directory as the project r
 
 ### Studio IPC connection failures
 
-`uip rpa` commands communicate with Studio Desktop via IPC. If Studio is not running, not responding, or has no project open, commands will fail with connection errors. Recovery steps:
-1. `uip rpa list-instances --output json` — check if Studio is running
-2. `uip rpa start-studio` — start Studio if not running
-3. `uip rpa open-project --project-dir "..."` — open the project if Studio has no project loaded
-4. If Studio is running but unresponsive, the user may need to restart it manually
+`uip rpa` commands communicate with Studio over IPC. By default this is a **headless Studio** that auto-launches from a NuGet package — no Studio Desktop required. Recovery steps when commands fail with connection errors:
+
+1. **Re-run the command.** Headless Studio relaunches automatically on the next call; transient pipe errors clear on retry.
+2. **Raise the timeout for the first call.** Cold NuGet restore of the headless Studio package can take 30–90 s — `uip rpa --timeout 600 <command>`.
+3. **`uip rpa open-project --project-dir "..."`** — open the project explicitly if Studio reports no project loaded.
+4. **Studio Desktop only** — if the failing command is `diff` or `focus-activity` (or the user set `UIPATH_RPA_TOOL_USE_STUDIO=1`), check Studio Desktop with the hidden `uip rpa list-instances --output json` and run `uip rpa start-studio --project-dir "..."` if no instance is up.
 
 ### CLI output format for parsing
 


### PR DESCRIPTION
**Jira:** [PILOT-4918](https://uipath.atlassian.net/browse/PILOT-4918)

## Summary

Recent `rpa-tool` releases ship a **headless Studio** (codename Helm — `UiPath.Studio.Helm.{Platform}` NuGet) that auto-resolves and auto-launches on first call. The `uipath-rpa` skill still walked every agent through "Step 0.2: Verify Studio is Running" with `list-instances`/`start-studio`, which is no longer needed for the standard authoring loop.

This PR rewrites the skill docs to reflect the headless-default model. Studio Desktop is now flagged as required only for the two commands that genuinely need its UI:

| Command | Why |
|---------|-----|
| \`uip rpa diff\` | Opens an interactive diff window in Studio's UI |
| \`uip rpa focus-activity\` | Highlights an activity in Studio's active workflow designer |

`focus-activity` is in turn a prerequisite for the activity-targeted debug commands `TestActivity`, `StartDebuggingFromHere`, and activity-targeted `ToggleBreakpoint` — those recipes now carry a Studio-Desktop callout and a headless fallback.

## Files touched

- \`SKILL.md\` — Step 0 simplified; no Studio Desktop check in the default flow.
- \`references/environment-setup.md\` — replaced "Verify Studio is Running" with a "Studio Desktop vs headless Studio" preamble; added an "Edge case: requiring Studio Desktop" section at the bottom.
- \`references/cli-reference.md\` — added "Studio Desktop vs headless Studio (Helm)" section listing the two Studio-Desktop-only commands; reframed \`list-instances\`/\`start-studio\`/\`focus-activity\` as edge cases; rewrote IPC connection-refused recovery row.
- \`references/debugging.md\` — added "Studio Desktop vs headless" section; per-recipe Studio-Desktop callouts on workflows #1–#3.
- \`references/validation-guide.md\` — flagged the Studio Desktop requirement on the "Focus Activity for Debugging" section.
- \`references/coded/coding-guidelines.md\` — dropped \`--studio-dir\` from the \`get-errors\` example; rewrote three Common Issues rows.
- \`references/coded/operations-guide.md\` — dropped \`--studio-dir\` from the \`create-project\` example.
- \`references/xaml/common-pitfalls.md\` — rewrote "Studio IPC connection failures" recovery steps to be headless-aware.

## Terminology

Aligned with the rest of the repo: "Studio" generically (Helm IS Studio), "Studio Desktop" only when UI matters, "headless Studio" / "Helm" only where load-bearing (auto-launch, cold-cache timeout).

## Test plan

- [ ] On a clean machine without Studio Desktop installed, follow the skill's quick-start and confirm \`uip rpa create-project\` / \`get-errors\` / \`build\` / \`run-file\` succeed via headless Studio.
- [ ] Confirm \`uip rpa diff\` and \`uip rpa focus-activity\` still surface clear guidance to run \`start-studio\` first.
- [ ] Verify all relative links resolve (\`environment-setup.md#edge-case-requiring-studio-desktop\` from \`debugging.md\` and \`validation-guide.md\`).
- [ ] Skim for stale "Studio is running" / "list-instances" guidance; should only appear in the edge-case sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PILOT-4918]: https://uipath.atlassian.net/browse/PILOT-4918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ