### PR TITLE
fix: Add (?s) DOTALL flag to data-fabric coder_eval command patterns

### DIFF
--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -93,6 +93,7 @@ uip df records query <entity-id> \
 | Explore only native entities | `entities list --native-only` |
 | Create a new entity | `entities create <name> --body '{"fields":[{"fieldName":"Title","type":"STRING"}]}'` |
 | Update entity / add fields | `entities update <id> --body '{"addFields":[{"fieldName":"NewField","type":"STRING"}]}'` |
+| Update existing field metadata | `entities update <id> --body '{"updateFields":[{"id":"<field-uuid>","displayName":"New Label","isRequired":true}]}'` — `id` is the field UUID from `entities get Fields[].ID` |
 | Update entity metadata | `entities update <id> --body '{"displayName":"New Name","description":"desc"}'` |
 | Read records (first page) | `records list <entity-id> --limit 50` |
 | Read records (next page) | `records list <entity-id> --cursor <NextCursor>` |

--- a/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
@@ -104,7 +104,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used fieldName key in entity create body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+create.*fieldName'
+    command_pattern: '(?s)uip\s+df\s+entities\s+create.*fieldName'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -112,7 +112,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used addFields key when evolving schema"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+update.*addFields'
+    command_pattern: '(?s)uip\s+df\s+entities\s+update.*addFields'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -120,7 +120,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used filterGroup key in records query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*filterGroup'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*filterGroup'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -128,7 +128,7 @@ success_criteria:
   - type: command_executed
     description: "Agent included Id key in records update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+update.*\"Id\"'
+    command_pattern: '(?s)uip\s+df\s+records\s+update.*\"Id\"'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
@@ -87,7 +87,7 @@ success_criteria:
   - type: command_executed
     description: "Agent uploaded product image"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+files\s+upload\s+.*--file'
+    command_pattern: '(?s)uip\s+df\s+files\s+upload\s+.*--file'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -95,7 +95,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used fieldName key in entity create body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+create.*fieldName'
+    command_pattern: '(?s)uip\s+df\s+entities\s+create.*fieldName'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -103,7 +103,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used filterGroup key in records query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*filterGroup'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*filterGroup'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -111,7 +111,7 @@ success_criteria:
   - type: command_executed
     description: "Agent included Id key in records update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+update.*\"Id\"'
+    command_pattern: '(?s)uip\s+df\s+records\s+update.*\"Id\"'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
@@ -76,7 +76,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran records import with --file"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+import\s+.*--file'
+    command_pattern: '(?s)uip\s+df\s+records\s+import\s+.*--file'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
@@ -90,7 +90,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used fieldName key in entities create body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+create.*fieldName'
+    command_pattern: '(?s)uip\s+df\s+entities\s+create.*fieldName'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
@@ -158,7 +158,7 @@ success_criteria:
   - type: command_executed
     description: "Agent attempted file upload (error scenarios)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+files\s+upload\s+.*--file'
+    command_pattern: '(?s)uip\s+df\s+files\s+upload\s+.*--file'
     min_count: 3
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/integration_files.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_files.yaml
@@ -90,7 +90,7 @@ success_criteria:
   - type: command_executed
     description: "Agent uploaded file at least twice (v1 and v2 overwrite)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+files\s+upload\s+.*--file'
+    command_pattern: '(?s)uip\s+df\s+files\s+upload\s+.*--file'
     min_count: 2
     weight: 3.0
     pass_threshold: 1.0
@@ -98,7 +98,7 @@ success_criteria:
   - type: command_executed
     description: "Agent downloaded file at least twice (after v1 and after v2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+files\s+download\s+.*--destination'
