### PR TITLE
docs(uipath-platform/solution): expand resource refresh + deploy gotchas

### DIFF
--- a/skills/uipath-platform/references/solution/develop-solution.md
+++ b/skills/uipath-platform/references/solution/develop-solution.md
@@ -85,7 +85,7 @@ uip solution resource list ./InvoiceAutomation --kind Queue --search "Invoice" -
 
 ## Step 6: Refresh Resources
 
-Re-scan all projects and sync resource declarations from their `bindings_v2.json` files.
+Re-scan all projects and sync resource declarations from their `bindings_v2.json` files. Refresh is the only way to reconcile a solution's local artefacts with cloud entities — run it after adding/importing projects, after editing `bindings_v2.json`, or before any `pack` / `upload`.
 
 ```bash
 uip solution resource refresh ./InvoiceAutomation --output json
@@ -93,12 +93,38 @@ uip solution resource refresh ./InvoiceAutomation --output json
 
 | Field | Meaning |
 |-------|---------|
-| `Created` | New resources added to the solution manifest |
-| `Imported` | Resources matched and imported from Orchestrator |
+| `Created` | New local skeletons created (resource didn't exist in cloud) |
+| `Imported` | Cloud resources imported into the solution (artefact files written + linked) |
 | `Skipped` | Resources already tracked in the solution |
-| `Warnings` | Any issues encountered during sync |
+| `Warnings` | Bindings that couldn't be resolved (logged for follow-up) |
 
-Run after adding/importing projects or editing any project's `bindings_v2.json`.
+### What `refresh` actually does
+
+1. **Discover bindings** — reads `bindings_v2.json` from each project (solution root copy is also read for agent projects).
+2. **Discover cloud GUIDs** — for agent projects, supplements bindings with `<project>/resources/<X>/resource.json` files. These carry a `referenceKey` (GUID) for tools/escalations/contexts that the agent depends on; the GUID is the unambiguous cloud identity (binding names alone aren't unique across folders).
+3. **Reconcile in-solution projects (`.uipx`)** — generates project artefact files (`process/<type>/`, `package/`) from SDK templates. Internal to the solution; no debug overwrite written.
+4. **Sync external references** — for each cloud resource the solution depends on, calls Orchestrator/Apps APIs and writes:
+   - The artefact files under `resources/solution_folder/<kind>/...`
+   - A user-scoped debug overwrite at `userProfile/<userId>/debug_overwrites.json` linking the local skeleton to the cloud entity (key + folder + FQN). Studio Web's runtime needs the FQN populated to resolve "configured folder" lookups.
+
+### App resources
+
+When an agent's escalation channel (`channels[].properties.resourceKey`) points to an Action Center App, refresh imports four artefact files:
+
+```
+resources/solution_folder/app/<subType>/<AppName>.json
+resources/solution_folder/appVersion/<AppVersionTitle>.json
+resources/solution_folder/package/<AppVersionTitle>.json
+resources/solution_folder/process/webApp/<AppName>.json
+```
+
+Plus debug overwrites for the App and its codeBehindProcess. The App's `spec.version` must match the cloud Apps service `semVersion` (current published) — otherwise Studio Web's Health Analyzer flags "App is no longer available".
+
+### Folder disambiguation
+
+When a name (e.g. `orders` queue) exists in multiple cloud folders, refresh prefers the folder declared in the binding's `folderPath`. Without a folder hint and multiple matches, refresh marks the binding unresolved and emits a warning rather than picking one silently.
+
+The placeholder `solution_folder` (and `.`) in a binding's folder field means "no folder" / tenant scope — they're not real cloud folders.
 
 ## Step 7: Upload to Studio Web
 
@@ -165,8 +191,22 @@ Adding a project does not automatically sync its resources. The refresh scans al
 
 | Virtualizable | Non-virtualizable |
 |---------------|-------------------|
-| Queue, Asset, Bucket | Process, Connection |
-| Can exist as local placeholders (created at deploy time) | Must reference an existing Orchestrator resource |
+| Queue, Asset, Bucket | Process, Connection, App |
+| Can exist as local placeholders (created at deploy time) | Must reference an existing Orchestrator/IS/Apps resource |
+
+If a non-virtualizable resource isn't found in cloud, refresh emits a warning and the deployment will fail until the resource is provisioned (or the binding is fixed/removed).
+
+### `bindings_v2.json` locations
+
+Studio Web writes bindings in two places depending on project type:
+- `<project>/bindings_v2.json` — for flow / RPA projects
+- Solution root `bindings_v2.json` — added for agent projects (Studio Web mirrors them up)
+
+Refresh reads both. Don't hand-edit these — they're regenerated whenever Studio Web saves the project.
+
+### Per-user debug overwrites
+
+`userProfile/<userId>/debug_overwrites.json` is per-user state (the `userId` is your UiPath user GUID). Refresh writes only your own entries; another user opening the bundled solution would have separate entries. The bundle (`.uis`) carries `userProfile/` for everyone who ran refresh; Studio Web picks the active user's at runtime.
 
 ### `upload` overwrites on matching SolutionId
 

--- a/skills/uipath-platform/references/solution/develop-solution.md
+++ b/skills/uipath-platform/references/solution/develop-solution.md
@@ -22,6 +22,7 @@ graph LR
     A[solution new] --> B[project add / import]
     B --> C[resource refresh]
     C --> D[resource list]
+    D --> G[resource get]
     D --> E[upload]
     B --> F[project remove]
 ```
@@ -69,26 +70,36 @@ uip solution project remove ./InvoiceAutomation/OldProject --output json
 
 ## Step 5: List Resources
 
-Show resources declared in the solution, available in Orchestrator, or both.
+Show resources declared in the solution, available in Orchestrator, or both. Run from inside the solution directory (default), or pass `--solution-folder <path>` to target another location.
 
 ```bash
-uip solution resource list ./InvoiceAutomation --output json
-uip solution resource list ./InvoiceAutomation --source local --output json
-uip solution resource list ./InvoiceAutomation --kind Queue --search "Invoice" --output json
+# from inside the solution dir
+uip solution resource list --output json
+uip solution resource list --source local --output json
+uip solution resource list --kind Queue --search "Invoice" --output json
+
+# explicit folder
+uip solution resource list --solution-folder ./InvoiceAutomation --output json
 ```
 
 | Option | Values | Default |
 |--------|--------|---------|
-| `--kind <kind>` | `Queue`, `Asset`, `Bucket`, `Process`, `Connection` | All kinds |
+| `--solution-folder <path>` | Path to solution root | Current working directory |
+| `--kind <kind>` | `Queue`, `Asset`, `Bucket`, `Process`, `Connection`, `App`, `Index`, `Trigger` (any RCS kind) | All kinds |
 | `--search <term>` | Name substring match | No filter |
 | `--source <source>` | `all`, `local`, `remote` | `all` |
+| `--login-validity <minutes>` | Minimum minutes left on token before refresh | `10` |
 
 ## Step 6: Refresh Resources
 
 Re-scan all projects and sync resource declarations from their `bindings_v2.json` files. Refresh is the only way to reconcile a solution's local artefacts with cloud entities — run it after adding/importing projects, after editing `bindings_v2.json`, or before any `pack` / `upload`.
 
 ```bash
-uip solution resource refresh ./InvoiceAutomation --output json
+# from inside the solution dir
+uip solution resource refresh --output json
+
+# explicit folder
+uip solution resource refresh --solution-folder ./InvoiceAutomation --output json
 ```
 
 | Field | Meaning |
@@ -126,7 +137,51 @@ When a name (e.g. `orders` queue) exists in multiple cloud folders, refresh pref
 
 The placeholder `solution_folder` (and `.`) in a binding's folder field means "no folder" / tenant scope — they're not real cloud folders.
 