+    command_pattern: '(?s)uip\s+df\s+files\s+download\s+.*--destination'
     min_count: 2
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
@@ -147,7 +147,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used fieldName (not name) in entity create body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+create.*fieldName'
+    command_pattern: '(?s)uip\s+df\s+entities\s+create.*fieldName'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -155,7 +155,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used addFields key in entities update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+update.*addFields'
+    command_pattern: '(?s)uip\s+df\s+entities\s+update.*addFields'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -163,7 +163,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used updateFields with lowercase id key"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+update.*updateFields.*\"id\"'
+    command_pattern: '(?s)uip\s+df\s+entities\s+update.*updateFields.*\"id\"'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -171,7 +171,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used filterGroup key in records query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*filterGroup'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*filterGroup'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -179,7 +179,7 @@ success_criteria:
   - type: command_executed
     description: "Agent included Id key in records update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+update.*\"Id\"'
+    command_pattern: '(?s)uip\s+df\s+records\s+update.*\"Id\"'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
@@ -184,7 +184,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used filterGroup key in records query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*filterGroup'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*filterGroup'
     min_count: 4
     weight: 2.5
     pass_threshold: 1.0
@@ -192,7 +192,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used logicalOperator in AND filterGroup query (step 4e)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*logicalOperator'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*logicalOperator'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -200,7 +200,7 @@ success_criteria:
   - type: command_executed
     description: "Agent included Id key in records update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+update.*\"Id\"'
+    command_pattern: '(?s)uip\s+df\s+records\s+update.*\"Id\"'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
@@ -105,7 +105,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran filter queries with --body (AND, OR, nested, sort, projection)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query\s+.*--body'
+    command_pattern: '(?s)uip\s+df\s+records\s+query\s+.*--body'
     min_count: 4
     weight: 3.0
     pass_threshold: 1.0
@@ -129,7 +129,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used filterGroup key in records query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*filterGroup'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*filterGroup'
     min_count: 3
     weight: 2.5
     pass_threshold: 1.0
@@ -137,7 +137,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used logicalOperator in filterGroup body (AND=0 / OR=1)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*logicalOperator'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*logicalOperator'
     min_count: 2
     weight: 2.0
     pass_threshold: 1.0
@@ -145,7 +145,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used sortOptions with isDescending in query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*sortOptions'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*sortOptions'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -153,7 +153,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used selectedFields projection in query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*selectedFields'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*selectedFields'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
@@ -60,7 +60,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran records import with --file flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+import\s+.*--file'
+    command_pattern: '(?s)uip\s+df\s+records\s+import\s+.*--file'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_entities.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_entities.yaml
@@ -65,7 +65,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used fieldName (not name) in entity create body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+create.*fieldName'
+    command_pattern: '(?s)uip\s+df\s+entities\s+create.*fieldName'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -81,7 +81,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used addFields key in entities update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+update.*addFields'
+    command_pattern: '(?s)uip\s+df\s+entities\s+update.*addFields'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -89,7 +89,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used updateFields with lowercase id key in entities update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+entities\s+update.*updateFields.*\"id\"'
+    command_pattern: '(?s)uip\s+df\s+entities\s+update.*updateFields.*\"id\"'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_files.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_files.yaml
@@ -61,7 +61,7 @@ success_criteria:
   - type: command_executed
     description: "Agent uploaded file using files upload with --file flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+files\s+upload\s+.*--file'
+    command_pattern: '(?s)uip\s+df\s+files\s+upload\s+.*--file'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -69,7 +69,7 @@ success_criteria:
   - type: command_executed
     description: "Agent downloaded file using files download with --destination flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+files\s+download\s+.*--destination'
+    command_pattern: '(?s)uip\s+df\s+files\s+download\s+.*--destination'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_records.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_records.yaml
@@ -74,7 +74,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used array body for batch insert (routes to batch endpoint)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+insert.*\['
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\['
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -90,7 +90,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used filterGroup in records query body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+query.*filterGroup'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*filterGroup'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -106,7 +106,7 @@ success_criteria:
   - type: command_executed
     description: "Agent included Id key in records update body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+records\s+update.*\"Id\"'
+    command_pattern: '(?s)uip\s+df\s+records\s+update.*\"Id\"'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0


### PR DESCRIPTION
Added (?s) inline DOTALL flag to 35 cross-line command_pattern regexes across 13 test files so .* matches across      
  newlines in multiline Bash commands.   