-## Step 7: Upload to Studio Web
+## Step 7: Get a Single Resource Configuration
+
+Fetch the full configuration (`spec`, `apiVersion`, `isOverridable`, `resourceOverwrite`) for a specific resource by key. Useful when you need the resolved server state for a binding — e.g., constructing a deploy override, resolving an entry-point ID, inspecting a connection's authentication mode.
+
+```bash
+# from inside the solution dir
+uip solution resource get <resource-key> --output json
+
+# explicit folder + transitive deps
+uip solution resource get <resource-key> --solution-folder ./InvoiceAutomation --include-dependencies --output json
+```
+
+| Option | Purpose |
+|--------|---------|
+| `--solution-folder <path>` | Solution root (default cwd) |
+| `--include-dependencies` | Return the resource **plus** every dependency configuration in one shot |
+| `--login-validity <minutes>` | Minimum minutes left on token before refresh (default `10`) |
+
+### How resolution works
+
+`get` accepts any key from `solution resource list` — local or remote — and dispatches accordingly:
+
+1. **Local first** — calls SDK `getConfigurationAsync(key)`, which reads `resources/solution_folder/**/<resource>.json` and returns the design-time spec (plus any debug overwrite). This is what's bundled at pack time. Output is a subset of the cloud spec — good enough for most planning work.
+2. **Fallback to RCS + FPS** — if the key isn't in the local solution, the CLI scans the resource catalog (`searchFolderEntities`) for it. On match, it builds a `ResourceReferenceModel` and calls the SDK's `IImportResourceHelper.exportResourceAsync` (the same workhorse `refresh` uses). The returned `ResourceDefinition` is mapped to the same `ResourceConfiguration` shape, so callers get a uniform output regardless of source.
+3. **No match anywhere** → exits with `Failure` and `Resource '<key>' was not found in the solution or in the resource catalog`.
+
+### Local vs remote spec — they're not identical
+
+The local file is what `refresh` (and `solution project add`) wrote to disk: a declarative subset of the cloud entity. The remote (FPS) spec includes server-resolved fields the local can't have:
+
+| Field | Local | Remote (FPS) |
+|-------|-------|--------------|
+| `name`, `package`, basic metadata | ✅ | ✅ |
+| `apiVersion` | ✅ | ✅ |
+| `entryPointUniqueId` / `entryPoints` | ❌ usually `null` | ✅ alocate de server la deploy |
+| `inputArgumentsSchemaV2` / `outputArgumentsSchemaV2` | ❌ | ✅ |
+| `agentMemory`, `targetRuntime`, `environmentVariables` | ❌ | ✅ runtime defaults |
+
+If you need the full server spec for a resource that's already in the solution (e.g., for a deploy override), `--include-dependencies` paired with manual inspection of the dependency graph is one option; the cleaner path is to delete the local file and let `refresh` re-import it from the cloud.
+
+### Why `solution resource list` and `get` aren't symmetric
+
+`list --source remote` returns entities from RCS that are **visible to your user** — including ones not bound to this solution. `get` is solution-context-aware: it considers anything in your `.uipx`'s solution_folder as "local", and falls back to RCS for everything else. A key shown by `list --source remote` that isn't bound to the solution will resolve via the FPS fallback.
+
+## Step 8: Upload to Studio Web
 
 Upload the solution for browser-based editing. Accepts a directory, `.uipx` file, or `.uis` archive.
 
@@ -136,7 +191,7 @@ uip solution upload ./InvoiceAutomation --output json
 
 If the `SolutionId` in `.uipx` matches an existing Studio Web solution, the upload overwrites it.
 
-## Step 8: Delete from Studio Web
+## Step 9: Delete from Studio Web
 
 Remove a solution from Studio Web by its UUID (returned by `upload`).
 
@@ -160,11 +215,17 @@ uip solution new "InvoiceAutomation" --output json
 uip solution project add ./InvoiceAutomation/Processor --output json
 uip solution project add ./InvoiceAutomation/Reporter --output json
 
-# 3. Sync resource declarations from project bindings
-uip solution resource refresh ./InvoiceAutomation --output json
+# 3. Move into the solution dir so subsequent commands default --solution-folder
+cd ./InvoiceAutomation
 
-# 4. Verify resources are tracked
-uip solution resource list ./InvoiceAutomation --source local --output json
+# 4. Sync resource declarations from project bindings
+uip solution resource refresh --output json
+
+# 5. Verify resources are tracked
+uip solution resource list --source local --output json
+
+# 6. Inspect one resource's full configuration (local + RCS fallback)
+uip solution resource get <resource-key> --output json
 ```
 
 ---
@@ -219,6 +280,14 @@ Get the UUID from `upload` output or Studio Web -- the name string is not accept
 ### `.uipx` auto-discovery
 
 When `[solutionFile]` is omitted, the CLI walks up from the project path looking for a single `.uipx` file. If multiple `.uipx` files exist in the same directory, specify which one explicitly.
+
+### `--solution-folder` defaults to cwd
+
+`resource list / refresh / get` default `--solution-folder` to the current working directory. Run them from inside the solution dir for the shortest invocation (`uip solution resource list`) or pass `--solution-folder <path>` explicitly. Older docs and examples that pass the path as a positional (`uip solution resource list ./InvoiceAutomation`) are out of date.
+
+### `resource get` for cross-folder inspection
+
+Because `get` falls back to RCS + FPS export when the key isn't local, it works as a quick way to fetch the full server spec for any resource your tenant exposes — even ones that aren't yet bound to this solution. Pair with `solution resource list --source remote` to discover keys.
 
 ---
 

--- a/skills/uipath-platform/references/solution/pack-and-deploy.md
+++ b/skills/uipath-platform/references/solution/pack-and-deploy.md
@@ -48,7 +48,7 @@ uip solution pack ./MySolution ./output --name "MySolution" --version "2.0.0" --
 | `--name <name>` | Override the package name | Name from `.uipx` |
 | `--version <version>` | Set the package version | `1.0.0` |
 
-The output is a `.zip` file named `<name>_<version>.zip` written under `<outputPath>/`. Run `solution resource refresh` first to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
+The output is a `.zip` file named `<name>_<version>.zip` written under `<outputPath>/`. Run `solution resource refresh` first (from inside the solution dir, or with `--solution-folder <path>`) to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
 
 ## Step 2: Publish to the Solution Feed
 

--- a/skills/uipath-platform/references/solution/pack-and-deploy.md
+++ b/skills/uipath-platform/references/solution/pack-and-deploy.md
@@ -44,11 +44,11 @@ uip solution pack ./MySolution ./output --name "MySolution" --version "2.0.0" --
 | Option | Description | Default |
 |--------|-------------|---------|
 | `<solutionPath>` | Directory containing a `.uipx` or `.uis` file (required) | -- |
-| `<outputPath>` | Directory where the .zip will be written (required) | -- |
+| `<outputPath>` | Directory where the .zip will be written (required positional, no default — omitting it errors with `missing required argument 'outputPath'`) | -- |
 | `--name <name>` | Override the package name | Name from `.uipx` |
 | `--version <version>` | Set the package version | `1.0.0` |
 
-The output is a `.zip` file named `<name>.<version>.zip`.
+The output is a `.zip` file named `<name>_<version>.zip` written under `<outputPath>/`. Run `solution resource refresh` first to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
 
 ## Step 2: Publish to the Solution Feed
 
@@ -105,6 +105,13 @@ The `deploy run` command returns a pipeline deployment ID. Use it to check progr
 ```bash
 uip solution deploy status <pipeline-deployment-id> --output json
 ```
+
+> **Heads up:** `deploy run`'s polling is unreliable for long-running deployments. The CLI may print
+> `Result: Failure / Deployment polling failed: Response returned an error code` and `deploy status`
+> may then return `HTTP 404 Pipeline deployment not found` even when the deployment **succeeded**
+> server-side (the pipeline record can expire shortly after completion). Always cross-check with
+> `solution deploy list` and look up the deployment by name before treating a polling failure as a
+> real error.
 
 ## Step 6: List Deployments
 
@@ -246,7 +253,11 @@ These are different commands with different destinations:
 
 ### `--folder-path` is the Parent
 
-On `deploy run`, `--folder-path` is the **parent** folder, not the deployment folder itself. The deployment folder is `--folder-name`, created inside `--folder-path`.
+On `deploy run`, `--folder-path` is the **parent** folder, not the deployment folder itself. The deployment folder is `--folder-name`, created inside `--folder-path`. To produce a nested layout like `Shared/Nica/Solution`, pre-create `Shared/Nica` (or use a previous deploy to make it) and pass `--folder-path "Shared/Nica" --folder-name "Solution"`.
+
+### Polling false-positives on `deploy run`
+
+`deploy run` may report `Failure / Deployment polling failed` even when the deployment succeeded — the pipeline ID expires after completion and `deploy status` then 404s. Always verify with `solution deploy list` (look up the deployment by name + check `OperationStatus`) before treating it as a real error. CI scripts should fall back to `deploy list` on polling failure rather than failing the pipeline.
 
 ### Config `link` Connects to Existing Resources
 

--- a/skills/uipath-platform/references/solution/solution.md
+++ b/skills/uipath-platform/references/solution/solution.md
@@ -39,7 +39,14 @@ graph LR
     D --> E[publish]
     E --> F[deploy run]
     F --> G[activate]
+    C --> H[upload]
 ```
+
+Two distinct distribution paths from the same solution source:
+- **`pack` → `publish` → `deploy run`** — promotes a versioned package to Orchestrator.
+- **`upload`** — pushes the solution to Studio Web for browser-based debugging only. Does not produce a published package and cannot be deployed via `deploy run`.
+
+Always run `resource refresh` before either path so the bundled artefact files and `userProfile/<userId>/debug_overwrites.json` reflect the current cloud state.
 
 ---
 

--- a/skills/uipath-platform/references/solution/solution.md
+++ b/skills/uipath-platform/references/solution/solution.md
@@ -64,8 +64,9 @@ uip solution
   │     ├── remove <projectPath> [solutionFile] Unregister a project from .uipx
   │     └── import --source <path>              Copy external project into solution and register
   ├── resource
-  │     ├── list [solutionPath]           List local, remote, or all resources
-  │     └── refresh [solutionPath]        Sync resource declarations from project bindings
+  │     ├── list                          List local, remote, or all resources (--solution-folder, default cwd)
+  │     ├── refresh                       Sync resource declarations from project bindings (--solution-folder, default cwd)
+  │     └── get <resource-key>            Get full configuration for a single resource — local or remote (--solution-folder, default cwd)
   ├── deploy
   │     ├── run -n <name>                 Deploy a published solution package
   │     ├── status <id>                   Check deployment status


### PR DESCRIPTION
## Summary
- `resource refresh` now explains the actual mechanism (binding discovery, `referenceKey` disambiguation from agent's resource.json, `.uipx` project reconcile, per-user debug_overwrites)
- New "App resources" subsection documenting the 4 artefact files refresh produces + what triggers Studio Web's "App is no longer available" warning (version drift vs Apps `semVersion`)
- Moved App to the non-virtualizable list alongside Process/Connection
- `pack` docs the required `<outputPath>` positional + the `<name>_<version>.zip` output naming
- `deploy run` warns about false-positive polling failures (pipeline ID expires post-completion → 404s on `deploy status`) and recommends `solution deploy list` as the fallback truth source
- `solution.md` lifecycle clarifies the two distribution paths (pack/publish/deploy vs upload) and notes that `upload` is debug-only

## Test plan
- [x] Manually verified each rule against the corresponding CLI behaviour while debugging `uip solution resource refresh` and `uip solution deploy run` end-to-end on agent solutions
- [x] Skill content stays in sync with the latest solution-tool changes (PR UiPath/cli#1146)