### PR TITLE
docs(uipath-rpa): refresh bundled activity docs from Activities repo

### DIFF
--- a/skills/uipath-rpa/references/activity-docs/UiPath.Callout.Activities/26.0/README.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Callout.Activities/26.0/README.md
@@ -1,0 +1,34 @@
+# UiPath.Callout.Activities
+
+> NuGet Package ID: `UiPath.Callout.Activities`
+
+## Overview
+
+The Callout Activities package provides the **Show Callout** activity, which displays a form-based callout anchored to a UI element on screen. Unlike regular forms, callouts automatically track and follow their target element, providing contextual guidance overlays for attended automations.
+
+## Activity
+
+| Activity | Description |
+|----------|-------------|
+| [Show Callout](activities.md) | Displays a callout anchored to a UI element |
+
+## How Callouts Differ from Forms
+
+| Aspect | Forms | Callouts |
+|--------|-------|----------|
+| Positioning | Manual (Left/Top) or unset | Anchored to a UI element, auto-positioned |
+| Pointer | No | Yes (visual arrow toward target) |
+| Window chrome | Configurable | Off by default |
+| Taskbar | Configurable | Hidden by default |
+| Execution mode | Async or Sync | Always Async |
+| ContinueOnError | Not available | Available (defaults to true) |
+| Auto-close timer | Not available | Available |
+| Requires UI target | No | Yes |
+
+## Dependencies
+
+This package depends on `UiPath.Form.Activities` (for the forms infrastructure) and uses UI Automation for element targeting.
+
+## Platform Support
+
+Windows only (requires native UI element tracking).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Callout.Activities/26.0/activities.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Callout.Activities/26.0/activities.md
@@ -1,0 +1,49 @@
+# Show Callout Activity Reference
+
+Displays a form-based callout anchored to a UI element. The callout tracks the target's position and follows it in real time.
+
+## Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| FormId | String | *(required)* | The callout form to display (selected in the designer) |
+| InstanceName | String | `null` | Optional tag to distinguish multiple callout instances |
+| Target | *(via Indicate Target)* | `null` | UI element to anchor to, captured using the Indicate Target button |
+| UiElement | UiElement | `null` | Alternative: a UiElement variable from a previous UI Automation activity |
+| ContinueOnError | Boolean | `true` | If true, exceptions are suppressed and the activity completes gracefully |
+| AutomaticallyCloseAfter | TimeSpan? | `null` | Auto-close the callout after this duration |
+| Arguments | Dictionary | `{}` | Field bindings (same as Show Form) |
+| Width | Int32? | 300 | Width in pixels |
+| Height | Int32? | 280 | Height in pixels |
+| Title | String | `null` | Custom window title |
+| ShowMargin | Boolean? | `false` | Window chrome (off by default) |
+| ShowInTaskbar | Boolean? | `false` | Taskbar visibility (hidden by default) |
+
+## Target Selection
+
+**Either Target or UiElement must be provided.** A validation error is raised if both are empty.
+
+- **Target** (recommended): Click the "Indicate Target" button in the designer to visually select the UI element the callout should point to. This captures a selector, just like other UI Automation activities.
+- **UiElement**: Pass a `UiElement` variable obtained from a previous activity (e.g., Find Element). Useful when the target is already known at runtime.
+
+When `UiElement` is set, the Indicate Target button is hidden (and vice versa).
+
+## Behaviour
+
+- The callout is always **async**: the activity completes immediately after the callout is shown, and the workflow continues while the callout remains visible.
+- The callout displays a **visual pointer** (arrow) toward the target element.
+- Position and Z-order are managed automatically - the callout follows the target if it moves and stays visually associated with the target's window.
+- Properties like Left, Top, WindowState, and TopMost are auto-managed and hidden in the designer.
+
+## Auto-Close
+
+Set `AutomaticallyCloseAfter` to a `TimeSpan` value to have the callout close itself after a duration. Useful for transient guidance messages (e.g., "Click this button" that disappears after 10 seconds).
+
+## Error Handling
+
+With `ContinueOnError = true` (the default), if the target element cannot be found or the callout fails to display, the activity completes without throwing. Set to `false` if you need strict error handling.
+
+Common error scenarios:
+- Target element not found on screen
+- UI Automation services not available
+- Form not found (invalid FormId)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AddSensitivityLabelX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AddSensitivityLabelX.md
@@ -1,0 +1,32 @@
+# Add or Update Excel Sensitivity Label
+
+`UiPath.Excel.Activities.Business.AddSensitivityLabelX`
+
+Adds a sensitivity label to an Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | Workbook handle obtained from an `ExcelApplicationCard`. |
+| `SensitivityLabel` | Sensitivity label | InArgument | `object` | Yes | | String Id for the sensitivity label or an instance of IExcelLabelObject |
+| `Justification` | Justification | InArgument | `string` | No | | Justification to use when applying the label |
+
+## XAML Example
+```xml
+<excel:AddSensitivityLabelX
+  DisplayName="Add or Update Excel Sensitivity Label"
+  Workbook="[workbookHandle]"
+  SensitivityLabel="[labelIdOrObject]"
+  Justification="[&quot;Business requirement&quot;]" />
+```
+
+## Notes
+- The `SensitivityLabel` property accepts either a string label ID or an `IExcelLabelObject` instance.
+- The `Justification` property is optional and is used when applying or changing the label.
+- If both a justification is set on the `IExcelLabelObject` and in the `Justification` property, the `Justification` property value takes precedence.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AppendRange.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AppendRange.md
@@ -1,0 +1,41 @@
+# Append Range Workbook
+
+`UiPath.Excel.Activities.AppendRange`
+
+Appends the data from a DataTable to a spreadsheet. If the sheet does not exist, a new one is created with the SheetName value. Changes are immediately saved.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `DataTable` | DataTable | InArgument | `DataTable` | Yes | | The DataTable object containing the input data to append |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+## XAML Example
+
+```xml
+<excel:AppendRange
+  DisplayName="Append Range Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  DataTable="[dataToAppend]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- Data is appended after the last row with data in the sheet.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AppendRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AppendRangeX.md
@@ -1,0 +1,55 @@
+# Append Range
+
+`UiPath.Excel.Activities.Business.AppendRangeX`
+
+Copies the data in a table, range, or sheet and pastes it after existing data in another specified table, range, or sheet.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SourceRange` | Excel range to append | InArgument | `IReadRangeRef` | Yes | | Excel range to append. |
+| `DestinationRange` | Append after range | InArgument | `IReadWriteRangeRef` | Yes | | Target range after which to append the new range. |
+| `PasteOptions` | What to copy | Property | `CopyPasteRangeOptions` | No | `All` | The value formatting for the new range. |
+| `Transpose` | Transpose | Property | `bool` | No | `False` | Inserts columns as rows and rows as columns. |
+| `StartingColumnName` | Starting in column | InArgument | `string` | No | | Append the data starting with the first empty cell in the specified column. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Exclude source headers | `bool` | `False` | First row from the selected range will not be written to the destination. |
+| `DestinationHasHeaders` | Destination has headers | `bool` | `False` | If true, the first row of the destination range contains column names and will be used to identify the Starting Column. |
+
+### Enum Reference
+
+#### `CopyPasteRangeOptions`
+| Value | Display Name |
+|-------|-------------|
+| `All` | All |
+| `Values` | Values |
+| `Formulas` | Formulas |
+| `Formats` | Formats |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:AppendRangeX
+    SourceRange="[SourceRange]"
+    DestinationRange="[DestRange]"
+    PasteOptions="All"
+    Transpose="False"
+    HasHeaders="False"
+    DestinationHasHeaders="False"
+    DisplayName="Append Range" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- Both `SourceRange` and `DestinationRange` must be valid ranges; otherwise, an `ArgumentNullException` is thrown at runtime.
+- When `StartingColumnName` is specified and `DestinationHasHeaders` is `True`, the activity uses the header row of the destination to locate the column where appending begins.
+- If `HasHeaders` is `True`, the first row of the source range is excluded from the appended data.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AppendWriteCsvFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AppendWriteCsvFile.md
@@ -1,0 +1,59 @@
+# Write CSV
+
+`UiPath.CSV.Activities.AppendWriteCsvFile`
+
+Copies a DataTable and pastes it in a specified CSV file, either appending after existing data or replacing any existing data in the file.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | Local CSV file | InArgument | `string` | Conditional | | The full local path of the CSV file. Alternative to `PathResource` — use one or the other |
+| `PathResource` | Resource CSV file | InArgument | `IResource` | Conditional | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `FilePath` — use one or the other |
+| `DataTable` | What to write | InArgument | `DataTable` | Yes | | The input DataTable containing the data to write to the CSV file |
+| `CsvAction` | How to write | Property | `CsvWriteAction` | Yes | `Write` | Select how to write data into the file |
+| `AddHeaders` | Include headers | Property | `bool` | | `True` | Whether the column names from the DataTable will be added to the output CSV file |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `DelimitatorForViewModel` | Delimiter | `DelimiterOptions` | `Comma` | Specifies the delimiter in the CSV file |
+| `Encoding` | Encoding | `InArgument<string>` | | The character encoding to use (e.g. "utf-8", "utf-16") |
+| `ShouldQuote` | Should quote | `bool` | `True` | When set to true, a field is quoted when writing if it starts/ends with a space, contains \r or \n, or contains the CSV delimiter |
+
+## Valid Configurations
+
+This activity supports two input modes via `[OverloadGroup]`:
+
+**Mode A — Local File**: Set `FilePath` to the full path of the CSV file.
+**Mode B — Resource File**: Set `PathResource` to an `IResource` reference.
+
+Properties `FilePath` and `PathResource` are mutually exclusive.
+
+### Enum Reference
+
+**`CsvWriteAction`**: `Append`, `Write`
+
+**`DelimiterOptions`**: `Comma`, `Semicolon`, `Pipe`, `Caret`, `Tab`
+
+## XAML Example
+
+```xml
+<csv:AppendWriteCsvFile
+  DisplayName="Write CSV"
+  FilePath="[&quot;output.csv&quot;]"
+  DataTable="[dataToWrite]"
+  CsvAction="Write"
+  AddHeaders="True"
+  ShouldQuote="True" />
+```
+
+## Notes
+
+- `Write` mode replaces any existing file content. `Append` mode adds data after existing rows.
+- When neither `FilePath` nor `PathResource` is set, the activity will fail at runtime.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AutoFillX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AutoFillX.md
@@ -1,0 +1,30 @@
+# Auto Fill
+
+`UiPath.Excel.Activities.Business.AutoFillX`
+
+Automatically fills cells downward based on the pattern detected in the specified start range. Works with both regular ranges and Excel tables.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `StartRange` | Start range | InArgument | `IWellDefinedReadRangeRef` | Yes | | Data source to fill cells with. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:AutoFillX
+    StartRange="[myRange]"
+    DisplayName="Auto Fill" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- When the start range refers to an Excel table, the activity fills down within the table structure.
+- When the start range refers to a regular cell range, the activity uses the address-based auto-fill.
+- The range must be a valid, well-defined range; otherwise a runtime error is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AutoFitX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/AutoFitX.md
@@ -1,0 +1,37 @@
+# Autofit Range
+
+`UiPath.Excel.Activities.Business.AutoFitX`
+
+Fits data in cells.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Range | InArgument | `IReadRangeRef` | Yes | | Data source. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Columns` | Columns | `bool` | `True` | If true, applies autofit only on range's columns. |
+| `Rows` | Rows | `bool` | `True` | If true, applies autofit only on range's rows. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:AutoFitX
+    Range="[MyRange]"
+    Columns="True"
+    Rows="True"
+    DisplayName="Autofit Range" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- At least one of `Columns` or `Rows` must be `True`; otherwise, a validation error is raised at design time.
+- The activity supports ranges, tables, pivot tables, and entire sheets.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ChangePivotTableDataSourceX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ChangePivotTableDataSourceX.md
@@ -1,0 +1,32 @@
+# Change Pivot Table Data Source
+
+`UiPath.Excel.Activities.Business.ChangePivotTableDataSourceX`
+
+Changes the data source of an existing pivot table to a new range within the same workbook.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `PivotTable` | Pivot table | InArgument | `IPivotTableRef` | Yes | | The original Pivot table to be updated. |
+| `NewSourceRange` | New source | InArgument | `IWellDefinedReadRangeRef` | Yes | | The new range to be used as Source for the Pivot Table. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:ChangePivotTableDataSourceX
+    PivotTable="[pivotTableRef]"
+    NewSourceRange="[newRange]"
+    DisplayName="Change Pivot Table Data Source" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The pivot table and the new source range must be in the same workbook. Using different workbooks for the source and pivot table is not supported and throws an error.
+- The pivot table must exist on the specified worksheet; otherwise an `ArgumentException` is thrown.
+- The pivot table reference must include a valid address, worksheet, and parent handle.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ClearRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ClearRangeX.md
@@ -1,0 +1,36 @@
+# Clear Sheet/Range/Table
+
+`UiPath.Excel.Activities.Business.ClearRangeX`
+
+Clears the data from a spreadsheet sheet, range, or table.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `TargetRange` | Range to clear | InArgument | `IReadWriteRangeRef` | Yes | | Accepts a sheet, range or table to clear the data from. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `False` | First row in the range is a header row. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:ClearRangeX
+    TargetRange="[MyRange]"
+    HasHeaders="False"
+    DisplayName="Clear Sheet/Range/Table" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- When `HasHeaders` is `True`, the first row (header row) of the range is preserved and only the data rows are cleared.
+- For pivot tables, the activity clears the pivot table. For tables, it clears the range address. For regular ranges, it builds a range excluding headers if specified.
+- The target range must be valid; otherwise, an `ArgumentNullException` is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CopyChartToClipboardX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CopyChartToClipboardX.md
@@ -1,0 +1,58 @@
+# Copy/Save Chart
+
+`UiPath.Excel.Activities.Business.CopyChartToClipboardX`
+
+Copies an Excel chart to the clipboard or saves it as a picture file, depending on the selected action.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Chart` | Chart | InArgument | `IChartRef` | Yes | | Choose the chart. |
+| `Action` | Action | Property | `ExcelChartAction` | Yes | `CopyToClipboard` | Action to apply to the selected chart. |
+| `FilePath` | File name | InArgument | `string` | Conditional | | File where the chart will be saved. Only visible and required when Action is SaveAsPicture. |
+| `ReplaceFile` | Replace existing file | Property | `bool` | No | `True` | Whether to replace an existing file at the specified path. Only visible when Action is SaveAsPicture. |
+
+## Conditional Visibility
+
+- `FilePath` and `ReplaceFile` are only visible when `Action` is `SaveAsPicture`.
+- When `Action` is `SaveAsPicture`, `FilePath` is required (validated at design time).
+
+### Enum Reference
+
+#### `ExcelChartAction`
+| Value | Display Name |
+|-------|-------------|
+| `CopyToClipboard` | Copy to clipboard |
+| `SaveAsPicture` | Save as picture |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:CopyChartToClipboardX
+    Chart="[chartRef]"
+    Action="CopyToClipboard"
+    DisplayName="Copy Chart to Clipboard" />
+</excel:ExcelApplicationCard>
+```
+
+### Save as picture variant
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:CopyChartToClipboardX
+    Chart="[chartRef]"
+    Action="SaveAsPicture"
+    FilePath="[&quot;C:\output\chart.png&quot;]"
+    ReplaceFile="True"
+    DisplayName="Save Chart as Picture" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The chart reference is typically obtained from the output of `InsertExcelChartX` or by referencing an existing chart in the workbook.
+- When saving as picture, the file path must be a valid absolute path; an error is thrown if the folder does not exist.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CopyPasteRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CopyPasteRangeX.md
@@ -1,0 +1,51 @@
+# Copy/Paste Range
+
+`UiPath.Excel.Activities.Business.CopyPasteRangeX`
+
+Copies a range or sheet and optionally pastes it to another location in the current workbook or a different one.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SourceRange` | Source range | InArgument | `IReadRangeRef` | Yes | | The range to copy. |
+| `DestinationRange` | Destination | InArgument | `IReadWriteRangeRef` | Yes | | Where to put the copied range. |
+| `PasteOptions` | What to copy | Property | `CopyPasteRangeOptions` | No | `All` | The value formatting to insert. |
+| `ExcludeHeaders` | Exclude header from source range | Property | `bool` | No | `False` | Excludes the header row from the source range when copying. |
+| `ExcludeHeaderFromSourceTable` | Exclude headers from source table | Property | `bool` | No | `True` | Excludes headers from the source table when copying. |
+| `Transpose` | Transpose | Property | `bool` | No | `False` | Inserts columns as rows and rows as columns. |
+
+### Enum Reference
+
+#### `CopyPasteRangeOptions`
+| Value | Display Name |
+|-------|-------------|
+| `All` | All |
+| `Values` | Values |
+| `Formulas` | Formulas |
+| `Formats` | Formats |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:CopyPasteRangeX
+    SourceRange="[SourceRange]"
+    DestinationRange="[DestRange]"
+    PasteOptions="All"
+    ExcludeHeaders="False"
+    ExcludeHeaderFromSourceTable="True"
+    Transpose="False"
+    DisplayName="Copy/Paste Range" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- Either `SourceRange` or `DestinationRange` can be a clipboard placeholder, but not both simultaneously.
+- When the destination is a clipboard placeholder, the source is copied to the system clipboard. When the source is a clipboard placeholder, the clipboard contents are pasted at the destination.
+- If the destination covers an entire sheet, the paste target defaults to cell A1.
+- Both source and destination must be valid ranges or clipboard placeholders; otherwise, an `ArgumentNullException` is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreateNewWorkbook.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreateNewWorkbook.md
@@ -1,0 +1,49 @@
+# Create New Workbook
+
+`UiPath.Excel.Activities.CreateNewWorkbook`
+
+Creates a new Excel workbook at the specified file path.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | Yes | | The full local path where the new workbook will be created |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the initial sheet in the workbook |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ConflictResolution` | Conflict Behavior | `InArgument<ConflictBehavior>` | `Replace` | What to do if a file already exists at the path |
+| `Password` | Password | `InArgument<string>` | | The password for the new workbook |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `WorkbookFile` | Workbook File | `Workbook` | The newly created Workbook object |
+
+### Enum Reference
+
+**`ConflictBehavior`**: `Replace`, `Skip`, `Error`
+
+## XAML Example
+
+```xml
+<excel:CreateNewWorkbook
+  DisplayName="Create New Workbook"
+  WorkbookPath="[&quot;C:\Reports\new_report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  WorkbookFile="[newWorkbook]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPathResource` is hidden for this activity — only local file path is supported.
+- The `Workbook` input property (from base class) is hidden — this activity creates a new workbook rather than using an existing one.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreatePivotTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreatePivotTable.md
@@ -1,0 +1,61 @@
+# Create Pivot Table Workbook
+
+`UiPath.Excel.Activities.CreatePivotTable`
+
+Creates a pivot table in a workbook from a specified data source (sheet range or table).
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `UseTableSource` | Use table source | Property | `bool` | | `False` | When True, uses a named table as source instead of sheet/range |
+| `SourceSheet` | Source sheet | InArgument | `string` | | | The sheet containing the source data. Visible when `UseTableSource` is False |
+| `SourceRange` | Source range | InArgument | `string` | | | The range of source data. Visible when `UseTableSource` is False |
+| `SourceTable` | Source table name | InArgument | `string` | | | Name of the source table for the pivot. Visible when `UseTableSource` is True |
+| `SheetName` | Pivot sheet name | InArgument | `string` | Yes | | The sheet where the pivot table will be placed |
+| `PlacementCell` | Pivot placement cell | InArgument | `string` | | | Cell specifying where the pivot table will be created |
+| `PivotTableName` | Pivot table name | InArgument | `string` | Yes | | Name of the new pivot table |
+| `PivotTableFields` | Pivot table fields | Property | `List<InArgument<PivotTableField>>` | | | The pivot table field definitions (static list) |
+| `PivotTableFieldsVariable` | Pivot table fields variable | InArgument | `IEnumerable<PivotTableField>` | | | The pivot table field definitions (variable/expression) |
+| `LayoutRowType` | Layout | InArgument | `PivotTableLayoutRowType` | | | The layout style for pivot table rows |
+| `ValuesMode` | Values added as | InArgument | `PivotTableValuesMode` | | | How values are displayed in the pivot table |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+## Valid Configurations
+
+This activity supports two data source modes controlled by `UseTableSource`:
+
+**Mode A — Sheet Range** (default): Set `SourceSheet` and `SourceRange`. `SourceTable` is hidden.
+**Mode B — Named Table**: Set `UseTableSource` to True and provide `SourceTable`. `SourceSheet` and `SourceRange` are hidden.
+
+`PivotTableFields` and `PivotTableFieldsVariable` are alternative input modes (static list vs. expression).
+
+## XAML Example
+
+```xml
+<excel:CreatePivotTable
+  DisplayName="Create Pivot Table Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SourceSheet="[&quot;Data&quot;]"
+  SourceRange="[&quot;A1:E100&quot;]"
+  SheetName="[&quot;PivotSheet&quot;]"
+  PlacementCell="[&quot;A1&quot;]"
+  PivotTableName="[&quot;SalesPivot&quot;]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreatePivotTableXv2.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreatePivotTableXv2.md
@@ -1,0 +1,106 @@
+# Create Pivot Table
+
+`UiPath.Excel.Activities.Business.CreatePivotTableXv2`
+
+Creates a new pivot table from a specified data range and places it at a destination range. This is a container activity that holds child `PivotTableFieldX` activities to define the pivot table's rows, columns, filters, and values.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Table range | InArgument | `IReadRangeRef` | Yes | | Table or range to analyze with a pivot table. |
+| `TableName` | New table name | InArgument | `string` | Yes | | Name of the new pivot table. |
+| `DestinationRange` | Destination range | InArgument | `IReadWriteRangeRef` | Yes | | Where to place the new pivot table. |
+| `LayoutRowType` | Layout | Property | `PivotTableLayoutRowType` | No | `Compact` | Enhance the pivot table layout and format. The compact form optimizes for readability, while tabular and outline forms include field headers. |
+| `ValuesMode` | Values added as | Property | `PivotTableValuesMode` | No | `Columns` | Select how to add the values in the pivot table, either as columns (the default option) or rows. |
+
+### Designer Controls (Not Mapped to XAML)
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `AddPivotField` | Add Pivot Table Field | Action Button | Inserts a new `PivotTableFieldX` child activity into the body. |
+
+## Child Activity: PivotTableFieldX
+
+`UiPath.Excel.Activities.Business.PivotTableFieldX`
+
+Each child activity defines a single pivot table field. Add one per field using the **Add Pivot Table Field** button. At least one is required.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FieldName` | Field | InArgument | `string` | Yes | | The name of the source column to use as a pivot field. |
+| `Type` | Is a | Property | `PivotTableFieldType` | Yes | `Row` | The role of the field in the pivot table. |
+| `Function` | Function | Property | `PivotTableFunction` | No | `Sum` | The aggregation function to apply. Only visible when `Type` is `Value`. |
+
+#### `PivotTableFieldType`
+| Value | Display Name |
+|-------|-------------|
+| `Row` | Row |
+| `Column` | Column |
+| `Filter` | Filter |
+| `Value` | Value |
+
+#### `PivotTableFunction`
+| Value | Display Name |
+|-------|-------------|
+| `Sum` | Sum |
+| `Count` | Count |
+| `Average` | Average |
+| `Max` | Max |
+| `Min` | Min |
+| `Product` | Product |
+| `CountNumbers` | CountNumbers |
+| `StdDev` | StdDev |
+| `StdDevp` | StdDevp |
+| `Var` | Var |
+| `Varp` | Varp |
+
+## Enum Reference
+
+#### `PivotTableLayoutRowType`
+| Value | Display Name |
+|-------|-------------|
+| `Compact` | Compact |
+| `Tabular` | Tabular |
+| `Outline` | Outline |
+
+#### `PivotTableValuesMode`
+| Value | Display Name |
+|-------|-------------|
+| `Columns` | Columns |
+| `Rows` | Rows |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:CreatePivotTableXv2
+    Range="[sourceRange]"
+    TableName="PivotTable1"
+    DestinationRange="[destRange]"
+    LayoutRowType="Compact"
+    ValuesMode="Columns"
+    DisplayName="Create Pivot Table">
+    <excel:CreatePivotTableXv2.Body>
+      <ActivityAction x:TypeArguments="excel:PivotTableDescriptor">
+        <ActivityAction.Argument>
+          <DelegateInArgument x:TypeArguments="excel:PivotTableDescriptor" Name="PivotTableDescriptor" />
+        </ActivityAction.Argument>
+        <Sequence DisplayName="Do">
+          <!-- PivotTableFieldX child activities here -->
+        </Sequence>
+      </ActivityAction>
+    </excel:CreatePivotTableXv2.Body>
+  </excel:CreatePivotTableXv2>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The source range and destination range must be in the same workbook. Using different workbooks throws an error.
+- The `HasHeaders` property is always `True` and not visible in the designer.
+- When the source range represents an entire sheet, the activity clips it to the used range before creating the pivot table.
+- At least one `PivotTableFieldX` child activity is required; otherwise a runtime error occurs.
+- Filter fields are added in reverse order so they appear top-to-bottom in the same order as defined in the activity.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreateTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/CreateTableX.md
@@ -1,0 +1,47 @@
+# Format as Table
+
+`UiPath.Excel.Activities.Business.CreateTableX`
+
+Formats a range of cells as a table with a specified name.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Table range | InArgument | `IReadWriteRangeRef` | Yes | | Range to format as table. |
+| `TableName` | Table name (optional) | InArgument | `string` | No | | Name of the new table. If left blank, a table name will be automatically generated. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `True` | The first row of the range is used as a header row for the table. |
+| `ReplaceExisting` | Replace existing | `bool` | `True` | If a table with this name already exists, it will be converted to a range so the new table can be created. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutTableName` | Save new table name as | `string` | Name of the new table. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:CreateTableX
+    Range="[MyRange]"
+    TableName="SalesData"
+    HasHeaders="True"
+    ReplaceExisting="True"
+    OutTableName="[CreatedTableName]"
+    DisplayName="Format as Table" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The table name must be a valid Excel name. If the provided name is invalid, an `ArgumentException` is thrown.
+- When `ReplaceExisting` is `True` and a table with the specified name already exists, the existing table is first converted to a plain range before the new table is created.
+- When `ReplaceExisting` is `False` and a table with the same name exists, an `ArgumentException` is thrown.
+- If the range is an entire sheet, it is automatically clipped to the used range before table creation.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DeleteColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DeleteColumnX.md
@@ -1,0 +1,39 @@
+# Delete Column
+
+`UiPath.Excel.Activities.Business.DeleteColumnX`
+
+Deletes a specified column from a sheet, table or range.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Source range | InArgument | `IReadWriteRangeRef` | Yes | | Source range. |
+| `ColumnName` | Column name | InArgument | `string` | Yes | | The column to delete. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `True` | Indicates the first row in the range is a header row. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:DeleteColumnX
+    Range="[MyRange]"
+    ColumnName="Email"
+    HasHeaders="True"
+    DisplayName="Delete Column" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- When `HasHeaders` is `True`, the `ColumnName` refers to the header value of the column to delete.
+- When `HasHeaders` is `False`, the `ColumnName` refers to column letter addresses (e.g. `A`, `B:D`). Multiple column ranges can be specified.
+- For tables, the column is deleted by its name directly from the table structure.
+- The range must be valid and `ColumnName` must not be empty; otherwise, an exception is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DeleteRowsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DeleteRowsX.md
@@ -1,0 +1,57 @@
+# Delete Rows
+
+`UiPath.Excel.Activities.Business.DeleteRowsX`
+
+Deletes the specified rows from a sheet, table, or range.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Source range | InArgument | `IReadWriteRangeRef` | Yes | | The sheet, table, or range from which to delete rows. |
+| `DeleteRowsOption` | What to delete | Property | `DeleteRowsOption` | Yes | `Specific` | The type of delete to perform. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `RowPositions` | At position | `InArgument<string>` | | The rows to delete when the option 'Specific rows' is selected. |
+| `HasHeaders` | Has headers | `bool` | `True` | The first row in the range is not deleted when the option 'All visible rows' is selected. |
+
+## Valid Configurations
+
+- `RowPositions` is only visible when `DeleteRowsOption` is set to `Specific`.
+- When `DeleteRowsOption` is `Specific`, `RowPositions` is required and must follow a valid row index format (e.g., `"1"`, `"1-3"`, `"1,3,5"`).
+
+### Enum Reference
+
+#### `DeleteRowsOption`
+| Value | Display Name |
+|-------|-------------|
+| `Specific` | Specific rows |
+| `Visible` | All visible rows |
+| `Hidden` | All hidden rows |
+| `Duplicates` | Duplicate rows |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:DeleteRowsX
+    Range="[MyRange]"
+    DeleteRowsOption="Specific"
+    RowPositions="1,3,5"
+    HasHeaders="True"
+    DisplayName="Delete Rows" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- A design-time warning is displayed if this activity is placed inside an `ExcelForEachRowX` activity when both target the same range. Use a filter and delete all visible rows instead.
+- When targeting a table, the first row (header) is always preserved, and row deletion operates on the data rows.
+- When `HasHeaders` is `True` on a non-table range, the first row is preserved during deletion.
+- The `RowPositions` format supports individual rows (`1,3,5`) and ranges (`2-5`).
+- The activity cannot delete the current row when used with a `CurrentRow` reference.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DeleteSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DeleteSheetX.md
@@ -1,0 +1,27 @@
+# Delete Sheet
+
+`UiPath.Excel.Activities.Business.DeleteSheetX`
+
+Deletes a specified sheet from an Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Sheet` | Select sheet | InArgument | `ISheetRef` | Yes | | The sheet to delete from the Excel workbook. |
+
+## XAML Example
+```xml
+<excel:DeleteSheetX
+  DisplayName="Delete Sheet"
+  Sheet="[sheetReference]" />
+```
+
+## Notes
+- The `Sheet` property must reference an existing sheet in the workbook.
+- Throws `ArgumentNullException` if the sheet reference is null.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DuplicateSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/DuplicateSheetX.md
@@ -1,0 +1,30 @@
+# Duplicate Sheet
+
+`UiPath.Excel.Activities.Business.DuplicateSheetX`
+
+Creates a copy of the specified sheet in an Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SheetToDuplicate` | Sheet to duplicate | InArgument | `ISheetRef` | Yes | | The sheet to copy. |
+| `NewSheetName` | Rename to | InArgument | `string` | Yes | `"New Sheet"` | Name of the new copy. |
+
+## XAML Example
+```xml
+<excel:DuplicateSheetX
+  DisplayName="Duplicate Sheet"
+  SheetToDuplicate="[sourceSheet]"
+  NewSheetName="[&quot;Sheet1 Copy&quot;]" />
+```
+
+## Notes
+- The new sheet is inserted after the source sheet.
+- The `NewSheetName` defaults to `"New Sheet"` if not specified.
+- Throws `ArgumentNullException` if the sheet reference is null or the new name is empty.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExcelApplicationCard.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExcelApplicationCard.md
@@ -1,0 +1,97 @@
+# Use Excel File
+
+`UiPath.Excel.Activities.Business.ExcelApplicationCard`
+
+Opens an Excel workbook and provides a scope for child activities to interact with it. This is the primary container for all Windows Excel activities that operate on a workbook.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** None (this is a scope activity itself)
+
+## Properties
+
+### File
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | Workbook path | InArgument | `string` | Yes | | The path to the Excel file. If the file does not exist and you select the CreateNewFile option, StudioX creates the file. |
+| `Password` | Password | InArgument | `string` | No | `null` | The password required for opening the Excel workbook, if the file is password-protected. |
+| `SecurePassword` | Secure password | InArgument | `SecureString` | No | `null` | Secure string variant of the open password. Cannot be set simultaneously with Password. |
+| `EditPassword` | Edit password | InArgument | `string` | No | `null` | The password required for editing the Excel workbook, if the file is password-protected. |
+| `SecureEditPassword` | Secure edit password | InArgument | `SecureString` | No | `null` | Secure string variant of the edit password. Cannot be set simultaneously with EditPassword. |
+
+### Options
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `CreateNewFile` | Create if not exists | Property | `bool` | No | `True` | If the workbook cannot be found at the specified path, a new Excel workbook is created. When cleared, an error message is displayed if the workbook is not found. |
+| `AutoSave` | Save changes | Property | `bool` | No | `True` | Saves the workbook after each Excel activity that makes a change to its content. Use the Save Excel File activity when disabled. |
+| `ReadOnly` | Read-only | Property | `bool` | No | `False` | Opens the workbook in read-only mode. |
+| `KeepExcelFileOpen` | Keep excel file open | Property | `bool` | No | `False` | Keeps the workbook open after running the project, instead of closing it. |
+| `UseTemplate` | Use template | Property | `bool` | No | `False` | Enables template file support. When enabled, the TemplatePath property becomes visible. |
+| `TemplatePath` | Template | InArgument | `string` | No | `null` | A file that represents the structure of a file that will only exist when the automation is run. Only visible when UseTemplate is True. |
+| `ReadFormatting` | Read formatting | Property | `ReadFormattingOptions?` | No | `null` (Same as project) | Choose what formatting should be applied to values read from Excel. |
+| `ResizeWindow` | Resize window | Property | `ResizeWindowOptions` | No | `None` | Resizes the Excel window accordingly. If Show Excel Window is set to false in the Project Settings, this property is ignored. |
+| `SensitivityOperation` | Sensitivity operation | Property | `ExcelLabelOperation` | No | `None` | Sensitivity operation to be applied using the sensitivity label. |
+| `SensitivityLabel` | Sensitivity label | InArgument | `object` | No | | String Id for the sensitivity label or an instance of IExcelLabelObject. Used only when the sensitivity operation is Add. |
+
+### Designer
+| Name | Display Name | Kind | Type | Required | Description |
+|------|-------------|------|------|----------|-------------|
+| `VariableName` | Reference as | NotMappedProperty | `string` | Yes | The name used to reference this workbook in child activities. |
+
+## Conditional Visibility
+
+- `TemplatePath` is only visible when `UseTemplate` is `True`.
+- `Password` and `SecurePassword` are mutually exclusive (menu action toggles between them).
+- `EditPassword` and `SecureEditPassword` are mutually exclusive (menu action toggles between them).
+- `Visible` property is deprecated and hidden.
+- `Body` property is hidden.
+
+### Enum Reference
+
+#### `ReadFormattingOptions`
+| Value | Display Name |
+|-------|-------------|
+| `Default` | Default |
+| `RawValue` | Raw value |
+| `DisplayValue` | Display value |
+
+#### `ResizeWindowOptions`
+| Value | Display Name |
+|-------|-------------|
+| `None` | None |
+| `Minimize` | Minimize |
+| `Maximize` | Maximize |
+
+#### `ExcelLabelOperation`
+| Value | Display Name |
+|-------|-------------|
+| `None` | None |
+| `Add` | Add |
+| `Clear` | Clear |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard
+  WorkbookPath="[filePath]"
+  AutoSave="True"
+  CreateNewFile="True"
+  ReadOnly="False"
+  DisplayName="Use Excel File">
+  <excel:ExcelApplicationCard.Body>
+    <ActivityAction x:TypeArguments="excel:IWorkbookQuickHandle">
+      <ActivityAction.Argument>
+        <DelegateInArgument x:TypeArguments="excel:IWorkbookQuickHandle" Name="Excel" />
+      </ActivityAction.Argument>
+      <Sequence DisplayName="Do">
+        <!-- child activities here -->
+      </Sequence>
+    </ActivityAction>
+  </excel:ExcelApplicationCard.Body>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- This activity acts as a scope (container) for other Excel activities. Most Windows Excel activities must be placed inside it.
+- It is recommended to use this activity inside an `ExcelProcessScopeX` or `SequenceX` for better Excel process lifecycle management. A design-time warning is shown if not.
+- When opening URLs (SharePoint), the file is opened in read-only mode and paths longer than 255 characters are rejected.
+- The `CreateNewFile` option is not supported with URL-based paths.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExcelForEachRowX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExcelForEachRowX.md
@@ -1,0 +1,71 @@
+# For Each Excel Row
+
+`UiPath.Excel.Activities.Business.ExcelForEachRowX`
+
+Repeats the contained activities once for each row in the specified sheet, range, or table.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | In range | InArgument | `IReadRangeRef` | Yes | | Sheet, range, or table to repeat actions for each row. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `False` | The first row in the range is a header row. |
+| `EmptyRowBehavior` | Empty row behavior | `EmptyRowBehavior` | `Stop` | Desired action when an empty row is reached in the specified range. |
+| `SaveAfterEachRow` | Save after each row | `bool` | `False` | Saves the workbook after running the actions for each row. Otherwise workbook is saved when all actions for the Excel file finish. |
+
+### Body
+| Name | Type | Description |
+|------|------|-------------|
+| `Body` | `ActivityAction<CurrentRowQuickHandle, int>` | The activities to execute for each row. Exposes `CurrentRow` (the current row handle) and `CurrentIndex` (the row index) as iteration variables. |
+
+### Enum Reference
+
+#### `EmptyRowBehavior`
+| Value | Display Name |
+|-------|-------------|
+| `StopAfterThreeConsecutiveEmptyRows` | Stop after 3 consecutive empty rows |
+| `Stop` | Stop |
+| `Skip` | Skip |
+| `Process` | Process |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:ExcelForEachRowX
+    Range="[MyRange]"
+    HasHeaders="True"
+    EmptyRowBehavior="Stop"
+    SaveAfterEachRow="False"
+    DisplayName="For Each Excel Row">
+    <excel:ExcelForEachRowX.Body>
+      <ActivityAction x:TypeArguments="excel:CurrentRowQuickHandle, x:Int32">
+        <ActivityAction.Argument1>
+          <DelegateInArgument x:TypeArguments="excel:CurrentRowQuickHandle" Name="CurrentRow" />
+        </ActivityAction.Argument1>
+        <ActivityAction.Argument2>
+          <DelegateInArgument x:TypeArguments="x:Int32" Name="CurrentIndex" />
+        </ActivityAction.Argument2>
+        <Sequence DisplayName="Do">
+          <!-- Activities to execute per row go here -->
+        </Sequence>
+      </ActivityAction>
+    </excel:ExcelForEachRowX.Body>
+  </excel:ExcelForEachRowX>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The iteration variable name defaults to `CurrentRow` and can be renamed in the designer via the "For each" property.
+- The `CurrentIndex` variable provides the 1-based index of the current row within the iteration (the first processed row has `CurrentIndex` = 1).
+- When `HasHeaders` is `True` and the source is a range (not a table), the first row is treated as a header and iteration starts from the second row.
+- When `SaveAfterEachRow` is `False`, auto-save is disabled during iteration and re-enabled after the loop completes, which improves performance for large datasets.
+- The variable name for the iterator must be a valid identifier; otherwise, a validation error is raised.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExcelProcessScopeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExcelProcessScopeX.md
@@ -1,0 +1,86 @@
+# Excel Process Scope
+
+`UiPath.Excel.Activities.Business.ExcelProcessScopeX`
+
+Manages the lifecycle of an Excel process instance. All `ExcelApplicationCard` activities placed inside this scope share the same Excel process, providing fine-grained control over how Excel is started, reused, and closed.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** None (this is a scope activity itself)
+
+## Properties
+
+### Options
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ProcessMode` | Process mode | Property | `ExcelProcessMode?` | No | `null` (Same as project) | Controls whether the Excel process scope creates a new process, reuses an existing process if available, or ensures a unique process for attended users. |
+| `LaunchMethod` | Launch method | Property | `ExcelStartMethod?` | No | `null` (Same as project) | Controls how the Excel process will be launched. Either via COM, or as a full process. |
+| `LaunchTimeout` | Launch timeout | Property | `int?` | No | `null` (Same as project) | Time to wait for Excel to start if launched as a full process. The default is 20 seconds. |
+| `FileConflictResolution` | File conflict resolution | Property | `ExcelFileConflictResolution?` | No | `null` (Same as project) | Action to be executed if Excel document conflicts are detected between Excel processes. |
+| `ExistingProcessAction` | Existing processes action | Property | `ExistingExcelProcessAction?` | No | `null` (Same as project) | Action to be executed if other Excel processes are running. |
+| `DisplayAlerts` | Display alerts | Property | `bool?` | No | `null` (Same as project) | If true, Microsoft Excel can display alerts and messages. The default is False. |
+| `ShowExcelWindow` | Show Excel window | Property | `bool?` | No | `null` (Same as project) | If true, Excel windows will appear during automation. The default is True. |
+| `MacroSettings` | Macro settings | Property | `MacroSetting?` | No | `null` (Same as project) | Enable or disable Macros. Default is Enable all. |
+
+## Enum Reference
+
+#### `ExcelProcessMode`
+| Value | Display Name |
+|-------|-------------|
+| `AlwaysCreateNew` | Always create new |
+| `AttendedUser` | Attended user |
+| `ReuseIfExists` | Reuse if exists |
+| `OnlyIfExists` | Only if exists |
+
+#### `ExcelStartMethod`
+| Value | Display Name |
+|-------|-------------|
+| `Automation` | Automation (COM) |
+| `Application` | Application (full process) |
+
+#### `ExcelFileConflictResolution`
+| Value | Display Name |
+|-------|-------------|
+| `None` | None |
+| `CloseWithoutSaving` | Close without saving |
+| `PromptUser` | Prompt user |
+| `ThrowException` | Throw exception |
+
+#### `ExistingExcelProcessAction`
+| Value | Display Name |
+|-------|-------------|
+| `None` | None |
+| `ForceKill` | Force kill |
+
+#### `MacroSetting`
+| Value | Display Name |
+|-------|-------------|
+| `EnableAll` | Enable all |
+| `DisableAll` | Disable all |
+| `ReadFromExcelSettings` | Read from Excel settings |
+
+## XAML Example
+```xml
+<excel:ExcelProcessScopeX
+  ProcessMode="{x:Null}"
+  LaunchMethod="{x:Null}"
+  DisplayName="Excel Process Scope">
+  <excel:ExcelProcessScopeX.Body>
+    <ActivityAction x:TypeArguments="excel:IExcelProcess">
+      <ActivityAction.Argument>
+        <DelegateInArgument x:TypeArguments="excel:IExcelProcess" Name="ExcelProcessScopeTag" />
+      </ActivityAction.Argument>
+      <Sequence DisplayName="Do">
+        <!-- ExcelApplicationCard activities here -->
+      </Sequence>
+    </ActivityAction>
+  </excel:ExcelProcessScopeX.Body>
+</excel:ExcelProcessScopeX>
+```
+
+## Notes
+- All nullable properties default to project-level settings when left unset (`null`).
+- The `Body` property is hidden in the designer.
+- When the scope completes or faults, it automatically quits the Excel process it manages.
+- The `ProcessMode` controls whether existing Excel processes are reused or new ones are created.
+- If `ProcessMode` is set to `AttendedUser`, the `FileConflictResolution` value is ignored and treated as `PromptUser`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExecuteMacroX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExecuteMacroX.md
@@ -1,0 +1,58 @@
+# Run Spreadsheet Macro
+
+`UiPath.Excel.Activities.Business.ExecuteMacroX`
+
+Executes a specified macro within a macro-enabled workbook.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook name | InArgument | `IWorkbookQuickHandle` | Yes | | Workbook containing the macro to execute. |
+| `MacroName` | Macro name | InArgument | `string` | Yes | | Name of the macro to run. |
+
+### Designer Controls (Not Mapped to XAML)
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `AddMacroArgument` | Add Macro Argument | Action Button | Inserts a new `ExecuteMacroArgumentX` child activity to pass an argument to the macro. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Macro result | `OutArgument` | Save the value returned by the macro (if any). |
+
+## Child Activity: ExecuteMacroArgumentX
+
+`UiPath.Excel.Activities.Business.ExecuteMacroArgumentX`
+
+Each child activity represents a single argument passed to the macro. Add one per argument using the **Add Macro Argument** button.
+
+| Name | Display Name | Kind | Type | Required | Description |
+|------|-------------|------|------|----------|-------------|
+| `ArgumentValue` | Argument value | InArgument | `object` | Yes | The value to be passed to the input argument of the macro. |
+
+## XAML Example
+```xml
+<excel:ExecuteMacroX
+  DisplayName="Run Spreadsheet Macro"
+  Workbook="[workbookHandle]"
+  MacroName="[&quot;MyMacro&quot;]"
+  Result="[macroResult]">
+  <excel:ExecuteMacroX.Body>
+    <excel:ExecuteMacroArgumentX
+      DisplayName="Macro Argument"
+      ArgumentValue="[argValue]" />
+  </excel:ExecuteMacroX.Body>
+</excel:ExecuteMacroX>
+```
+
+## Notes
+- This activity supports child `ExecuteMacroArgumentX` activities to pass arguments to the macro.
+- Use the **Add Macro Argument** action button in the designer to add arguments.
+- The maximum number of macro arguments is limited by `ExcelConstants.MaxNumberOfMacroArguments`.
+- The `Result` output is a non-generic `OutArgument`; the actual type depends on what the macro returns.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExportExcelToCsvX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ExportExcelToCsvX.md
@@ -1,0 +1,32 @@
+# Export to CSV
+
+`UiPath.Excel.Activities.Business.ExportExcelToCsvX`
+
+Exports the specified range, table, pivotTable or sheet to a CSV file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | Write to what file | InArgument | `string` | Yes | | The file path where the CSV file will be written. |
+| `TargetRange` | Write from | InArgument | `IReadRangeRef` | Yes | | The range, table, pivot table, or sheet to export. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:ExportExcelToCsvX
+    FilePath="[&quot;C:\Output\data.csv&quot;]"
+    TargetRange="[MyRange]"
+    DisplayName="Export to CSV" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The file path must point to a valid location with an existing parent folder; otherwise, an exception is thrown.
+- For sheets, the entire sheet is exported as CSV. For ranges, tables, and pivot tables, only the specified data is exported.
+- The target range must be valid; otherwise, an `ArgumentNullException` is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FillRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FillRangeX.md
@@ -1,0 +1,33 @@
+# Fill Range
+
+`UiPath.Excel.Activities.Business.FillRangeX`
+
+Enters a formula or value in all the cells in a range.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `DestinationRange` | Where to write | InArgument | `IWellDefinedReadWriteRangeRef` | Yes | | Range to fill with the formula or value. |
+| `Value` | What to write | InArgument | `object` | Yes | | Formula or value to add to the cells in the range. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:FillRangeX
+    DestinationRange="[MyRange]"
+    Value="=SUM(A1:A10)"
+    DisplayName="Fill Range" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `Value` property accepts both literal values and Excel formulas (prefixed with `=`).
+- The value is converted to a string representation before being written to each cell in the range.
+- The destination range must be a well-defined range (not an entire sheet); otherwise, a validation error is raised.
+- The activity supports cancellation and checks for cancellation requests during execution.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FilterPivotTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FilterPivotTableX.md
@@ -1,0 +1,75 @@
+# Filter Pivot Table
+
+`UiPath.Excel.Activities.Business.FilterPivotTableX`
+
+Applies a filter to a specified column of a pivot table, or clears any existing filter on that column.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Table` | Pivot table to filter | InArgument | `IPivotTableRef` | Yes | | The pivot table to filter. |
+| `ColumnName` | Column name | InArgument | `string` | Yes | | The column used as a filter in the pivot table. |
+
+### Options
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ClearFilter` | Clear any existing filter | Property | `bool` | No | `False` | Clear any existing filters applied to the target range. |
+
+### Designer Controls
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `BasicFilter` | Basic filter | `ExcelFilterSettings` (NotMapped) | Configures the filter values to apply. Only visible when ClearFilter is False. |
+
+### Internal
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `FilterArgument` | (hidden) | Property | `FilterArgument` | Stores the filter configuration. Not visible in the designer. |
+
+## Conditional Visibility
+
+- `BasicFilter` is hidden when `ClearFilter` is `True`.
+- `FilterArgument` is always hidden (serialized internally).
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:FilterPivotTableX
+    Table="[pivotTableRef]"
+    ColumnName="Region"
+    ClearFilter="False"
+    DisplayName="Filter Pivot Table">
+    <excel:FilterPivotTableX.FilterArgument>
+      <excel:FilterArgument>
+        <excel:FilterArgument.BasicFiltersArgument>
+          <excel:BasicFiltersArgument>
+            <!-- filter values configured here -->
+          </excel:BasicFiltersArgument>
+        </excel:FilterArgument.BasicFiltersArgument>
+      </excel:FilterArgument>
+    </excel:FilterPivotTableX.FilterArgument>
+  </excel:FilterPivotTableX>
+</excel:ExcelApplicationCard>
+```
+
+### Clear filter variant
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:FilterPivotTableX
+    Table="[pivotTableRef]"
+    ColumnName="Region"
+    ClearFilter="True"
+    DisplayName="Clear Pivot Table Filter" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `ColumnName` is required and validated at design time; an error is shown if it is empty.
+- When `ClearFilter` is `False`, at least one filter value must be provided; otherwise a validation error occurs.
+- The pivot table must exist on the specified worksheet; otherwise an `ArgumentException` is thrown.
+- The pivot table reference must include a valid address, worksheet, and parent handle.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FilterX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FilterX.md
@@ -1,0 +1,97 @@
+# Filter
+
+`UiPath.Excel.Activities.Business.FilterX`
+
+Creates a filter in a range, table, or sheet based on the values in a single column. Can also be used to clear existing filters.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Source range | InArgument | `IReadWriteRangeRef` | Yes | | The sheet, range, or table to filter. |
+| `ColumnName` | Column name | InArgument | `string` | Yes (when not clearing) | | The column containing the values to filter. Required when `ClearFilter` is `False`. When `ClearFilter` is `True`, if provided, only the specified column's filter is cleared; otherwise all filters are cleared. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ClearFilter` | Clear any existing filter | `bool` | `False` | Clear any existing filters already applied to the target range. |
+| `UseAdvancedFilter` | Use advanced filter | `bool` | `False` | Switch between basic and advanced filter modes. Hidden when `ClearFilter` is `True`. |
+| `BasicFilter` | Basic filter | `ExcelFilterSettings` | | A list of values to match against. Rows matching any of the listed values are shown. Visible when `ClearFilter` is `False` and `UseAdvancedFilter` is `False`. |
+| `AdvancedFilter` | Advanced filter | `ExcelFilterSettings` | | One or two conditions using operators (e.g., equals, greater than, starts with) combined with a logical operator (And/Or). Visible when `ClearFilter` is `False` and `UseAdvancedFilter` is `True`. |
+
+## Valid Configurations
+
+- **Clear all filters:** Set `ClearFilter` to `True` and leave `ColumnName` empty.
+- **Clear a specific column filter:** Set `ClearFilter` to `True` and specify `ColumnName`.
+- **Basic filter:** Set `ClearFilter` to `False`, `UseAdvancedFilter` to `False`, and configure `BasicFilter` with a list of values.
+- **Advanced filter:** Set `ClearFilter` to `False`, `UseAdvancedFilter` to `True`, and configure `AdvancedFilter` with one or two conditions.
+
+### Enum Reference
+
+#### `FilterMode`
+| Value | Display Name |
+|-------|-------------|
+| `Basic` | Basic |
+| `Advanced` | Advanced |
+
+#### `LogicalOperator`
+| Value | Display Name |
+|-------|-------------|
+| `And` | And |
+| `Or` | Or |
+
+#### `ExcelFilterOperator`
+| Value | Display Name |
+|-------|-------------|
+| `NONE` | None |
+| `LT` | < |
+| `GT` | > |
+| `LTE` | <= |
+| `GTE` | >= |
+| `EQ` | = |
+| `NOTEQ` | != |
+| `EMPTY` | Is Empty |
+| `NOTEMPTY` | Is Not Empty |
+| `STARTSWITH` | Starts With |
+| `ENDSWITH` | Ends With |
+| `CONTAINS` | Contains |
+| `NOTSTARTSWITH` | Does Not Start With |
+| `NOTENDSWITH` | Does Not End With |
+| `NOTCONTAINS` | Does Not Contain |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <!-- Basic filter example -->
+  <excel:FilterX
+    Range="[MyRange]"
+    ColumnName="Status"
+    ClearFilter="False"
+    DisplayName="Filter">
+    <excel:FilterX.FilterArgument>
+      <excel:FilterArgument Mode="Basic">
+        <excel:FilterArgument.BasicFiltersArgument>
+          <excel:BasicFilterArgument>
+            <excel:BasicFilterArgument.BasicFilters>
+              <InArgument x:TypeArguments="x:String">Active</InArgument>
+              <InArgument x:TypeArguments="x:String">Pending</InArgument>
+            </excel:BasicFilterArgument.BasicFilters>
+          </excel:BasicFilterArgument>
+        </excel:FilterArgument.BasicFiltersArgument>
+      </excel:FilterArgument>
+    </excel:FilterX.FilterArgument>
+  </excel:FilterX>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `FilterArgument` property is not directly visible in the designer; instead, the designer exposes `BasicFilter` and `AdvancedFilter` views.
+- The `HasHeaders` property is always `True` and not exposed in the designer.
+- When clearing filters, if `ColumnName` is omitted, all column filters on the range are cleared.
+- The filter range cannot overlap any existing Excel tables.
+- Advanced filter supports up to two conditions linked by an `And`/`Or` logical operator.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FindFirstLastDataRowX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FindFirstLastDataRowX.md
@@ -1,0 +1,65 @@
+# Find First/Last Data Row
+
+`UiPath.Excel.Activities.Business.FindFirstLastDataRowX`
+
+Finds the first and the last rows containing data in a given sheet, range or table.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Source range | InArgument | `IReadRangeRef` | Yes | | Range to search. |
+| `ColumnName` | Column name | InArgument | `string` | Yes | | Column to search for data values. |
+| `FirstRowOffset` | First row offset | Property | `int` | No | `0` | Adds the number specified to the first row containing data. Enables scenarios such as "find the 3rd row containing data". |
+| `LastRowOffset` | Last row offset | Property | `int` | No | `0` | Subtracts the number specified to the last row containing data. Enables scenarios such as "find the 4th row from the bottom". |
+| `BlankRowsToSkip` | Blank rows to skip | Property | `int` | No | `1` | Consecutive blank rows allowed in the data prior to determining the data in the range has ended. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `True` | Indicates if first row in the range is a header row. |
+| `ConfigureLastRowAs` | Configure last row as | `LastRowConfiguration` | `LastPopulatedRow` | Configure whether we want to return the last row as the last populated row or return the first row that is empty. |
+| `VisibleRowsOnly` | Visible rows only | `bool` | `False` | Use only the visible rows, taking into account filters applied and ignoring hidden values. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `FirstRowIndex` | First row index | `int` | Number of the first non-blank row in the range. If no data is found, the value will be -1. |
+| `LastRowIndex` | Last row index | `int` | Number of the last non-blank row in the range. If no data is found, the value will be -1. |
+
+### Enum Reference
+
+#### `LastRowConfiguration`
+| Value | Display Name |
+|-------|-------------|
+| `LastPopulatedRow` | Last populated row |
+| `FirstEmptyRow` | First empty row |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:FindFirstLastDataRowX
+    Range="[MyRange]"
+    ColumnName="Name"
+    FirstRowOffset="0"
+    LastRowOffset="0"
+    BlankRowsToSkip="1"
+    HasHeaders="True"
+    ConfigureLastRowAs="LastPopulatedRow"
+    VisibleRowsOnly="False"
+    FirstRowIndex="[FirstRow]"
+    LastRowIndex="[LastRow]"
+    DisplayName="Find First/Last Data Row" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `ColumnName` must reference a valid column in the range. For tables, use the table column name. For ranges with headers, use the header value. For ranges without headers, use the column letter.
+- If no data is found in the specified column, both `FirstRowIndex` and `LastRowIndex` return `-1`.
+- Negative values for `BlankRowsToSkip` are treated as `0`.
+- The activity handles ranges, tables, and pivot tables, each resolving the target column address differently.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FindReplaceValueX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FindReplaceValueX.md
@@ -1,0 +1,66 @@
+# Find/Replace Value
+
+`UiPath.Excel.Activities.Business.FindReplaceValueX`
+
+Searches in a specified range for a certain value. Depending on the Operation chosen, it either returns the location of the cell or it replaces the value(s) with another given value.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Operation` | Operation | Property | `FindReplaceOptions` | Yes | `Find` | Depending on the Operation chosen, it either returns the location of the cell or it replaces the value(s) with another given value. |
+| `WhereToSearch` | Where to search | InArgument | `IReadRangeRef` | Yes | | Range where to search the value. |
+| `ValueToFind` | Value to find | InArgument | `object` | Yes | | Value to search for. |
+| `ReplaceWith` | Replace with | InArgument | `object` | No | | Value to replace with. |
+| `LookIn` | Look in | Property | `LookInOptions` | No | `Values` | To search for data with specific details, in the box, click Formulas, Values. |
+| `MatchCase` | Match case | Property | `bool` | No | `False` | Check this if you want to search for case-sensitive data. |
+| `MatchEntireCellContents` | Match entire cell contents | Property | `bool` | No | `False` | Check this if you want to search for cells that contain just the characters that you typed in the Value to find field. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `FoundAt` | Found at | `string` | Address where the value was found. |
+
+### Enum Reference
+
+#### `FindReplaceOptions`
+| Value | Display Name |
+|-------|-------------|
+| `Find` | Find |
+| `Replace` | Replace |
+| `ReplaceAll` | Replace all |
+
+#### `LookInOptions`
+| Value | Display Name |
+|-------|-------------|
+| `Values` | Values |
+| `Formulas` | Formulas |
+
+## Valid Configurations
+
+- When `Operation` is `Replace` or `ReplaceAll`, `LookIn` must be set to `Values`. Attempting to replace in `Formulas` raises a validation error.
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:FindReplaceValueX
+    Operation="Find"
+    WhereToSearch="[MyRange]"
+    ValueToFind="SearchText"
+    LookIn="Values"
+    MatchCase="False"
+    MatchEntireCellContents="False"
+    FoundAt="[ResultAddress]"
+    DisplayName="Find/Replace Value" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `ValueToFind` must not be null or empty; otherwise, an `ArgumentException` is thrown.
+- Replace operations (`Replace` and `ReplaceAll`) only work when `LookIn` is set to `Values`. A design-time validation error is raised if `LookIn` is set to `Formulas` with a replace operation.
+- The `FoundAt` output contains the cell address (e.g., `$A$1`) where the value was found, or `null` if not found.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ForEachSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ForEachSheetX.md
@@ -1,0 +1,54 @@
+# For Each Excel Sheet
+
+`UiPath.Excel.Activities.Business.ForEachSheetX`
+
+Repeats actions for each sheet in an Excel workbook.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | The source workbook for the sheets. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `VariableName` | For each | `string` | `"CurrentSheet"` | Name of the variable representing the current sheet in the loop body. |
+
+### Loop Variables
+| Name | Type | Description |
+|------|------|-------------|
+| `CurrentSheet` | `WorksheetQuickHandle` | The current sheet in the iteration. |
+| `CurrentIndex` | `int` | The 1-based index of the current sheet. |
+
+## XAML Example
+```xml
+<excel:ForEachSheetX
+  DisplayName="For Each Excel Sheet"
+  Workbook="[workbookHandle]">
+  <excel:ForEachSheetX.Body>
+    <ActivityAction x:TypeArguments="excel:WorksheetQuickHandle, x:Int32">
+      <ActivityAction.Argument1>
+        <DelegateInArgument x:TypeArguments="excel:WorksheetQuickHandle" Name="CurrentSheet" />
+      </ActivityAction.Argument1>
+      <ActivityAction.Argument2>
+        <DelegateInArgument x:TypeArguments="x:Int32" Name="CurrentIndex" />
+      </ActivityAction.Argument2>
+      <Sequence DisplayName="Do">
+        <!-- Activities to execute for each sheet -->
+      </Sequence>
+    </ActivityAction>
+  </excel:ForEachSheetX.Body>
+</excel:ForEachSheetX>
+```
+
+## Notes
+- Only visible sheets are iterated; hidden sheets are skipped.
+- The loop variable name defaults to `CurrentSheet` but can be renamed in the designer.
+- The `CurrentIndex` variable is 1-based.
+- The activity sets each sheet as the active sheet before executing the body.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FormatRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/FormatRangeX.md
@@ -1,0 +1,155 @@
+# Format Range
+
+`UiPath.Excel.Activities.Business.FormatRangeX`
+
+Sets the format for all the cells in a specified range.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Source range | InArgument | `IReadRangeRef` | Yes | | The range to format. |
+
+### Format Settings
+
+The Format section is organized into three tabs: **Data Type**, **Alignment**, and **Font**. A tab selector (`FormatType`) controls which tab is displayed.
+
+#### Format Tab Selector
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FormatType` | Format | `CellFormatType` | `DataType` | Selects the active format settings tab. |
+
+#### Data Type Tab
+| Name | Display Name | Type | Default | Visible When | Description |
+|------|-------------|------|---------|------------|-------------|
+| `CategoryType` | Category | `CellFormat` | `General` | Always (within Data Type tab) | The cell format category. |
+| `NumberDecimalPlaces` | Decimals | `int` | `2` | CategoryType = Number | Number of decimal places. |
+| `NumberUseThousandSeparator` | Use 1000 Separator | `bool` | `False` | CategoryType = Number | Use a thousand separator. |
+| `CurrencyDecimalPlaces` | Decimals | `int` | `2` | CategoryType = Currency | Number of decimal places for currency. |
+| `CurrencyUseThousandSeparator` | Use 1000 Separator | `bool` | `False` | CategoryType = Currency | Use a thousand separator for currency. |
+| `CurrencySymbol` | Symbol | `string` | `$` | CategoryType = Currency | The currency symbol. |
+| `CurrencySetAtTheEnd` | Set at the end | `bool` | `False` | CategoryType = Currency | Place the currency symbol after the value. |
+| `PercentageDecimalPlaces` | Decimals | `int` | `2` | CategoryType = Percentage | Number of decimal places for percentage. |
+| `DateType` | Date format | `DateType` | `Short` | CategoryType = Date | The date format to use. |
+| `TimeType` | Time format | `TimeType` | `HoursMinutes` | CategoryType = Time | The time format to use. |
+| `TimeIsAMPM` | AM/PM | `bool` | `False` | CategoryType = Time | Use 12-hour AM/PM format. |
+| `CustomFormatAsString` | Custom format | `string` | `#,##0_);[Red](#,##0)` | CategoryType = Custom | A custom Excel format string. |
+
+#### Alignment Tab
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HorizontalAlignment` | Horizontal | `ExcelRangeHorizontalAlignment` | `xlHAlignGeneral` | Horizontal alignment for cell content. |
+| `VerticalAlignment` | Vertical | `ExcelRangeVerticalAlignment` | `xlVAlignBottom` | Vertical alignment for cell content. |
+| `WrapText` | Wrap text | `bool` | `False` | Wrap text within the cell. |
+
+#### Font Tab
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FontFamily` | Font | `string` | `Calibri` | The font family name. |
+| `FontStyle` | Font style | `ExcelRangeFontStyle` | `Regular` | The font style. |
+| `FontSize` | Font size | `double` | `11` | The font size in points. |
+| `FontColor` | Font color | `string` | `Black` | The font color (system color name). |
+| `FontFillColor` | Fill color | `string` | `Transparent` | The cell background fill color (system color name). |
+| `FontUnderlineStyle` | Underline style | `ExcelRangeUnderlineStyle` | `None` | The underline style for the font. |
+
+### Enum Reference
+
+#### `CellFormatType`
+| Value | Display Name |
+|-------|-------------|
+| `DataType` | Data Type |
+| `Alignment` | Alignment |
+| `Font` | Font |
+
+#### `CellFormat`
+| Value | Display Name |
+|-------|-------------|
+| `General` | General |
+| `Number` | Number |
+| `Date` | Date |
+| `Time` | Time |
+| `Percentage` | Percentage |
+| `Currency` | Currency |
+| `Text` | Text |
+| `Custom` | Custom |
+
+#### `DateType`
+| Value | Display Name |
+|-------|-------------|
+| `Long` | Long |
+| `Short` | Short |
+
+#### `TimeType`
+| Value | Display Name |
+|-------|-------------|
+| `HoursMinutes` | Hours:Minutes |
+| `HoursMinutesSeconds` | Hours:Minutes:Seconds |
+
+#### `ExcelRangeHorizontalAlignment`
+| Value | Display Name |
+|-------|-------------|
+| `xlHAlignGeneral` | General |
+| `xlHAlignLeft` | Left |
+| `xlHAlignCenter` | Center |
+| `xlHAlignRight` | Right |
+| `xlHAlignFill` | Fill |
+| `xlHAlignJustify` | Justify |
+| `xlHAlignCenterAcrossSelection` | Center Across Selection |
+| `xlHAlignDistributed` | Distributed |
+
+#### `ExcelRangeVerticalAlignment`
+| Value | Display Name |
+|-------|-------------|
+| `xlVAlignTop` | Top |
+| `xlVAlignCenter` | Center |
+| `xlVAlignBottom` | Bottom |
+| `xlVAlignJustify` | Justify |
+| `xlVAlignDistributed` | Distributed |
+
+#### `ExcelRangeFontStyle`
+| Value | Display Name |
+|-------|-------------|
+| `Regular` | Regular |
+| `Italic` | Italic |
+| `Bold` | Bold |
+| `BoldItalic` | Bold Italic |
+
+#### `ExcelRangeUnderlineStyle`
+| Value | Display Name |
+|-------|-------------|
+| `None` | None |
+| `Single` | Single |
+| `Double` | Double |
+| `SingleAccounting` | Single Accounting |
+| `DoubleAccounting` | Double Accounting |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:FormatRangeX
+    Range="[MyRange]"
+    DisplayName="Format Range">
+    <excel:FormatRangeX.Format>
+      <excel:NumberFormat DecimalPlaces="2" UseThousandSeparator="True" />
+    </excel:FormatRangeX.Format>
+    <excel:FormatRangeX.Alignment>
+      <excel:AlignmentOptions HorizontalAlignment="xlHAlignCenter" VerticalAlignment="xlVAlignCenter" WrapText="False" />
+    </excel:FormatRangeX.Alignment>
+    <excel:FormatRangeX.Font>
+      <excel:FontOptions FontFamilyName="Calibri" Style="Bold" Size="12" Color="Black" FillColor="Transparent" UnderlineStyle="None" />
+    </excel:FormatRangeX.Font>
+  </excel:FormatRangeX>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `Format`, `Alignment`, and `Font` properties are not directly visible in the designer; instead, the designer presents them as tabbed sections within the **Format** category.
+- Only one format settings tab is visible at a time, controlled by the `FormatType` selector.
+- The `CategoryType` selection (General, Number, Date, etc.) determines which sub-properties are shown within the Data Type tab.
+- A format must be selected; leaving the `Format` property null causes a validation error.
+- The `Format` property defaults to `GeneralFormat`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetCellColor.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetCellColor.md
@@ -1,0 +1,47 @@
+# Get Cell Color Workbook
+
+`UiPath.Excel.Activities.GetCellColor`
+
+Gets the background color of a specified cell in a spreadsheet.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `Cell` | Cell | InArgument | `string` | Yes | | The cell to get the color from (e.g. "A1") |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Color` | Color | `System.Drawing.Color` | The background color of the specified cell |
+
+## XAML Example
+
+```xml
+<excel:GetCellColor
+  DisplayName="Get Cell Color Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  Cell="[&quot;A1&quot;]"
+  Color="[cellColor]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetCellColorX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetCellColorX.md
@@ -1,0 +1,34 @@
+# Get Cell Color
+
+`UiPath.Excel.Activities.GetCellColorX`
+
+Reads the background color of a specified Excel cell and outputs it as a `System.Drawing.Color` value.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Cell` | Cell | InArgument | `IReadCellRef` | Yes | | The address of the cell from which to read the value. |
+
+### Output
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `OutputColor` | Saved Color | OutArgument | `System.Drawing.Color` | Where to save the Color of the specified cell. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:GetCellColorX
+    Cell="[cellRef]"
+    OutputColor="[outputColor]"
+    DisplayName="Get Cell Color" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `Cell` must be a valid single-cell reference; otherwise a runtime error is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetSelectedRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetSelectedRangeX.md
@@ -1,0 +1,34 @@
+# Get Selected Range
+
+`UiPath.Excel.Activities.Windows.Business.GetSelectedRangeX`
+
+Get the selected range from the target Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Target Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | The workbook from which to get selected range. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Range` | Range | `OutArgument<IReadRangeRef>` | The selected range. |
+
+## XAML Example
+```xml
+<excelwin:GetSelectedRangeX
+  Workbook="[CurrentWorkbook]"
+  Range="[SelectedRange]"
+  DisplayName="Get Selected Range"
+  xmlns:excelwin="clr-namespace:UiPath.Excel.Activities.Windows.Business;assembly=UiPath.Excel.Activities" />
+```
+
+## Notes
+- The `Workbook` property is auto-filled from the parent `ExcelApplicationCard` scope.
+- Returns the currently selected range in the active workbook as an `IReadRangeRef` that can be passed to other range activities.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetSensitivityLabelX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetSensitivityLabelX.md
@@ -1,0 +1,33 @@
+# Get Excel Sensitivity Label
+
+`UiPath.Excel.Activities.Business.GetSensitivityLabelX`
+
+Retrieves the sensitivity label from an Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | Workbook handle obtained from an `ExcelApplicationCard`. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SensitivityLabel` | Sensitivity label | `OutArgument<IExcelLabelObject>` | Instance of IExcelLabelObject where to store the sensitivity label. |
+
+## XAML Example
+```xml
+<excel:GetSensitivityLabelX
+  DisplayName="Get Excel Sensitivity Label"
+  Workbook="[workbookHandle]"
+  SensitivityLabel="[labelOutput]" />
+```
+
+## Notes
+- The output `SensitivityLabel` contains an `IExcelLabelObject` with the label ID and justification.
+- Returns `null` if no sensitivity label is applied to the workbook.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetSheets.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetSheets.md
@@ -1,0 +1,45 @@
+# Get Sheets Workbook
+
+`UiPath.Excel.Activities.GetSheets`
+
+Gets the list of sheet names from a workbook.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `OnlyVisibleSheets` | Visible sheets only | `bool` | `False` | When True, only returns visible sheets (excludes hidden and very hidden sheets) |
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Sheets | `IEnumerable<string>` | The list of sheet names in the workbook |
+
+## XAML Example
+
+```xml
+<excel:GetSheets
+  DisplayName="Get Sheets Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  Result="[sheetNames]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- `SheetName` is not used by this activity (hidden in the designer).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetTableRange.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/GetTableRange.md
@@ -1,0 +1,49 @@
+# Get Table Range Workbook
+
+`UiPath.Excel.Activities.GetTableRange`
+
+Extracts the range of an Excel table from a specified spreadsheet.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `TableName` | TableName | InArgument | `string` | Yes | | The name of the table |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `IsPivot` | IsPivot | `bool` | | Indicates whether the table is a pivot table |
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Range` | Range | `string` | The range of the specified table (e.g. "A1:D10") |
+
+## XAML Example
+
+```xml
+<excel:GetTableRange
+  DisplayName="Get Table Range Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  TableName="[&quot;SalesTable&quot;]"
+  Range="[tableRange]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- Set `IsPivot` to `True` when the target table is a pivot table.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertChart.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertChart.md
@@ -1,0 +1,74 @@
+# Insert Chart Workbook
+
+`UiPath.Excel.Activities.InsertChart`
+
+Inserts a chart into a workbook based on data from a sheet range or named table.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `UseTableSource` | Use table source | Property | `bool` | | `False` | When True, uses a named table as the data source instead of sheet/range |
+| `SourceSheet` | Source sheet | InArgument | `string` | | | The sheet containing the chart data. Visible when `UseTableSource` is False |
+| `SourceRange` | Source range | InArgument | `string` | | | The range of source data. Visible when `UseTableSource` is False |
+| `SourceTable` | Source table name | InArgument | `string` | | | Name of the source table. Visible when `UseTableSource` is True |
+| `SheetName` | Insert into sheet | InArgument | `string` | Yes | `"Sheet1"` | The sheet where the chart will be placed |
+| `ChartCategory` | Chart category | Property | `ExcelChartCategory` | Yes | `Column` | The chart category (e.g. Column, Bar, Line, Pie) |
+| `ChartType` | Chart type | Property | `ExcelChartType` | Yes | `xlColumnClustered` | The specific chart type within the selected category |
+| `ChartHeight` | Chart height | InArgument | `int` | Yes | `211` | The height of the chart in pixels |
+| `ChartWidth` | Chart width | InArgument | `int` | Yes | `355` | The width of the chart in pixels |
+| `Left` | Chart left | InArgument | `int` | Yes | `60` | The left position of the chart in pixels |
+| `Top` | Chart top | InArgument | `int` | Yes | `20` | The top position of the chart in pixels |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `ChartName` | Save chart to | `string` | The name of the inserted chart, for use with Update Chart |
+
+## Valid Configurations
+
+This activity supports two data source modes controlled by `UseTableSource`:
+
+**Mode A — Sheet Range** (default): Set `SourceSheet` and `SourceRange`. `SourceTable` is hidden.
+**Mode B — Named Table**: Set `UseTableSource` to True and provide `SourceTable`. `SourceSheet` and `SourceRange` are hidden.
+
+### Conditional Properties
+
+- **`ChartType`** — The available chart types change based on the selected `ChartCategory`. When `ChartCategory` changes, the `ChartType` dropdown is filtered to show only types in that category.
+
+## XAML Example
+
+```xml
+<excel:InsertChart
+  DisplayName="Insert Chart Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SourceSheet="[&quot;Data&quot;]"
+  SourceRange="[&quot;A1:C10&quot;]"
+  SheetName="[&quot;Charts&quot;]"
+  ChartCategory="Column"
+  ChartType="xlColumnClustered"
+  ChartHeight="[400]"
+  ChartWidth="[600]"
+  Left="[10]"
+  Top="[10]"
+  ChartName="[insertedChartName]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertColumnX.md
@@ -1,0 +1,87 @@
+# Insert Column
+
+`UiPath.Excel.Activities.Business.InsertColumnX`
+
+Inserts a column in a sheet, table, or range at the specified location.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Range | InArgument | `IReadWriteRangeRef` | Yes | | Range in which the column will be inserted. |
+| `RelativeColumnName` | Relative to column | InArgument | `string` | Yes | | Column next to which the new column will be inserted. |
+| `RelativePosition` | Where to insert | Property | `ColumnRelativePosition` | Yes | | Before or after the 'Relative to column'. |
+| `NewColumnName` | Add header | InArgument | `string` | No | | Value to use for the header row. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `True` | The first row in the range is a header row. |
+
+### Format Settings
+
+This activity supports the **Data Type** format tab only (no Alignment or Font tabs). The `FormatType` selector is hidden since only one option is available.
+
+#### Data Type Tab
+| Name | Display Name | Type | Default | Visible When | Description |
+|------|-------------|------|---------|------------|-------------|
+| `CategoryType` | Category | `CellFormat` | `General` | Always (within Data Type tab) | The cell format category for the new column. |
+| `NumberDecimalPlaces` | Decimals | `int` | `2` | CategoryType = Number | Number of decimal places. |
+| `NumberUseThousandSeparator` | Use 1000 Separator | `bool` | `False` | CategoryType = Number | Use a thousand separator. |
+| `CurrencyDecimalPlaces` | Decimals | `int` | `2` | CategoryType = Currency | Number of decimal places for currency. |
+| `CurrencyUseThousandSeparator` | Use 1000 Separator | `bool` | `False` | CategoryType = Currency | Use a thousand separator for currency. |
+| `CurrencySymbol` | Symbol | `string` | `$` | CategoryType = Currency | The currency symbol. |
+| `CurrencySetAtTheEnd` | Set at the end | `bool` | `False` | CategoryType = Currency | Place the currency symbol after the value. |
+| `PercentageDecimalPlaces` | Decimals | `int` | `2` | CategoryType = Percentage | Number of decimal places for percentage. |
+| `DateType` | Date format | `DateType` | `Short` | CategoryType = Date | The date format to use. |
+| `TimeType` | Time format | `TimeType` | `HoursMinutes` | CategoryType = Time | The time format to use. |
+| `TimeIsAMPM` | AM/PM | `bool` | `False` | CategoryType = Time | Use 12-hour AM/PM format. |
+| `CustomFormatAsString` | Custom format | `string` | `#,##0_);[Red](#,##0)` | CategoryType = Custom | A custom Excel format string. |
+
+### Enum Reference
+
+#### `ColumnRelativePosition`
+| Value | Display Name |
+|-------|-------------|
+| `Before` | Before |
+| `After` | After |
+
+#### `CellFormat`
+| Value | Display Name |
+|-------|-------------|
+| `General` | General |
+| `Number` | Number |
+| `Date` | Date |
+| `Time` | Time |
+| `Percentage` | Percentage |
+| `Currency` | Currency |
+| `Text` | Text |
+| `Custom` | Custom |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:InsertColumnX
+    Range="[MyRange]"
+    RelativeColumnName="Name"
+    RelativePosition="After"
+    NewColumnName="Email"
+    HasHeaders="True"
+    DisplayName="Insert Column">
+    <excel:InsertColumnX.ColumnFormat>
+      <excel:GeneralFormat />
+    </excel:InsertColumnX.ColumnFormat>
+  </excel:InsertColumnX>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `ColumnFormat` property is not directly visible in the designer; instead, the designer shows a Data Type tab within the Format category.
+- Unlike `FormatRangeX`, this activity only exposes the Data Type format settings (no Alignment or Font tabs), and the `FormatType` selector is hidden.
+- When inserting into a table, the behavior differs slightly: the column is inserted relative to the table structure, and a header must be provided.
+- The `RelativeColumnName` must reference an existing column in the range; otherwise, a runtime error occurs.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertExcelChartX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertExcelChartX.md
@@ -1,0 +1,77 @@
+# Insert Chart
+
+`UiPath.Excel.Activities.Business.InsertExcelChartX`
+
+Inserts an Excel chart into a specified sheet based on data from a given range. Supports various chart categories and types with configurable dimensions and position.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Data range | InArgument | `IReadRangeRef` | Yes | | Data range to chart. |
+| `InsertIntoSheet` | Insert into sheet | InArgument | `ISheetRef` | Yes | | The sheet in which to insert the chart. |
+| `ChartCategory` | Chart category | Property | `ExcelChartCategory` | Yes | `Column` | Choose the chart to create based on the selected chart type. |
+| `ChartType` | Chart type | Property | `ExcelChartType` | Yes | `xlColumnClustered` | Choose the chart to create based on the selected chart type. Available types depend on ChartCategory. |
+| `ChartHeight` | Chart height | InArgument | `int` | Yes | (default) | Specify the height of the chart. Minimum enforced value is 50. |
+| `ChartWidth` | Chart width | InArgument | `int` | Yes | (default) | Specify the width of the chart. Minimum enforced value is 50. |
+| `Left` | Chart left | InArgument | `int` | Yes | (default) | Coordinates of how far to the right of the sheet the new chart will appear. |
+| `Top` | Chart top | InArgument | `int` | Yes | (default) | Coordinates of how far below the top of the sheet the new chart will appear. |
+
+### Output
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `InsertedChart` | Save chart to | OutArgument | `IChartRef` | Saves the chart for use in other activities. |
+
+## Conditional Behavior
+
+- When `ChartCategory` changes, the available `ChartType` values are filtered to only those belonging to the selected category.
+- If the current `ChartType` does not belong to the newly selected `ChartCategory`, `ChartType` is reset to the first type in the category.
+
+### Enum Reference
+
+#### `ExcelChartCategory`
+| Value | Display Name |
+|-------|-------------|
+| `Area` | Area |
+| `Bar` | Bar |
+| `Column` | Column |
+| `Line` | Line |
+| `Pie` | Pie |
+| `Scatter` | Scatter |
+
+#### `ExcelChartType` (grouped by category)
+
+**Area:** `xlArea`, `xlAreaStacked`, `xlAreaStacked100`
+**Bar:** `xlBarClustered`, `xlBarStacked`, `xlBarStacked100`
+**Column:** `xlColumnClustered`, `xlColumnStacked`, `xlColumnStacked100`
+**Line:** `xlLine`, `xlLineMarkers`, `xlLineMarkersStacked`, `xlLineMarkersStacked100`, `xlLineStacked`, `xlLineStacked100`
+**Pie:** `xlPie`, `xlDoughnut`
+**Scatter:** `xlXYScatterSmoothNoMarkers`, `xlXYScatterSmooth`, `xlXYScatterLinesNoMarkers`, `xlXYScatterLines`, `xlXYScatter`
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:InsertExcelChartX
+    Range="[dataRange]"
+    InsertIntoSheet="[targetSheet]"
+    ChartCategory="Column"
+    ChartType="xlColumnClustered"
+    ChartHeight="300"
+    ChartWidth="500"
+    Left="100"
+    Top="50"
+    InsertedChart="[chartOutput]"
+    DisplayName="Insert Chart" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The source range and destination sheet must be in the same workbook.
+- If the width or height is less than 50, it is automatically increased to 50 at runtime.
+- When the source range represents an entire sheet, the activity trims it to the used range before creating the chart.
+- Pivot table ranges are excluded from the range selector.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertRowsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertRowsX.md
@@ -1,0 +1,56 @@
+# Insert Rows
+
+`UiPath.Excel.Activities.Business.InsertRowsX`
+
+Inserts one or more rows in a table, range, or sheet at the specified location.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Source range | InArgument | `IReadWriteRangeRef` | Yes | | The sheet, range, or table in which to insert the new rows. |
+| `NbOfRows` | Number of rows | InArgument | `int` | Yes | | Number of rows to insert. |
+| `InsertPosition` | Insert position | Property | `InsertRowPosition` | No | `End` | Where in the range to insert the new rows. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `SpecificIndex` | Specific index | `InArgument<int>` | | Row number in the range after which to insert the new rows if 'At position' is set to 'Specific index'. |
+| `HasHeaders` | Has headers | `bool` | `True` | The first row in the range is a header row. |
+
+## Valid Configurations
+
+- `SpecificIndex` is only visible when `InsertPosition` is set to `Specific`.
+- When `InsertPosition` is `Specific`, `SpecificIndex` is required; a validation error is raised if it is not set.
+
+### Enum Reference
+
+#### `InsertRowPosition`
+| Value | Display Name |
+|-------|-------------|
+| `Start` | Start |
+| `End` | End |
+| `Specific` | Specific index |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:InsertRowsX
+    Range="[MyRange]"
+    NbOfRows="3"
+    InsertPosition="End"
+    HasHeaders="True"
+    DisplayName="Insert Rows" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `NbOfRows` must be a positive integer; otherwise, an `ArgumentException` is thrown.
+- When `InsertPosition` is `Specific`, the `SpecificIndex` must be within the bounds of the range (1 to number of rows); otherwise, an `IndexOutOfRangeException` is thrown.
+- For tables, rows are inserted using table-specific operations. For regular ranges, the `HasHeaders` setting offsets the insertion position by one row when `True`.
+- When inserting at the `End` of a sheet, the range is clipped to the used range before determining the insertion point.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InsertSheetX.md
@@ -1,0 +1,35 @@
+# Insert Sheet
+
+`UiPath.Excel.Activities.Business.InsertSheetX`
+
+Inserts a sheet in an Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Create in workbook | InArgument | `IWorkbookQuickHandle` | Yes | | Excel workbook in which to insert the sheet. |
+| `Name` | New sheet name | InArgument | `string` | Yes | | Name of the new sheet. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `ReferenceNewSheetAs` | Reference new sheet as | `OutArgument<ISheetRef>` | Name you will use to refer to the new sheet in other activities. |
+
+## XAML Example
+```xml
+<excel:InsertSheetX
+  DisplayName="Insert Sheet"
+  Workbook="[workbookHandle]"
+  Name="[&quot;NewSheet&quot;]"
+  ReferenceNewSheetAs="[newSheetRef]" />
+```
+
+## Notes
+- The `ReferenceNewSheetAs` output provides a sheet reference that can be used by subsequent activities.
+- Throws `ArgumentNullException` if the workbook is null or the sheet name is empty.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InvokeVBAX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/InvokeVBAX.md
@@ -1,0 +1,63 @@
+# Invoke VBA
+
+`UiPath.Excel.Activities.Business.InvokeVBAX`
+
+Invokes a macro from an external file containing VBA code and runs it against an Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Target workbook | InArgument | `IWorkbookQuickHandle` | Yes | | Workbook on which to execute the VBA function. |
+| `EntryMethodName` | Entry method name | InArgument | `string` | Yes | `"Main"` | The Sub/Function name to be invoked. Must be implemented in the code file. |
+| `CodeFilePath` | Code file path | InArgument | `string` | Yes | | Full path to the (text) file containing the necessary VBA Sub/Function definitions. |
+
+### Designer Controls (Not Mapped to XAML)
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `AddVBAArgument` | Add VBA Argument | Action Button | Inserts a new `InvokeVBAArgumentX` child activity to pass an argument to the VBA function. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Output | `OutArgument` | Entry method return value, if any. |
+
+## Child Activity: InvokeVBAArgumentX
+
+`UiPath.Excel.Activities.Business.InvokeVBAArgumentX`
+
+Each child activity represents a single argument passed to the VBA Sub/Function. Add one per argument using the **Add VBA Argument** button.
+
+| Name | Display Name | Kind | Type | Required | Description |
+|------|-------------|------|------|----------|-------------|
+| `ArgumentValue` | Argument value | InArgument | `object` | Yes | The value to be passed to the input argument of the VBA Sub/Function. |
+
+## XAML Example
+```xml
+<excel:InvokeVBAX
+  DisplayName="Invoke VBA"
+  Workbook="[workbookHandle]"
+  EntryMethodName="[&quot;Main&quot;]"
+  CodeFilePath="[&quot;C:\Scripts\macro.vb&quot;]"
+  Result="[vbaResult]">
+  <excel:InvokeVBAX.Body>
+    <excel:InvokeVBAArgumentX
+      DisplayName="VBA Argument"
+      ArgumentValue="[argValue]" />
+  </excel:InvokeVBAX.Body>
+</excel:InvokeVBAX>
+```
+
+## Notes
+- This activity supports child `InvokeVBAArgumentX` activities to pass arguments to the VBA function.
+- Use the **Add VBA Argument** action button in the designer to add arguments.
+- The maximum number of arguments is limited by `ExcelConstants.MaxNumberOfMacroArguments`.
+- The `CodeFilePath` must point to a text file containing valid VBA Sub/Function definitions.
+- The `EntryMethodName` defaults to `"Main"` if not specified.
+- The `Result` output is a non-generic `OutArgument`; the actual type depends on what the VBA function returns.
+- COM exceptions during VBA execution are wrapped in `ExcelException` with contextual information.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/LookupX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/LookupX.md
@@ -1,0 +1,41 @@
+# Lookup
+
+`UiPath.Excel.Activities.Business.LookupX`
+
+Finds data in a range or sheet using Excel's LOOKUP function.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SourceRange` | Range | InArgument | `IReadRangeRef` | Yes | | Range to search for the value to lookup. |
+| `ResultRange` | Source of results | InArgument | `IReadRangeRef` | No | | Range from where value is returned. Must be a single row or single column if provided. |
+| `Label` | Value to lookup | InArgument | `object` | Yes | | The value to lookup in the indicated range. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Value` | Result | `OutArgument` | Save the value returned by the LOOKUP. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:LookupX
+    SourceRange="[SearchRange]"
+    ResultRange="[ReturnRange]"
+    Label="[SearchValue]"
+    Value="[Result]"
+    DisplayName="Lookup" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `Label` property accepts any object type; the value is compared to entries in the `SourceRange`.
+- If `ResultRange` is not provided, the result is returned from the same range as the source.
+- The `ResultRange` must be one-dimensional (single row or single column); a multi-dimensional range throws an error.
+- The `Value` output is an untyped `OutArgument` and can hold any value type returned by the lookup.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/MatchFunctionX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/MatchFunctionX.md
@@ -1,0 +1,49 @@
+# Match
+
+`UiPath.Excel.Activities.Business.MatchFunctionX`
+
+Searches for a specified item in a range of cells, and then returns the relative position of that item in the range.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ValueToMatch` | Value to match | InArgument | `object` | Yes | | The value to match in the indicated range. |
+| `InRange` | In range | InArgument | `IWellDefinedReadRangeRef` | Yes | | Range to search for the value to match. Must be a single row or single column. |
+| `MatchFunctionType` | Match type | Property | `MatchType` | No | `LargestValueLessOrEqual` | Used to specify how we are matching the value to match with values in given range. The default value for this argument is 1. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SaveTo` | Save to | `OutArgument<int>` | Save the value returned by the Match function. The value returned is the position of the matched value within the range, not the value itself. |
+
+## Enum Reference
+
+### `MatchType`
+| Value | Description |
+|-------|-------------|
+| `LargestValueLessOrEqual` (1) | MATCH finds the largest value that is less than or equal to the lookup value. The values in the range must be in ascending order. |
+| `ExactlyEqual` (0) | MATCH finds the first value that is exactly equal to the lookup value. The values in the range can be in any order. |
+| `SmallestValueGreaterOrEqual` (-1) | MATCH finds the smallest value that is greater than or equal to the lookup value. The values in the range must be in descending order. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:MatchFunctionX
+    ValueToMatch="[SearchValue]"
+    InRange="[LookupRange]"
+    MatchFunctionType="ExactlyEqual"
+    SaveTo="[MatchPosition]"
+    DisplayName="Match" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `InRange` must be one-dimensional (single row or single column); a multi-dimensional range throws an error.
+- The returned position is 1-based relative to the start of the range.
+- This activity mirrors the behavior of Excel's native `MATCH` function.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ProtectSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ProtectSheetX.md
@@ -1,0 +1,59 @@
+# Protect Sheet
+
+`UiPath.Excel.Activities.Business.ProtectSheetX`
+
+Protects a sheet in an Excel workbook.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Sheet` | Sheet | InArgument | `ISheetRef` | Yes | | Choose sheet to protect. |
+| `Password` | Password | InArgument | `string` | Conditional | | Password to protect the sheet. |
+| `SecurePassword` | Password (SecureString) | InArgument | `SecureString` | Conditional | | Password to protect the sheet as a SecureString type. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `AdditionalPermissions` | Additional permissions | `ProtectSheetAdditionalPermissions` | `None` | Grant users of the sheet additional capabilities. |
+
+### Enum Reference
+
+#### `ProtectSheetAdditionalPermissions`
+| Value | Description |
+|-------|-------------|
+| `None` | No additional permissions |
+| `AllowDeletingColumns` | Allow deleting columns |
+| `AllowDeletingRows` | Allow deleting rows |
+| `DrawingObjects` | Drawing objects |
+| `Scenarios` | Scenarios |
+| `AllowFiltering` | Allow filtering |
+| `AllowFormattingCells` | Allow formatting cells |
+| `AllowFormattingColumns` | Allow formatting columns |
+| `AllowFormattingRows` | Allow formatting rows |
+| `AllowInsertingColumns` | Allow inserting columns |
+| `AllowInsertingHyperlinks` | Allow inserting hyperlinks |
+| `AllowInsertingRows` | Allow inserting rows |
+| `AllowSorting` | Allow sorting |
+| `AllowUsingPivotTables` | Allow using pivot tables |
+
+## XAML Example
+```xml
+<excel:ProtectSheetX
+  DisplayName="Protect Sheet"
+  Sheet="[sheetReference]"
+  Password="[passwordVar]"
+  AdditionalPermissions="AllowFiltering, AllowSorting" />
+```
+
+## Notes
+- Either `Password` or `SecurePassword` must be set, but not both. Setting both causes a validation error.
+- Setting neither `Password` nor `SecurePassword` also causes a validation error -- a password is required.
+- Using a literal string for `Password` produces a validation warning; prefer `SecurePassword` or a variable for security.
+- `AdditionalPermissions` is a flags enum -- multiple values can be combined.
+- The `Password` and `SecurePassword` properties are toggled via a context menu in the designer (Use String / Use SecureString).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCell.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCell.md
@@ -1,0 +1,48 @@
+# Read Cell Workbook
+
+`UiPath.Excel.Activities.ReadCell`
+
+Reads the value of a cell from a spreadsheet.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `Cell` | Cell | InArgument | `string` | Yes | | The cell to read (e.g. "A1") |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `PreserveFormat` | Use display format | `bool` | | Preserves the cell formatting when reading the value |
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Result | `object` | The value read from the specified cell |
+
+## XAML Example
+
+```xml
+<excel:ReadCell
+  DisplayName="Read Cell Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  Cell="[&quot;A1&quot;]"
+  Result="[cellValue]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCellFormula.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCellFormula.md
@@ -1,0 +1,48 @@
+# Read Cell Formula Workbook
+
+`UiPath.Excel.Activities.ReadCellFormula`
+
+Reads the formula of a cell from a spreadsheet as a string.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `Cell` | Cell | InArgument | `string` | Yes | | The cell to read the formula from (e.g. "A1") |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Result | `string` | The formula from the specified cell as a string (e.g. "=SUM(A1:A10)") |
+
+## XAML Example
+
+```xml
+<excel:ReadCellFormula
+  DisplayName="Read Cell Formula Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  Cell="[&quot;B5&quot;]"
+  Result="[formula]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- Returns the formula string (e.g. "=SUM(A1:A10)"), not the computed value.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCellFormulaX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCellFormulaX.md
@@ -1,0 +1,36 @@
+# Read Cell Formula
+
+`UiPath.Excel.Activities.Business.ReadCellFormulaX`
+
+Reads the formula from a specified Excel cell and saves it as a string. The returned formula includes the leading `=` sign.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Cell` | Cell | InArgument | `IReadCellRef` | Yes | | The address of the cell from which to read the formula. |
+
+### Output
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `SaveTo` | Save to | OutArgument | `string` | Where to save the formula read from the cell. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:ReadCellFormulaX
+    Cell="[cellRef]"
+    SaveTo="[formulaResult]"
+    DisplayName="Read Cell Formula" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- If the cell does not contain a formula, an empty string is returned.
+- The returned formula string is prefixed with `=` (e.g., `=SUM(A1:A10)`).
+- The `Cell` must be a valid single-cell reference; otherwise a runtime error is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCellValueX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCellValueX.md
@@ -1,0 +1,43 @@
+# Read Cell Value
+
+`UiPath.Excel.Activities.Business.ReadCellValueX`
+
+Reads the value from a specified Excel cell. Can return either the formatted display value or the raw underlying value.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Cell` | Cell | InArgument | `IReadCellRef` | Yes | | The address of the cell from which to read the value. |
+
+### Options
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `GetFormattedText` | Get formatted text | Property | `bool` | No | `True` | Retrieves value including any formatting applied in Excel. If false, the raw value is retrieved. |
+
+### Output
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `SaveTo` | Save to | OutArgument | `object` | Where to save the value read from the cell. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:ReadCellValueX
+    Cell="[cellRef]"
+    GetFormattedText="True"
+    SaveTo="[cellValue]"
+    DisplayName="Read Cell Value" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `SaveTo` output is a non-generic `OutArgument` and can hold any type (string, number, date, etc.).
+- When `GetFormattedText` is `True`, the value as displayed in Excel (e.g., "$1,234.56") is returned.
+- When `GetFormattedText` is `False`, the raw underlying value (e.g., `1234.56`) is returned.
+- The `Cell` must be a valid single-cell reference; otherwise a runtime error is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadColumn.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadColumn.md
@@ -1,0 +1,49 @@
+# Read Column Workbook
+
+`UiPath.Excel.Activities.ReadColumn`
+
+Reads the values from a column beginning from the cell specified in the StartingCell field, and stores them in an IEnumerable<object> variable.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `StartingCell` | StartingCell | InArgument | `string` | Yes | | The cell from which to start reading the column (e.g. "A1") |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `PreserveFormat` | Use display format | `bool` | | Preserves the cell formatting when reading values |
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Result | `IEnumerable<object>` | The values read from the column |
+
+## XAML Example
+
+```xml
+<excel:ReadColumn
+  DisplayName="Read Column Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  StartingCell="[&quot;A1&quot;]"
+  Result="[columnValues]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- Reads from the starting cell downward until empty cells are encountered.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCsvFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadCsvFile.md
@@ -1,0 +1,59 @@
+# Read CSV
+
+`UiPath.CSV.Activities.ReadCsvFile`
+
+Copies all entries from a specified CSV file to a DataTable for later use in the automation.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | Read from local file | InArgument | `string` | Conditional | | The full local path of the CSV file. Alternative to `PathResource` — use one or the other |
+| `PathResource` | Read from resource file | InArgument | `IResource` | Conditional | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `FilePath` — use one or the other |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `IncludeColumnNames` | Has headers | `bool` | `True` | Specifies if the first row in the CSV file should be considered to contain the column names. If set to false, the output DataTable will have columns with default names |
+| `DelimitatorForViewModel` | Delimiter | `DelimiterOptions` | `Comma` | Specifies the delimiter in the CSV file |
+| `Encoding` | Encoding | `InArgument<string>` | | The character encoding to use (e.g. "utf-8", "utf-16"). Defaults to UTF-8 |
+| `IgnoreQuotes` | Ignore quotes | `InArgument<bool>` | | When set, quoted fields are not treated specially — quotes are treated as regular characters |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `DataTable` | CSV Range | `DataTable` | The data retrieved from the CSV file as a DataTable |
+
+## Valid Configurations
+
+This activity supports two input modes via `[OverloadGroup]`:
+
+**Mode A — Local File**: Set `FilePath` to the full path of the CSV file.
+**Mode B — Resource File**: Set `PathResource` to an `IResource` reference.
+
+Properties `FilePath` and `PathResource` are mutually exclusive.
+
+### Enum Reference
+
+**`DelimiterOptions`**: `Comma`, `Semicolon`, `Pipe`, `Caret`, `Tab`
+
+## XAML Example
+
+```xml
+<csv:ReadCsvFile
+  DisplayName="Read CSV"
+  FilePath="[&quot;data.csv&quot;]"
+  IncludeColumnNames="True"
+  DataTable="[csvData]" />
+```
+
+## Notes
+
+- When neither `FilePath` nor `PathResource` is set, the activity will fail at runtime.
+- The `Encoding` property accepts standard .NET encoding names (e.g. "utf-8", "utf-16", "ascii").

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadRange.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadRange.md
@@ -1,0 +1,50 @@
+# Read Range Workbook
+
+`UiPath.Excel.Activities.ReadRange`
+
+Reads the value of a range from a spreadsheet as a DataTable. If Range isn't specified, the whole spreadsheet is read. If range is specified as a cell, the whole spreadsheet starting from that cell is read.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | `"Sheet1"` | The name of the sheet from the workbook |
+| `Range` | Range | InArgument | `string` | | `"A1:A2"` | The range to read in Excel format (e.g. "A1:B10"). If a single cell is specified, reads from that cell to the end of the sheet |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `AddHeaders` | Add headers | `bool` | `True` | Specifies if the first row of the range should be used as column names in the output DataTable |
+| `PreserveFormat` | Use display format | `bool` | `False` | Preserves the cell formatting when reading values |
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `DataTable` | DataTable | `DataTable` | The data read from the specified range as a DataTable |
+
+## XAML Example
+
+```xml
+<excel:ReadRange
+  DisplayName="Read Range Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  Range="[&quot;A1:D10&quot;]"
+  AddHeaders="True"
+  DataTable="[outputData]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadRangeX.md
@@ -1,0 +1,54 @@
+# Read Range
+
+`UiPath.Excel.Activities.Business.ReadRangeX`
+
+Reads the value of an Excel range as a DataTable.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Range | InArgument | `IReadRangeRef` | Yes | | Range to read. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ReadFormatting` | Read formatting | `ReadFormattingOptions?` | `null` (same as project) | Choose what formatting should be applied to the values. Any value other than 'Default' will result in much slower performance. Null means that the formatting options are the same as for the parent card. |
+| `HasHeaders` | Has headers | `bool` | `True` | First row in the range is a header row. |
+| `VisibleOnly` | Visible rows only | `bool` | `True` | Read only the visible rows. Ignores filtered and hidden values. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SaveTo` | Save to | `OutArgument<DataTable>` | The DataTable where to save the contents of the range. To paste the data from the clipboard use Copy/Paste Range or other dedicated Paste activities. |
+
+## Enum Reference
+
+### `ReadFormattingOptions`
+| Value | Description |
+|-------|-------------|
+| `Default` (0) | Overrides the project setting. Takes the default formatting returned by the COM API. |
+| `RawValue` (1) | Overrides the project setting. Always retrieves the raw value and ignores all formatting. |
+| `DisplayValue` (2) | Overrides the project setting. Takes the value as displayed in Excel. Truncated values (e.g. `####`) are returned as-is. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:ReadRangeX
+    Range="[MyRange]"
+    HasHeaders="True"
+    VisibleOnly="True"
+    SaveTo="[OutputDataTable]"
+    DisplayName="Read Range" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- When the range is a single cell, the activity reads the entire sheet starting from that cell (backward-compatible behavior).
+- Setting `ReadFormatting` to `null` inherits the formatting option from the parent `ExcelApplicationCard`.
+- The `VisibleOnly` flag is useful when reading from filtered data -- it ignores hidden and filtered rows.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadRow.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/ReadRow.md
@@ -1,0 +1,49 @@
+# Read Row Workbook
+
+`UiPath.Excel.Activities.ReadRow`
+
+Reads the values of an Excel row beginning from the cell specified in the StartingCell field, and stores them in an IEnumerable<object> variable.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `StartingCell` | StartingCell | InArgument | `string` | Yes | | The cell from which to start reading the row (e.g. "A1") |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `PreserveFormat` | Use display format | `bool` | | Preserves the cell formatting when reading values |
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Result | `IEnumerable<object>` | The values read from the row |
+
+## XAML Example
+
+```xml
+<excel:ReadRow
+  DisplayName="Read Row Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  StartingCell="[&quot;A1&quot;]"
+  Result="[rowValues]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- Reads from the starting cell to the end of the row (until empty cells are encountered).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RefreshDataConnectionsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RefreshDataConnectionsX.md
@@ -1,0 +1,27 @@
+# Refresh Excel Data Connections
+
+`UiPath.Excel.Activities.Business.RefreshDataConnectionsX`
+
+Get the latest data by refreshing all sources in the workbook.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | Takes a handle to the Excel workbook. |
+
+## XAML Example
+```xml
+<excel:RefreshDataConnectionsX
+  DisplayName="Refresh Excel Data Connections"
+  Workbook="[workbookHandle]" />
+```
+
+## Notes
+- Refreshes all external data connections in the workbook (e.g., database queries, web queries, linked data sources).
+- Throws `ArgumentNullException` if the workbook handle is null.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RefreshPivotTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RefreshPivotTableX.md
@@ -1,0 +1,42 @@
+# Refresh Pivot Table
+
+`UiPath.Excel.Activities.Business.RefreshPivotTableX`
+
+Refreshes a specified pivot table or all pivot tables in the workbook. Optionally updates the layout row type.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Table` | Pivot table to refresh | InArgument | `IPivotTableRef` | Yes | | The pivot table to refresh. |
+| `LayoutRowType` | Layout | Property | `PivotTableLayoutRowType?` | No | `null` | Enhance the pivot table layout and format. The compact form optimizes for readability, while tabular and outline forms include field headers. |
+
+## Enum Reference
+
+#### `PivotTableLayoutRowType`
+| Value | Display Name |
+|-------|-------------|
+| `Compact` | Compact |
+| `Tabular` | Tabular |
+| `Outline` | Outline |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:RefreshPivotTableX
+    Table="[pivotTableRef]"
+    LayoutRowType="{x:Null}"
+    DisplayName="Refresh Pivot Table" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- If the pivot table reference has the special "Refresh All Pivot Tables" name with empty worksheet and address, all pivot tables in the workbook are refreshed.
+- When refreshing a specific pivot table, it must exist on the specified worksheet; otherwise an `ArgumentException` is thrown.
+- When `LayoutRowType` is set (not null), the layout is applied before refreshing the data.
+- The pivot table reference must include a valid parent handle; otherwise an `ArgumentNullException` is thrown.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RemoveDuplicatesX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RemoveDuplicatesX.md
@@ -1,0 +1,54 @@
+# Remove Duplicates
+
+`UiPath.Excel.Activities.Business.RemoveDuplicatesX`
+
+Delete duplicate rows from a range, table, or sheet by comparing values in specified columns.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Range | InArgument | `IReadWriteRangeRef` | Yes | | Range from which to remove duplicates. |
+| `ColumnsCompareMode` | Compare mode | Property | `ColumnsCompare` | No | `IndividualColumns` | Whether to compare individual columns or all columns when identifying duplicates. Displayed as a radio group in the designer. |
+| `Columns` | Columns to compare | Property | `List<InArgument<string>>` | No | | The columns that will be compared to determine if a row is a duplicate. If the values in all of the indicated columns are the same as a previous row, it is considered a duplicate. Visible only when `ColumnsCompareMode` is `IndividualColumns`. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `True` | The first row in the range is a header row. |
+
+### Enum Reference
+
+#### `ColumnsCompare`
+| Value | Display Name |
+|-------|-------------|
+| `IndividualColumns` | Individual columns |
+| `AllColumns` | All columns |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:RemoveDuplicatesX
+    Range="[MyRange]"
+    HasHeaders="True"
+    ColumnsCompareMode="IndividualColumns"
+    DisplayName="Remove Duplicates">
+    <excel:RemoveDuplicatesX.Columns>
+      <InArgument x:TypeArguments="x:String">Name</InArgument>
+      <InArgument x:TypeArguments="x:String">Email</InArgument>
+    </excel:RemoveDuplicatesX.Columns>
+  </excel:RemoveDuplicatesX>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- When `ColumnsCompareMode` is `IndividualColumns`, at least one column must be specified in the `Columns` list.
+- When `ColumnsCompareMode` is `AllColumns`, all columns in the range are used for duplicate comparison and the `Columns` property is hidden.
+- Duplicate column names in the `Columns` list are not allowed.
+- Empty column entries in the `Columns` list are not allowed.
+- Rows are considered duplicates when all compared columns have the same values as a previous row.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RenameSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/RenameSheetX.md
@@ -1,0 +1,28 @@
+# Rename Sheet
+
+`UiPath.Excel.Activities.Business.RenameSheetX`
+
+Renames a sheet in an Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `From` | From | InArgument | `ISheetRef` | Yes | | The sheet to rename. |
+| `To` | To | InArgument | `string` | Yes | | New name to give the selected sheet. |
+
+## XAML Example
+```xml
+<excel:RenameSheetX
+  DisplayName="Rename Sheet"
+  From="[sheetReference]"
+  To="[&quot;RenamedSheet&quot;]" />
+```
+
+## Notes
+- Throws `ArgumentNullException` if the sheet reference is null or the new name is empty.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SaveAsPdfX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SaveAsPdfX.md
@@ -1,0 +1,52 @@
+# Save As PDF
+
+`UiPath.Excel.Activities.Business.SaveAsPdfX`
+
+Saves an Excel file as a PDF file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | Excel file to save to PDF format. |
+| `DestinationPdfPath` | Destination pdf path | InArgument | `string` | Yes | | Name of the new PDF file. |
+| `StartPage` | Start page | InArgument | `int?` | No | | Start export at this page. |
+| `EndPage` | End page | InArgument | `int?` | No | | Stop export at this page. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `SaveQuality` | Save quality | `PdfSaveQuality` | `StandardQuality` | Quality of the PDF file. Higher quality creates a bigger file. |
+| `ReplaceExisting` | Replace existing | `bool` | `True` | If a file with this name already exists, replace it. Otherwise an error will occur if the file already exists. |
+
+### Enum Reference
+
+#### `PdfSaveQuality`
+| Value | Description |
+|-------|-------------|
+| `StandardQuality` | Standard quality |
+| `MinimumQuality` | Minimum quality |
+
+## XAML Example
+```xml
+<excel:SaveAsPdfX
+  DisplayName="Save As PDF"
+  Workbook="[workbookHandle]"
+  DestinationPdfPath="[&quot;C:\Output\report.pdf&quot;]"
+  StartPage="[1]"
+  EndPage="[5]"
+  SaveQuality="StandardQuality"
+  ReplaceExisting="True" />
+```
+
+## Notes
+- If the destination path does not include a `.pdf` extension, it is added automatically.
+- `StartPage` and `EndPage` must be positive integers (greater than 0) when specified.
+- `StartPage` must be less than or equal to `EndPage` when both are specified.
+- The destination folder must already exist; the activity does not create directories.
+- The `DestinationPdfPath` category in the designer is **File**.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SaveExcelFileAsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SaveExcelFileAsX.md
@@ -1,0 +1,48 @@
+# Save Excel File As
+
+`UiPath.Excel.Activities.Business.SaveExcelFileAsX`
+
+Save an Excel file as a different file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | Which workbook to save. |
+| `SaveAsFileType` | Save as type | Property | `ExcelSaveAsType` | Yes | `OpenXmlWorkbook` | Format to save the workbook. |
+| `FilePath` | Save as file | InArgument | `string` | Yes | | Name of the new file. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ReplaceExisting` | Replace existing | `bool` | `True` | Replace existing file of the same name. |
+
+### Enum Reference
+
+#### `ExcelSaveAsType`
+| Value | Description |
+|-------|-------------|
+| `OpenXmlWorkbook` | Normal workbook (.xlsx) |
+| `BinaryWorkbook` | Binary workbook (.xlsb) |
+| `MacroEnabledWorkbook` | Macro enabled workbook (.xlsm) |
+| `OldWorkbook` | Excel 97-2003 workbook (.xls) |
+
+## XAML Example
+```xml
+<excel:SaveExcelFileAsX
+  DisplayName="Save Excel File As"
+  Workbook="[workbookHandle]"
+  SaveAsFileType="OpenXmlWorkbook"
+  FilePath="[&quot;C:\Output\report_copy.xlsx&quot;]"
+  ReplaceExisting="True" />
+```
+
+## Notes
+- If the file path does not end with the correct extension for the selected file type, the extension is appended automatically.
+- The destination folder must already exist; the activity does not create directories.
+- If `ReplaceExisting` is `False` and a file with the same name already exists, the activity throws an `ArgumentException`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SaveExcelFileX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SaveExcelFileX.md
@@ -1,0 +1,27 @@
+# Save Excel File
+
+`UiPath.Excel.Activities.Business.SaveExcelFileX`
+
+Saves any pending changes in the selected Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Workbook` | Workbook | InArgument | `IWorkbookQuickHandle` | Yes | | File to save any pending changes to. |
+
+## XAML Example
+```xml
+<excel:SaveExcelFileX
+  DisplayName="Save Excel File"
+  Workbook="[workbookHandle]" />
+```
+
+## Notes
+- This activity saves the workbook in place (overwrites the existing file).
+- Use `SaveExcelFileAsX` if you need to save to a different path or format.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SelectRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SelectRangeX.md
@@ -1,0 +1,28 @@
+# Select Range
+
+`UiPath.Excel.Activities.Windows.Business.SelectRangeX`
+
+Selects a range in the specified Excel file.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Range | InArgument | `IReadRangeRef` | Yes | | Range to select. |
+
+## XAML Example
+```xml
+<excelwin:SelectRangeX
+  Range="[TargetRange]"
+  DisplayName="Select Range"
+  xmlns:excelwin="clr-namespace:UiPath.Excel.Activities.Windows.Business;assembly=UiPath.Excel.Activities" />
+```
+
+## Notes
+- This activity selects the specified range in the Excel UI, making it the active selection.
+- The range must be valid; an invalid range throws an `ArgumentNullException`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SetRangeColor.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SetRangeColor.md
@@ -1,0 +1,42 @@
+# Set Range Color Workbook
+
+`UiPath.Excel.Activities.SetRangeColor`
+
+Sets the background color of a specified range of cells in a spreadsheet.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | | The name of the sheet from the workbook |
+| `Range` | Range | InArgument | `string` | Yes | | The range to color (e.g. "A1:B10") |
+| `Color` | Color | InArgument | `System.Drawing.Color` | Yes | | The color to apply to the range |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+## XAML Example
+
+```xml
+<excel:SetRangeColor
+  DisplayName="Set Range Color Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  Range="[&quot;A1:D10&quot;]"
+  Color="[System.Drawing.Color.Yellow]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SortX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/SortX.md
@@ -1,0 +1,68 @@
+# Sort Range
+
+`UiPath.Excel.Activities.Business.SortX`
+
+Sorts the data in a specified sheet, table, or range by one or more columns.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Range` | Range | InArgument | `IReadWriteRangeRef` | Yes | | Range to sort. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HasHeaders` | Has headers | `bool` | `True` | First row in the range is a header row. |
+| `AddSortColumn` | Add sort column | Action button | | Add a sort by column setting. Inserts a `SortColumnX` child activity. |
+
+### Child Activity: `SortColumnX`
+
+Each sort column is configured as a child `SortColumnX` activity inside the `SortX` body.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ColumnName` | Column | InArgument | `string` | Yes | | The column to sort. |
+| `SortDirection` | Direction | Property | `SortDirectionType` | No | `Ascending` | Sort order for the values in the column. |
+
+## Enum Reference
+
+### `SortDirectionType`
+| Value | Description |
+|-------|-------------|
+| `Ascending` | Sort in ascending order (A-Z, smallest to largest). |
+| `Descending` | Sort in descending order (Z-A, largest to smallest). |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:SortX
+    Range="[DataRange]"
+    HasHeaders="True"
+    DisplayName="Sort Range">
+    <excel:SortX.Body>
+      <ActivityAction x:TypeArguments="x:Object">
+        <ActivityAction.Handler>
+          <Sequence>
+            <excel:SortColumnX
+              ColumnName="[&quot;Name&quot;]"
+              SortDirection="Ascending"
+              DisplayName="Sort Column Configuration" />
+          </Sequence>
+        </ActivityAction.Handler>
+      </ActivityAction>
+    </excel:SortX.Body>
+  </excel:SortX>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- `SortX` is a container activity; one or more `SortColumnX` child activities must be added to define the sort criteria.
+- Sort columns are applied in order -- the first child defines the primary sort, the second defines the secondary sort, etc.
+- If no `SortColumnX` children are present, the activity throws an error.
+- The `HasHeaders` property is not visible in the designer's property panel but is configurable in the activity card.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/TextToColumnsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/TextToColumnsX.md
@@ -1,0 +1,76 @@
+# Text to Columns
+
+`UiPath.Excel.Activities.Business.TextToColumnsX`
+
+Splits the text from a cell, range, or table into different columns.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SourceRange` | Source range | InArgument | `IWellDefinedReadRangeRef` | Yes | | Range containing the text to split. |
+| `DestinationRange` | Destination | InArgument | `IReadWriteRangeRef` | Yes | | Where the split data will be saved. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ParsingType` | Parsing type | `TextToColumnsParsingType` | `Delimited` | Delimited: data is separated by certain characters. Fixed width: data is separated in groups of a certain number of characters. |
+| `NumberOfCharactersPerColumn` | Number of characters per column | `InArgument<int>` | | Width of each unit of data to be split. Visible only when `ParsingType` is `FixedWidth`. Required when `ParsingType` is `FixedWidth`. |
+| `SplitByTabs` | Split by tabs | `bool` | `True` | Data is separated by a tab. Visible only when `ParsingType` is `Delimited`. |
+| `SplitBySemicolon` | Split by semicolon | `bool` | `True` | Data is separated by a semicolon. Visible only when `ParsingType` is `Delimited`. |
+| `SplitByComma` | Split by comma | `bool` | `True` | Data is separated by a comma. Visible only when `ParsingType` is `Delimited`. |
+| `SplitBySpace` | Split by space | `bool` | `True` | Data is separated by a space. Visible only when `ParsingType` is `Delimited`. |
+| `SplitByLineBreak` | Split by new line | `bool` | `False` | Data is separated by a new line. Visible only when `ParsingType` is `Delimited`. Cannot be used together with `SplitByOther`. |
+| `SplitByOther` | Split by other | `bool` | `False` | Data is separated by a character not listed. Visible only when `ParsingType` is `Delimited`. |
+| `OtherSeparator` | Other delimiter | `char?` | | Enter the character that separates the data. Visible only when `ParsingType` is `Delimited`. Required when `SplitByOther` is `True`. |
+| `ConsecutiveOperatorsAsOne` | Consecutive operators as one | `bool` | `True` | Data contains delimiters with multiple characters. Visible only when `ParsingType` is `Delimited`. |
+| `TextQualifier` | Text qualifier | `TextToColumnsTextQualifier` | `None` | The character that encloses text in your data. Text between two consecutive text qualifiers is treated as one value. Visible only when `ParsingType` is `Delimited`. |
+
+## Valid Configurations
+
+When `ParsingType` is `Delimited`, the delimiter options (`SplitByTabs`, `SplitBySemicolon`, `SplitByComma`, `SplitBySpace`, `SplitByLineBreak`, `SplitByOther`, `OtherSeparator`, `ConsecutiveOperatorsAsOne`, `TextQualifier`) are visible. When `ParsingType` is `FixedWidth`, only `NumberOfCharactersPerColumn` is visible.
+
+### Enum Reference
+
+#### `TextToColumnsParsingType`
+| Value | Display Name |
+|-------|-------------|
+| `Delimited` | Delimited |
+| `FixedWidth` | Fixed Width |
+
+#### `TextToColumnsTextQualifier`
+| Value | Display Name |
+|-------|-------------|
+| `None` | None |
+| `DoubleQuote` | Double Quote |
+| `SingleQuote` | Single Quote |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:TextToColumnsX
+    SourceRange="[SourceRange]"
+    DestinationRange="[DestRange]"
+    ParsingType="Delimited"
+    SplitByComma="True"
+    SplitByTabs="False"
+    SplitBySemicolon="False"
+    SplitBySpace="False"
+    SplitByLineBreak="False"
+    SplitByOther="False"
+    ConsecutiveOperatorsAsOne="True"
+    TextQualifier="None"
+    DisplayName="Text to Columns" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- Source and destination must be on the same worksheet.
+- `SplitByLineBreak` and `SplitByOther` cannot both be `True` at the same time. Internally, line break splitting uses the "Other" mechanism.
+- When `ParsingType` is `FixedWidth`, `NumberOfCharactersPerColumn` is required.
+- When `SplitByOther` is `True`, `OtherSeparator` must be specified.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/UnprotectSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/UnprotectSheetX.md
@@ -1,0 +1,32 @@
+# Unprotect Sheet
+
+`UiPath.Excel.Activities.Business.UnprotectSheetX`
+
+Unprotects a sheet in an Excel workbook.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Sheet` | Sheet | InArgument | `ISheetRef` | Yes | | Choose sheet to unprotect. |
+| `Password` | Password | InArgument | `string` | Conditional | | Password to unprotect the sheet. |
+| `SecurePassword` | Password (SecureString) | InArgument | `SecureString` | Conditional | | Password to unprotect the sheet as a SecureString type. |
+
+## XAML Example
+```xml
+<excel:UnprotectSheetX
+  DisplayName="Unprotect Sheet"
+  Sheet="[sheetReference]"
+  Password="[passwordVar]" />
+```
+
+## Notes
+- Either `Password` or `SecurePassword` must be set, but not both. Setting both causes a validation error.
+- Setting neither `Password` nor `SecurePassword` also causes a validation error -- a password is required.
+- Using a literal string for `Password` produces a validation warning; prefer `SecurePassword` or a variable for security.
+- The `Password` and `SecurePassword` properties are toggled via a context menu in the designer (Use String / Use SecureString).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/UpdateChart.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/UpdateChart.md
@@ -1,0 +1,44 @@
+# Update Chart Workbook
+
+`UiPath.Excel.Activities.UpdateChart`
+
+Updates an existing chart in a workbook by applying modifications such as changing the data range, title, axis labels, or legend visibility.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `ChartName` | Chart | InArgument | `string` | Yes | | The name of the chart to update |
+| `SheetName` | SheetName | InArgument | `string` | | | The sheet containing the chart |
+| `Modifications` | Chart modifications | Property | `List<InArgument<IChartModification>>` | | | Chart modifications to apply (static list of modification activities) |
+| `ModificationsVariable` | Chart modifications variable | InArgument | `IEnumerable<IChartModification>` | | | Chart modifications to apply (variable/expression) |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+## XAML Example
+
+```xml
+<excel:UpdateChart
+  DisplayName="Update Chart Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Charts&quot;]"
+  ChartName="[&quot;SalesChart&quot;]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- `Modifications` and `ModificationsVariable` are alternative input modes (static list vs. expression).
+- Available chart modification types include: ChangeDataRange, ModifyChartTitle, ShowHideDataLabels, ShowHideLegend, UpdateAxisBounds, UpdateAxisTitle.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/UpdateChartX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/UpdateChartX.md
@@ -1,0 +1,63 @@
+# Update Chart
+
+`UiPath.Excel.Activities.Business.UpdateChartX`
+
+Applies one or more modifications to an existing Excel chart. This is a container activity that holds child modification activities, each representing a specific chart change.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Chart` | Chart | InArgument | `IChartRef` | Yes | | Chart to update. |
+
+### Designer Controls (Not Mapped to XAML)
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `ModificationToAdd` | Modification type | `UpdateChartModification` | Selects the type of modification to add as a child activity. |
+| `AddModification` | Add Modification | Action Button | Inserts a new child modification activity of the selected type. |
+
+## Available Modification Types
+
+Child modification activities are added inside the `UpdateChartX` body. Each modification is a separate activity:
+
+### `UpdateChartModification` Enum
+| Value | Description |
+|-------|-------------|
+| `ChangeDataRange` | Changes the data range of the chart. |
+| `ModifyChartTitle` | Modifies the chart title. |
+| `UpdateAxisTitle` | Updates an axis title. |
+| `UpdateAxisBounds` | Updates axis bounds (min/max). |
+| `ShowHideLegend` | Shows or hides the chart legend. |
+| `ShowHideDataLabels` | Shows or hides data labels. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:UpdateChartX
+    Chart="[chartRef]"
+    DisplayName="Update Chart">
+    <excel:UpdateChartX.Body>
+      <ActivityAction x:TypeArguments="excel:UpdateChartXDescriptor">
+        <ActivityAction.Argument>
+          <DelegateInArgument x:TypeArguments="excel:UpdateChartXDescriptor" Name="UpdateChartXDescriptor" />
+        </ActivityAction.Argument>
+        <Sequence DisplayName="Do">
+          <!-- Add modification activities here, e.g.: -->
+          <!-- <excel:ModifyChartTitleModification ... /> -->
+        </Sequence>
+      </ActivityAction>
+    </excel:UpdateChartX.Body>
+  </excel:UpdateChartX>
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- This activity inherits from `BaseParentActivityWithDescriptor` and executes its child modification activities sequentially.
+- At least one child modification activity is required; otherwise a runtime error occurs.
+- The chart reference is typically obtained from the output of `InsertExcelChartX` or by referencing an existing chart.
+- The "Add Modification" button in the designer inserts a new child activity of the selected type into the body.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/VLookupX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/VLookupX.md
@@ -1,0 +1,43 @@
+# VLookup
+
+`UiPath.Excel.Activities.Business.VLookupX`
+
+Finds data in a range or sheet using Excel's VLOOKUP function.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SourceRange` | In range | InArgument | `IReadRangeRef` | Yes | | Range to search for the value to lookup. |
+| `Label` | Value to lookup | InArgument | `object` | Yes | | The value to lookup in the indicated range. |
+| `ColumnIndex` | Column index | InArgument | `int` | No | | The column number in the range containing the value to return. If not specified, defaults to the last column in the range. |
+| `ExactMatch` | Exact match | Property | `bool` | No | `True` | Return only exact matches. Otherwise approximate matches are returned. |
+
+### Output
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Value` | Output to | `OutArgument` | Save the value returned by the VLOOKUP. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:VLookupX
+    SourceRange="[LookupRange]"
+    Label="[SearchValue]"
+    ColumnIndex="3"
+    ExactMatch="True"
+    Value="[Result]"
+    DisplayName="VLookup" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `Label` property accepts any object type; the value is compared to entries in the first column of the `SourceRange`.
+- If `ColumnIndex` is not specified or is `0`, the activity returns the value from the last column in the range.
+- When `ExactMatch` is `False`, the first column of `SourceRange` must be sorted in ascending order for correct approximate matching behavior.
+- The `Value` output is an untyped `OutArgument` and can hold any value type returned by the lookup.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteCell.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteCell.md
@@ -1,0 +1,42 @@
+# Write Cell Workbook
+
+`UiPath.Excel.Activities.WriteCell`
+
+Writes a text value into a cell in a spreadsheet. If the sheet does not exist, a new one is created with the SheetName value. If a value exists, it is overwritten. Changes are immediately saved.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | `"Sheet1"` | The name of the destination sheet. Category: Destination |
+| `Cell` | Cell | InArgument | `string` | Yes | `"A1"` | The destination cell (e.g. "A1"). Category: Destination |
+| `Text` | Text | InArgument | `string` | Yes | | The value to write into the cell |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+## XAML Example
+
+```xml
+<excel:WriteCell
+  DisplayName="Write Cell Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  Cell="[&quot;A1&quot;]"
+  Text="[&quot;Hello World&quot;]" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteCellX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteCellX.md
@@ -1,0 +1,43 @@
+# Write Cell
+
+`UiPath.Excel.Activities.Business.WriteCellX`
+
+Writes a value or formula to a specified Excel cell. Supports an auto-increment row feature for use inside loops.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Value` | What to write | InArgument | `object` | Yes | | The value or formula to enter into the cell. |
+
+### Destination
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Cell` | Where to write | InArgument | `IReadWriteCellRef` | Yes | | The cell in which to write the value or formula. |
+
+### Options
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AutoIncrementRow` | Auto increment row | Property | `bool` | No | `False` | When inside a For Each activity, relative cell references (no $) will automatically increase the row number each iteration. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Use Excel File">
+  <excel:WriteCellX
+    Cell="[cellRef]"
+    Value="[valueToWrite]"
+    AutoIncrementRow="False"
+    DisplayName="Write Cell" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- This activity extends `NativeActivity` (not `ExcelBusinessActivity`) to support the auto-increment row tracking state across iterations.
+- When `AutoIncrementRow` is enabled, each subsequent execution targeting the same cell address within the same workbook/sheet automatically offsets to the next row.
+- The `Cell` must be a valid single-cell reference with read-write access; otherwise a runtime error is thrown.
+- Both values and formulas (starting with `=`) can be written.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteRange.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteRange.md
@@ -1,0 +1,45 @@
+# Write Range Workbook
+
+`UiPath.Excel.Activities.WriteRange`
+
+Writes the data from a DataTable to a spreadsheet starting from StartingCell. If StartingCell isn't specified, writing begins at A1. If the sheet does not exist, a new one is created with the SheetName value. All cells within the DataTable range are overwritten. Changes are immediately saved.
+
+**Package:** `UiPath.Excel.Activities`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkbookPath` | File (local path) | InArgument | `string` | | | The full local path of the workbook. Alternative to `WorkbookPathResource` — use one or the other |
+| `WorkbookPathResource` | File | InArgument | `IResource` | | | A resource reference (e.g. a local file, remote file, or abstract resource). Alternative to `WorkbookPath` — use one or the other |
+| `SheetName` | SheetName | InArgument | `string` | Yes | `"Sheet1"` | The name of the destination sheet. Category: Destination |
+| `StartingCell` | StartingCell | InArgument | `string` | | `"A1"` | The starting cell (in range format) from which the input will be written. Category: Destination |
+| `DataTable` | DataTable | InArgument | `DataTable` | Yes | | The DataTable to write to the spreadsheet |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `AddHeaders` | Add headers | `bool` | `True` | Specifies if the first row written should be the column names from the DataTable input |
+| `Password` | Password | `InArgument<string>` | | The password of the workbook, if necessary |
+| `Workbook` | Workbook | `InArgument<Workbook>` | | Existing workbook object to use instead of a file path |
+
+## XAML Example
+
+```xml
+<excel:WriteRange
+  DisplayName="Write Range Workbook"
+  WorkbookPath="[&quot;report.xlsx&quot;]"
+  SheetName="[&quot;Sheet1&quot;]"
+  StartingCell="[&quot;A1&quot;]"
+  DataTable="[dataToWrite]"
+  AddHeaders="True" />
+```
+
+## Notes
+
+- Uses the file-based workbook engine (not Excel Interop). Works cross-platform.
+- `WorkbookPath` and `WorkbookPathResource` are mutually exclusive — set one or the other.
+- If the target sheet does not exist, it is created automatically.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/activities/WriteRangeX.md
@@ -1,0 +1,47 @@
+# Write Range
+
+`UiPath.Excel.Activities.Business.WriteRangeX`
+
+Write Range is intended for writing data from external Data Table sources into Excel.
+
+**Package:** `UiPath.Excel.Activities`
+**Platform:** Windows only
+**Required Scope:** `ExcelApplicationCard`
+
+## Properties
+
+### Input
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | What to write | InArgument | `DataTable` | Yes | | Write Range is intended for writing data from external Data Table sources into Excel. Use the 'Copy/Paste Range' activity when moving data between locations in Excel. |
+
+### Output
+| Name | Display Name | Kind | Type | Required | Description |
+|------|-------------|------|------|----------|-------------|
+| `Destination` | Destination | InArgument | `IReadWriteRangeRef` | Yes | Where to write the data. |
+
+### Configuration
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Append` | Append | `bool` | `False` | Append the new data starting at the first blank row in the indicated range. |
+| `ExcludeHeaders` | Exclude headers | `bool` | `False` | Indicates any headers (or the first row in the selected range) will not be written to the destination range. |
+| `IgnoreEmptySource` | Ignore empty source | `bool` | `False` | When checked, if the source data table is empty it will be ignored. Otherwise it will throw an error. |
+
+## XAML Example
+```xml
+<excel:ExcelApplicationCard DisplayName="Excel Application Scope">
+  <excel:WriteRangeX
+    Source="[MyDataTable]"
+    Destination="[DestRange]"
+    Append="False"
+    ExcludeHeaders="False"
+    IgnoreEmptySource="False"
+    DisplayName="Write Range" />
+</excel:ExcelApplicationCard>
+```
+
+## Notes
+- The `Destination` property is categorized as "Output" in the activity class but functions as an input specifying where data is written (it is an `InArgument`, not an `OutArgument`).
+- When `Append` is `True`, data is written starting at the first blank row in the destination range.
+- When `IgnoreEmptySource` is `False` (default), an empty `DataTable` (no rows and no columns, or no rows when headers are excluded) throws an error.
+- Use the 'Copy/Paste Range' activity instead when moving data between locations within Excel.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/coded-api.md
@@ -1,0 +1,878 @@
+# Excel Activities — Coded Workflow API
+
+`UiPath.Excel.Activities`
+
+Perform Excel operations — read, write, format, chart, filter, sort, and manage workbooks — from coded C# workflows.
+
+**Service accessor:** `excel` (type `IExcelService`)
+**Required package:** `"UiPath.Excel.Activities": "*"` in project.json dependencies
+
+## Auto-Imported Namespaces
+
+These namespaces are automatically available in coded workflows when this package is installed:
+
+```
+System
+System.Collections.Generic
+System.Data
+UiPath.Excel
+UiPath.Excel.Activities
+UiPath.Excel.Activities.API
+UiPath.Excel.Activities.API.Models
+```
+
+> **Note:** Some types used in CSV, formatting, protection, and window-resize operations live outside these namespaces. Add `using UiPath.CSV;` for `DelimitatorOptions`, `using System.Drawing;` for `Color`, `using System.Security;` for `SecureString`, `using UiPath.Excel.Model;` for `ResizeWindowOptions`, and `using UiPath.Excel.Activities.Business;` for formatting types such as `ICellFormat`, `GeneralFormat`, and `ExcelFormatParameters` as needed.
+
+## Service Overview
+
+The `excel` service exposes two API surfaces:
+
+1. **Portable API** (`IWorkHandle`) — Cross-platform workbook operations over Excel files (XLSX and legacy XLS). Use `excel.UseWorkBook(...)` to get an `IWorkHandle`, then call extension methods for read/write/cell operations. Works on all platforms.
+2. **Windows/Interop API** (`IWorkbookQuickHandle`) — Full-featured Excel interop operations. Use `excel.UseExcelFile(...)` to get an `IWorkbookQuickHandle` with sheet/table/chart indexers, optionally targeting a specific Excel process created via `excel.ExcelProcessScope(...)` and passed through `UseOptions.ExcelProcess`. Windows only.
+
+---
+
+## Portable Workbook Operations
+
+These methods work cross-platform over Excel workbook formats (XLSX via Open XML, with support for legacy XLS).
+
+### `IWorkHandle UseWorkBook(WorkbookOptions options)`
+
+Opens or creates a workbook using the specified options. When `CreateNew` is true and the file does not exist, a new workbook is created. When `CreateNew` is true and the file already exists, the `ConflictBehavior` setting controls whether to replace, fail, or skip. When `ConflictBehavior` is null (default) or `CreateNew` is false, the existing file is opened.
+
+**Parameters:**
+- `options` (`WorkbookOptions`) — Options for the workbook
+
+**Returns:** `IWorkHandle` — Disposable handle to the workbook. Use with `using` statement.
+
+### `IWorkHandle UseWorkBook(string path, bool createNew = true)`
+
+Opens a workbook at the specified path.
+
+**Parameters:**
+- `path` (`string`) — Path of the workbook
+- `createNew` (`bool`) — If the workbook does not exist, determines if a new workbook is created. Default: `true`
+
+**Returns:** `IWorkHandle` — Disposable handle to the workbook. Use with `using` statement.
+
+---
+
+## Windows/Interop Workbook Operations
+
+These methods require Excel interop (Windows only) and provide full Excel feature support.
+
+### `IWorkbookQuickHandle UseExcelFile(UseOptions options)`
+
+Opens an Excel file using interop with detailed configuration options.
+
+**Parameters:**
+- `options` (`UseOptions`) — Options used when opening or creating the file
+
+**Returns:** `IWorkbookQuickHandle` — Disposable handle for the Excel file with sheet/table/chart indexers.
+
+### `IWorkbookQuickHandle UseExcelFile(string path)`
+
+Opens an Excel file using interop with default options: creates the file if it does not exist and saves changes when the handle is disposed.
+
+**Parameters:**
+- `path` (`string`) — The path of the Excel file
+
+**Returns:** `IWorkbookQuickHandle` — Disposable handle for the Excel file.
+
+### `IWorkbookQuickHandle UseExcelFile(string path, bool saveChanges, bool createIfNotExist)`
+
+Opens an Excel file using interop with save and create options.
+
+**Parameters:**
+- `path` (`string`) — The path of the Excel file
+- `saveChanges` (`bool`) — True to save changes after workbook operations
+- `createIfNotExist` (`bool`) — True to create the file if it does not exist
+
+**Returns:** `IWorkbookQuickHandle` — Disposable handle for the Excel file.
+
+### `IExcelProcess ExcelProcessScope(ScopeOptions options)`
+
+Controls interaction with the Excel application process. The returned `IExcelProcess` should be disposed when no longer needed.
+
+**Parameters:**
+- `options` (`ScopeOptions`) — Options for interaction with Excel
+
+**Returns:** `IExcelProcess` — Disposable process controller for how Excel files are handled.
+
+### `IExcelProcess ExcelProcessScope()`
+
+Creates an `IExcelProcess` using default options (retrieved from project settings).
+
+**Returns:** `IExcelProcess` — Disposable process controller.
+
+---
+
+## Handle Types
+
+### `IWorkHandle`
+
+Handle to the workbook for portable (Open XML) coded operations.
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` explicitly.
+
+#### Extension Methods (Portable)
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `ReadRange(string sheetName, string range, bool addHeaders, bool preserveFormat)` | `DataTable` | Reads a range as DataTable. If range is empty, reads whole sheet. If range is a single cell, reads from that cell onward. |
+| `WriteRange(string sheetName, string startingCell, DataTable table, bool addHeaders)` | `void` | Writes DataTable data starting at the specified cell. Creates sheet if it doesn't exist. Changes saved immediately. |
+| `AppendRange(string sheetName, DataTable table)` | `void` | Appends DataTable data after existing data in the sheet. Creates sheet if it doesn't exist. |
+| `ReadCell(string sheetName, string cell, bool preserveFormat)` | `object` | Reads a single cell value. |
+| `ReadCellFormula(string sheetName, string cell)` | `string` | Reads the formula from a cell. |
+| `ReadColumn(string sheetName, string startingCell, bool preserveFormat)` | `IEnumerable<object>` | Reads values from a column starting at the specified cell. |
+| `ReadRow(string sheetName, string startingCell, bool preserveFormat)` | `IEnumerable<object>` | Reads values from a row starting at the specified cell. |
+| `WriteCell(string sheetName, string cell, string text)` | `void` | Writes a value into a cell. Creates sheet if it doesn't exist. |
+| `GetTableRange(string sheetName, string tableName, bool isPivot)` | `string` | Extracts the range of an Excel table or pivot table from the specified sheet, depending on `isPivot`. |
+| `GetCellColor(string sheetName, string cell)` | `Color` | Retrieves the fill color of a cell. |
+| `SetRangeColor(string sheetName, string range, Color color)` | `void` | Sets the fill color for a range. |
+| `GetSheets(bool onlyVisibleSheets = false)` | `IEnumerable<string>` | Returns the list of sheet names from the workbook. |
+| `CreatePivotTable(string targetSheet, IPivotTableInfo pivotTableInfo)` | `void` | Creates a pivot table in the specified sheet. |
+| `InsertChart(CreateChartConfig config)` | `string` | Inserts a chart into the workbook. Returns the chart name. |
+| `UpdateChart(UpdateChartConfiguration config)` | `void` | Applies modifications to an existing chart. |
+
+### `IWorkbookQuickHandle`
+
+Handle for Windows/Interop Excel operations with rich indexer access.
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` explicitly.
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `SelectedRange` | `RangeValue` | The currently selected range in the Excel application. |
+| `SelectedCell` | `ExcelValue` | The currently selected cell in the Excel application. |
+| `SelectedSheet` | `WorksheetQuickHandle` | The worksheet currently selected in the Excel application. |
+| `Sheet` | `IWorksheetIndexer` | Array of workbook sheets; use `Sheet["SheetName"]` to select a sheet (`ISheetRef`). |
+| `Table` | `ITableIndexer` | Reference to a particular table; use `Table["TableName"]` to select a table (`ITableRef`). |
+| `FilePath` | `string` | The workbook file path. |
+| `AllPivotTables` | `IPivotTableRef` | Reference to refresh all pivot tables in the workbook. |
+
+#### Extension Methods (Windows/Interop)
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `ForEachSheet(Action<ISheetRef> act)` | `void` | Iterates over each visible sheet in the workbook. |
+| `ForEachSheet(Func<ISheetRef, bool> func)` | `void` | Iterates over sheets; return `false` to break. |
+| `InsertSheet(string sheetName)` | `ISheetRef` | Inserts a new sheet in the workbook. |
+| `ExecuteMacro(string macroName, IList<object> macroArguments)` | `object` | Executes a macro within a macro-enabled workbook. |
+| `InvokeVBA(string codeFilePath, string entryMethodname, IList<object> arguments)` | `object` | Invokes a VBA function from an external code file. |
+| `RefreshDataConnections()` | `void` | Refreshes all data sources in the workbook. |
+| `SaveExcelFile()` | `void` | Saves any pending changes. |
+| `SaveExcelFileAs(string filePath, bool replaceExisting, ExcelSaveAsType saveAsType)` | `void` | Saves the workbook as a different file/format. |
+| `SaveExcelFileAs(string filePath, ExcelSaveAsType saveAsType)` | `void` | Saves as a different file (replaces existing by default). |
+| `SaveAsPdf(string filePath, bool replaceExisting, int? startPage, int? endPage, PdfSaveQuality saveQuality)` | `void` | Saves the workbook as PDF with page range and quality options. |
+| `SaveAsPdf(string filePath, bool replaceExisting)` | `void` | Saves the workbook as PDF (all pages, standard quality). |
+| `SaveAsPdf(string filePath)` | `void` | Saves as PDF (replaces existing, standard quality). |
+| `AddSensitivityLabel(IExcelLabelObject label)` | `void` | Adds or updates a sensitivity label on the workbook. |
+| `GetSensitivityLabel()` | `IExcelLabelObject` | Retrieves the sensitivity label from the workbook. |
+
+### Range Reference Types
+
+The Windows API uses typed references for ranges, cells, sheets, tables, and charts. These are obtained from `IWorkbookQuickHandle` indexers.
+
+| Type | Description | Obtained From |
+|------|-------------|---------------|
+| `ISheetRef` | Reference to a worksheet. Extends `IReadWriteRangeRef`. Has `Name` property. | `handle.Sheet["SheetName"]` |
+| `ITableRef` | Reference to an Excel table. Has `TableName` and `Columns` properties. | `handle.Table["TableName"]` (returns `RangeValue`, which implements `ITableRef`) |
+| `IPivotTableRef` | Reference to a pivot table. Has `TableName` property. | Via `ISheetRef` or `AllPivotTables` |
+| `IChartRef` | Reference to a chart. Has `ChartName`, `ParentSheet`, `ChartInfo` properties. | Via chart operations |
+| `IReadRangeRef` | Readable range (may be dynamic). Has `Worksheet`, `Address`, `FirstCell`, `FullRangeName`, `RowCount` properties and `GetNumberOfColumns()`, `GetTableOrRangeColumns(bool)`, `ToRawDataTable()`, `ReadAsDataTable(bool, bool, bool, bool, ReadFormattingOptions?)` methods. | Via sheet/table refs |
+| `IReadWriteRangeRef` | Readable and writable range. | Extends `IReadRangeRef` |
+| `IWellDefinedReadRangeRef` | Range with fixed address and size. | Via specific range operations |
+| `IWellDefinedReadWriteRangeRef` | Writable range with fixed address and size. Extends `IWellDefinedReadRangeRef` and `IReadWriteRangeRef`. | Via `FillRange` target; base of `ICurrentRowQuickHandle` |
+| `IReadCellRef` | Readable cell reference. Has `Address`, `Worksheet`. | Via cell operations |
+| `IReadWriteCellRef` | Readable and writable cell reference. | Extends `IReadCellRef` |
+| `ICurrentRowQuickHandle` | Current row in a ForEachRow loop. Access cells by name `row["Column"]` or by index `row.ByIndex[0]`. | Via `ForEachRow` callback |
+
+### Range Extension Methods (Windows/Interop)
+
+These extension methods operate on the range reference types obtained from `IWorkbookQuickHandle`.
+
+#### Read Operations
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `ReadRange(bool hasHeaders, ReadFormattingOptions? readFormattingOptions, bool visibleRowsOnly)` | `IReadRangeRef` | `DataTable` | Reads range as DataTable with formatting and visibility options. |
+| `ReadRange(bool hasHeaders, bool visibleRowsOnly)` | `IReadRangeRef` | `DataTable` | Reads range as DataTable using the workbook formatting settings and specified visibility options. |
+| `ReadCellValue(bool getFormattedText)` | `IReadCellRef` | `object` | Reads a cell value. When `getFormattedText` is true, returns the display value (e.g., `"$15.00"`); when false, returns the raw value (e.g., `15`). |
+| `ReadCellValue()` | `IReadCellRef` | `object` | Reads the formatted cell value. |
+| `FindFirstLastDataRow(string columnName, bool hasHeaders, bool visibleRowsOnly, int firstRowOffset, int lastRowOffset, int blankRowsToSkip, LastRowConfiguration configureLastRowAs)` | `IReadRangeRef` | `(int first, int last)` | Finds first and last rows with data. Returns -1 if no data found. |
+| `FindFirstLastDataRow(string columnName, bool hasHeaders, bool visibleRowsOnly, LastRowConfiguration configureLastRowAs)` | `IReadRangeRef` | `(int first, int last)` | Finds first/last data rows with default offsets. |
+| `FindFirstLastDataRow(string columnName)` | `IReadRangeRef` | `(int first, int last)` | Finds first/last data rows with all defaults. |
+| `FindReplaceValue(object valueToFind, FindReplaceOptions operation, object replaceWith, LookInOptions lookIn, bool matchCase, bool matchEntireCellContents)` | `IReadRangeRef` | `string` | Finds or replaces a value. Returns cell address where found. |
+| `LookupRange(object label, IReadRangeRef resultRange)` | `IReadRangeRef` | `object` | LOOKUP function: finds data in a range. |
+| `LookupRange(object label)` | `IReadRangeRef` | `object` | LOOKUP with default result range. |
+| `VLookup(object label, int? columnIndex, bool exactMatch)` | `IReadRangeRef` | `object` | VLOOKUP function. |
+| `VLookup(object label)` | `IReadRangeRef` | `object` | VLOOKUP with exact match and default column. |
+| `MatchFunction(object valueToMatch, MatchType matchFunctionType)` | `IWellDefinedReadRangeRef` | `int` | MATCH function: returns relative position of matched value. |
+| `MatchFunction(object valueToMatch)` | `IWellDefinedReadRangeRef` | `int` | MATCH with default type (LargestValueLessOrEqual). |
+| `GetCellColorInternal()` | `IReadCellRef` | `Color` | Extracts the background color of a cell. **Note:** The `Internal` suffix is part of the public API method name. |
+
+#### Write Operations
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `WriteRange(DataTable source, bool append, bool excludeHeaders, bool ignoreEmptySource)` | `IReadWriteRangeRef` | `void` | Writes DataTable into Excel. |
+| `WriteRange(DataTable source, bool append, bool excludeHeaders)` | `IReadWriteRangeRef` | `void` | Writes DataTable (throws on empty source). |
+| `WriteCell(object value, int rowOffset)` | `IReadWriteCellRef` | `void` | Writes a value/formula into a cell with row offset. |
+| `WriteCell(object value)` | `IReadWriteCellRef` | `void` | Writes a value/formula into a cell. |
+| `AppendRange(IReadRangeRef source, string columnName, bool transpose, CopyPasteRangeOptions pasteOptions, bool destinationHasHeaders, bool excludeSourceHeaders)` | `IReadWriteRangeRef` | `void` | Appends data from source range to destination. |
+| `AppendRange(IReadRangeRef source, bool transpose, CopyPasteRangeOptions pasteOptions, bool excludeSourceHeaders)` | `IReadWriteRangeRef` | `void` | Appends data with paste options. |
+| `AppendRange(IReadRangeRef source)` | `IReadWriteRangeRef` | `void` | Appends data with all defaults. |
+| `CopyPasteRange(IReadRangeRef sourceRange, bool excludeSourceHeaders, bool excludeDestinationHeaders, bool transpose, CopyPasteRangeOptions options)` | `IReadWriteRangeRef` | `void` | Copies and pastes a range to another location. |
+| `FillRange(object value)` | `IWellDefinedReadWriteRangeRef` | `void` | Fills all cells in range with a formula or value. |
+| `ClearRange(bool hasHeaders)` | `IReadWriteRangeRef` | `void` | Clears data from a range/sheet/table. |
+| `ClearRange()` | `IReadWriteRangeRef` | `void` | Clears data (no headers). |
+
+#### Row & Column Operations
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `InsertRows(int nbOfRows, InsertRowPosition insertPosition, int specificIndex, bool hasHeaders)` | `IReadWriteRangeRef` | `void` | Inserts rows at the specified location. |
+| `InsertRows(int nbOfRows)` | `IReadWriteRangeRef` | `void` | Inserts rows at the end (default). |
+| `DeleteColumn(string columnName, bool hasHeaders)` | `IReadWriteRangeRef` | `void` | Deletes a column from a range. |
+| `DeleteColumn(DeleteRowsOption deleteOption, string rowPositions, bool hasHeaders)` | `IReadWriteRangeRef` | `void` | Deletes rows by option (specific, visible, hidden, duplicates). **Note:** Method is named `DeleteColumn` for legacy reasons but deletes rows — see the `DeleteRowsOption` parameter. |
+| `InsertColumn(string columnName, ColumnRelativePosition position, bool hasHeaders, string newColumnHeader, ICellFormat columnFormat)` | `IReadWriteRangeRef` | `void` | Inserts a column at the specified location. |
+| `InsertColumn(string columnName)` | `IReadWriteRangeRef` | `void` | Inserts a column before the target (defaults). |
+| `RemoveDuplicates(bool hasHeaders, ColumnsCompare columnsMode, IEnumerable<string> columns)` | `IReadWriteRangeRef` | `void` | Removes duplicate rows. |
+| `ForEachRow(EmptyRowBehavior emptyRowBehavior, bool forceFirstRowAsHeaders, bool saveAfterEachRow, Func<ICurrentRowQuickHandle, bool> func)` | `IReadRangeRef` | `void` | Iterates over each row; return `false` to break. |
+| `ForEachRow(EmptyRowBehavior emptyRowBehavior, bool forceFirstRowAsHeaders, bool saveAfterEachRow, Action<ICurrentRowQuickHandle> act)` | `IReadRangeRef` | `void` | Iterates over each row. |
+| `ForEachRow(Func<ICurrentRowQuickHandle, bool> func)` | `IReadRangeRef` | `void` | Iterates rows with defaults (stop on empty). |
+| `ForEachRow(Action<ICurrentRowQuickHandle> act)` | `IReadRangeRef` | `void` | Iterates rows with defaults. |
+
+#### Formatting & Appearance
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `Autofit(bool columns, bool rows)` | `IReadRangeRef` | `void` | Autofits columns and/or rows. |
+| `Autofit()` | `IReadRangeRef` | `void` | Autofits both columns and rows. |
+| `Autofill()` | `IWellDefinedReadRangeRef` | `void` | Autofills a range using its data source pattern. |
+| `FormatRange(ICellFormat format, AlignmentOptions alignment, FontOptions font)` | `IReadRangeRef` | `void` | Sets format, alignment, and font for cells in a range. |
+| `SelectRange()` | `IReadRangeRef` | `void` | Selects a range in the Excel application. |
+
+#### Sheet Operations
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `DeleteSheet()` | `ISheetRef` | `void` | Deletes the sheet from the workbook. |
+| `DuplicateSheet(string name)` | `ISheetRef` | `void` | Creates a copy of the sheet. |
+| `RenameSheet(string name)` | `ISheetRef` | `void` | Renames the sheet. |
+| `ProtectSheet(string password, ProtectSheetAdditionalPermissions additionalPermissions)` | `ISheetRef` | `void` | Protects the sheet with a password. |
+| `ProtectSheet(string password)` | `ISheetRef` | `void` | Protects the sheet (no additional permissions). |
+| `ProtectSheet(SecureString securedPassword, ProtectSheetAdditionalPermissions additionalPermissions)` | `ISheetRef` | `void` | Protects the sheet with a secure password. |
+| `ProtectSheet(SecureString securedPassword)` | `ISheetRef` | `void` | Protects the sheet with a secure password (no additional permissions). |
+| `UnprotectSheet(string password)` | `ISheetRef` | `void` | Unprotects the sheet. |
+| `UnprotectSheet(SecureString securedPassword)` | `ISheetRef` | `void` | Unprotects the sheet with a secure password. |
+
+#### Table & Pivot Operations
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `CreateTable(bool hasHeaders, bool replaceExisting, string tableName)` | `IReadWriteRangeRef` | `string` | Formats range as a named table. Returns the table name. |
+| `CreateTable(bool replaceExisting, string tableName)` | `IReadWriteRangeRef` | `string` | Creates a table (assumes headers). |
+| `CreatePivotTable(string destinationTableName, IReadWriteRangeRef destination, PivotTableDescriptor descriptor)` | `IReadRangeRef` | `void` | Creates a pivot table from range/table data. |
+| `ChangePivotTableDataSource(IPivotTableRef pivotTable)` | `IWellDefinedReadRangeRef` | `void` | Changes the data source of a pivot table. |
+| `RefreshPivotTable(PivotTableLayoutRowType? layoutRowType)` | `IPivotTableRef` | `void` | Refreshes pivot table data and optionally changes layout. |
+| `FilterPivotTable(string columnName, IEnumerable<string> values, bool clearFilter)` | `IPivotTableRef` | `void` | Filters a pivot table by column values. |
+| `Filter(FilterOptions options)` | `IReadWriteRangeRef` | `void` | Filters a range/table/sheet by column values. |
+| `Sort(SortXDescriptor descriptor, bool hasHeaders)` | `IReadWriteRangeRef` | `void` | Sorts data by one or more columns. |
+| `TextToColumns(IReadWriteRangeRef destRange, TextToColumnsOptions options)` | `IWellDefinedReadRangeRef` | `void` | Splits text into columns using delimiters or fixed width. |
+| `TextToColumns(IReadWriteRangeRef destRange)` | `IWellDefinedReadRangeRef` | `void` | Splits text into columns using default options. |
+
+#### Chart Operations
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `InsertExcelChart(ISheetRef sheet, ExcelChartCategory chartCategory, ExcelChartType chartType, int left, int top, int width, int height)` | `IReadRangeRef` | `IChartRef` | Creates a chart from range data. |
+| `GetChart(ExcelChartAction action, string fileName, bool replaceFile)` | `IChartRef` | `void` | Saves chart to file or copies to clipboard. |
+| `GetChart()` | `IChartRef` | `void` | Copies chart to clipboard. |
+
+#### Export Operations
+
+| Method | Extends | Return Type | Description |
+|--------|---------|------------|-------------|
+| `ExportExcelToSCV(string fileName)` | `IReadRangeRef` | `void` | Exports a range, table, sheet, or pivot table to a CSV file. **Note:** The `SCV` suffix is intentional — it matches the public API method name. |
+
+### `IExcelProcess`
+
+Controls interaction with the Excel application process.
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` explicitly.
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ProcessId` | `int?` | The process ID of the Excel process. Is `null` until the Excel process is created or attached. |
+| `Visible` | `bool` | Whether the Excel window is visible. |
+
+#### Methods
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `IsAlive()` | `bool` | Checks whether the Excel process is still running. |
+| `Quit()` | `bool` | Terminates the Excel process. Returns true if successfully quit. |
+
+### `ICurrentRowQuickHandle`
+
+Represents the current row during a `ForEachRow` loop. Extends `IWellDefinedReadWriteRangeRef`.
+
+#### Indexers
+
+| Indexer | Type | Description |
+|---------|------|-------------|
+| `this[string column]` | `ExcelValue` (get/set) | Access cell value by column name. |
+| `ByIndex[int index]` | `ExcelValue` (get/set) | Access cell value by column index. |
+| `ByField[string name]` | `ExcelValue` (get/set) | Access cell value by field name. |
+
+### `ExcelValue`
+
+Represents a cell value from an Excel document (Windows/Interop API). Returned by `ICurrentRowQuickHandle` indexers and the `SelectedCell` property.
+
+> All constructors are `internal`, so you do not use `new ExcelValue(...)` directly. In practice, you work with `ExcelValue` instances by reading from handle indexers (e.g., `row["Column"]`) and assigning primitive values to cells (e.g., `row["Column"] = 5;`) which are implicitly converted to `ExcelValue`. You can also use the typed value properties below to read or set the underlying cell value — see **Implicit Conversions** for the full list of supported types.
+
+#### Read-Only Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Color` | `System.Drawing.Color` | The background color of the cell. |
+| `Formula` | `string` | The formula of the cell (if any). |
+| `RawValue` | `object` | The unformatted value of the cell. |
+| `RawValueType` | `Type` | The CLR type of the raw value. |
+| `Worksheet` | `string` | The name of the worksheet the cell belongs to. |
+| `Address` | `string` | The cell address (e.g., `"A1"`). |
+
+#### Typed Value Properties (get/set)
+
+Use these to read or write cell values with type safety. The setter persists the value back to Excel.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `StringValue` | `string` | Read/write a string value. |
+| `Int32Value` | `int` | Read/write an integer value. |
+| `BooleanValue` | `bool` | Read/write a boolean value. |
+| `DoubleValue` | `double` | Read/write a double value. |
+| `DecimalValue` | `decimal` | Read/write a decimal value. |
+| `DateTimeValue` | `DateTime` | Read/write a DateTime value. |
+| `TimeSpanValue` | `TimeSpan` | Read/write a TimeSpan value. |
+
+#### Implicit Conversions
+
+`ExcelValue` supports implicit conversion **from** `bool`, `int`, `long`, `double`, `decimal`, `string`, `DateTime`, and `TimeSpan` (allowing direct cell assignment) and **to** the same types (allowing direct reading):
+
+```csharp
+row["Quantity"] = 5;             // implicit conversion from int to ExcelValue
+row["Name"] = "Alice";           // implicit conversion from string to ExcelValue
+string name = row["Name"];       // implicit conversion from ExcelValue to string
+int quantity = row["Quantity"];   // implicit conversion from ExcelValue to int
+```
+
+### `RangeValue`
+
+Represents a range in Excel (Windows/Interop API). Returned by `IWorkbookQuickHandle.SelectedRange` and table indexers. Implements `ITableRef` and `IPivotTableRef`. Supports implicit conversion to and from `DataTable`, so `DataTable data = handle.Table["TableName"];` works directly.
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Worksheet` | `string` | The name of the worksheet the range belongs to. |
+| `Address` | `string` | The address of the range (e.g., `"A1:D10"`). |
+| `FullRangeName` | `string` | The full name of the range (e.g., `"Sheet1!A1:D10"`). |
+| `FirstCell` | `string` | The address of the first cell in the range. |
+| `RowCount` | `int` | The number of rows in the range. |
+| `Columns` | `IEnumerable<string>` | The list of columns (when the range represents a table). |
+| `TableName` | `string` | The table name (when the range represents a table). |
+| `RangeType` | `ExcelRangeType` | The type of range: `Range`, `Table`, `PivotTable`, `Sheet`, or `DataTable`. |
+| `DataTableOutValue` | `DataTable` | Helper DataTable for Out/InOut arguments. The getter always returns a new empty DataTable and does not read the current range contents (this is by design). |
+
+---
+
+## Static CSV Methods
+
+These are static methods on the `ExcelOperations` class (no handle required).
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `ExcelOperations.ReadCsvFile(string filePath, DelimitatorOptions delimiter, bool includeColumnNames, string encodingStr, bool ignoreQuotes)` | `DataTable` | Reads a CSV file into a DataTable. |
+| `ExcelOperations.WriteCsvFile(string filePath, DataTable data, DelimitatorOptions delimiter, bool addHeaders, string encodingStr, bool shouldQuote)` | `void` | Writes a DataTable to a CSV file (replaces existing data). |
+| `ExcelOperations.AppendCsvFile(string filePath, DataTable data, DelimitatorOptions delimiter, string encodingStr)` | `void` | Appends a DataTable to an existing CSV file. |
+
+---
+
+## Options & Configuration Classes
+
+### `WorkbookOptions`
+
+Options for opening or creating a workbook (portable API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Path` | `string` | `null` | Path of the workbook. |
+| `Password` | `string` | `null` | Password of the workbook, if necessary. |
+| `CreateNew` | `bool` | `true` | Create the workbook if it does not exist. |
+| `ConflictBehavior` | `ConflictBehavior?` | `null` | Behavior when a file already exists and `CreateNew` is true. When null, the existing file is opened. |
+
+### `UseOptions`
+
+Options for opening or creating Excel files (Windows/Interop API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ExcelProcess` | `IExcelProcess` | `null` | Controls interaction with Excel. If null, options are retrieved from project settings. |
+| `Path` | `string` | `null` | Path of the Excel file. |
+| `Password` | `string` | `null` | Password for the Excel file. |
+| `EditPassword` | `string` | `null` | Edit password for the Excel file. |
+| `CreateIfNotExist` | `bool` | `true` | Create the file if it does not exist. |
+| `KeepExcelOpen` | `bool` | `false` | Keep the file open after the operation. |
+| `ReadFormatting` | `ReadFormattingOptions?` | `null` | How to format read values (Default, RawValue, DisplayValue). Null reads from project settings. |
+| `ReadOnly` | `bool` | `false` | Open the workbook as read-only. |
+| `ResizeWindow` | `ResizeWindowOptions` | `None` | Resize the Excel window (None, Minimize, Maximize). |
+| `SaveChanges` | `bool` | `true` | Save changes after workbook operations. |
+| `SensitivityOperation` | `ExcelLabelOperation` | `None` | Sensitivity label operation when opening/creating. |
+| `SensitivityLabel` | `IExcelLabelObject` | `null` | Sensitivity label to apply (only when SensitivityOperation is Add). |
+
+### `ScopeOptions`
+
+Options for controlling the Excel process (Windows/Interop API). If a property is null, it is retrieved from project settings.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `DisplayAllerts` | `bool?` | `null` | Allow Excel to display alerts and messages. **Note:** The property name is intentionally spelled `DisplayAllerts` (not "Alerts") to match the source API. |
+| `ExistingProcessAction` | `ExistingExcelProcessAction?` | `null` | Action if other Excel processes are running. |
+| `FileConflictResolution` | `ExcelFileConflictResolution?` | `null` | Action if Excel document conflicts are detected between processes. |
+| `LaunchMethod` | `ExcelStartMethod?` | `null` | How the Excel process is launched. |
+| `LaunchTimeout` | `int?` | `null` | Time to wait for Excel to start (full process launch). |
+| `MacroSetting` | `MacroSetting?` | `null` | Enable or disable macros. |
+| `ProcessMode` | `ExcelProcessMode?` | `null` | New process, reuse if available, or unique for attended users. |
+| `ShowExcelWindow` | `bool?` | `null` | Show the Excel window during automation. |
+
+### `FilterOptions`
+
+Options for filtering ranges (Windows/Interop API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ColumnName` | `string` | `null` | Column containing the values to filter. |
+| `ClearFilter` | `bool` | `false` | Clear any existing filter applied to the target range. |
+| `Filter` | `IFilter` | `null` | Filter implementation: `BasicFilter` (list of values) or `AdvancedFilter` (conditions). |
+
+### `BasicFilter`
+
+Simple filter matching a list of values. Implements `IFilter`.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Values` | `List<string>` | empty list | List of matching values. |
+
+### `AdvancedFilter`
+
+Filter with operator conditions. Implements `IFilter`.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Operator` | `LogicalOperator` | `And` | Operator between the two conditions. |
+| `Condition1` | `ExcelFilterOperator` | — | Operator for the first condition. |
+| `Value1` | `string` | `null` | Value for the first condition. |
+| `Condition2` | `ExcelFilterOperator` | — | Operator for the second condition. |
+| `Value2` | `string` | `null` | Value for the second condition. |
+
+### `TextToColumnsOptions`
+
+Options for splitting text into columns.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ParsingType` | `TextToColumnsParsingType` | `Delimited` | Delimited (by characters) or FixedWidth (by character count). |
+| `NumberOfCharactersPerColumn` | `int` | `0` | Width of each data unit (fixed width mode). |
+| `ColumnsDelimiters` | `TextToColumnsDelimiters` | Tab, Semicolon, Comma, Space | Delimiters to use (flags enum). |
+| `SplitByLineBreak` | `bool` | `false` | Split by line breaks. |
+| `OtherSeparator` | `char?` | `null` | Custom separator character (when `Other` flag is set). |
+| `ConsecutiveOperatorsAsOne` | `bool` | `true` | Treat consecutive delimiters as one. |
+| `TextQualifier` | `TextToColumnsTextQualifier` | `None` | Character that encloses text values. |
+
+### `CreateChartConfig`
+
+Configuration for creating a chart (portable API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `UseTableSource` | `bool` | `false` | Use a table as the data source (instead of a range). |
+| `SourceSheet` | `string` | `null` | Sheet containing the source data. |
+| `SourceRange` | `string` | `null` | Range address for the chart data (when `UseTableSource` is false). |
+| `SourceTable` | `string` | `null` | Table name for the chart data (when `UseTableSource` is true). |
+| `PlacementSheet` | `string` | `null` | Sheet where the chart will be placed. |
+| `ChartCategory` | `ExcelChartCategory` | `Column` | Chart category (Area, Bar, Column, Line, Pie, Scatter). |
+| `ChartType` | `ExcelChartType` | `xlColumnClustered` | Specific chart subtype. |
+| `Height` | `int` | `211` | Chart height in points. |
+| `Width` | `int` | `355` | Chart width in points. |
+| `Left` | `int` | `60` | Left position in points. |
+| `Top` | `int` | `20` | Top position in points. |
+
+### `UpdateChartConfiguration`
+
+Configuration for updating an existing chart (portable API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ChartName` | `string` | `null` | Name of the chart to update. |
+| `PlacementSheet` | `string` | `null` | Sheet containing the chart. |
+| `Type` | `ChartModificationType` | — | Type of modification to apply. |
+| `Modifications` | `IEnumerable<IChartModification>` | `null` | Collection of modifications to apply. |
+
+#### Chart Modification Types (`IChartModification`)
+
+Each modification type corresponds to a `ChartModificationType` value:
+
+**`ChangeDataRangeChartModification`**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `UseTableSource` | `bool` | Use a table as the data source. |
+| `TableName` | `string` | Table name (when `UseTableSource` is true). |
+| `SheetName` | `string` | Sheet containing the data range. |
+| `Range` | `string` | Range address for the new data. |
+
+**`ModifyChartTitleChartModification`**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Title` | `string` | New chart title text. |
+| `ShowTitle` | `bool` | Whether to display the title. |
+
+**`UpdateAxisTitleChartModification`**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Axis` | `AxisOrientationType` | Which axis to update (`Horizontal` or `Vertical`). |
+| `ShowTitle` | `bool` | Whether to display the axis title. |
+| `Title` | `string` | New axis title text. |
+
+**`UpdateAxisBoundsChartModification`**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Axis` | `AxisOrientationType` | Which axis to update (`Horizontal` or `Vertical`). |
+| `MinBound` | `double?` | Minimum axis value (null for auto). |
+| `MaxBound` | `double?` | Maximum axis value (null for auto). |
+
+**`ShowHideLegendChartModification`**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ShowLegend` | `bool` | Whether to display the chart legend. |
+
+**`ShowHideDataLabelsChartModification`**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ShowDataLabels` | `bool` | Whether to display data labels. |
+
+### `PivotTableDescriptor`
+
+Describes the structure of a pivot table (Windows/Interop API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Rows` | `List<RowPivotTableFieldDescription>` | empty list | Fields to use as row labels. |
+| `Columns` | `List<ColumnPivotTableFieldDescription>` | empty list | Fields to use as column labels. |
+| `Filters` | `List<FilterPivotTableFieldDescription>` | empty list | Fields to use as report filters. |
+| `Values` | `List<ValuePivotTableFieldDescription>` | empty list | Fields to aggregate as values. |
+| `ValuesMode` | `PivotTableValuesMode` | `Columns` | Display values in columns or rows. |
+| `LayoutRowType` | `PivotTableLayoutRowType` | `Compact` | Row layout type (Compact, Tabular, Outline). |
+
+**Pivot field description types** — All inherit from `PivotTableFieldDescriptionBase` with a `Name` property (the source column name). `ValuePivotTableFieldDescription` adds:
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Function` | `PivotTableFunction` | — | Aggregation function (Sum, Count, Average, Max, Min, Product, etc.). |
+
+### `IPivotTableInfo`
+
+Marker interface for pivot table creation info (portable API). Used by `IWorkHandle.CreatePivotTable`. No properties — implementations define the pivot table structure.
+
+### `SortXDescriptor`
+
+Describes columns to sort by (Windows/Interop API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `SortColumns` | `List<SortXColumnModel>` | empty list | Ordered list of columns to sort by. |
+
+### `SortXColumnModel`
+
+Holds sort information for a single column.
+
+**Constructor:** `SortXColumnModel(string columnName, OrderType sortOrder)`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ColumnName` | `string` | Name of the column to sort by. |
+| `SortOrder` | `OrderType` | Sort direction: `Ascending` or `Descending`. |
+| `ColumnIndex` | `int` | Column index (set automatically during sort). |
+
+### `ICellFormat`
+
+Represents a cell number format for formatting operations.
+
+| Member | Type | Description |
+|--------|------|-------------|
+| `FormatType` | `CellFormat` | The format category: `General`, `Number`, `Date`, `Time`, `Percentage`, `Currency`, `Text`, `Custom`. |
+| `UseLocal` | `bool` | Whether to use locale-specific formatting. |
+| `ToExcelString(ExcelFormatParameters)` | `string` | Converts the format to an Excel format string. |
+
+### `AlignmentOptions`
+
+Alignment settings for `FormatRange`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `HorizontalAlignment` | `ExcelRangeHorizontalAlignment` | Horizontal alignment. |
+| `VerticalAlignment` | `ExcelRangeVerticalAlignment` | Vertical alignment. |
+| `WrapText` | `bool` | Whether to wrap text in the cell. |
+
+### `FontOptions`
+
+Font settings for `FormatRange`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `FontFamilyName` | `string` | Font family name (e.g., `"Calibri"`). |
+| `Style` | `ExcelRangeFontStyle` | Font style (bold, italic, etc.). |
+| `Size` | `double` | Font size in points. |
+| `Color` | `Color` | Font foreground color. |
+| `FillColor` | `Color` | Cell fill/background color. |
+| `UnderlineStyle` | `ExcelRangeUnderlineStyle` | Underline style. |
+
+### `IExcelLabelObject`
+
+Sensitivity label to apply to or retrieve from a workbook.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `LabelId` | `string` | Sensitivity label ID. |
+| `Justification` | `string` | Justification for changing the label. |
+
+---
+
+## Enum Reference
+
+**`ConflictBehavior`**: `Replace`, `Fail`, `Skip`
+
+**`ReadFormattingOptions`**: `Default`, `RawValue`, `DisplayValue`
+
+**`ResizeWindowOptions`**: `None`, `Minimize`, `Maximize`
+
+**`ExcelLabelOperation`**: `None`, `Add`, `Clear`
+
+**`EmptyRowBehavior`**: `StopAfterThreeConsecutiveEmptyRows`, `Stop`, `Skip`, `Process`
+
+**`PdfSaveQuality`**: `StandardQuality`, `MinimumQuality`
+
+**`ExcelSaveAsType`**: `OpenXmlWorkbook`, `BinaryWorkbook`, `MacroEnabledWorkbook`, `OldWorkbook`
+
+**`ExcelChartAction`**: `CopyToClipboard`, `SaveAsPicture`
+
+**`ExcelChartCategory`**: `Area`, `Bar`, `Column`, `Line`, `Pie`, `Scatter`
+
+**`CopyPasteRangeOptions`**: `All`, `Values`, `Formulas`, `Formats`
+
+**`FindReplaceOptions`**: `Find`, `Replace`, `ReplaceAll`
+
+**`LookInOptions`**: `Values`, `Formulas`
+
+**`DeleteRowsOption`**: `Specific`, `Visible`, `Hidden`, `Duplicates`
+
+**`InsertRowPosition`**: `Start`, `End`, `Specific`
+
+**`ColumnRelativePosition`**: `Before`, `After`
+
+**`ColumnsCompare`**: `IndividualColumns`, `AllColumns`
+
+**`MatchType`**: `LargestValueLessOrEqual`, `ExactlyEqual`, `SmallestValueGreaterOrEqual`
+
+**`LastRowConfiguration`**: `LastPopulatedRow`, `FirstEmptyRow`
+
+**`PivotTableLayoutRowType`**: `Compact`, `Tabular`, `Outline`
+
+**`ProtectSheetAdditionalPermissions`** (flags): `None`, `AllowDeletingColumns`, `AllowDeletingRows`, `DrawingObjects`, `Scenarios`, `AllowFiltering`, `AllowFormattingCells`, `AllowFormattingColumns`, `AllowFormattingRows`, `AllowInsertingColumns`, `AllowInsertingHyperlinks`, `AllowInsertingRows`, `AllowSorting`, `AllowUsingPivotTables`
+
+**`DelimitatorOptions`**: `Comma`, `Semicolon`, `Pipe`, `Caret`, `Tab`
+
+**`ExcelProcessMode`**: `AlwaysCreateNew`, `AttendedUser`, `ReuseIfExists`, `OnlyIfExists`
+
+**`ExcelFileConflictResolution`**: `None`, `CloseWithoutSaving`, `PromptUser`, `ThrowException`
+
+**`ExistingExcelProcessAction`**: `None`, `ForceKill`
+
+**`ExcelStartMethod`**: `Automation`, `Application`
+
+**`MacroSetting`**: `EnableAll`, `DisableAll`, `ReadFromExcelSettings`
+
+**`LogicalOperator`**: `And`, `Or`
+
+**`ExcelFilterOperator`**: `NONE`, `LT` (<), `GT` (>), `LTE` (<=), `GTE` (>=), `EQ` (=), `NOTEQ` (!=), `EMPTY`, `NOTEMPTY`, `STARTSWITH`, `ENDSWITH`, `CONTAINS`, `NOTSTARTSWITH`, `NOTENDSWITH`, `NOTCONTAINS`
+
+**`ExcelChartType`**: `xlArea`, `xlAreaStacked`, `xlAreaStacked100`, `xlBarClustered`, `xlBarStacked`, `xlBarStacked100`, `xlColumnClustered`, `xlColumnStacked`, `xlColumnStacked100`, `xlLine`, `xlLineMarkers`, `xlLineMarkersStacked`, `xlLineMarkersStacked100`, `xlLineStacked`, `xlLineStacked100`, `xlDoughnut`, `xlPie`, `xlXYScatterSmoothNoMarkers`, `xlXYScatterSmooth`, `xlXYScatterLinesNoMarkers`, `xlXYScatterLines`, `xlXYScatter`, `Other`
+
+**`TextToColumnsParsingType`**: `Delimited`, `FixedWidth`
+
+**`TextToColumnsDelimiters`** (flags): `None`, `Tab`, `Semicolon`, `Comma`, `Space`, `Other`
+
+**`TextToColumnsTextQualifier`**: `None`, `DoubleQuote`, `SingleQuote`
+
+**`PivotTableFunction`**: `Sum`, `Count`, `Average`, `Max`, `Min`, `Product`, `CountNumbers`, `StdDev`, `StdDevp`, `Var`, `Varp`
+
+**`PivotTableValuesMode`**: `Columns`, `Rows`
+
+**`ChartModificationType`**: `ChangeDataRange`, `ModifyChartTitle`, `UpdateAxisTitle`, `UpdateAxisBounds`, `ShowHideLegend`, `ShowHideDataLabels`
+
+**`ExcelRangeType`**: `Range`, `Table`, `PivotTable`, `Sheet`, `DataTable`
+
+**`OrderType`**: `Ascending`, `Descending`
+
+**`CellFormat`**: `General`, `Number`, `Date`, `Time`, `Percentage`, `Currency`, `Text`, `Custom`
+
+**`ExcelRangeHorizontalAlignment`**: `xlHAlignGeneral`, `xlHAlignLeft`, `xlHAlignCenter`, `xlHAlignRight`, `xlHAlignFill`, `xlHAlignJustify`, `xlHAlignCenterAcrossSelection`, `xlHAlignDistributed`
+
+**`ExcelRangeVerticalAlignment`**: `xlVAlignTop`, `xlVAlignCenter`, `xlVAlignBottom`, `xlVAlignJustify`, `xlVAlignDistributed`
+
+**`ExcelRangeFontStyle`**: `Regular`, `Italic`, `Bold`, `BoldItalic`
+
+**`ExcelRangeUnderlineStyle`**: `None`, `Single`, `Double`, `SingleAccounting`, `DoubleAccounting`
+
+**`AxisOrientationType`**: `Horizontal`, `Vertical`
+
+---
+
+## Common Patterns
+
+### Read and process Excel data (Portable)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var workbook = excel.UseWorkBook("C:\\Data\\report.xlsx", createNew: false);
+    var data = workbook.ReadRange("Sheet1", "A1:D100", addHeaders: true, preserveFormat: false);
+
+    foreach (DataRow row in data.Rows)
+    {
+        var name = row["Name"].ToString();
+        var amount = Convert.ToDecimal(row["Amount"]);
+        Log($"Processing {name}: {amount:C}");
+    }
+}
+```
+
+### Read, transform, and write back (Windows/Interop)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var file = excel.UseExcelFile("C:\\Data\\sales.xlsx", saveChanges: true, createIfNotExist: false);
+    var sheet = file.Sheet["Sales"];
+
+    var data = sheet.ReadRange(hasHeaders: true, visibleRowsOnly: false);
+
+    // Add a computed column
+    data.Columns.Add("Total", typeof(decimal));
+    foreach (DataRow row in data.Rows)
+    {
+        row["Total"] = Convert.ToDecimal(row["Quantity"]) * Convert.ToDecimal(row["Price"]);
+    }
+
+    // Write results to a new sheet
+    var resultsSheet = file.InsertSheet("Results");
+    resultsSheet.WriteRange(data, append: false, excludeHeaders: false);
+}
+```
+
+### Iterate rows and update cells (Windows/Interop)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var file = excel.UseExcelFile("C:\\Data\\inventory.xlsx");
+    var sheet = file.Sheet["Inventory"];
+
+    sheet.ForEachRow(EmptyRowBehavior.Stop, forceFirstRowAsHeaders: true, saveAfterEachRow: false, row =>
+    {
+        var quantity = row["Quantity"].Int32Value;
+        if (quantity < 10)
+        {
+            row["Status"].StringValue = "Low Stock";
+        }
+    });
+}
+```
+
+### Create a workbook with options (Portable)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var options = new WorkbookOptions
+    {
+        Path = "C:\\Output\\new_report.xlsx",
+        CreateNew = true,
+        ConflictBehavior = ConflictBehavior.Replace
+    };
+
+    using var workbook = excel.UseWorkBook(options);
+    var report = new DataTable();
+    report.Columns.Add("Date", typeof(string));
+    report.Columns.Add("Revenue", typeof(decimal));
+    report.Rows.Add("2026-01-01", 15000.50m);
+    report.Rows.Add("2026-01-02", 22300.75m);
+
+    workbook.WriteRange("Summary", "A1", report, addHeaders: true);
+}
+```
+
+### Excel Process Scope with filtering and export (Windows/Interop)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var process = excel.ExcelProcessScope(new ScopeOptions
+    {
+        ShowExcelWindow = false,
+        MacroSetting = MacroSetting.DisableAll
+    });
+
+    var useOptions = new UseOptions
+    {
+        Path = "C:\\Data\\large_dataset.xlsx",
+        ExcelProcess = process,
+        SaveChanges = false,
+        ReadOnly = true
+    };
+
+    using var file = excel.UseExcelFile(useOptions);
+    var sheet = file.Sheet["Data"];
+
+    // Filter to specific values
+    sheet.Filter(new FilterOptions
+    {
+        ColumnName = "Region",
+        Filter = new BasicFilter { Values = new List<string> { "North", "East" } }
+    });
+
+    // Read only visible (filtered) rows
+    var filtered = sheet.ReadRange(hasHeaders: true, visibleRowsOnly: true);
+
+    // Export to CSV
+    ExcelOperations.WriteCsvFile("C:\\Output\\filtered.csv", filtered, UiPath.CSV.DelimitatorOptions.Comma,
+        addHeaders: true, encodingStr: "utf-8", shouldQuote: true);
+}
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.6/overview.md
@@ -1,0 +1,124 @@
+# UiPath Excel Activities
+
+`UiPath.Excel.Activities`
+
+Activities for reading, writing, and manipulating Excel workbooks, CSV files, charts, pivot tables, and cell formatting. Includes both cross-platform (file-based) and Windows-only (Excel Interop) activities.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+
+## Activities
+
+### Cross-Platform — CSV
+
+| Activity | Description |
+|----------|-------------|
+| [Read CSV](activities/ReadCsvFile.md) | Reads all entries from a CSV file into a DataTable |
+| [Write CSV](activities/AppendWriteCsvFile.md) | Writes or appends a DataTable to a CSV file |
+
+### Cross-Platform — Workbook
+
+| Activity | Description |
+|----------|-------------|
+| [Read Range Workbook](activities/ReadRange.md) | Reads a range from a spreadsheet as a DataTable |
+| [Write Range Workbook](activities/WriteRange.md) | Writes a DataTable to a spreadsheet starting from a cell |
+| [Read Cell Workbook](activities/ReadCell.md) | Reads the value of a cell as a string |
+| [Read Cell Formula Workbook](activities/ReadCellFormula.md) | Reads the formula of a cell as a string |
+| [Write Cell Workbook](activities/WriteCell.md) | Writes a value into a cell |
+| [Append Range Workbook](activities/AppendRange.md) | Appends a DataTable after existing data in a sheet |
+| [Get Table Range Workbook](activities/GetTableRange.md) | Gets the range of a named table |
+| [Read Row Workbook](activities/ReadRow.md) | Reads row values starting from a cell |
+| [Read Column Workbook](activities/ReadColumn.md) | Reads column values starting from a cell |
+| [Create Pivot Table Workbook](activities/CreatePivotTable.md) | Creates a pivot table from a data source |
+| [Get Cell Color Workbook](activities/GetCellColor.md) | Gets the background color of a cell |
+| [Set Range Color Workbook](activities/SetRangeColor.md) | Sets the background color of a range |
+| [Create New Workbook](activities/CreateNewWorkbook.md) | Creates a new Excel workbook |
+| [Get Sheets Workbook](activities/GetSheets.md) | Gets the list of sheet names |
+| [Insert Chart Workbook](activities/InsertChart.md) | Inserts a chart into a workbook |
+| [Update Chart Workbook](activities/UpdateChart.md) | Updates an existing chart with modifications |
+
+### Windows — Scopes
+
+| Activity | Description |
+|----------|-------------|
+| [Use Excel File](activities/ExcelApplicationCard.md) | Opens an Excel file and provides a scope for Excel activities |
+| [Excel Process Scope](activities/ExcelProcessScopeX.md) | Manages the Excel application process lifecycle |
+
+### Windows — Range
+
+| Activity | Description |
+|----------|-------------|
+| [Read Range](activities/ReadRangeX.md) | Reads data from a range into a DataTable |
+| [Write Range](activities/WriteRangeX.md) | Writes a DataTable to a range |
+| [Append Range](activities/AppendRangeX.md) | Appends data after existing content |
+| [Clear Range](activities/ClearRangeX.md) | Clears the contents of a range |
+| [Copy Paste Range](activities/CopyPasteRangeX.md) | Copies a range and pastes it to a destination |
+| [Fill Range](activities/FillRangeX.md) | Fills a range using auto-fill rules |
+| [Auto Fit](activities/AutoFitX.md) | Auto-fits column widths or row heights |
+| [Create Table](activities/CreateTableX.md) | Creates a named table from a range |
+| [Delete Column](activities/DeleteColumnX.md) | Deletes a column from a sheet |
+| [Delete Rows](activities/DeleteRowsX.md) | Deletes rows from a sheet |
+| [Insert Rows](activities/InsertRowsX.md) | Inserts rows into a sheet |
+| [Insert Column](activities/InsertColumnX.md) | Inserts a column into a sheet |
+| [For Each Excel Row](activities/ExcelForEachRowX.md) | Iterates over each row in a range |
+| [Export to CSV](activities/ExportExcelToCsvX.md) | Exports an Excel range to a CSV file |
+| [Find/Replace Value](activities/FindReplaceValueX.md) | Finds and optionally replaces values in a range |
+| [Find First/Last Data Row](activities/FindFirstLastDataRowX.md) | Finds the first and last row with data |
+| [Lookup Range](activities/LookupX.md) | Looks up a value in a range and returns the cell address |
+| [MATCH Function](activities/MatchFunctionX.md) | Finds the position of a value in a range |
+| [VLOOKUP](activities/VLookupX.md) | Performs a vertical lookup in a range |
+| [Filter](activities/FilterX.md) | Applies filters to a range |
+| [Sort](activities/SortX.md) | Sorts a range by one or more columns |
+| [Text to Columns](activities/TextToColumnsX.md) | Splits text in a column into multiple columns |
+| [Remove Duplicates](activities/RemoveDuplicatesX.md) | Removes duplicate rows from a range |
+| [Format Range](activities/FormatRangeX.md) | Applies formatting (font, alignment, data type) to a range |
+| [Get Selected Range](activities/GetSelectedRangeX.md) | Gets the currently selected range in Excel |
+| [Select Range](activities/SelectRangeX.md) | Selects a range in the active Excel workbook |
+
+### Windows — Cell
+
+| Activity | Description |
+|----------|-------------|
+| [Read Cell Value](activities/ReadCellValueX.md) | Reads the value of a cell |
+| [Read Cell Formula](activities/ReadCellFormulaX.md) | Reads the formula of a cell |
+| [Write Cell](activities/WriteCellX.md) | Writes a value to a cell |
+| [Auto Fill](activities/AutoFillX.md) | Auto-fills cells based on a source range pattern |
+| [Get Cell Color](activities/GetCellColorX.md) | Gets the background color of a cell |
+
+### Windows — Workbook Management
+
+| Activity | Description |
+|----------|-------------|
+| [Save Excel File](activities/SaveExcelFileX.md) | Saves the current Excel file |
+| [Save Excel File As](activities/SaveExcelFileAsX.md) | Saves the Excel file with a new name or format |
+| [Save As PDF](activities/SaveAsPdfX.md) | Exports the workbook or sheet to PDF |
+| [Insert Sheet](activities/InsertSheetX.md) | Inserts a new sheet |
+| [Delete Sheet](activities/DeleteSheetX.md) | Deletes a sheet |
+| [Duplicate Sheet](activities/DuplicateSheetX.md) | Duplicates a sheet |
+| [Rename Sheet](activities/RenameSheetX.md) | Renames a sheet |
+| [For Each Sheet](activities/ForEachSheetX.md) | Iterates over each sheet in a workbook |
+| [Protect Sheet](activities/ProtectSheetX.md) | Protects a sheet with a password |
+| [Unprotect Sheet](activities/UnprotectSheetX.md) | Removes protection from a sheet |
+| [Run Spreadsheet Macro](activities/ExecuteMacroX.md) | Executes an Excel macro |
+| [Invoke VBA](activities/InvokeVBAX.md) | Invokes a VBA script from a code file |
+| [Refresh Data Connections](activities/RefreshDataConnectionsX.md) | Refreshes all data connections in the workbook |
+| [Add Sensitivity Label](activities/AddSensitivityLabelX.md) | Adds or updates a sensitivity label |
+| [Get Sensitivity Label](activities/GetSensitivityLabelX.md) | Gets the current sensitivity label |
+
+### Windows — Pivot Table
+
+| Activity | Description |
+|----------|-------------|
+| [Create Pivot Table](activities/CreatePivotTableXv2.md) | Creates a pivot table from a data source |
+| [Change Pivot Table Data Source](activities/ChangePivotTableDataSourceX.md) | Changes the data source of a pivot table |
+| [Refresh Pivot Table](activities/RefreshPivotTableX.md) | Refreshes a pivot table |
+| [Filter Pivot Table](activities/FilterPivotTableX.md) | Applies filters to a pivot table |
+
+### Windows — Chart
+
+| Activity | Description |
+|----------|-------------|
+| [Insert Excel Chart](activities/InsertExcelChartX.md) | Inserts a chart into a sheet |
+| [Update Chart](activities/UpdateChartX.md) | Updates an existing chart with modifications |
+| [Copy Chart to Clipboard](activities/CopyChartToClipboardX.md) | Copies a chart to the clipboard |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Forms.Activities/26.0/README.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Forms.Activities/26.0/README.md
@@ -1,0 +1,59 @@
+# UiPath.Form.Activities
+
+> NuGet Package ID: `UiPath.Form.Activities`
+
+## Overview
+
+The Forms Activities package provides workflow activities for displaying and interacting with Form.io-based forms in UiPath automations. Forms are designed in UiPath Studio's Form Designer and displayed at runtime as standalone windows.
+
+The package supports both **synchronous** (blocking) and **asynchronous** (non-blocking) form display, bi-directional data binding with workflow variables (including Global Variables), event-driven triggers, and programmatic manipulation of running forms.
+
+## Activities
+
+| Activity | Description |
+|----------|-------------|
+| [Show Form](activities.md#show-form) | Displays a form designed in Studio |
+| [Close Form](activities.md#close-form) | Closes a running form |
+| [Get Form Fields](activities.md#get-form-fields) | Reads field values from a running form |
+| [Set Form Fields](activities.md#set-form-fields) | Sets field values on a running form |
+| [Change Form Properties](activities.md#change-form-properties) | Modifies window properties (size, position, title, state) |
+| [Hide Form](activities.md#hide-form) | Hides a running form window |
+| [Bring Form To Front](activities.md#bring-form-to-front) | Brings a hidden form back to the foreground |
+| [Execute Script](activities.md#execute-script) | Executes JavaScript within a running form |
+| [Form Trigger](triggers.md) | Reacts to form events (value changes, button clicks, etc.) |
+
+## Documentation
+
+- **[activities.md](activities.md)** - Activity reference: properties, usage, and errors
+- **[triggers.md](triggers.md)** - Form event triggers and supported event types
+
+## Key Concepts
+
+### Form Identification
+
+Every form has a **FormId** (the design-time source identifier, set automatically when you pick a form in the designer) and an optional **InstanceName** that distinguishes multiple instances of the same form. All form-action activities (Close, Get/Set Fields, etc.) use these two properties to address a specific running form.
+
+### Execution Modes
+
+- **Async** (`IsAsync = true`, default): Show Form completes immediately. The workflow continues while the form stays open. Use triggers and Get/Set Form Fields to interact with it.
+- **Sync** (`IsAsync = false`): Show Form blocks until the form is closed. Out-argument values are applied when the form closes.
+
+### Data Binding
+
+Form field values can be bound to workflow variables via the `Arguments` dictionary:
+- **InArgument**: Provides initial values when the form is shown
+- **OutArgument**: Receives values when the form closes (sync) or in real time (async)
+- **InOutArgument**: Both directions
+
+### Global Variables
+
+When form arguments reference Global Variables, changes propagate bidirectionally in real time: modifying the Global Variable updates the form field, and modifying the form field updates the Global Variable.
+
+## Common Errors
+
+| Error | Cause |
+|-------|-------|
+| Form not found | No running form matches the FormId/InstanceName, or no form has been shown yet |
+| Form already displayed | Trying to show a form with the same FormId and InstanceName as one already open |
+| No form selected | FormId is not set (pick a form in the designer) |
+| No event selected | Form Trigger used without selecting an event |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Forms.Activities/26.0/activities.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Forms.Activities/26.0/activities.md
@@ -1,0 +1,147 @@
+# Forms Activities Reference
+
+## Show Form
+
+Displays a form designed in UiPath Studio.
+
+### Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| FormId | String | *(required)* | The form to display (selected in the designer) |
+| InstanceName | String | `null` | Optional tag to distinguish multiple instances of the same form |
+| IsAsync | Boolean | `true` | If true, the activity completes immediately; if false, blocks until the form is closed |
+| Arguments | Dictionary | `{}` | Bindings between form field IDs and workflow variables |
+| Width | Int32? | `null` | Window width in pixels |
+| Height | Int32? | `null` | Window height in pixels |
+| Left | Int32? | `null` | Window X position in pixels |
+| Top | Int32? | `null` | Window Y position in pixels |
+| Title | String | `null` | Custom window title |
+| ShowMargin | Boolean? | `null` | Whether the window has standard chrome (title bar, borders) |
+| ShowInTaskbar | Boolean? | `null` | Whether the form appears in the taskbar |
+| TopMost | Boolean? | `null` | Whether the form stays on top of other windows |
+| WindowState | WindowState? | `null` | Initial window state (Normal, Minimized, Maximized) |
+
+### Usage Notes
+
+- If a form with the same FormId and InstanceName is already open, the existing window is reused rather than opening a duplicate.
+- In **sync mode**, Out and InOut arguments are updated when the form closes.
+- In **async mode**, Out and InOut arguments bound to Global Variables update in real time as the user interacts with the form.
+
+---
+
+## Close Form
+
+Programmatically closes a running form.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormId | String | The form to close |
+| InstanceName | String | The instance tag (if multiple instances exist) |
+
+---
+
+## Get Form Fields
+
+Reads field values from a running form.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormId | String | The form to read from |
+| InstanceName | String | The instance tag |
+| Arguments | Dictionary&lt;String, OutArgument&gt; | Map of form field IDs to output variables |
+
+### Usage Notes
+
+- Each key in `Arguments` is a form field ID; the corresponding variable receives the field's value.
+- Values are automatically converted to match the variable's type.
+- Throws if no form matches, or if multiple forms match the selector (use InstanceName to disambiguate).
+
+---
+
+## Set Form Fields
+
+Sets field values on a running form.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormId | String | The form to update |
+| InstanceName | String | The instance tag |
+| Arguments | Dictionary&lt;String, InArgument&gt; | Map of form field IDs to input values |
+
+### Usage Notes
+
+- Each key in `Arguments` is a form field ID; the corresponding value is pushed to the form.
+- Throws if no form matches the selector.
+
+---
+
+## Change Form Properties
+
+Modifies the window properties of a running form. Only properties that are set (non-null) are applied; others remain unchanged.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormId | String | The form to modify |
+| InstanceName | String | The instance tag |
+| Width | Int32? | Window width in pixels |
+| Height | Int32? | Window height in pixels |
+| Left | Int32? | Window X position |
+| Top | Int32? | Window Y position |
+| Title | String | Window title |
+| ShowMargin | Boolean? | Window chrome visibility |
+| TopMost | Boolean? | Always-on-top state |
+| WindowState | WindowState? | Window state (Normal, Minimized, Maximized) |
+
+---
+
+## Hide Form
+
+Hides a running form window without closing it. The form remains active in the background.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormId | String | The form to hide |
+| InstanceName | String | The instance tag |
+
+---
+
+## Bring Form To Front
+
+Brings a previously hidden form back to the foreground.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormId | String | The form to restore |
+| InstanceName | String | The instance tag |
+
+---
+
+## Execute Script
+
+Executes JavaScript code within the context of a running form.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormId | String | The target form |
+| InstanceName | String | The instance tag |
+| Source | String | JavaScript source code to execute |
+
+### Usage Notes
+
+- If `Source` is empty, the activity completes without error and returns an empty result.
+- The script runs inside the form's browser context and can interact with the form's DOM and Form.io API.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Forms.Activities/26.0/triggers.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Forms.Activities/26.0/triggers.md
@@ -1,0 +1,54 @@
+# Form Triggers
+
+## Overview
+
+The **Form Trigger** activity monitors a running form and fires when a specific event occurs (e.g., a field value changes, a button is clicked, the window state changes). It can be used inside a **Trigger Scope** or as a standalone trigger.
+
+## Properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| FormId | String | No | The form to monitor (selected in the designer) |
+| InstanceName | String | No | Instance tag filter |
+| Event | String | Yes | The event to listen for (selected from a dropdown of available events) |
+| MessageId | String | No | For message events only: filters by message ID |
+| Enabled | Boolean | No | Whether the trigger is active |
+| SchedulingMode | TriggerActionSchedulingMode | No | How trigger firings are scheduled (only visible outside Trigger Scope) |
+
+## Event Types and Output
+
+When you select a form in the designer, the available events are populated from the form definition. The trigger output varies based on the event type:
+
+| Event Data Type | Output Properties |
+|----------------|-------------------|
+| Number | `Value` (Double?) |
+| Boolean | `Value` (Boolean?) |
+| Text | `Text` (String) |
+| Password | `Password` (SecureString) |
+| Window State | `State` (WindowState) |
+| Message | `Data` (String), `Id` (String) |
+| DataTable | `Value` (DataTable) |
+| Dictionary | `Value` (Dictionary&lt;String, String&gt;) |
+| *(generic)* | Base properties only |
+
+### Base Properties (always available)
+
+All trigger outputs include:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| FormSourceId | String | The form's design-time identifier |
+| InstanceName | String | The form's instance tag |
+| Index | Int32? | Event index within the form |
+
+## Usage
+
+1. Add a **Form Trigger** activity (typically inside a **Trigger Scope**)
+2. Select the form to monitor
+3. Select the event from the dropdown (populated from the form definition)
+4. For **Message** events, set the `MessageId` to filter which messages trigger the action
+5. Use the trigger output properties in the trigger body
+
+## Message Events
+
+Message events are for custom form-to-workflow communication via JavaScript `postMessage`. Set the `MessageId` property to filter by message type. The `Data` property contains the message payload as a string.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/ClassifyDocument.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/ClassifyDocument.md
@@ -1,0 +1,166 @@
+# Classify Document
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.ClassifyDocument`
+
+Classifies a document according to the configured classifier in the Document Understanding framework. Supports pretrained classifiers for standard document types (invoices, receipts, id_cards, passports, purchase_orders, utility_bills, remittance_advices, bills_of_lading, checks).
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ProjectId` | Document Understanding project | InArgument | `string` | Yes | | The Document Understanding project ID. Should be a GUID-formatted string (e.g., `"00000000-0000-0000-0000-000000000000"` for the Predefined project). Internally parsed via `Guid.Parse()` at runtime. For custom projects, if the GUID is unknown, set `ProjectName` to the project's display name and use a non-GUID placeholder string for ProjectId (e.g., ProjectId="placeholder"). Do not use "00000000-0000-0000-0000-000000000000" — that is the Predefined project's real GUID and will be accepted as-is without triggering name-based resolution — **Studio resolves `ProjectId` from `ProjectName` at design time**. Set as a **literal attribute value** (not a VB expression). |
+| `ProjectVersionNumber` | Version | InArgument | `int` | No | | The version number referencing a snapshot of the Document Understanding project. Use this **or** `ProjectTag` (not both). For the Predefined project, use `0`. |
+| `ProjectTag` | Tag | InArgument | `string` | No | | An alternative to version number. A tag referencing a snapshot of the Document Understanding project (e.g., `"Production"`). For the Predefined project, use `"Production"`. |
+| `ClassifierId` | Classifier | InArgument | `string` | Yes | | The classifier to use. For the Predefined project, use `ml-classification` (recommended) or a document-type-specific identifier (see Enum Reference). For custom DU projects, use the **classifier name** from the project. Ask the user for this name. Studio resolves names to internal GUIDs at design time. Set `ClassifierName` to the same value. |
+| `FileInput` | Input | InArgument | `IResource` | Yes | | Document Data referencing the digitized input file, or the input file itself if Document Data has not been created yet. |
+| `TimeoutInSeconds` | Timeout (seconds) | InArgument | `int` | Yes | `3600` | Maximum execution time in seconds. If exceeded, the operation is terminated. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `MinimumConfidence` | Minimum confidence | `float` | `0` | Minimum confidence threshold for classification. If the classification confidence is below this value, the document type is set to Unknown. |
+| `RuntimeAssetPath` | Runtime Credentials Asset | `string` | | Orchestrator credentials asset path for cross-org authentication. Format: `<orchestratorFolder>/<assetName>`. |
+| `RuntimeTenantUrl` | Runtime Tenant Url | `string` | | URL to an external tenant for cross-org authentication. Format: `https://<base_url>/<organization>/<tenant>`. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ClassificationResults` | Document data | OutArgument | `DocumentData` | Classification results. The `DocumentType` property contains the classified type, confidence, and identifiers. May contain multiple subdocuments if document splitting is enabled. See Type Reference below. |
+
+### Studio UI Display Properties
+
+These properties control how Studio's designer renders dropdown selections and drive name-based resolution. When generating XAML programmatically, always set them alongside their corresponding functional properties. They are marked `Browsable(false)` in the source code but are serialized in XAML by Studio.
+
+| Property | Type | Role | Example Value |
+|----------|------|------|---------------|
+| `ProjectName` | `string` | **Drives resolution of `ProjectId`** — Studio looks up the project by this name and populates `ProjectId` with the GUID at design time. | `"Predefined"` |
+| `ProjectVersionName` | `string` | Mirrors `ProjectTag` | `"Production"` |
+| `ClassifierName` | `string` | Mirrors `ClassifierId` | `"ML Classification"` |
+
+## Type Reference
+
+### DocumentData
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification.DocumentData`
+**Assembly:** `UiPath.IntelligentOCR.StudioWeb.Activities`
+**XAML xmlns:** `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `DocumentType` | `DocumentType` | The classified document type (see below). |
+| `SubDocuments` | `IDocumentData[]` | Array of subdocuments when splitting is enabled. |
+| `FileDetails` | `FileDetails` | File path, name, extension, and page range of the source document. |
+| `DocumentMetadata` | `DocumentMetadata` | OCR text (`Text`), document object model (`DocumentObjectModel`), language, and extraction results as DataTables (`ResultsAsDataTables`). |
+
+### DocumentType
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification.DocumentType`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `DisplayName` | `string` | Human-readable label (e.g., `"Invoices"`). |
+| `Id` | `string` | Machine identifier (e.g., `"invoices"`). Use this for programmatic comparisons and for passing to ExtractDocumentData's `DocType`. |
+| `Confidence` | `float` | Classification confidence score (0.0 to 1.0). |
+| `Name` | `string` | **Obsolete.** Use `Id` instead. |
+| `Url` | `string` | Reference URL for the document type definition. |
+
+**VB expression examples:**
+- `classificationResults.DocumentType.Id` — returns `"invoices"`
+- `classificationResults.DocumentType.DisplayName` — returns `"Invoices"`
+- `classificationResults.DocumentType.Confidence` — returns confidence score
+
+## Enum Reference
+
+### Classifier Identifiers
+
+| Identifier | Display Name | Description |
+|------------|-------------|-------------|
+| `ml-classification` | ML Classification | General-purpose multi-class classifier that distinguishes between all supported pretrained document types. **Recommended for most use cases.** |
+
+### Pretrained Document Type Identifiers
+
+These lowercase identifiers can be used as `ClassifierId` for single-type classification:
+
+| Identifier | Display Name |
+|------------|-------------|
+| `invoices` | Invoices |
+| `receipts` | Receipts |
+| `id_cards` | ID Cards |
+| `passports` | Passports |
+| `purchase_orders` | Purchase Orders |
+| `utility_bills` | Utility Bills |
+| `remittance_advices` | Remittance Advices |
+| `bills_of_lading` | Bills of Lading |
+| `checks` | Checks |
+
+## XAML Example
+
+Classifies a document using the Predefined project with the ML Classification classifier. Replace `[inputFile]` with an `IResource` variable pointing to the document.
+
+```xml
+<du:ClassifyDocument
+    DisplayName="Classify Document"
+    ProjectId="00000000-0000-0000-0000-000000000000"
+    ProjectName="Predefined"
+    ProjectTag="Production"
+    ProjectVersionName="Production"
+    ProjectVersionNumber="0"
+    ClassifierId="ml-classification"
+    ClassifierName="ML Classification"
+    FileInput="[inputFile]"
+    TimeoutInSeconds="[3600]"
+    ClassificationResults="[classificationResults]">
+  <du:ClassifyDocument.GptPromptWithVariables>
+    <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+  </du:ClassifyDocument.GptPromptWithVariables>
+</du:ClassifyDocument>
+```
+
+**Required variable declaration:**
+
+```xml
+<Variable x:TypeArguments="duc:DocumentData" Name="classificationResults" />
+```
+
+**Required XAML namespace prefixes:**
+
+```xml
+xmlns:du="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:duc="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"
+```
+
+**Required expression namespace imports:**
+
+```xml
+<TextExpression.NamespacesForImplementation>
+  <scg:List x:TypeArguments="x:String">
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities</x:String>
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification</x:String>
+  </scg:List>
+</TextExpression.NamespacesForImplementation>
+<TextExpression.ReferencesForImplementation>
+  <scg:List x:TypeArguments="AssemblyReference">
+    <AssemblyReference>UiPath.IntelligentOCR.StudioWeb.Activities</AssemblyReference>
+  </scg:List>
+</TextExpression.ReferencesForImplementation>
+```
+
+## Notes
+
+- `ProjectId` should be a GUID-formatted string at runtime (`Guid.Parse()` is used). The Predefined project GUID is `00000000-0000-0000-0000-000000000000`. For custom projects, Studio resolves `ProjectId` from `ProjectName` at design time — so if `ProjectName` is set to a valid project name, the GUID does not need to be known at authoring time.
+- Properties backed by Studio dropdown widgets (`ProjectId`, `ProjectTag`, `ProjectVersionNumber`, `ClassifierId`) should be set as **literal attribute values** rather than VB/C# expressions (e.g., `ProjectId="00000000-..."` not `ProjectId="[&quot;00000000-...&quot;]"`) to ensure the dropdown displays correctly in the designer.
+- For the Predefined project, the standard version configuration is: `ProjectTag="Production"`, `ProjectVersionNumber="0"`, `ProjectVersionName="Production"`.
+- `ProjectVersionNumber` and `ProjectTag` are two ways to reference a project snapshot. Use one or the other. If neither is specified, the Staging version is used by default; if not available, the latest version is used.
+- For custom DU projects, set `ClassifierId` to the **classifier name** from the project. Studio resolves the name to the internal GUID at design time. Set `ClassifierName` to the same value. Ask the user for the classifier name if not provided.
+- The `ClassificationResults` output is of type `DocumentData` (namespace `UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification`). Access the classified type via `classificationResults.DocumentType.Id` (lowercase identifier like `"invoices"`) or `classificationResults.DocumentType.DisplayName` (human-readable like `"Invoices"`). Do **not** use `.ToString()` on `DocumentType` — it returns the CLR type name, not the classification label.
+- `DocumentType.Name` is obsolete — use `DocumentType.Id` instead.
+- `RuntimeAssetPath` and `RuntimeTenantUrl` enable cross-organization access. Both must be set together.
+- In a typical pipeline, this is the first activity. Its `ClassificationResults` output (`DocumentData`) feeds into classification validation activities and/or directly into `ExtractDocumentDataWithDocumentData` as `FileInput` (`DocumentData` implements `IResource`).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateClassificationValidationTask.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateClassificationValidationTask.md
@@ -1,0 +1,52 @@
+# Create Classification Validation Task
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.CreateClassificationValidationAction`
+
+Creates a Classification Validation Task in Action Center to verify the classification results, without waiting for its completion. Returns a token that can be passed to the **Wait for Classification Validation Task & Resume** activity to later retrieve the validated results.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AutomaticClassificationResults` | Document Data | InArgument | `DocumentData` | Yes | | The classification result, output of the Classify Document activity. |
+| `ActionTitle` | Action title | InArgument | `string` | Yes | | Title of the action as it appears in Action Center. |
+| `ActionPriority` | Action priority | InArgument | `string` | | | Priority of the action. |
+| `ActionCatalogue` | Action catalog | InArgument | `string` | | | Catalog where the action will be available in Action Center. |
+| `OrchestratorFolderName` | Orchestrator folder | InArgument | `string` | | | Orchestrator folder where the action will be available. |
+| `OrchestratorBucketName` | Orchestrator bucket | InArgument | `string` | | `"DU_Validation"` | Orchestrator storage bucket for documents and data required for validation. The bucket must exist in the target tenant. Do not set this property unless the user specifies a bucket name — omitting it uses the default. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `EnablePageReordering` | Enable Page Reordering | `bool` | `false` | Whether page reordering should be enabled in Classification Station. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `CreatedClassificationValidationAction` | Created Classification Validation Task | OutArgument | `CreatedClassificationValidationAction` | Token representing the created classification validation task. Pass this to the **Wait for Classification Validation Task & Resume** activity. |
+
+## XAML Example
+
+```xml
+<duVal:CreateClassificationValidationAction
+    DisplayName="Create Classification Validation Task"
+    AutomaticClassificationResults="[classificationResults]"
+    ActionTitle="[&quot;Validate classification&quot;]"
+
+    CreatedClassificationValidationAction="[createdClassificationAction]" />
+```
+
+> Namespace prefix `duVal` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+## Notes
+
+- This activity does **not** suspend the workflow. Use **Wait for Classification Validation Task & Resume** to wait for task completion.
+- The output `CreatedClassificationValidationAction` must be passed to **Wait for Classification Validation Task & Resume** to retrieve the validated results.
+- In a typical pipeline, this activity follows **Classify Document**. The validated `DocumentData` output (from the subsequent Wait activity) is passed as `FileInput` to **Extract Document Data**.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateClassificationValidationTaskAndWait.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateClassificationValidationTaskAndWait.md
@@ -1,0 +1,53 @@
+# Create Classification Validation Task and Wait
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.CreateClassificationValidationActionAndWait`
+
+Creates a Classification Validation Task in Action Center to verify the classification results and suspends the workflow until the task is completed. After a human reviewer submits the validated classification, the workflow resumes with the corrected results.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AutomaticClassificationResults` | Document Data | InArgument | `DocumentData` | Yes | | The classification result, output of the Classify Document activity. |
+| `ActionTitle` | Action title | InArgument | `string` | Yes | | Title of the action as it appears in Action Center. |
+| `ActionPriority` | Action priority | InArgument | `string` | | | Priority of the action. |
+| `ActionCatalogue` | Action catalog | InArgument | `string` | | | Catalog where the action will be available in Action Center. |
+| `OrchestratorFolderName` | Orchestrator folder | InArgument | `string` | | | Orchestrator folder where the action will be available. |
+| `OrchestratorBucketName` | Orchestrator bucket | InArgument | `string` | | `"DU_Validation"` | Orchestrator storage bucket for documents and data required for validation. The bucket must exist in the target tenant. Do not set this property unless the user specifies a bucket name — omitting it uses the default. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `EnablePageReordering` | Enable Page Reordering | `bool` | `false` | Whether page reordering should be enabled in Classification Station. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ValidatedClassificationResults` | Document data | OutArgument | `DocumentData` | Validated classification data containing changes made by the reviewer in Classification Station. |
+
+## XAML Example
+
+```xml
+<duVal:CreateClassificationValidationActionAndWait
+    DisplayName="Create Classification Validation Task and Wait"
+    AutomaticClassificationResults="[classificationResults]"
+    ActionTitle="[&quot;Validate classification&quot;]"
+
+    ValidatedClassificationResults="[validatedClassification]" />
+```
+
+> Namespace prefix `duVal` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+## Notes
+
+- This is a **persistent activity**. The workflow suspends after creating the validation task and resumes only when the task is completed in Action Center. The project must have `"supportsPersistence": true` in `project.json` (under `"runtimeOptions"`). Without this, the workflow will fail at runtime.
+- Cannot be placed inside a No Persist Scope.
+- For a non-blocking alternative, use **Create Classification Validation Task** followed by **Wait for Classification Validation Task & Resume**.
+- In a typical pipeline, this activity follows **Classify Document**. The `ValidatedClassificationResults` output (`DocumentData`) is passed as `FileInput` to **Extract Document Data**.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateDocumentValidationArtifacts.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateDocumentValidationArtifacts.md
@@ -1,0 +1,59 @@
+# Create Document Validation Artifacts
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.Artifacts.CreateDocumentValidationArtifacts`
+
+Uploads document data, DOM, taxonomy, and extraction results to an Orchestrator storage bucket as validation artifacts. These artifacts can be used for external validation through UiPath Apps. Returns a `ContentValidationData` object to be passed to **Retrieve Document Validation Artifacts** after validation is complete.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AutomaticExtractionResults` | Document Data | InArgument | `IDocumentData<ExtendedExtractionResultsForDocumentData>` | Yes | | The extraction result, output of the Extract Document Data activity. |
+| `OrchestratorFolderName` | Orchestrator folder | InArgument | `string` | | | Orchestrator folder where the storage bucket is located. |
+| `OrchestratorBucketName` | Orchestrator bucket | InArgument | `string` | | `"DU_Validation"` | Orchestrator storage bucket to store documents and data required for validation. The bucket must exist in the target tenant. Do not set this property unless the user specifies a bucket name — omitting it uses the default. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ContentValidationData` | Content Validation Data Object | OutArgument | `ContentValidationData` | Object containing references to the uploaded validation artifacts. Pass this to **Retrieve Document Validation Artifacts** after validation. |
+
+## XAML Example
+
+```xml
+<duArt:CreateDocumentValidationArtifacts
+    x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"
+    DisplayName="Create Document Validation Artifacts"
+    AutomaticExtractionResults="[extractionResults]"
+
+    ContentValidationData="[contentValidationData]" />
+```
+
+> Namespace prefix `duArt` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.Artifacts;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+> Namespace prefix `du` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+### DictionaryData Variant
+
+When using `DictionaryData` for the extraction pipeline (recommended for agent-generated workflows):
+
+```xml
+<duArt:CreateDocumentValidationArtifacts
+    x:TypeArguments="du:DictionaryData"
+    DisplayName="Create Document Validation Artifacts"
+    AutomaticExtractionResults="[extractionResults]"
+
+    ContentValidationData="[contentValidationData]" />
+```
+
+## Notes
+
+- This is a generic activity. In XAML, use `x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"` or `x:TypeArguments="du:DictionaryData"`.
+- The type argument **must match** the type argument used in `ExtractDocumentDataWithDocumentData`.
+- Use this activity together with **Retrieve Document Validation Artifacts** for external validation through UiPath Apps, as an alternative to the Action Center-based validation activities.
+- The artifacts are stored in the specified Orchestrator storage bucket and can be consumed by a UiPath App for human review.
+- In a typical pipeline, this activity follows Extract Document Data as an alternative to the Action Center validation path.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateValidationTask.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateValidationTask.md
@@ -1,0 +1,86 @@
+# Create Validation Task
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.CreateValidationAction`
+
+Creates a Document Validation Task in Action Center to verify extracted document data, without waiting for its completion. Returns a token that can be passed to the **Wait for Validation Task and Resume** activity to later retrieve the validated results.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AutomaticExtractionResults` | Document Data | InArgument | `IDocumentData<ExtendedExtractionResultsForDocumentData>` | Yes | | The extraction result, output of the Extract Document Data activity. |
+| `ActionTitle` | Action title | InArgument | `string` | Yes | | Title of the action as it appears in Action Center. |
+| `ActionPriority` | Action priority | InArgument | `string` | | | Priority of the action. |
+| `ActionCatalogue` | Action catalog | InArgument | `string` | | | Catalog where the action will be available in Action Center. |
+| `OrchestratorFolderName` | Orchestrator folder | InArgument | `string` | | | Orchestrator folder where the action will be available. |
+| `OrchestratorBucketName` | Orchestrator bucket | InArgument | `string` | | `"DU_Validation"` | Orchestrator storage bucket for documents and data required for validation. The bucket must exist in the target tenant. Do not set this property unless the user specifies a bucket name — omitting it uses the default. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FieldsValidationConfidence` | Extracted fields validation confidence % | `int?` | | Upper-limit confidence score for filtering extracted fields that need human review. |
+| `EnableRTLControls` | Enable RTL controls | `bool` | `false` | Enable right-to-left controls in Validation Station. |
+| `DisplayMode` | Display mode | `DisplayModeArgument` | `Classic` | Display mode for Validation Station. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `CreatedValidationAction` | Created document validation task | OutArgument | `CreatedValidationAction<ExtendedExtractionResultsForDocumentData>` | Token representing the created validation task. Pass this to the **Wait for Validation Task and Resume** activity. |
+
+## Enum Reference
+
+**`DisplayModeArgument`**: `Classic`, `Compact`
+
+## XAML Example
+
+```xml
+<duVal:CreateValidationAction
+    x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"
+    DisplayName="Create Validation Task"
+    AutomaticExtractionResults="[extractionResults]"
+    ActionTitle="[&quot;Validate extraction&quot;]"
+
+    CreatedValidationAction="[createdValidationAction]" />
+```
+
+> Namespace prefix `duVal` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+> Namespace prefix `du` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+### DictionaryData Variant
+
+When using `DictionaryData` for the extraction pipeline (recommended for agent-generated workflows):
+
+```xml
+<duVal:CreateValidationAction
+    x:TypeArguments="du:DictionaryData"
+    DisplayName="Create Validation Task"
+    AutomaticExtractionResults="[extractionResults]"
+    ActionTitle="[&quot;Validate extraction&quot;]"
+
+    CreatedValidationAction="[createdValidationAction]" />
+```
+
+**Required variable declarations:**
+
+```xml
+<Variable x:TypeArguments="dux:IDocumentData(du:DictionaryData)" Name="extractionResults" />
+<Variable x:TypeArguments="duVal:CreatedValidationAction(du:DictionaryData)" Name="createdValidationAction" />
+```
+
+> Namespace prefix `du` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+> Namespace prefix `dux` is an alias for the same namespace — use either consistently.
+
+## Notes
+
+- This activity does **not** suspend the workflow. Use **Wait for Validation Task and Resume** to wait for task completion.
+- This is a generic activity. In XAML, use `x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"` or `x:TypeArguments="du:DictionaryData"`.
+- The type argument **must match** the type argument used in `ExtractDocumentDataWithDocumentData`. If extraction used `DictionaryData`, this activity must also use `DictionaryData`.
+- The output `CreatedValidationAction` must be passed to **Wait for Validation Task and Resume** to retrieve the validated results.
+- In a typical pipeline, this activity follows Extract Document Data and precedes Wait for Validation Task and Resume.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateValidationTaskAndWait.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/CreateValidationTaskAndWait.md
@@ -1,0 +1,84 @@
+# Create Validation Task and Wait
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.ValidateDocumentDataWithDocumentData`
+
+Creates a Document Validation Task in Action Center to verify extracted document data and suspends the workflow until the task is completed. After a human reviewer submits the validated data, the workflow resumes with the corrected extraction results.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AutomaticExtractionResults` | Document Data | InArgument | `IDocumentData<ExtendedExtractionResultsForDocumentData>` | Yes | | The extraction result, output of the Extract Document Data activity. |
+| `ActionTitle` | Action title | InArgument | `string` | Yes | | Title of the action as it appears in Action Center. |
+| `ActionPriority` | Action priority | InArgument | `string` | | | Priority of the action. |
+| `ActionCatalogue` | Action catalog | InArgument | `string` | | | Catalog where the action will be available in Action Center. |
+| `OrchestratorFolderName` | Orchestrator folder | InArgument | `string` | | | Orchestrator folder where the action will be available. |
+| `OrchestratorBucketName` | Orchestrator bucket | InArgument | `string` | | `"DU_Validation"` | Orchestrator storage bucket for documents and data required for validation. The bucket must exist in the target tenant. Do not set this property unless the user specifies a bucket name — omitting it uses the default. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FieldsValidationConfidence` | Extracted fields validation confidence % | `int?` | | Upper-limit confidence score for filtering extracted fields that need human review. |
+| `EnableRTLControls` | Enable RTL controls | `bool` | `false` | Enable right-to-left controls in Validation Station. |
+| `DisplayMode` | Display mode | `DisplayModeArgument` | `Classic` | Display mode for Validation Station. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ValidatedExtractionResults` | Document data | OutArgument | `IDocumentData<ExtendedExtractionResultsForDocumentData>` | Validated extracted data containing changes made by the reviewer in Validation Station. |
+
+## Enum Reference
+
+**`DisplayModeArgument`**: `Classic`, `Compact`
+
+## XAML Example
+
+```xml
+<duVal:ValidateDocumentDataWithDocumentData
+    x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"
+    DisplayName="Create Validation Task and Wait"
+    AutomaticExtractionResults="[extractionResults]"
+    ActionTitle="[&quot;Validate extraction&quot;]"
+
+    ValidatedExtractionResults="[validatedResults]" />
+```
+
+> Namespace prefix `duVal` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+> Namespace prefix `du` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+### DictionaryData Variant
+
+When using `DictionaryData` for the extraction pipeline (recommended for agent-generated workflows):
+
+```xml
+<duVal:ValidateDocumentDataWithDocumentData
+    x:TypeArguments="du:DictionaryData"
+    DisplayName="Create Validation Task and Wait"
+    AutomaticExtractionResults="[extractionResults]"
+    ActionTitle="[&quot;Validate extraction&quot;]"
+
+    ValidatedExtractionResults="[validatedResults]" />
+```
+
+**Required variable declarations:**
+
+```xml
+<Variable x:TypeArguments="dux:IDocumentData(du:DictionaryData)" Name="extractionResults" />
+<Variable x:TypeArguments="dux:IDocumentData(du:DictionaryData)" Name="validatedResults" />
+```
+
+## Notes
+
+- This is a **persistent activity**. The workflow suspends after creating the validation task and resumes only when the task is completed in Action Center. The project must have `"supportsPersistence": true` in `project.json` (under `"runtimeOptions"`). Without this, the workflow will fail at runtime.
+- This is a generic activity. In XAML, use `x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"` or `x:TypeArguments="du:DictionaryData"`.
+- The type argument **must match** the type argument used in `ExtractDocumentDataWithDocumentData`. If extraction used `DictionaryData`, this activity must also use `DictionaryData`.
+- For a non-blocking alternative, use **Create Validation Task** followed by **Wait for Validation Task and Resume** to separate task creation from waiting.
+- Cannot be placed inside a No Persist Scope.
+- In a typical pipeline, this activity follows Extract Document Data. It combines the functionality of Create Validation Task + Wait for Validation Task and Resume into a single step.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/ExtractDocumentData.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/ExtractDocumentData.md
@@ -1,0 +1,249 @@
+# Extract Document Data
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.ExtractDocumentDataWithDocumentData`
+
+Extracts data from a document and stores the results into automatically generated variables. Supports pretrained extractors for standard document types (invoices, receipts, id_cards, passports, purchase_orders, utility_bills, remittance_advices, bills_of_lading, checks) and custom DU project extractors.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## References
+
+- [Data Type Patterns](ExtractDocumentData/data-type-patterns.md) — DictionaryData API, type propagation rules, and pipeline variable declarations
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ProjectId` | Document Understanding project | InArgument | `string` | Yes | | The Document Understanding project ID. Should be a GUID-formatted string (parsed via `Guid.Parse()` at runtime). The Predefined project GUID is `"00000000-0000-0000-0000-000000000000"`. For custom projects, if the GUID is unknown, set `ProjectName` to the project's display name and use a non-GUID placeholder string for ProjectId (e.g., ProjectId="placeholder"). Do not use "00000000-0000-0000-0000-000000000000" — that is the Predefined project's real GUID and will be accepted as-is without triggering name-based resolution — **Studio resolves `ProjectId` from `ProjectName` at design time**. Set as a **literal attribute value** (not a VB expression). |
+| `ProjectVersionNumber` | Version | InArgument | `int` | No | | The version number referencing a snapshot of the Document Understanding project. Use this **or** `ProjectTag` (not both). For the Predefined project, use `0`. |
+| `ProjectTag` | Tag | InArgument | `string` | No | | An alternative to version number. A tag referencing a snapshot of the Document Understanding project. For the Predefined project, use `"Production"`. |
+| `DocType` | Extractor | InArgument | `string` | Conditional | | The extractor identifier (**lowercase**). Required unless `ModernDocumentTypeId="use_classification_result"` is used (in which case set `DocType="{x:Null}"`). Pretrained values (Predefined project only): `invoices`, `receipts`, `id_cards`, `passports`, `purchase_orders`, `utility_bills`, `remittance_advices`, `bills_of_lading`, `checks`. For custom DU projects: use the **document type name** as it appears in the project (e.g., `"invoices"`) — ask the user for this name if not provided (they can find it in the project's Document Types tab). Studio resolves it to the correct extractor at design time. Alternatively, use the extractor GUID if known. See Enum Reference. |
+| `ModernDocumentTypeId` | Document type | InArgument | `string` | Conditional | | The document type ID defining the fields to extract. Required unless `DocType` is set (both can be set together). **For pretrained extractors, use the same lowercase identifier as `DocType`** (e.g., `"invoices"`, `"receipts"`). For custom DU projects, use the **document type name** from the project's Document Types tab (e.g., `"invoices"`) — ask the user for this name if not provided. Studio resolves the name to the internal GUID at design time. The GUID can also be used directly if known. Set to `"use_classification_result"` to dynamically resolve the document type from the upstream ClassifyDocument result (requires `FileInput` to be a `DocumentData`; set `DocType="{x:Null}"` when using this). Together with `DocType`, these two properties fully specify the extraction target. |
+| `FileInput` | Input | InArgument | `IResource` | Yes | | Document Data referencing the digitized input file, or the input file itself if Document Data has not been created yet. Accepts a `DocumentData` object from ClassifyDocument directly. |
+| `TimeoutInSeconds` | Timeout (seconds) | InArgument | `int` | Yes | `3600` | Maximum execution time in seconds. If exceeded, the operation is terminated. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ApplyAutoValidation` | Auto-validation | `bool` | `false` | Whether to apply automatic validation based on configurations provided as input or at the Document Understanding project level. |
+| `AutoValidationConfidenceThreshold` | Confidence threshold | `int?` | `0` | Extraction results below this confidence threshold are auto-validated when `ApplyAutoValidation` is enabled. |
+| `GenerateData` | Generate data type | `bool` | `false` | When `true`, generates a strongly-typed output with fields available under the `Data` property. When `false`, fields are retrieved via method calls by ID (using `DictionaryData`). **Agents should always set this to `False`** — `True` requires Studio's design-time JIT compilation which agents cannot trigger. Also, `GenerateData=True` is incompatible with `ModernDocumentTypeId="use_classification_result"`. See Type Reference for details. |
+| `ActivityMajorVersion` | Activity major version | `int` | | Internal version flag. **Always set `ActivityMajorVersion="2"`** in generated XAML. If omitted or set to a value less than `2`, Studio displays a migration warning banner ("The activity has been updated to a new major version…") that requires manual acknowledgement. Setting this to `2` suppresses the warning. |
+| `RuntimeAssetPath` | Runtime Credentials Asset | `string` | | Orchestrator credentials asset path for cross-org authentication. Format: `<orchestratorFolder>/<assetName>`. |
+| `RuntimeTenantUrl` | Runtime Tenant Url | `string` | | URL to an external tenant for cross-org authentication. Format: `https://<base_url>/<organization>/<tenant>`. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ExtractionResults` | Document data | OutArgument | `IDocumentData<ExtendedExtractionResultsForDocumentData>` | Extracted data in a (field-name, field-value) format. For example: ('invoice-date', '01/04/2022'). See Type Reference below. |
+
+### Studio UI Display Properties
+
+These properties control how Studio's designer renders dropdown selections and drive name-based resolution. When generating XAML programmatically, always set them alongside their corresponding functional properties. They are marked `Browsable(false)` in the source code but are serialized in XAML by Studio.
+
+| Property | Type | Role | Example Value (for `invoices` extractor) |
+|----------|------|------|------------------------------------------|
+| `ProjectName` | `string` | **Drives resolution of `ProjectId`** — Studio looks up the project by this name and populates `ProjectId` with the GUID at design time. | `"Predefined"` |
+| `ProjectVersionName` | `string` | Mirrors `ProjectTag` | `"Production"` |
+| `ExtractorName` | `string` | Mirrors `DocType` | `"Invoices"` (capitalized display name) |
+| `ModernDocumentTypeName` | `string` | Mirrors `ModernDocumentTypeId` | `"Invoices"` (capitalized display name) |
+
+## Type Reference
+
+### IDocumentData\<T\>
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction.IDocumentData<T>`
+**Assembly:** `UiPath.IntelligentOCR.StudioWeb.Activities`
+**XAML xmlns:** `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`
+
+The output `ExtractionResults` implements `IDocumentData<T>` where `T` is `ExtendedExtractionResultsForDocumentData` (or a Studio-generated subclass when `GenerateData=True`).
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Data` | `T` | Strongly-typed extraction results (available when `GenerateData=True`). |
+| `DocumentType` | `DocumentType` | The document type used for extraction. |
+| `SubDocuments` | `IDocumentData[]` | Subdocuments (if splitting occurred upstream). |
+| `FileDetails` | `FileDetails` | File path, name, extension, and page range. |
+| `DocumentMetadata` | `DocumentMetadata` | OCR text (`Text`), DOM (`DocumentObjectModel`), and `ResultsAsDataTables` for tabular export. |
+
+### ExtendedExtractionResultsForDocumentData
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction.ExtendedExtractionResultsForDocumentData`
+**XAML xmlns:** `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`
+
+Base type argument for the generic activity. When `GenerateData=True`, Studio generates a type-specific subclass at design time with strongly-typed properties for each extracted field, accessible via `ExtractionResults.Data`. The generated subclass has a dynamic assembly name and namespace — this is normal and handled automatically by Studio.
+
+### DictionaryData
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction.DictionaryData`
+**XAML xmlns:** `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities` (prefix `dux`)
+
+Extends `ExtendedExtractionResultsForDocumentData`. Provides methods to access extracted fields and tables by name or ID without requiring Studio's design-time code generation. **Recommended type argument for agent-generated workflows** when `GenerateData=False`.
+
+Key methods: `GetField(string)`, `GetFieldValue(string)`, `GetTable(string)`, `GetFields()`, `GetTables()`. See [Data Type Patterns](ExtractDocumentData/data-type-patterns.md) for the full API reference.
+
+## Enum Reference
+
+### Pretrained Extractor Identifiers (DocType and ModernDocumentTypeId values)
+
+Use these **lowercase** identifiers for both `DocType` and `ModernDocumentTypeId`. Do not use the capitalized display names for these properties (use capitalized names only for the display properties `ExtractorName` and `ModernDocumentTypeName`).
+
+| Identifier (DocType & ModernDocumentTypeId) | Display Name (ExtractorName & ModernDocumentTypeName) |
+|---------------------------------------------|------------------------------------------------------|
+| `invoices` | `Invoices` |
+| `receipts` | `Receipts` |
+| `id_cards` | `ID Cards` |
+| `passports` | `Passports` |
+| `purchase_orders` | `Purchase Orders` |
+| `utility_bills` | `Utility Bills` |
+| `remittance_advices` | `Remittance Advices` |
+| `bills_of_lading` | `Bills of Lading` |
+| `checks` | `Checks` |
+
+**Special ModernDocumentTypeId values:**
+- `use_classification_result` — Dynamically resolves the document type from the upstream ClassifyDocument result. When using this value, set `DocType="{x:Null}"` and pass a `DocumentData` from ClassifyDocument as `FileInput`. The activity determines the extractor and document type from the classification output at runtime. Works with both Predefined and custom DU projects. **Cannot be used with `GenerateData=True`.**
+
+**Custom DU project values:**
+When targeting a custom DU project (not Predefined), set `DocType` to the document type name from the project's Document Types tab (e.g., `"invoices"`). Ask the user for this name if not provided. Studio resolves the name to the correct extractor at design time. The predefined identifiers listed above only work with the Predefined project (`ProjectId="00000000-0000-0000-0000-000000000000"`). For custom projects, the document type names are project-specific.
+
+## XAML Example
+
+Extracts invoice data using the Predefined project with a pretrained extractor. Replace `[inputFile]` with an `IResource` variable pointing to the document (or a `DocumentData` from ClassifyDocument).
+
+```xml
+<du:ExtractDocumentDataWithDocumentData
+    x:TypeArguments="dux:ExtendedExtractionResultsForDocumentData"
+    DisplayName="Extract Document Data"
+    ActivityMajorVersion="2"
+    ProjectId="00000000-0000-0000-0000-000000000000"
+    ProjectName="Predefined"
+    ProjectTag="Production"
+    ProjectVersionName="Production"
+    ProjectVersionNumber="0"
+    DocType="[&quot;invoices&quot;]"
+    ExtractorName="Invoices"
+    ModernDocumentTypeId="invoices"
+    ModernDocumentTypeName="Invoices"
+    FileInput="[inputFile]"
+    TimeoutInSeconds="[3600]"
+    ExtractionResults="[extractionResults]">
+  <du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+    <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+  </du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+</du:ExtractDocumentDataWithDocumentData>
+```
+
+**Required variable declaration:**
+
+```xml
+<Variable x:TypeArguments="dux:IDocumentData(dux:ExtendedExtractionResultsForDocumentData)" Name="extractionResults" />
+```
+
+### DictionaryData Variant
+
+When generating workflows programmatically, use `DictionaryData` as the type argument. This provides field access methods without requiring Studio's JIT code generation:
+
+```xml
+<du:ExtractDocumentDataWithDocumentData
+    x:TypeArguments="dux:DictionaryData"
+    DisplayName="Extract Document Data"
+    ActivityMajorVersion="2"
+    ProjectId="00000000-0000-0000-0000-000000000000"
+    ProjectName="Predefined"
+    ProjectTag="Production"
+    ProjectVersionName="Production"
+    ProjectVersionNumber="0"
+    DocType="[&quot;invoices&quot;]"
+    ExtractorName="Invoices"
+    ModernDocumentTypeId="invoices"
+    ModernDocumentTypeName="Invoices"
+    FileInput="[inputFile]"
+    TimeoutInSeconds="[3600]"
+    ExtractionResults="[extractionResults]">
+  <du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+    <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+  </du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+</du:ExtractDocumentDataWithDocumentData>
+```
+
+**Required variable declaration:**
+
+```xml
+<Variable x:TypeArguments="dux:IDocumentData(dux:DictionaryData)" Name="extractionResults" />
+```
+
+### Custom DU Project Variant
+
+When targeting a custom DU project, use the document type name from the project for both `DocType` and `ModernDocumentTypeId`. Studio resolves these to the correct internal identifiers at design time. `ProjectId` must still be a GUID.
+
+```xml
+<du:ExtractDocumentDataWithDocumentData
+    x:TypeArguments="dux:DictionaryData"
+    DisplayName="Extract Document Data"
+    ActivityMajorVersion="2"
+    ProjectId="{your-project-guid}"
+    ProjectName="{Your Project Name}"
+    ProjectTag="{your-version-tag}"
+    ProjectVersionName="{your-version-tag}"
+    ProjectVersionNumber="{version-number}"
+    DocType="invoices"
+    ExtractorName="invoices"
+    ModernDocumentTypeId="invoices"
+    ModernDocumentTypeName="invoices"
+    FileInput="[inputFile]"
+    TimeoutInSeconds="[3600]"
+    GenerateData="False"
+    ExtractionResults="[extractionResults]">
+  <du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+    <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+  </du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+</du:ExtractDocumentDataWithDocumentData>
+```
+
+After opening the workflow in Studio, the designer resolves `ModernDocumentTypeId` from the name to the project-specific GUID. The `DocType` name is also validated against the project's registered extractors.
+
+**Required XAML namespace prefixes:**
+
+```xml
+xmlns:du="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:dux="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"
+```
+
+**Required expression namespace imports:**
+
+```xml
+<TextExpression.NamespacesForImplementation>
+  <scg:List x:TypeArguments="x:String">
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities</x:String>
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction</x:String>
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification</x:String>
+  </scg:List>
+</TextExpression.NamespacesForImplementation>
+<TextExpression.ReferencesForImplementation>
+  <scg:List x:TypeArguments="AssemblyReference">
+    <AssemblyReference>UiPath.IntelligentOCR.StudioWeb.Activities</AssemblyReference>
+  </scg:List>
+</TextExpression.ReferencesForImplementation>
+```
+
+## Notes
+
+- This is a generic activity. In XAML, use `x:TypeArguments="dux:ExtendedExtractionResultsForDocumentData"` (from namespace `UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction`, prefix `dux`).
+- `ProjectId` should be a GUID-formatted string at runtime (`Guid.Parse()` is used). The Predefined project GUID is `00000000-0000-0000-0000-000000000000`. For custom projects, Studio resolves `ProjectId` from `ProjectName` at design time — so if `ProjectName` is set to a valid project name, the GUID does not need to be known at authoring time. When `ProjectTag` is set, `ProjectVersionNumber` is also auto-resolved by Studio — agents can set `ProjectVersionNumber="0"` as a placeholder.
+- Properties backed by Studio dropdown widgets (`ProjectId`, `ProjectTag`, `ProjectVersionNumber`) should be set as **literal attribute values** rather than VB/C# expressions to ensure the dropdown displays correctly in the designer.
+- For the Predefined project, the standard version configuration is: `ProjectTag="Production"`, `ProjectVersionNumber="0"`, `ProjectVersionName="Production"`.
+- `ProjectVersionNumber` and `ProjectTag` are alternatives. Use one or the other.
+- `DocType` values are **lowercase identifiers**. For the Predefined project, use predefined names (e.g., `invoices`). For custom DU projects, use the document type name as it appears in the project (e.g., `"invoices"` if the project defines a document type named "invoices") — ask the user for this name if not provided (found in the project's Document Types tab). Studio resolves names to the correct extractor at design time.
+- `ModernDocumentTypeId` uses the **same lowercase identifier** as `DocType` for pretrained extractors (e.g., both are `"invoices"`). For custom DU projects, use the document type name — Studio resolves it to the internal GUID at design time. The GUID can also be used directly if known.
+- The legacy `ExtractorDocumentType` property does **not** exist on this activity. Use `DocType` (extractor identifier) and `ModernDocumentTypeId` (document type definition) instead.
+- **Always set `ActivityMajorVersion="2"`** in generated XAML. Without this, Studio shows a migration warning banner ("The activity has been updated to a new major version…") that requires manual acknowledgement before the activity can be used.
+- **Agents should always set `GenerateData="False"`.** `GenerateData=True` requires Studio's design-time JIT compilation which agents cannot trigger, and is incompatible with `ModernDocumentTypeId="use_classification_result"`.
+- When `GenerateData=True`, Studio generates a type-specific assembly at design time, producing a subclass of `ExtendedExtractionResultsForDocumentData` with typed field properties accessible via `ExtractionResults.Data`. The generated type has a dynamic assembly name — this is expected behavior.
+- `RuntimeAssetPath` and `RuntimeTenantUrl` enable cross-organization access. Both must be set together.
+- The type argument chosen for this activity (`ExtendedExtractionResultsForDocumentData`, `DictionaryData`, or a generated type) **must be used consistently** across all downstream validation activities (`CreateValidationAction<T>`, `WaitForValidationAction<T>`, `ValidateDocumentDataWithDocumentData<T>`, `CreateDocumentValidationArtifacts<T>`). Mismatched type arguments cause runtime errors. See [Data Type Patterns](ExtractDocumentData/data-type-patterns.md) for details.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/ExtractDocumentData/data-type-patterns.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/ExtractDocumentData/data-type-patterns.md
@@ -1,0 +1,224 @@
+# Data Type Patterns for Document Understanding Pipelines
+
+When using `ExtractDocumentDataWithDocumentData<T>`, the type argument `T` determines how extraction results are accessed and how downstream validation activities must be typed. This document covers the two patterns and their pipeline-wide implications.
+
+## Overview
+
+| Pattern | Type Argument | `GenerateData` | Field Access | Agent-Compatible |
+|---------|--------------|-----------------|--------------|------------------|
+| **DictionaryData** | `dux:DictionaryData` | `False` | `GetField("fieldName")`, `GetFieldValue("fieldName")` | Yes (recommended) |
+| **Generated Type** | Studio-generated subclass | `True` | `extractionResults.Data.FieldName` | No (requires Studio JIT compilation) |
+
+**For agent-generated workflows, always use `DictionaryData` with `GenerateData="False"`.** The generated type pattern requires Studio's design-time code generation, which is not available when an LLM agent produces XAML directly. Additionally, `GenerateData=True` is incompatible with `ModernDocumentTypeId="use_classification_result"`.
+
+## DictionaryData API Reference
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction.DictionaryData`
+
+`DictionaryData` extends `ExtendedExtractionResultsForDocumentData` and provides methods to access extracted fields and tables by name or ID.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Handler` | `ExtractionResultHandler` | Low-level handler for direct access to the underlying extraction result. |
+
+### Methods
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `GetFields()` | `ResultsDataPoint[]` | Returns all non-table extracted fields. |
+| `GetTables()` | `ResultsTable[]` | Returns all extracted tables. |
+| `GetField(string fieldIdOrName)` | `ResultsDataPoint` | Returns a single field by its ID or name. Case-insensitive. Throws if multiple fields match. |
+| `GetTable(string tableIdOrName)` | `ResultsTable` | Returns a single table by its ID or name. Case-insensitive. Throws if multiple tables match. See [Table Access Patterns](#table-access-patterns) for the full `ResultsTable` → `ResultsTableValue` → `ResultsTableCell` type hierarchy. |
+| `GetFieldValue(string fieldIdOrName)` | `ResultsValue` | Returns the first value of a field. Returns `null` if the field is missing. Throws if the field is not found. |
+| `GetFieldValue(string fieldIdOrName, int index)` | `ResultsValue` | Returns the value at a specific index. Throws if the index is out of range. |
+| `GetFieldValues(string fieldIdOrName)` | `ResultsValue[]` | Returns all values of a field. Returns an empty array if the field is missing. |
+| `SetFieldValue(string fieldIdOrName, ResultsValue value)` | `void` | Replaces all values of a field with a single value. |
+| `SetFieldValue(string fieldIdOrName, ResultsValue value, int index)` | `void` | Sets the value at a specific index. |
+| `SetFieldValues(string fieldIdOrName, ResultsValue[] values)` | `void` | Replaces all values of a field. |
+
+### Field Lookup Behavior
+
+`GetField`, `GetFieldValue`, `GetFieldValues`, `GetTable`, and their setter counterparts resolve fields in this order:
+1. Match by **full field ID** (case-insensitive)
+2. Match by **short field ID** (the part after the last `.` in the field ID, case-insensitive)
+3. Match by **field name** (case-insensitive)
+
+If more than one field matches at any step, an `ArgumentException` is thrown.
+
+## Table Access Patterns
+
+Extraction results can contain **tables** (e.g., line items on a receipt or invoice). Accessing table data requires navigating a specific type hierarchy that differs from simple field access.
+
+### Type Chain
+
+```
+DictionaryData
+  .GetTable("fieldId")        → ResultsTable
+    .Values                   → ResultsTableValue[]  (typically one element)
+    .GetValue()               → ResultsTableValue     (shorthand for Values(0))
+
+ResultsTableValue
+  .NumberOfRows               → Int32                 (includes header row)
+  .ColumnInfo                 → ResultsTableColumnInfo[]
+  .Cells                      → ResultsTableCell[]    (flat array, row-major order)
+  .GetCell(rowIndex, colIndex)→ ResultsTableCell       (helper, avoids manual indexing)
+  .GetRow(rowIndex)           → IEnumerable(Of ResultsTableCell)
+  .GetRows()                  → IEnumerable(Of ResultsTableCell())
+
+ResultsTableCell
+  .Values                     → ResultsValue[]        (typically one element)
+  .GetValue()                 → ResultsValue           (shorthand for Values(0))
+  .RowIndex                   → Int32
+  .ColumnIndex                → Int32
+  .IsHeader                   → Boolean
+  .IsMissing                  → Boolean
+
+ResultsTableColumnInfo
+  .FieldId                    → String                 (column identifier, e.g., "description")
+  .FieldName                  → String                 (display name)
+
+ResultsValue
+  .Value                      → String                 (the extracted text)
+  .Confidence                 → Single
+  .OcrConfidence              → Single
+  .OperatorConfirmed          → Boolean
+```
+
+### Key Points
+
+- **`ResultsTable.Values`** returns `ResultsTableValue[]`, **not** `ResultsValue[]`. Do not confuse with `ResultsDataPoint.Values`.
+- **`ResultsTableCell.Values`** returns `ResultsValue[]` (same as simple fields). Access the text with `.Values(0).Value` or the shorthand `.GetValue().Value`.
+- **`Cells` is a flat row-major array.** To access a cell manually: `Cells(rowIndex * ColumnInfo.Length + columnIndex)`. Prefer the helper methods `GetCell(row, col)`, `GetRow(row)`, or `GetRows()` instead.
+- **Row 0 is the header row.** Data rows start at index 1. `NumberOfRows` includes the header.
+
+### Iterating Table Rows (VB.NET)
+
+Find columns by `FieldId`, then iterate data rows:
+
+```vb
+' Get the table and its first value
+Dim table As ResultsTable = extractionResults.Data.GetTable("items")
+Dim tv As ResultsTableValue = table.GetValue()
+
+' Find column indices by FieldId
+Dim descCol As Integer = -1
+Dim amountCol As Integer = -1
+For i As Integer = 0 To tv.ColumnInfo.Length - 1
+    Select Case tv.ColumnInfo(i).FieldId
+        Case "description" : descCol = i
+        Case "line-amount" : amountCol = i
+    End Select
+Next
+
+' Iterate data rows (row 0 is the header, skip it)
+For row As Integer = 1 To tv.NumberOfRows - 1
+    Dim description As String = tv.GetCell(row, descCol).GetValue().Value
+    Dim amount As String = tv.GetCell(row, amountCol).GetValue().Value
+    ' ... use description and amount
+Next
+```
+
+### Alternative: Using GetRows()
+
+```vb
+Dim table As ResultsTable = extractionResults.Data.GetTable("items")
+Dim tv As ResultsTableValue = table.GetValue()
+
+For Each row As ResultsTableCell() In tv.GetRows()
+    ' Skip header row
+    If row(0).IsHeader Then Continue For
+    ' Access cells by column index
+    Dim description As String = row(descCol).GetValue().Value
+    Dim amount As String = row(amountCol).GetValue().Value
+Next
+```
+
+### Predefined Extractor Table Fields
+
+The Predefined project extractors define these table fields and column IDs:
+
+**Receipts** (`DocType="receipts"`) — table field: `items`
+
+| Column FieldId | Column Name |
+|----------------|-------------|
+| `description` | Description |
+| `quantity` | Quantity |
+| `unit-price` | Unit Price |
+| `line-amount` | Line Amount |
+
+**Invoices** (`DocType="invoices"`) — table field: `items`
+
+| Column FieldId | Column Name |
+|----------------|-------------|
+| `description` | Description |
+| `quantity` | Quantity |
+| `unit-price` | Unit Price |
+| `line-amount` | Line Amount |
+| `item-po-no` | Purchase Order Number |
+| `line-no` | Line Number |
+| `part-no` | Part Number |
+
+**Purchase Orders** (`DocType="purchase_orders"`) — table field: `items`
+
+| Column FieldId | Column Name |
+|----------------|-------------|
+| `description` | Description |
+| `quantity` | Quantity |
+| `unit-price` | Unit Price |
+| `line-amount` | Line Amount |
+
+> **Note:** For custom DU projects, the table field IDs and column IDs are project-specific. Ask the user for the table field name and column names.
+
+## Pipeline-Wide Type Propagation
+
+The type argument `T` chosen for `ExtractDocumentDataWithDocumentData<T>` must be used consistently across **all** downstream activities that handle extraction results. Mismatched type arguments will cause runtime errors.
+
+| Activity | Generic Parameter | DictionaryData Type Argument |
+|----------|-------------------|------------------------------|
+| `ExtractDocumentDataWithDocumentData<T>` | `T` | `dux:DictionaryData` |
+| `CreateValidationAction<T>` | `T` | `dux:DictionaryData` |
+| `WaitForValidationAction<T>` | `T` | `dux:DictionaryData` |
+| `ValidateDocumentDataWithDocumentData<T>` | `T` | `dux:DictionaryData` |
+| `CreateDocumentValidationArtifacts<T>` | `T` | `dux:DictionaryData` |
+
+Classification validation activities (`CreateClassificationValidationAction`, `WaitForClassificationValidationAction`, `CreateClassificationValidationActionAndWait`) are **not** generic and are unaffected by this choice.
+
+## Variable Declarations for DictionaryData Pipeline
+
+Complete variable block for a pipeline with classification validation and extraction validation:
+
+```xml
+<Sequence.Variables>
+  <!-- Classification -->
+  <Variable x:TypeArguments="duc:DocumentData" Name="classificationResults" />
+  <Variable x:TypeArguments="duVal:CreatedClassificationValidationAction" Name="classificationTask" />
+  <Variable x:TypeArguments="duc:DocumentData" Name="validatedClassificationResults" />
+  <!-- Extraction (DictionaryData) -->
+  <Variable x:TypeArguments="dux:IDocumentData(dux:DictionaryData)" Name="extractionResults" />
+  <Variable x:TypeArguments="duVal:CreatedValidationAction(dux:DictionaryData)" Name="extractionValidationTask" />
+  <Variable x:TypeArguments="dux:IDocumentData(dux:DictionaryData)" Name="validatedExtractionResults" />
+</Sequence.Variables>
+```
+
+Required XAML namespace prefixes for these variables:
+
+```xml
+xmlns:duc="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:dux="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:duVal="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+```
+
+## GenerateData=True Pattern (Studio Only)
+
+When `GenerateData=True`, Studio generates a subclass of `ExtendedExtractionResultsForDocumentData` at design time with strongly-typed properties for each extracted field. The generated type has a dynamic name and assembly (e.g., `AdiTest11InvoicesV3` in assembly `ExtendedExtractionRe.O9Rcc1EXZGC1VPCKY1e5Dfq3`).
+
+This pattern:
+- Requires Studio's design-time JIT compilation
+- Produces a user/project-specific type name that cannot be predicted
+- Enables `extractionResults.Data.InvoiceNumber`, `extractionResults.Data.TotalAmount`, etc.
+- All downstream validation activities must use the same generated type as their type argument
+- **Incompatible with `ModernDocumentTypeId="use_classification_result"`**
+
+**Agents should never use this pattern.** Always set `GenerateData="False"` and use `DictionaryData` as the type argument.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/RetrieveDocumentValidationArtifacts.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/RetrieveDocumentValidationArtifacts.md
@@ -1,0 +1,50 @@
+# Retrieve Document Validation Artifacts
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.Artifacts.RetrieveDocumentValidationArtifacts`
+
+Retrieves completed validation artifacts from an Orchestrator storage bucket and reconstructs the validated extraction results. Used after a UiPath App-based validation flow has been completed.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ContentValidationData` | Content Validation Data Object | InArgument | `ContentValidationData` | Yes | | The output of the **Create Document Validation Artifacts** activity. |
+| `CompletedAppAction` | Completed Action Object | InArgument | `object` | | | The completed action object from the UiPath App validation flow. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `RemoveDataFromStorage` | Remove Data From Storage | `bool` | `false` | If true, all associated data is deleted from the storage bucket after retrieval. |
+| `ReturnAutomaticExtractionResults` | Return Automatic Extraction Results | `bool` | `false` | If true, returns the original automatic extraction results instead of the validated results. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ValidatedExtractionResults` | Document data | OutArgument | `IDocumentData<DictionaryData>` | Validated extracted data containing changes made by the reviewer, or automatic extraction results if `ReturnAutomaticExtractionResults` is true. |
+
+## XAML Example
+
+```xml
+<duArt:RetrieveDocumentValidationArtifacts
+    DisplayName="Retrieve Document Validation Artifacts"
+    ContentValidationData="[contentValidationData]"
+    CompletedAppAction="[completedAction]"
+    RemoveDataFromStorage="[True]"
+    ValidatedExtractionResults="[validatedResults]" />
+```
+
+> Namespace prefix `duArt` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.Artifacts;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+## Notes
+
+- Use this activity after **Create Document Validation Artifacts** and a UiPath App-based validation flow.
+- The output type is `IDocumentData<DictionaryData>` (not the generic `ExtendedExtractionResultsForDocumentData`), as the validated data is deserialized from storage in a generic format.
+- Set `RemoveDataFromStorage` to `true` to clean up the storage bucket after retrieval.
+- Set `ReturnAutomaticExtractionResults` to `true` if you want to skip the validated results and use the original automatic extraction instead.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/WaitForClassificationValidationTaskAndResume.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/WaitForClassificationValidationTaskAndResume.md
@@ -1,0 +1,40 @@
+# Wait for Classification Validation Task & Resume
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.WaitForClassificationValidationAction`
+
+Waits for the completion of a Classification Validation Task (created by the **Create Classification Validation Task** activity) and resumes the workflow with the validated classification results.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `CreatedClassificationValidationAction` | Created Classification Validation Task | InArgument | `CreatedClassificationValidationAction` | Yes | | The output of the **Create Classification Validation Task** activity. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ValidatedClassificationResults` | Document data | OutArgument | `DocumentData` | Validated classification data containing changes made by the reviewer in Classification Station. |
+
+## XAML Example
+
+```xml
+<duVal:WaitForClassificationValidationAction
+    DisplayName="Wait for Classification Validation Task"
+    CreatedClassificationValidationAction="[createdClassificationAction]"
+    ValidatedClassificationResults="[validatedClassification]" />
+```
+
+> Namespace prefix `duVal` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+## Notes
+
+- This is a **persistent activity**. The workflow suspends while waiting for the validation task to be completed in Action Center. The project must have `"supportsPersistence": true` in `project.json` (under `"runtimeOptions"`). Without this, the workflow will fail at runtime.
+- Cannot be placed inside a No Persist Scope.
+- Must be used after a **Create Classification Validation Task** activity. The `CreatedClassificationValidationAction` input must come from that activity's output.
+- In a typical pipeline, the `ValidatedClassificationResults` output (`DocumentData`) is passed as `FileInput` to **Extract Document Data**. `DocumentData` implements `IResource`, so it can be used directly.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/WaitForValidationTaskAndResume.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/activities/WaitForValidationTaskAndResume.md
@@ -1,0 +1,63 @@
+# Wait for Validation Task and Resume
+
+`UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.WaitForValidationAction`
+
+Waits for the completion of a Document Validation Task (created by the **Create Validation Task** activity) and resumes the workflow with the validated extraction results.
+
+**Package:** `UiPath.DocumentUnderstanding.Activities`
+**Category:** Document Understanding
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `CreatedValidationAction` | Created document validation task | InArgument | `CreatedValidationAction<ExtendedExtractionResultsForDocumentData>` | Yes | | The output of the **Create Validation Task** activity. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ValidatedExtractionResults` | Document data | OutArgument | `IDocumentData<ExtendedExtractionResultsForDocumentData>` | Validated extracted data containing changes made by the reviewer in Validation Station. |
+
+## XAML Example
+
+```xml
+<duVal:WaitForValidationAction
+    x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"
+    DisplayName="Wait for Validation Task and Resume"
+    CreatedValidationAction="[createdValidationAction]"
+    ValidatedExtractionResults="[validatedResults]" />
+```
+
+> Namespace prefix `duVal` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+> Namespace prefix `du` maps to `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+### DictionaryData Variant
+
+When using `DictionaryData` for the extraction pipeline (recommended for agent-generated workflows):
+
+```xml
+<duVal:WaitForValidationAction
+    x:TypeArguments="du:DictionaryData"
+    DisplayName="Wait for Validation Task and Resume"
+    CreatedValidationAction="[createdValidationAction]"
+    ValidatedExtractionResults="[validatedResults]" />
+```
+
+**Required variable declarations:**
+
+```xml
+<Variable x:TypeArguments="duVal:CreatedValidationAction(du:DictionaryData)" Name="createdValidationAction" />
+<Variable x:TypeArguments="dux:IDocumentData(du:DictionaryData)" Name="validatedResults" />
+```
+
+## Notes
+
+- This is a **persistent activity**. The workflow suspends while waiting for the validation task to be completed in Action Center. The project must have `"supportsPersistence": true` in `project.json` (under `"runtimeOptions"`). Without this, the workflow will fail at runtime.
+- This is a generic activity. In XAML, use `x:TypeArguments="du:ExtendedExtractionResultsForDocumentData"` or `x:TypeArguments="du:DictionaryData"`.
+- The type argument **must match** the type argument used in `ExtractDocumentDataWithDocumentData` and `CreateValidationAction`. All three must use the same `T`.
+- Cannot be placed inside a No Persist Scope.
+- Must be used after a **Create Validation Task** activity. The `CreatedValidationAction` input must come from that activity's output.
+- In a typical pipeline, this is the final extraction validation step. The `ValidatedExtractionResults` output contains the human-reviewed data.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.IntelligentOCR.StudioWeb.Activities/3.1/overview.md
@@ -1,0 +1,516 @@
+# UiPath Document Understanding Activities
+
+`UiPath.DocumentUnderstanding.Activities`
+
+Activities for document classification, data extraction, and human-in-the-loop validation using the UiPath Document Understanding framework. Supports pretrained models for standard document types and custom DU project models.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+
+## Activities
+
+### Document Understanding
+
+| Activity | Description |
+|----------|-------------|
+| [Classify Document](activities/ClassifyDocument.md) | Classifies a document according to the configured classifier. |
+| [Extract Document Data](activities/ExtractDocumentData.md) | Extracts data from a document using pretrained or custom project extractors. |
+
+### Document Validation — Extraction
+
+| Activity | Description |
+|----------|-------------|
+| [Create Validation Task and Wait](activities/CreateValidationTaskAndWait.md) | Creates a Document Validation Task in Action Center and waits for completion. |
+| [Create Validation Task](activities/CreateValidationTask.md) | Creates a Document Validation Task in Action Center without waiting. |
+| [Wait for Validation Task and Resume](activities/WaitForValidationTaskAndResume.md) | Waits for a Document Validation Task to be completed and resumes the workflow. |
+
+### Document Validation — Classification
+
+| Activity | Description |
+|----------|-------------|
+| [Create Classification Validation Task](activities/CreateClassificationValidationTask.md) | Creates a Classification Validation Task in Action Center without waiting. |
+| [Create Classification Validation Task and Wait](activities/CreateClassificationValidationTaskAndWait.md) | Creates a Classification Validation Task in Action Center and waits for completion. |
+| [Wait for Classification Validation Task & Resume](activities/WaitForClassificationValidationTaskAndResume.md) | Waits for a Classification Validation Task to be completed and resumes the workflow. |
+
+### Document Validation — Artifacts
+
+| Activity | Description |
+|----------|-------------|
+| [Create Document Validation Artifacts](activities/CreateDocumentValidationArtifacts.md) | Uploads extraction results to an Orchestrator storage bucket for external validation via UiPath Apps. |
+| [Retrieve Document Validation Artifacts](activities/RetrieveDocumentValidationArtifacts.md) | Retrieves validated extraction results from an Orchestrator storage bucket. |
+
+## Required XAML Namespace Declarations
+
+All Document Understanding activities require these namespace declarations.
+
+**XAML xmlns prefixes:**
+
+```xml
+xmlns:du="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:duc="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:dux="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:duVal="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:duArt="clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation.Artifacts;assembly=UiPath.IntelligentOCR.StudioWeb.Activities"
+xmlns:uicore="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"
+```
+
+**TextExpression.NamespacesForImplementation** (required for VB expressions referencing DU types):
+
+```xml
+<TextExpression.NamespacesForImplementation>
+  <scg:List x:TypeArguments="x:String">
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities</x:String>
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification</x:String>
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction</x:String>
+    <x:String>UiPath.IntelligentOCR.StudioWeb.Activities.DataValidation</x:String>
+  </scg:List>
+</TextExpression.NamespacesForImplementation>
+```
+
+**TextExpression.ReferencesForImplementation:**
+
+```xml
+<TextExpression.ReferencesForImplementation>
+  <scg:List x:TypeArguments="AssemblyReference">
+    <AssemblyReference>UiPath.IntelligentOCR.StudioWeb.Activities</AssemblyReference>
+  </scg:List>
+</TextExpression.ReferencesForImplementation>
+```
+
+## Type Reference
+
+Key types used across Document Understanding activities. All types are in assembly `UiPath.IntelligentOCR.StudioWeb.Activities`.
+
+### DocumentData (Classification)
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification.DocumentData`
+**XAML xmlns:** `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`
+
+Output of ClassifyDocument. Implements `IDocumentData` and `ILocalResource`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `DocumentType` | `DocumentType` | The classified document type (see below). |
+| `SubDocuments` | `IDocumentData[]` | Array of subdocuments when splitting is enabled. |
+| `FileDetails` | `FileDetails` | File path, name, extension, and page range. |
+| `DocumentMetadata` | `DocumentMetadata` | OCR text, DOM, language, and results as DataTables. |
+
+### DocumentType
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DocumentClassification.DocumentType`
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `DisplayName` | `string` | Human-readable label (e.g., `"Invoices"`). |
+| `Id` | `string` | Machine identifier (e.g., `"invoices"`). Use this for programmatic comparisons. |
+| `Confidence` | `float` | Classification confidence score (0.0 to 1.0). |
+| `Name` | `string` | **Obsolete.** Use `Id` instead. |
+| `Url` | `string` | Reference URL for the document type definition. |
+
+### IDocumentData\<T\> (Extraction)
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction.IDocumentData<T>`
+**XAML xmlns:** `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities`
+
+Output of ExtractDocumentData. Extends the classification `IDocumentData` with strongly-typed extraction results.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Data` | `T` | Strongly-typed extraction results (available when `GenerateData=True`). |
+| `DocumentType` | `DocumentType` | The document type used for extraction. |
+| `SubDocuments` | `IDocumentData[]` | Subdocuments (if splitting occurred upstream). |
+| `DocumentMetadata` | `DocumentMetadata` | OCR text, DOM, and `ResultsAsDataTables` for tabular export. |
+
+### ExtendedExtractionResultsForDocumentData
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction.ExtendedExtractionResultsForDocumentData`
+
+Base type argument for `ExtractDocumentDataWithDocumentData<T>`. When `GenerateData=True`, Studio generates a subclass with strongly-typed properties for each extracted field.
+
+### DictionaryData
+
+**CLR type:** `UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction.DictionaryData`
+**XAML xmlns:** `clr-namespace:UiPath.IntelligentOCR.StudioWeb.Activities.DataExtraction;assembly=UiPath.IntelligentOCR.StudioWeb.Activities` (prefix `dux`)
+
+Extends `ExtendedExtractionResultsForDocumentData`. Provides methods to access extracted fields and tables by name or ID. **Recommended type argument for agent-generated workflows** since it does not require Studio's design-time JIT code generation.
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `GetField(string fieldIdOrName)` | `ResultsDataPoint` | Returns a field by ID or name. |
+| `GetFieldValue(string fieldIdOrName)` | `ResultsValue` | Returns the first value of a field. |
+| `GetFieldValues(string fieldIdOrName)` | `ResultsValue[]` | Returns all values of a field. |
+| `GetFields()` | `ResultsDataPoint[]` | Returns all non-table fields. |
+| `GetTable(string tableIdOrName)` | `ResultsTable` | Returns a table by ID or name. |
+| `GetTables()` | `ResultsTable[]` | Returns all tables. |
+
+See [Data Type Patterns](activities/ExtractDocumentData/data-type-patterns.md) for the full API reference, including setter methods, lookup behavior, and **table access patterns** (`ResultsTable` → `ResultsTableValue` → `ResultsTableCell` type hierarchy with code examples).
+
+## Activity Data Flow
+
+Document Understanding workflows follow a pipeline pattern. The output of each activity feeds into the next. The type argument `<T>` chosen for extraction must be consistent across all downstream extraction validation activities.
+
+```
+ClassifyDocument
+  Output: DocumentData ──────────────────────────────────┐
+                                                          │
+  ┌───────────────────────────────────────────────────────┘
+  │
+  ├──> [Optional] Classification Validation
+  │    CreateClassificationValidationAction
+  │      Input:  DocumentData
+  │      Output: CreatedClassificationValidationAction (token)
+  │                │
+  │    WaitForClassificationValidationAction
+  │      Input:  CreatedClassificationValidationAction
+  │      Output: DocumentData (validated)
+  │
+  ├──> ExtractDocumentDataWithDocumentData<T>
+  │      Input:  DocumentData (as FileInput — implements IResource)
+  │      Output: IDocumentData<T>
+  │                │
+  │    ┌───────────┘
+  │    │
+  │    ├──> [Optional] Extraction Validation (Action Center)
+  │    │    CreateValidationAction<T>
+  │    │      Input:  IDocumentData<T>
+  │    │      Output: CreatedValidationAction<T> (token)
+  │    │                │
+  │    │    WaitForValidationAction<T>
+  │    │      Input:  CreatedValidationAction<T>
+  │    │      Output: IDocumentData<T> (validated)
+  │    │
+  │    └──> [Alternative] Extraction Validation (UiPath Apps)
+  │         CreateDocumentValidationArtifacts<T>
+  │           Input:  IDocumentData<T>
+  │           Output: ContentValidationData
+  │                     │
+  │         RetrieveDocumentValidationArtifacts
+  │           Input:  ContentValidationData
+  │           Output: IDocumentData<DictionaryData> (validated)
+```
+
+**Key points:**
+- `DocumentData` from ClassifyDocument implements `IResource`, so it can be passed directly as `FileInput` to ExtractDocumentData.
+- `<T>` is either `DictionaryData` (recommended for agents) or a Studio-generated type. All generic activities in the extraction validation path must use the same `T`.
+- Classification validation activities are **not** generic.
+- The "and Wait" variants (`CreateClassificationValidationActionAndWait`, `ValidateDocumentDataWithDocumentData`) combine the create + wait steps into a single persistent activity.
+
+## Persistence Requirement for Validation Workflows
+
+Workflows that use any `Wait` or `...AndWait` validation activity suspend execution until a human completes a task in Action Center. For this to work, the UiPath project must have persistence enabled in `project.json`.
+
+**When to enable:** Any workflow containing `WaitForValidationAction`, `WaitForClassificationValidationAction`, `ValidateDocumentDataWithDocumentData`, or `CreateClassificationValidationActionAndWait`.
+
+**How to enable:** Set `"supportsPersistence": true` inside the `"runtimeOptions"` object in `project.json`:
+
+```json
+{
+  "runtimeOptions": {
+    "supportsPersistence": true
+  }
+}
+```
+
+If this setting is missing or `false`, the workflow will fail at runtime when it reaches a persistent activity. **Agents must always set this when generating workflows that include validation activities.**
+
+## Common Patterns
+
+### Classify then Extract
+
+A typical workflow classifies a document first, then extracts data based on the classification result. The `classificationResults.DocumentType.Id` value from ClassifyDocument provides the lowercase identifier needed for ExtractDocumentData's `DocType`.
+
+```xml
+<Sequence DisplayName="Classify then Extract">
+  <Sequence.Variables>
+    <Variable x:TypeArguments="duc:DocumentData" Name="classificationResults" />
+    <Variable x:TypeArguments="dux:IDocumentData(dux:ExtendedExtractionResultsForDocumentData)" Name="extractionResults" />
+  </Sequence.Variables>
+
+  <!-- Step 1: Classify the document -->
+  <du:ClassifyDocument
+      DisplayName="Classify Document"
+      ProjectId="00000000-0000-0000-0000-000000000000"
+      ProjectName="Predefined"
+      ProjectTag="Production"
+      ProjectVersionName="Production"
+      ProjectVersionNumber="0"
+      ClassifierId="ml-classification"
+      ClassifierName="ML Classification"
+      FileInput="[inputFile]"
+      TimeoutInSeconds="[3600]"
+      ClassificationResults="[classificationResults]">
+    <du:ClassifyDocument.GptPromptWithVariables>
+      <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+    </du:ClassifyDocument.GptPromptWithVariables>
+  </du:ClassifyDocument>
+
+  <!-- Step 2: Extract using the classification result -->
+  <du:ExtractDocumentDataWithDocumentData
+      x:TypeArguments="dux:ExtendedExtractionResultsForDocumentData"
+      DisplayName="Extract Document Data"
+      ActivityMajorVersion="2"
+      ProjectId="00000000-0000-0000-0000-000000000000"
+      ProjectName="Predefined"
+      ProjectTag="Production"
+      ProjectVersionName="Production"
+      ProjectVersionNumber="0"
+      DocType="[classificationResults.DocumentType.Id]"
+      FileInput="[classificationResults]"
+      TimeoutInSeconds="[3600]"
+      ExtractionResults="[extractionResults]">
+    <du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+      <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+    </du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+  </du:ExtractDocumentDataWithDocumentData>
+</Sequence>
+```
+
+**Key points:**
+- The `FileInput` for ExtractDocumentData accepts the `classificationResults` directly — `DocumentData` implements `IResource`, passing along the digitized document.
+- `classificationResults.DocumentType.Id` provides the lowercase identifier (e.g., `"invoices"`) needed for `DocType`.
+- Both activities use the Predefined project GUID `00000000-0000-0000-0000-000000000000`.
+- Studio UI display properties (`ProjectName`, `ProjectVersionName`, `ClassifierName`) must be set alongside functional properties for dropdowns to render correctly.
+- For the Predefined project, always set `ProjectTag="Production"`, `ProjectVersionNumber="0"`, `ProjectVersionName="Production"`.
+- This pattern uses `ExtendedExtractionResultsForDocumentData` as the base type. For agent-generated workflows, prefer the `DictionaryData` variant shown below which provides field access methods.
+
+### Full Pipeline with Human-in-the-Loop Validation (DictionaryData)
+
+A complete Document Understanding pipeline that classifies a document, validates the classification via Action Center, extracts data, and validates the extraction. Uses `DictionaryData` throughout for agent-compatible field access.
+
+This example processes all files from a folder. Adapt by replacing the `ForEach` with your own document source.
+
+```xml
+<Sequence DisplayName="Document Understanding Pipeline">
+  <Sequence.Variables>
+    <Variable x:TypeArguments="x:String" Default="InputDocs\" Name="documentsFolderPath" />
+  </Sequence.Variables>
+
+  <uicore:ForEach x:TypeArguments="x:String" DisplayName="Process each document" Values="[directory.GetFiles(documentsFolderPath)]">
+    <uicore:ForEach.Body>
+      <ActivityAction x:TypeArguments="x:String">
+        <ActivityAction.Argument>
+          <DelegateInArgument x:TypeArguments="x:String" Name="currentFile" />
+        </ActivityAction.Argument>
+        <Sequence DisplayName="Process document">
+          <Sequence.Variables>
+            <Variable x:TypeArguments="x:String" Name="fileName" />
+            <!-- Classification -->
+            <Variable x:TypeArguments="duc:DocumentData" Name="classificationResults" />
+            <Variable x:TypeArguments="duVal:CreatedClassificationValidationAction" Name="classificationTask" />
+            <Variable x:TypeArguments="duc:DocumentData" Name="validatedClassificationResults" />
+            <!-- Extraction (DictionaryData) -->
+            <Variable x:TypeArguments="dux:IDocumentData(dux:DictionaryData)" Name="extractionResults" />
+            <Variable x:TypeArguments="duVal:CreatedValidationAction(dux:DictionaryData)" Name="extractionValidationTask" />
+            <Variable x:TypeArguments="dux:IDocumentData(dux:DictionaryData)" Name="validatedExtractionResults" />
+          </Sequence.Variables>
+
+          <Assign DisplayName="Get file name">
+            <Assign.To>
+              <OutArgument x:TypeArguments="x:String">[fileName]</OutArgument>
+            </Assign.To>
+            <Assign.Value>
+              <InArgument x:TypeArguments="x:String">[System.IO.Path.GetFileNameWithoutExtension(currentFile)]</InArgument>
+            </Assign.Value>
+          </Assign>
+
+          <!-- Step 1: Classify the document -->
+          <du:ClassifyDocument
+              DisplayName="Classify Document"
+              ProjectId="00000000-0000-0000-0000-000000000000"
+              ProjectName="Predefined"
+              ProjectTag="Production"
+              ProjectVersionName="Production"
+              ProjectVersionNumber="0"
+              ClassifierId="ml-classification"
+              ClassifierName="ML Classification"
+              FileInput="[LocalResource.FromPath(currentFile)]"
+              TimeoutInSeconds="[3600]"
+              ClassificationResults="[classificationResults]">
+            <du:ClassifyDocument.GptPromptWithVariables>
+              <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+            </du:ClassifyDocument.GptPromptWithVariables>
+          </du:ClassifyDocument>
+
+          <!-- Step 2: Create classification validation task -->
+          <duVal:CreateClassificationValidationAction
+              DisplayName="Create Classification Validation Task"
+              AutomaticClassificationResults="[classificationResults]"
+              ActionTitle="[fileName + &quot;_classification&quot;]"
+              CreatedClassificationValidationAction="[classificationTask]" />
+
+          <!-- Step 3: Wait for human to validate classification -->
+          <duVal:WaitForClassificationValidationAction
+              DisplayName="Wait for Classification Validation Task &amp; Resume"
+              CreatedClassificationValidationAction="[classificationTask]"
+              ValidatedClassificationResults="[validatedClassificationResults]" />
+
+          <!-- Step 4: Extract data using validated classification result -->
+          <du:ExtractDocumentDataWithDocumentData
+              x:TypeArguments="dux:DictionaryData"
+              DisplayName="Extract Document Data"
+              ActivityMajorVersion="2"
+              DocType="{x:Null}"
+              GenerateData="False"
+              ProjectId="00000000-0000-0000-0000-000000000000"
+              ProjectName="Predefined"
+              ProjectTag="Production"
+              ProjectVersionName="Production"
+              ProjectVersionNumber="0"
+              ModernDocumentTypeId="use_classification_result"
+              FileInput="[validatedClassificationResults]"
+              TimeoutInSeconds="[3600]"
+              ExtractionResults="[extractionResults]">
+            <du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+              <scg:Dictionary x:TypeArguments="x:String, InArgument(x:String)" />
+            </du:ExtractDocumentDataWithDocumentData.GptPromptWithVariables>
+          </du:ExtractDocumentDataWithDocumentData>
+
+          <!-- Step 5: Create extraction validation task -->
+          <duVal:CreateValidationAction
+              x:TypeArguments="dux:DictionaryData"
+              DisplayName="Create Validation Task"
+              AutomaticExtractionResults="[extractionResults]"
+              ActionTitle="[fileName + &quot;_extraction&quot;]"
+              CreatedValidationAction="[extractionValidationTask]" />
+
+          <!-- Step 6: Wait for human to validate extraction -->
+          <duVal:WaitForValidationAction
+              x:TypeArguments="dux:DictionaryData"
+              DisplayName="Wait for Validation Task and Resume"
+              CreatedValidationAction="[extractionValidationTask]"
+              ValidatedExtractionResults="[validatedExtractionResults]" />
+
+        </Sequence>
+      </ActivityAction>
+    </uicore:ForEach.Body>
+  </uicore:ForEach>
+</Sequence>
+```
+
+**Key points:**
+- All extraction-related activities use `x:TypeArguments="dux:DictionaryData"` consistently.
+- `ModernDocumentTypeId="use_classification_result"` dynamically resolves the extractor from the classification result at runtime. When using this, set `DocType="{x:Null}"`. This is incompatible with `GenerateData=True`.
+- `GenerateData="False"` is required for agent-generated workflows. Agents should always set this explicitly. `GenerateData=True` requires Studio's design-time JIT compilation and is incompatible with `use_classification_result`.
+- `FileInput="[validatedClassificationResults]"` passes the validated `DocumentData` directly — it implements `IResource`.
+- `LocalResource.FromPath(currentFile)` creates an `IResource` from a file path for the initial classification.
+- Classification validation and extraction validation tasks are created in Action Center. The workflow suspends at each `Wait` activity until a human completes the task.
+- **Persistence requirement:** Any workflow that uses `Wait` or `...AndWait` activities (e.g., `WaitForValidationAction`, `WaitForClassificationValidationAction`, `ValidateDocumentDataWithDocumentData`, `CreateClassificationValidationActionAndWait`) requires `"supportsPersistence": true` in `project.json` under `"runtimeOptions"`. Without this, the workflow will fail at runtime. When generating a workflow that includes any of these activities, always ensure this setting is present in `project.json`.
+- For workflows without validation, omit steps 2-3 (classification validation) and/or steps 5-6 (extraction validation). Pass `classificationResults` directly to `FileInput` if skipping classification validation.
+- Use UiPath control flow activities (`uicore:ForEach`, `uicore:InterruptibleWhile`) from `UiPath.Core.Activities` (assembly `UiPath.System.Activities`), **not** the .NET equivalents from the default XAML namespace. The UiPath versions require explicit `.Body` wrappers (e.g., `<uicore:ForEach.Body>`) around their content.
+
+### Custom DU Project Pipeline
+
+To use a custom Document Understanding project instead of Predefined, substitute these values in the pipeline above. Studio resolves all names to internal GUIDs at design time — the agent only needs names from the user, not GUIDs.
+
+```xml
+<!-- ClassifyDocument: replace Predefined project and classifier -->
+<du:ClassifyDocument
+    ProjectId="placeholder"
+    ProjectName="{Your Project Name}"
+    ProjectTag="{your-version-tag}"
+    ProjectVersionName="{your-version-tag}"
+    ProjectVersionNumber="0"
+    ClassifierId="{your-classifier-name}"
+    ClassifierName="{your-classifier-name}"
+    ... />
+
+<!-- ExtractDocumentDataWithDocumentData: replace Predefined project and extractor -->
+<du:ExtractDocumentDataWithDocumentData
+    x:TypeArguments="dux:DictionaryData"
+    ActivityMajorVersion="2"
+    ProjectId="placeholder"
+    ProjectName="{Your Project Name}"
+    ProjectTag="{your-version-tag}"
+    ProjectVersionName="{your-version-tag}"
+    ProjectVersionNumber="0"
+    DocType="{document-type-name}"
+    ExtractorName="{document-type-name}"
+    ModernDocumentTypeId="{document-type-name}"
+    ModernDocumentTypeName="{document-type-name}"
+    ... />
+```
+
+**Project name resolution:** `ProjectName` is the driving property. When the user opens the workflow in Studio, it performs the following resolutions at design time:
+- `ProjectId` is resolved from `ProjectName` to the actual project GUID
+- `ProjectVersionNumber` is resolved from `ProjectTag` to the correct version number
+- Classifier and extractor names are resolved to internal identifiers
+
+This works for both DU and IXP projects. The agent can set `ProjectId="placeholder"` and `ProjectVersionNumber="0"` — Studio overwrites both with the correct values.
+
+**Key differences from Predefined:**
+- `ProjectName` is the project's display name. Studio uses it to resolve `ProjectId` to the correct GUID at design time.
+- `ProjectId` can be a placeholder — Studio resolves it from `ProjectName`. If the user provides the GUID, use it; otherwise `"placeholder"` works.
+- `ClassifierId` is the **classifier name** from the custom project. Studio resolves the name to the internal GUID at design time. Set `ClassifierName` to the same value.
+- `DocType` is the **document type name** from the project (e.g., `"invoices"`). Studio resolves the name to the correct extractor at design time. When using `ModernDocumentTypeId="use_classification_result"`, set `DocType="{x:Null}"`.
+- `ModernDocumentTypeId` is the **document type name** from the project (same value as `DocType`). Studio resolves it to the internal GUID at design time. Alternatively, set to `"use_classification_result"` to dynamically resolve from the classification output (set `DocType="{x:Null}"` when using this).
+- `ProjectTag` and `ProjectVersionNumber` reflect the custom project's version. When `ProjectTag` is set, `ProjectVersionNumber` is auto-resolved by Studio — agents can set `ProjectVersionNumber="0"` as a safe placeholder.
+- Classification and extraction can use **different projects**. For example, `ClassifyDocument` can use a DU classification project while `ExtractDocumentDataWithDocumentData` uses a separate IXP extraction project. When `ModernDocumentTypeId="use_classification_result"` is set, the extraction project resolves the document type from the classification output at runtime, even across projects.
+
+### Agent Guidance: Custom DU Projects
+
+When a user says "use my DU project called X", the agent already has the project name. Collect the remaining values below. **No GUIDs are needed** — Studio resolves all names to GUIDs at design time.
+
+#### Required Information Checklist
+
+| # | What to ask the user | Maps to XAML property |
+|---|----------------------|-----------------------|
+| 1 | **Project name** — typically already given in the user's request (e.g., "use my project called X") | `ProjectName` on both `ClassifyDocument` and `ExtractDocumentDataWithDocumentData`. **This is the driving property** — Studio uses it to resolve `ProjectId` to the correct GUID at design time. |
+| 2 | **Version tag or number** — e.g., `"Production"`, `"live"` | `ProjectTag` and `ProjectVersionName` (use the tag string), **or** `ProjectVersionNumber` (use the number). When `ProjectTag` is set, Studio auto-resolves `ProjectVersionNumber`. |
+| 3 | **Classifier name** — the name of the classifier in the project. Ask the user. | `ClassifierId` and `ClassifierName` on `ClassifyDocument` (set both to the same name). Studio resolves the name to the internal GUID at design time. |
+| 4 | **Document type name(s)** — the name of each document type to extract (e.g., `"invoices"`, `"purchase_orders"`). Ask the user. | `DocType`, `ModernDocumentTypeId`, `ExtractorName`, `ModernDocumentTypeName` on `ExtractDocumentDataWithDocumentData` (set all four to the same name). Studio resolves names to GUIDs at design time. |
+
+#### What the agent can set without asking
+
+- `ProjectId="placeholder"` — Studio resolves the correct GUID from `ProjectName` at design time. If the user provides a GUID, use it; otherwise a placeholder works.
+- `ProjectVersionNumber="0"` — when `ProjectTag` is set, Studio auto-resolves the correct version number. Use `0` as a safe placeholder.
+- `GenerateData="False"` — always use this for agent-generated workflows.
+- `ActivityMajorVersion="2"` — always set this on `ExtractDocumentDataWithDocumentData`.
+- `x:TypeArguments="dux:DictionaryData"` — always use this type argument.
+- `TimeoutInSeconds="[3600]"` — standard default.
+- `ProjectTag` / `ProjectVersionName` — if the user says "production", use `"Production"`.
+- If the user confirms that classification validation is in the pipeline, the agent can use `ModernDocumentTypeId="use_classification_result"` with `DocType="{x:Null}"` instead of asking for document type names (item 4). This dynamically resolves the extractor from the classification result.
+
+#### UI-to-XAML Property Mapping
+
+The table below shows how values from the Document Understanding UI map to XAML attributes on each activity.
+
+**ClassifyDocument:**
+
+| User-provided value | XAML property | Format | Example |
+|---------------------|---------------|--------|---------|
+| Project name | `ProjectName` | Display string — **Studio resolves `ProjectId` from this** | `"My Invoice Project"` |
+| (auto-resolved) | `ProjectId` | GUID or placeholder — Studio resolves from `ProjectName` | `"placeholder"` |
+| Version tag | `ProjectTag` | String | `"Production"` |
+| Version tag | `ProjectVersionName` | Same as `ProjectTag` | `"Production"` |
+| (auto-resolved) | `ProjectVersionNumber` | Integer — Studio resolves from `ProjectTag`. Use `"0"` as placeholder. | `"0"` |
+| Classifier name | `ClassifierId` | Classifier name — Studio resolves to GUID | `"My Classifier"` |
+| Classifier name | `ClassifierName` | Same name | `"My Classifier"` |
+
+**ExtractDocumentDataWithDocumentData:**
+
+| User-provided value | XAML property | Format | Example |
+|---------------------|---------------|--------|---------|
+| Project name | `ProjectName` | Display string — **Studio resolves `ProjectId` from this** | `"My Invoice Project"` |
+| (auto-resolved) | `ProjectId` | GUID or placeholder — Studio resolves from `ProjectName` | `"placeholder"` |
+| Version tag | `ProjectTag` | String | `"Production"` |
+| Version tag | `ProjectVersionName` | Same as `ProjectTag` | `"Production"` |
+| (auto-resolved) | `ProjectVersionNumber` | Integer — Studio resolves from `ProjectTag`. Use `"0"` as placeholder. | `"0"` |
+| Document type name | `DocType` | Lowercase document type name — Studio resolves to extractor | `"invoices"` |
+| Document type name | `ExtractorName` | Same name | `"invoices"` |
+| Document type name | `ModernDocumentTypeId` | Same name — Studio resolves to GUID | `"invoices"` |
+| Document type name | `ModernDocumentTypeName` | Same name | `"invoices"` |
+
+> **Note:** Studio resolves all names to internal GUIDs at design time when the user opens the workflow. The agent does not need any GUIDs from the user — `ProjectName` drives the resolution of `ProjectId`, and all other names (classifier, document type, extractor) are resolved similarly.
+
+#### Example agent interaction
+
+> **User:** "Create a DU workflow using my project called Invoice Processing"
+>
+> **Agent should ask:** "I have the project name ('Invoice Processing'). To complete the workflow, I also need:
+> 1. The **classifier name** from your project (e.g., 'My Classifier')
+> 2. The **document type name(s)** you want to extract (e.g., 'invoices')
+> 3. The **version tag** (e.g., 'Production') or version number to use
+>
+> If classification validation is part of the workflow, I can skip the document type names and use the classification result directly. No GUIDs are needed — Studio resolves everything from the names when you open the workflow."

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/DrawPattern.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/DrawPattern.md
@@ -1,0 +1,47 @@
+# ActivityNameDrawPattern
+
+`UiPath.MobileAutomation.Activities.DrawPattern`
+
+Create finger paths using input points that will be executed on the screen device.
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `PointX` | Point X | InArgument | `double` | | | X coordinate for the touch point |
+| `PointY` | Point Y | InArgument | `double` | | | Y coordinate for the touch point |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `CoordinatesType` | CoordinatesType | `CoordinatesTypeEnum` | | Whether the dimensions should be described in device independent or physical (real) device pixels |
+| `PointOperations` | Point Operations | `List<PointOperation>` | | List of point operations defining the pattern |
+
+## Enum Reference
+
+**`CoordinatesTypeEnum`**: `DeviceIndependent`, `Physical`
+
+## XAML Example
+
+```xml
+<ma:DrawPattern DisplayName="Draw Pattern"
+                CoordinatesType="DeviceIndependent">
+  <ma:DrawPattern.PointOperations>
+    <!-- Define point operations for the pattern -->
+  </ma:DrawPattern.PointOperations>
+</ma:DrawPattern>
+```
+
+## Notes
+
+- This activity creates complex finger paths using multiple input points
+- Device independent pixels are recommended for multi-device automation as they are more reliable
+- Physical pixels represent the true resolution of the screen and differ per device
+- Useful for creating custom gestures, drawing patterns (like unlock patterns), or complex touch sequences
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ElementExists.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ElementExists.md
@@ -1,0 +1,41 @@
+# Element Exists
+
+`UiPath.MobileAutomation.Activities.ElementExists`
+
+Element Exists
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Element Exists |
+| `WaitTimeout` | Wait Timeout | InArgument | `int` | | `30000` | Maximum time to wait for the element in milliseconds |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Exists` | Exists | `bool` | True if element exists, False otherwise |
+
+## XAML Example
+
+```xml
+<ma:ElementExists DisplayName="Element Exists"
+                  Selector="[&quot;&lt;mobile id='submit_button' /&gt;&quot;]"
+                  WaitTimeout="[10000]"
+                  Exists="[elementFound]" />
+```
+
+## Notes
+
+- This activity checks whether a mobile UI element exists on the screen
+- Returns True if the element is found within the timeout period, False otherwise
+- Does not throw an exception if the element is not found
+- Useful for conditional logic based on element presence
+- The WaitTimeout parameter specifies maximum wait time in milliseconds
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ExecuteCommand.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ExecuteCommand.md
@@ -1,0 +1,45 @@
+# ExecuteCommandDisplayNameDisplayName
+
+`UiPath.MobileAutomation.Activities.ExecuteCommand`
+
+Executes Appium mobile commands.
+WARNING: Please check the available commands for your Appium version.
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Command` | Execute Command | InArgument | `string` | Yes | | Executes Appium mobile commands. WARNING: Please check the available commands for your Appium version. |
+| `Parameters` | Parameters | Property | `InArgument<Dictionary<string,object>>` | | | Arguments of the command |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Output` | Output | `object` | The result of the executed command |
+
+## XAML Example
+
+```xml
+<ma:ExecuteCommand DisplayName="Execute Command"
+                   Command="[&quot;mobile: shell&quot;]"
+                   Output="[commandOutput]">
+  <ma:ExecuteCommand.Parameters>
+    <InArgument x:TypeArguments="scg:Dictionary(x:String, x:Object)">[New Dictionary(Of String, Object) From {{"command", "echo"}, {"args", New String() {"Hello"}}}]</InArgument>
+  </ma:ExecuteCommand.Parameters>
+</ma:ExecuteCommand>
+```
+
+## Notes
+
+- This activity allows execution of any Appium mobile command directly
+- The available commands depend on your Appium server version
+- Use with caution as incorrect commands can cause unexpected behavior
+- The Parameters property accepts a dictionary of command arguments
+- Refer to the Appium documentation for available commands: http://appium.io/docs/
+- The Output returns the result of the command as an object, which may need to be cast to the appropriate type

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetAttribute.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetAttribute.md
@@ -1,0 +1,41 @@
+# Get Attribute
+
+`UiPath.MobileAutomation.Activities.GetAttribute`
+
+Get Attribute
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Target element selector |
+| `AttributeName` | Attribute Name | InArgument | `string` | Yes | | Get Attribute |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Value` | Value | `string` | Value of the specified attribute |
+
+## XAML Example
+
+```xml
+<ma:GetAttribute DisplayName="Get Attribute"
+                 Selector="[&quot;&lt;mobile id='username_field' /&gt;&quot;]"
+                 AttributeName="[&quot;text&quot;]"
+                 Value="[attributeValue]" />
+```
+
+## Notes
+
+- This activity retrieves the value of a specified attribute from a mobile UI element
+- Common attributes include: `text`, `name`, `value`, `enabled`, `displayed`, `selected`, `resource-id`, `content-desc`
+- The available attributes depend on the platform (Android/iOS) and element type
+- Returns the attribute value as a string
+- If the attribute doesn't exist, the behavior depends on the Appium version
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetDeviceOrientation.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetDeviceOrientation.md
@@ -1,0 +1,34 @@
+# Get Device Orientation
+
+`UiPath.MobileAutomation.Activities.GetDeviceOrientation`
+
+Get the current device orientation
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Orientation` | Get Device Orientation | `ScreenOrientation` | Get the current device orientation |
+
+## Enum Reference
+
+**`ScreenOrientation`**: `Portrait`, `Landscape`
+
+## XAML Example
+
+```xml
+<ma:GetDeviceOrientation DisplayName="Get Device Orientation"
+                         Orientation="[deviceOrientation]" />
+```
+
+## Notes
+
+- This activity retrieves the current orientation of the mobile device screen
+- Returns either Portrait or Landscape orientation
+- Useful for implementing orientation-specific automation logic
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetLogTypes.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetLogTypes.md
@@ -1,0 +1,28 @@
+# Get Log Types
+
+`UiPath.MobileAutomation.Activities.GetLogTypes`
+
+Get all available log types for a session
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Logging & Debugging
+
+## Properties
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `LogTypes` | Get Log Types | `string[]` | Get all available log types for a session |
+
+## XAML Example
+
+```xml
+<ma:GetLogTypes DisplayName="Get Log Types" LogTypes="[logTypesArray]" />
+```
+
+## Notes
+
+- This activity retrieves all available log types that can be used with the Get Logs activity
+- Must be used within a Mobile Device Connection scope
+- The output is an array of strings containing the available log type names

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetLogs.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetLogs.md
@@ -1,0 +1,34 @@
+# Get Logs
+
+`UiPath.MobileAutomation.Activities.GetLogs`
+
+Get logs for a log type
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Logging & Debugging
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AppendToLogFile` | AppendToLogFile | InArgument | `bool` | Yes | `true` | If the new logs should be appended to the file or to recreate the file |
+| `LogFilePath` | LogFilePath | InArgument | `string` | Yes | | The file where the logs are written |
+| `LogType` | Get Logs | InArgument | `string` | Yes | | Get logs for a log type |
+
+## XAML Example
+
+```xml
+<ma:GetLogs DisplayName="Get Logs"
+            LogType="[&quot;logcat&quot;]"
+            LogFilePath="[&quot;C:\Logs\device.log&quot;]"
+            AppendToLogFile="[True]" />
+```
+
+## Notes
+
+- This activity retrieves logs from the mobile device for a specific log type
+- Use Get Log Types activity to discover available log types first
+- The logs are written to the specified file path
+- When AppendToLogFile is True, new logs are appended to existing file content; when False, the file is recreated

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetPageSource.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetPageSource.md
@@ -1,0 +1,30 @@
+# Get Page Source
+
+`UiPath.MobileAutomation.Activities.GetPageSource`
+
+Gets page source
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Logging & Debugging
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `PageSourceFilePath` | Get Page Source | InArgument | `string` | Yes | | Gets page source |
+
+## XAML Example
+
+```xml
+<ma:GetPageSource DisplayName="Get Page Source"
+                  PageSourceFilePath="[&quot;C:\Logs\page_source.xml&quot;]" />
+```
+
+## Notes
+
+- This activity captures the current page source (UI hierarchy) from the mobile device
+- The page source is saved as XML to the specified file path
+- Useful for debugging and understanding the UI structure of mobile applications
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetSelectedItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetSelectedItem.md
@@ -1,0 +1,38 @@
+# Get Selected Item
+
+`UiPath.MobileAutomation.Activities.GetSelectedItem`
+
+Get Selected Item
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Target element selector |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SelectedItem` | Get Selected Item | `string` | Get Selected Item |
+
+## XAML Example
+
+```xml
+<ma:GetSelectedItem DisplayName="Get Selected Item"
+                    Selector="[&quot;&lt;mobile class='android.widget.Spinner' /&gt;&quot;]"
+                    SelectedItem="[selectedValue]" />
+```
+
+## Notes
+
+- This activity retrieves the currently selected item from a selection element (dropdown, spinner, picker, etc.)
+- Returns the text of the selected item as a string
+- Useful for dropdowns, spinners, pickers, and other selection controls
+- The element must support selection operations
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetSessionIdentifier.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetSessionIdentifier.md
@@ -1,0 +1,30 @@
+# Get Session Identifier
+
+`UiPath.MobileAutomation.Activities.GetSessionIdentifier`
+
+Get Session Identifier
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SessionId` | Get Session Identifier | `string` | Get Session Identifier |
+
+## XAML Example
+
+```xml
+<ma:GetSessionIdentifier DisplayName="Get Session Identifier"
+                         SessionId="[sessionIdentifier]" />
+```
+
+## Notes
+
+- This activity retrieves the unique session identifier for the current Appium session
+- The session ID can be used for advanced scenarios like sharing sessions or debugging
+- Returns a string containing the session identifier
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetSystemTime.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetSystemTime.md
@@ -1,0 +1,31 @@
+# Get System time
+
+`UiPath.MobileAutomation.Activities.GetSystemTime`
+
+Get the system time from a mobile device
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SystemTime` | Get System time | `DateTime` | Get the system time from a mobile device |
+
+## XAML Example
+
+```xml
+<ma:GetSystemTime DisplayName="Get System Time"
+                  SystemTime="[deviceTime]" />
+```
+
+## Notes
+
+- This activity retrieves the current system time from the mobile device
+- Returns a DateTime object representing the device's system time
+- Useful for time-based validations or logging
+- The time zone will be based on the device's configured time zone
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/GetText.md
@@ -1,0 +1,38 @@
+# Get Text
+
+`UiPath.MobileAutomation.Activities.GetText`
+
+Get Text
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Target element selector |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Text` | Get Text | `string` | Get Text |
+
+## XAML Example
+
+```xml
+<ma:GetText DisplayName="Get Text"
+            Selector="[&quot;&lt;mobile id='message_label' /&gt;&quot;]"
+            Text="[elementText]" />
+```
+
+## Notes
+
+- This activity retrieves the text content of a mobile UI element
+- Returns the visible text of the element as a string
+- For input fields, this typically returns the current value
+- For labels and text views, returns the displayed text
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/InstallApp.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/InstallApp.md
@@ -1,0 +1,33 @@
+# Install App
+
+`UiPath.MobileAutomation.Activities.InstallApp`
+
+Install App
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Application
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AppPath` | Install App | InArgument | `string` | Yes | | Install App |
+
+## XAML Example
+
+```xml
+<ma:InstallApp DisplayName="Install App"
+               AppPath="[&quot;C:\Apps\myapp.apk&quot;]" />
+```
+
+## Notes
+
+- This activity installs a mobile application on the connected device
+- For Android, provide the path to an APK file
+- For iOS, provide the path to an IPA or APP file
+- The app path can be a local file path or a URL
+- The device must allow installation from external sources (Android) or be properly provisioned (iOS)
+- If the app is already installed, the behavior depends on the platform and Appium settings
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ManageCurrentApp.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ManageCurrentApp.md
@@ -1,0 +1,46 @@
+# Manage Current App
+
+`UiPath.MobileAutomation.Activities.ManageCurrentApp`
+
+Manage an app using a command
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Application
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Command` | Manage Current App | InArgument | `ManageCurrentAppCommandEnum` | Yes | `Launch` | Manage an app using a command |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Result | `bool` | Result of the command |
+
+## Enum Reference
+
+**`ManageCurrentAppCommandEnum`**: `Launch`, `Close`, `Reset`, `Activate`, `Terminate`, `GetState`
+
+## XAML Example
+
+```xml
+<ma:ManageCurrentApp DisplayName="Manage Current App"
+                     Command="Launch"
+                     Result="[commandResult]" />
+```
+
+## Notes
+
+- This activity manages the currently configured application in the Mobile Device Connection
+- Available commands:
+  - **Launch**: Start the application
+  - **Close**: Close the application
+  - **Reset**: Reset the application to its initial state
+  - **Activate**: Bring the application to the foreground
+  - **Terminate**: Force stop the application
+  - **GetState**: Get the current state of the application
+- The Result output indicates whether the command was successful

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ManageOtherApp.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/ManageOtherApp.md
@@ -1,0 +1,49 @@
+# Manage Other App
+
+`UiPath.MobileAutomation.Activities.ManageOtherApp`
+
+Manage other app using commands
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Application
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `App` | App | InArgument | `string` | Yes | | App representing the ios bundle id or android package name |
+| `Command` | Manage Other App | InArgument | `ManageOtherAppCommandEnum` | Yes | `Activate` | Manage other app using commands |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Result | `bool` | Result of the command |
+
+## Enum Reference
+
+**`ManageOtherAppCommandEnum`**: `Activate`, `Terminate`, `Install`, `Remove`, `GetState`
+
+## XAML Example
+
+```xml
+<ma:ManageOtherApp DisplayName="Manage Other App"
+                   App="[&quot;com.example.otherapp&quot;]"
+                   Command="Activate"
+                   Result="[commandResult]" />
+```
+
+## Notes
+
+- This activity manages applications other than the one currently configured in the Mobile Device Connection
+- For Android, use the package name (e.g., "com.android.settings")
+- For iOS, use the bundle ID (e.g., "com.apple.mobilesafari")
+- Available commands:
+  - **Activate**: Bring the application to the foreground
+  - **Terminate**: Force stop the application
+  - **Install**: Install the application on the device
+  - **Remove**: Uninstall the application from the device
+  - **GetState**: Get the current state of the application
+- The Result output indicates whether the command was successful

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/MobileDeviceConnection.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/MobileDeviceConnection.md
@@ -1,0 +1,88 @@
+# ActivityNameMobileDeviceConnection
+
+`UiPath.MobileAutomation.Activities.MobileDeviceConnection`
+
+ActivityDescriptionMobileDeviceConnection
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AppiumUrl` | Appium Url | InArgument | `string` | | | The URL of the Appium server |
+| `Arguments` | Capabilities | Property | `Dictionary<string, Argument>` | | `new Dictionary<string, Argument>()` | The requested capabilities for the connection. See http://appium.io/docs/en/writing-running-appium/caps for a list of Appium capabilities. |
+| `CollectPageSource` | Collect Page Source | InArgument | `Collect` | | | Specify if a page source is retrieved after executing each activity. Supported values are None and AfterActivity |
+| `CollectScreenshot` | Collect Screenshot | InArgument | `Collect` | | | Specify if a screenshot is retrieved after executing each activity. Supported values are None and AfterActivity |
+| `ContinueOnError` | ContinueOnError | InArgument | `bool` | | | Specifies to continue executing the remaining activities even if the current activity failed. Only boolean values (True, False) are supported. |
+| `HttpHeaders` | Http Headers | Property | `Dictionary<string, Argument>` | | `new Dictionary<string, Argument>()` | Http headers added to the requests. |
+| `InputConnection` | InputConnection | InArgument | `MobileDevice` | | | Input mobile device connection |
+| `LoggingEnabled` | Logging Enabled | InArgument | `bool` | | | Enables or disables the logging during execution. Only boolean values (True, False) are supported. |
+| `LoggingFolderPath` | Logging Folder Path | InArgument | `string` | | | A valid folder path where the logging outputs are stored. |
+| `MirroringEnabled` | Mirroring Enabled | InArgument | `bool` | | `Constants.DefaultMirroringEnabled` | |
+
+### Input/Output Connections
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `InputConnection` | InputConnection | InArgument | `MobileDevice` | | | Input mobile device connection |
+| `OutputConnection` | OutputConnection | OutArgument | `MobileDevice` | | | Output mobile device connection |
+
+### Options
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Close` | Close | `MobileConnectionCloseMode?` | `null` | Close connection. Null value is treated like Always |
+
+## Enum Reference
+
+**`Collect`**: `None`, `AfterActivity`
+
+**`MobileConnectionCloseMode`**: `Always`, `Never`, `IfNotInputConnection`
+
+## XAML Example
+
+```xml
+<ma:MobileDeviceConnection DisplayName="Mobile Device Connection"
+                          AppiumUrl="[&quot;http://127.0.0.1:4723/wd/hub&quot;]"
+                          OutputConnection="[mobileDevice]"
+                          Close="Always">
+  <ma:MobileDeviceConnection.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <InArgument x:TypeArguments="x:String" x:Key="platformName">Android</InArgument>
+      <InArgument x:TypeArguments="x:String" x:Key="deviceName">Android Emulator</InArgument>
+      <InArgument x:TypeArguments="x:String" x:Key="app">C:\apps\myapp.apk</InArgument>
+    </scg:Dictionary>
+  </ma:MobileDeviceConnection.Arguments>
+  <ma:MobileDeviceConnection.Body>
+    <!-- Mobile automation activities go here -->
+  </ma:MobileDeviceConnection.Body>
+</ma:MobileDeviceConnection>
+```
+
+## Project Settings
+
+This activity reads default values from project-level settings (configurable in UiPath Studio under Project Settings). When a property's value is not explicitly set, the project setting is used as the default.
+
+| Property | Setting Key | Default | Description |
+|----------|-----------|---------|-------------|
+| `CvApiKey` | `UiPath.Sdk.Activities.CvScope.ApiKey` | `Constants.CvDefaultApiKey` | Computer Vision API key |
+| `CvServer` | `UiPath.Sdk.Activities.CvScope.Server` | `Constants.CvDefaultServer` | Computer Vision server URL |
+| `CvUseLocalServer` | `UiPath.Sdk.Activities.CvScope.UseLocalServer` | `Constants.CvDefaultUseLocalServer` | Use local Computer Vision server |
+| `MirroringEnabled` | `UiPath.Sdk.Activities.Generic.MirroringEnabled` | `Constants.DefaultMirroringEnabled` | Enable device mirroring |
+
+## Notes
+
+- This is a container activity that establishes and maintains a connection to an Appium server
+- All mobile automation activities must be placed inside this scope
+- The Capabilities (Arguments) property is used to configure the device and application settings according to Appium specifications
+- Common capabilities include: `platformName`, `deviceName`, `app`, `appPackage`, `appActivity`, `bundleId`, `udid`, etc.
+- The Close property controls when the connection is terminated:
+  - **Always**: Close connection when scope exits
+  - **Never**: Keep connection open after scope exits
+  - **IfNotInputConnection**: Close only if this scope created the connection (not passed via InputConnection)
+- InputConnection/OutputConnection allow chaining multiple connection scopes or reusing existing connections
+- Logging capabilities allow capturing screenshots and page sources for debugging

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/OpenDeepLink.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/OpenDeepLink.md
@@ -1,0 +1,34 @@
+# Open DeepLink
+
+`UiPath.MobileAutomation.Activities.OpenDeepLink`
+
+Go to a deeplink inside an application
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Application
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `App` | App | InArgument | `string` | | | App representing the ios bundle id or android package name |
+| `Url` | Open DeepLink | InArgument | `string` | Yes | | Go to a deeplink inside an application |
+
+## XAML Example
+
+```xml
+<ma:OpenDeepLink DisplayName="Open DeepLink"
+                 Url="[&quot;myapp://products/1234&quot;]"
+                 App="[&quot;com.example.myapp&quot;]" />
+```
+
+## Notes
+
+- This activity opens a deep link URL within a mobile application
+- Deep links allow direct navigation to specific content or features within an app
+- The App parameter is optional; if not specified, the system will attempt to determine which app should handle the deep link
+- For Android, use the package name for the App parameter
+- For iOS, use the bundle ID for the App parameter
+- The URL format depends on how the target application has configured its deep linking scheme

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/OpenUrl.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/OpenUrl.md
@@ -1,0 +1,30 @@
+# Url
+
+`UiPath.MobileAutomation.Activities.OpenUrl`
+
+Open a certain URL in the current active web browser.
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Application
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Url` | Open URL | InArgument | `string` | Yes | | Open a certain URL in the current active web browser. |
+
+## XAML Example
+
+```xml
+<ma:OpenUrl DisplayName="Open URL"
+            Url="[&quot;https://www.example.com&quot;]" />
+```
+
+## Notes
+
+- This activity opens a URL in the currently active web browser on the mobile device
+- The browser must already be open and active
+- For navigating to URLs in a specific browser app, use the Open DeepLink activity instead
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/PositionalSwipe.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/PositionalSwipe.md
@@ -1,0 +1,40 @@
+# Positional Swipe
+
+`UiPath.MobileAutomation.Activities.PositionalSwipe`
+
+Positional Swipe
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `StartX` | Start X | InArgument | `int` | Yes | | X coordinate of the starting point |
+| `StartY` | Start Y | InArgument | `int` | Yes | | Y coordinate of the starting point |
+| `EndX` | End X | InArgument | `int` | Yes | | X coordinate of the ending point |
+| `EndY` | End Y | InArgument | `int` | Yes | | Y coordinate of the ending point |
+| `Duration` | Positional Swipe | InArgument | `int` | | `500` | Duration of the swipe in milliseconds |
+
+## XAML Example
+
+```xml
+<ma:PositionalSwipe DisplayName="Positional Swipe"
+                    StartX="[100]"
+                    StartY="[500]"
+                    EndX="[100]"
+                    EndY="[100]"
+                    Duration="[300]" />
+```
+
+## Notes
+
+- This activity performs a swipe gesture between two specific coordinates on the screen
+- The swipe moves from (StartX, StartY) to (EndX, EndY)
+- Duration controls the speed of the swipe in milliseconds (default: 500ms)
+- Uses absolute screen coordinates
+- Useful for custom swipe gestures or when element-based swipes are not suitable
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/PressHardwareButton.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/PressHardwareButton.md
@@ -1,0 +1,37 @@
+# Press Hardware Button
+
+`UiPath.MobileAutomation.Activities.PressHardwareButton`
+
+Press Hardware Button
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Hardware Interaction
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Button` | Press Hardware Button | InArgument | `HardwareButton` | Yes | | Press Hardware Button |
+
+## Enum Reference
+
+**`HardwareButton`**: `Home`, `Back`, `Menu`, `VolumeUp`, `VolumeDown`, `Power`, `Camera`, `Search`
+
+## XAML Example
+
+```xml
+<ma:PressHardwareButton DisplayName="Press Hardware Button"
+                        Button="Back" />
+```
+
+## Notes
+
+- This activity simulates pressing a hardware button on the mobile device
+- Available buttons depend on the device platform:
+  - **Android**: Home, Back, Menu, VolumeUp, VolumeDown, Power, Camera, Search
+  - **iOS**: Home, VolumeUp, VolumeDown, Power (limited button support)
+- Not all buttons may be available on all devices
+- The Power button behavior may vary by device and platform
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetDeviceGeoLocation.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetDeviceGeoLocation.md
@@ -1,0 +1,36 @@
+# Set Device GeoLocation
+
+`UiPath.MobileAutomation.Activities.SetDeviceGeoLocation`
+
+Set Device GeoLocation
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Latitude` | Latitude | InArgument | `double` | Yes | | Latitude coordinate |
+| `Longitude` | Longitude | InArgument | `double` | Yes | | Longitude coordinate |
+| `Altitude` | Set Device GeoLocation | InArgument | `double` | | `0` | Altitude in meters |
+
+## XAML Example
+
+```xml
+<ma:SetDeviceGeoLocation DisplayName="Set Device GeoLocation"
+                         Latitude="[37.7749]"
+                         Longitude="[-122.4194]"
+                         Altitude="[10.0]" />
+```
+
+## Notes
+
+- This activity sets the GPS location of the mobile device
+- Latitude and Longitude are required, Altitude is optional (default: 0)
+- Useful for testing location-based features without physical movement
+- The device must support GPS simulation or location mocking
+- Some apps may require location services to be enabled
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetDeviceOrientation.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetDeviceOrientation.md
@@ -1,0 +1,34 @@
+# Set Device Orientation
+
+`UiPath.MobileAutomation.Activities.SetDeviceOrientation`
+
+Set device orientation
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Orientation` | Set Device Orientation | InArgument | `ScreenOrientation` | Yes | | Set device orientation |
+
+## Enum Reference
+
+**`ScreenOrientation`**: `Portrait`, `Landscape`
+
+## XAML Example
+
+```xml
+<ma:SetDeviceOrientation DisplayName="Set Device Orientation"
+                         Orientation="Landscape" />
+```
+
+## Notes
+
+- This activity changes the orientation of the mobile device screen
+- Available orientations: Portrait or Landscape
+- The device must support orientation changes for this activity to work
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetSelectedItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetSelectedItem.md
@@ -1,0 +1,34 @@
+# Set Selected Item
+
+`UiPath.MobileAutomation.Activities.SetSelectedItem`
+
+Set Selected Item
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Target element selector |
+| `Item` | Set Selected Item | InArgument | `string` | Yes | | Set Selected Item |
+
+## XAML Example
+
+```xml
+<ma:SetSelectedItem DisplayName="Set Selected Item"
+                    Selector="[&quot;&lt;mobile class='android.widget.Spinner' /&gt;&quot;]"
+                    Item="[&quot;Option 2&quot;]" />
+```
+
+## Notes
+
+- This activity selects an item from a selection element (dropdown, spinner, picker, etc.)
+- The Item parameter specifies the text of the item to select
+- Works with dropdowns, spinners, pickers, and other selection controls
+- The element must support selection operations
+- If the item is not found in the list, an exception is thrown
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/SetText.md
@@ -1,0 +1,44 @@
+# Set Text
+
+`UiPath.MobileAutomation.Activities.SetText`
+
+Set Text
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Interaction
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Target` | Target | InArgument | `TargetElement` | Yes | | The target element to set text in |
+| `Text` | Set Text | InArgument | `string` | Yes | | Set Text |
+| `ClearBeforeTyping` | Clear Before Typing | Property | `bool` | | `true` | Clear the field before entering text |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ClearBeforeTyping` | Clear Before Typing | `bool` | `true` | Clear the field before entering text |
+
+## XAML Example
+
+```xml
+<ma:SetText DisplayName="Set Text"
+            Text="[&quot;example@email.com&quot;]"
+            ClearBeforeTyping="True">
+  <ma:SetText.Target>
+    <ma:TargetElement Selector="&lt;mobile id='email_input' /&gt;" />
+  </ma:SetText.Target>
+</ma:SetText>
+```
+
+## Notes
+
+- This activity enters text into a mobile input field
+- When ClearBeforeTyping is True, the existing text is cleared before entering new text
+- When ClearBeforeTyping is False, the new text is appended to existing text
+- The target element must be an editable field (text input, text area, etc.)
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/Swipe.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/Swipe.md
@@ -1,0 +1,38 @@
+# Swipe
+
+`UiPath.MobileAutomation.Activities.Swipe`
+
+Swipe
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | | | Target element selector (optional - swipes screen if not specified) |
+| `Direction` | Swipe | InArgument | `SwipeDirectionEnum` | Yes | | Swipe direction |
+
+## Enum Reference
+
+**`SwipeDirectionEnum`**: `Up`, `Down`, `Left`, `Right`
+
+## XAML Example
+
+```xml
+<ma:Swipe DisplayName="Swipe"
+          Direction="Up"
+          Selector="[&quot;&lt;mobile class='android.widget.ScrollView' /&gt;&quot;]" />
+```
+
+## Notes
+
+- This activity performs a swipe gesture on the screen or on a specific element
+- Available directions: Up, Down, Left, Right
+- If Selector is provided, the swipe is performed on that specific element
+- If Selector is not provided, the swipe is performed on the entire screen
+- Useful for scrolling lists, switching between screens, or revealing hidden UI elements
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/TakeScreenshot.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/TakeScreenshot.md
@@ -1,0 +1,31 @@
+# Take Screenshot
+
+`UiPath.MobileAutomation.Activities.TakeScreenshot`
+
+Take a screenshot from a mobile device
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ScreenshotFilePath` | Take Screenshot | InArgument | `string` | Yes | | Take a screenshot from a mobile device |
+
+## XAML Example
+
+```xml
+<ma:TakeScreenshot DisplayName="Take Screenshot"
+                   ScreenshotFilePath="[&quot;C:\Screenshots\device_screen.png&quot;]" />
+```
+
+## Notes
+
+- This activity captures a screenshot of the current mobile device screen
+- The screenshot is saved to the specified file path
+- Supports common image formats (typically PNG)
+- Useful for documentation, debugging, or validation purposes
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/TakeScreenshotPart.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/TakeScreenshotPart.md
@@ -1,0 +1,34 @@
+# Take Screenshot Part
+
+`UiPath.MobileAutomation.Activities.TakeScreenshotPart`
+
+Take Screenshot Part
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** Mobile Device
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Target element selector |
+| `ScreenshotFilePath` | Take Screenshot Part | InArgument | `string` | Yes | | Take Screenshot Part |
+
+## XAML Example
+
+```xml
+<ma:TakeScreenshotPart DisplayName="Take Screenshot Part"
+                       Selector="[&quot;&lt;mobile id='product_image' /&gt;&quot;]"
+                       ScreenshotFilePath="[&quot;C:\Screenshots\element.png&quot;]" />
+```
+
+## Notes
+
+- This activity captures a screenshot of a specific mobile UI element
+- The screenshot is cropped to only include the target element
+- The screenshot is saved to the specified file path
+- Supports common image formats (typically PNG)
+- Useful for capturing specific UI components for documentation or validation
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/Tap.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/Tap.md
@@ -1,0 +1,33 @@
+# Tap
+
+`UiPath.MobileAutomation.Activities.Tap`
+
+Tap
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Target element selector |
+| `TapCount` | Tap | InArgument | `int` | | `1` | Number of taps to perform |
+
+## XAML Example
+
+```xml
+<ma:Tap DisplayName="Tap"
+        Selector="[&quot;&lt;mobile id='submit_button' /&gt;&quot;]"
+        TapCount="[1]" />
+```
+
+## Notes
+
+- This activity performs a tap (click/touch) action on a mobile UI element
+- TapCount specifies the number of consecutive taps (default: 1)
+- Use TapCount=2 for double-tap gestures
+- The element must be visible and interactive
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/TypeText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/activities/TypeText.md
@@ -1,0 +1,41 @@
+# Type Text
+
+`UiPath.MobileAutomation.Activities.TypeText`
+
+Type Text
+
+**Package:** `UiPath.MobileAutomation.Activities`
+**Category:** UI Automation
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Selector` | Selector | InArgument | `string` | Yes | | Target element selector |
+| `Text` | Type Text | InArgument | `string` | Yes | | Type Text |
+| `ClearText` | Clear Text | Property | `bool` | | `true` | Clear existing text before typing |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ClearText` | Clear Text | `bool` | `true` | Clear existing text before typing |
+
+## XAML Example
+
+```xml
+<ma:TypeText DisplayName="Type Text"
+             Selector="[&quot;&lt;mobile id='email_input' /&gt;&quot;]"
+             Text="[&quot;user@example.com&quot;]"
+             ClearText="True" />
+```
+
+## Notes
+
+- This activity types text into a mobile input field
+- When ClearText is True, existing text is cleared before typing
+- When ClearText is False, new text is appended to existing text
+- The target element must be an editable field (text input, text area, etc.)
+- Must be used within a Mobile Device Connection scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MobileAutomation.Activities/25.10/overview.md
@@ -1,0 +1,123 @@
+# UiPath Mobile Automation Activities
+
+This package provides activities for automating mobile applications on Android and iOS devices using the Appium framework.
+
+**Package ID:** `UiPath.MobileAutomation.Activities`
+
+## Activity Categories
+
+### Mobile Device
+
+Core mobile device management and connection activities.
+
+- **[MobileDeviceConnection](activities/MobileDeviceConnection.md)** - Establishes and maintains a connection to an Appium server. Container scope for all mobile automation activities.
+- **[ExecuteCommand](activities/ExecuteCommand.md)** - Executes a custom Appium command on the mobile device.
+- **[GetDeviceOrientation](activities/GetDeviceOrientation.md)** - Gets the current orientation of the mobile device (portrait/landscape).
+- **[SetDeviceOrientation](activities/SetDeviceOrientation.md)** - Sets the orientation of the mobile device.
+- **[SetDeviceGeoLocation](activities/SetDeviceGeoLocation.md)** - Sets the geolocation of the mobile device for testing location-based features.
+- **[GetSystemTime](activities/GetSystemTime.md)** - Gets the system time from the mobile device.
+- **[TakeScreenshot](activities/TakeScreenshot.md)** - Captures a screenshot of the entire mobile device screen.
+- **[TakeScreenshotPart](activities/TakeScreenshotPart.md)** - Captures a screenshot of a specific element or region on the mobile device.
+- **[GetSessionIdentifier](activities/GetSessionIdentifier.md)** - Gets the unique session identifier for the current Appium session.
+- **[Tap](activities/Tap.md)** - Performs a tap gesture on the mobile device screen at specified coordinates.
+
+### Mobile Application
+
+Activities for managing mobile applications and navigation.
+
+- **[ManageCurrentApp](activities/ManageCurrentApp.md)** - Manages the currently active application (background, activate, terminate, etc.).
+- **[ManageOtherApp](activities/ManageOtherApp.md)** - Manages other installed applications by bundle/package ID.
+- **[InstallApp](activities/InstallApp.md)** - Installs a mobile application from a local file path.
+- **[OpenDeepLink](activities/OpenDeepLink.md)** - Opens a deep link URL within a mobile application.
+- **[OpenUrl](activities/OpenUrl.md)** - Opens a URL in the mobile browser or application.
+
+### UI Automation
+
+Activities for interacting with mobile UI elements.
+
+- **[ElementExists](activities/ElementExists.md)** - Checks if a UI element exists on the mobile screen.
+- **[GetAttribute](activities/GetAttribute.md)** - Gets an attribute value from a mobile UI element.
+- **[GetText](activities/GetText.md)** - Gets the text content from a mobile UI element.
+- **[SetText](activities/SetText.md)** - Sets text in a mobile input field.
+- **[TypeText](activities/TypeText.md)** - Types text into the currently focused mobile input field.
+- **[GetSelectedItem](activities/GetSelectedItem.md)** - Gets the currently selected item from a mobile picker/dropdown.
+- **[SetSelectedItem](activities/SetSelectedItem.md)** - Selects an item in a mobile picker/dropdown.
+- **[Swipe](activities/Swipe.md)** - Performs a swipe gesture on a mobile element in a specified direction.
+- **[PositionalSwipe](activities/PositionalSwipe.md)** - Performs a swipe gesture between specific coordinates on the mobile screen.
+- **[DrawPattern](activities/DrawPattern.md)** - Draws a pattern lock gesture on Android devices.
+
+### Hardware Interaction
+
+Activities for interacting with mobile device hardware.
+
+- **[PressHardwareButton](activities/PressHardwareButton.md)** - Presses a hardware button (Home, Back, Volume Up/Down, Power, etc.) on the mobile device.
+
+### Logging & Debugging
+
+Activities for debugging and diagnostics.
+
+- **[GetLogTypes](activities/GetLogTypes.md)** - Gets all available log types for the current Appium session.
+- **[GetLogs](activities/GetLogs.md)** - Retrieves logs of a specific type from the mobile device/Appium server.
+- **[GetPageSource](activities/GetPageSource.md)** - Gets the XML page source of the current mobile screen for debugging UI hierarchy.
+
+## Prerequisites
+
+- **Appium Server** - An Appium server must be running and accessible. See [http://appium.io](http://appium.io) for installation instructions.
+- **Mobile Device or Emulator** - A physical device (connected via USB/network) or emulator/simulator.
+- **Platform-specific drivers**:
+  - **Android**: UIAutomator2 driver (default)
+  - **iOS**: XCUITest driver (requires macOS and Xcode)
+
+## Common Workflow Pattern
+
+All mobile automation workflows follow this pattern:
+
+1. **Use MobileDeviceConnection scope** - All mobile activities must be inside this container
+2. **Configure Appium capabilities** - Set platformName, deviceName, app path, etc.
+3. **Perform mobile actions** - Use UI automation, device interaction, and app management activities
+4. **Handle connection lifecycle** - The scope manages connection open/close automatically
+
+## Example Workflow Structure
+
+```xml
+<ma:MobileDeviceConnection DisplayName="Mobile Device Connection"
+                          AppiumUrl="http://127.0.0.1:4723/wd/hub"
+                          OutputConnection="[mobileDevice]">
+  <ma:MobileDeviceConnection.Arguments>
+    <scg:Dictionary x:TypeArguments="x:String, Argument">
+      <InArgument x:TypeArguments="x:String" x:Key="platformName">Android</InArgument>
+      <InArgument x:TypeArguments="x:String" x:Key="deviceName">Android Emulator</InArgument>
+      <InArgument x:TypeArguments="x:String" x:Key="app">C:\apps\myapp.apk</InArgument>
+    </scg:Dictionary>
+  </ma:MobileDeviceConnection.Arguments>
+
+  <ma:MobileDeviceConnection.Body>
+    <!-- Your mobile automation activities here -->
+    <ma:Tap Target="{maui:Target}" />
+    <ma:SetText Target="{maui:Target}" Text="Hello Mobile" />
+    <ma:GetText Target="{maui:Target}" Result="[textValue]" />
+  </ma:MobileDeviceConnection.Body>
+</ma:MobileDeviceConnection>
+```
+
+## Platform Support
+
+Most activities work on both **Android** and **iOS**, but some features may be platform-specific:
+
+- **DrawPattern** - Android only (pattern lock)
+- **PressHardwareButton** - Some buttons are platform-specific (e.g., Android Back button)
+- Appium capabilities and element selectors differ between platforms
+
+## Notes
+
+- **Namespace prefix**: Mobile Automation activities use the `ma:` XML namespace prefix in XAML
+- **Appium version compatibility**: This package is compatible with Appium 1.x and 2.x servers
+- **Target resolution**: Mobile UI elements are typically targeted using descriptors generated by the UiPath Mobile Device Manager
+- **Computer Vision support**: Activities support CV-based targeting as an alternative to native element selectors
+- **Resource keys**: Some activity display names in the generated docs show resource keys (e.g., "ActivityNameXxx") instead of friendly names. Refer to UiPath Studio's activity panel for correct display names.
+
+## Additional Resources
+
+- [Appium Documentation](http://appium.io/docs)
+- [Appium Desired Capabilities](http://appium.io/docs/en/writing-running-appium/caps)
+- UiPath Mobile Automation Guide (check UiPath documentation portal)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ConvertEmailToPDF.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ConvertEmailToPDF.md
@@ -1,0 +1,59 @@
+# Convert Email to PDF
+
+`UiPath.PDF.Activities.PDF.NetCore.ConvertEmailToPDF`
+
+Converts a `MailMessage` object to a PDF file. The activity automatically detects whether the email body is HTML or plain text and applies the appropriate rendering template, preserving the subject, sender, and recipient metadata as a formatted header block. Optional page header/footer HTML templates, paper size, margin, and scale settings are available for layout customization.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Email` | Email | `InArgument` | `MailMessage` | Yes | | | The email message to convert to PDF. Both HTML and plain-text bodies are supported. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `HeaderHtml` | Html Header Content | `InArgument<string>` | | An HTML string to use as a page header template. |
+| `FooterHtml` | Html Footer Content | `InArgument<string>` | | An HTML string to use as a page footer template. |
+| `PaperSize` | Paper Size | `InArgument<PdfPaperSize>` | `A4` | The paper size used for the PDF output. |
+| `Margin` | Margin | `InArgument<int>` | `0` | Page margin in points. |
+| `Scale` | Scale | `InArgument<double>` | `1.0` | Page rendering scale. Must be between 0.1 and 2 inclusive. |
+| `KeepBackground` | Keep Background | `InArgument<bool>` | `true` | Whether to preserve background color and graphics during conversion. |
+| `OutputFileName` | Output File Path | `InArgument<string>` | | Full path of the output PDF file. If not specified, a default file name is generated. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFile` | Output File | `ILocalResource` | The resulting PDF file as a local resource. |
+
+### Enum Reference
+
+**`PdfPaperSize`**: `A4`, `A3`, `A5`, `A2`, `A6`, `Letter`, `Legal`, `Tabloid`, `Ledger`, `Executive`, `Statement`, `B4`, `B5`, `Number10Envelope`, `DLEnvelope`, `C5Envelope`, `C4Envelope`
+
+## XAML Example
+
+```xml
+<pdf:ConvertEmailToPDF
+    DisplayName="Convert Email to PDF"
+    Email="[mailMessage]"
+    PaperSize="Letter"
+    OutputFileName="[&quot;C:\output\email-export.pdf&quot;]"
+    OutputFile="[outputFile]" />
+```
+
+> The `pdf` namespace prefix maps to `clr-namespace:UiPath.PDF.Activities.PDF.NetCore;assembly=UiPath.PDF.Activities`.
+
+## Notes
+
+- The `Email` argument accepts a `System.Net.Mail.MailMessage` object. Use a mail activity (e.g., Get Mail, Get IMAP Mail Messages) to obtain a `MailMessage`, then pass it directly to this activity.
+- The activity inspects `MailMessage.IsBodyHtml` and `AlternateViews` to automatically select either the HTML or plain-text rendering template. No manual mode switch is required.
+- Rendered output includes a header block with **Subject**, **From**, and **To** fields extracted from the message.
+- `Scale` must be ≥ 0.1 and ≤ 2. Values outside this range will cause a runtime error.
+- When `OutputFileName` is omitted, a default PDF file name is generated in the current working directory.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ConvertHtmlToPDF.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ConvertHtmlToPDF.md
@@ -1,0 +1,91 @@
+# Convert HTML to PDF
+
+`UiPath.PDF.Activities.PDF.NetCore.ConvertHtmlToPDF`
+
+Converts HTML content to a PDF file. The HTML can be supplied as an inline string or read from a local file, controlled by the **Input mode** selector. Optional header, footer, paper size, margin, scale, and background settings allow full control over the rendered output.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name   | Display Name | Kind         | Type     | Required | Default | Placeholder | Description                                                                  |
+| ------ | ------------ | ------------ | -------- | -------- | ------- | ----------- | ---------------------------------------------------------------------------- |
+| `Html` | HTML content | `InArgument` | `string` | Yes† | | | The HTML string to convert to PDF. Visible when **Input mode** is `Content`. |
+| `FileName` | File (local path) | `InArgument` | `string` | Yes* | | | Local path to an HTML file to convert. Visible when **Input mode** is `File`. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | `InArgument` | `IResource` | Yes* | | | A file resource handle pointing to the HTML file to convert. Visible when **Input mode** is `File`. Mutually exclusive with `FileName`. |
+
+> *†Required when `InputMode` is `Content`. \*Exactly one of `FileName` or `ResourceFile` is required when `InputMode` is `File` (`[OverloadGroup]`).*
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InputMode` | Input mode | `ItemInputMode` | `Content` | Selects whether the HTML source is an inline string (`Content`) or a file (`File`). Controls which input properties are visible. |
+| `PaperSize` | Paper Size | `InArgument<PdfPaperSize>` | `A4` | The paper size used for the PDF output. |
+| `Margin` | Margin | `InArgument<int>` | `0` | Page margin in points. |
+| `Scale` | Scale | `InArgument<double>` | `1.0` | Page rendering scale. Must be between 0.1 and 2 inclusive. |
+| `KeepBackground` | Keep Background | `InArgument<bool>` | `true` | Whether to preserve background color and graphics during conversion. |
+| `HeaderHtml` | Html Header Content | `InArgument<string>` | | An HTML document to use as a page header template. Visible when **Header input mode** is `Content`. |
+| `HeaderInputMode` | Header input mode | `ItemInputMode` | `Content` | Selects whether the header source is an inline string or a file. |
+| `FooterHtml` | Html Footer Content | `InArgument<string>` | | An HTML document to use as a page footer template. Visible when **Footer input mode** is `Content`. |
+| `FooterInputMode` | Footer input mode | `ItemInputMode` | `Content` | Selects whether the footer source is an inline string or a file. |
+| `OutputFileName` | Output File Path | `InArgument<string>` | | Full path of the output PDF file. If not specified, a default file name is generated. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFile` | Output File | `ILocalResource` | The resulting PDF file as a local resource. |
+
+## Valid Configurations
+
+**Mode 1 — Inline HTML content (default):**
+Set `InputMode` to `Content` and provide the `Html` string. `FileName` and `ResourceFile` are hidden.
+
+**Mode 2 — HTML from a local file path:**
+Set `InputMode` to `File` and provide `FileName`. `Html` is hidden. `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`).
+
+**Mode 3 — HTML from a file resource:**
+Set `InputMode` to `File` and provide `ResourceFile`. `Html` is hidden.
+
+The same three modes apply independently to `HeaderInputMode` and `FooterInputMode`.
+
+### Conditional Properties
+
+These properties appear or change behavior based on other property values (controlled by ViewModel rules and dependencies):
+
+- **`Html`** (InArgument\<string\>) — Visible only when `InputMode` is `Content`. When `InputMode` switches to `File`, `Html` is hidden and the `Item` (FileName/ResourceFile) fields appear.
+- **`FileName`** (InArgument\<string\>) — Visible only when `InputMode` is `File`.
+- **`ResourceFile`** (InArgument\<IResource\>) — Visible only when `InputMode` is `File`.
+- **`HeaderHtml`** (InArgument\<string\>) — Visible only when `HeaderInputMode` is `Content`.
+- **`FooterHtml`** (InArgument\<string\>) — Visible only when `FooterInputMode` is `Content`.
+
+### Enum Reference
+
+**`ItemInputMode`**: `Content`, `File`
+
+**`PdfPaperSize`**: `A4`, `A3`, `A5`, `A2`, `A6`, `Letter`, `Legal`, `Tabloid`, `Ledger`, `Executive`, `Statement`, `B4`, `B5`, `Number10Envelope`, `DLEnvelope`, `C5Envelope`, `C4Envelope`
+
+## XAML Example
+
+```xml
+<pdf:ConvertHtmlToPDF
+    DisplayName="Convert Html to PDF"
+    Html="[htmlString]"
+    OutputFileName="[&quot;C:\output\report.pdf&quot;]"
+    PaperSize="A4"
+    Scale="[1.0]"
+    OutputFile="[outputFile]" />
+```
+
+> The `pdf` namespace prefix maps to `clr-namespace:UiPath.PDF.Activities.PDF.NetCore;assembly=UiPath.PDF.Activities`.
+
+## Notes
+
+- `FileName` and `ResourceFile` are decorated with `[OverloadGroup]` — at most one may be bound at runtime. Bind `FileName` for a plain string path, or `ResourceFile` when working with storage buckets and file resources.
+- `Scale` must be ≥ 0.1 and ≤ 2. Values outside this range will cause a runtime error.
+- When `OutputFileName` is omitted, a default PDF file name is generated in the current working directory.
+- Header and footer HTML templates have their own independent `InputMode` selectors (`HeaderInputMode`, `FooterInputMode`).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ConvertTextToPDF.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ConvertTextToPDF.md
@@ -1,0 +1,95 @@
+# Convert Text to PDF
+
+`UiPath.PDF.Activities.PDF.NetCore.ConvertTextToPDF`
+
+Converts plain text content to a PDF file. The text can be supplied as an inline string or read from a local file, controlled by the **Input mode** selector. Font size, text alignment, paper size, margin, scale, and optional header/footer HTML templates are available for layout customization.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes† | | | The plain-text string to convert to PDF. Visible when **Input mode** is `Content`. |
+| `FileName` | File (local path) | `InArgument` | `string` | Yes* | | | Local path to a plain-text file to convert. Visible when **Input mode** is `File`. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | `InArgument` | `IResource` | Yes* | | | A file resource handle pointing to the text file to convert. Visible when **Input mode** is `File`. Mutually exclusive with `FileName`. |
+
+> *†Required when `InputMode` is `Content`. \*Exactly one of `FileName` or `ResourceFile` is required when `InputMode` is `File` (`[OverloadGroup]`).*
+| `FontSize` | Font size | `InArgument` | `int` | | `12` | | The font size in points used to render the text. |
+| `TextAlignment` | Text Alignment | `InArgument` | `TextAlignment` | | `Justify` | | Text alignment on the page. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InputMode` | Input mode | `ItemInputMode` | `Content` | Selects whether the text source is an inline string (`Content`) or a file (`File`). Controls which input properties are visible. |
+| `PaperSize` | Paper Size | `InArgument<PdfPaperSize>` | `A4` | The paper size used for the PDF output. |
+| `Margin` | Margin | `InArgument<int>` | `0` | Page margin in points. |
+| `Scale` | Scale | `InArgument<double>` | `1.0` | Page rendering scale. Must be between 0.1 and 2 inclusive. |
+| `HeaderHtml` | Html Header Content | `InArgument<string>` | | An HTML document to use as a page header template. Visible when **Header input mode** is `Content`. |
+| `HeaderInputMode` | Header input mode | `ItemInputMode` | `Content` | Selects whether the header source is an inline string or a file. |
+| `FooterHtml` | Html Footer Content | `InArgument<string>` | | An HTML document to use as a page footer template. Visible when **Footer input mode** is `Content`. |
+| `FooterInputMode` | Footer input mode | `ItemInputMode` | `Content` | Selects whether the footer source is an inline string or a file. |
+| `OutputFileName` | Output File Path | `InArgument<string>` | | Full path of the output PDF file. If not specified, a default file name is generated. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFile` | Output File | `ILocalResource` | The resulting PDF file as a local resource. |
+
+## Valid Configurations
+
+**Mode 1 — Inline text content (default):**
+Set `InputMode` to `Content` and provide the `Text` string. `FileName` and `ResourceFile` are hidden.
+
+**Mode 2 — Text from a local file path:**
+Set `InputMode` to `File` and provide `FileName`. `Text` is hidden. `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`).
+
+**Mode 3 — Text from a file resource:**
+Set `InputMode` to `File` and provide `ResourceFile`. `Text` is hidden.
+
+The same three modes apply independently to `HeaderInputMode` and `FooterInputMode`.
+
+### Conditional Properties
+
+These properties appear or change behavior based on other property values (controlled by ViewModel rules and dependencies):
+
+- **`Text`** (InArgument\<string\>) — Visible only when `InputMode` is `Content`. When `InputMode` switches to `File`, `Text` is hidden and the `Item` (FileName/ResourceFile) fields appear.
+- **`FileName`** (InArgument\<string\>) — Visible only when `InputMode` is `File`.
+- **`ResourceFile`** (InArgument\<IResource\>) — Visible only when `InputMode` is `File`.
+- **`HeaderHtml`** (InArgument\<string\>) — Visible only when `HeaderInputMode` is `Content`.
+- **`FooterHtml`** (InArgument\<string\>) — Visible only when `FooterInputMode` is `Content`.
+
+### Enum Reference
+
+**`ItemInputMode`**: `Content`, `File`
+
+**`TextAlignment`**: `Justify`, `Left`, `Right`, `Center`
+
+**`PdfPaperSize`**: `A4`, `A3`, `A5`, `A2`, `A6`, `Letter`, `Legal`, `Tabloid`, `Ledger`, `Executive`, `Statement`, `B4`, `B5`, `Number10Envelope`, `DLEnvelope`, `C5Envelope`, `C4Envelope`
+
+## XAML Example
+
+```xml
+<pdf:ConvertTextToPDF
+    DisplayName="Convert Text to PDF"
+    Text="[reportText]"
+    FontSize="[14]"
+    TextAlignment="Left"
+    OutputFileName="[&quot;C:\output\report.pdf&quot;]"
+    OutputFile="[outputFile]" />
+```
+
+> The `pdf` namespace prefix maps to `clr-namespace:UiPath.PDF.Activities.PDF.NetCore;assembly=UiPath.PDF.Activities`.
+
+## Notes
+
+- `FileName` and `ResourceFile` are decorated with `[OverloadGroup]` — at most one may be bound at runtime.
+- The `KeepBackground` property inherited from the base class is hidden for this activity because background styling is not applicable to plain-text conversion.
+- `Scale` must be ≥ 0.1 and ≤ 2. Values outside this range will cause a runtime error.
+- When `OutputFileName` is omitted, a default PDF file name is generated in the current working directory.
+- Header and footer HTML templates have their own independent `InputMode` selectors (`HeaderInputMode`, `FooterInputMode`).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ExportPDFPageAsImage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ExportPDFPageAsImage.md
@@ -1,0 +1,57 @@
+# Export PDF Page As Image
+
+`UiPath.PDF.Activities.PDF.ExportPDFPageAsImage`
+
+Exports a single page from a PDF file as an image. The page is rendered at the specified DPI and saved to the output path. Supported image formats are PNG, JPEG, BMP, GIF, and TIFF — the format is determined automatically from the output file extension.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileName` | File (local path) | `InArgument` | `string` | Yes* | | | Local path to the source PDF file. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | `InArgument` | `IResource` | Yes* | | | A file resource handle pointing to the source PDF file. Mutually exclusive with `FileName`. |
+| `PageNumber` | Page Number | `InArgument` | `int` | Yes | | | The 1-based page number to export as an image. Must be ≥ 1 and not exceed the total page count. |
+| `OutputFileName` | Output File Path | `InArgument` | `string` | Yes | | | Full path of the output image file. The file extension determines the image format (`.png`, `.jpg`/`.jpeg`, `.bmp`, `.gif`, `.tif`/`.tiff`). |
+| `Password` | Password | `InArgument` | `string` | | | | Password for password-protected PDF files. Leave empty for unprotected files. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ImageDpi` | Image DPI | `ImageDpi` | `Medium` | The DPI (dots per inch) at which the page is rendered. Higher DPI produces sharper images at the cost of larger file size. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFile` | Output File | `ILocalResource` | The exported image file as a local resource. |
+
+### Enum Reference
+
+**`ImageDpi`**: `Low` (96 dpi), `Medium` (150 dpi), `High` (270 dpi)
+
+## XAML Example
+
+```xml
+<pdf:ExportPDFPageAsImage
+    DisplayName="Export PDF Page As Image"
+    FileName="[&quot;C:\documents\report.pdf&quot;]"
+    PageNumber="[1]"
+    OutputFileName="[&quot;C:\output\page1.png&quot;]"
+    ImageDpi="High"
+    OutputFile="[outputImage]" />
+```
+
+> The `pdf` namespace prefix maps to `clr-namespace:UiPath.PDF.Activities.PDF;assembly=UiPath.PDF.Activities`.
+
+## Notes
+
+- `FileName` and `ResourceFile` are decorated with `[OverloadGroup]` — exactly one must be provided. Use `FileName` for plain local paths; use `ResourceFile` when working with storage buckets or file resources.
+- `PageNumber` is 1-based. Providing a value less than 1, or greater than the document's page count, raises an `ArgumentException` at runtime.
+- The output image format is inferred from the `OutputFileName` extension. Supported extensions: `.png`, `.jpg`, `.jpeg`, `.bmp`, `.gif`, `.tif`, `.tiff`.
+- `ImageDpi` is a plain enum property set directly as an XML attribute — it is not wrapped in a VB expression.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ExtractImagesFromPDF.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ExtractImagesFromPDF.md
@@ -1,0 +1,57 @@
+# Extract Images From PDF
+
+`UiPath.PDF.Activities.PDF.ExtractImagesFromPDF`
+
+Extract all images embedded in a PDF file and save them to a local folder. The activity returns the list of saved image files as `ILocalResource` references.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileName` | File (local path) | `InArgument` | `string` | Yes* | | | The local file path of the PDF to extract images from. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | `InArgument` | `IResource` | Yes* | | | A file resource representing the PDF to extract images from. Mutually exclusive with `FileName`. |
+| `Password` | Password | `InArgument` | `string` | | `null` | | The password used to open a password-protected PDF. Leave empty if the file is not encrypted. |
+| `OutputFolderName` | Output Folder | `InArgument` | `string` | | | | The folder path where the extracted images are saved. If omitted, images are saved to the current working directory. |
+
+> *\*Exactly one of `FileName` or `ResourceFile` is required (`[OverloadGroup]`).*
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ImageExtension` | Image Type | `ImageExtension` | `PNG` | The image format used when saving the extracted images. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFiles` | Output Files | `IEnumerable<ILocalResource>` | A collection of local resource references pointing to each extracted image file. |
+
+### Enum Reference
+
+**`ImageExtension`**: `PNG`, `JPEG`, `TIFF`, `BMP`, `GIF`
+
+## XAML Example
+
+```xml
+<!-- xmlns:upap="clr-namespace:UiPath.PDF.Activities.PDF;assembly=UiPath.PDF.Activities" -->
+
+<upap:ExtractImagesFromPDF
+    DisplayName="Extract Images From PDF"
+    FileName="[pdfFilePath]"
+    ImageExtension="JPEG"
+    OutputFolderName="[outputFolder]"
+    OutputFiles="[extractedImages]" />
+```
+
+## Notes
+
+- `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`). Supply exactly one. In the designer, a context menu lets you switch between **Use File Path** and **Use a File Resource**.
+- Output images are named using the pattern `{pdfName}.{pageNumber}.{imageNumber}.{ext}` (e.g. `report.1.1.png`). Mask images follow the pattern `{pdfName}.{pageNumber}.mask-{maskNumber}.{ext}`.
+- The `OutputFolderName` path must already exist; the activity does not create directories.
+- `ImageExtension` is a plain enum property set as a direct XML attribute in XAML, not wrapped in an expression.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ExtractPDFPageRange.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ExtractPDFPageRange.md
@@ -1,0 +1,50 @@
+# Extract PDF Page Range
+
+`UiPath.PDF.Activities.PDF.ExtractPDFPageRange`
+
+Extracts a specified range of pages from a PDF file and writes them to a new PDF. The page range is expressed as a string (e.g., `"2-4"`). Supports password-protected source files.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileName` | File (local path) | InArgument | `string` | Yes* | | | The local file path of the source PDF. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | InArgument | `IResource` | Yes* | | | The file resource to read from. Mutually exclusive with `FileName`. |
+| `Range` | Range | InArgument | `string` | Yes | | | The page range to extract (e.g., `"2-4"`). Must be a valid range within the document's page count. |
+| `Password` | Password | InArgument | `string` | | `null` | | The password used to open a password-protected PDF. Leave empty if the file is not protected. |
+| `OutputFileName` | Output File Path | InArgument | `string` | | | | Full path where the extracted-page PDF will be saved. If not specified, a default path is generated automatically. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFile` | Output File | `ILocalResource` | The resulting PDF containing only the extracted pages, as a local resource. |
+
+## Notes
+
+- `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`). Provide exactly one.
+- The `Range` format is `"start-end"` (e.g., `"2-4"` extracts pages 2, 3, and 4). An invalid range format throws a `RangeFormatException`.
+- Page numbers are 1-based. Providing a range that exceeds the document's page count is a validation error at runtime.
+
+## XAML Example
+
+```xml
+<pdf:ExtractPDFPageRange
+    DisplayName="Extract PDF Page Range"
+    FileName="[inputFilePath]"
+    Range="[&quot;2-4&quot;]"
+    Password="[filePassword]"
+    OutputFileName="[outputFilePath]"
+    OutputFile="[extractedFile]" />
+```
+
+> Namespace prefix `pdf` maps to `clr-namespace:UiPath.PDF.Activities.PDF;assembly=UiPath.PDF.Activities`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/GetPDFPageCount.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/GetPDFPageCount.md
@@ -1,0 +1,48 @@
+# Get PDF Page Count
+
+`UiPath.PDF.Activities.PDF.GetPDFPageCount`
+
+Reads a PDF document and returns the total number of pages it contains. Optionally accepts a password for password-protected files.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileName` | File (local path) | InArgument | `string` | Yes* | | | The local file path of the PDF document. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | InArgument | `IResource` | Yes* | | | The file resource to read from. Mutually exclusive with `FileName`. |
+| `Password` | Password | InArgument | `string` | | `null` | | The password used to open a password-protected PDF. Leave empty if the file is not protected. |
+
+> *\*Exactly one of `FileName` or `ResourceFile` is required (`[OverloadGroup]`).*
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `PageCount` | PageCount | `int` | The total number of pages found in the supplied PDF document. |
+
+## Notes
+
+- `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`). Provide exactly one.
+- `FileName` accepts a local file system path (e.g., `"C:\docs\report.pdf"`).
+- `ResourceFile` accepts an `IResource` object, enabling use with storage buckets and other resource providers.
+
+## XAML Example
+
+```xml
+<pdf:GetPDFPageCount
+    DisplayName="Get PDF Page Count"
+    FileName="[inputFilePath]"
+    Password="[filePassword]"
+    PageCount="[pageCount]" />
+```
+
+> Namespace prefix `pdf` maps to `clr-namespace:UiPath.PDF.Activities.PDF;assembly=UiPath.PDF.Activities`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/JoinPDF.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/JoinPDF.md
@@ -1,0 +1,75 @@
+# Join PDF Files
+
+`UiPath.PDF.Activities.PDF.JoinPDF`
+
+Merges two or more PDF files into a single output PDF. Supports two input modes: providing files as a collection (array of paths or resource array) or providing files individually one by one. The merged file is written to `OutputFileName` and returned via `OutputFile`.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileList` | Files (local paths) | InArgument | `string[]` | Yes† | | | An array of local PDF file paths to merge. Visible only when `InputMode` is `Collection`. Mutually exclusive with `ResourceFileList`. |
+| `ResourceFileList` | Files | InArgument | `IResource[]` | Yes† | | | An array of file resources to merge. Visible only when `InputMode` is `Collection`. Mutually exclusive with `FileList`. |
+| `IndividualResourceFileList` | Files | Property | `IEnumerable<InArgument<IResource>>` | | | | Individual file resource arguments added one by one. Visible only when `InputMode` is `Individual`. |
+| `OutputFileName` | Output File Path | InArgument | `string` | | | | Full path where the merged PDF will be saved. If not specified, a default path is generated automatically. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InputMode` | Input Mode | `ItemsInputMode` | `Collection` | Controls how input files are specified. `Collection` uses `FileList`/`ResourceFileList`; `Individual` uses `IndividualResourceFileList`. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFile` | Output File | `ILocalResource` | The merged PDF file as a local resource. |
+
+## Conditional Properties
+
+These properties appear or change behavior based on other property values:
+
+- **`FileList`** (InArgument\<string[]\>) — Visible only when `InputMode` is `Collection`. Provide either `FileList` or `ResourceFileList`, not both.
+- **`ResourceFileList`** (InArgument\<IResource[]\>) — Visible only when `InputMode` is `Collection`. Provide either `ResourceFileList` or `FileList`, not both.
+- **`IndividualResourceFileList`** (IEnumerable\<InArgument\<IResource\>\>) — Visible only when `InputMode` is `Individual`.
+
+## Enum Reference
+
+**`ItemsInputMode`**: `Collection` (Use a collection of PDF files), `Individual` (Use individual PDF files)
+
+## Notes
+
+- At least two files must be provided regardless of input mode; fewer than two files is a validation error.
+- When `InputMode` is `Collection`, setting both `FileList` and `ResourceFileList` is a validation error — use one or the other.
+- File paths are validated for existence and `.pdf` extension before merging.
+
+## XAML Example
+
+### Collection mode (local paths)
+
+```xml
+<pdf:JoinPDF
+    DisplayName="Join PDF Files"
+    InputMode="Collection"
+    FileList="[new String() {&quot;C:\docs\part1.pdf&quot;, &quot;C:\docs\part2.pdf&quot;}]"
+    OutputFileName="[outputFilePath]"
+    OutputFile="[mergedFile]" />
+```
+
+### Collection mode (file resources)
+
+```xml
+<pdf:JoinPDF
+    DisplayName="Join PDF Files"
+    InputMode="Collection"
+    ResourceFileList="[resourceArray]"
+    OutputFileName="[outputFilePath]"
+    OutputFile="[mergedFile]" />
+```
+
+> Namespace prefix `pdf` maps to `clr-namespace:UiPath.PDF.Activities.PDF;assembly=UiPath.PDF.Activities`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ManagePDFPassword.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ManagePDFPassword.md
@@ -1,0 +1,54 @@
+# Manage PDF Password
+
+`UiPath.PDF.Activities.PDF.ManagePDFPassword`
+
+Sets, changes, or removes the user and/or owner password on a PDF file. At least one password field must be provided. The activity writes the resulting file to the path specified by `OutputFileName` (or a generated default path) and returns it as an `ILocalResource` via `OutputFile`.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileName` | File (local path) | InArgument | `string` | Yes* | | | The local file path of the source PDF. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | InArgument | `IResource` | Yes* | | | The file resource to read from. Mutually exclusive with `FileName`. |
+| `OldUserPassword` | OldUserPassword | InArgument | `string` | | `null` | | The current user password of the PDF. Required if the file is protected with a user password. |
+| `NewUserPassword` | NewUserPassword | InArgument | `string` | | `null` | | The new user password to set. Leave empty to remove the user password. |
+| `OldOwnerPassword` | OldOwnerPassword | InArgument | `string` | | `null` | | The current owner (permissions) password. Must be supplied to gain owner rights when changing passwords. |
+| `NewOwnerPassword` | NewOwnerPassword | InArgument | `string` | | `null` | | The new owner password to set. Leave empty to remove the owner password. |
+| `OutputFileName` | Output File Path | InArgument | `string` | | | | Full path where the modified PDF will be saved. If not specified, a default path is generated automatically. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `OutputFile` | Output File | `ILocalResource` | The resulting modified PDF file as a local resource. |
+
+## Notes
+
+- `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`). Provide exactly one.
+- At least one of the four password arguments (`OldUserPassword`, `NewUserPassword`, `OldOwnerPassword`, `NewOwnerPassword`) must be set; providing none is a validation error.
+- The user password and owner password must not be identical.
+- If the file is protected with a user password, either `OldUserPassword` or `OldOwnerPassword` must be supplied to open it.
+- Owner rights are required to change passwords. If the supplied password does not grant owner rights, the activity throws.
+
+## XAML Example
+
+```xml
+<pdf:ManagePDFPassword
+    DisplayName="Manage PDF Password"
+    FileName="[inputFilePath]"
+    OldUserPassword="[currentPassword]"
+    NewUserPassword="[newPassword]"
+    OutputFileName="[outputFilePath]"
+    OutputFile="[outputFile]" />
+```
+
+> Namespace prefix `pdf` maps to `clr-namespace:UiPath.PDF.Activities.PDF;assembly=UiPath.PDF.Activities`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadPDFText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadPDFText.md
@@ -1,0 +1,48 @@
+# Read PDF Text
+
+`UiPath.PDF.Activities.ReadPDFText`
+
+Read and return all text content from a PDF file as a single string. Supports reading a specific page range and optionally preserving the original text formatting.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileName` | File (local path) | `InArgument` | `string` | Yes* | | | The local file path of the PDF to read. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | `InArgument` | `IResource` | Yes* | | | A file resource representing the PDF to read. Mutually exclusive with `FileName`. |
+| `Password` | Password | `InArgument` | `string` | | `null` | | The password used to open a password-protected PDF. Leave empty if the file is not encrypted. |
+
+> *\*Exactly one of `FileName` or `ResourceFile` is required (`[OverloadGroup]`).*
+| `Range` | Range | `InArgument` | `string` | | `"All"` | | The page range to read (e.g. `"2-4"`, `"1,3,5"`, or `"All"`). Defaults to all pages. |
+| `PreserveFormatting` | PreserveFormatting | `InArgument` | `bool` | | `false` | | When `true`, whitespace and layout formatting from the PDF are preserved in the extracted text. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Text` | Text | `string` | The extracted text content from the specified page range. |
+
+## XAML Example
+
+```xml
+<!-- xmlns:ui="http://schemas.uipath.com/workflow/activities" -->
+
+<ui:ReadPDFText
+    DisplayName="Read PDF Text"
+    FileName="[pdfFilePath]"
+    Range="[pageRange]"
+    PreserveFormatting="[preserveFormatting]"
+    Text="[outputText]" />
+```
+
+## Notes
+
+- `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`). Supply exactly one. In the designer, a context menu lets you switch between **Use File Path** and **Use a File Resource**.
+- The `Range` property accepts formats such as `"All"`, `"1"`, `"2-5"`, or comma-separated page numbers. An invalid format raises an exception at runtime.
+- `PreserveFormatting` defaults to `false`; when `false`, text is extracted without spatial layout information.
+- For scanned PDFs where native text extraction returns empty results, use **Read PDF With OCR** instead.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadPDFWithOCR.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadPDFWithOCR.md
@@ -1,0 +1,146 @@
+# Read PDF With OCR
+
+`UiPath.PDF.Activities.ReadPDFWithOCR`
+
+Reads all characters from a specified PDF file and stores the result in a string variable by using OCR technology. Use this activity for scanned PDFs where native text extraction returns empty results.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FileName` | File (local path) | `InArgument` | `string` | Yes | | The full path of the PDF file to be read. |
+| `Password` | Password | `InArgument` | `string` | | `null` | The password of the PDF file, if necessary. Leave empty if the file is not encrypted. |
+| `Range` | Range | `InArgument` | `string` | | `"All"` | The page range to read (e.g. `"2-4"`, `"1,3,5"`, or `"All"`). If the range isn't specified, the whole file is read. |
+| `DegreeOfParallelism` | DegreeOfParallelism | `InArgument` | `int` | Yes | `1` | Number of pages to be OCRed in parallel. A value of `-1` indicates the operation will be executed on available LogicalProcessorCount - 1. A positive value n will execute the operation on n logical processors, no greater than LogicalProcessorCount - 1. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ImageDpi` | Image DPI | `ImageDpi` | `Medium` | Image DPI used for OCR. Higher DPI produces more accurate OCR results at the cost of slower processing. |
+
+### OCR Engine
+
+| Name | Display Name | Type | Required | Description |
+|------|-------------|------|----------|-------------|
+| `OCREngine` | OCR Engine | `ActivityFunc<Image, IEnumerable<KeyValuePair<Rectangle, String>>>` | Yes | The OCR engine activity used to extract text from PDF page images. Drop an OCR engine activity into this scope. **Use UiPath Document OCR** (`ocr:UiPathDocumentOCR`) — see OCR Engine Selection below. |
+
+#### OCR Engine Selection
+
+**Use UiPath Document OCR** (`ocr:UiPathDocumentOCR`) as the default OCR engine for PDF OCR activities. It provides the best accuracy for document-oriented content (tables, paragraphs, mixed layouts, skewed scans).
+
+**Do NOT use UiPath Screen OCR** (`ocr:UiPathScreenOCR`) with PDF activities. Screen OCR is designed for live screen captures and UI automation scenarios, not for document processing. It will produce inferior results on scanned documents.
+
+| Engine | Use With PDF? | Designed For |
+|--------|---------------|--------------|
+| UiPath Document OCR | **Yes (recommended)** | Document processing, PDFs — requires `Endpoint` and `ApiKey` |
+| OmniPage OCR | Acceptable | Document processing |
+| Google Cloud Vision OCR | Acceptable | General-purpose OCR |
+| Microsoft OCR | Acceptable | General-purpose OCR |
+| UiPath Screen OCR | **No** | Live screen captures, UI automation |
+
+> **Required credentials for UiPath Document OCR:** `Endpoint` and `ApiKey` are user/organization-specific values that cannot be auto-discovered. The agent **must ask the user** for these values before generating the workflow. Do not leave them as `{x:Null}` or use placeholder strings — the workflow will fail at runtime without valid credentials.
+>
+> - **Endpoint**: The Document OCR service URL (e.g., `https://du.uipath.com/ocr` or a staging/on-prem URL).
+> - **ApiKey**: The authentication key for the OCR service.
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Text` | Text | `string` | The extracted string containing all recognized text from the specified page range. |
+
+### Enum Reference
+
+**`ImageDpi`**: `Low` (96 dpi), `Medium` (150 dpi), `High` (270 dpi)
+
+## XAML Examples
+
+### With UiPath Document OCR
+
+```xml
+<!-- Required namespace declarations:
+     xmlns:ui="http://schemas.uipath.com/workflow/activities"
+     xmlns:ocr="http://schemas.uipath.com/workflow/activities/ocr"
+     xmlns:sd="clr-namespace:System.Drawing;assembly=System.Drawing"
+     xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"
+
+     Required package: UiPath.OCR.Activities (provides UiPath Document OCR, Google Cloud Vision OCR, Microsoft OCR, etc.)
+-->
+
+<ui:ReadPDFWithOCR
+    DisplayName="Read PDF With OCR"
+    FileName="[pdfFilePath]"
+    Range="[pageRange]"
+    Password="[password]"
+    DegreeOfParallelism="-1"
+    ImageDpi="Medium"
+    Text="[outputText]">
+  <ui:ReadPDFWithOCR.OCREngine>
+    <ActivityFunc x:TypeArguments="sd:Image, scg:IEnumerable(scg:KeyValuePair(sd:Rectangle, x:String))">
+      <ActivityFunc.Argument>
+        <DelegateInArgument x:TypeArguments="sd:Image" Name="Image" />
+      </ActivityFunc.Argument>
+      <ocr:UiPathDocumentOCR
+          DisplayName="UiPath Document OCR"
+          Image="[Image]"
+          Endpoint="[ocrEndpoint]"
+          ApiKey="[ocrApiKey]"
+          Language="auto"
+          Scale="1"
+          Timeout="100000" />
+    </ActivityFunc>
+  </ui:ReadPDFWithOCR.OCREngine>
+</ui:ReadPDFWithOCR>
+```
+
+### Minimal (OCR engine placeholder)
+
+```xml
+<!-- xmlns:ui="http://schemas.uipath.com/workflow/activities" -->
+<!-- xmlns:sd="clr-namespace:System.Drawing;assembly=System.Drawing" -->
+<!-- xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib" -->
+
+<ui:ReadPDFWithOCR
+    DisplayName="Read PDF With OCR"
+    FileName="[pdfFilePath]"
+    Range="All"
+    DegreeOfParallelism="-1"
+    ImageDpi="Medium"
+    Text="[outputText]">
+  <ui:ReadPDFWithOCR.OCREngine>
+    <ActivityFunc x:TypeArguments="sd:Image, scg:IEnumerable(scg:KeyValuePair(sd:Rectangle, x:String))">
+      <ActivityFunc.Argument>
+        <DelegateInArgument x:TypeArguments="sd:Image" Name="Image" />
+      </ActivityFunc.Argument>
+      <!-- Insert an OCR engine activity here. The engine MUST bind Image="[Image]" to the delegate argument.
+           RECOMMENDED: ocr:UiPathDocumentOCR (best for document/PDF content)
+             - Requires Endpoint and ApiKey (ask user for these values)
+             - xmlns:ocr="http://schemas.uipath.com/workflow/activities/ocr"
+           ACCEPTABLE alternatives:
+             - uoa:OmniPageOCR (from UiPath.OmniPage.Activities)
+             - ui:GoogleCloudOCR (requires API key)
+             - ui:MicrosoftOCR
+             Note: GoogleCloudOCR and MicrosoftOCR use the ui: prefix (xmlns:ui="http://schemas.uipath.com/workflow/activities"), NOT ocr:.
+           NOT RECOMMENDED for document processing:
+             - ocr:UiPathScreenOCR (designed for screen captures, not documents)
+      -->
+    </ActivityFunc>
+  </ui:ReadPDFWithOCR.OCREngine>
+</ui:ReadPDFWithOCR>
+```
+
+## Notes
+
+- This activity requires an OCR engine to be placed inside the `OCREngine` scope. Without an OCR engine, a validation error is raised: the activity will not work without one.
+- The `OCREngine` child element is an `ActivityFunc` delegate — it must contain exactly one OCR engine activity. **The OCR engine must set `Image="[Image]"` to bind to the delegate argument** — without this binding the engine receives no input.
+- **OCR engine packages must be installed separately.** The most common package is `UiPath.OCR.Activities` (namespace `xmlns:ocr="http://schemas.uipath.com/workflow/activities/ocr"`), which provides UiPath Document OCR, Google Cloud Vision OCR, and Microsoft OCR. Use `uip rpa find-activities --query "OCR engine"` to discover available engines and `uip rpa install-or-update-packages` to install the required package.
+- The `DegreeOfParallelism` factory default is `-1` (maximum parallelism). A value of `-1` means the activity uses `LogicalProcessorCount - 1` threads. Values exceeding the processor count are capped automatically.
+- `ImageDpi` is a plain enum property set directly as an XML attribute — it is not wrapped in a VB expression.
+- The `Range` property accepts formats such as `"All"`, `"1"`, `"2-5"`, or comma-separated page numbers. An invalid format raises an exception at runtime.
+- For PDFs with embedded (native) text, prefer **Read PDF Text** instead — it is faster and does not require an OCR engine.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadXPSText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadXPSText.md
@@ -1,0 +1,47 @@
+# Read XPS Text
+
+`UiPath.XPS.Activities.ReadXPSText`
+
+Read and return all text content from an XPS (XML Paper Specification) file as a single string. Supports reading a specific page range.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > PDF
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FileName` | File (local path) | `InArgument` | `string` | Yes* | | | The local file path of the XPS file to read. Mutually exclusive with `ResourceFile`. |
+| `ResourceFile` | File | `InArgument` | `IResource` | Yes* | | | A file resource representing the XPS file to read. Mutually exclusive with `FileName`. |
+| `Password` | Password | `InArgument` | `string` | | `null` | | The password used to open a password-protected XPS file. Leave empty if the file is not encrypted. |
+
+> *\*Exactly one of `FileName` or `ResourceFile` is required (`[OverloadGroup]`).*
+| `Range` | Range | `InArgument` | `string` | | `"All"` | | The page range to read (e.g. `"2-4"`, `"1,3,5"`, or `"All"`). Defaults to all pages. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Text` | Text | `string` | The extracted text content from the specified page range. |
+
+## XAML Example
+
+```xml
+<!-- xmlns:ui="http://schemas.uipath.com/workflow/activities" -->
+
+<ui:ReadXPSText
+    DisplayName="Read XPS Text"
+    FileName="[xpsFilePath]"
+    Range="[pageRange]"
+    Text="[outputText]" />
+```
+
+## Notes
+
+- `FileName` and `ResourceFile` are mutually exclusive (`[OverloadGroup]`). Supply exactly one. In the designer, a context menu lets you switch between **Use File Path** and **Use a File Resource**.
+- The `Range` property accepts formats such as `"All"`, `"1"`, `"2-5"`, or comma-separated page numbers. An invalid format raises an exception at runtime.
+- This activity is only available on Windows (`#if !NETPORTABLE_UIPATH`). It uses the Windows-native XPS reader and cannot be used in cross-platform workflows.
+- Unlike `ReadPDFText`, there is no `PreserveFormatting` option for XPS files.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadXPSWithOCR.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/activities/ReadXPSWithOCR.md
@@ -1,0 +1,135 @@
+# Read XPS With OCR
+
+`UiPath.XPS.Activities.ReadXPSWithOCR`
+
+Reads all characters from a specified XPS (XML Paper Specification) file and stores the result in a string variable by using OCR technology. Use this activity for scanned XPS documents where native text extraction returns empty results.
+
+**Package:** `UiPath.PDF.Activities`
+**Category:** App Integration > XPS
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FileName` | File (local path) | `InArgument` | `string` | Yes | | The full path of the XPS file to be read. |
+| `Password` | Password | `InArgument` | `string` | | `null` | The password of the XPS file, if necessary. Leave empty if the file is not encrypted. |
+| `Range` | Range | `InArgument` | `string` | | `"All"` | The page range to read (e.g. `"2-4"`, `"1,3,5"`, or `"All"`). If the range isn't specified, the whole file is read. |
+| `DegreeOfParallelism` | DegreeOfParallelism | `InArgument` | `int` | Yes | `1` | Number of pages to be OCRed in parallel. A value of `-1` indicates the operation will be executed on available LogicalProcessorCount - 1. A positive value n will execute the operation on n logical processors, no greater than LogicalProcessorCount - 1. |
+
+### OCR Engine
+
+| Name | Display Name | Type | Required | Description |
+|------|-------------|------|----------|-------------|
+| `OCREngine` | OCR Engine | `ActivityFunc<Image, IEnumerable<KeyValuePair<Rectangle, String>>>` | Yes | The OCR engine activity used to extract text from XPS page images. Drop an OCR engine activity into this scope. **Use UiPath Document OCR** (`ocr:UiPathDocumentOCR`) — see OCR Engine Selection below. |
+
+#### OCR Engine Selection
+
+**Use UiPath Document OCR** (`ocr:UiPathDocumentOCR`) as the default OCR engine for XPS OCR activities. It provides the best accuracy for document-oriented content (tables, paragraphs, mixed layouts, skewed scans).
+
+**Do NOT use UiPath Screen OCR** (`ocr:UiPathScreenOCR`) with XPS activities. Screen OCR is designed for live screen captures and UI automation scenarios, not for document processing. It will produce inferior results on scanned documents.
+
+| Engine | Use With XPS? | Designed For |
+|--------|---------------|--------------|
+| UiPath Document OCR | **Yes (recommended)** | Document processing, PDFs/XPS — requires `Endpoint` and `ApiKey` |
+| OmniPage OCR | Acceptable | Document processing |
+| Google Cloud Vision OCR | Acceptable | General-purpose OCR |
+| Microsoft OCR | Acceptable | General-purpose OCR |
+| UiPath Screen OCR | **No** | Live screen captures, UI automation |
+
+> **Required credentials for UiPath Document OCR:** `Endpoint` and `ApiKey` are user/organization-specific values that cannot be auto-discovered. The agent **must ask the user** for these values before generating the workflow. Do not leave them as `{x:Null}` or use placeholder strings — the workflow will fail at runtime without valid credentials.
+>
+> - **Endpoint**: The Document OCR service URL (e.g., `https://du.uipath.com/ocr` or a staging/on-prem URL).
+> - **ApiKey**: The authentication key for the OCR service.
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Text` | Text | `string` | The extracted string containing all recognized text from the specified page range. |
+
+## XAML Examples
+
+### With UiPath Document OCR
+
+```xml
+<!-- Required namespace declarations:
+     xmlns:ui="http://schemas.uipath.com/workflow/activities"
+     xmlns:ocr="http://schemas.uipath.com/workflow/activities/ocr"
+     xmlns:sd="clr-namespace:System.Drawing;assembly=System.Drawing"
+     xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"
+
+     Required package: UiPath.OCR.Activities (provides UiPath Document OCR, Google Cloud Vision OCR, Microsoft OCR, etc.)
+-->
+
+<ui:ReadXPSWithOCR
+    DisplayName="Read XPS With OCR"
+    FileName="[xpsFilePath]"
+    Range="[pageRange]"
+    Password="[password]"
+    DegreeOfParallelism="1"
+    Text="[outputText]">
+  <ui:ReadXPSWithOCR.OCREngine>
+    <ActivityFunc x:TypeArguments="sd:Image, scg:IEnumerable(scg:KeyValuePair(sd:Rectangle, x:String))">
+      <ActivityFunc.Argument>
+        <DelegateInArgument x:TypeArguments="sd:Image" Name="Image" />
+      </ActivityFunc.Argument>
+      <ocr:UiPathDocumentOCR
+          DisplayName="UiPath Document OCR"
+          Image="[Image]"
+          Endpoint="[ocrEndpoint]"
+          ApiKey="[ocrApiKey]"
+          Language="auto"
+          Scale="1"
+          Timeout="100000" />
+    </ActivityFunc>
+  </ui:ReadXPSWithOCR.OCREngine>
+</ui:ReadXPSWithOCR>
+```
+
+### Minimal (OCR engine placeholder)
+
+```xml
+<!-- xmlns:ui="http://schemas.uipath.com/workflow/activities" -->
+<!-- xmlns:sd="clr-namespace:System.Drawing;assembly=System.Drawing" -->
+<!-- xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib" -->
+
+<ui:ReadXPSWithOCR
+    DisplayName="Read XPS With OCR"
+    FileName="[xpsFilePath]"
+    Range="All"
+    DegreeOfParallelism="1"
+    Text="[outputText]">
+  <ui:ReadXPSWithOCR.OCREngine>
+    <ActivityFunc x:TypeArguments="sd:Image, scg:IEnumerable(scg:KeyValuePair(sd:Rectangle, x:String))">
+      <ActivityFunc.Argument>
+        <DelegateInArgument x:TypeArguments="sd:Image" Name="Image" />
+      </ActivityFunc.Argument>
+      <!-- Insert an OCR engine activity here. The engine MUST bind Image="[Image]" to the delegate argument.
+           RECOMMENDED: ocr:UiPathDocumentOCR (best for document/XPS content)
+             - Requires Endpoint and ApiKey (ask user for these values)
+             - xmlns:ocr="http://schemas.uipath.com/workflow/activities/ocr"
+           ACCEPTABLE alternatives:
+             - uoa:OmniPageOCR (from UiPath.OmniPage.Activities)
+             - ui:GoogleCloudOCR (requires API key)
+             - ui:MicrosoftOCR
+             Note: GoogleCloudOCR and MicrosoftOCR use the ui: prefix (xmlns:ui="http://schemas.uipath.com/workflow/activities"), NOT ocr:.
+           NOT RECOMMENDED for document processing:
+             - ocr:UiPathScreenOCR (designed for screen captures, not documents)
+      -->
+    </ActivityFunc>
+  </ui:ReadXPSWithOCR.OCREngine>
+</ui:ReadXPSWithOCR>
+```
+
+## Notes
+
+- This activity requires an OCR engine to be placed inside the `OCREngine` scope. Without an OCR engine, a validation error is raised: the activity will not work without one.
+- The `OCREngine` child element is an `ActivityFunc` delegate — it must contain exactly one OCR engine activity. **The OCR engine must set `Image="[Image]"` to bind to the delegate argument** — without this binding the engine receives no input.
+- **OCR engine packages must be installed separately.** The most common package is `UiPath.OCR.Activities` (namespace `xmlns:ocr="http://schemas.uipath.com/workflow/activities/ocr"`), which provides UiPath Document OCR, Google Cloud Vision OCR, and Microsoft OCR. Use `uip rpa find-activities --query "OCR engine"` to discover available engines and `uip rpa install-or-update-packages` to install the required package.
+- Unlike `ReadPDFWithOCR`, there is no `ImageDpi` configuration property — the XPS reader uses a fixed internal rendering DPI.
+- The `Range` property accepts formats such as `"All"`, `"1"`, `"2-5"`, or comma-separated page numbers. An invalid format raises an exception at runtime.
+- This activity is only available on Windows (`#if !NETPORTABLE_UIPATH`). It uses the Windows-native XPS reader and cannot be used in cross-platform workflows.
+- For XPS files with embedded (native) text, prefer **Read XPS Text** instead — it is faster and does not require an OCR engine.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.PDF.Activities/4.1/overview.md
@@ -1,0 +1,29 @@
+# UiPath PDF Activities
+
+`UiPath.PDF.Activities`
+
+A set of activities for working with PDF and XPS documents: read text, extract images, export pages as images, join and split PDF files, manage passwords, and convert HTML, plain text, and email content to PDF.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+
+## Activities
+
+### App Integration > PDF
+
+| Activity                                                       | Description                                                                                               |
+| -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| [Get PDF Page Count](activities/GetPDFPageCount.md)            | Pick a PDF document and get its page count.                                                               |
+| [Manage PDF Password](activities/ManagePDFPassword.md)         | Manage the password set for a PDF file.                                                                   |
+| [Join PDF Files](activities/JoinPDF.md)                        | Merge two or more PDF files together into a single document.                                              |
+| [Extract PDF Page Range](activities/ExtractPDFPageRange.md)    | Extract a range of pages from a PDF file into a new document.                                             |
+| [Convert HTML to PDF](activities/ConvertHtmlToPDF.md)          | Convert HTML content to a PDF file.                                                                       |
+| [Convert Text to PDF](activities/ConvertTextToPDF.md)          | Convert plain text content to a PDF file.                                                                 |
+| [Convert Email to PDF](activities/ConvertEmailToPDF.md)        | Convert an email message to a PDF file.                                                                   |
+| [Export PDF Page As Image](activities/ExportPDFPageAsImage.md) | Export a single PDF page as an image at a specified DPI.                                                  |
+| [Extract Images From PDF](activities/ExtractImagesFromPDF.md)  | Extract all embedded images from a PDF file and save them to a folder.                                    |
+| [Read PDF Text](activities/ReadPDFText.md)                     | Read and return all text from a PDF file, with optional formatting preservation and page range filtering. |
+| [Read PDF With OCR](activities/ReadPDFWithOCR.md)              | Read all characters from a PDF file using OCR technology, for scanned PDFs where native text extraction returns empty results. Use UiPath Document OCR as the OCR engine (requires Endpoint and ApiKey). |
+| [Read XPS Text](activities/ReadXPSText.md)                     | Read and return all text from an XPS file, with optional page range filtering. Windows only.              |
+| [Read XPS With OCR](activities/ReadXPSWithOCR.md)              | Read all characters from an XPS file using OCR technology, for scanned documents. Windows only. Use UiPath Document OCR as the OCR engine (requires Endpoint and ApiKey). |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/ActivateSolutionDeployment.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/ActivateSolutionDeployment.md
@@ -1,0 +1,43 @@
+# Activate Solution Deployment
+
+`UiPath.Pipelines.Activities.ActivateSolutionDeployment`
+
+Activates a solution deployment.
+
+Calls the Solutions API to trigger the activation of an existing deployment, then polls for the activation status until a terminal state is reached (success or failure). Transient server errors are retried automatically (up to 3 times via Polly).
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionDeploymentName` | Solution deployment name | `InArgument` | `string` | Yes | — | — | Name of the solution deployment to be activated. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## XAML Example
+
+```xml
+<pip:ActivateSolutionDeployment
+    Tenant="[tenant]"
+    SolutionDeploymentName="MyDeployment"
+    DisplayName="Activate Solution Deployment" />
+```
+
+## Notes
+
+- Both `Tenant` and `SolutionDeploymentName` are required.
+- The activity polls the deployment instance status until the activation reaches a terminal state. If the status is `ActivateProgress`, the activity waits and polls again.
+- Throws `ActivateSolutionException` on activation failure, timeout, or invalid status transitions.
+- Valid terminal success status: `SuccessfulActivate`.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Analyze.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Analyze.md
@@ -1,0 +1,50 @@
+# Analyze
+
+`UiPath.Pipelines.Activities.Analyze`
+
+Analyzes a project against workflow analysis rules.
+
+Delegates to the `PipelinesWrapper` child process which calls `uipcli` internally. When an `AnalyzePolicy` is provided, the activity retrieves the governance policy data from AutomationOps and passes it to the analyzer. The analysis result is returned as a `DataTable` with columns: `Level`, `ErrorCode`, `RuleName`, `FilePath`, `Recommendation`.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RepositoryPath` | Repository path | `InArgument` | `string` | Yes | — | — | Absolute path to the cloned repository. |
+| `ProjectPath` | Project path | `InArgument` | `string` | No | `project.json` | — | Relative path to the `project.json` file. Defaults to `project.json` in the repository root. |
+| `AnalyzePolicy` | Policy | `InArgument` | `AnalyzePolicy` | No | — | — | The governance policy containing the workflow analyzer rules to check. Accepts a string policy identifier (implicit conversion). |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `AnalysisResult` | Analysis result | `DataTable` | Result of the analysis. Columns: `Level`, `ErrorCode`, `RuleName`, `FilePath`, `Recommendation`. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+
+## XAML Example
+
+```xml
+<pip:Analyze
+    RepositoryPath="[repoPath]"
+    ProjectPath="src/project.json"
+    AnalysisResult="[analysisResult]"
+    DisplayName="Analyze" />
+```
+
+## Notes
+
+- `RepositoryPath` is required; `ProjectPath` and `AnalyzePolicy` are optional.
+- If `AnalyzePolicy` is not provided, default workflow analysis rules apply.
+- If `AnalyzePolicy` is provided, the activity contacts the AutomationOps service to download the governance policy rules file before running the analyzer.
+- When analysis finds rule violations, the `AnalysisResult` table is still populated but an `AnalyzeErrorException` is thrown unless `ContinueOnError` is `true`.
+- The `Analyze` activity does **not** require an Orchestrator `Tenant` argument. It inherits from `ContinuableAsyncCodeActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Build.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Build.md
@@ -1,0 +1,60 @@
+# Build
+
+`UiPath.Pipelines.Activities.Build`
+
+Packages an automation project into a NuGet package (`.nupkg`).
+
+Delegates to the `PipelinesWrapper` child process which calls `uipcli` internally. Before packing, it optionally validates the project against the configured Orchestrator library feeds. The resulting package path is written to the `PackagePath` output argument.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RepositoryPath` | Repository path | `InArgument` | `string` | Yes | — | — | Absolute path to the cloned repository. |
+| `ProjectPath` | Project path | `InArgument` | `string` | No | `project.json` | — | Relative path to the `project.json` file. Defaults to `project.json` in the repository root. |
+| `Author` | Author | `InArgument` | `string` | No | Current user | — | Author to be set on the package. |
+| `Version` | Version | `InArgument` | `string` | No | From `project.json` | — | Version of the package. If not provided, defaults to the version in `project.json`. |
+| `IncludeSources` | Include sources | `InArgument` | `bool` | No | `false` | — | Sets whether the automation source code shall be packed as well. |
+| `SeparateRuntimeDependencies` | Separate runtime dependencies | `InArgument` | `bool` | No | `true` | — | Enables the output split to runtime and design libraries. |
+| `SkipValidate` | Skip validation | `InArgument` | `bool` | No | `false` | — | Skips project validation. |
+| `RepositoryType` | Repository type | `InArgument` | `string` | No | — | — | The used source control type (e.g. `git`, `svn`, `uip`). |
+| `RepositoryUrl` | Repository URL | `InArgument` | `string` | No | — | — | Remote repository URL of the `project.json` file. |
+| `RepositoryBranch` | Repository branch | `InArgument` | `string` | No | — | — | Source branch for the package. |
+| `RepositoryCommit` | Repository commit | `InArgument` | `string` | No | — | — | Commit ID (the commit SHA for git repositories). |
+| `ReleaseNotes` | Release notes | `InArgument` | `string` | No | — | — | Release notes for the package. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `PackagePath` | NuGet Package path | `string` | Absolute path to the built NuGet package (`.nupkg`). |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+
+## XAML Example
+
+```xml
+<pip:Build
+    RepositoryPath="[repoPath]"
+    ProjectPath="src/project.json"
+    Version="1.0.0"
+    PackagePath="[packagePath]"
+    DisplayName="Build" />
+```
+
+## Notes
+
+- `RepositoryPath` is the only required property; all others are optional.
+- When `SkipValidate` is `false` (the default), the activity first validates the project using `uipcli` before packing. Validation checks library feed compatibility.
+- The `SeparateRuntimeDependencies` property defaults to `true`, which splits the output package into runtime and design-time libraries.
+- Repository metadata properties (`RepositoryType`, `RepositoryUrl`, `RepositoryBranch`, `RepositoryCommit`) are embedded in the package manifest and used by Orchestrator for source-tracking.
+- The `Build` activity does **not** require an Orchestrator connection (no `Tenant` argument). It inherits directly from `ContinuableAsyncCodeActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Clone.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Clone.md
@@ -1,0 +1,54 @@
+# Clone
+
+`UiPath.Pipelines.Activities.Clone`
+
+Clones a git repository.
+
+Delegates to the `PipelinesWrapper` child process which calls `uipcli` internally. If no `AccessToken` is supplied, the activity automatically retrieves a robot token from the AutomationOps service. If no `DestinationPath` is specified, the repository is cloned into a uniquely-named subdirectory of the system temp folder. A configurable `TimeoutMS` limits how long the clone may run.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RepoUrl` | Repository URL | `InArgument` | `string` | Yes | — | — | The URL of the git repository. |
+| `CommitSha` | Commit SHA | `InArgument` | `string` | No | — | — | The commit identifier. If empty, will automatically be retrieved from the pipeline run context. |
+| `AccessToken` | Access token | `InArgument` | `string` | No | Robot token | — | Security token for accessing the repository. If empty, the robot token is used automatically. **Marked as secret — value is not logged.** |
+| `DestinationPath` | Destination path | `InArgument` | `string` | No | System temp folder | — | Directory path where the repository will be cloned. A new directory is created in the system temp folder if not specified. |
+| `SkipCertificateCheck` | Skip certificate check | `InArgument` | `bool` | No | `false` | — | If enabled, skips SSL certificate checks when interacting with the version control system. Use with caution — this bypasses an important security feature. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `RepositoryPath` | Repository path | `string` | Absolute path to the cloned repository. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `60000` | Timeout in milliseconds. |
+
+## XAML Example
+
+```xml
+<pip:Clone
+    RepoUrl="https://github.com/org/repo.git"
+    CommitSha="[commitSha]"
+    RepositoryPath="[repoPath]"
+    DisplayName="Clone" />
+```
+
+## Notes
+
+- `RepoUrl` is the only required property.
+- `AccessToken` is annotated with `[SecretValue]`, so its value is suppressed in diagnostic logs.
+- If `AccessToken` is omitted, the activity calls the AutomationOps service (`IAutomationOpsClient.GetAccessTokenAsync`) to obtain a robot-scoped token automatically.
+- When `SkipCertificateCheck` is `true`, a warning is written to the robot log before cloning proceeds.
+- The clone operation runs against the `TimeoutMS` deadline; a `TimeoutException` is thrown if exceeded.
+- Inherits from `CicdBaseActivity` — no Orchestrator `Tenant` argument required.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DeleteSolutionPackage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DeleteSolutionPackage.md
@@ -1,0 +1,43 @@
+# Delete Solution Package
+
+`UiPath.Pipelines.Activities.DeleteSolutionPackage`
+
+Deletes a solution package.
+
+Calls the Solutions API to delete the specified version of a solution package. Transient server errors are retried automatically (up to 3 times via Polly).
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionPackageName` | Solution package name | `InArgument` | `string` | Yes | — | — | Name of the solution package to be deleted. |
+| `SolutionPackageVersion` | Solution package version | `InArgument` | `string` | Yes | — | — | Version of the solution package to be deleted. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## XAML Example
+
+```xml
+<pip:DeleteSolutionPackage
+    Tenant="[tenant]"
+    SolutionPackageName="MySolution"
+    SolutionPackageVersion="1.0.0"
+    DisplayName="Delete Solution Package" />
+```
+
+## Notes
+
+- `Tenant`, `SolutionPackageName`, and `SolutionPackageVersion` are all required.
+- Throws `DeleteSolutionPackageException` if the deletion fails.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DeploySolution.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DeploySolution.md
@@ -1,0 +1,54 @@
+# Deploy Solution
+
+`UiPath.Pipelines.Activities.DeploySolution`
+
+Deploys a solution.
+
+Calls the Solutions API to install a solution package under a named deployment, using the provided configuration file. It then polls the pipeline deployment status until a terminal state is reached. Transient server errors are retried automatically (up to 3 times via Polly).
+
+The activity reads the configuration file from `PathToSolutionPackageConfiguration`, auto-detects whether it is JSON or YAML, and passes it to the API as the deployment configuration.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionDeploymentName` | Deployment name | `InArgument` | `string` | Yes | — | — | Name of the solution deployment. |
+| `SolutionPackageName` | Solution package name | `InArgument` | `string` | Yes | — | — | Name of the solution package to be deployed. |
+| `SolutionPackageVersion` | Solution package version | `InArgument` | `string` | Yes | — | — | Version of the solution package to be deployed. |
+| `SolutionRootFolderName` | Solution root folder name | `InArgument` | `string` | Yes | — | — | Name of the solution root folder. |
+| `PathToSolutionPackageConfiguration` | Path to solution package configuration | `InArgument` | `string` | Yes | — | — | Path to the solution package configuration file (JSON or YAML) used for deployment. |
+| `DestinationOrchestratorFolder` | Destination folder | `InArgument` | `OrchestratorFolder` | No | — | — | Orchestrator folder that will be used as parent for the solution root folder. If empty, the solution is deployed as a new root folder under the tenant. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## XAML Example
+
+```xml
+<pip:DeploySolution
+    Tenant="[tenant]"
+    SolutionDeploymentName="MyDeployment"
+    SolutionPackageName="MySolution"
+    SolutionPackageVersion="1.0.0"
+    SolutionRootFolderName="SolutionRoot"
+    PathToSolutionPackageConfiguration="[configFilePath]"
+    DisplayName="Deploy Solution" />
+```
+
+## Notes
+
+- `Tenant`, `SolutionDeploymentName`, `SolutionPackageName`, `SolutionPackageVersion`, `SolutionRootFolderName`, and `PathToSolutionPackageConfiguration` are all required.
+- The configuration file format (JSON or YAML) is auto-detected from the file content.
+- The activity polls through validation and deployment phases. Polling intervals are controlled by `SolutionsActivitiesSettings.PollingDelay`.
+- Throws `DeploySolutionException` on validation failure, conflict-fixing errors, deployment schedule errors, or deployment failure.
+- Inherits from `BaseSolutionsActivity`. Uses the `SolutionsClientWrapper` (not the plain `SolutionsClient`) to support the pipeline deployment flow.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DownloadPackage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DownloadPackage.md
@@ -1,0 +1,59 @@
+# Download Package
+
+`UiPath.Pipelines.Activities.DownloadPackage`
+
+Downloads a package from Orchestrator.
+
+The activity resolves the target Orchestrator feed based on the `Folder` and `IsLibrary` arguments (see feed selection logic below), then downloads the specified package version as a `.nupkg` file to the user profile packages directory (`~/packages`).
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | The Orchestrator tenant to connect to. Accepts an `OrchestratorTenant` object or a plain tenant name string. |
+| `PackageName` | Package name | `InArgument` | `string` | Yes | — | — | Name of the package to be downloaded. |
+| `Folder` | Orchestrator folder | `InArgument` | `OrchestratorFolder` | No | — | — | Orchestrator folder. If not provided, the Orchestrator Tenant feed will be used. |
+| `PackageVersion` | Package version | `InArgument` | `string` | No | Latest | — | Version of the package to be downloaded. If not provided, the latest version is downloaded. |
+| `IsLibrary` | Is library | `InArgument` | `bool` | No | `false` | — | Specifies package type so the package is searched on the proper feed. `false` = process feed, `true` = libraries feed. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `PackagePath` | Package path | `string` | Absolute path of the downloaded package file (e.g. `~/packages/PackageName.Version.nupkg`). |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `60000` | Timeout in milliseconds. |
+
+## Feed Selection Logic
+
+- If `IsLibrary = true`: uses the Tenant Libraries feed.
+- If `IsLibrary = false` and `Folder` is provided: uses the Folder feed (falls back to Tenant Processes feed if no folder-specific feed exists).
+- If `IsLibrary = false` and no `Folder`: uses the Tenant Processes feed.
+
+## XAML Example
+
+```xml
+<pip:DownloadPackage
+    Tenant="[tenant]"
+    PackageName="MyProcess"
+    PackageVersion="1.0.0"
+    PackagePath="[packagePath]"
+    DisplayName="Download Package" />
+```
+
+## Notes
+
+- `Tenant` and `PackageName` are required.
+- If `PackageVersion` is omitted, the activity automatically fetches the latest available version.
+- Downloaded packages are saved to `~/packages/{PackageName}.{PackageVersion}.nupkg`.
+- Inherits from `CicdBaseOrchestratorPackageActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DownloadSolutionPackage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DownloadSolutionPackage.md
@@ -1,0 +1,50 @@
+# Download Solution Package
+
+`UiPath.Pipelines.Activities.DownloadSolutionPackage`
+
+Downloads a solution package.
+
+Checks the state of the specified solution package version (must be `Active` or `Ready`), then downloads the package zip archive via the Solutions API and returns the local file path.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionPackageName` | Solution package name | `InArgument` | `string` | Yes | — | — | Name of the solution package to be downloaded. |
+| `SolutionPackageVersion` | Solution package version | `InArgument` | `string` | No | Latest | — | Version of the solution package to be downloaded. Defaults to latest if not specified. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `PathToSolutionPackage` | Path to solution package | `string` | Folder path where the solution package is downloaded. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## XAML Example
+
+```xml
+<pip:DownloadSolutionPackage
+    Tenant="[tenant]"
+    SolutionPackageName="MySolution"
+    SolutionPackageVersion="1.0.0"
+    PathToSolutionPackage="[downloadPath]"
+    DisplayName="Download Solution Package" />
+```
+
+## Notes
+
+- `Tenant` and `SolutionPackageName` are required.
+- Throws `SolutionPackageStateException` if the package version is in `Pending` or `Failed` state.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DownloadSolutionPackageConfiguration.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/DownloadSolutionPackageConfiguration.md
@@ -1,0 +1,62 @@
+# Download Solution Package Configuration
+
+`UiPath.Pipelines.Activities.DownloadSolutionPackageConfiguration`
+
+Downloads a solution package configuration file.
+
+Checks the state of the specified solution package version (must be `Active` or `Ready`), then downloads the configuration in the requested format (JSON or YAML) to a temporary file and returns the path.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionPackageName` | Solution package name | `InArgument` | `string` | Yes | — | — | Name of the solution package. |
+| `SolutionPackageVersion` | Solution package version | `InArgument` | `string` | No | Latest | — | Version of the solution package. Defaults to latest if not specified. |
+| `SolutionPackageConfigurationFormat` | Solution package configuration format | `InArgument` | `ConfigurationFormat` | No | `Json` | — | Format of the downloaded configuration file. Available values: `Json`, `Yaml`. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `PathToSolutionPackageConfiguration` | Path to solution package configuration | `string` | Absolute path where the solution package configuration is downloaded (a temp file with extension `.json` or `.yaml`). |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## ConfigurationFormat Enum
+
+| Value | Description |
+|-------|-------------|
+| `Json` (0) | Configuration file in JSON format. |
+| `Yaml` (1) | Configuration file in YAML format. |
+
+## XAML Example
+
+```xml
+<pip:DownloadSolutionPackageConfiguration
+    Tenant="[tenant]"
+    SolutionPackageName="MySolution"
+    SolutionPackageVersion="1.0.0"
+    SolutionPackageConfigurationFormat="{x:Static pip:ConfigurationFormat.Json}"
+    PathToSolutionPackageConfiguration="[configPath]"
+    DisplayName="Download Solution Package Configuration" />
+```
+
+## Notes
+
+- `Tenant` and `SolutionPackageName` are required.
+- `SolutionPackageConfigurationFormat` defaults to `Json`.
+- The downloaded file is written to a uniquely-named temporary file in the system temp directory with the appropriate extension.
+- Throws `SolutionPackageStateException` if the package version is in `Pending` or `Failed` state.
+- Throws `DownloadSolutionPackageConfigurationException` if the download fails.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/PublishPackage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/PublishPackage.md
@@ -1,0 +1,50 @@
+# Publish Package
+
+`UiPath.Pipelines.Activities.PublishPackage`
+
+Publishes a package to Orchestrator.
+
+The activity inspects the `.nupkg` file to determine its package type (Process, Tests, Library, Template, or Generic), then selects the appropriate Orchestrator feed and uploads the package. Process and Tests packages go to the process feed; Library, Template, and Generic packages go to the library feed.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | The Orchestrator tenant to connect to. |
+| `PackagePath` | Package path | `InArgument` | `string` | Yes | — | — | Absolute file path of the package to publish. |
+| `Folder` | Folder name | `InArgument` | `OrchestratorFolder` | No | — | — | Orchestrator folder. If not provided, the Orchestrator Tenant feed will be used. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `60000` | Timeout in milliseconds. |
+
+## Feed Selection Logic
+
+The package type is auto-detected from the `.nupkg` file:
+- `Library`, `Template`, `Generic` → uploaded to the Libraries feed.
+- `Process`, `Tests` → uploaded to the Processes feed.
+
+If `Folder` is provided, the folder's own feed is used (falling back to the Tenant Processes feed). If `Folder` is omitted, the Tenant-level feed is used.
+
+## XAML Example
+
+```xml
+<pip:PublishPackage
+    Tenant="[tenant]"
+    PackagePath="[packagePath]"
+    DisplayName="Publish Package" />
+```
+
+## Notes
+
+- Both `Tenant` and `PackagePath` are required.
+- The activity has no output arguments — it fails with an exception if the upload fails.
+- Inherits from `CicdBaseOrchestratorPackageActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/PublishSolutionPackage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/PublishSolutionPackage.md
@@ -1,0 +1,47 @@
+# Publish Solution Package
+
+`UiPath.Pipelines.Activities.PublishSolutionPackage`
+
+Publishes a solution package.
+
+Calls the Solutions API to publish a solution project as a versioned package, then polls the publish status until a terminal state is reached (`Completed` or `Faulted`). Transient server errors are retried automatically (up to 3 times via Polly).
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionProjectName` | Solution project name | `InArgument` | `string` | Yes | — | — | Name of the solution project to be published. |
+| `SolutionPackageName` | Solution package name | `InArgument` | `string` | Yes | — | — | Name of the published solution package. |
+| `SolutionPackageVersion` | Solution package version | `InArgument` | `string` | Yes | — | — | Version of the published solution package. |
+| `SolutionPackageDescription` | Solution package description | `InArgument` | `string` | No | — | — | Description for the published solution package. |
+| `SolutionRootFolder` | Solution root folder | `InArgument` | `string` | No | — | — | The name given at deployment time for the solution root folder. Administrators may change this during deployment. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## XAML Example
+
+```xml
+<pip:PublishSolutionPackage
+    Tenant="[tenant]"
+    SolutionProjectName="MySolutionProject"
+    SolutionPackageName="MySolution"
+    SolutionPackageVersion="1.0.0"
+    DisplayName="Publish Solution Package" />
+```
+
+## Notes
+
+- `Tenant`, `SolutionProjectName`, `SolutionPackageName`, and `SolutionPackageVersion` are required.
+- Throws `PublishSolutionPackageException` if publishing faults or if polling times out with `InProgress` status.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/ResyncSolutionProject.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/ResyncSolutionProject.md
@@ -1,0 +1,52 @@
+# Re-sync Solution Project
+
+`UiPath.Pipelines.Activities.ResyncSolutionProject`
+
+Re-syncs a solution project with Orchestrator. Note: Components may be removed if they are no longer available in the source.
+
+Calls the Solutions API to synchronize the specified project, then polls the sync status until a terminal state is reached. The `SolutionSyncOption` controls which properties are updated.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionProjectName` | Solution project name | `InArgument` | `string` | Yes | — | — | Name of the solution project to be synced. |
+| `SolutionSyncOption` | Sync option | `InArgument` | `SolutionProjectSyncOption` | No | `Sync` | — | Controls which properties to sync. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## SolutionProjectSyncOption Enum
+
+| Value | Display Name | Description |
+|-------|-------------|-------------|
+| `Sync` (0) | Read-only properties | Syncs read-only properties to source value. Configurable properties are not updated. |
+| `Reset` (1) | All properties | Syncs all properties to source value. Existing edits are overridden. |
+
+## XAML Example
+
+```xml
+<pip:ResyncSolutionProject
+    Tenant="[tenant]"
+    SolutionProjectName="MySolutionProject"
+    SolutionSyncOption="{x:Static pip:SolutionProjectSyncOption.Sync}"
+    DisplayName="Re-sync Solution Project" />
+```
+
+## Notes
+
+- `Tenant` and `SolutionProjectName` are required.
+- `SolutionSyncOption` defaults to `Sync` (read-only properties only).
+- Throws `SolutionProjectSyncException` if sync fails or if polling times out with `InProgress` status.
+- Deleted source components may be removed from Orchestrator during re-sync.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/RunExistingTestSet.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/RunExistingTestSet.md
@@ -1,0 +1,58 @@
+# Run Existing Test Set
+
+`UiPath.Pipelines.Activities.RunExistingTestSet`
+
+Runs an existing test set created in Orchestrator. Requires a UiPath Testing license.
+
+This is a **persistent activity** (annotated with `[PersistentActivity]`). After triggering the test set execution on Orchestrator, the Robot suspends the workflow and resumes automatically when the test jobs complete. On resume, it generates a JUnit XML report and an `UiPathTestReport` object.
+
+Unlike `RunTests`, this activity does not build or upload a package — it targets a test set that already exists in Orchestrator and starts execution immediately.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | The Orchestrator tenant to connect to. |
+| `Folder` | Folder name | `InArgument` | `OrchestratorFolder` | Yes | — | — | Orchestrator folder where the tests shall be run. |
+| `TestSetName` | Test set name | `InArgument` | `string` | Yes | — | — | Name of the test set to be run. |
+| `AttachRobotLogs` | Attach Robot logs | `InArgument` | `bool` | No | `false` | — | Include test set execution logs in the report. |
+| `RetryCount` | Number of retries | `InArgument` | `int` | No | `0` | — | Number of times failed test cases should be re-executed. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `ResultFilePath` | Results file path | `string` | Absolute path to the test results in JUnit XML format. Always returned, even if tests fail or `ContinueOnError` is set. |
+| `TestSetReport` | Test set report | `UiPathTestReport` | Returns the test set report as an object. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+
+## XAML Example
+
+```xml
+<pip:RunExistingTestSet
+    Tenant="[tenant]"
+    Folder="[folder]"
+    TestSetName="MyTestSet"
+    ResultFilePath="[resultFilePath]"
+    TestSetReport="[testReport]"
+    DisplayName="Run Existing Test Set" />
+```
+
+## Notes
+
+- `Tenant`, `Folder`, and `TestSetName` are required.
+- This is a persistent activity: the Robot can be suspended while waiting for Orchestrator to complete the test jobs.
+- `ResultFilePath` is always written, even when tests fail or exceptions occur.
+- If `RetryCount > 0`, failed test cases are automatically re-executed up to that many times.
+- The test set must already exist in Orchestrator under the specified folder. If it does not exist or the robot lacks permissions, a `GetTestSetInvalidNameOrInsufficientPermissionsException` is thrown.
+- Inherits from `BaseTestingActivity` → `BasePersistentActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/RunTests.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/RunTests.md
@@ -1,0 +1,74 @@
+# Run Tests
+
+`UiPath.Pipelines.Activities.RunTests`
+
+Builds, publishes, and runs a test project against Orchestrator. Requires a UiPath Testing license.
+
+This is a **persistent activity** (annotated with `[PersistentActivity]`). After triggering the test set execution on Orchestrator, the Robot suspends the workflow and resumes automatically when the test jobs complete. On resume, it generates a JUnit XML report and an `UiPathTestReport` object.
+
+Internally, the activity:
+1. Validates and builds (packs) the test project using the `PipelinesWrapper` child process.
+2. Uploads the package to the specified Orchestrator folder.
+3. Creates a transient test set named `CI_{timestamp}_{packageName}_{version}`.
+4. Starts execution and suspends until jobs complete.
+5. On resume, writes the JUnit XML report file and the `UiPathTestReport` output.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | The Orchestrator tenant to connect to. |
+| `Folder` | Folder name | `InArgument` | `OrchestratorFolder` | Yes | — | — | Orchestrator folder where the tests shall be run. |
+| `RepositoryPath` | Repository path | `InArgument` | `string` | Yes | — | — | Absolute path to the repository. |
+| `ProjectPath` | Project path | `InArgument` | `string` | No | `project.json` | — | Relative path to the `project.json` file. Defaults to `project.json` in the repository root. |
+| `Author` | Author | `InArgument` | `string` | No | Current user | — | Author to be set on the package. |
+| `Version` | Version | `InArgument` | `string` | No | `major.minor.timestamp` | — | Version of the package. Defaults to `major.minor.timestamp` where major and minor are from the project version. |
+| `SkipValidate` | Skip validation | `InArgument` | `bool` | No | `false` | — | Skips project validation. |
+| `SeparateRuntimeDependencies` | Separate runtime dependencies | `InArgument` | `bool` | No | `false` | — | Enables the output split to runtime and design libraries. |
+| `AttachRobotLogs` | Attach Robot logs | `InArgument` | `bool` | No | `false` | — | Include test set execution logs in the report. |
+| `RetryCount` | Number of retries | `InArgument` | `int` | No | `0` | — | Number of times failed test cases should be re-executed. |
+| `RepositoryType` | Repository type | `InArgument` | `string` | No | — | — | The used source control type (e.g. `git`, `svn`, `uip`). |
+| `RepositoryUrl` | Repository URL | `InArgument` | `string` | No | — | — | Remote repository URL of the `project.json` file. |
+| `RepositoryBranch` | Repository branch | `InArgument` | `string` | No | — | — | Source branch for the package. |
+| `RepositoryCommit` | Repository commit | `InArgument` | `string` | No | — | — | Commit ID (the commit SHA for git repositories). |
+| `ReleaseNotes` | Release notes | `InArgument` | `string` | No | — | — | Release notes for the package. |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `ResultFilePath` | Results file path | `string` | Absolute path to the test results in JUnit XML format. Always returned, even if tests fail or `ContinueOnError` is set. |
+| `TestSetReport` | Test set report | `UiPathTestReport` | Returns the test set report as an object. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+
+## XAML Example
+
+```xml
+<pip:RunTests
+    Tenant="[tenant]"
+    Folder="[folder]"
+    RepositoryPath="[repoPath]"
+    ProjectPath="tests/project.json"
+    ResultFilePath="[resultFilePath]"
+    TestSetReport="[testReport]"
+    DisplayName="Run Tests" />
+```
+
+## Notes
+
+- `Tenant`, `Folder`, and `RepositoryPath` are required.
+- This is a persistent activity: the Robot can be suspended while waiting for Orchestrator to complete the test jobs, which may take arbitrarily long. This allows the Robot license to be freed during the wait.
+- `ResultFilePath` is always written, even when tests fail or exceptions occur.
+- If `RetryCount > 0`, failed test cases are automatically re-executed up to that many times.
+- The version format must be `major.minor` or `major.minor.patch` using numeric tokens only. The activity appends a timestamp to create the final version (`major.minor.timestamp`).
+- Inherits from `BaseTestingActivity` → `BasePersistentActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Stage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/Stage.md
@@ -1,0 +1,44 @@
+# Stage
+
+`UiPath.Pipelines.Activities.Stage`
+
+Container activity for reporting pipeline stage status to Automation Ops - Pipelines.
+
+`Stage` wraps its child activity body in a `TryCatch`. On success it calls `EndStage` (reporting success telemetry to AutomationOps); on failure it calls `ErrorStage` (reporting the error) and then re-throws the exception. This makes pipeline stage execution visible in the AutomationOps Pipelines dashboard.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Body
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Activities` | Activities | `ActivityDelegate` | The activities to execute inside this stage. Drop activities here. |
+
+> `Stage` does **not** inherit from `CicdBaseActivity` — it inherits directly from `Activity`. It has no `ContinueOnError`, `TimeoutMS`, or `Tenant` arguments of its own; those are handled by the individual activities inside it.
+
+## XAML Example
+
+```xml
+<pip:Stage DisplayName="Build Stage">
+    <pip:Stage.Activities>
+        <ActivityAction>
+            <ActivityAction.Handler>
+                <Sequence>
+                    <pip:Clone RepoUrl="[repoUrl]" RepositoryPath="[repoPath]" />
+                    <pip:Build RepositoryPath="[repoPath]" PackagePath="[packagePath]" />
+                </Sequence>
+            </ActivityAction.Handler>
+        </ActivityAction>
+    </pip:Stage.Activities>
+</pip:Stage>
+```
+
+## Notes
+
+- `Stage` is a `sealed` class; it cannot be subclassed.
+- Stage lifecycle events (`StartStage`, `EndStage`, `ErrorStage`) are reported automatically to the AutomationOps service and appear on the Automation Ops - Pipelines dashboard.
+- If any child activity throws, `ErrorStage` is called with the exception and the exception is re-thrown. The `Stage` activity itself does not swallow errors.
+- Nesting `Stage` activities is not recommended; each `Stage` represents a discrete named pipeline step.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/UninstallSolution.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/UninstallSolution.md
@@ -1,0 +1,43 @@
+# Uninstall Solution
+
+`UiPath.Pipelines.Activities.UninstallSolution`
+
+Uninstalls a deployed solution.
+
+Calls the Solutions API to trigger uninstallation of the specified deployment, then polls the deployment instance status until a terminal state is reached (`SuccessfulUninstall` or `FailedUninstall`). Transient server errors are retried automatically (up to 3 times via Polly).
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `SolutionDeploymentName` | Solution deployment name | `InArgument` | `string` | Yes | — | — | Name of the solution deployment to be uninstalled. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## XAML Example
+
+```xml
+<pip:UninstallSolution
+    Tenant="[tenant]"
+    SolutionDeploymentName="MyDeployment"
+    DisplayName="Uninstall Solution" />
+```
+
+## Notes
+
+- Both `Tenant` and `SolutionDeploymentName` are required.
+- The activity polls the deployment instance status until the uninstallation reaches a terminal state.
+- Throws `UninstallSolutionException` on failure, timeout, or invalid status (e.g. if the deployment is in an install or activate state).
+- Valid terminal success status: `SuccessfulUninstall`.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/UpdateProcess.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/UpdateProcess.md
@@ -1,0 +1,47 @@
+# Update Process
+
+`UiPath.Pipelines.Activities.UpdateProcess`
+
+Updates a process in Orchestrator to a new package version.
+
+The activity looks up the named process in the specified Orchestrator folder, optionally validates that it is backed by the expected package name, resolves the target version (defaulting to the latest available), and then updates the process version via the Orchestrator API.
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | The Orchestrator tenant to connect to. |
+| `Folder` | Folder name | `InArgument` | `OrchestratorFolder` | Yes | — | — | Orchestrator folder containing the process. For sub-folders use the full path (e.g. `Parent/Child`). |
+| `ProcessName` | Process name | `InArgument` | `string` | Yes | — | — | The name of the process to be updated. |
+| `PackageName` | Package name | `InArgument` | `string` | No | — | — | The package name behind the process. If provided and it does not match, the activity fails. If not provided, this check is ignored. |
+| `PackageVersion` | Package version | `InArgument` | `string` | No | Latest | — | The version of the package to update the process to. If not provided, defaults to the latest version. Fails if the process already uses this version. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `60000` | Timeout in milliseconds. |
+
+## XAML Example
+
+```xml
+<pip:UpdateProcess
+    Tenant="[tenant]"
+    Folder="[folder]"
+    ProcessName="MyProcess"
+    PackageVersion="[newVersion]"
+    DisplayName="Update Process" />
+```
+
+## Notes
+
+- `Tenant`, `Folder`, and `ProcessName` are required.
+- If `PackageName` is supplied and does not match the process's backing package key, a `DifferentPackageNameException` is thrown.
+- If the resolved `PackageVersion` is the same as the version the process already uses, a `SameVersionUpdateException` is thrown.
+- Inherits from `CicdBaseOrchestratorPackageActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/UploadSolutionPackage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/activities/UploadSolutionPackage.md
@@ -1,0 +1,43 @@
+# Upload Solution Package
+
+`UiPath.Pipelines.Activities.UploadSolutionPackage`
+
+Uploads a solution package zip archive to Orchestrator.
+
+Reads the specified zip file and uploads it via the Solutions API. The activity then polls the package version state until it leaves `Pending` (reaching `Ready`, `Active`, or `Failed`). Transient server errors are retried automatically (up to 3 times via Polly).
+
+**Package:** `UiPath.Pipelines.Activities`
+**Category:** Pipelines
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Tenant` | Tenant | `InArgument` | `OrchestratorTenant` | Yes | — | — | Name of the tenant where the solution operation is executed. |
+| `PathToSolutionPackage` | Path to solution package | `InArgument` | `string` | Yes | — | — | Absolute file path to the solution package zip archive. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | `InArgument` | `bool` | `false` | If set, continues executing even if this activity fails. |
+| `TimeoutMS` | Timeout (milliseconds) | `InArgument` | `int` | `120000` | Timeout in milliseconds (default 2 minutes). |
+
+## XAML Example
+
+```xml
+<pip:UploadSolutionPackage
+    Tenant="[tenant]"
+    PathToSolutionPackage="[packageZipPath]"
+    DisplayName="Upload Solution Package" />
+```
+
+## Notes
+
+- Both `Tenant` and `PathToSolutionPackage` are required.
+- The file at `PathToSolutionPackage` must be a valid solution package zip archive.
+- Throws `SolutionPackageStateException` if the package ends up in `Failed` or `Pending` state after polling.
+- Throws `UploadSolutionPackageException` if the upload API call fails.
+- Inherits from `BaseSolutionsActivity`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Pipelines.Activities/3.0/overview.md
@@ -1,0 +1,72 @@
+# UiPath.Pipelines.Activities
+
+**Assembly:** `UiPath.Pipelines.Activities.dll`
+**Category:** Pipelines
+
+The `UiPath.Pipelines.Activities` package provides activities for building CI/CD pipelines in UiPath Studio. It covers the full automation lifecycle: cloning source repositories, analyzing workflow quality, packaging, publishing to Orchestrator, running tests, and managing Solutions deployments.
+
+---
+
+## CI/CD Activities
+
+| Activity | Class | Description |
+|----------|-------|-------------|
+| [Build](activities/Build.md) | `UiPath.Pipelines.Activities.Build` | Packages an automation project into a NuGet package. |
+| [Analyze](activities/Analyze.md) | `UiPath.Pipelines.Activities.Analyze` | Analyzes a project against workflow analysis rules. |
+| [Clone](activities/Clone.md) | `UiPath.Pipelines.Activities.Clone` | Clones a git repository. |
+| [Download Package](activities/DownloadPackage.md) | `UiPath.Pipelines.Activities.DownloadPackage` | Downloads a package from Orchestrator. |
+| [Publish Package](activities/PublishPackage.md) | `UiPath.Pipelines.Activities.PublishPackage` | Publishes a package to Orchestrator. |
+| [Stage](activities/Stage.md) | `UiPath.Pipelines.Activities.Stage` | Container activity for reporting pipeline stage status to Automation Ops. |
+| [Update Process](activities/UpdateProcess.md) | `UiPath.Pipelines.Activities.UpdateProcess` | Updates an Orchestrator process to a new package version. |
+| [Run Tests](activities/RunTests.md) | `UiPath.Pipelines.Activities.RunTests` | Builds, uploads, and runs a test project against Orchestrator. |
+| [Run Existing Test Set](activities/RunExistingTestSet.md) | `UiPath.Pipelines.Activities.RunExistingTestSet` | Runs a pre-existing test set defined in Orchestrator. |
+
+## Solutions Activities
+
+| Activity | Class | Description |
+|----------|-------|-------------|
+| [Activate Solution Deployment](activities/ActivateSolutionDeployment.md) | `UiPath.Pipelines.Activities.ActivateSolutionDeployment` | Activates a solution deployment. |
+| [Delete Solution Package](activities/DeleteSolutionPackage.md) | `UiPath.Pipelines.Activities.DeleteSolutionPackage` | Deletes a solution package. |
+| [Deploy Solution](activities/DeploySolution.md) | `UiPath.Pipelines.Activities.DeploySolution` | Deploys a solution. |
+| [Download Solution Package](activities/DownloadSolutionPackage.md) | `UiPath.Pipelines.Activities.DownloadSolutionPackage` | Downloads a solution package. |
+| [Download Solution Package Configuration](activities/DownloadSolutionPackageConfiguration.md) | `UiPath.Pipelines.Activities.DownloadSolutionPackageConfiguration` | Downloads a solution package configuration file. |
+| [Publish Solution Package](activities/PublishSolutionPackage.md) | `UiPath.Pipelines.Activities.PublishSolutionPackage` | Publishes a solution package. |
+| [Re-sync Solution Project](activities/ResyncSolutionProject.md) | `UiPath.Pipelines.Activities.ResyncSolutionProject` | Re-syncs a solution project with Orchestrator. |
+| [Uninstall Solution](activities/UninstallSolution.md) | `UiPath.Pipelines.Activities.UninstallSolution` | Uninstalls a deployed solution. |
+| [Upload Solution Package](activities/UploadSolutionPackage.md) | `UiPath.Pipelines.Activities.UploadSolutionPackage` | Uploads a solution package zip archive to Orchestrator. |
+
+---
+
+## Architecture Notes
+
+### CI/CD Activity Hierarchy
+
+```
+ContinuableAsyncCodeActivity
+└── CicdBaseActivity                          # ContinueOnError + TimeoutMS (60 s default)
+    ├── Clone, Analyze, Build                 # No Orchestrator client; delegate to PipelinesWrapper
+    └── CicdBaseOrchestratorPackageActivity   # Adds Tenant + OrchestratorClient
+        ├── PublishPackage, UpdateProcess, DownloadPackage
+        └── BaseTestingActivity (persistent)
+            ├── RunTests
+            └── RunExistingTestSet
+```
+
+### Solutions Activity Hierarchy
+
+```
+ContinuableAsyncCodeActivity
+└── BaseSolutionsActivity                     # Tenant (required), ContinueOnError, TimeoutMS (120 s default)
+    └── All 9 Solutions activities
+```
+
+### Key Custom Types
+
+| Type | Description |
+|------|-------------|
+| `OrchestratorTenant` | Wraps a tenant name string; has implicit conversion from/to `string`. |
+| `OrchestratorFolder` | Wraps a folder path string; has implicit conversion from/to `string`. |
+| `AnalyzePolicy` | Governance policy identifier; has implicit conversion from `string`. |
+| `UiPathTestReport` | Aggregated test set execution results object. |
+| `ConfigurationFormat` | Enum: `Json` (0), `Yaml` (1). |
+| `SolutionProjectSyncOption` | Enum: `Sync` (0) — read-only properties, `Reset` (1) — all properties. |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/AddSensitivityLabel.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/AddSensitivityLabel.md
@@ -1,0 +1,35 @@
+# Add Sensitivity Label
+
+`UiPath.Presentations.Activities.AddSensitivityLabel`
+
+Adds a sensitivity label to a PowerPoint document.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | The presentation to which to add the sensitivity label |
+| `SensitivityLabel` | Sensitivity label | InArgument | `object` | Yes | | | String ID or an `IPptLabelObject` instance to add to the file |
+| `Justification` | Justification | InArgument | `string` | | | | Justification to use when applying the label |
+
+## XAML Example
+
+```xml
+<pres:AddSensitivityLabel
+    DisplayName="Add Sensitivity Label"
+    Presentation="[presentation]"
+    SensitivityLabel="[&quot;label-guid-here&quot;]"
+    Justification="[&quot;Business requirement&quot;]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- `SensitivityLabel` can be either a string label ID or an `IPptLabelObject` instance from `GetSensitivityLabel`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/CopyPasteSlide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/CopyPasteSlide.md
@@ -1,0 +1,44 @@
+# Copy Paste Slide
+
+`UiPath.Presentations.Activities.CopyPasteSlide`
+
+Copies a slide from one presentation and pastes it to another position, optionally in a different presentation. Can also move slides.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SourcePresentation` | Source presentation | InArgument | `IPresentationQuickHandle` | Yes | | | The presentation from which to copy the slide |
+| `SlideToCopy` | The index of the slide to copy | InArgument | `int` | Yes | | | The index of the slide to copy |
+| `DestinationPresentation` | Destination presentation | InArgument | `IPresentationQuickHandle` | Yes | | | The presentation to which the slide will be copied |
+| `WhereToInsert` | Where to insert | InArgument | `int` | Yes | | | The index at which to insert the copied slide |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Move` | Move | `bool` | `false` | Whether to move (delete original) or copy the slide |
+
+## XAML Example
+
+```xml
+<pres:CopyPasteSlide
+    DisplayName="Copy Slide"
+    SourcePresentation="[sourcePresentation]"
+    SlideToCopy="[1]"
+    DestinationPresentation="[destPresentation]"
+    WhereToInsert="[3]"
+    Move="False" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Source and destination presentations must both be open within `PowerPointApplicationScope` scopes
+- Set `Move` to `true` to remove the slide from the source presentation after copying

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/DeleteSlide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/DeleteSlide.md
@@ -1,0 +1,32 @@
+# Delete Slide
+
+`UiPath.Presentations.Activities.DeleteSlide`
+
+Deletes a slide from a presentation using the PowerPoint Interop API.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation from which to delete the slide |
+| `DeletePosition` | Slide number | InArgument | `int` | Yes | | | Position of the slide to delete |
+
+## XAML Example
+
+```xml
+<pres:DeleteSlide
+    DisplayName="Delete Slide"
+    Presentation="[presentation]"
+    DeletePosition="[3]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/FindAndReplaceTextInPresentation.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/FindAndReplaceTextInPresentation.md
@@ -1,0 +1,52 @@
+# Replace Text in Presentation
+
+`UiPath.Presentations.Activities.FindAndReplaceTextInPresentation`
+
+Replaces all occurrences of a text within a presentation with another text using the PowerPoint Interop API.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation in which to search and replace text |
+| `SearchFor` | Find what | InArgument | `string` | Yes | | | The text to be replaced. Only String variables and strings are supported |
+| `ReplaceWith` | Replace with | InArgument | `string` | Yes | | | The text to replace with. Only String variables and strings are supported |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `MatchCase` | Match case | `bool` | `false` | Whether to replace text that only matches specific capitalization |
+| `WholeWordsOnly` | Whole words only | `bool` | `false` | Whether to replace entire words, not parts of a longer word. Throws if the search text contains non-alphanumeric characters |
+| `ReplaceAll` | Replace All | `bool` | `true` | Replace all occurrences. If false, only the first occurrence is replaced |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `NumberOfReplacements` | Number of replacements | `int` | The number of replacements made |
+
+## XAML Example
+
+```xml
+<pres:FindAndReplaceTextInPresentation
+    DisplayName="Replace Text"
+    Presentation="[presentation]"
+    SearchFor="[&quot;{{date}}&quot;]"
+    ReplaceWith="[DateTime.Now.ToString(&quot;yyyy-MM-dd&quot;)]"
+    MatchCase="True"
+    ReplaceAll="True"
+    NumberOfReplacements="[replacementCount]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- `WholeWordsOnly` is disabled in PowerPoint when using non-alphanumeric characters

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/FormatSlideContent.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/FormatSlideContent.md
@@ -1,0 +1,72 @@
+# Format Slide Content
+
+`UiPath.Presentations.Activities.FormatSlideContent`
+
+Modifies formatting of slide content elements such as Z-index, font size, or shape name using the PowerPoint Interop API.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation in which to modify content |
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | Slide number containing the content to update |
+| `ShapeName` | Content to modify | InArgument | `string` | Yes | | | Name of the element to modify |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ModificationToAdd` | Modification type | `FormatSlideContentModificationType` | | The type of modification to apply. Used with the Add modification button |
+| `AddModification` | Add modification | ActionButton | | Designer button to add the selected modification type |
+
+### Enum Reference
+
+**`FormatSlideContentModificationType`**: `ZIndex` (Bring to front / Send to back), `FontSize` (Set font size), `ChangeShapeName` (Change shape name)
+
+## Child Activities (Modifications)
+
+When the **Add modification** button is clicked in the designer, a child activity is added inside the `FormatSlideContent` scope based on the selected `ModificationToAdd` value. Each child activity represents a single formatting operation:
+
+| ModificationType | Child Activity Class | Properties |
+|-----------------|---------------------|------------|
+| `ZIndex` | `ZIndexFormatSlideModification` | `Action` (`ZIndexChangeType`, required, default `BringToFront`) — the Z-order action to apply |
+| `FontSize` | `FontSizeFormatSlideContentModification` | `FontSize` (InArgument `int`, required) — the font size to set |
+| `ChangeShapeName` | `ChangeShapeNameSlideContentModification` | `NewShapeName` (InArgument `string`, required) — the new name to assign to the shape |
+
+**`ZIndexChangeType`**: `BringToFront`, `SendToBack`
+
+Multiple modifications can be stacked inside a single `FormatSlideContent` activity.
+
+## XAML Example
+
+```xml
+<pres:FormatSlideContent
+    DisplayName="Format Slide Content"
+    Presentation="[presentation]"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Title 1&quot;]">
+    <pres:FontSizeFormatSlideContentModification
+        DisplayName="Set font size"
+        FontSize="[24]" />
+    <pres:ZIndexFormatSlideModification
+        DisplayName="Bring to front / Send to back"
+        Action="BringToFront" />
+    <pres:ChangeShapeNameSlideContentModification
+        DisplayName="Change shape name"
+        NewShapeName="[&quot;UpdatedTitle&quot;]" />
+</pres:FormatSlideContent>
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- At least one child modification is required — the activity fails validation if no modifications are added
+- Modifications are added via the designer's Add modification button; each modification type creates a child activity element in XAML
+- Multiple modifications can be applied in a single `FormatSlideContent` invocation

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/GetSensitivityLabel.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/GetSensitivityLabel.md
@@ -1,0 +1,38 @@
+# Get Sensitivity Label
+
+`UiPath.Presentations.Activities.GetSensitivityLabel`
+
+Retrieves the sensitivity label from a PowerPoint file.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | The presentation from which to retrieve the sensitivity label |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SensitivityLabel` | Sensitivity Label | `IPptLabelObject` | The sensitivity label retrieved from the presentation |
+
+## XAML Example
+
+```xml
+<pres:GetSensitivityLabel
+    DisplayName="Get Sensitivity Label"
+    Presentation="[presentation]"
+    SensitivityLabel="[labelResult]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- Returns an `IPptLabelObject` with `LabelId` and `Justification` properties

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/InsertFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/InsertFile.md
@@ -1,0 +1,40 @@
+# Add File to Slide
+
+`UiPath.Presentations.Activities.InsertFile`
+
+Inserts a file from disk into a slide and displays it as an icon.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation where to insert the file |
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | The index of the slide to insert into |
+| `ShapeName` | Content placeholder | InArgument | `string` | | | | The name of the shape where to insert |
+| `FilePath` | File to add | InArgument | `string` | Yes | | | The path to the file to insert |
+| `IconLabel` | Icon label | InArgument | `string` | | | | Caption for the icon. Defaults to the file name |
+| `NewShapeName` | New shape name | InArgument | `string` | | | | New name to assign to the shape |
+
+## XAML Example
+
+```xml
+<pres:InsertFile
+    DisplayName="Add File to Slide"
+    Presentation="[presentation]"
+    SlideIndex="[2]"
+    FilePath="[&quot;C:\Documents\report.pdf&quot;]"
+    IconLabel="[&quot;Q4 Report&quot;]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- The file is embedded as an OLE object and displayed as an icon
+- `ShapeName` is optional — if omitted, the file is inserted at a default position on the slide

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/InsertSlide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/InsertSlide.md
@@ -1,0 +1,58 @@
+# Add New Slide
+
+`UiPath.Presentations.Activities.InsertSlide`
+
+Inserts a new slide into a presentation using the PowerPoint Interop API.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation where to insert the slide |
+| `SlideMasterName` | Slide Master | InArgument | `string` | Yes | `"(default)"` | | The name of the Slide Master containing the desired layout. When set to `"(default)"`, the first available slide master is used automatically |
+| `LayoutName` | Layout | InArgument | `string` | Yes | | | The name of the layout |
+| `InsertPosition` | Insert position | InArgument | `int` | | | | Position at which to insert the new slide (visible only when `InsertType` is `SpecifiedIndex`) |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertType` | Add as | `InsertPositionType` | `End` | Position where to insert: Beginning, End, or a specific index |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `InsertedAtPosition` | Save new slide number as | `int` | The index at which the slide was inserted |
+
+### Conditional Properties
+
+- **`InsertPosition`** (`int`) — Only visible when `InsertType` is `SpecifiedIndex`. Hidden when `InsertType` is `Beginning` or `End`.
+
+### Enum Reference
+
+**`InsertPositionType`**: `SpecifiedIndex` (At specified index), `Beginning` (At start), `End` (At end)
+
+## XAML Example
+
+```xml
+<pres:InsertSlide
+    DisplayName="Add New Slide"
+    Presentation="[presentation]"
+    SlideMasterName="[&quot;(default)&quot;]"
+    LayoutName="[&quot;Title and Content&quot;]"
+    InsertType="End"
+    InsertedAtPosition="[newSlideIndex]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- `InsertPosition` is only shown when `InsertType` is `SpecifiedIndex`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/InsertTextInPresentation.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/InsertTextInPresentation.md
@@ -1,0 +1,43 @@
+# Add Text to Slide
+
+`UiPath.Presentations.Activities.InsertTextInPresentation`
+
+Inserts text into a placeholder using the PowerPoint Interop API.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation where to insert |
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | The index of the slide containing the desired text form |
+| `ShapeName` | Content placeholder | InArgument | `string` | Yes | | | The name of the shape where to insert |
+| `Text` | Text to add | InArgument | `string` | Yes | | | Text to insert |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ClearExistingText` | Clear existing text in content placeholder | `bool` | `false` | If true, clears the text in the content placeholder before adding the new text |
+
+## XAML Example
+
+```xml
+<pres:InsertTextInPresentation
+    DisplayName="Add Text to Slide"
+    Presentation="[presentation]"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Title 1&quot;]"
+    Text="[&quot;Quarterly Report&quot;]"
+    ClearExistingText="True" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PasteIntoSlide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PasteIntoSlide.md
@@ -1,0 +1,43 @@
+# Paste Item into Slide
+
+`UiPath.Presentations.Activities.PasteIntoSlide`
+
+Pastes the clipboard content into a slide in a presentation.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation in which to paste the item |
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | Slide number on which to paste the item |
+| `ShapeName` | Content placeholder | InArgument | `string` | Yes | | | Placeholder shape on the slide where the item will be pasted |
+| `Left` | Left | InArgument | `float?` | | | | How far right to move the item |
+| `Top` | Top | InArgument | `float?` | | | | How far down to move the item |
+| `Width` | Item width | InArgument | `float?` | | | | Width of the inserted item |
+| `Height` | Item height | InArgument | `float?` | | | | Height of the inserted item |
+| `NewShapeName` | New shape name | InArgument | `string` | | | | New name to assign to the shape |
+
+## XAML Example
+
+```xml
+<pres:PasteIntoSlide
+    DisplayName="Paste Item into Slide"
+    Presentation="[presentation]"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Content Placeholder&quot;]"
+    Width="[400.0F]"
+    Height="[300.0F]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- Requires content to already be on the clipboard before this activity runs
+- Position and size are optional; when omitted, uses the placeholder's dimensions

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PowerPointApplicationScope.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PowerPointApplicationScope.md
@@ -1,0 +1,63 @@
+# Use PowerPoint Presentation
+
+`UiPath.Presentations.Activities.PowerPointApplicationScope`
+
+Opens or creates a PowerPoint file for use in automation. Acts as a scope container for Windows-based PowerPoint activities that require an open presentation handle (`IPresentationQuickHandle`).
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `PresentationPath` | Path | InArgument | `string` | Yes | | | The path to the presentation |
+| `Password` | Password | InArgument | `string` | | | | The password for opening the presentation, if needed |
+| `EditPassword` | Edit password | InArgument | `string` | | | | The editing password, if needed |
+| `SensitivityLabel` | Sensitivity label | InArgument | `object` | | | | String ID for the sensitivity label or an `IPptLabelObject` instance. Used only when `SensitivityOperation` is `Add` |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `AutoSave` | Save changes | `bool` | `true` | Saves the presentation after each PowerPoint activity that makes a change to its content |
+| `CreateIfNotExists` | Create if not exists | `bool` | `true` | If the presentation cannot be found at the specified path, a new PowerPoint presentation is created. When cleared, an error is thrown instead |
+| `ReadOnly` | Read only | `bool` | `false` | Opens the presentation in read-only mode. Enables data extraction from locked or edit-password-protected files |
+| `SensitivityOperation` | Sensitivity operation | `PptLabelOperation` | `None` | Sensitivity label operation to apply when opening the presentation |
+
+### Scope Reference
+
+This is a scope activity. Child activities receive a presentation handle via a `DelegateInArgument<IPresentationQuickHandle>` defined inside the `Body` property. In the designer, this appears as the **Reference as** field (default: `"PowerPoint"`). In XAML, the reference name is serialized as the `Name` attribute of the `DelegateInArgument` element.
+
+### Enum Reference
+
+**`PptLabelOperation`**: `None` (No operation), `Add` (Add or update sensitivity label), `Clear` (Remove sensitivity label)
+
+## XAML Example
+
+```xml
+<pres:PowerPointApplicationScope
+    DisplayName="Use PowerPoint Presentation"
+    PresentationPath="[&quot;C:\Presentations\report.pptx&quot;]"
+    AutoSave="True">
+    <pres:PowerPointApplicationScope.Body>
+        <ActivityAction x:TypeArguments="pres:IPresentationQuickHandle">
+            <ActivityAction.Argument>
+                <DelegateInArgument x:TypeArguments="pres:IPresentationQuickHandle" Name="presentation" />
+            </ActivityAction.Argument>
+            <!-- Child activities go here, referencing [presentation] -->
+        </ActivityAction>
+    </pres:PowerPointApplicationScope.Body>
+</pres:PowerPointApplicationScope>
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint to be installed
+- This is a scope activity: Windows-based PowerPoint activities that take `IPresentationQuickHandle` must be placed inside this scope
+- The `DelegateInArgument` name (shown as "Reference as" in the designer) defines how child activities reference the presentation handle
+- `SensitivityLabel` is only used when `SensitivityOperation` is `Add`
+- `CreateIfNotExists` defaults to `true` — if the file doesn't exist, a new presentation is created

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentAddTextToSlide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentAddTextToSlide.md
@@ -1,0 +1,52 @@
+# Add Text to Slide
+
+`UiPath.Presentations.Activities.PptDocumentAddTextToSlide`
+
+Inserts text into a placeholder. This activity can be used without Desktop PowerPoint installed and is faster than its Interop equivalent.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | The index of the slide containing the desired text form |
+| `ShapeName` | Content placeholder | InArgument | `string` | Yes | | | The name of the shape where to insert |
+| `Text` | Text to add | InArgument | `string` | Yes | | | Text to insert |
+| `FilePath` | Presentation (local path) | InArgument | `string` | Conditional | | | Presentation where to insert |
+| `PathResource` | Presentation | InArgument | `IResource` | Conditional | | | Presentation where to insert |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ClearExistingText` | Clear existing text in content placeholder | `bool` | `false` | If true, clears the text in the content placeholder before adding the new text |
+
+## Valid Configurations
+
+This activity supports two file input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Resource**: Set `PathResource` to an `IResource` handle from UiPath's storage system.
+**Mode B — Local Path**: Set `FilePath` to a local file path string.
+
+Properties `FilePath` and `PathResource` are mutually exclusive.
+
+## XAML Example
+
+```xml
+<pres:PptDocumentAddTextToSlide
+    DisplayName="Add Text to Slide"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Title 1&quot;]"
+    Text="[&quot;Hello World&quot;]"
+    FilePath="[&quot;C:\Presentations\demo.pptx&quot;]"
+    ClearExistingText="True" />
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentCreateNew.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentCreateNew.md
@@ -1,0 +1,77 @@
+# Create New PowerPoint Document
+
+`UiPath.Presentations.Activities.PptDocumentCreateNew`
+
+Creates a new PowerPoint document at the specified location, optionally based on a template.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `FilePath` | Path | InArgument | `string` | Yes | | | The path for the new PowerPoint presentation |
+| `UseTemplate` | Use Template | Property | `bool` | | `false` | | When enabled, creates the presentation using a template. When disabled, creates a blank presentation |
+| `TemplatePath` | Template Path | InArgument | `string` | Conditional | | | Path to a PowerPoint template file (.potx, .potm, .pptx, .pptm). Visible and required when `UseTemplate` is true and local path mode is selected |
+| `TemplateResource` | Template Resource | InArgument | `IResource` | Conditional | | | File resource used as template. Visible and required when `UseTemplate` is true and resource mode is selected |
+| `PreserveTemplateMetadata` | Preserve Template Metadata | Property | `bool` | | `true` | | When enabled, preserves author/creator info from the template. When disabled, replaces with current user. Visible only when `UseTemplate` is true |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ConflictResolution` | Conflict Behavior | `ConflictBehavior` | `Replace` | What to do if a file already exists at the specified path |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Presentation` | Presentation | `IResource` | The generated PowerPoint presentation as a file resource |
+
+## Valid Configurations
+
+**Mode A — Blank presentation**: Leave `UseTemplate` as `false`. Only `FilePath` is required.
+
+**Mode B — From template (local path)**: Set `UseTemplate` to `true`, provide `TemplatePath`. `TemplateResource` is hidden.
+
+**Mode C — From template (resource)**: Set `UseTemplate` to `true`, provide `TemplateResource`. `TemplatePath` is hidden.
+
+### Conditional Properties
+
+- **`TemplatePath`** / **`TemplateResource`** — Only visible when `UseTemplate` is `true`. Mutually exclusive (switched via designer menu). The visible one becomes required.
+- **`PreserveTemplateMetadata`** — Only visible when `UseTemplate` is `true`.
+
+### Enum Reference
+
+**`ConflictBehavior`**: `Replace` (Replace existing file), `Fail` (Fail if file exists), `Skip` (Skip if file exists, return existing path)
+
+## XAML Example
+
+**Create blank presentation:**
+```xml
+<pres:PptDocumentCreateNew
+    DisplayName="Create New Presentation"
+    FilePath="[&quot;C:\Output\report.pptx&quot;]"
+    ConflictResolution="Replace"
+    Presentation="[newPresentation]" />
+```
+
+**Create from template:**
+```xml
+<pres:PptDocumentCreateNew
+    DisplayName="Create From Template"
+    FilePath="[&quot;C:\Output\report.pptx&quot;]"
+    UseTemplate="True"
+    TemplatePath="[&quot;C:\Templates\corporate.pptx&quot;]"
+    PreserveTemplateMetadata="True"
+    Presentation="[newPresentation]" />
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux
+- Output `Presentation` is an `IResource` handle that can be passed to other portable PowerPoint activities via `PathResource`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentDeleteSlide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentDeleteSlide.md
@@ -1,0 +1,39 @@
+# Delete Slide
+
+`UiPath.Presentations.Activities.PptDocumentDeleteSlide`
+
+Deletes a slide from a presentation. This activity can be used without Desktop PowerPoint installed and is faster than its Interop equivalent.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | Position of the slide to delete |
+| `FilePath` | Presentation (local path) | InArgument | `string` | Conditional | | | Presentation to delete from |
+| `PathResource` | Presentation | InArgument | `IResource` | Conditional | | | Presentation to delete from |
+
+## Valid Configurations
+
+This activity supports two file input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Resource**: Set `PathResource` to an `IResource` handle.
+**Mode B — Local Path**: Set `FilePath` to a local file path string.
+
+## XAML Example
+
+```xml
+<pres:PptDocumentDeleteSlide
+    DisplayName="Delete Slide"
+    SlideIndex="[3]"
+    FilePath="[&quot;C:\Presentations\demo.pptx&quot;]" />
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentFindAndReplaceTextInPresentation.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentFindAndReplaceTextInPresentation.md
@@ -1,0 +1,59 @@
+# Replace Text in Presentation
+
+`UiPath.Presentations.Activities.PptDocumentFindAndReplaceTextInPresentation`
+
+Replaces all occurrences of a text within a presentation with another text. This activity can be used without Desktop PowerPoint installed and is faster than its Interop equivalent.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SearchFor` | Find what | InArgument | `string` | Yes | | | The text to be replaced. Only String variables and strings are supported |
+| `ReplaceWith` | Replace with | InArgument | `string` | Yes | | | The text to replace with. Only String variables and strings are supported. Must not be null or empty |
+| `FilePath` | Presentation (local path) | InArgument | `string` | Conditional | | | Presentation to search |
+| `PathResource` | Presentation | InArgument | `IResource` | Conditional | | | Presentation to search |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `MatchCase` | Match case | `bool` | `false` | Whether to replace text that only matches specific capitalization |
+| `WholeWordsOnly` | Whole words only | `bool` | `false` | Whether to replace entire words, not parts of a longer word. Throws if the search text contains non-alphanumeric characters |
+| `ReplaceAll` | Replace All | `bool` | `true` | Replace all occurrences. If false, only the first occurrence is replaced |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `NumberOfReplacements` | Number of replacements | `int` | The number of replacements made |
+
+## Valid Configurations
+
+This activity supports two file input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Resource**: Set `PathResource` to an `IResource` handle.
+**Mode B — Local Path**: Set `FilePath` to a local file path string.
+
+## XAML Example
+
+```xml
+<pres:PptDocumentFindAndReplaceTextInPresentation
+    DisplayName="Replace Text in Presentation"
+    SearchFor="[&quot;{{placeholder}}&quot;]"
+    ReplaceWith="[&quot;Actual Value&quot;]"
+    FilePath="[&quot;C:\Presentations\report.pptx&quot;]"
+    MatchCase="True"
+    ReplaceAll="True"
+    NumberOfReplacements="[replacementCount]" />
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux
+- `WholeWordsOnly` is not supported when the search text contains non-alphanumeric characters — throws at runtime

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentFormatSlideContent.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentFormatSlideContent.md
@@ -1,0 +1,64 @@
+# Format Slide Content
+
+`UiPath.Presentations.Activities.PptDocumentFormatSlideContent`
+
+Modifies formatting of slide content elements such as Z-order, font size, or shape name. This activity can be used without Desktop PowerPoint installed.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SlideNumber` | Slide number | InArgument | `int` | Yes | | | Slide number containing the content to update |
+| `ContentToModify` | Content to modify | InArgument | `string` | Yes | | | Name of the element to modify |
+| `PathResource` | Presentation | InArgument | `IResource` | Conditional | | | Presentation to modify/format |
+| `Presentation` | Presentation (local path) | InArgument | `string` | Conditional | | | Presentation to modify/format |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ModificationToAdd` | Modification type | `PptDocumentSlideContentModificationType` | | The type of modification to apply. Used with the Add modification button to queue modifications |
+| `AddModification` | Add modification | ActionButton | | Designer button to add the selected modification type to the activity |
+
+## Valid Configurations
+
+This activity supports two file input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Resource**: Set `PathResource` to an `IResource` handle.
+**Mode B — Local Path**: Set `Presentation` to a local file path string.
+
+### Enum Reference
+
+**`PptDocumentSlideContentModificationType`**: `ZOrder` (Change Z-order/layering), `FontSize` (Change font size), `ChangeShapeName` (Rename the shape)
+
+## XAML Example
+
+```xml
+<pres:PptDocumentFormatSlideContent
+    DisplayName="Format Slide Content"
+    SlideNumber="[1]"
+    ContentToModify="[&quot;Title 1&quot;]"
+    PathResource="[presentationResource]">
+    <pres:ShapeFontSizeSlideContentModification
+        DisplayName="Set font size"
+        FontSize="[24]" />
+    <pres:ShapeZOrderSlideContentModification
+        DisplayName="Bring to front / Send to back"
+        Action="BringToFront" />
+    <pres:ShapeChangeNameSlideContentModification
+        DisplayName="Change shape name"
+        NewShapeName="[&quot;UpdatedTitle&quot;]" />
+</pres:PptDocumentFormatSlideContent>
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux
+- At least one child modification is required — the activity fails validation if no modifications are added
+- Modifications are added via the designer's Add modification button; each modification type creates a child element in XAML

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentInsertSlide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentInsertSlide.md
@@ -1,0 +1,77 @@
+# Add New Slide
+
+`UiPath.Presentations.Activities.PptDocumentInsertSlide`
+
+Inserts a new slide into a presentation. This activity can be used without Desktop PowerPoint installed and is faster than its Interop equivalent.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SlideMasterName` | Slide Master | InArgument | `string` | Yes | `"(default)"` | | The name of the Slide Master containing the desired layout. When set to `"(default)"`, the first available slide master is used automatically |
+| `LayoutName` | Layout | InArgument | `string` | Yes | | | The name of the layout |
+| `InsertPosition` | Insert position | InArgument | `int` | | | | Position at which to insert the new slide (visible only when `InsertType` is `SpecifiedIndex`) |
+| `FilePath` | Presentation (local path) | InArgument | `string` | Conditional | | | Presentation where to insert |
+| `PathResource` | Presentation | InArgument | `IResource` | Conditional | | | Presentation where to insert |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertType` | Add as | `InsertPositionType` | `End` | Position where to insert: Beginning, End, or a specific index |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `InsertedAtPosition` | Save new slide number as | `int` | The index at which the slide was inserted |
+
+## Valid Configurations
+
+This activity supports two file input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Resource**: Set `PathResource` to an `IResource` handle.
+**Mode B — Local Path**: Set `FilePath` to a local file path string.
+
+### Conditional Properties
+
+- **`InsertPosition`** (`int`) — Only visible when `InsertType` is `SpecifiedIndex`. Hidden when `InsertType` is `Beginning` or `End`.
+
+### Enum Reference
+
+**`InsertPositionType`**: `SpecifiedIndex` (At specified index), `Beginning` (At start), `End` (At end)
+
+## XAML Example
+
+**Insert at end (default):**
+```xml
+<pres:PptDocumentInsertSlide
+    DisplayName="Add New Slide"
+    SlideMasterName="[&quot;(default)&quot;]"
+    LayoutName="[&quot;Title and Content&quot;]"
+    InsertType="End"
+    FilePath="[&quot;C:\Presentations\demo.pptx&quot;]"
+    InsertedAtPosition="[newSlideIndex]" />
+```
+
+**Insert at specific position:**
+```xml
+<pres:PptDocumentInsertSlide
+    DisplayName="Add New Slide at Position"
+    SlideMasterName="[&quot;(default)&quot;]"
+    LayoutName="[&quot;Blank&quot;]"
+    InsertType="SpecifiedIndex"
+    InsertPosition="[2]"
+    FilePath="[&quot;C:\Presentations\demo.pptx&quot;]"
+    InsertedAtPosition="[newSlideIndex]" />
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentReplaceShapeWithDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentReplaceShapeWithDataTable.md
@@ -1,0 +1,59 @@
+# Add Data Table to Slide
+
+`UiPath.Presentations.Activities.PptDocumentReplaceShapeWithDataTable`
+
+Inserts a data table into a presentation by replacing an empty placeholder or a previous DataTable. This activity can be used without Desktop PowerPoint installed and is faster than its Interop equivalent.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | Slide index that will be modified |
+| `ShapeName` | Content placeholder | InArgument | `string` | Yes | | | Placeholder on the slide where the table will be created |
+| `TableToInsert` | Table to add | InArgument | `DataTable` | Yes | | | The DataTable to insert into the slide |
+| `FilePath` | Presentation (local path) | InArgument | `string` | Conditional | | | Presentation where to insert |
+| `PathResource` | Presentation | InArgument | `IResource` | Conditional | | | Presentation where to insert |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ExcludeHeaders` | Exclude source headers | `bool` | `false` | If checked, the activity will not copy the first line of the source range |
+| `AppendMode` | Behavior | `TableAppendMode` | `CreateNewTable` | How the table data should be added to the slide |
+| `StartRow` | Overwrite starting in row | `int` | `0` | Overwrite data starting in a specified row (0 is the header row, 1 is the first data row) |
+| `StartColumn` | Overwrite starting in column | `int` | `1` | Overwrite data starting in a specified column (1 is the first column) |
+
+## Valid Configurations
+
+This activity supports two file input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Resource**: Set `PathResource` to an `IResource` handle.
+**Mode B — Local Path**: Set `FilePath` to a local file path string.
+
+### Enum Reference
+
+**`TableAppendMode`**: `CreateNewTable` (Replace shape with new table), `AppendToTable` (Append data to existing table), `OverwriteExistingData` (Overwrite cells in existing table)
+
+## XAML Example
+
+```xml
+<pres:PptDocumentReplaceShapeWithDataTable
+    DisplayName="Add Data Table to Slide"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Table Placeholder&quot;]"
+    TableToInsert="[myDataTable]"
+    FilePath="[&quot;C:\Presentations\report.pptx&quot;]"
+    AppendMode="CreateNewTable"
+    ExcludeHeaders="False" />
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux
+- `StartRow` and `StartColumn` are most relevant when `AppendMode` is `OverwriteExistingData`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentReplaceShapeWithMedia.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/PptDocumentReplaceShapeWithMedia.md
@@ -1,0 +1,53 @@
+# Add Image/Video to Slide
+
+`UiPath.Presentations.Activities.PptDocumentReplaceShapeWithMedia`
+
+Replaces a placeholder shape with a media element (image or video). This activity can be used without Desktop PowerPoint installed and is faster than its Interop equivalent.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | The index of the slide on which to do the replacement |
+| `ShapeName` | Shape Name | InArgument | `string` | Yes | | | The name of the shape to replace with media |
+| `Media` | Image/Video file | InArgument | `string` | Yes | | | Absolute path to an existing media file (image or video) to use for replacement |
+| `FilePath` | Presentation (local path) | InArgument | `string` | Conditional | | | Presentation where to insert |
+| `PathResource` | Presentation | InArgument | `IResource` | Conditional | | | Presentation where to insert |
+| `NewShapeName` | New Shape Name | InArgument | `string` | | | | The new name to assign to the shape |
+| `Left` | Left | InArgument | `float?` | | | | How far right to move the item (points). Must not be negative |
+| `Top` | Top | InArgument | `float?` | | | | How far down to move the item (points). Must not be negative |
+| `Width` | Item width | InArgument | `float?` | | | | Width of the inserted item (points). Must not be less than 50 |
+| `Height` | Item height | InArgument | `float?` | | | | Height of the inserted item (points). Must not be less than 50 |
+
+## Valid Configurations
+
+This activity supports two file input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Resource**: Set `PathResource` to an `IResource` handle.
+**Mode B — Local Path**: Set `FilePath` to a local file path string.
+
+## XAML Example
+
+```xml
+<pres:PptDocumentReplaceShapeWithMedia
+    DisplayName="Add Image to Slide"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Picture Placeholder&quot;]"
+    Media="[&quot;C:\Images\logo.png&quot;]"
+    FilePath="[&quot;C:\Presentations\demo.pptx&quot;]"
+    Width="[200.0F]"
+    Height="[150.0F]" />
+```
+
+## Notes
+
+- Does not require Desktop PowerPoint to be installed (uses OpenXML SDK)
+- Cross-platform: works on both Windows and Linux
+- Position and size values are in points
+- When position/size values are not specified, the media inherits the placeholder's dimensions
+- `Left` and `Top` must not be negative; `Width` and `Height` must not be less than 50

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/ReplaceShapeWithDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/ReplaceShapeWithDataTable.md
@@ -1,0 +1,52 @@
+# Add Data Table to Slide
+
+`UiPath.Presentations.Activities.ReplaceShapeWithDataTable`
+
+Inserts a data table into a presentation by replacing an empty placeholder or a previous DataTable, using the PowerPoint Interop API.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation in which to insert the table |
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | Slide number on which to insert the table |
+| `ShapeName` | Content placeholder | InArgument | `string` | Yes | | | Placeholder shape on the slide where the table will be created |
+| `TableToInsert` | Table to add | InArgument | `DataTable` | Yes | | | The DataTable to insert into the slide |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ExcludeHeaders` | Exclude source headers | `bool` | `false` | If checked, the activity will not copy the first line of the source range |
+| `AppendMode` | Behavior | `TableAppendMode` | `CreateNewTable` | How the table data should be added to the slide |
+| `StartRow` | Overwrite starting in row | `int` | `0` | Overwrite data starting in a specified row (0 = header row, 1 = first data row) |
+| `StartColumn` | Overwrite starting in column | `int` | `1` | Overwrite data starting in a specified column (1 = first column) |
+
+### Enum Reference
+
+**`TableAppendMode`**: `CreateNewTable` (Replace shape with new table), `AppendToTable` (Append data to existing table), `OverwriteExistingData` (Overwrite cells in existing table)
+
+## XAML Example
+
+```xml
+<pres:ReplaceShapeWithDataTable
+    DisplayName="Add Data Table to Slide"
+    Presentation="[presentation]"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Table Placeholder&quot;]"
+    TableToInsert="[myDataTable]"
+    AppendMode="CreateNewTable"
+    ExcludeHeaders="False" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- `StartRow` and `StartColumn` are most relevant when `AppendMode` is `OverwriteExistingData`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/ReplaceShapeWithMedia.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/ReplaceShapeWithMedia.md
@@ -1,0 +1,46 @@
+# Add Image/Video to Slide
+
+`UiPath.Presentations.Activities.ReplaceShapeWithMedia`
+
+Replaces a placeholder shape with a media element (image or video) using the PowerPoint Interop API.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation in which to do the replacement |
+| `SlideIndex` | Slide number | InArgument | `int` | Yes | | | The index of the slide on which to do the replacement |
+| `ShapeName` | Shape Name | InArgument | `string` | Yes | | | The name of the shape to replace with media |
+| `Media` | Image/Video file | InArgument | `string` | Yes | | | Media to use for replacement. Must be a valid absolute file path to an existing file |
+| `NewShapeName` | New Shape Name | InArgument | `string` | | | | The new name to assign to the shape selected |
+| `Left` | Left | InArgument | `float?` | | | | Specify how far right to move the item (points). Must not be negative |
+| `Top` | Top | InArgument | `float?` | | | | Specify how far down to move the item (points). Must not be negative |
+| `Width` | Item width | InArgument | `float?` | | | | Width of the inserted item (points). Must not be less than 50 |
+| `Height` | Item height | InArgument | `float?` | | | | Height of the inserted item (points). Must not be less than 50 |
+
+## XAML Example
+
+```xml
+<pres:ReplaceShapeWithMedia
+    DisplayName="Add Image to Slide"
+    Presentation="[presentation]"
+    SlideIndex="[1]"
+    ShapeName="[&quot;Picture Placeholder&quot;]"
+    Media="[&quot;C:\Images\chart.png&quot;]"
+    Width="[300.0F]"
+    Height="[200.0F]" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- Position and size values are in points
+- When position/size are not specified, the media inherits the placeholder's dimensions
+- `Left` and `Top` must not be negative; `Width` and `Height` must not be less than 50

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/RunMacro.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/RunMacro.md
@@ -1,0 +1,66 @@
+# Run Presentation Macro
+
+`UiPath.Presentations.Activities.RunMacro`
+
+Runs a specified macro in a macro-enabled PowerPoint presentation.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation name | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation containing the macro to run |
+| `MacroName` | Macro name | InArgument | `string` | Yes | | | Name of the macro to run |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `AddMacroArgument` | Add Macro Argument | ActionButton | | Designer button to add an argument to pass to the macro |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Returned value | `object` | The value returned by the macro (if any) |
+
+## Child Activities (Macro Arguments)
+
+When the **Add Macro Argument** button is clicked in the designer, a `RunMacroArgument` child activity is added inside the `RunMacro` scope. Each child represents one positional argument passed to the macro.
+
+| Child Activity Class | Properties |
+|---------------------|------------|
+| `RunMacroArgument` | `ArgumentValue` (InArgument `object`, required) — the value to pass to the macro's input argument |
+
+Multiple `RunMacroArgument` children can be stacked; they are passed to the macro in order.
+
+## XAML Example
+
+```xml
+<pres:RunMacro
+    DisplayName="Run Presentation Macro"
+    Presentation="[presentation]"
+    MacroName="[&quot;Module1.FormatAllSlides&quot;]"
+    Result="[macroResult]">
+    <pres:RunMacroArgument
+        DisplayName="Macro Argument"
+        ArgumentValue="[&quot;Slide1&quot;]" />
+    <pres:RunMacroArgument
+        DisplayName="Macro Argument"
+        ArgumentValue="[42]" />
+</pres:RunMacro>
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- The presentation must be macro-enabled (.pptm format)
+- Macro arguments are added via the designer's Add Macro Argument button; each argument creates a child activity element in XAML
+- Arguments are passed to the macro in the order they appear
+- The macro name should include the module name (e.g., `Module1.MacroName`)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/SavePresentationAsPdf.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/SavePresentationAsPdf.md
@@ -1,0 +1,39 @@
+# Save Presentation as PDF
+
+`UiPath.Presentations.Activities.SavePresentationAsPdf`
+
+Exports a PowerPoint presentation to PDF format.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation to save as PDF |
+| `PdfPath` | Save as file | InArgument | `string` | Yes | | | The path where the PDF will be saved |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ReplaceExisting` | Replace existing | `bool` | `true` | If a file with this name already exists, replace it. Otherwise an error occurs |
+
+## XAML Example
+
+```xml
+<pres:SavePresentationAsPdf
+    DisplayName="Save as PDF"
+    Presentation="[presentation]"
+    PdfPath="[&quot;C:\Output\report.pdf&quot;]"
+    ReplaceExisting="True" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/SavePresentationFileAs.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/activities/SavePresentationFileAs.md
@@ -1,0 +1,46 @@
+# Save PowerPoint File As
+
+`UiPath.Presentations.Activities.SavePresentationFileAs`
+
+Saves a PowerPoint file as a new file in the specified format.
+
+**Package:** `UiPath.Presentations.Activities`
+**Category:** PowerPoint.Windows
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `Presentation` | Presentation | InArgument | `IPresentationQuickHandle` | Yes | | | Presentation to save |
+| `FilePath` | Save as file | InArgument | `string` | Yes | | | Name and location of the new file |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `SaveAsFileType` | Save as type | `PresentationSaveAsType` | `XmlPresentation` | Format to save the presentation |
+| `ReplaceExisting` | Replace existing | `bool` | `true` | If a file with this name already exists, replace it. Otherwise an error occurs |
+
+### Enum Reference
+
+**`PresentationSaveAsType`**: `XmlPresentation` (.pptx format), `MacroEnabledPresentation` (.pptm format), `OldPresentation` (.ppt legacy format)
+
+## XAML Example
+
+```xml
+<pres:SavePresentationFileAs
+    DisplayName="Save PowerPoint File As"
+    Presentation="[presentation]"
+    FilePath="[&quot;C:\Output\report_copy.pptx&quot;]"
+    SaveAsFileType="XmlPresentation"
+    ReplaceExisting="True" />
+```
+
+## Notes
+
+- Windows only — requires Desktop PowerPoint
+- Must be placed inside a `PowerPointApplicationScope`
+- The correct file extension is automatically appended based on `SaveAsFileType` if `FilePath` does not already end with it (e.g., saving as `XmlPresentation` with path `C:\report` produces `C:\report.pptx`)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/coded-api.md
@@ -1,0 +1,416 @@
+# Presentations — Coded Workflow API
+
+`UiPath.Presentations.Activities`
+
+Provides PowerPoint presentation operations for coded workflows using both OpenXml (cross-platform) and COM Interop (Windows-only) engines.
+
+**Service accessor:** `powerpoint` (type `IPresentationsService`)
+**Required package:** `"UiPath.Presentations.Activities": "*"` in project.json dependencies
+
+## Auto-Imported Namespaces
+
+These namespaces are automatically available in coded workflows when this package is installed:
+
+```
+System
+System.Collections.Generic
+System.Data
+UiPath.Presentations
+UiPath.Presentations.Activities
+UiPath.Presentations.Activities.API
+UiPath.Presentations.Activities.API.Models
+```
+
+## Service Overview
+
+The `powerpoint` service provides:
+
+- **Handle-based API** — Call `UsePresentationDocument(...)` or `UsePowerPointPresentation(...)` to open/create a PowerPoint file and receive a disposable handle
+- **OpenXml engine (cross-platform)** — `UsePresentationDocument` returns `IPresentationDocumentHandle` with extension methods for slide operations
+- **COM Interop engine (Windows-only)** — `UsePowerPointPresentation` returns `IPresentation` with extension methods for richer operations including macros, Save As, PDF export, and sensitivity labels
+
+---
+
+## Opening / Creating Presentations (Cross-Platform — OpenXml)
+
+These methods use the OpenXml engine and work on all platforms.
+
+### `IPresentationDocumentHandle UsePresentationDocument(string path)`
+
+Opens a PowerPoint document using OpenXml. If the document does not exist, a new one is created.
+
+**Parameters:**
+- `path` (`string`) — Path of the document
+
+**Returns:** `IPresentationDocumentHandle` — Disposable handle to the presentation. Use with `using` statement.
+
+```csharp
+using var ppt = powerpoint.UsePresentationDocument("report.pptx");
+```
+
+### `IPresentationDocumentHandle UsePresentationDocument(string path, bool createNew)`
+
+Opens a PowerPoint document using OpenXml. Controls whether a new file is created if it does not exist.
+
+**Parameters:**
+- `path` (`string`) — Path of the document
+- `createNew` (`bool`) — If the document does not exist, determines if a new document is created. The single-parameter overload `UsePresentationDocument(path)` always creates if missing; use this overload with `false` to open existing files only
+
+**Returns:** `IPresentationDocumentHandle` — Disposable handle to the presentation.
+
+```csharp
+// Open existing only — throws if file does not exist
+using var ppt = powerpoint.UsePresentationDocument("existing.pptx", createNew: false);
+```
+
+### `IPresentationDocumentHandle UsePresentationDocument(PresentationCreateOptions options)`
+
+Creates a new PowerPoint document using OpenXml with full control over creation options, including template usage, metadata preservation, and conflict resolution.
+
+**Parameters:**
+- `options` (`PresentationCreateOptions`) — Options for creating the presentation
+
+**Returns:** `IPresentationDocumentHandle` — Disposable handle to the presentation.
+
+```csharp
+using var ppt = powerpoint.UsePresentationDocument(new PresentationCreateOptions
+{
+    Path = "report.pptx",
+    TemplatePath = "template.potx",
+    PreserveTemplateMetadata = false,
+    ConflictResolution = ConflictBehavior.Replace,
+    CreateNew = true
+});
+```
+
+---
+
+## Opening / Creating Presentations (Windows-Only — COM Interop)
+
+These methods use the PowerPoint COM Interop engine. **Windows only.**
+
+### `IPresentation UsePowerPointPresentation(string path)`
+
+Opens or creates a PowerPoint file.
+
+**Parameters:**
+- `path` (`string`) — The path of the PowerPoint file
+
+**Returns:** `IPresentation` — Disposable handle for presentation operations.
+
+```csharp
+using var ppt = powerpoint.UsePowerPointPresentation("report.pptx");
+```
+
+### `IPresentation UsePowerPointPresentation(string path, bool saveChanges, bool createIfNotExist)`
+
+Opens or creates a PowerPoint file with save and creation control.
+
+**Parameters:**
+- `path` (`string`) — The path of the PowerPoint file
+- `saveChanges` (`bool`) — `true` to save changes after operations
+- `createIfNotExist` (`bool`) — `true` to create the file if it does not exist
+
+**Returns:** `IPresentation` — Disposable handle for presentation operations.
+
+```csharp
+using var ppt = powerpoint.UsePowerPointPresentation("report.pptx",
+    saveChanges: true, createIfNotExist: false);
+```
+
+### `IPresentation UsePowerPointPresentation(UseOptions options)`
+
+Opens or creates a PowerPoint file with full options control.
+
+**Parameters:**
+- `options` (`UseOptions`) — Options for opening or creating the file
+
+**Returns:** `IPresentation` — Disposable handle for presentation operations.
+
+```csharp
+using var ppt = powerpoint.UsePowerPointPresentation(new UseOptions
+{
+    Path = "report.pptx",
+    Password = "secret",
+    AutoSave = true,
+    CreateIfNotExist = true,
+    ReadOnly = false
+});
+```
+
+---
+
+## Handle Types
+
+### `IPresentationDocumentHandle` (Cross-Platform)
+
+Handle to a PowerPoint presentation opened via OpenXml. All operations are provided as extension methods.
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` explicitly.
+
+#### Extension Methods
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `AddTextToSlide(int slideNumber, string contentPlaceholder, string textToAdd, bool clearExisting = false)` | `void` | Inserts text into a placeholder on a slide |
+| `DeleteSlide(int slideNumber)` | `void` | Deletes a slide at the specified position |
+| `AddNewSlide(string layout, InsertPositionType addAs = InsertPositionType.End, string slideMaster = "(default)")` | `int?` | Inserts a new slide and returns the position |
+| `AddNewSlide(int insertPosition, string layout, InsertPositionType addAs = InsertPositionType.End, string slideMaster = "(default)")` | `int?` | Inserts a new slide at a specific position. **Note:** Although the underlying signature is `int?`, passing `null` will throw — always provide a positive integer |
+| `AddDataTableToSlide(int slideNumber, string contentPlaceholder, DataTable tableToAdd, bool excludeHeaders, TableAppendMode behaviour, int startRow, int startColumn)` | `void` | Inserts a DataTable with row/column offsets |
+| `AddDataTableToSlide(int slideNumber, string contentPlaceholder, DataTable tableToAdd, bool excludeHeaders, TableAppendMode behaviour)` | `void` | Inserts a DataTable into a placeholder |
+| `ReplaceTextInPresentation(string findWhat, string replaceWith, bool matchCase = false, bool wholeWordsOnly = false, bool replaceAll = true)` | `int` | Replaces text occurrences; returns replacement count |
+| `AddImageOrVideoToSlide(int slideNumber, string contentPlaceholder, string imageOrVideoFile)` | `void` | Replaces a placeholder with an image or video |
+| `AddImageOrVideoToSlide(int slideNumber, string contentPlaceholder, string imageOrVideoFile, float? left, float? top, float? width, float? height, string newShapeName)` | `void` | Replaces a placeholder with media, with size/position control |
+| `FormatSlideContent(int slideNumber, string contentToModify, List<ISlideContentModicationModel> modifications)` | `void` | Applies formatting modifications to slide content |
+
+### `IPresentation` (Windows-Only)
+
+Handle to a PowerPoint presentation opened via COM Interop. **Windows only.**
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` explicitly.
+
+#### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `NumberOfSlides` | `int` | The number of slides currently in the presentation |
+| `Location` | `string` | The file path or URI of the presentation |
+| `Hwnd` | `int` | Window handle for the presentation |
+| `Pid` | `int` | PID of the PowerPoint process hosting the presentation |
+| `SlideOperations` | `ISlideOperations` | Low-level slide operations. Prefer the extension methods below for coded workflows |
+| `SlideContentOperations` | `ISlideContentOperations` | Low-level content operations. Prefer the extension methods below for coded workflows |
+
+#### Methods
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `BringToFront()` | `void` | Brings the presentation window to front and activates it |
+
+> Additional public methods are also available on `IPresentation` but are not listed here. Use the extension methods below for `SaveAsPdf`, `SaveAs`, and `RunMacro` in coded workflows; call `ClosePresentation` and `ValidateSlideIndex` directly on `IPresentation` as needed (disposing the handle also closes the presentation).
+
+#### Extension Methods
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `AddTextToSlide(int slideNumber, string contentPlaceholder, string textToAdd, bool clearExistingText = true)` | `void` | Inserts text into a placeholder on a slide |
+| `DeleteSlide(int slideNumber)` | `void` | Deletes a slide at the specified position |
+| `AddNewSlide(string layout, InsertPositionType addAs = InsertPositionType.End, string slideMaster = "(default)")` | `int` | Inserts a new slide; returns computed insert position. **Note:** The current implementation does not pass the computed position to the underlying insert call — the slide may not be inserted at the position indicated by `addAs` |
+| `AddNewSlide(string layout, int insertPosition, InsertPositionType addAs = InsertPositionType.End, string slideMaster = "(default)")` | `int` | Inserts a new slide at a specific position. **Note:** Parameter order is `(layout, insertPosition)` here vs `(insertPosition, layout)` in OpenXml |
+| `CopyPasteSlide(IPresentation destinationPresentation, int slideToCopy, int whereToInsert, bool move = false)` | `void` | Copies/moves a slide to another presentation |
+| `AddDataTableToSlide(int slideNumber, string contentPlaceholder, DataTable tableToAdd, TableAppendMode behaivour = TableAppendMode.CreateNewTable)` | `void` | Inserts a DataTable into a placeholder |
+| `AddDataTableToSlide(int slideNumber, string contentPlaceholder, DataTable tableToAdd, TableAppendMode behaivour = TableAppendMode.CreateNewTable, bool excludeSourceHeaders = false)` | `void` | Inserts a DataTable with header exclusion option |
+| `AddDataTableToSlide(int slideNumber, string contentPlaceholder, DataTable tableToAdd, bool excludeSourceHeaders, TableAppendMode behaivour, int overwriteStartingInRow, int overwriteStartingInColumn)` | `void` | Inserts a DataTable with row/column offsets |
+| `ReplaceTextInPresentation(string findWhat, string replaceWith, bool matchCase = false, bool wholeWordsOnly = false, bool replaceAll = true)` | `int` | Replaces text occurrences; returns replacement count |
+| `AddImageOrVideoToSlide(int slideNumber, string contentPlaceholder, string imageOrVideoPath)` | `void` | Replaces a placeholder with an image or video |
+| `AddImageOrVideoToSlide(int slideNumber, string contentPlaceholder, string imageOrVideoPath, float? left, float? top, float? width, float? height, string newShapeName)` | `void` | Replaces a placeholder with media, with size/position control |
+| `PasteItemIntoSlide(int slideNumber, string contentPlaceholder)` | `void` | Pastes clipboard content into a slide placeholder |
+| `PasteItemIntoSlide(int slideNumber, string contentPlaceholder, float? left, float? top, float? width, float? height, string newShapeName)` | `void` | Pastes clipboard content with size/position control |
+| `AddFileToSlide(int slideNumber, string fileToAdd)` | `void` | Inserts a file as an icon on a slide |
+| `AddFileToSlide(int slideNumber, string contentPlaceholder, string fileToAdd, string iconLabel)` | `void` | Inserts a file into a placeholder with an icon label |
+| `AddFileToSlide(int slideNumber, string contentPlaceholder, string fileToAdd, string iconLabel, string newShapeName)` | `void` | Inserts a file with icon label and custom shape name |
+| `SavePresentationAs(string filePath, PresentationSaveAsType presentationSaveAsType = PresentationSaveAsType.XmlPresentation, bool replaceExisting = true)` | `void` | Saves presentation as a new file in specified format |
+| `SavePresentationAsPDF(string pathToDestinationPDF, bool replaceExisting = true)` | `void` | Exports presentation to PDF |
+| `RunPresentationMacro(string macroName, IList<object> macroArguments)` | `object` | Runs a macro and returns the result |
+| `FormatSlideContent(int slideNumber, string contentToModify, List<IFormatSlideModicationModel> modifications)` | `void` | Applies formatting modifications to slide content |
+| `AddSensitivityLabel(IPptLabelObject label)` | `void` | Applies a sensitivity label to the presentation |
+| `GetSensitivityLabel()` | `IPptLabelObject` | Retrieves the sensitivity label from the presentation |
+
+> **Note:** The COM `AddDataTableToSlide` parameter name `behaivour` is a known misspelling in the API. The OpenXml equivalent uses the correct spelling `behaviour`. Use the exact spelling shown above when calling COM methods.
+
+---
+
+## Options & Configuration Classes
+
+### `PresentationCreateOptions`
+
+Options for creating a new PowerPoint presentation (OpenXml engine).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Path` | `string` | `null` | Path of the PowerPoint file to create |
+| `TemplatePath` | `string` | `null` | Path to a template file (.potx, .potm, .pptx, .pptm) to use as the base. When null/empty, an embedded default template is used |
+| `PreserveTemplateMetadata` | `bool` | `true` | When true, keeps the original template's author and timestamp metadata. When false, replaces with current user and updates timestamps. Only relevant when TemplatePath is set |
+| `ConflictResolution` | `ConflictBehavior` | `Skip` | How to handle the case when the file already exists |
+| `CreateNew` | `bool` | `true` | If the document at Path does not exist, determines if a new document is created |
+
+### `UseOptions`
+
+Options for opening or creating PowerPoint files (Windows COM Interop engine).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Path` | `string` | `null` | Path of the PowerPoint file |
+| `Password` | `string` | `null` | Password for the PowerPoint file |
+| `EditPassword` | `string` | `null` | Edit password for the PowerPoint file |
+| `CreateIfNotExist` | `bool` | `true` | If true, creates the file if it does not exist |
+| `ReadOnly` | `bool` | `false` | If true, opens the presentation as read-only |
+| `AutoSave` | `bool` | `true` | If true, saves changes after presentation operations |
+| `SensitivityOperation` | `PptLabelOperation` | `None` | Sensitivity label operation to execute when opening/creating the file |
+| `SensitivityLabel` | `PptLabelObject` | `null` | Sensitivity label object to apply. Only used if SensitivityOperation is `Add` |
+
+### `IPptLabelObject` / `PptLabelObject`
+
+Represents a sensitivity label to apply to a presentation (Windows-only).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `LabelId` | `string` | `null` | Sensitivity label ID |
+| `Justification` | `string` | `null` | Justification for changing the label |
+
+---
+
+## Enum Reference
+
+**`ConflictBehavior`**: `Replace`, `Fail`, `Skip`
+- `Replace` — Deletes the existing file and creates a new one
+- `Fail` — Throws an exception if the file already exists
+- `Skip` — Keeps the existing file and opens it as-is (default)
+
+**`InsertPositionType`**: `SpecifiedIndex`, `Beginning`, `End`
+- `SpecifiedIndex` — Insert at a specific slide index
+- `Beginning` — Insert at the start of the presentation
+- `End` — Insert at the end of the presentation (default)
+
+**`TableAppendMode`**: `CreateNewTable`, `AppendToTable`, `OverwriteExistingData`
+- `CreateNewTable` — Completely replaces the target shape with a new table
+- `AppendToTable` — Appends data to an existing table
+- `OverwriteExistingData` — Overwrites specific cells in an existing table
+
+**`PresentationSaveAsType`** (Windows-only): `XmlPresentation`, `MacroEnabledPresentation`, `OldPresentation`
+- `XmlPresentation` — PowerPoint .pptx format (default)
+- `MacroEnabledPresentation` — PowerPoint .pptm format
+- `OldPresentation` — Legacy .ppt format
+
+**`PptLabelOperation`** (Windows-only): `None`, `Add`, `Clear`
+- `None` — No sensitivity label operation
+- `Add` — Add or update the sensitivity label
+- `Clear` — Remove the sensitivity label
+
+**`ZOrderChangeType`** (OpenXml): `BringToFront`, `SendToBack` — Used with `ShapeZOrderModificationModel` in `FormatSlideContent` modifications
+
+**`ZIndexChangeType`** (Windows): `BringToFront`, `SendToBack` — Used with `ZIndexModificationModel` in `FormatSlideContent` modifications
+
+---
+
+## Modification Models
+
+> **Coded workflows limitation.** The built-in modification model types have `internal` constructors and cannot be instantiated directly from coded workflows. However, the `FormatSlideContent` extension method can still be used by providing custom implementations of the public interfaces described below.
+
+### `ISlideContentModicationModel` (Cross-Platform)
+
+Interface for slide content modifications used with `FormatSlideContent` (OpenXml engine). Built-in implementations (not directly constructible from coded workflows):
+
+| Class | Constructor Parameters | Description |
+|-------|----------------------|-------------|
+| `ShapeZOrderModificationModel` | `ZOrderChangeType zOrderChange` | Changes a shape's Z-order (bring to front or send to back) |
+| `ShapeFontSizeModificationModel` | `int fontSize` | Changes the font size of text in a shape |
+| `ShapeChangeNameModel` | `string newName` | Renames a shape |
+
+### `IFormatSlideModicationModel` (Windows-Only)
+
+Interface for slide content modifications used with `FormatSlideContent` (COM Interop engine). Built-in implementations (not directly constructible from coded workflows):
+
+| Class | Constructor Parameters | Description |
+|-------|----------------------|-------------|
+| `ZIndexModificationModel` | `ZIndexChangeType zIndexChange` | Changes a shape's Z-index (bring to front or send to back) |
+| `FontSizeModificationModel` | `int fontSize` | Changes the font size of text in a shape |
+| `ChangeShapeNameModel` | `string newName` | Renames a shape |
+
+---
+
+## Common Patterns
+
+### Open a presentation and add text to a slide (cross-platform)
+
+> **Engine difference:** `AddTextToSlide` defaults to `clearExisting: false` (OpenXml) vs `clearExistingText: true` (COM). When switching engines, explicitly pass this parameter to avoid unexpected append/replace behavior.
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var ppt = powerpoint.UsePresentationDocument("report.pptx");
+    ppt.AddTextToSlide(1, "Title 1", "Quarterly Report", clearExisting: true);
+    ppt.AddTextToSlide(1, "Content Placeholder 1", "Revenue grew 15% this quarter.");
+}
+```
+
+### Create a presentation from a template and insert a data table (cross-platform)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var ppt = powerpoint.UsePresentationDocument(new PresentationCreateOptions
+    {
+        Path = "sales-report.pptx",
+        TemplatePath = "corporate-template.potx",
+        PreserveTemplateMetadata = false,
+        ConflictResolution = ConflictBehavior.Replace
+    });
+
+    // Add a title slide
+    ppt.AddNewSlide("Title Slide");
+    ppt.AddTextToSlide(1, "Title 1", "Sales Report");
+
+    // Add a content slide with a data table
+    ppt.AddNewSlide("Title and Content");
+    var salesData = new DataTable("SalesData");
+    salesData.Columns.Add("Region", typeof(string));
+    salesData.Columns.Add("Quarter", typeof(string));
+    salesData.Columns.Add("Sales", typeof(double));
+    salesData.Rows.Add("North", "Q1", 120000.0);
+    salesData.Rows.Add("North", "Q2", 135000.0);
+    salesData.Rows.Add("South", "Q1", 98000.0);
+    salesData.Rows.Add("South", "Q2", 112500.0);
+    ppt.AddDataTableToSlide(2, "Content Placeholder 1", salesData,
+        excludeHeaders: false, behaviour: TableAppendMode.CreateNewTable);
+}
+```
+
+### Find and replace text across the entire presentation (cross-platform)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var ppt = powerpoint.UsePresentationDocument("template.pptx");
+    int replaced = ppt.ReplaceTextInPresentation(
+        findWhat: "{{CompanyName}}",
+        replaceWith: "Acme Corp",
+        matchCase: false,
+        replaceAll: true);
+    Log($"Replaced {replaced} occurrences.");
+}
+```
+
+### Insert images and save as PDF (Windows-only)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var ppt = powerpoint.UsePowerPointPresentation("deck.pptx");
+    ppt.AddImageOrVideoToSlide(1, "Picture Placeholder 1", @"C:\images\chart.png");
+    ppt.AddTextToSlide(1, "Title 1", "Monthly Metrics");
+    ppt.SavePresentationAsPDF(@"C:\output\deck.pdf", replaceExisting: true);
+}
+```
+
+### Copy slides between presentations and run a macro (Windows-only)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var source = powerpoint.UsePowerPointPresentation("source.pptx");
+    using var dest = powerpoint.UsePowerPointPresentation("destination.pptm",
+        saveChanges: true, createIfNotExist: true);
+
+    // Copy slide 2 from source to position 1 in destination
+    source.CopyPasteSlide(dest, slideToCopy: 2, whereToInsert: 1);
+
+    // Run a macro in the destination presentation
+    var result = dest.RunPresentationMacro("FormatAllSlides", new List<object> { "Arial", 12 });
+    Log($"Macro returned: {result}");
+}
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.6/overview.md
@@ -1,0 +1,76 @@
+# UiPath Presentations Activities
+
+`UiPath.Presentations.Activities`
+
+Activities for automating PowerPoint presentations — creating, editing, and formatting slides, inserting text, data tables, media, and managing files.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+
+## Activities
+
+### PowerPoint (Cross-Platform)
+
+These activities use the OpenXML SDK and do **not** require Desktop PowerPoint to be installed. They work on both Windows and Linux.
+
+| Activity | Description |
+|----------|-------------|
+| [Create New PowerPoint Document](activities/PptDocumentCreateNew.md) | Creates a new PowerPoint document, optionally from a template |
+| [Add Text to Slide](activities/PptDocumentAddTextToSlide.md) | Inserts text into a slide placeholder |
+| [Add New Slide](activities/PptDocumentInsertSlide.md) | Inserts a new slide at a specified position |
+| [Delete Slide](activities/PptDocumentDeleteSlide.md) | Deletes a slide from a presentation |
+| [Replace Text in Presentation](activities/PptDocumentFindAndReplaceTextInPresentation.md) | Finds and replaces text across all slides |
+| [Add Data Table to Slide](activities/PptDocumentReplaceShapeWithDataTable.md) | Inserts a DataTable into a slide placeholder |
+| [Add Image/Video to Slide](activities/PptDocumentReplaceShapeWithMedia.md) | Replaces a placeholder with an image or video |
+| [Format Slide Content](activities/PptDocumentFormatSlideContent.md) | Modifies Z-order, font size, or shape name |
+
+### PowerPoint.Windows
+
+These activities use the PowerPoint Interop (COM) API and require Desktop PowerPoint to be installed. **Windows only.**
+
+#### Scope
+
+| Activity | Description |
+|----------|-------------|
+| [Use PowerPoint Presentation](activities/PowerPointApplicationScope.md) | Opens or creates a PowerPoint file as a scope for child activities |
+
+#### Slide Operations
+
+| Activity | Description |
+|----------|-------------|
+| [Add New Slide](activities/InsertSlide.md) | Inserts a new slide at a specified position |
+| [Delete Slide](activities/DeleteSlide.md) | Deletes a slide from a presentation |
+| [Copy Paste Slide](activities/CopyPasteSlide.md) | Copies or moves a slide between presentations |
+
+#### Content
+
+| Activity | Description |
+|----------|-------------|
+| [Add Text to Slide](activities/InsertTextInPresentation.md) | Inserts text into a slide placeholder |
+| [Replace Text in Presentation](activities/FindAndReplaceTextInPresentation.md) | Finds and replaces text across all slides |
+| [Add Data Table to Slide](activities/ReplaceShapeWithDataTable.md) | Inserts a DataTable into a slide placeholder |
+| [Add Image/Video to Slide](activities/ReplaceShapeWithMedia.md) | Replaces a placeholder with an image or video |
+| [Paste Item into Slide](activities/PasteIntoSlide.md) | Pastes clipboard content into a slide |
+| [Add File to Slide](activities/InsertFile.md) | Inserts a file as an icon on a slide |
+| [Format Slide Content](activities/FormatSlideContent.md) | Modifies Z-index, font size, or shape name |
+
+#### File Operations
+
+| Activity | Description |
+|----------|-------------|
+| [Save Presentation as PDF](activities/SavePresentationAsPdf.md) | Exports a presentation to PDF |
+| [Save PowerPoint File As](activities/SavePresentationFileAs.md) | Saves a presentation in a different format |
+
+#### Sensitivity Labels
+
+| Activity | Description |
+|----------|-------------|
+| [Add Sensitivity Label](activities/AddSensitivityLabel.md) | Adds a sensitivity label to a presentation |
+| [Get Sensitivity Label](activities/GetSensitivityLabel.md) | Retrieves the sensitivity label from a presentation |
+
+#### Macros
+
+| Activity | Description |
+|----------|-------------|
+| [Run Presentation Macro](activities/RunMacro.md) | Runs a VBA macro in a macro-enabled presentation |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddDataColumn.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddDataColumn.md
@@ -1,0 +1,66 @@
+# Add Data Column
+
+`UiPath.Core.Activities.AddDataColumn`
+
+Adds a DataColumn to a specified DataTable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InArgument | DataTable | Yes | — | The DataTable to which the column will be added. |
+| ColumnName | Column Name | InArgument | String | Yes* | — | The name of the new column to create. Mutually exclusive with **Column**. Used when defining a new column by name. |
+| Column | Column | InArgument | DataColumn | Yes* | — | An existing DataColumn object to add directly. Mutually exclusive with **Column Name**. |
+
+\* Exactly one of `ColumnName` or `Column` must be provided (overload groups).
+
+### Configuration
+
+When creating a new column by **Column Name**, the following options are available:
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| AllowDBNull | Allow DB Null | InArgument\<Boolean\> | true | Whether the column allows null/DBNull values. |
+| AutoIncrement | Auto Increment | InArgument\<Boolean\> | false | Whether the column value auto-increments. Applicable only to numeric types. When true, **Default Value** is hidden. |
+| DefaultValue | Default Value | InArgument\<T\> | — | Default value for new rows. Hidden when **Auto Increment** is true. |
+| MaxLength | Max Length | InArgument\<Int32\> | 100 | Maximum character length. Visible only when the column type is `String`. |
+| Unique | Unique | InArgument\<Boolean\> | false | Whether column values must be unique across all rows. |
+
+The column's data type `T` (TypeArgument) controls which options are relevant:
+- `AutoIncrement` is only applicable to numeric types (e.g. `Int32`, `Int64`).
+- `MaxLength` is only visible when `T` is `String`.
+- When `Column` (existing DataColumn object) is used, all Options properties are ignored.
+
+## Valid Configurations
+
+| Mode | Required properties |
+|------|-------------------|
+| New column by name | `DataTable` + `ColumnName` (+ optional Options) |
+| Existing column object | `DataTable` + `Column` |
+
+## XAML Example
+
+```xml
+<!-- New String column with name -->
+<ui:AddDataColumn x:TypeArguments="x:String"
+                  DisplayName="Add Data Column"
+                  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:AddDataColumn.DataTable>
+    <InArgument x:TypeArguments="sd:DataTable">[myDataTable]</InArgument>
+  </ui:AddDataColumn.DataTable>
+  <ui:AddDataColumn.ColumnName>
+    <InArgument x:TypeArguments="x:String">"Department"</InArgument>
+  </ui:AddDataColumn.ColumnName>
+  <ui:AddDataColumn.AllowDBNull>
+    <InArgument x:TypeArguments="x:Boolean">True</InArgument>
+  </ui:AddDataColumn.AllowDBNull>
+  <ui:AddDataColumn.MaxLength>
+    <InArgument x:TypeArguments="x:Int32">100</InArgument>
+  </ui:AddDataColumn.MaxLength>
+</ui:AddDataColumn>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddDataRow.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddDataRow.md
@@ -1,0 +1,60 @@
+# Add Data Row
+
+`UiPath.Core.Activities.AddDataRow`
+
+Adds a DataRow to a specified DataTable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| ArrayRow | Array Row | InArgument | Object[] | Yes* | — | An array of values whose elements map positionally to each column of the DataTable. Mutually exclusive with **Data Row**. |
+| DataRow | Data Row | InArgument | DataRow | Yes* | — | An existing DataRow object to add to the DataTable. Mutually exclusive with **Array Row**. |
+
+### Input/Output
+
+> These properties require a **variable** binding — the activity reads the incoming value and writes an updated value back. Do not use literal expressions.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InOutArgument | DataTable | Yes | — | The DataTable to which the row will be added. The variable is updated in place. |
+
+\* Exactly one of `ArrayRow` or `DataRow` must be provided (overload groups).
+
+## Valid Configurations
+
+| Mode | Required properties |
+|------|-------------------|
+| Add by array | `DataTable` + `ArrayRow` |
+| Add by DataRow | `DataTable` + `DataRow` |
+
+## XAML Example
+
+```xml
+<!-- Using ArrayRow -->
+<ui:AddDataRow DisplayName="Add Data Row"
+               xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:AddDataRow.DataTable>
+    <InOutArgument x:TypeArguments="sd:DataTable">[myDataTable]</InOutArgument>
+  </ui:AddDataRow.DataTable>
+  <ui:AddDataRow.ArrayRow>
+    <InArgument x:TypeArguments="x:Object[]">[New Object() {"Alice", 30, "HR"}]</InArgument>
+  </ui:AddDataRow.ArrayRow>
+</ui:AddDataRow>
+
+<!-- Using DataRow -->
+<ui:AddDataRow DisplayName="Add Data Row"
+               xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:AddDataRow.DataTable>
+    <InOutArgument x:TypeArguments="sd:DataTable">[myDataTable]</InOutArgument>
+  </ui:AddDataRow.DataTable>
+  <ui:AddDataRow.DataRow>
+    <InArgument x:TypeArguments="sd:DataRow">[myDataRow]</InArgument>
+  </ui:AddDataRow.DataRow>
+</ui:AddDataRow>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddLogFields.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddLogFields.md
@@ -1,0 +1,39 @@
+# Add Log Fields
+
+`UiPath.Core.Activities.AddLogFields`
+
+Adds custom log fields to each Log Message.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Logging
+
+## Properties
+
+### Input
+
+_No input arguments._
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| Fields | Fields | `Dictionary<string, InArgument>` | — | A collection of key-value pairs to attach to every subsequent log message as custom fields. |
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:AddLogFields>
+  <ui:AddLogFields.Fields>
+    <x:Reference>fieldsDictionary</x:Reference>
+  </ui:AddLogFields.Fields>
+</ui:AddLogFields>
+```
+
+## Notes
+
+- Fields added here persist for the lifetime of the workflow execution until explicitly removed with **Remove Log Fields**.
+- Use string keys that do not conflict with built-in UiPath log field names (e.g., `robotName`, `processName`).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddOrSubtractFromDate.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddOrSubtractFromDate.md
@@ -1,0 +1,55 @@
+# Add or Subtract from Date
+
+`UiPath.Activities.System.Date.AddOrSubtractFromDate`
+
+Allows to add or subtract a specified unit of time from the source date.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Source date | InArgument | `DateTime` | Yes | — | The base `DateTime` value to modify. |
+| `AmountOfTime` | Amount | InArgument | `Int32` | No | — | The numeric amount to add or subtract. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `SelectedOperation` | Operation | `DateOperations` | `Add` | Whether to add to or subtract from the source date. Displayed as a radio-button group. |
+| `UnitOfTime` | Unit | `UnitsOfTime` | `Days` | The unit of time that `AmountOfTime` represents. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `DateTime` | The resulting `DateTime` after the specified amount has been added or subtracted. |
+
+### Enum Reference
+
+**`DateOperations`**: `Add`, `Subtract`
+
+**`UnitsOfTime`** (available for this activity — `DayOfTheWeek` is excluded): `Seconds`, `Minutes`, `Hours`, `Days`, `Weeks`, `Months`, `Years`
+
+## XAML Example
+
+```xml
+<ucs:AddOrSubtractFromDate
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Date;assembly=UiPath.System.Activities.Standard"
+  Source="[startDate]"
+  SelectedOperation="Add"
+  UnitOfTime="Months"
+  AmountOfTime="[3]"
+  Result="[futureDate]" />
+```
+
+## Notes
+
+- `Weeks` is calculated as `AmountOfTime * 7` days.
+- `Months` and `Years` use .NET's `DateTime.AddMonths` and `DateTime.AddYears`, which handle month-length and leap-year boundaries automatically (e.g. adding one month to January 31 gives the last day of February).
+- For the `Subtract` operation the `AmountOfTime` is negated internally, so the value of `AmountOfTime` should always be a positive integer.
+- `DayOfTheWeek` is not available as a unit for this activity; use **Get Next or Previous Date** instead for day-of-week navigation.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddQueueItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddQueueItem.md
@@ -1,0 +1,60 @@
+# Add Queue Item
+
+`UiPath.Core.Activities.AddQueueItem`
+
+Adds a new item in the queue. The status of the item will be New.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `QueueType` | Queue name | InArgument | `string` | Yes | — | The name of the queue to add the item to. |
+| `DeferDate` | Postpone | InArgument | `DateTime` | No | null | The earliest date and time after which the item may be processed. |
+| `DueDate` | Deadline | InArgument | `DateTime` | No | null | The latest date and time by which the item should be processed. |
+| `Reference` | Reference | InArgument | `string` | No | null | An external reference tag for the queue item. |
+| `ItemInformationCollection` | Item Collection | InArgument | `Dictionary<string, object>` | No | null | A variable dictionary containing the item's specific data. Used when item data is bound at runtime. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Priority` | Priority | `QueueItemPriority` | Normal | The priority of the queue item. |
+| `ItemInformation` | Item Information | `Dictionary<string, InArgument>` | — | The inline key-value collection of specific data for the queue item. Keys can be auto-populated from the Orchestrator queue schema. |
+
+## Valid Configurations
+
+- Either `ItemInformation` (inline dictionary) or `ItemInformationCollection` (variable) may be used to supply specific data. Both can be set simultaneously and their values are merged at runtime.
+- When `QueueType` is set to a literal queue name, the designer offers a **Refresh Arguments** menu action on `ItemInformation` to auto-populate keys from the Orchestrator queue JSON schema.
+
+### Enum Reference
+
+**QueueItemPriority**
+
+| Value | Description |
+|-------|-------------|
+| `Low` | Lower than normal priority. |
+| `Normal` | Default priority. |
+| `High` | Higher than normal priority. |
+
+## XAML Example
+
+```xml
+<ui:AddQueueItem
+    QueueType="&quot;InvoiceProcessing&quot;"
+    Priority="Normal"
+    Reference="&quot;INV-2024-001&quot;"
+    DueDate="[DateTime.Now.AddDays(1)]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- The item is created with status **New**. To immediately begin processing, use **Add Transaction Item** instead.
+- `FolderPath` is an advanced/hidden property that overrides the Orchestrator folder resolved from the robot context.
+- `ServiceBaseAddress` is deprecated and ignored.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddTransactionItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AddTransactionItem.md
@@ -1,0 +1,44 @@
+# Add Transaction Item
+
+`UiPath.Core.Activities.AddTransactionItem`
+
+Adds a new item in the queue and starts a transaction. The status of the item will be set to InProgress. Returns the item as a QueueItem variable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Reference` | Reference | InArgument | `string` | No | — | An external reference tag for the queue item. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `TransactionInformation` | Reference | `Dictionary<string, InArgument>` | null | The inline key-value collection of specific data for the transaction item. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `TransactionItem` | Transaction Item | OutArgument | `QueueItem` | The queue item that was created and immediately set to In Progress. |
+
+## XAML Example
+
+```xml
+<ui:AddTransactionItem
+    Reference="&quot;TXN-001&quot;"
+    TransactionItem="[transactionItem]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- Unlike **Add Queue Item**, this activity immediately sets the new item's status to **In Progress**, making it ready for processing in a single step.
+- The returned `QueueItem` should be passed to **Set Transaction Status** when processing is complete.
+- `ServiceBaseAddress` is deprecated and ignored.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AppendItemToCollection.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AppendItemToCollection.md
@@ -1,0 +1,40 @@
+# Append Items to Collection
+
+`UiPath.Activities.System.Collections.AppendItemToCollection`1``
+
+Appends one or more items at the end of the specified collection.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Collection
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Collection` | Collection | `InArgument` | `ICollection<T>` | Yes | — | The collection to which items are appended. |
+| `Items` | Items | `InArgument` | `IEnumerable<InArgument<T>>` | Yes | — | One or more items to append to the collection. At least one item must be provided. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | `OutArgument` | `List<T>` | The updated collection after appending. When bound, a new `List<T>` is returned containing all original elements plus the appended items and the original collection is not modified. When not bound, items are appended directly to the existing collection object. |
+
+## XAML Example
+
+```xml
+<usc:AppendItemToCollection x:TypeArguments="x:String"
+    DisplayName="Append Items to Collection"
+    Collection="[myList]"
+    Result="[updatedList]"
+    xmlns:usc="clr-namespace:UiPath.Activities.System.Collections;assembly=UiPath.System.Activities"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+```
+
+## Notes
+
+The type parameter `T` is inferred from the connected variable or argument.
+
+Throws an error if the target collection is fixed-size (e.g., an array). Use a `List<T>` when mutation is required.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AppendLine.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/AppendLine.md
@@ -1,0 +1,48 @@
+# Append Line
+
+`UiPath.Core.Activities.AppendLine`
+
+Adds the specified text to a file after the existing content. If it does not already exist, the file is created.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FileName` | Append Line | `InArgument` | `string` | Yes* | — | Full path of the file to append to. Overload group: `FileName`. |
+| `File` | File | `InArgument` | `ILocalResource` | Yes* | — | Local resource reference to the file to append to. Overload group: `File`. |
+| `Text` | Text | `InArgument` | `string` | Yes | — | The text to append. A newline is added after the existing content before writing. |
+| `Encoding` | Encoding | `InArgument` | `string` | No | `null` | The encoding to use when appending (e.g. `"utf-8"`). When `null`, the system default is used. Configurable as a project setting. |
+| `UseDefaultEncoding` | Use default encoding | `InArgument` | `bool` | No | `false` | When `true`, ignores the `Encoding` value and uses the system default encoding. |
+
+## Valid Configurations
+
+Two mutually exclusive modes determine how the file is specified:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Local path | `FileName` | String expression resolving to a local file path. |
+| Resource | `File` | `ILocalResource` expression (e.g. from Create File). |
+
+## XAML Example
+
+```xml
+<ui:AppendLine
+    DisplayName="Append Line"
+    FileName="&quot;C:\logs\process.log&quot;"
+    Text="[logEntry]"
+    Encoding="&quot;utf-8&quot;" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- Unlike **Write Text File**, this activity preserves existing file content and adds the new text after it.
+- If the target file does not exist, it is created.
+- The `Encoding` property can be set at project level via **Project Settings** (`Section.AppendLine, Property.Encoding`).
+- When `UseDefaultEncoding` is `true`, the `Encoding` argument is ignored regardless of its value.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Beep.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Beep.md
@@ -1,0 +1,34 @@
+# Beep
+
+`UiPath.Core.Activities.Beep`
+
+Generates a simple tone on the speaker.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Environment
+
+## Properties
+
+### Input
+
+_No input properties._
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:Beep />
+```
+
+## Notes
+
+- Plays the system `Beep` sound using `System.Media.SystemSounds.Beep.Play()`.
+- The tone is determined by the operating system's default beep sound; frequency and duration cannot be customised through this activity.
+- If the system has no audio output device or the beep sound is muted, the activity completes silently without error.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/BeginProcess.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/BeginProcess.md
@@ -1,0 +1,83 @@
+# Run Parallel Process
+
+`UiPath.Core.Activities.BeginProcess`
+
+Starts a UiPath process in the background via Orchestrator without waiting for it to complete. The calling workflow continues immediately after the process is launched. Only input arguments are passed to the target process; output arguments are not supported.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow > Invoke
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ProcessName` | Process name / Package name | `InArgument` | `string` | Yes | — | The name of the Orchestrator process (when `UsePackage` is `False`) or the package name (when `UsePackage` is `True`). Supports auto-complete from available processes in the configured folder. |
+| `FolderPath` | Folder Path | `InArgument` | `string` | No | — | The Orchestrator folder containing the process or package. Leave empty to use the folder of the current process. |
+| `EntryPointPath` | Entry point | `InArgument` | `string` | No | — | The entry point `.xaml` path within the package. Only applicable when `UsePackage` is `True`. Cannot be used when `UsePackage` is `False`. |
+| `Arguments` | Arguments | `Dictionary<string, InArgument>` | — | No | `{}` | A dictionary of input arguments to pass to the launched process. Use the **Import Arguments** menu action to auto-populate from the selected process's schema. Only `In` direction arguments are supported. Use the **Use an expression** menu action to switch to expression mode. |
+| `ArgumentsVariable` | Arguments variable | `InArgument` | `Dictionary<string, object>` | No | — | An expression-based alternative to `Arguments`. When set, this takes precedence over the `Arguments` dictionary at runtime. Use the **Use arguments** menu action to switch back to the literal dictionary. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `UsePackage` | Use package | `bool` | `True` | When `True`, the process is identified by its package name and optional entry point. When `False`, the process is identified by its Orchestrator process name. |
+| `TargetSession` | Target session | `InvokeProcessTargetSession` | `Current` | The session in which the child process is started. |
+
+## Valid Configurations
+
+| `UsePackage` | `ProcessName` | `EntryPointPath` |
+|---|---|---|
+| `False` (by process name) | Orchestrator process name | Not allowed (validation error if set) |
+| `True` (by package name) | Package name | Optional `.xaml` entry point path |
+
+## XAML Example
+
+```xml
+<!-- Start a process by Orchestrator process name (fire and forget) -->
+<ui:BeginProcess
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Run Parallel Process"
+    UsePackage="False">
+  <ui:BeginProcess.ProcessName>
+    <InArgument x:TypeArguments="x:String">
+      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="&quot;InvoiceProcessor&quot;" />
+    </InArgument>
+  </ui:BeginProcess.ProcessName>
+  <ui:BeginProcess.FolderPath>
+    <InArgument x:TypeArguments="x:String">
+      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="&quot;Finance/Shared&quot;" />
+    </InArgument>
+  </ui:BeginProcess.FolderPath>
+</ui:BeginProcess>
+```
+
+```xml
+<!-- Start a process by package name with a specific entry point -->
+<ui:BeginProcess
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Run Parallel Process"
+    UsePackage="True">
+  <ui:BeginProcess.ProcessName>
+    <InArgument x:TypeArguments="x:String">
+      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="&quot;MyPackage&quot;" />
+    </InArgument>
+  </ui:BeginProcess.ProcessName>
+  <ui:BeginProcess.EntryPointPath>
+    <InArgument x:TypeArguments="x:String">
+      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="&quot;Main.xaml&quot;" />
+    </InArgument>
+  </ui:BeginProcess.EntryPointPath>
+</ui:BeginProcess>
+```
+
+## Notes
+
+- **Fire and forget** — unlike **Invoke Process** or **Run Job**, `BeginProcess` does not wait for the launched process to finish. The calling workflow immediately continues after the child process is started.
+- Only `In` direction arguments are supported in `Arguments`. Output arguments from the child process are not accessible.
+- `Arguments` and `ArgumentsVariable` are mutually exclusive in the designer. Use the menu action on either property to toggle between the literal argument dictionary and a single expression variable. At runtime, `ArgumentsVariable` takes precedence over `Arguments` when both are set.
+- Requires an active Orchestrator connection and the target process to be published and available in the specified folder.
+- `EntryPointPath` is only valid when `UsePackage` is `True`. Setting it when `UsePackage` is `False` causes a validation error.
+- The **Import Arguments** menu action on the `Arguments` property auto-populates the argument dictionary from Orchestrator when a valid `ProcessName` (and optionally `EntryPointPath`) is set to a literal string.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Break.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Break.md
@@ -1,0 +1,25 @@
+# Break
+
+`UiPath.Core.Activities.Break`
+
+Exits the Loop activity (For Each, While, Do While) or Trigger Scope activity in which it is placed and continues the workflow execution with the activity that follows it.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow.Control
+
+## Properties
+
+No configurable properties.
+
+## XAML Example
+
+```xml
+<ui:Break DisplayName="Break"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+Must be placed directly or indirectly inside a loop activity (`For Each`, `While`, `Do While`) or a Trigger Scope activity. A validation error is raised at design time if neither a loop nor an interruptible trigger scope is found in the parent chain.
+
+When placed inside a Trigger Scope, `Break` signals the trigger's internal bookmark to stop the trigger loop and resume execution after the scope.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/BuildCollection.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/BuildCollection.md
@@ -1,0 +1,52 @@
+# Build Collection
+
+`UiPath.Activities.System.Collections.BuildCollection`1``
+
+Create a collection of items that have the same type as the first specified element.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Collection
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FirstItem` | First Item | `InArgument` | `T` | Yes | — | The first element of the new collection. The type of this argument determines `T` for the entire activity. |
+| `NextItems` | Next Items | `InArgument` | `List<InArgument<T>>` | No | — | Additional individual items to include in the collection. Mutually exclusive with `Items` — only one may be set at a time. Visible by default when `Items` is not bound. |
+| `Items` | Items | `InArgument` | `ICollection<T>` | No | — | An existing collection whose elements are appended after `FirstItem`. Mutually exclusive with `NextItems` — only one may be set at a time. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | `OutArgument` | `List<T>` | The newly built collection containing `FirstItem` followed by either all `NextItems` or all elements from `Items`. |
+
+## Valid Configurations
+
+The designer enforces that `NextItems` and `Items` cannot both be set simultaneously. A context menu on each property lets you switch modes:
+
+| Mode | Visible properties |
+|------|--------------------|
+| Individual items mode (default) | `FirstItem`, `NextItems` |
+| Collection mode | `FirstItem`, `Items` |
+
+Use the **"Use Items"** menu action on `NextItems` to switch to collection mode, or **"Use Next Items"** on `Items` to switch back.
+
+## XAML Example
+
+```xml
+<usc:BuildCollection x:TypeArguments="x:String"
+    DisplayName="Build Collection"
+    FirstItem="[&quot;alpha&quot;]"
+    Result="[builtList]"
+    xmlns:usc="clr-namespace:UiPath.Activities.System.Collections;assembly=UiPath.System.Activities"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+```
+
+## Notes
+
+The type parameter `T` is inferred from the connected variable or argument.
+
+The activity always returns a new `List<T>` — the source collections or arguments are not modified. Setting both `NextItems` and `Items` is a validation error.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/BulkAddQueueItems.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/BulkAddQueueItems.md
@@ -1,0 +1,62 @@
+# Bulk Add Queue Items
+
+`UiPath.Core.Activities.BulkAddQueueItems`
+
+Adds a collection of items from a Data Table to a queue. The status of the items will be New.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `QueueName` | Queue name | InArgument | `string` | Yes | — | The name of the queue to add items to. |
+| `QueueItemsDataTable` | Data Table | InArgument | `DataTable` | Yes | — | The DataTable whose rows are uploaded as queue items. Each column becomes a specific data field. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `CommitType` | Commit Type | `CommitTypeEnum` | AllOrNothing | Controls how failures during the bulk upload are handled. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `DataTable` | A DataTable containing the rows that failed to be added to the queue. Empty when all items succeeded. |
+
+## Valid Configurations
+
+- The `CommitType` property controls transactional behaviour:
+  - `AllOrNothing` — the entire upload is rolled back if any item fails.
+  - `ProcessAllIndependently` — each item is committed independently; failed rows are returned in `Result`.
+
+### Enum Reference
+
+**CommitTypeEnum**
+
+| Value | Description |
+|-------|-------------|
+| `AllOrNothing` | All items are added or none are. If any item fails, the whole batch is rolled back. |
+| `ProcessAllIndependently` | Items are processed independently. Failed items are returned in the output DataTable. |
+
+## XAML Example
+
+```xml
+<ui:BulkAddQueueItems
+    QueueName="&quot;InvoiceProcessing&quot;"
+    QueueItemsDataTable="[invoiceTable]"
+    CommitType="AllOrNothing"
+    Result="[failedItems]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- Each DataTable row becomes one queue item. Column names become the specific data field keys.
+- All items are created with status **New**.
+- When `CommitType` is `ProcessAllIndependently`, inspect the `Result` DataTable after execution to handle failed rows.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ChangeCase.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ChangeCase.md
@@ -1,0 +1,55 @@
+# Change Case
+
+`UiPath.Activities.System.Text.ChangeCase`
+
+Select the desired letter case to convert the text to.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Source | InArgument | `String` | Yes | — | The text whose case is to be changed. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ChangeCaseOptions` | Desired letter case | `ChangeCaseOptions` | — | The target case transformation to apply. Required. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `String` | The text after the case transformation has been applied. |
+
+### Enum Reference
+
+**`ChangeCaseOptions`**: `LowerCase`, `UpperCase`, `SentenceCase`, `CapitalizeEachWord`
+
+| Value | Behavior |
+|-------|----------|
+| `LowerCase` | Converts all characters to lower case using the current culture. |
+| `UpperCase` | Converts all characters to upper case using the current culture. |
+| `SentenceCase` | Capitalizes the first letter after sentence-ending punctuation (`.`, `!`, `?`) and after newlines. If the input is already in `UpperCase` or `CapitalizeEachWord` format, it is first converted to lower case. |
+| `CapitalizeEachWord` | Title-cases the string using the current culture's `TextInfo.ToTitleCase`. If the input is entirely in upper case, it is first converted to lower case. |
+
+## XAML Example
+
+```xml
+<ucs:ChangeCase
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Text;assembly=UiPath.System.Activities.Standard"
+  Source="[inputText]"
+  ChangeCaseOptions="CapitalizeEachWord"
+  Result="[titleCasedText]" />
+```
+
+## Notes
+
+- `SentenceCase` and `CapitalizeEachWord` use the runtime's current culture for Unicode-aware transformations.
+- `SentenceCase` detects sentence boundaries at `.`, `!`, and `?` followed by whitespace, as well as at all common newline sequences (`\r\n`, `\r`, `\n`, `\u0085`, `\u2028`, `\u2029`).
+- Acronyms and all-caps words are preserved as-is by `SentenceCase` unless the entire input is in upper case.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ChangeType.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ChangeType.md
@@ -1,0 +1,47 @@
+# Change Type
+
+`UiPath.Core.Activities.ChangeType<T>`
+
+Changes the data type of a variable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming.String
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Value | Value | InArgument | `object` | Yes | — | The value whose type is to be converted. Accepts any object. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Result | Result | OutArgument | `T` | The input value converted to the generic type parameter `T`. |
+
+## XAML Example
+
+```xml
+<!-- Convert a string to Integer -->
+<ui:ChangeType x:TypeArguments="x:Int32">
+  <ui:ChangeType.Value>
+    <InArgument x:TypeArguments="x:Object">[stringVariable]</InArgument>
+  </ui:ChangeType.Value>
+  <ui:ChangeType.Result>
+    <OutArgument x:TypeArguments="x:Int32">[intVariable]</OutArgument>
+  </ui:ChangeType.Result>
+</ui:ChangeType>
+```
+
+## Notes
+
+- This is a generic activity; the target type `T` is set at design time in Studio's type picker.
+- Conversion is performed via `System.Convert.ChangeType`, so the input value must implement `IConvertible` or a compatible conversion must exist.
+- If the conversion fails at runtime (e.g., converting `"abc"` to `Int32`), a `FormatException` or `InvalidCastException` is thrown.
+- Common use cases: converting a `string` read from a file or UI element to a numeric or date type.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CheckFalse.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CheckFalse.md
@@ -1,0 +1,41 @@
+# Check False
+
+`UiPath.Core.Activities.CheckFalse`
+
+Checks if a given boolean expression is false and generates an error with a specified message when the expression is true.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow.Checkpoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Expression` | Expression | `InArgument` | `bool` | Yes | — | The boolean expression to evaluate. The activity passes when this evaluates to `False`. |
+| `ErrorMessage` | ErrorMessage | `InArgument` | `string` | No | — | The message included in the thrown exception when `Expression` evaluates to `True`. If omitted, a default checkpoint failure message is used. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | `OutArgument` | `bool` | Set to `True` when the expression passes (i.e. the condition is `False`). Not set (remains `False`) when the assertion fails because the exception is thrown before the result is written. |
+
+## XAML Example
+
+```xml
+<ui:CheckFalse DisplayName="Check False"
+    Expression="[hasError]"
+    ErrorMessage="[&quot;An error was detected&quot;]"
+    Result="[checkResult]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+When `Expression` is `True`, the activity sets `Result` to `False` and immediately throws a `CheckpointException` (a subclass of `Exception`) with the provided `ErrorMessage`. The workflow is aborted unless the exception is caught by an enclosing Try/Catch.
+
+Use `Check False` to assert that an error flag or undesirable condition is not set, and surface a clear diagnostic message when it is.
+
+`Check False` is the logical inverse of `Check True`: it succeeds when the expression is `False` and fails when it is `True`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CheckTrue.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CheckTrue.md
@@ -1,0 +1,39 @@
+# Check True
+
+`UiPath.Core.Activities.CheckTrue`
+
+Checks if a given boolean expression is true and generates an error with a specified message when the expression is false.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow.Checkpoint
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Expression` | Expression | `InArgument` | `bool` | Yes | — | The boolean expression to evaluate. The activity passes when this evaluates to `True`. |
+| `ErrorMessage` | ErrorMessage | `InArgument` | `string` | No | — | The message included in the thrown exception when `Expression` evaluates to `False`. If omitted, a default checkpoint failure message is used. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | `OutArgument` | `bool` | Set to `True` when the expression passes. Not set (remains `False`) when the assertion fails because the exception is thrown before the result is written. |
+
+## XAML Example
+
+```xml
+<ui:CheckTrue DisplayName="Check True"
+    Expression="[myValue &gt; 0]"
+    ErrorMessage="[&quot;Value must be positive&quot;]"
+    Result="[checkResult]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+When `Expression` is `False`, the activity sets `Result` to `False` and immediately throws a `CheckpointException` (a subclass of `Exception`) with the provided `ErrorMessage`. The workflow is aborted unless the exception is caught by an enclosing Try/Catch.
+
+Use `Check True` to assert preconditions or postconditions within a workflow and surface clear diagnostic messages when invariants are violated.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ClearDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ClearDataTable.md
@@ -1,0 +1,34 @@
+# Clear Data Table
+
+`UiPath.Core.Activities.ClearDataTable`
+
+Clears the specified DataTable of all data.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input/Output
+
+> These properties require a **variable** binding — the activity reads the incoming value and writes an updated value back. Do not use literal expressions.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InOutArgument | DataTable | Yes | — | The DataTable to clear. All rows are removed; the schema (columns) is preserved. The variable is updated in place. |
+
+## Notes
+
+- This activity removes all rows from the DataTable but retains the column definitions.
+- The DataTable variable passed in is modified directly via the `InOutArgument` binding.
+
+## XAML Example
+
+```xml
+<ui:ClearDataTable DisplayName="Clear Data Table"
+                   xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:ClearDataTable.DataTable>
+    <InOutArgument x:TypeArguments="sd:DataTable">[myDataTable]</InOutArgument>
+  </ui:ClearDataTable.DataTable>
+</ui:ClearDataTable>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CollectionToDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CollectionToDataTable.md
@@ -1,0 +1,43 @@
+# Collection to DataTable
+
+`UiPath.Core.Activities.CollectionToDataTable`1``
+
+Converts a Collection to a DataTable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Collection
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Collection` | Collection | `InArgument` | `ICollection<T>` | Yes | — | The collection to convert to a DataTable. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `DataTable` | DataTable | `OutArgument` | `DataTable` | The resulting DataTable. For primitive and built-in types (string, int, DateTime, etc.) the table has a single column named after the type. For complex types, each public instance property becomes a column. |
+
+## XAML Example
+
+```xml
+<ui:CollectionToDataTable x:TypeArguments="x:String"
+    DisplayName="Collection to DataTable"
+    Collection="[myStringList]"
+    DataTable="[resultTable]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+```
+
+## Notes
+
+The type parameter `T` is inferred from the connected variable or argument.
+
+**Primitive / built-in types** (`string`, `int`, `bool`, `decimal`, `DateTime`, `TimeSpan`, `DateTimeOffset`, `Guid`, enums) produce a single-column table whose column name matches the type name.
+
+**Complex types** produce one column per public instance property. If two properties share the same name (possible when interfaces are involved), the second column is disambiguated with the pattern `PropertyName_PropertyType`.
+
+The DataTable name is set to the type name of `T`. Null collection items are written as `DBNull` in the row.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CombineText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CombineText.md
@@ -1,0 +1,47 @@
+# Combine Text
+
+`UiPath.Activities.System.Text.CombineText`
+
+Combines text from a given collection, with the provided separator.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Text values | InArgument | `IEnumerable<String>` | No | — | The collection of text values to be joined together. |
+| `Separator` | Separator | InArgument | `String` | Yes | — | The text inserted between each value in the collection. Supports a dropdown of common predefined separators. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `String` | The single string produced by joining all values in the collection with the separator. |
+
+## Valid Configurations
+
+The `Separator` field supports a dropdown of predefined values as well as a free-form custom string. When a predefined separator is selected the internal `SeparatorKey` property is set automatically and is not exposed in the designer.
+
+### Enum Reference
+
+**`SeparatorOptions`**: `Custom`, `NewLine`, `Space`, `Tab`, `Comma`, `Colon`, `SemiColon`
+
+## XAML Example
+
+```xml
+<ucs:CombineText
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Text;assembly=UiPath.System.Activities.Standard"
+  Source="[wordList]"
+  Separator="[&quot;, &quot;]"
+  Result="[combinedText]" />
+```
+
+## Notes
+
+- Internally uses `String.Join` semantics: the separator is placed between elements only, not at the start or end of the result.
+- If `Source` is an empty collection the result is an empty string.
+- If the collection contains a single item the result equals that item (no separator is added).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Comment.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Comment.md
@@ -1,0 +1,31 @@
+# Comment
+
+`UiPath.Core.Activities.Comment`
+
+Adds a comment into the workflow.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Text` | Text | `string` | — | The comment text displayed on the activity in the designer canvas. |
+
+## XAML Example
+
+```xml
+<ui:Comment
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Comment"
+    Text="This section handles the invoice extraction logic." />
+```
+
+## Notes
+
+- **Comment** is a design-time annotation activity. It executes at runtime (it is a `CodeActivity`) but performs no meaningful operation — its sole purpose is to surface the `Text` note on the designer canvas.
+- The `Text` property is a plain `string`, not an `InArgument`, so it does not support VB/C# expressions; only literal text is accepted.
+- Use `Comment` to document intent, assumptions, or maintenance notes directly inside a workflow without affecting execution.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CommentOut.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CommentOut.md
@@ -1,0 +1,31 @@
+# Disabled Activities
+
+`UiPath.Core.Activities.CommentOut`
+
+A container where you can add activities that won't be executed at runtime.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+This activity has no configurable input or output properties. All activities placed inside the container are silently skipped at runtime.
+
+## XAML Example
+
+```xml
+<ui:CommentOut
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Disabled Activities">
+  <ui:CommentOut.Body>
+    <Sequence DisplayName="Ignored activities">
+      <!-- Disabled activities go here -->
+    </Sequence>
+  </ui:CommentOut.Body>
+</ui:CommentOut>
+```
+
+## Notes
+
+- Activities placed inside `CommentOut` are serialized in XAML but the `Execute` method does nothing — the body is never executed.
+- Use this activity to temporarily disable a block of logic without deleting it, similar to commenting out code.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CompressFiles.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CompressFiles.md
@@ -1,0 +1,83 @@
+# Compress/Zip Files
+
+`UiPath.Activities.System.Compression.Workflow.CompressFiles`
+
+Compresses given contents into a ZIP archive.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `CompressedFileName` | Compressed file name | `InArgument` | `string` | Yes | — | Name of the output compressed file to create (including `.zip` extension). |
+| `ResourcesToArchive` | Resources to zip | `Property` | `InArgument<IEnumerable<IResource>>` | No | — | Collection of `IResource` items to compress. |
+| `ContentToArchive` | Content to zip | `Property` | `List<InArgument<string>>` | No | — | List of local file or folder paths to compress. |
+| `AllowDuplicateContentNames` | Allow contents with duplicate names | `InArgument` | `bool` | No | `false` | When `true`, files with identical names from different directories are all included in the archive. |
+| `Password` | Password | `InArgument` | `string` | No | — | Password to protect the archive. Overload group: `Password`. |
+| `SecurePassword` | Secure Password | `InArgument` | `SecureString` | No | — | Password as a `SecureString` to protect the archive. Overload group: `Secure password`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `CompressionLevel` | Compression level | `ArchiveCompressionLevel` | — | Controls the trade-off between compression ratio and speed: `Optimal`, `Fastest`, `NoCompression`, or `SmallestSize`. |
+| `EncryptionAlgorithm` | Encryption algorithm | `ArchiveEncryptionAlgorithm` | — | Algorithm used for password encryption when a password is specified (e.g. `ZipCrypto`, `AES128`, `AES256`). |
+| `OverrideExistingFile` | Overwrite existing file | `bool` | `true` | When `true`, replaces an existing archive file with the same name. |
+| `CodePage` | Name encoding | `CodePages` | — | Text encoding used for file names inside the archive. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `CompressedFileInfo` | Compressed file | `OutArgument` | `FileInfo` | `FileInfo` object representing the created archive. |
+| `CompressedResource` | Compressed file reference | `OutArgument` | `ILocalResource` | `ILocalResource` reference to the created archive. |
+
+## Valid Configurations
+
+### Source selection
+
+Two complementary approaches to specify what to compress (can be combined):
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Path list | `ContentToArchive` | A list of string expressions — each resolving to a local file or folder path. |
+| Resource list | `ResourcesToArchive` | An expression resolving to `IEnumerable<IResource>`. |
+
+### Password protection
+
+Two mutually exclusive overload groups:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Plain text password | `Password` | Password as a plain `string`. |
+| Secure password | `SecurePassword` | Password as a `SecureString` for improved security. |
+
+## XAML Example
+
+```xml
+<ui2:CompressFiles
+    DisplayName="Compress/Zip Files"
+    CompressedFileName="&quot;C:\output\archive.zip&quot;"
+    CompressionLevel="Optimal"
+    OverrideExistingFile="True"
+    CompressedFileInfo="[zipFileInfo]"
+    CompressedResource="[zipResource]">
+  <ui2:CompressFiles.ContentToArchive>
+    <InArgument x:TypeArguments="x:String">&quot;C:\reports\summary.xlsx&quot;</InArgument>
+    <InArgument x:TypeArguments="x:String">&quot;C:\reports\details.csv&quot;</InArgument>
+  </ui2:CompressFiles.ContentToArchive>
+</ui2:CompressFiles>
+```
+
+`xmlns:ui2="clr-namespace:UiPath.Activities.System.Compression.Workflow;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- At least one of `ContentToArchive` or `ResourcesToArchive` should be provided; supplying neither produces an empty archive.
+- When a folder path is included in `ContentToArchive`, all files within that folder are added recursively.
+- `EncryptionAlgorithm` only takes effect when `Password` or `SecurePassword` is set.
+- `CompressedResource` and `CompressedFileInfo` both reference the same output file; use whichever is more convenient for downstream activities.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Continue.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Continue.md
@@ -1,0 +1,25 @@
+# Continue
+
+`UiPath.Core.Activities.Continue`
+
+Skips the current iteration in a Loop activity (For Each, While, Do While) and continues the execution with the next iteration.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow.Control
+
+## Properties
+
+No configurable properties.
+
+## XAML Example
+
+```xml
+<ui:Continue DisplayName="Continue"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+Must be placed directly or indirectly inside a loop activity (`For Each`, `While`, `Do While`). A validation error is raised at design time if no enclosing loop is found in the parent chain.
+
+Execution resumes at the top of the next iteration. Any activities after `Continue` within the same iteration body are skipped.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CopyFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CopyFile.md
@@ -1,0 +1,57 @@
+# Copy File
+
+`UiPath.Core.Activities.CopyFile`
+
+Copies a specified file to another location.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | From | `InArgument` | `string` | Yes* | — | Full path of the source file to copy. Mutually exclusive with `PathResource`. |
+| `PathResource` | From | `InArgument` | `IResource` | Yes* | — | Resource reference to the source file. Mutually exclusive with `Path`. |
+| `Destination` | To | `InArgument` | `string` | Yes* | — | Destination path or folder for the copied file. Mutually exclusive with `DestinationResource`. |
+| `DestinationResource` | To | `InArgument` | `IResource` | Yes* | — | Resource reference to the destination. Mutually exclusive with `Destination`. |
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | No | — | When `true`, execution continues even if an error occurs. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Overwrite` | Overwrite | `bool` | `false` | When `true`, overwrites the destination file if it already exists. |
+
+## Valid Configurations
+
+Each of the source and destination supports two mutually exclusive input modes, toggled via a context menu action in Studio:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Local path (source) | `Path` | String expression resolving to a local file path. Default mode. |
+| Resource (source) | `PathResource` | `IResource` expression (e.g. a Storage Bucket file resource). |
+| Local path (destination) | `Destination` | String expression resolving to a local path or folder. Default mode. |
+| Resource (destination) | `DestinationResource` | `IResource` expression for the destination. |
+
+Only one property per pair is visible at a time. A validation error is raised if neither the path nor the resource is provided for either side.
+
+## XAML Example
+
+```xml
+<ui:CopyFile
+    DisplayName="Copy File"
+    Path="&quot;C:\source\report.pdf&quot;"
+    Destination="&quot;C:\archive\report.pdf&quot;"
+    Overwrite="True" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- If `Destination` resolves to an existing **folder**, the source file is copied into that folder keeping its original name.
+- If `Destination` is a full file path, the parent directory must already exist.
+- This activity produces no output argument. The resulting file path equals the resolved destination value.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CopyFolderX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CopyFolderX.md
@@ -1,0 +1,56 @@
+# Copy Folder
+
+`UiPath.Core.Activities.CopyFolderX`
+
+Copies a specified folder to another location.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `From` | From | `InArgument` | `string` | Yes* | — | Full path of the source folder. Visible when `FromResource` has no value. |
+| `FromResource` | Source Folder Resource | `InArgument` | `IResource` | Yes* | — | Resource reference to the source folder. Visible when `From` has no value. |
+| `To` | To | `InArgument` | `string` | Yes* | — | Destination path for the copied folder. Visible when `ToResource` has no value. |
+| `ToResource` | Destination Folder Resource | `InArgument` | `IResource` | Yes* | — | Resource reference to the destination folder. Visible when `To` has no value. |
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | No | `null` | When `true`, execution continues even if an error occurs. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `IncludeSubfolders` | Include subfolders | `bool` | `true` | When `true`, copies all subfolders recursively. |
+| `Overwrite` | Overwrite | `bool` | `true` | When `true`, overwrites files in the destination that already exist. |
+
+## Valid Configurations
+
+Both source and destination support two mutually exclusive input modes toggled via context menu in Studio:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Local path (source) | `From` | String expression resolving to a local folder path. Default mode. |
+| Resource (source) | `FromResource` | `IResource` expression for the source folder. |
+| Local path (destination) | `To` | String expression resolving to a local folder path. Default mode. |
+| Resource (destination) | `ToResource` | `IResource` expression for the destination folder. |
+
+## XAML Example
+
+```xml
+<ui:CopyFolderX
+    DisplayName="Copy Folder"
+    From="&quot;C:\source\reports&quot;"
+    To="&quot;C:\archive\reports&quot;"
+    IncludeSubfolders="True"
+    Overwrite="True" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- The copy is recursive by default (`IncludeSubfolders = true`).
+- This activity produces no output argument.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CreateDirectory.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CreateDirectory.md
@@ -1,0 +1,40 @@
+# Create Folder
+
+`UiPath.Core.Activities.CreateDirectory`
+
+Creates a folder in the specified location.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Create Folder | `InArgument` | `string` | Yes | — | Full path of the folder to create, including the new folder name. |
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | No | — | When `true`, execution continues even if an error occurs. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Output` | Folder | `OutArgument` | `ILocalResource` | Reference to the newly created folder. |
+
+## XAML Example
+
+```xml
+<ui:CreateDirectory
+    DisplayName="Create Folder"
+    Path="&quot;C:\output\reports\2024&quot;"
+    Output="[newFolder]" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- If the folder already exists, the activity does not raise an error and returns a reference to the existing folder.
+- Intermediate directories in the path are created automatically if they do not exist.
+- The `Output` argument returns an `ILocalResource` that can be passed to other activities.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CreateFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/CreateFile.md
@@ -1,0 +1,51 @@
+# Create File
+
+`UiPath.Core.Activities.CreateFile`
+
+Creates a file in the specified location.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Create File | `InArgument` | `string` | Yes* | — | Path of the folder in which to create the file. Visible when `PathResource` has no value. |
+| `PathResource` | Path Resource | `InArgument` | `IResource` | Yes* | — | Resource reference to the target folder. Visible when `Path` has no value. |
+| `Name` | File name | `InArgument` | `string` | No | — | Name of the file to be created, including extension. |
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | No | `null` | When `true`, execution continues even if an error occurs. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Output` | Output File | `OutArgument` | `ILocalResource` | Reference to the newly created file. |
+
+## Valid Configurations
+
+The target folder supports two mutually exclusive input modes:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Local path | `Path` | String expression resolving to a local folder path. Default mode. |
+| Resource | `PathResource` | `IResource` expression pointing to the target folder. |
+
+## XAML Example
+
+```xml
+<ui:CreateFile
+    DisplayName="Create File"
+    Path="&quot;C:\output&quot;"
+    Name="&quot;result.txt&quot;"
+    Output="[createdFile]" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- If a file with the same name already exists in the target folder, the activity raises an error.
+- The `Output` argument returns an `ILocalResource` that can be passed directly to other file activities (e.g. Write Text File, Read Text File).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Delete.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Delete.md
@@ -1,0 +1,43 @@
+# Delete File or Folder
+
+`UiPath.Core.Activities.Delete`
+
+Deletes the file or folder in the specified location.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Delete | `InArgument` | `string` | Yes* | — | Full path of the file or folder to delete. Overload group: `Path`. |
+| `ResourceFile` | File | `InArgument` | `ILocalResource` | Yes* | — | Local resource reference to the file or folder to delete. Overload group: `ResourceFile`. |
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | No | — | When `true`, execution continues even if an error occurs. |
+
+## Valid Configurations
+
+Two mutually exclusive overload groups are supported:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Path string | `Path` | String expression resolving to a local file or folder path. |
+| Resource | `ResourceFile` | `ILocalResource` reference (e.g. output of Create File or Create Folder). |
+
+## XAML Example
+
+```xml
+<ui:Delete
+    DisplayName="Delete File or Folder"
+    Path="&quot;C:\temp\old_report.pdf&quot;" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- When deleting a folder, all contents (files and subfolders) are removed recursively.
+- This activity produces no output argument.
+- If the specified path does not exist and `ContinueOnError` is `false`, the activity raises an error.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DeleteQueueItems.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DeleteQueueItems.md
@@ -1,0 +1,37 @@
+# Delete Queue Items
+
+`UiPath.Core.Activities.DeleteQueueItems`
+
+Deletes items with the New state from a specified queue.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FolderPath` | Folder Path | InArgument | `string` | No | — | The Orchestrator folder path to use. Overrides the robot's default folder. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `QueueItems` | Queue Items | `InArgument<IEnumerable<QueueItem>>` | — | The collection of queue items to delete. Only items with status **New** can be deleted. |
+
+## XAML Example
+
+```xml
+<ui:DeleteQueueItems
+    QueueItems="[itemsToDelete]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- Only queue items with status **New** can be deleted. Attempting to delete items in other states (In Progress, Successful, Failed, etc.) will result in an error.
+- Use **Get Queue Items** to retrieve the collection of items to pass to this activity.
+- `FolderPath` overrides the Orchestrator folder context for the delete operation.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DeleteStorageFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DeleteStorageFile.md
@@ -1,0 +1,33 @@
+# Delete Storage File
+
+`UiPath.Core.Activities.Storage.DeleteStorageFile`
+
+Deletes a certain file from the designated Orchestrator storage bucket.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Storage
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Path | InArgument | `string` | Yes | — | The path of the file to delete within the storage bucket (e.g., `reports/output.pdf`). |
+
+## XAML Example
+
+```xml
+<ui:DeleteStorageFile
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.Storage;assembly=UiPath.System.Activities"
+    DisplayName="Delete Storage File"
+    Path="[&quot;reports/output.pdf&quot;]" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection with access to storage buckets.
+- The storage bucket name and folder path are configured in the Orchestrator connection context (via `StorageBucketName` and `FolderPath` inherited from the base storage activity class).
+- `Path` is the path of the file within the bucket, not a local file system path.
+- If the file does not exist in the bucket, the activity throws a runtime error.
+- This operation is permanent and cannot be undone.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DoWhile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DoWhile.md
@@ -1,0 +1,53 @@
+# Do While
+
+`UiPath.Core.Activities.InterruptibleDoWhile`
+
+Executes contained activities first and then loops if the condition is True.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `MaxIterations` | Max Iterations | `InArgument` | `int` | No | — | Maximum number of iterations. A value of `0` means unlimited. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Body` | Body | `Activity` | — | The container holding the child activities to execute on each iteration. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `CurrentIndex` | Current Index | `OutArgument` | `int` | The zero-based index of the current iteration. |
+
+## XAML Example
+
+```xml
+<ui:InterruptibleDoWhile
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Do While">
+  <ui:InterruptibleDoWhile.Body>
+    <Sequence DisplayName="Body">
+      <!-- child activities go here -->
+    </Sequence>
+  </ui:InterruptibleDoWhile.Body>
+  <ui:InterruptibleDoWhile.Condition>
+    <VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="counter &lt; 10" />
+  </ui:InterruptibleDoWhile.Condition>
+</ui:InterruptibleDoWhile>
+```
+
+## Notes
+
+- **Do While** is a container/scope activity. Child activities are placed inside its `Body`.
+- Unlike **While**, the body is executed **at least once** — the `Condition` is evaluated **after** each iteration.
+- The loop continues as long as `Condition` evaluates to `True`.
+- Use a `Break` activity inside the body to exit the loop early; use `Continue` to skip to the next iteration.
+- Setting `MaxIterations` provides an upper bound to prevent infinite loops.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DownloadFileFromUrl.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DownloadFileFromUrl.md
@@ -1,0 +1,52 @@
+# Download File from URL
+
+`UiPath.Activities.System.FileOperations.DownloadFileFromUrl`
+
+Use this activity to download any file from a given URL.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Url` | URL | `InArgument` | `string` | Yes | — | The full URL from which to download the file. |
+| `ConflictResolution` | If file already exists | `InArgument` | `FileConflictBehavior` | No | `FileConflictBehavior.Rename` | Behaviour when a file with the same name already exists at the save location: `Replace`, `Skip`, or `Rename`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FileName` | Save file as | `InArgument` | `string` | No | — | Custom file name to use when saving. Leave empty to use the original file name from the URL. |
+| `Timeout` | Timeout (seconds) | `InArgument` | `int?` | No | `600` | Duration in seconds to wait for the server to begin the download response before raising an error. Default is 600 seconds. |
+| `UserAgentHeader` | User Agent | `InArgument` | `string` | No | — | Value for the HTTP `User-Agent` request header, used to identify the requesting party to the server. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ResponseAttachment` | Downloaded File | `OutArgument` | `ILocalResource` | Reference to the downloaded file saved on disk. |
+
+## XAML Example
+
+```xml
+<ui2:DownloadFileFromUrl
+    DisplayName="Download File from URL"
+    Url="&quot;https://example.com/reports/monthly.xlsx&quot;"
+    FileName="&quot;monthly_report.xlsx&quot;"
+    ConflictResolution="FileConflictBehavior.Rename"
+    Timeout="120"
+    ResponseAttachment="[downloadedFile]" />
+```
+
+`xmlns:ui2="clr-namespace:UiPath.Activities.System.FileOperations;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- The file is saved to the robot's working directory by default when no explicit save path is configured. Use `FileName` to specify a full path if a particular destination is required.
+- `ConflictResolution` defaults to `Rename`, which appends a numeric suffix to avoid overwriting existing files.
+- The `Timeout` applies only to the time waiting for the server to **start** streaming the response — it does not limit the total download duration.
+- For servers that require a specific browser identity, set `UserAgentHeader` to a browser user-agent string.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DownloadStorageFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/DownloadStorageFile.md
@@ -1,0 +1,43 @@
+# Download Storage File
+
+`UiPath.Core.Activities.Storage.DownloadStorageFile`
+
+Downloads a copy of a file in an Orchestrator storage bucket locally.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Storage
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Path | InArgument | `string` | Yes | — | The path of the file within the storage bucket to download (e.g., `reports/output.pdf`). |
+| `Destination` | Destination | InArgument | `string` | No | — | The local file system path where the downloaded file will be saved. If omitted, the file is saved in the current working directory using the source file's name. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `ILocalResource` | A reference to the downloaded local file, providing access to the file name and full local path. |
+
+## XAML Example
+
+```xml
+<ui:DownloadStorageFile
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.Storage;assembly=UiPath.System.Activities"
+    DisplayName="Download Storage File"
+    Path="[&quot;reports/output.pdf&quot;]"
+    Destination="[&quot;C:\Temp\output.pdf&quot;]"
+    Result="{x:Reference downloadedFile}" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection with access to storage buckets.
+- The storage bucket name and folder path are configured in the Orchestrator connection context (via `StorageBucketName` and `FolderPath` inherited from the base storage activity class).
+- `Path` refers to the file's path within the Orchestrator storage bucket, not a local path.
+- If `Destination` is not specified, the file is saved to the process working directory using only the filename portion of `Path`.
+- If the destination file already exists locally, it is overwritten.
+- The `Result` output provides an `ILocalResource` object. Use `Result.LocalPath` (via the `ILocalResource` interface) to get the full path of the downloaded file.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ElseIf.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ElseIf.md
@@ -1,0 +1,61 @@
+# Else If
+
+`UiPath.Core.Activities.IfElseIfV2`
+
+Else If activity chooses between different paths based on a series of conditions being true or false.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Condition` | Condition | `InArgument` | `bool` | No | — | The Boolean condition for the leading `If` branch. Additional Else If branches each have their own condition. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ElseIfs` | Else Ifs | `BindingList<IfElseIfBlock>` | — | The ordered list of Else If branch blocks, each with its own condition and body. |
+| `Else` | "Else" | `Activity` | — | The body executed when no branch condition is satisfied. Optional. |
+
+## XAML Example
+
+```xml
+<ui:IfElseIfV2
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Else If">
+  <ui:IfElseIfV2.Condition>
+    <InArgument x:TypeArguments="x:Boolean">
+      <VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="score &gt;= 90" />
+    </InArgument>
+  </ui:IfElseIfV2.Condition>
+  <!-- Then body -->
+  <ui:IfElseIfV2.ElseIfs>
+    <ui:IfElseIfBlock>
+      <ui:IfElseIfBlock.Condition>
+        <InArgument x:TypeArguments="x:Boolean">
+          <VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="score &gt;= 70" />
+        </InArgument>
+      </ui:IfElseIfBlock.Condition>
+      <!-- Else If body -->
+    </ui:IfElseIfBlock>
+  </ui:IfElseIfV2.ElseIfs>
+  <ui:IfElseIfV2.Else>
+    <Sequence DisplayName="Else">
+      <!-- fallback activities -->
+    </Sequence>
+  </ui:IfElseIfV2.Else>
+</ui:IfElseIfV2>
+```
+
+## Notes
+
+- **Else If** is a container/scope activity with multiple branches: an initial `If` branch, zero or more `Else If` branches, and an optional `Else` branch.
+- Branches are evaluated in order; the first branch whose condition is `True` is executed and the remaining branches are skipped.
+- The `AddElseIfButton` property (widget `AddActivityWidget`) is a designer-only control for appending new Else If branches — it is not a runtime argument.
+- The `Then` body (the first `If` branch container) has `isVisible: false` in the JSON metadata; it is managed directly by the designer canvas rather than the properties panel.
+- `BlockType` (`IfElseIfBlockType`) is a hidden internal design-time property that controls the block kind; it is not intended for direct configuration.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/EvaluateBusinessRule.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/EvaluateBusinessRule.md
@@ -1,0 +1,44 @@
+# Evaluate Business Rule
+
+`UiPath.Core.Activities.EvaluateBusinessRule`
+
+Evaluates a DMN (Decision Model and Notation) business rule file and returns the result.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `BusinessRule` | Business Rule | `InArgument` | `string` | Yes | — | The path or identifier of the DMN business rule file to evaluate. Supports expression auto-complete. |
+| `Arguments` | Arguments | `Property` | `Dictionary<string, Argument>` | No | `new Dictionary<string, Argument>()` | The named input and output arguments passed to and from the business rule. Populated from the rule file definition. |
+| `ArgumentsVariable` | Arguments variable | `Property` | `InArgument<Dictionary<string, object>>` | No | — | An alternative way to supply input arguments as a single dictionary variable instead of individual named arguments. |
+
+## XAML Example
+
+```xml
+<ui:EvaluateBusinessRule
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Evaluate Business Rule">
+  <ui:EvaluateBusinessRule.BusinessRule>
+    <InArgument x:TypeArguments="x:String">
+      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="&quot;Rules\LoanApproval.dmn&quot;" />
+    </InArgument>
+  </ui:EvaluateBusinessRule.BusinessRule>
+  <ui:EvaluateBusinessRule.Arguments>
+    <!-- argument entries are populated automatically from the .dmn file -->
+  </ui:EvaluateBusinessRule.Arguments>
+</ui:EvaluateBusinessRule>
+```
+
+## Notes
+
+- This activity is marked **experimental** in the designer (indicated by the `ExperimentalLabel` property rendered as an info label).
+- `Arguments` and `ArgumentsVariable` provide two different ways to supply input data to the rule:
+  - `Arguments` is a structured dictionary of typed `Argument` objects (input and output) that is populated automatically when a valid `BusinessRule` file is selected.
+  - `ArgumentsVariable` accepts a pre-built `Dictionary<string, object>` variable for dynamic or programmatic argument supply.
+- Output values from the DMN decision are written back into the output-direction entries of the `Arguments` dictionary.
+- The `InfoBox` property is a designer-only text block used to surface contextual help; it has no runtime effect.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExistsInCollection.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExistsInCollection.md
@@ -1,0 +1,43 @@
+# Exists In Collection
+
+`UiPath.Activities.System.Collections.ExistsInCollection`1``
+
+Checks if the given Item exists in the collection.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Collection
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Collection` | Collection | `InArgument` | `ICollection<T>` | Yes | — | The collection to search. |
+| `Item` | Item | `InArgument` | `T` | Yes | — | The element to look for. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Exists` | Exists | `OutArgument` | `bool` | `True` if the item is found in the collection; `False` otherwise. |
+| `Index` | Index | `OutArgument` | `int` | The zero-based index of the first occurrence of the item, or `-1` if the item is not found. |
+
+## XAML Example
+
+```xml
+<usc:ExistsInCollection x:TypeArguments="x:String"
+    DisplayName="Exists In Collection"
+    Collection="[myList]"
+    Item="[&quot;target&quot;]"
+    Exists="[itemExists]"
+    Index="[itemIndex]"
+    xmlns:usc="clr-namespace:UiPath.Activities.System.Collections;assembly=UiPath.System.Activities"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+```
+
+## Notes
+
+The type parameter `T` is inferred from the connected variable or argument.
+
+The activity throws an error if `Collection` or `Item` is null at runtime. Equality is determined by the default `ICollection<T>.Contains` implementation, which uses the type's `Equals` method.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExtractDateTime.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExtractDateTime.md
@@ -1,0 +1,50 @@
+# Extract Date and Time from Text
+
+`UiPath.Activities.System.Text.ExtractDateTime`
+
+Extracts date and time from the given input text matching the specified format and outputs it as a variable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Source | InArgument | `String` | Yes | — | The text from which date and time values are to be extracted. |
+| `Format` | Date and time format | InArgument | `String` | Yes | — | The expected date/time format string. Accepts standard single-character format specifiers (e.g. `d`, `D`, `f`, `F`, `g`, `G`) or custom format patterns (e.g. `MM/dd/yyyy`). Supports autocomplete. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `LocalizationCode` | Localization code | `CultureInfo` | `CultureInfo.CurrentCulture` | The culture used to interpret the format string and parse month/day names. Select from a dropdown of all installed cultures. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `DateTime` | The first `DateTime` value extracted from the text. |
+| `Results` | All Extracted DateTimes | OutArgument | `IEnumerable<DateTime>` | A collection of all `DateTime` values found in the text that match the specified format. |
+
+## XAML Example
+
+```xml
+<ucs:ExtractDateTime
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Text;assembly=UiPath.System.Activities.Standard"
+  Source="[reportText]"
+  Format="[&quot;MM/dd/yyyy&quot;]"
+  LocalizationCode="[System.Globalization.CultureInfo.GetCultureInfo(&quot;en-US&quot;)]"
+  Result="[firstDate]"
+  Results="[allDates]" />
+```
+
+## Notes
+
+- Standard single-character format specifiers (e.g. `d`) are expanded into all matching patterns for the selected culture before matching, enabling robust extraction.
+- Custom format strings must exactly describe the date/time structure present in the source text; unrecognised occurrences are silently skipped.
+- `Result` holds only the first match. Iterate over `Results` to process all occurrences.
+- Full-name patterns such as `MMMM` (full month name) require the correct `LocalizationCode` to parse successfully.
+- The activity uses `DateTime.TryParseExact` internally, so format strings follow standard .NET date/time format specifier rules.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExtractFiles.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExtractFiles.md
@@ -1,0 +1,66 @@
+# Extract/Unzip Files
+
+`UiPath.Activities.System.Compression.Workflow.ExtractFiles`
+
+Extracts all contents of a zipped (compressed) file.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FileToExtract` | File to extract | `InArgument` | `string` | Yes* | — | Full path of the ZIP file to extract. Overload group: `FileToExtract`. |
+| `File` | File | `InArgument` | `IResource` | Yes* | — | Resource reference to the ZIP file to extract. Overload group: `File`. |
+| `DestinationFolder` | Destination folder | `InArgument` | `string` | No | — | Path of the folder where contents are extracted. If empty, the folder containing the ZIP file is used. |
+| `ConflictResolution` | If file already exists | `InArgument` | `FileConflictBehavior` | No | `FileConflictBehavior.Replace` | Behaviour when an extracted file already exists at the destination: `Replace`, `Skip`, or `Rename`. |
+| `Password` | Password | `InArgument` | `string` | No | — | Password required to extract a password-protected archive. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ExtractToADedicatedFolder` | Extract to dedicated folder | `bool` | `true` | When `true`, extracts contents into a new subfolder named after the ZIP file. |
+| `SkipUnsupportedFiles` | Skip unsupported files | `bool` | `false` | When `true`, files that cannot be extracted are silently skipped instead of causing an error. |
+| `CodePage` | Name encoding | `CodePages` | — | Text encoding used for file names inside the archive. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Content` | Extracted Files | `OutArgument` | `ILocalResource[]` | Array of references to all extracted files. |
+| `DestinationFolderInfo` | Extracted contents folder | `OutArgument` | `DirectoryInfo` | Reference to the folder containing the extracted content. |
+
+## Valid Configurations
+
+Two mutually exclusive modes determine how the archive file is specified:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Local path | `FileToExtract` | String expression resolving to a local ZIP file path. |
+| Resource | `File` | `IResource` expression (e.g. from a Storage Bucket or Create File). |
+
+## XAML Example
+
+```xml
+<ui2:ExtractFiles
+    DisplayName="Extract/Unzip Files"
+    FileToExtract="&quot;C:\downloads\archive.zip&quot;"
+    DestinationFolder="&quot;C:\output&quot;"
+    ExtractToADedicatedFolder="True"
+    ConflictResolution="FileConflictBehavior.Replace"
+    Content="[extractedFiles]"
+    DestinationFolderInfo="[extractedFolder]" />
+```
+
+`xmlns:ui2="clr-namespace:UiPath.Activities.System.Compression.Workflow;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- Supported archive format is ZIP. GZip is not supported by this activity.
+- When `ExtractToADedicatedFolder` is `true` and `DestinationFolder` is set, a new subfolder named after the ZIP file is created inside `DestinationFolder`.
+- The `Content` array lists only extracted files, not directories.
+- For password-protected archives, supply the `Password` argument; leaving it empty for a protected archive results in an error unless `SkipUnsupportedFiles` is `true`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExtractText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ExtractText.md
@@ -1,0 +1,71 @@
+# Extract Text
+
+`UiPath.Activities.System.Text.ExtractText`
+
+Extracts text from the given input matching the specified criteria. The following extraction options are available: value between two strings, e-mail addresses, URLs, and text from HTML code.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Source | InArgument | `String` | Yes | — | The input text from which to extract content. |
+| `StartingText` | Starting text | InArgument | `String` | No | — | Text that marks the beginning of the substring to extract. Defaults to start of text when empty. Visible only when `ExtractOptions` is `BetweenStrings`. |
+| `EndingText` | Ending text | InArgument | `String` | No | — | Text that marks the ending of the substring to extract. Defaults to end of text when empty. Visible only when `ExtractOptions` is `BetweenStrings`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ExtractOptions` | What to extract | `TextExtractOptions` | — | The extraction mode that determines what kind of content is extracted. Required. |
+| `IgnoreDuplicates` | Ignore duplicates | `Boolean` | `false` | When enabled, duplicate extracted values are removed from the results. Not visible for `FromHTML` mode. |
+| `MatchCase` | Match case | `Boolean` | `false` | When enabled, the search for `StartingText` and `EndingText` is case-sensitive. Visible only when `ExtractOptions` is `BetweenStrings`. |
+| `ExtractBaseURLOnly` | Extract base URL only | `Boolean` | `false` | When enabled, only the scheme and host part of each URL is extracted (e.g. `https://example.com`). Visible only when `ExtractOptions` is `URLs`. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result / First match | OutArgument | `String` | The first extracted value. Display name changes based on the selected `ExtractOptions`. Not produced in `FromHTML` mode when using the `Results` output. |
+| `Results` | Results | OutArgument | `IEnumerable<String>` | All extracted values. Not available in `FromHTML` mode (use `Result` instead for that mode). |
+
+## Valid Configurations
+
+The visible properties change depending on the value of `ExtractOptions`:
+
+| `ExtractOptions` | `StartingText` | `EndingText` | `MatchCase` | `IgnoreDuplicates` | `ExtractBaseURLOnly` | `Results` |
+|---|---|---|---|---|---|---|
+| `BetweenStrings` | Visible | Visible | Visible | Visible | Hidden | Visible |
+| `Email` | Hidden | Hidden | Hidden | Visible | Hidden | Visible |
+| `URLs` | Hidden | Hidden | Hidden | Visible | Visible | Visible |
+| `FromHTML` | Hidden | Hidden | Hidden | Hidden | Hidden | Hidden |
+
+### Enum Reference
+
+**`TextExtractOptions`**: `BetweenStrings`, `Email`, `URLs`, `FromHTML`
+
+## XAML Example
+
+```xml
+<ucs:ExtractText
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Text;assembly=UiPath.System.Activities.Standard"
+  Source="[htmlContent]"
+  ExtractOptions="BetweenStrings"
+  StartingText="[&quot;&lt;b&gt;&quot;]"
+  EndingText="[&quot;&lt;/b&gt;&quot;]"
+  MatchCase="False"
+  IgnoreDuplicates="True"
+  Result="[firstBoldText]"
+  Results="[allBoldTexts]" />
+```
+
+## Notes
+
+- For `BetweenStrings`: if `StartingText` is empty the extraction starts from the beginning of the source; if `EndingText` is empty the extraction runs to the end of the source.
+- For `FromHTML`: HTML tags, scripts, and head sections are removed and HTML entities are decoded. Only the `Result` output is populated; `Results` is not used.
+- For `Email` and `URLs`, the activity uses built-in regular expressions to identify matching patterns.
+- `ExtractBaseURLOnly` (URLs mode) returns only the scheme and authority (e.g. `https://example.com`), discarding any path or query string.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FilterCollection.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FilterCollection.md
@@ -1,0 +1,52 @@
+# Filter Collection
+
+`UiPath.Activities.System.Collections.FilterCollection`1``
+
+Filter a collection based on custom conditions.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Collection
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Collection` | Collection | `InArgument` | `ICollection<T>` | Yes | — | The collection to filter. |
+| `FilterAction` | Filter Action | `InArgument` | `FilterAction` | No | `KeepMatchingElementsOnly` | Determines whether matching elements are kept or removed. Accepted values: `KeepMatchingElementsOnly`, `RemoveMatchingElements`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Filter` | Filter | `CollectionFilterSettings` | — | The filter conditions configured through the designer's visual filter builder. Contains a logical operator (`And` / `Or`) and one or more individual filter criteria (property path, comparison operator, value). Not directly editable in XAML — use the designer UI to configure conditions. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | `OutArgument` | `List<T>` | The filtered collection. When `Result` is not bound, the original collection object is mutated in-place. When `Result` is bound to a different variable, a new `List<T>` is returned. |
+
+## Valid Configurations
+
+When `Collection` is changed after filter conditions have already been set, the designer resets all conditions to ensure the criteria remain compatible with the new element type. This is enforced by the `EnsureCorrectFilterTypes` rule in `FilterCollectionViewModel`.
+
+For simple types (primitive, string, enum, etc.) the designer exposes a single `CurrentItem` criterion targeting the element value directly. For complex types, each public property (including nested properties up to a configured depth) is offered as a filterable criterion.
+
+## XAML Example
+
+```xml
+<usc:FilterCollection x:TypeArguments="x:String"
+    DisplayName="Filter Collection"
+    Collection="[myList]"
+    Result="[filteredList]"
+    xmlns:usc="clr-namespace:UiPath.Activities.System.Collections;assembly=UiPath.System.Activities"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+```
+
+## Notes
+
+The type parameter `T` is inferred from the connected variable or argument.
+
+The `Filter` property is persisted in the XAML as a `CollectionFilterSettings` object but should always be configured through the Studio designer's visual filter builder rather than edited directly in XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FilterDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FilterDataTable.md
@@ -1,0 +1,93 @@
+# Filter Data Table
+
+`UiPath.Core.Activities.FilterDataTable`
+
+Filters a DataTable by specifying conditions in the Filter widget. The activity can keep or delete rows according to the logical conditions that are specified in the properties.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InArgument | DataTable | No | — | The DataTable to filter. |
+| FilterRowsMode | Filter Rows Mode | InArgument | SelectMode | No | — | Whether matching rows are kept or removed. See **Enum Reference** below. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| Filters | Filters | Property (List\<FilterOperationArgument\>) | — | The filter conditions built using the designer's Filter widget. Each condition specifies a column reference, an operator, and an operand value. Conditions are combined with a shared logical operator (AND or OR). |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| OutputDataTable | Output Data Table | OutArgument | DataTable | The filtered DataTable result. |
+| OutputFirstRow | Output First Row | OutArgument | DataRow | The first DataRow of the filtered result, for convenience. |
+
+## Filter Conditions
+
+Each row in the **Filters** list targets one column and applies one operator. Conditions are all combined with the same logical operator (AND or OR) — mixed logical operators within a single filter set are not supported.
+
+### Column reference
+
+The column for each condition is specified as an `InArgument` expression that evaluates to:
+- A column **name** (String expression)
+- A column **index** (Int32 expression)
+- A **DataColumn** object expression
+
+### Supported filter operators
+
+| Operator | Symbol / Name | Notes |
+|----------|--------------|-------|
+| `LT` | `<` | Numeric/comparable types |
+| `GT` | `>` | Numeric/comparable types |
+| `LTE` | `<=` | Numeric/comparable types |
+| `GTE` | `>=` | Numeric/comparable types |
+| `EQ` | `=` | Any type |
+| `NOTEQ` | `!=` | Any type |
+| `EMPTY` | Is Empty | No value operand required |
+| `NOTEMPTY` | Is Not Empty | No value operand required |
+| `STARTSWITH` | Starts With | String only |
+| `ENDSWITH` | Ends With | String only |
+| `CONTAINS` | Contains | String only |
+| `NOTSTARTSWITH` | Does Not Start With | String only |
+| `NOTENDSWITH` | Does Not End With | String only |
+| `NOTCONTAINS` | Does Not Contain | String only |
+
+## Enum Reference
+
+### SelectMode
+
+| Value | Description |
+|-------|-------------|
+| `Keep` | Rows matching the filter conditions are retained; all others are removed. |
+| `Remove` | Rows matching the filter conditions are removed; all others are retained. |
+
+## Notes
+
+- The `Filters` property is populated via the visual Filter widget in Studio Designer — it is not intended to be set manually in XAML.
+- `FilterRowsMode` defaults to `Keep` when not specified.
+- The activity produces a **new** DataTable in `OutputDataTable`; the original DataTable is not modified.
+
+## XAML Example
+
+```xml
+<ui:FilterDataTable DisplayName="Filter Data Table"
+                    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:FilterDataTable.DataTable>
+    <InArgument x:TypeArguments="sd:DataTable">[myDataTable]</InArgument>
+  </ui:FilterDataTable.DataTable>
+  <ui:FilterDataTable.FilterRowsMode>
+    <InArgument x:TypeArguments="ui:SelectMode">Keep</InArgument>
+  </ui:FilterDataTable.FilterRowsMode>
+  <ui:FilterDataTable.OutputDataTable>
+    <OutArgument x:TypeArguments="sd:DataTable">[filteredTable]</OutArgument>
+  </ui:FilterDataTable.OutputDataTable>
+  <!-- Filters are configured via the visual widget in Studio -->
+</ui:FilterDataTable>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FindAndReplace.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FindAndReplace.md
@@ -1,0 +1,49 @@
+# Find and Replace
+
+`UiPath.Activities.System.Text.FindAndReplace`
+
+Search for a specified text and replace all occurrences with a new text.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Source | InArgument | `String` | Yes | — | The text in which to search and replace. |
+| `ValueToFind` | Value to find | InArgument | `String` | No | — | The text string to search for in the source text. |
+| `ReplaceWith` | Replace with | InArgument | `String` | No | — | The text string to substitute for each occurrence of `ValueToFind`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `MatchCase` | Match case | `Boolean` | `false` | When active, the search for `ValueToFind` is case-sensitive. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `String` | The resulting string after all occurrences of `ValueToFind` have been replaced with `ReplaceWith`. |
+
+## XAML Example
+
+```xml
+<ucs:FindAndReplace
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Text;assembly=UiPath.System.Activities.Standard"
+  Source="[inputText]"
+  ValueToFind="[&quot;foo&quot;]"
+  ReplaceWith="[&quot;bar&quot;]"
+  MatchCase="False"
+  Result="[outputText]" />
+```
+
+## Notes
+
+- All occurrences of `ValueToFind` in the source are replaced; the original string is not modified.
+- When `MatchCase` is `false`, the comparison uses `StringComparison.OrdinalIgnoreCase`. When `true`, it uses `StringComparison.Ordinal`.
+- Unlike the **Replace Matching Patterns** activity, this activity performs a plain string search with no regular expression syntax.
+- If `ValueToFind` is an empty string, the behavior follows standard .NET `String.Replace` semantics (no replacement is performed).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ForEach.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ForEach.md
@@ -1,0 +1,59 @@
+# For Each
+
+`UiPath.Core.Activities.ForEach`1`
+
+Performs an activity or a series of activities on each element of an enumeration.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Values` | Values | `InArgument` | `IEnumerable<T>` | No | — | The collection to iterate over. The element type `T` is inferred from the collection and determines the type of the iterator variable. |
+| `MaxIterations` | Max Iterations | `InArgument` | `int` | No | — | Maximum number of iterations. A value of `0` means unlimited. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `TypeOfValues` | Type Of Values | `Type` | — | The element type `T` of the collection. Shown as a type-picker widget when supported by the designer. Changing this value morphs the activity to the selected generic type. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `CurrentIndex` | Current Index | `OutArgument` | `int` | The zero-based index of the current iteration. |
+
+## XAML Example
+
+```xml
+<ui:ForEach x:TypeArguments="x:String"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="For Each">
+  <ui:ForEach.Values>
+    <InArgument x:TypeArguments="scg:IEnumerable(x:String)">
+      <VisualBasicValue x:TypeArguments="scg:IEnumerable(x:String)" ExpressionText="myList" />
+    </InArgument>
+  </ui:ForEach.Values>
+  <ActivityAction x:TypeArguments="x:String">
+    <ActivityAction.Argument>
+      <DelegateInArgument x:TypeArguments="x:String" Name="item" />
+    </ActivityAction.Argument>
+    <Sequence DisplayName="Body">
+      <!-- child activities reference the iterator variable "item" -->
+    </Sequence>
+  </ActivityAction>
+</ui:ForEach>
+```
+
+## Notes
+
+- **For Each** is a container/scope activity. Child activities are placed inside the `ActivityAction` body and can reference the iterator variable (e.g. `item`).
+- The activity is generic (`ForEach<T>`); the type argument `T` is inferred from the `Values` collection or set explicitly via the `TypeOfValues` type picker.
+- The iterator variable name is auto-suggested based on the element type (e.g. `stringItem` for `String`) and can be renamed. If the suggested name was not changed manually, it is automatically updated when the type changes.
+- `TypeOfValues` is only visible when the designer supports the `TypePicker` widget; in other environments the type is set implicitly.
+- Use a `Break` activity inside the body to exit the loop early; use `Continue` to skip to the next element.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ForEachRow.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ForEachRow.md
@@ -1,0 +1,50 @@
+# For Each Row in Data Table
+
+`UiPath.Core.Activities.ForEachRow`
+
+Executes an action once for each row in the DataTable provided.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InArgument | DataTable | Yes | — | The DataTable whose rows will be iterated. |
+| MaxIterations | Max Iterations | InArgument | Int32 | No | — | Maximum number of rows to process. Leave empty to iterate all rows. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| CurrentIndex | Current Index | OutArgument | Int32 | The zero-based index of the row currently being processed. |
+
+## Notes
+
+- This is a container activity. The **Body** sequence executes once for each row in the DataTable.
+- Inside the body, the current row is available through the `CurrentRow` variable of type `DataRow`. The variable name is fixed and defined by the activity.
+- `TypeArgument` is `DataRow`.
+- `ColumnCount`, `ColumnNames`, and `ColumnSelectionType` are internal designer-state properties (`browsable: false`) used to render column binding hints in the designer body. They are not workflow arguments and should not be set manually.
+
+## XAML Example
+
+```xml
+<ui:ForEachRow DisplayName="For Each Row in Data Table"
+               DataTable="[myDataTable]"
+               xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+               xmlns:sd="clr-namespace:System.Data;assembly=System.Data">
+  <ui:ForEachRow.Body>
+    <ActivityAction x:TypeArguments="sd:DataRow">
+      <ActivityAction.Argument>
+        <DelegateInArgument x:TypeArguments="sd:DataRow" Name="CurrentRow" />
+      </ActivityAction.Argument>
+      <Sequence DisplayName="Body">
+        <!-- Activities that reference CurrentRow go here -->
+      </Sequence>
+    </ActivityAction>
+  </ui:ForEachRow.Body>
+</ui:ForEachRow>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FormatDateAsText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FormatDateAsText.md
@@ -1,0 +1,47 @@
+# Format Date as Text
+
+`UiPath.Activities.System.Date.FormatDateAsText`
+
+Format the source DateTime variable in a text (string).
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Source date | InArgument | `DateTime` | Yes | — | The `DateTime` value to format as text. |
+| `Format` | Date and time format | InArgument | `String` | Yes | — | The format string used to render the date. Accepts standard single-character specifiers (e.g. `d`, `D`, `f`, `F`, `g`, `G`) or custom patterns (e.g. `yyyy-MM-dd`). Supports autocomplete. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `LocalizationCode` | Localization code | `CultureInfo` | `CultureInfo.CurrentCulture` | The culture used to format the date, including the names of months and days. Select from a dropdown of all installed cultures. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `String` | The date formatted as a text string according to the specified format and culture. |
+
+## XAML Example
+
+```xml
+<ucs:FormatDateAsText
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Date;assembly=UiPath.System.Activities.Standard"
+  Source="[invoiceDate]"
+  Format="[&quot;MMMM dd, yyyy&quot;]"
+  LocalizationCode="[System.Globalization.CultureInfo.GetCultureInfo(&quot;en-US&quot;)]"
+  Result="[formattedDate]" />
+```
+
+## Notes
+
+- The format string follows standard .NET `DateTime.ToString(format, culture)` rules.
+- Full-name patterns such as `MMMM` (full month name) or `dddd` (full day name) are culture-sensitive and require the correct `LocalizationCode` to produce localized output.
+- Standard single-character specifiers such as `d`, `D`, `f`, `F`, `g`, `G`, `r`, `s`, `u` are fully supported; the autocomplete widget lists common options.
+- The `LocalizationCode` dropdown lists all cultures available on the machine via `CultureInfo.GetCultures(CultureTypes.AllCultures)`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FormatValue.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/FormatValue.md
@@ -1,0 +1,58 @@
+# Format Value
+
+`UiPath.Core.Activities.FormatValue`
+
+Associates a specific format to a GenericValue variable for use with `.ToString` and `Parse` operations. Supported formats are Number, DateTime, Currency, and Percentage.
+
+**Package:** `UiPath.System.Activities`
+**Platform:** Windows only
+**Category:** Programming > GenericValue
+
+## Properties
+
+### Input/Output
+
+> These properties require a **variable** binding — the activity reads the incoming value and writes an updated value back. Do not use literal expressions.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Value | Value | InOutArgument | GenericValue | Yes | — | The GenericValue variable to format. The activity reads its current value, applies the format, and writes the formatted value back to the same variable. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| Format | Format | IFormatProvider | `GeneralNumberFormatProvider` | The format to apply to the value. Select one of the four format provider types via the property editor (Number, DateTime, Currency, Percentage). |
+
+## Format Provider Reference
+
+The `Format` property accepts one of four `GenericValueFormatProvider` implementations, selectable in Studio's property editor:
+
+| Format Type | Display Name | Description |
+|-------------|-------------|-------------|
+| `GeneralNumberFormatProvider` | Number | Formats the value as a number. Configurable: `DecimalSeparator`, `GroupSeparator`, `DecimalDigits`. |
+| `DateTimeFormatProvider` | DateTime | Formats the value as a date/time using a short date pattern. Configurable: `Pattern` (date/time format string). |
+| `CurrencyNumberFormatProvider` | Currency | Formats the value as currency. Configurable: `Symbol`, `DecimalSeparator`, `GroupSeparator`, `DecimalDigits`. |
+| `PercentageNumberFormatProvider` | Percentage | Formats the value as a percentage. Configurable: `Symbol` (default `%`), `DecimalSeparator`, `GroupSeparator`, `DecimalDigits`. |
+
+## XAML Example
+
+```xml
+<!-- Format a GenericValue as a Number with 2 decimal places -->
+<ui:FormatValue DisplayName="Format Value"
+                xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+                xmlns:uic="clr-namespace:UiPath.Core;assembly=UiPath.System.Activities">
+  <ui:FormatValue.Value>
+    <InOutArgument x:TypeArguments="uic:GenericValue">[myGenericValue]</InOutArgument>
+  </ui:FormatValue.Value>
+  <ui:FormatValue.Format>
+    <uic:GeneralNumberFormatProvider DecimalDigits="2" DecimalSeparator="." GroupSeparator="," />
+  </ui:FormatValue.Format>
+</ui:FormatValue>
+```
+
+## Notes
+
+- `Value` is an `InOutArgument<GenericValue>` — it must be bound to a variable, not a literal.
+- The format is applied in-place: after execution, the same variable holds a `GenericValue` with the `FormatProvider` set, which affects subsequent `.ToString()` and type-conversion calls.
+- This activity is Windows-only (not available in cross-platform/Linux robots).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GenerateDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GenerateDataTable.md
@@ -1,0 +1,76 @@
+# Generate Data Table From Text
+
+`UiPath.Core.Activities.GenerateDataTable`
+
+Generate a DataTable from structured text.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Input | Input | InArgument | String | Yes* | — | The text to parse into a DataTable. Used with the **Use Text** overload group. |
+| ContinueOnError | Continue On Error | InArgument | Boolean | No | — | If true, the workflow continues even if the activity throws an error. |
+
+\* `Input` is required when using the text-based parsing mode. The **Use Positions** overload group uses `Positions` instead (for positional/fixed-width parsing from coordinate data, typically used with Digitizer outputs).
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| ParsingMethod | Parsing Method | Property (DataTableParsingMethod) | — | Determines how the text is split into columns. See **Enum Reference** below. |
+| AutoDetectTypes | Auto Detect Types | Property (Boolean) | true | When true, column data types are inferred from the parsed values. |
+| UseColumnHeader | Use Column Header | Property (Boolean) | false | When true, the first row of the text is treated as column headers. |
+| UseRowHeader | Use Row Header | Property (Boolean) | false | When true, the first column is treated as row labels. |
+| AllowMisalignedColumns | Allow Misaligned Columns | Property (Boolean) | false | When true, rows with a different number of columns than the header are accepted rather than causing an error. |
+| ColumnSeparators | Column Separators | InArgument | String | — | Custom column delimiter string(s). Visible only when `ParsingMethod` is `Custom`. |
+| NewLineSeparator | New Line Separator | InArgument | String | — | Custom row delimiter string. Visible only when `ParsingMethod` is `Custom`. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| DataTable | Data Table | OutArgument | DataTable | The DataTable generated from the parsed text. |
+
+## Valid Configurations
+
+| Mode | Required properties |
+|------|-------------------|
+| Parse from text | `Input` + `ParsingMethod` |
+| Custom delimiters | `Input` + `ParsingMethod` = `Custom` + `ColumnSeparators` and/or `NewLineSeparator` |
+
+## Enum Reference
+
+### DataTableParsingMethod
+
+| Value | Description |
+|-------|-------------|
+| `CSV` | Parses the input as comma-separated values. |
+| `Custom` | Uses the values supplied in `ColumnSeparators` and `NewLineSeparator` to split the text. |
+
+## Notes
+
+- `CSVParsing` (`isVisible: false`) is a hidden legacy argument; use `ParsingMethod` instead.
+- `PreserveNewLines` and `PreserveStrings` are hidden internal properties (`browsable: false`, `isVisible: false`) and should not be set manually.
+- `ColumnSizes` and `Positions` support fixed-width / positional parsing flows (e.g. outputs from document digitization) and are not used in standard text-to-table scenarios.
+
+## XAML Example
+
+```xml
+<ui:GenerateDataTable DisplayName="Generate Data Table From Text"
+                      AutoDetectTypes="True"
+                      UseColumnHeader="True"
+                      ParsingMethod="CSV"
+                      xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:GenerateDataTable.Input>
+    <InArgument x:TypeArguments="x:String">[csvText]</InArgument>
+  </ui:GenerateDataTable.Input>
+  <ui:GenerateDataTable.DataTable>
+    <OutArgument x:TypeArguments="sd:DataTable">[resultTable]</OutArgument>
+  </ui:GenerateDataTable.DataTable>
+</ui:GenerateDataTable>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetCurrentJobInfo.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetCurrentJobInfo.md
@@ -1,0 +1,34 @@
+# Get Current Job Info
+
+`UiPath.Core.Activities.GetCurrentJobInfo`
+
+Provides runtime job info such as process name and version, workflow name, robot name, and mode of execution.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Get Current Job Info | `OutArgument` | `CurrentJobInfo` | An object containing runtime information about the current job, including process name, process version, workflow name, robot name, and execution mode. |
+
+## XAML Example
+
+```xml
+<ui:GetCurrentJobInfo
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Get Current Job Info">
+  <ui:GetCurrentJobInfo.Result>
+    <OutArgument x:TypeArguments="ui:CurrentJobInfo">[jobInfo]</OutArgument>
+  </ui:GetCurrentJobInfo.Result>
+</ui:GetCurrentJobInfo>
+```
+
+## Notes
+
+- The output `CurrentJobInfo` object exposes properties such as process name, process version, workflow file name, robot name, and the mode of execution (e.g. attended, unattended, debug).
+- This activity is useful for logging, branching on execution context, or passing runtime metadata to downstream activities or external systems.
+- Coded workflow support is enabled for this activity — it can be used directly in coded automations.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetEnvironmentFolder.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetEnvironmentFolder.md
@@ -1,0 +1,58 @@
+# Get Environment Folder
+
+`UiPath.Core.Activities.GetEnvironmentFolder`
+
+Gets the path to the specified system special folder.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Environment
+
+## Properties
+
+### Input
+
+_No input arguments._
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| SpecialFolder | Special Folder | `System.Environment.SpecialFolder` | — | The well-known system folder whose path is to be retrieved. Required. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| FolderPath | Folder Path | OutArgument | `string` | The full file system path of the selected special folder. |
+
+## Enum Reference
+
+### System.Environment.SpecialFolder (common values)
+
+| Value | Typical path |
+|-------|-------------|
+| `Desktop` | `C:\Users\<user>\Desktop` |
+| `MyDocuments` | `C:\Users\<user>\Documents` |
+| `ApplicationData` | `C:\Users\<user>\AppData\Roaming` |
+| `LocalApplicationData` | `C:\Users\<user>\AppData\Local` |
+| `ProgramFiles` | `C:\Program Files` |
+| `System` | `C:\Windows\System32` |
+| `Windows` | `C:\Windows` |
+| `Temp` | User temporary folder |
+
+See the full list in the [.NET documentation](https://learn.microsoft.com/dotnet/api/system.environment.specialfolder).
+
+## XAML Example
+
+```xml
+<ui:GetEnvironmentFolder SpecialFolder="MyDocuments">
+  <ui:GetEnvironmentFolder.FolderPath>
+    <OutArgument x:TypeArguments="x:String">[documentsPath]</OutArgument>
+  </ui:GetEnvironmentFolder.FolderPath>
+</ui:GetEnvironmentFolder>
+```
+
+## Notes
+
+- Returns the path as reported by the operating system; the folder is not guaranteed to exist if the OS profile is incomplete.
+- On multi-user systems the returned path is always relative to the current user's profile.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetEnvironmentVariable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetEnvironmentVariable.md
@@ -1,0 +1,42 @@
+# Get Environment Variable
+
+`UiPath.Core.Activities.GetEnvironmentVariable`
+
+Gets the contents of the specified environment variable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Environment
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Variable | Variable | InArgument | `string` | Yes | — | The name of the environment variable to retrieve. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| VariableValue | Variable Value | OutArgument | `string` | The value of the specified environment variable. Returns an empty string if the variable does not exist. |
+
+## XAML Example
+
+```xml
+<ui:GetEnvironmentVariable Variable="PATH">
+  <ui:GetEnvironmentVariable.VariableValue>
+    <OutArgument x:TypeArguments="x:String">[pathValue]</OutArgument>
+  </ui:GetEnvironmentVariable.VariableValue>
+</ui:GetEnvironmentVariable>
+```
+
+## Notes
+
+- Environment variable names are case-insensitive on Windows but case-sensitive on Linux/macOS.
+- Reads from the combined scope of Process, User, and Machine variables in the standard .NET resolution order.
+- Use **Set Environment Variable** to create or update a variable, and **Get Environment Folder** to retrieve well-known system folder paths.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetJobs.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetJobs.md
@@ -1,0 +1,80 @@
+# Get Jobs
+
+`UiPath.Core.Activities.GetJobs`
+
+Retrieves a list of Orchestrator jobs according to a custom filter, using the Orchestrator API.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Jobs
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Filter` | Filter | InArgument | `string` | No | — | An OData filter expression string applied to the jobs query. Used when `FilterBuilder` is not active. |
+| `Skip` | Skip | InArgument | `int` | No | — | The number of jobs to skip for pagination. |
+| `Top` | Top | InArgument | `int` | No | — | The maximum number of jobs to return. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FilterBuilder` | Filter Builder | `JobFilterSettings` | — | A structured filter built using the visual Filter Builder widget. Supports filtering by State, JobPriority, Key, ReleaseName, CreationTime, StartTime, and EndTime. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `IEnumerable<OrchestratorJob>` | The list of jobs matching the specified filters. |
+
+## Valid Configurations
+
+- Either `Filter` (OData string expression) or `FilterBuilder` (visual widget) may be used to apply filter criteria. The designer provides a menu toggle to switch between the two modes.
+- `FilterBuilder` supports the following criteria fields: **State**, **JobPriority**, **Key**, **ReleaseName**, **CreationTime**, **StartTime**, **EndTime**.
+- `Skip` and `Top` provide pagination support for large result sets.
+
+### Enum Reference
+
+**JobFilterField** (available in FilterBuilder)
+
+| Criteria | Supported Operators |
+|----------|---------------------|
+| `State` | Equals, NotEquals |
+| `JobPriority` | Equals, NotEquals |
+| `Key` | Equals (GUID) |
+| `ReleaseName` | Equals, Contains, StartsWith, EndsWith |
+| `CreationTime` | OlderThan, NewerThan, OlderThanOrEqual, NewerThanOrEqual |
+| `StartTime` | OlderThan, NewerThan, OlderThanOrEqual, NewerThanOrEqual |
+| `EndTime` | OlderThan, NewerThan, OlderThanOrEqual, NewerThanOrEqual |
+
+**JobState** (values available in FilterBuilder State criteria)
+
+| Value | Description |
+|-------|-------------|
+| `Pending` | Job is queued but not yet started. |
+| `Running` | Job is currently executing. |
+| `Stopping` | Job has been requested to stop gracefully. |
+| `Terminating` | Job is being forcibly terminated. |
+| `Faulted` | Job ended with an error. |
+| `Successful` | Job completed successfully. |
+| `Stopped` | Job was stopped before completion. |
+| `Suspended` | Job is suspended. |
+| `Resumed` | Job has been resumed from suspension. |
+
+## XAML Example
+
+```xml
+<ui:GetJobs
+    Top="[20]"
+    Result="[jobs]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- `Result` is a collection of `OrchestratorJob` objects. Each object exposes properties such as `Id`, `Key`, `State`, `ReleaseName`, `StartTime`, `EndTime`, and `Info`.
+- `FolderPath` is an advanced/hidden property that overrides the Orchestrator folder context for the query.
+- Use `Top` to limit result size. Without it, the API may return a large number of records.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetLastDownloadedFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetLastDownloadedFile.md
@@ -1,0 +1,58 @@
+# Wait for Download
+
+`UiPath.Core.Activities.GetLastDownloadedFile`
+
+Detects a file download from any application and waits for the download to complete before any further processing of the file in the automation.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `DownloadFolder` | Downloads folder | `InArgument` | `string` | Yes | `GetDownloadsFolder()` | Path of the folder to monitor for new downloads. Defaults to the system Downloads folder. |
+| `Timeout` | Timeout | `InArgument` | `int` | No | — | Maximum time in milliseconds to wait for a download to complete before raising an error. |
+| `IgnoreFiles` | Ignore file extensions | `InArgument` | `string` | No | — | Comma-separated list of file extensions to ignore (e.g. `".crdownload,.tmp"`). |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Body` | Body | `ActivityAction` | — | Optional container for activities to execute while monitoring for the download (e.g. clicking a download button). Rendered as a visual container in Studio when supported. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `File` | Downloaded file | `OutArgument` | `FileInfo` | `FileInfo` object for the downloaded file. |
+| `FileResource` | File Resource | `OutArgument` | `ILocalResource` | `ILocalResource` reference to the downloaded file. |
+
+## XAML Example
+
+```xml
+<ui:GetLastDownloadedFile
+    DisplayName="Wait for Download"
+    DownloadFolder="&quot;C:\Users\user\Downloads&quot;"
+    Timeout="30000"
+    File="[downloadedFileInfo]"
+    FileResource="[downloadedResource]">
+  <ui:GetLastDownloadedFile.Body>
+    <ActivityAction>
+      <!-- Place activities that trigger the download here -->
+    </ActivityAction>
+  </ui:GetLastDownloadedFile.Body>
+</ui:GetLastDownloadedFile>
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- Place the activity that triggers the file download (e.g. a **Click** activity on a download button) inside the `Body` container so the monitoring starts before the download is initiated.
+- The activity monitors the `DownloadFolder` for new files; it waits until an in-progress download (e.g. `.crdownload` or `.part` partial files) is fully completed.
+- Use `IgnoreFiles` to filter out temporary files created by browsers during the download process.
+- Both `File` (legacy) and `FileResource` (recommended) outputs reference the same downloaded file.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetProcesses.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetProcesses.md
@@ -1,0 +1,42 @@
+# Get Processes
+
+`UiPath.Core.Activities.GetProcesses`
+
+Gets the list of all running processes.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Application
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| ContinueOnError | Continue On Error | InArgument | `bool` | No | — | When `True`, execution continues to the next activity even if this activity throws an error. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Processes | Processes | OutArgument | `Collection<Process>` | The collection of `System.Diagnostics.Process` objects representing every currently running process. |
+
+## XAML Example
+
+```xml
+<ui:GetProcesses>
+  <ui:GetProcesses.Processes>
+    <OutArgument x:TypeArguments="scg:Collection(sd:Process)">[processList]</OutArgument>
+  </ui:GetProcesses.Processes>
+</ui:GetProcesses>
+```
+
+## Notes
+
+- Returns all processes visible to the current user account. Processes owned by other users may be excluded depending on OS permissions.
+- Each `Process` object in the output collection exposes properties such as `ProcessName`, `Id`, `MainWindowTitle`, `StartTime`, etc.
+- Use **Kill Process** to terminate a specific process from the returned collection.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetQueueItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetQueueItem.md
@@ -1,0 +1,63 @@
+# Get Transaction Item
+
+`UiPath.Core.Activities.GetQueueItem`
+
+Gets an item from the queue so that you can process it (start the transaction) and sets its status to In Progress.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `QueueType` | Queue name | InArgument | `string` | Yes | — | The name of the queue from which to retrieve the next item. |
+| `Reference` | Reference | InArgument | `string` | No | null | Filters retrieved items by reference value. Used together with `FilterStrategy`. |
+| `FolderPath` | Folder Path | InArgument | `string` | No | null | The Orchestrator folder path to use. Overrides the robot's default folder. |
+| `TimeoutMS` | Timeout (milliseconds) | InArgument | `int` | No | — | The maximum time to wait for the activity to complete before throwing an error. |
+| `ContinueOnError` | Continue On Error | InArgument | `bool` | No | false | When true, execution continues even if the activity throws an error. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FilterStrategy` | Filter Strategy | `ReferenceFilterStrategy` | StartsWith | Determines how the `Reference` filter is applied. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `TransactionItem` | Transaction Item | OutArgument | `QueueItem` | The retrieved queue item, now set to In Progress. Returns null if the queue is empty. |
+| `SpecificData` | Specific Data | OutArgument | `object` | The raw specific data payload of the retrieved queue item. |
+
+## Valid Configurations
+
+- If the queue contains no items with status **New**, `TransactionItem` is set to null and no error is thrown.
+- `Reference` and `FilterStrategy` work together: only items whose reference matches the filter are considered.
+
+### Enum Reference
+
+**ReferenceFilterStrategy**
+
+| Value | Description |
+|-------|-------------|
+| `StartsWith` | The item's reference must start with the specified value. |
+| `Equals` | The item's reference must exactly match the specified value. |
+
+## XAML Example
+
+```xml
+<ui:GetQueueItem
+    QueueType="&quot;InvoiceProcessing&quot;"
+    TransactionItem="[transactionItem]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- The retrieved item is immediately set to status **In Progress**. Use **Set Transaction Status** to mark it as Successful or Failed after processing.
+- If the queue is empty, `TransactionItem` is null. Always null-check the output before processing.
+- Use **Wait Queue Item** if you need the activity to block until an item becomes available.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetQueueItems.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetQueueItems.md
@@ -1,0 +1,69 @@
+# Get Queue Items
+
+`UiPath.Core.Activities.GetQueueItems`
+
+Retrieves a list of transactions from an indicated queue, according to multiple filters, such as creation date, priority, state and reference.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `QueueName` | Queue name | InArgument | `string` | Yes | — | The name of the queue from which to retrieve items. |
+| `Filter` | Filter | InArgument | `string` | No | null | An OData filter expression string applied to the query. Used when `FilterBuilder` is not active. |
+| `Skip` | Skip | InArgument | `int` | No | — | The number of items to skip for pagination. |
+| `Top` | Top | InArgument | `int` | No | — | The maximum number of items to return. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FilterBuilder` | Filter Builder | `QueueItemFilterSettings` | null | A structured filter built using the visual Filter Builder widget. Supports filtering by Status, Priority, Reference, Duration, and date fields. |
+| `FilterByCurrentRobot` | Filter By Current Robot | `bool` | false | When true, only returns items processed by the current robot. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `IEnumerable<QueueItem>` | The list of queue items matching the specified filters. |
+
+## Valid Configurations
+
+- Either the `Filter` (OData string) or `FilterBuilder` (visual widget) may be used to apply filter criteria. The designer provides a toggle to switch between the two modes.
+- `FilterBuilder` supports the following criteria fields: **Status**, **Priority**, **Reference**, **Duration**, **CreationTime**, **StartProcessing**, **EndProcessing**.
+- `Skip` and `Top` provide pagination. Use them together to page through large result sets.
+
+### Enum Reference
+
+**QueueItemFilterCriteria** (available in FilterBuilder)
+
+| Criteria | Supported Operators |
+|----------|---------------------|
+| `Status` | Equals, NotEquals, OneOf, OneOfVariable |
+| `Priority` | Equals, NotEquals, EqualsVariable |
+| `Reference` | Equals, StartsWith, Contains, EndsWith |
+| `Duration` | LessThan, MoreThan, LessThanOrEqual, MoreThanOrEqual |
+| `CreationTime` | OlderThan, NewerThan, OlderThanOrEqual, NewerThanOrEqual |
+| `StartProcessing` | OlderThan, NewerThan, OlderThanOrEqual, NewerThanOrEqual |
+| `EndProcessing` | OlderThan, NewerThan, OlderThanOrEqual, NewerThanOrEqual |
+
+## XAML Example
+
+```xml
+<ui:GetQueueItems
+    QueueName="&quot;InvoiceProcessing&quot;"
+    Top="[50]"
+    Result="[queueItems]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- This activity retrieves queue items for reporting or inspection purposes. It does not change the status of items.
+- The legacy filter properties (`Duration`, `From`, `To`, `Priority`, `QueueItemStates`, `FilterStrategy`, `Reference`) are hidden in the designer. Existing workflows using those properties have their values automatically imported into `FilterBuilder` on first open.
+- `FolderPath` is an advanced/hidden property that overrides the Orchestrator folder resolved from the robot context.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetRobotAsset.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetRobotAsset.md
@@ -1,0 +1,47 @@
+# Get Asset
+
+`UiPath.Core.Activities.GetRobotAsset`
+
+Gets a specified asset by using a provided AssetName. If the asset is not global, it must be assigned to the local robot in order to be retrieved.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Assets
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AssetName` | Asset Name | InArgument | `string` | No | — | The name of the Orchestrator asset to retrieve. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `CacheStrategy` | Cache Strategy | `CacheStrategyEnum` | — | Controls whether and how the retrieved asset value is cached locally during robot execution. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Value` | Value | OutArgument | `object` | The value of the asset. The runtime type depends on the asset type configured in Orchestrator (text, integer, boolean, or credential). |
+
+## XAML Example
+
+```xml
+<ui:GetRobotAsset
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Get Asset"
+    AssetName="[&quot;DatabaseConnectionString&quot;]"
+    Value="{x:Reference assetValue}" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The asset must exist in Orchestrator before this activity is executed.
+- For **Per Robot** assets, the asset must be assigned to the robot running the process.
+- The `Value` output is typed as `object`. Cast it to the expected type (e.g., `String`, `Integer`, `Boolean`) after retrieval.
+- To retrieve a credential asset with separate `Username` and `Password` outputs, use **Get Credential** instead.
+- To retrieve a secret asset as a `SecureString`, use **Get Secret** instead.
+- `FolderPath` is available via the Orchestrator connection context (inherited from the base activity class) and can be configured in the activity's Orchestrator scope.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetRobotCredential.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetRobotCredential.md
@@ -1,0 +1,42 @@
+# Get Credential
+
+`UiPath.Core.Activities.GetRobotCredential`
+
+Gets a specified credential asset by using a provided Asset Name. If the credential asset is not global, it must be assigned to the local robot in order to be retrieved.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Assets
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AssetName` | Asset Name | InArgument | `string` | No | — | The name of the Orchestrator credential asset to retrieve. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Username` | Username | OutArgument | `string` | The username component of the credential. |
+| `Password` | Password | OutArgument | `SecureString` | The password component of the credential, returned as a `SecureString`. |
+
+## XAML Example
+
+```xml
+<ui:GetRobotCredential
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Get Credential"
+    AssetName="[&quot;SAPLoginCredential&quot;]"
+    Username="{x:Reference sapUser}"
+    Password="{x:Reference sapPassword}" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The asset must be of type **Credential** in Orchestrator.
+- For **Per Robot** credential assets, the asset must be assigned to the robot running the process.
+- The `Password` is returned as a `SecureString`. Use `System.Net.NetworkCredential` to convert to plaintext when required by a downstream activity.
+- `FolderPath` is available via the Orchestrator connection context (inherited from the base activity class) and can be configured in the activity's Orchestrator scope.
+- To retrieve only a secret (no username), use **Get Secret** instead.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetRowItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetRowItem.md
@@ -1,0 +1,64 @@
+# Get Row Item
+
+`UiPath.Core.Activities.GetRowItem`
+
+Gets a value from a DataRow variable according to a specified column.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Row | Row | InArgument | DataRow | Yes | — | The DataRow from which to read the value. |
+| ColumnName | Column Name | InArgument | String | No* | — | The name of the column whose value to retrieve. |
+| ColumnIndex | Column Number | InArgument | Int32 | No* | — | The zero-based index of the column whose value to retrieve. |
+
+\* One of `ColumnName` or `ColumnIndex` should be provided to identify the target cell. `Column` (a DataColumn object) is a third option available in the source but hidden in the designer (`isVisible: false`).
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Value | Value | OutArgument | Object | The value of the cell at the specified column in the given row. The type is `Object`; cast as needed. |
+
+## Notes
+
+- `Column` (DataColumn object overload) is present in the activity source but hidden in the designer (`isVisible: false`). Use `ColumnName` or `ColumnIndex` instead.
+- The returned `Value` is typed as `Object`. Use `.ToString()` or `CType(Value, T)` / `DirectCast` to convert to the desired type.
+- This activity does not support a typed `TypeArgument` at runtime; the value is always returned as `Object`.
+
+## XAML Example
+
+```xml
+<!-- Get value by column name -->
+<ui:GetRowItem DisplayName="Get Row Item"
+               xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:GetRowItem.Row>
+    <InArgument x:TypeArguments="sd:DataRow">[CurrentRow]</InArgument>
+  </ui:GetRowItem.Row>
+  <ui:GetRowItem.ColumnName>
+    <InArgument x:TypeArguments="x:String">"FirstName"</InArgument>
+  </ui:GetRowItem.ColumnName>
+  <ui:GetRowItem.Value>
+    <OutArgument x:TypeArguments="x:Object">[cellValue]</OutArgument>
+  </ui:GetRowItem.Value>
+</ui:GetRowItem>
+
+<!-- Get value by column index -->
+<ui:GetRowItem DisplayName="Get Row Item"
+               xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:GetRowItem.Row>
+    <InArgument x:TypeArguments="sd:DataRow">[CurrentRow]</InArgument>
+  </ui:GetRowItem.Row>
+  <ui:GetRowItem.ColumnIndex>
+    <InArgument x:TypeArguments="x:Int32">0</InArgument>
+  </ui:GetRowItem.ColumnIndex>
+  <ui:GetRowItem.Value>
+    <OutArgument x:TypeArguments="x:Object">[cellValue]</OutArgument>
+  </ui:GetRowItem.Value>
+</ui:GetRowItem>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetSecret.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetSecret.md
@@ -1,0 +1,41 @@
+# Get Secret
+
+`UiPath.Core.Activities.GetSecret`
+
+Gets a specified secret asset by using a provided Asset Name. If the secret asset is not global, it must be assigned to the local robot in order to be retrieved.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Assets
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AssetName` | Asset Name | InArgument | `string` | No | — | The name of the Orchestrator secret asset to retrieve. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Secret` | Password | OutArgument | `SecureString` | The secret value retrieved from Orchestrator, returned as a `SecureString` to avoid exposing the plaintext value in memory. |
+
+## XAML Example
+
+```xml
+<ui:GetSecret
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Get Secret"
+    AssetName="[&quot;ApiToken&quot;]"
+    Secret="{x:Reference apiToken}" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The asset must be of type **Secret** in Orchestrator.
+- Requires Orchestrator version 20.0 or later; an error is thrown at runtime if the connected Orchestrator version does not meet this minimum.
+- For **Per Robot** secret assets, the asset must be assigned to the robot running the process.
+- The secret is returned as a `SecureString` to minimize exposure of sensitive values. Use `System.Net.NetworkCredential` to convert to plaintext when required.
+- `FolderPath` is available via the Orchestrator connection context (inherited from the base activity class) and can be configured in the activity's Orchestrator scope.
+- To retrieve a credential with both `Username` and `Password` as separate outputs, use **Get Credential** instead.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetUsernamePasswordX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/GetUsernamePasswordX.md
@@ -1,0 +1,66 @@
+# Get Username/Password
+
+`UiPath.Activities.System.GetUsernamePasswordX`
+
+Securely store and load usernames and passwords.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Dialog
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| CredentialName | Credential Name | InArgument | `string` | No | — | The name used to look up the credential. Hidden in the designer by default; use `CredentialNameProperty` instead. |
+| OrchestratorCredentialName | Orchestrator credential name | InArgument | `string` | No | — | The name of the credential asset stored in Orchestrator. |
+| TimeoutInSeconds | Timeout (in seconds) | InArgument | `int` | No | — | How long to wait for user input before timing out. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| AppOrSite | App Or Site | `string` | — | A label identifying the application or site these credentials belong to, shown in the dialog prompt. |
+| AutosubmitTimeoutSeconds | Autosubmit timeout seconds | `int` | `AutosubmitTimeout` | Number of seconds before the dialog auto-submits when credentials are pre-filled. |
+| CredentialNameProperty | Credential Name Property | `string` | — | Design-time binding of the credential name; preferred over the `CredentialName` argument in the designer. |
+| CredentialsSource | Credentials source | `CredentialSource` | `CredentialSource.CredentialsManager` | Where to load the credentials from (Windows Credential Manager, Orchestrator asset, or prompt). |
+| ExistingCredentialWarning | Existing Credential Warning | `string` | — | Warning message displayed when a credential matching the given name already exists. |
+| MissingCredentialWarning | Missing Credential Warning | `string` | — | Warning message displayed when no matching credential is found. |
+| Password | Password | `string` | — | Design-time pre-fill for the password field. |
+| UserName | User Name | `string` | — | Design-time pre-fill for the username field. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Credential | Credential | OutArgument | `PasswordCredentials` | The retrieved or entered credentials, containing both username and secure password. |
+
+## Enum Reference
+
+### CredentialSource
+
+| Value | Description |
+|-------|-------------|
+| `CredentialsManager` | Load from the Windows Credential Manager |
+| `Orchestrator` | Load from an Orchestrator credential asset |
+| `Prompt` | Always show an interactive dialog to the user |
+
+## XAML Example
+
+```xml
+<ui:GetUsernamePasswordX AppOrSite="MyApp"
+                         CredentialsSource="CredentialsManager">
+  <ui:GetUsernamePasswordX.Credential>
+    <OutArgument x:TypeArguments="ui:PasswordCredentials">[myCredential]</OutArgument>
+  </ui:GetUsernamePasswordX.Credential>
+</ui:GetUsernamePasswordX>
+```
+
+## Notes
+
+- This activity is only supported on Windows.
+- The `Credential` output is a `PasswordCredentials` object whose `Password` property is a `SecureString`, keeping the secret out of plain memory.
+- When `CredentialsSource` is `Orchestrator`, provide `OrchestratorCredentialName` to identify the asset.
+- Hidden properties (`CredentialName`, `OrchestratorCredentialName`, `OrchestratorFolderPath`) are not visible in the Designer panel by default.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeCode.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeCode.md
@@ -1,0 +1,59 @@
+# Invoke Code
+
+`UiPath.Core.Activities.InvokeCode`
+
+Synchronously invokes VB.NET or C# code, optionally passing it a list of input arguments. This activity can also return out arguments to the caller workflow.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| ContinueOnError | Continue on error | InArgument | `bool` | No | — | When `True`, execution continues to the next activity even if this activity throws an error. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| Code | Code | `string` | — | The VB.NET or C# source code to execute. Required. Supports only string literals and String variables. |
+| Language | Language | `NetLanguage` | `NetLanguage.VBNet` | The programming language of the code snippet (`VBNet` or `CSharp`). |
+| Arguments | Arguments | `Dictionary<string, Argument>` | — | Named input/output argument bindings that make workflow variables available inside the code and allow returning values back to the workflow. |
+
+### Output
+
+_No dedicated output arguments. Return values are passed back through the `Arguments` dictionary using `OutArgument` or `InOutArgument` entries._
+
+## Enum Reference
+
+### NetLanguage
+
+| Value | Description |
+|-------|-------------|
+| `VBNet` | Visual Basic .NET (default) |
+| `CSharp` | C# |
+
+## XAML Example
+
+```xml
+<ui:InvokeCode Language="VBNet">
+  <ui:InvokeCode.Code>
+    <x:String>
+      result = input * 2
+    </x:String>
+  </ui:InvokeCode.Code>
+  <ui:InvokeCode.Arguments>
+    <x:Reference>invokeCodeArgs</x:Reference>
+  </ui:InvokeCode.Arguments>
+</ui:InvokeCode>
+```
+
+## Notes
+
+- Argument bindings in the `Arguments` dictionary use the variable name as the key; direction (`In`, `Out`, `InOut`) determines data flow.
+- The code snippet is compiled and executed at runtime in the same process as the robot; it has access to all .NET BCL types.
+- Use `InArgument` entries to pass data into the code and `OutArgument` entries to receive results back.
+- Both `VBNet` and `CSharp` are supported; choose the language that matches your Studio project settings for consistency.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeComMethod.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeComMethod.md
@@ -1,0 +1,63 @@
+# Invoke Com Method
+
+`UiPath.Core.Activities.InvokeComMethod`
+
+Invokes a method of a specified COM object.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming.Execute
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| MethodName | Method name | InArgument | `string` | Yes | — | The name of the method to invoke on the COM object. |
+| CLSID | CLSID | InArgument | `string` | No | — | The class identifier (CLSID) of the COM object to instantiate. Use either `CLSID` or `ProgID` to identify the target object. |
+| ProgID | ProgID | InArgument | `string` | No | — | The programmatic identifier (ProgID) of the COM object type. Use either `ProgID` or `CLSID`. |
+| ContinueOnError | Continue On Error | InArgument | `bool` | No | — | When `True`, execution continues to the next activity even if this activity throws an error. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| Arguments | Arguments | `Dictionary<string, Argument>` | — | Named parameter bindings passed to the COM method. |
+| BindingFlags | Binding flags | `BindingFlags` | — | Reflection binding flags controlling how the method is located and invoked. Supports multi-select. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Result | Result | OutArgument | `object` | The return value of the invoked COM method. Cast to the appropriate type as needed. |
+
+## Valid Configurations
+
+Provide exactly one of `CLSID` or `ProgID` to identify the COM server:
+
+| Scenario | Use |
+|----------|-----|
+| Known ProgID (e.g., `"Excel.Application"`) | `ProgID` |
+| Known CLSID GUID | `CLSID` |
+
+## XAML Example
+
+```xml
+<!-- Invoke a method using ProgID -->
+<ui:InvokeComMethod MethodName="Open">
+  <ui:InvokeComMethod.ProgID>
+    <InArgument x:TypeArguments="x:String">"Excel.Application"</InArgument>
+  </ui:InvokeComMethod.ProgID>
+  <ui:InvokeComMethod.Result>
+    <OutArgument x:TypeArguments="x:Object">[comResult]</OutArgument>
+  </ui:InvokeComMethod.Result>
+</ui:InvokeComMethod>
+```
+
+## Notes
+
+- This activity is only supported on Windows; COM is a Windows-specific technology.
+- `CLSID` and `ProgID` are mutually exclusive; supplying both may cause unexpected behaviour.
+- The `Result` is typed as `object`; use an Assign or Cast activity to convert it to the expected .NET type.
+- `BindingFlags` maps directly to `System.Reflection.BindingFlags`; the default (no flags set) uses standard late-binding invocation suitable for most COM objects.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeProcess.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeProcess.md
@@ -1,0 +1,70 @@
+# Invoke Process
+
+`UiPath.Core.Activities.InvokeProcess`
+
+Starts the specified process within the current robot execution. It waits for the invoked process to finish before resuming the execution. It returns output arguments.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ProcessName` | Process Name / Package Name | `InArgument` | `string` | Yes | — | The name of the Orchestrator process (when invoking by process name) or the package name (when invoking by package name). The display name changes based on the `Invoke Process By` selection. |
+| `FolderPath` | Folder Path | `InArgument` | `string` | No | — | The Orchestrator folder path used to locate the process. In solution scope, this field becomes read-only when a process is selected by literal name. |
+| `EntryPointPath` | Entry point | `InArgument` | `string` | No | — | The entry point `.xaml` path within the package. Only visible when **Invoke Process By** is set to `ByPackageName`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `UsePackage` | Use package | `bool` | `True` | Determines whether the process is looked up by package name (and entry point) or by Orchestrator process name. |
+| `TargetSession` | Target Session | `InvokeProcessTargetSession` | `Current` | The session in which the process executes. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `OutputArguments` | Output Arguments | `OutArgument` | `Dictionary<string, object>` | A dictionary containing the output arguments returned by the invoked process after it completes. |
+
+## Valid Configurations
+
+| `UsePackage` | Visible fields |
+|---|---|
+| `False` (by process name) | `ProcessName` (as "Process Name"), `FolderPath`, `NotMappedEntryPointPath` (read-only placeholder showing the detected entry point) |
+| `True` (by package name) | `ProcessName` (as "Package Name"), `FolderPath`, `EntryPointPath`, deprecation warning info box |
+
+## XAML Example
+
+```xml
+<ui:InvokeProcess
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Invoke Process"
+    UsePackage="False">
+  <ui:InvokeProcess.ProcessName>
+    <InArgument x:TypeArguments="x:String">
+      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="&quot;MyAutomation&quot;" />
+    </InArgument>
+  </ui:InvokeProcess.ProcessName>
+  <ui:InvokeProcess.FolderPath>
+    <InArgument x:TypeArguments="x:String">
+      <VisualBasicValue x:TypeArguments="x:String" ExpressionText="&quot;Shared&quot;" />
+    </InArgument>
+  </ui:InvokeProcess.FolderPath>
+  <ui:InvokeProcess.OutputArguments>
+    <OutArgument x:TypeArguments="scg:Dictionary(x:String, x:Object)" />
+  </ui:InvokeProcess.OutputArguments>
+</ui:InvokeProcess>
+```
+
+## Notes
+
+- The activity waits synchronously for the invoked process to finish before execution continues in the calling workflow.
+- **Invoke Process By** (`InvokeProcessBy`) is a designer-only radio-group control (`notMapped`) that sets `UsePackage` on the underlying activity and switches between process-name and package-name modes.
+- When invoking by package name, a deprecation warning info box is shown in the designer (`InvokeProcessInfoBox`).
+- In solution scope, `FolderPath` is automatically set from the selected process and becomes read-only; it is cleared if the process selection changes to a non-literal expression.
+- `Arguments` (the input/output argument dictionary passed to the process) is populated automatically by importing arguments from Orchestrator when a valid process and, if applicable, entry point are selected. Use the **Use an expression** menu action to switch to `ArgumentsVariable`, a single expression-based alternative. At runtime, `ArgumentsVariable` takes precedence over `Arguments` when both are set.
+- On non-Windows/Portable target frameworks, an incompatible target framework warning is displayed when a Legacy or Windows process is selected in solution scope.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeVBScript.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeVBScript.md
@@ -1,0 +1,58 @@
+# Invoke VBScript
+
+`UiPath.Core.Activities.InvokeVBScript`
+
+Executes a specified VBScript, optionally passing it a list of input parameters.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.VBScript
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| FileName | VBScript file name | InArgument | `string` | Yes | — | The full file path of the `.vbs` script to execute. |
+| TimeoutMS | Timeout | InArgument | `int` | No | — | Maximum time in milliseconds to wait for the script to finish. Only applies when `WaitForOutput` is `True`. |
+| KillOnTimeout | KillOnTimeout | InArgument | `bool` | No | `False` | When `True`, forcibly terminates the VBScript process if the timeout is reached. |
+| RunInBatchMode | HidePopups | InArgument | `bool` | No | `False` | When `True`, suppresses display alerts, scripting errors, and input dialogs (runs silently). |
+| UnicodeSupport | UnicodeSupport | InArgument | `bool` | No | `False` | When `True`, enables correct handling of non-ASCII characters (e.g., Japanese) in arguments and output. |
+| WaitForOutput | WaitForOutput | InArgument | `bool` | No | `True` | When `True`, the activity waits for the script to complete before proceeding. When `False`, the script runs asynchronously and `TimeoutMS` is ignored. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| Arguments | Arguments | `List<InArgument<string>>` | `[]` | Ordered list of string arguments passed to the VBScript at runtime. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Result | Result | OutArgument | `string` | The standard output produced by the VBScript execution. |
+
+## XAML Example
+
+```xml
+<ui:InvokeVBScript WaitForOutput="True" TimeoutMS="10000" KillOnTimeout="True">
+  <ui:InvokeVBScript.FileName>
+    <InArgument x:TypeArguments="x:String">"C:\Scripts\MyScript.vbs"</InArgument>
+  </ui:InvokeVBScript.FileName>
+  <ui:InvokeVBScript.Arguments>
+    <InArgument x:TypeArguments="x:String">arg1</InArgument>
+    <InArgument x:TypeArguments="x:String">arg2</InArgument>
+  </ui:InvokeVBScript.Arguments>
+  <ui:InvokeVBScript.Result>
+    <OutArgument x:TypeArguments="x:String">[scriptOutput]</OutArgument>
+  </ui:InvokeVBScript.Result>
+</ui:InvokeVBScript>
+```
+
+## Notes
+
+- This activity is only supported on Windows; it relies on the Windows Script Host (`cscript.exe`).
+- Arguments are passed positionally; access them in the script via `WScript.Arguments(0)`, `WScript.Arguments(1)`, etc.
+- When `WaitForOutput` is `False`, the `Result` output will be empty because the process has not yet completed.
+- `RunInBatchMode` (`HidePopups`) uses the `/B` switch of `cscript`, suppressing all UI interaction from the script.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeWorkflow.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/InvokeWorkflow.md
@@ -1,0 +1,45 @@
+# Invoke Workflow File
+
+`UiPath.Core.Activities.InvokeWorkflowFile`
+
+Synchronously invokes a specified workflow, optionally passing it a list of input arguments.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `WorkflowFileName` | Workflow file name | `InArgument` | `string` | Yes | — | The path to the `.xaml` workflow file to invoke. Supports expression auto-complete. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `UnSafe` | Isolated | `bool` | — | When `True`, the invoked workflow runs in an isolated process. |
+| `TargetSession` | Target Session | `InvokeWorkflowTargetSession` | `Current` | The session in which the invoked workflow executes. |
+
+## XAML Example
+
+```xml
+<ui:InvokeWorkflowFile
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Invoke Workflow File"
+    WorkflowFileName="[&quot;Workflows\Process.xaml&quot;]">
+  <ui:InvokeWorkflowFile.Arguments>
+    <x:Reference>__ReferenceID0</x:Reference>
+  </ui:InvokeWorkflowFile.Arguments>
+</ui:InvokeWorkflowFile>
+```
+
+## Notes
+
+- **Invoke Workflow File** is a container/scope activity in the sense that it passes arguments to and receives output from the invoked workflow file.
+- The invoked workflow runs **synchronously** — the current workflow pauses until the invoked one finishes.
+- `Arguments` is a dictionary of input/output arguments mapped to the invoked workflow's declared arguments; it is populated automatically from the target `.xaml` file when a valid `WorkflowFileName` is provided.
+- Setting `Isolated` (`UnSafe`) to `True` runs the invoked workflow in a separate process for fault isolation; this incurs additional overhead.
+- `TargetSession` controls which robot session executes the invoked workflow (e.g. `Current`, `Main`, `PictureInPicture`).
+- `AssemblyName` is a non-browsable internal property and is not intended for manual configuration.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/IsMatch.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/IsMatch.md
@@ -1,0 +1,51 @@
+# Is Text Matching
+
+`UiPath.Core.Activities.IsMatch`
+
+Indicates whether the specified regular expression finds a match in the specified input string, using the specified matching options.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Input` | Text to search in | InArgument | `String` | Yes | — | The string in which to search for a match. |
+| `Pattern` | Pattern | InArgument | `String` | Yes | — | The regular expression pattern to match against. |
+| `TimeoutMS` | Timeout (ms) | InArgument | `Int32` | No | — | Maximum time in milliseconds allowed for the match operation. Leave empty for no timeout. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `RegexOption` | Pattern options | `RegexOptions` | `IgnoreCase, Compiled` | Flags that control regular expression matching behavior. Multiple flags can be combined. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `Boolean` | `True` if the pattern finds at least one match in the input string; `False` otherwise. |
+
+### Enum Reference
+
+**`RegexOptions`** (flags, combinable): `None`, `IgnoreCase`, `Multiline`, `ExplicitCapture`, `Compiled`, `Singleline`, `IgnorePatternWhitespace`, `RightToLeft`, `ECMAScript`, `CultureInvariant`
+
+## XAML Example
+
+```xml
+<ui:IsMatch
+  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+  Input="[myText]"
+  Pattern="[&quot;\d{3}-\d{4}&quot;]"
+  RegexOption="IgnoreCase, Compiled"
+  Result="[isMatchResult]" />
+```
+
+## Notes
+
+- The default `RegexOption` is `IgnoreCase, Compiled`. Adjust this to change matching behavior (for example, use `None` for a case-sensitive match without JIT compilation overhead on one-off patterns).
+- Setting `TimeoutMS` prevents runaway backtracking on complex patterns against large inputs. A `RegexMatchTimeoutException` is thrown if the timeout expires.
+- The activity uses the .NET `Regex.IsMatch` static method, which caches the 15 most recently used patterns automatically.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/JoinDataTables.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/JoinDataTables.md
@@ -1,0 +1,85 @@
+# Join Data Tables
+
+`UiPath.Core.Activities.JoinDataTables`
+
+Combines rows from two tables by using values common to each other, according to a Join rule.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable1 | DataTable1 | InArgument | DataTable | Yes | — | The first (left) DataTable in the join. |
+| DataTable2 | DataTable2 | InArgument | DataTable | Yes | — | The second (right) DataTable in the join. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| JoinType | JoinType | Property (JoinType) | — | The type of join to perform. See **Enum Reference** below. |
+| Arguments | Arguments | Property (List\<JoinOperationArgument\>) | — | The join conditions built using the designer's Join widget. Each condition pairs a column from DataTable1 with a column from DataTable2 using a comparison operator. All conditions are combined with AND. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| OutputDataTable | Data Table | OutArgument | DataTable | The resulting joined DataTable. |
+
+## Join Conditions
+
+Each condition in **Arguments** references one column from each table and an operator. Only AND is supported as the logical operator between conditions.
+
+### Column reference
+
+Each side of a join condition is specified as an `InArgument` expression that evaluates to a column name (String), column index (Int32), or DataColumn object.
+
+### Supported join operators
+
+| Operator | Symbol |
+|----------|--------|
+| `LT` | `<` |
+| `GT` | `>` |
+| `LTE` | `<=` |
+| `GTE` | `>=` |
+| `EQ` | `=` |
+| `NOTEQ` | `!=` |
+
+## Enum Reference
+
+### JoinType
+
+| Value | Description |
+|-------|-------------|
+| `Inner` | Returns only rows where the join condition is satisfied in both tables. |
+| `Left` | Returns all rows from DataTable1 and matched rows from DataTable2. Unmatched rows from DataTable2 produce null values in the result. |
+| `Full` | Returns all rows from both tables. Rows without a match in the other table produce null values for the missing side. |
+
+## Notes
+
+- The `Arguments` property is populated via the visual Join widget in Studio Designer — it is not intended to be set manually in XAML.
+- `Column1` and `Column2` are internal designer-state properties (zero-based column counts) that track the column layout in the widget. They are not workflow arguments.
+- `Operation` is an internal property holding the join rule at runtime; it is not exposed as a designer argument.
+- The output is always a new DataTable; neither input table is modified.
+
+## XAML Example
+
+```xml
+<ui:JoinDataTables DisplayName="Join Data Tables"
+                   JoinType="Inner"
+                   xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:JoinDataTables.DataTable1>
+    <InArgument x:TypeArguments="sd:DataTable">[employeesTable]</InArgument>
+  </ui:JoinDataTables.DataTable1>
+  <ui:JoinDataTables.DataTable2>
+    <InArgument x:TypeArguments="sd:DataTable">[departmentsTable]</InArgument>
+  </ui:JoinDataTables.DataTable2>
+  <ui:JoinDataTables.OutputDataTable>
+    <OutArgument x:TypeArguments="sd:DataTable">[joinedTable]</OutArgument>
+  </ui:JoinDataTables.OutputDataTable>
+  <!-- Join conditions are configured via the visual widget in Studio -->
+</ui:JoinDataTables>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/KillProcess.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/KillProcess.md
@@ -1,0 +1,67 @@
+# Kill Process
+
+`UiPath.Core.Activities.KillProcess`
+
+Terminates a specified process.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Application
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Process | Process | InArgument | `Process` | No | — | A `System.Diagnostics.Process` object identifying the process to kill. Use this or `ProcessName`, not both. |
+| ProcessName | Process Name | InArgument | `string` | No | — | The name of the process to kill (without the `.exe` extension). Kills all matching processes. Use this or `Process`, not both. |
+| AppliesTo | Applies To | InArgument | `KillProcessApplyOn` | No | `KillProcessApplyOn.All` | Filters which instances of a named process to kill (All, current user, current session, or current desktop). Windows projects support all modes. |
+| ContinueOnError | Continue On Error | InArgument | `bool` | No | — | When `True`, execution continues to the next activity even if this activity throws an error. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## Valid Configurations
+
+Exactly one of `Process` or `ProcessName` must be provided (they belong to separate overload groups).
+
+| Scenario | Use |
+|----------|-----|
+| Have a `Process` object from Get Processes | `Process` argument |
+| Know only the process name | `ProcessName` argument |
+
+## Enum Reference
+
+### KillProcessApplyOn
+
+| Value | Description |
+|-------|-------------|
+| `All` | Kill all processes matching the name, regardless of owner |
+| `User` | Kill only processes owned by the current user (Windows only) |
+| `Session` | Kill only processes in the current Windows session |
+| `Desktop` | Kill only processes on the current Windows desktop |
+
+## XAML Example
+
+```xml
+<!-- Kill by name -->
+<ui:KillProcess ProcessName="notepad" AppliesTo="All" />
+
+<!-- Kill a specific process object -->
+<ui:KillProcess>
+  <ui:KillProcess.Process>
+    <InArgument x:TypeArguments="sd:Process">[myProcess]</InArgument>
+  </ui:KillProcess.Process>
+</ui:KillProcess>
+```
+
+## Notes
+
+- In Windows projects all `AppliesTo` filtering modes are available. In cross-platform projects only `All` is supported.
+- Killing a process by name terminates every running instance that matches; supply a `Process` object (from Get Processes) to target a single instance.
+- A `ProcessName` match is case-insensitive and should not include the `.exe` suffix.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ListStorageFiles.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ListStorageFiles.md
@@ -1,0 +1,36 @@
+# List Storage Files
+
+`UiPath.Core.Activities.Storage.ListStorageFiles`
+
+Lists the content of a certain directory in an Orchestrator storage bucket.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Storage
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Directory` | Directory | InArgument | `string` | Yes | `"\\"` | The path of the directory within the storage bucket to list (e.g., `reports/2024`). Defaults to the bucket root. |
+| `Filter` | Filter | InArgument | `string` | No | — | An optional filter expression to narrow down results by file name or pattern. |
+| `Recursive` | Recursive | InArgument | `bool` | No | `true` | When `True`, lists files in all subdirectories recursively. When `False`, lists only the immediate directory contents. |
+
+## XAML Example
+
+```xml
+<ui:ListStorageFiles
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.Storage;assembly=UiPath.System.Activities"
+    DisplayName="List Storage Files"
+    Directory="[&quot;reports/2024&quot;]"
+    Recursive="[False]" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection with access to storage buckets.
+- The storage bucket name and folder path are configured in the Orchestrator connection context (via `StorageBucketName` and `FolderPath` inherited from the base storage activity class).
+- `Directory` defaults to `"\\"` which represents the root of the bucket.
+- The activity returns a collection of file metadata objects. Iterate over the result to access individual file details such as name and path.
+- `Recursive` defaults to `True`; set it to `False` to list only the top-level entries in the specified directory.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/LogMessage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/LogMessage.md
@@ -1,0 +1,48 @@
+# Log Message
+
+`UiPath.Core.Activities.LogMessage`
+
+Writes the specified diagnostic message at the specified level. These messages are also sent to Orchestrator and displayed in the Logs page.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Logging
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Level | Level | InArgument | `LogLevel` | Yes | `LogLevel.Info` | The severity level of the log message. Configurable as a project setting. |
+| Message | Message | InArgument | `object` | No | — | The text of the message to log. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## Enum Reference
+
+### LogLevel
+
+| Value | Description |
+|-------|-------------|
+| `Trace` | Finest-grained informational events |
+| `Info` | Informational messages (default) |
+| `Warn` | Potentially harmful situations |
+| `Error` | Error events that might still allow the application to continue |
+| `Fatal` | Severe error events that will presumably abort execution |
+
+## XAML Example
+
+```xml
+<ui:LogMessage Level="Info" Message="Processing started" />
+```
+
+## Notes
+
+- `Level` is a project-level setting; the default (`Info`) can be changed project-wide in Studio project settings.
+- Messages logged here are visible both in the Studio Output panel and in the Orchestrator Logs page when running attended or unattended.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/LookupDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/LookupDataTable.md
@@ -1,0 +1,81 @@
+# Lookup Data Table
+
+`UiPath.Core.Activities.LookupDataTable`
+
+This activity searches for the value provided in the Lookup Value property inside the DataTable and returns the row index of the found cell. If the Target Column is set, it also returns the value from the cell with the specified Row.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InArgument | DataTable | Yes | — | The DataTable to search. |
+| LookupValue | Lookup Value | InArgument | String | Yes | — | The value to search for within the lookup column. |
+| LookupColumnName | Column Name | InArgument | String | Yes* | — | The name of the column to search in. Mutually exclusive with **Column Number** (lookup). |
+| LookupColumnIndex | Column Number | InArgument | Int32? | Yes* | — | The zero-based index of the column to search in. Mutually exclusive with **Column Name** (lookup). |
+| TargetColumnName | Column Name | InArgument | String | No | — | The name of the column from which to retrieve the cell value at the found row. Mutually exclusive with **Column Number** (target). |
+| TargetColumnIndex | Column Number | InArgument | Int32? | No | — | The zero-based index of the column from which to retrieve the cell value. Mutually exclusive with **Column Name** (target). |
+
+\* Exactly one of `LookupColumnName` or `LookupColumnIndex` must be provided. `LookupDataColumn` (a DataColumn object overload) exists in the source but is hidden (`isVisible: false`) and is not exposed in the designer UI.
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| RowIndex | RowIndex | OutArgument | Int32 | The zero-based index of the row where the lookup value was found. Returns `-1` if not found. |
+| CellValue | CellValue | OutArgument | Object | The value of the cell at the found row in the target column. Only populated when a target column is specified. |
+
+## Valid Configurations
+
+### Lookup column reference modes
+
+| Mode | Property to set |
+|------|----------------|
+| By column name | `LookupColumnName` |
+| By column index | `LookupColumnIndex` |
+
+### Target column reference modes (optional)
+
+| Mode | Property to set |
+|------|----------------|
+| By column name | `TargetColumnName` |
+| By column index | `TargetColumnIndex` |
+| No target column | Leave both empty — only `RowIndex` is populated |
+
+## Notes
+
+- `LookupDataColumn` (overload group `Lookup data column`) is present in the activity but hidden in the designer (`isVisible: false`). Use `LookupColumnName` or `LookupColumnIndex` instead.
+- `TargetDataColumn` (target column DataColumn object) is similarly hidden (`isVisible: false`). Use `TargetColumnName` or `TargetColumnIndex` instead.
+- `RowIndex` is `-1` when the lookup value is not found.
+- `CellValue` is `null` when no target column is specified or when the lookup value is not found.
+
+## XAML Example
+
+```xml
+<!-- Lookup by column name, retrieve value from target column by name -->
+<ui:LookupDataTable DisplayName="Lookup Data Table"
+                    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:LookupDataTable.DataTable>
+    <InArgument x:TypeArguments="sd:DataTable">[myDataTable]</InArgument>
+  </ui:LookupDataTable.DataTable>
+  <ui:LookupDataTable.LookupValue>
+    <InArgument x:TypeArguments="x:String">"Alice"</InArgument>
+  </ui:LookupDataTable.LookupValue>
+  <ui:LookupDataTable.LookupColumnName>
+    <InArgument x:TypeArguments="x:String">"FirstName"</InArgument>
+  </ui:LookupDataTable.LookupColumnName>
+  <ui:LookupDataTable.TargetColumnName>
+    <InArgument x:TypeArguments="x:String">"Department"</InArgument>
+  </ui:LookupDataTable.TargetColumnName>
+  <ui:LookupDataTable.RowIndex>
+    <OutArgument x:TypeArguments="x:Int32">[foundRowIndex]</OutArgument>
+  </ui:LookupDataTable.RowIndex>
+  <ui:LookupDataTable.CellValue>
+    <OutArgument x:TypeArguments="x:Object">[departmentValue]</OutArgument>
+  </ui:LookupDataTable.CellValue>
+</ui:LookupDataTable>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Matches.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Matches.md
@@ -1,0 +1,54 @@
+# Find Matching Patterns
+
+`UiPath.Core.Activities.Matches`
+
+Searches an input string for all occurrences of a regular expression and returns all the successful matches.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Input` | Text to search in | InArgument | `String` | Yes | — | The string in which to search for matches. |
+| `Pattern` | Pattern | InArgument | `String` | Yes | — | The regular expression pattern to match against. |
+| `TimeoutMS` | Timeout (ms) | InArgument | `Int32` | No | — | Maximum time in milliseconds allowed for each individual match operation. Leave empty for no timeout. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `RegexOption` | Pattern options | `RegexOptions` | `IgnoreCase, Compiled` | Flags that control regular expression matching behavior. Multiple flags can be combined. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `FirstMatch` | First Match | OutArgument | `String` | The value of the first successful match, or `null` if no match was found. |
+| `Matches` | Matches | OutArgument | `IEnumerable<Match>` | A collection of all successful `System.Text.RegularExpressions.Match` objects found in the input. |
+
+### Enum Reference
+
+**`RegexOptions`** (flags, combinable): `None`, `IgnoreCase`, `Multiline`, `ExplicitCapture`, `Compiled`, `Singleline`, `IgnorePatternWhitespace`, `RightToLeft`, `ECMAScript`, `CultureInvariant`
+
+## XAML Example
+
+```xml
+<ui:Matches
+  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+  Input="[myText]"
+  Pattern="[&quot;\b\w+\b&quot;]"
+  RegexOption="IgnoreCase, Compiled"
+  FirstMatch="[firstMatchResult]"
+  Matches="[allMatches]" />
+```
+
+## Notes
+
+- The `Matches` output is a collection of `System.Text.RegularExpressions.Match` objects. Access the matched string via `.Value` and capture groups via `.Groups`.
+- `FirstMatch` is a convenience output containing only the `.Value` of the first match in the collection.
+- If the pattern finds no matches, `Matches` is an empty collection and `FirstMatch` is `null`.
+- Setting `TimeoutMS` prevents runaway backtracking on complex patterns. A `RegexMatchTimeoutException` is thrown if the timeout expires.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MergeCollections.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MergeCollections.md
@@ -1,0 +1,41 @@
+# Merge Collections
+
+`UiPath.Activities.System.Collections.MergeCollections`1``
+
+Combine collections in a new collection that contains all the elements.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Collection
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Collection` | Collection | `InArgument` | `ICollection<T>` | Yes | — | The first collection to merge. |
+| `SecondCollection` | Second Collection | `InArgument` | `ICollection<T>` | Yes | — | The second collection to merge. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | `OutArgument` | `List<T>` | A new list containing all elements from `Collection` followed by all elements from `SecondCollection`. |
+
+## XAML Example
+
+```xml
+<usc:MergeCollections x:TypeArguments="x:String"
+    DisplayName="Merge Collections"
+    Collection="[firstList]"
+    SecondCollection="[secondList]"
+    Result="[mergedList]"
+    xmlns:usc="clr-namespace:UiPath.Activities.System.Collections;assembly=UiPath.System.Activities"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+```
+
+## Notes
+
+The type parameter `T` is inferred from the connected variable or argument.
+
+When `Result` is bound to the same variable as `Collection` or `SecondCollection`, the activity appends the other collection's elements in-place to avoid an unnecessary copy. In all other cases a new `List<T>` is allocated via `Enumerable.Concat`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MergeDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MergeDataTable.md
@@ -1,0 +1,64 @@
+# Merge Data Table
+
+`UiPath.Core.Activities.MergeDataTable`
+
+Merges the specified DataTable with the current DataTable, indicating whether to preserve changes and how to handle missing schema in the current DataTable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Source | Source | InArgument | DataTable | Yes | — | The DataTable whose rows will be merged into the destination. |
+
+### Input/Output
+
+> These properties require a **variable** binding — the activity reads the incoming value and writes an updated value back. Do not use literal expressions.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Destination | Destination | InOutArgument | DataTable | Yes | — | The target DataTable that receives the merged rows. Modified in place. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| MissingSchemaAction | MissingSchemaAction | Property (MissingSchemaAction) | Add | Controls what happens when the source contains columns not present in the destination. See **Enum Reference** below. |
+
+## Enum Reference
+
+### MissingSchemaAction
+
+This is the standard `System.Data.MissingSchemaAction` enumeration.
+
+| Value | Description |
+|-------|-------------|
+| `Add` | Adds the necessary columns to the destination schema to complete the merge. This is the default. |
+| `Ignore` | Ignores the extra columns. Data for those columns is discarded. |
+| `Error` | Throws a `SystemException` if a schema mismatch is encountered. |
+| `AddWithKey` | Adds the necessary columns and primary key information to complete the merge. |
+
+## Notes
+
+- The merge is performed using `DataTable.Merge(source, preserveChanges: true, missingSchemaAction)`.
+- Rows from **Source** are appended to **Destination**. Existing rows in Destination are not removed.
+- The **Destination** variable is updated in place via `InOutArgument`.
+
+## XAML Example
+
+```xml
+<ui:MergeDataTable DisplayName="Merge Data Table"
+                   MissingSchemaAction="Add"
+                   xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:MergeDataTable.Source>
+    <InArgument x:TypeArguments="sd:DataTable">[sourceTable]</InArgument>
+  </ui:MergeDataTable.Source>
+  <ui:MergeDataTable.Destination>
+    <InOutArgument x:TypeArguments="sd:DataTable">[destinationTable]</InOutArgument>
+  </ui:MergeDataTable.Destination>
+</ui:MergeDataTable>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MessageBox.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MessageBox.md
@@ -1,0 +1,69 @@
+# Message Box
+
+`UiPath.Core.Activities.MessageBox`
+
+Displays a message box with a specified text and buttons.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Dialog
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Text | Text | InArgument | `object` | Yes | — | The message to display in the body of the dialog. |
+| Caption | Caption | InArgument | `string` | No | — | The title bar text of the message box dialog. |
+| Buttons | Buttons | InArgument | `ButtonOptions` | No | `ButtonOptions.Ok` | Specifies which buttons to display. Configurable as a project setting. |
+| AutoCloseAfter | Automatically Close After | InArgument | `TimeSpan` | No | — | If set, the dialog closes automatically after this duration without user input. |
+| TopMost | TopMost | InArgument | `bool` | No | `true` | If set, always brings the message box to the foreground. Configurable as a project setting. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| ChosenButton | Chosen Button | OutArgument | `string` | The label of the button pressed by the user. Possible values: `Ok`, `Yes`, `No`, `Cancel`. |
+
+## Valid Configurations
+
+`Buttons` controls which buttons are rendered. Only the corresponding `ChosenButton` values are returned.
+
+| ButtonOptions value | Possible ChosenButton values |
+|--------------------|------------------------------|
+| `Ok` | `Ok` |
+| `OkCancel` | `Ok`, `Cancel` |
+| `YesNo` | `Yes`, `No` |
+| `YesNoCancel` | `Yes`, `No`, `Cancel` |
+
+## Enum Reference
+
+### ButtonOptions
+
+| Value | Buttons shown |
+|-------|--------------|
+| `Ok` | OK |
+| `OkCancel` | OK, Cancel |
+| `YesNo` | Yes, No |
+| `YesNoCancel` | Yes, No, Cancel |
+
+## XAML Example
+
+```xml
+<ui:MessageBox Caption="Confirm" Text="Do you want to continue?" Buttons="YesNo">
+  <ui:MessageBox.ChosenButton>
+    <OutArgument x:TypeArguments="x:String">[chosenButton]</OutArgument>
+  </ui:MessageBox.ChosenButton>
+</ui:MessageBox>
+```
+
+## Notes
+
+- This activity is only supported on Windows. It uses Win32 dialog APIs.
+- `Buttons` and `TopMost` are project-level settings with defaults `ButtonOptions.Ok` and `true` respectively.
+- If `AutoCloseAfter` elapses with no user interaction, `ChosenButton` receives the value of the default button for the chosen `Buttons` configuration.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MoveFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/MoveFile.md
@@ -1,0 +1,53 @@
+# Move File
+
+`UiPath.Core.Activities.MoveFile`
+
+Moves a specified file to another location.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Move File | `InArgument` | `string` | Yes* | — | Full path of the source file. Overload group: `Path`. |
+| `PathResource` | Input resource | `InArgument` | `IResource` | Yes* | — | Resource reference to the source file. Overload group: `PathResource`. |
+| `Destination` | Destination | `InArgument` | `string` | No | — | Destination path or folder for the moved file. |
+| `DestinationResource` | Destination resource | `InArgument` | `IResource` | No | — | Resource reference to the destination. |
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | No | — | When `true`, execution continues even if an error occurs. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Overwrite` | Overwrite | `bool` | `false` | When `true`, overwrites the destination file if it already exists. |
+
+## Valid Configurations
+
+| Mode | Source property | Destination property |
+|------|----------------|---------------------|
+| Local path | `Path` | `Destination` |
+| Resource | `PathResource` | `DestinationResource` |
+
+Source overload groups are `Path` and `PathResource`; these are mutually exclusive. Destination properties can be used independently of the source mode.
+
+## XAML Example
+
+```xml
+<ui:MoveFile
+    DisplayName="Move File"
+    Path="&quot;C:\inbox\report.pdf&quot;"
+    Destination="&quot;C:\processed\report.pdf&quot;"
+    Overwrite="False" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- If `Destination` is an existing **folder**, the source file is moved into that folder keeping its original name.
+- This activity produces no output argument.
+- Moving a file across volumes performs a copy-then-delete operation internally.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/OrchestratorHttpRequest.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/OrchestratorHttpRequest.md
@@ -1,0 +1,78 @@
+# Orchestrator HTTP Request
+
+`UiPath.Core.Activities.OrchestratorHttpRequest`
+
+Performs HTTP requests to the Orchestrator API by authenticating under the robot it is executed on.
+
+**Package:** `UiPath.System.Activities`
+**Category:** API
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `JSONPayload` | Relative Endpoint | InArgument | `string` | Conditional | — | The JSON request body. Required when `Method` is POST, PUT, or PATCH. Can also be configured as a project setting under `OrchestratorHTTPRequest / RelativeEndpoint`. |
+| `RelativeEndpoint` | Relative Endpoint | InArgument | `string` | No | — | The relative URL path of the Orchestrator API endpoint to call (e.g. `/odata/Queues`). |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Method` | Method | `OrchestratorAPIHttpMethods` | — | The HTTP method to use for the request. |
+| `ResponseHeaders` | Headers | `OutArgument<Dictionary<string, string>>` | — | Output property. See Output section. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `string` | The raw response body returned by the Orchestrator API as a JSON string. |
+| `StatusCode` | StatusCode | OutArgument | `int` | The HTTP status code of the response (e.g. 200, 201, 400, 404). |
+| `ResponseHeaders` | Headers | OutArgument | `Dictionary<string, string>` | The HTTP response headers returned by the Orchestrator API. |
+
+## Valid Configurations
+
+- `JSONPayload` is required when `Method` is `POST`, `PUT`, or `PATCH` (any method that requires a request body). The designer enforces this via an `InitializeRules` validation.
+- `RelativeEndpoint` is the path relative to the Orchestrator base URL (e.g. `/odata/Jobs`, `/odata/Queues(1234)/UiPathODataSvc.GetQueueItemById`).
+- `JSONPayload` can be saved as a project-level setting under the `OrchestratorHTTPRequest` section with key `RelativeEndpoint`.
+
+### Enum Reference
+
+**OrchestratorAPIHttpMethods**
+
+| Value | Description |
+|-------|-------------|
+| `GET` | Retrieve a resource or collection. No request body required. |
+| `POST` | Create a new resource. Requires a JSON body. |
+| `PUT` | Replace an existing resource. Requires a JSON body. |
+| `PATCH` | Partially update an existing resource. Requires a JSON body. |
+| `DELETE` | Delete a resource. No request body required. |
+
+## XAML Example
+
+```xml
+<!-- GET: retrieve queue definitions -->
+<ui:OrchestratorHttpRequest
+    RelativeEndpoint="&quot;/odata/QueueDefinitions&quot;"
+    Method="GET"
+    Result="[responseJson]"
+    StatusCode="[statusCode]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+
+<!-- POST: add a queue item directly via API -->
+<ui:OrchestratorHttpRequest
+    RelativeEndpoint="&quot;/odata/Queues/UiPathODataSvc.AddQueueItem&quot;"
+    Method="POST"
+    JSONPayload="[jsonBody]"
+    Result="[responseJson]"
+    StatusCode="[statusCode]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime. Authentication is handled automatically using the robot's credentials — no API key or token is required in the workflow.
+- The base URL of the Orchestrator instance is resolved from the robot's connection context. Only the relative path needs to be specified.
+- `Result` contains the raw JSON response body as a string. Deserialize it (e.g. using `Newtonsoft.Json.JObject.Parse`) to work with the response data.
+- `FolderPath` is an advanced/hidden property inherited from the base activity that can override the Orchestrator folder context.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/OutputDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/OutputDataTable.md
@@ -1,0 +1,41 @@
+# Output Data Table as Text
+
+`UiPath.Core.Activities.OutputDataTable`
+
+Writes a DataTable object to a string using the CSV format.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InArgument | DataTable | Yes | — | The DataTable to convert to a CSV-formatted string. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Text | Text | OutArgument | String | The resulting CSV string. Each row maps to a line; column values are comma-separated. |
+
+## Notes
+
+- The output uses CSV formatting: column values are separated by commas and each row ends with a newline.
+- Column headers are included as the first line of the output string.
+
+## XAML Example
+
+```xml
+<ui:OutputDataTable DisplayName="Output Data Table as Text"
+                    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:OutputDataTable.DataTable>
+    <InArgument x:TypeArguments="sd:DataTable">[myDataTable]</InArgument>
+  </ui:OutputDataTable.DataTable>
+  <ui:OutputDataTable.Text>
+    <OutArgument x:TypeArguments="x:String">[csvText]</OutArgument>
+  </ui:OutputDataTable.Text>
+</ui:OutputDataTable>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/PathExists.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/PathExists.md
@@ -1,0 +1,47 @@
+# Get Local File or Folder
+
+`UiPath.Core.Activities.PathExists`
+
+Checks if the specified path exists. The path can represent a file path or a directory path.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Get Local File or Folder | `InArgument` | `string` | Yes | — | The file or folder path to check for existence. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `PathType` | PathType | `PathType` | — | Constrains the check to a specific type: `Any`, `File`, or `Directory`. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Exists` | File or folder exists | `OutArgument` | `bool` | `true` if the path exists (and matches the specified `PathType`); otherwise `false`. |
+| `Resource` | File or folder object | `OutArgument` | `ILocalResource` | Reference to the existing file or folder resource. `null` if it does not exist. |
+
+## XAML Example
+
+```xml
+<ui:PathExists
+    DisplayName="Get Local File or Folder"
+    Path="&quot;C:\reports\summary.xlsx&quot;"
+    Exists="[fileExists]"
+    Resource="[fileResource]" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- Use the `Exists` output to branch execution with an **If** activity before attempting to read or manipulate the file.
+- The `Resource` output provides an `ILocalResource` suitable for use with other file activities without requiring a separate path string.
+- When `PathType` is set to `File`, a path that exists as a directory returns `Exists = false`, and vice versa.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Placeholder.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Placeholder.md
@@ -1,0 +1,32 @@
+# Workflow Placeholder
+
+`UiPath.Core.Activities.Placeholder`
+
+Adds a placeholder into the workflow.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow.Control
+
+## Properties
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Description` | Description | `string` | *(localised initial value)* | A free-text label describing what should be implemented here. Displayed as a multiline text block in the designer. |
+
+## XAML Example
+
+```xml
+<ui:Placeholder DisplayName="Workflow Placeholder"
+    Description="TODO: implement this step"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+`Placeholder` must be placed inside a `Sequence`. A validation error is raised if the direct parent is not a `Sequence`.
+
+At runtime the activity logs an informational message indicating that the placeholder was executed and then completes successfully without doing any work. It is intended as a design-time marker for steps that have not yet been implemented.
+
+The `Description` property is not mapped to a workflow argument — it is a plain string property stored directly on the activity.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/PostponeTransactionItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/PostponeTransactionItem.md
@@ -1,0 +1,38 @@
+# Postpone Transaction Item
+
+`UiPath.Core.Activities.PostponeTransactionItem`
+
+Adds time parameters between which a transaction must be processed (not before Postpone Date and no later than Deadline Date).
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `TransactionItem` | Transaction Item | InArgument | `QueueItem` | Yes | — | The transaction item to postpone. Must be an item currently In Progress. |
+| `DeferDate` | Postpone | InArgument | `DateTime` | Yes | null | The date after which the queue item may be processed. The item will not be picked up before this date. |
+| `DueDate` | Deadline | InArgument | `DateTime` | No | null | The date before which the queue item should be processed. |
+| `FolderPath` | Folder Path | InArgument | `string` | No | — | The Orchestrator folder path to use. Overrides the robot's default folder. |
+| `TimeoutMS` | Timeout (milliseconds) | InArgument | `int` | No | — | The maximum time in milliseconds to wait for the activity to complete before throwing an error. |
+| `ContinueOnError` | Continue On Error | InArgument | `bool` | No | false | When true, execution continues even if the activity throws an error. |
+
+## XAML Example
+
+```xml
+<ui:PostponeTransactionItem
+    TransactionItem="[transactionItem]"
+    DeferDate="[DateTime.Now.AddHours(2)]"
+    DueDate="[DateTime.Now.AddDays(1)]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- The `TransactionItem` must have status **In Progress**. This activity is typically called when a transient condition prevents immediate processing (for example, a downstream system is temporarily unavailable).
+- After being postponed, the item's status is changed back to **New** in Orchestrator with the specified scheduling window applied. It will not be picked up again until after `DeferDate`.
+- `DeferDate` is required. `DueDate` is optional but recommended to prevent indefinite deferral.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ProcessTrackingScope.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ProcessTrackingScope.md
@@ -1,0 +1,89 @@
+# Process Tracking Scope
+
+`UiPath.Core.Activities.ProcessTracking.ProcessTrackingScope`
+
+Enables Process Tracking. This will track the execution of a Sequence as a Task in Process Mining. You can configure this scope using properties panel and control how the execution gets tracked as part of a Task and Process within Process Mining.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Process Tracking
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `TaskName` | Task name | InArgument | `string` | No | — | The name to assign to the tracked task in Process Mining. |
+| `ObjectId` | Object ID | InArgument | `string` | No* | — | The identifier of the object associated with the current task. Required when `ProcessLogMode` is `ExistingTrace`. Used to continue a trace started in a previous automation. |
+| `ObjectType` | Object type | InArgument | `string` | No* | — | The type of the object associated with the current task (e.g., `"invoice"`, `"document"`). Required when `ProcessLogMode` is `ExistingTrace`. |
+| `ObjectInteraction` | Object interaction | InArgument | `PTSObjectInteraction` | No | `null` | The interaction type of the object for this task. Visible when `ProcessLogMode` is `ExistingTrace`. |
+| `ProcessCaseName` | Process name | InArgument | `string` | No* | — | The business process name for a new trace. Groups related tasks within the Process Tracking Service. Required when `ProcessLogMode` is `NewTrace`. |
+| `ProcessCaseNameToSwitchTo` | Process name | InArgument | `string` | No* | — | The name of an existing trace to track this task in. Required when `ProcessLogMode` is `ExistingTrace`. |
+
+*Required dynamically based on `ProcessLogMode` value.
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `IsPTSEnabled` | Process tracking | `bool` | — | Enables or disables process tracking for this scope. Only visible when the Process Mining service is connected. |
+| `ProcessLogMode` | How to track | `ProcessTrackingMode` | `ProcessTrackingMode.CurrentTrace` | Determines in which Process Mining trace the task execution is recorded. |
+
+## Valid Configurations
+
+The properties shown and required depend on the `ProcessLogMode` value:
+
+| `ProcessLogMode` | Visible / Required properties |
+|---|---|
+| `CurrentTrace` | `TaskName`, `ProcessLogMode`. Tracks in the currently active trace. No object or process identification required. |
+| `NewTrace` | `TaskName`, `ProcessLogMode`, `ProcessCaseName` (required). Starts a new trace for the specified business process. |
+| `ExistingTrace` | `TaskName`, `ProcessLogMode`, `ProcessCaseNameToSwitchTo` (required), `ObjectId` (required), `ObjectType` (required), `ObjectInteraction` (optional). Continues tracking in an existing trace identified by process name and object. |
+
+### Enum Reference
+
+**`ProcessTrackingMode`**
+
+| Value | Description |
+|-------|-------------|
+| `CurrentTrace` | Track the task in the currently active Process Mining trace. |
+| `NewTrace` | Create a new trace for the given process name and track this task in it. |
+| `ExistingTrace` | Switch to an existing trace (identified by process name and object) and track this task in it. |
+
+## XAML Example
+
+```xml
+<!-- Track in the current trace -->
+<ui:ProcessTrackingScope
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.ProcessTracking;assembly=UiPath.System.Activities"
+    DisplayName="Process Tracking Scope"
+    IsPTSEnabled="True"
+    TaskName="[&quot;ProcessInvoice&quot;]"
+    ProcessLogMode="CurrentTrace">
+  <Sequence>
+    <!-- automation activities here -->
+  </Sequence>
+</ui:ProcessTrackingScope>
+```
+
+```xml
+<!-- Start a new trace -->
+<ui:ProcessTrackingScope
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.ProcessTracking;assembly=UiPath.System.Activities"
+    DisplayName="Process Tracking Scope"
+    IsPTSEnabled="True"
+    TaskName="[&quot;ValidateInvoice&quot;]"
+    ProcessLogMode="NewTrace"
+    ProcessCaseName="[&quot;InvoiceProcessing&quot;]">
+  <Sequence>
+    <!-- automation activities here -->
+  </Sequence>
+</ui:ProcessTrackingScope>
+```
+
+## Notes
+
+- **Process Tracking Scope** is a container activity. All activities inside its body are tracked as part of the named task in Process Mining.
+- `IsPTSEnabled` is only visible in the designer when the Process Mining service is connected to the Studio project.
+- Use **Track Object** activities inside the scope to associate domain objects (invoices, documents, etc.) with the tracked task.
+- Use **Set Task Status** to explicitly set the outcome status of the task, and **Set Trace Status** to close and set the status of the enclosing trace.
+- `ObjectId` and `ObjectType` being required for `ExistingTrace` mode is enforced dynamically at runtime — the designer indicates this via the `IsRequired` flag on the respective properties.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/QueueTrigger.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/QueueTrigger.md
@@ -1,0 +1,46 @@
+# New Item Added to Queue
+
+`UiPath.Core.Activities.QueueTrigger`
+
+Start a job when a new item is added to the specified queue.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Triggers
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `QueueName` | Queue name | Property | `string` | Yes | — | The name of the Orchestrator queue used to trigger the job. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FolderPath` | Folder Path | `string` | `null` | The Orchestrator folder containing the queue. Leave empty to use the folder of the current process. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `TransactionItem` | Transaction Item | OutArgument | `QueueItem` | The new queue item that triggered the job. |
+| `ExtractedQueueItem` | Specific Data | OutArgument | `object` | The specific data payload extracted from the queue item. |
+
+## XAML Example
+
+```xml
+<ui:QueueTrigger
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="New Item Added to Queue"
+    QueueName="InvoiceProcessingQueue"
+    TransactionItem="{x:Reference transactionItem}" />
+```
+
+## Notes
+
+- **New Item Added to Queue** is a trigger scope/container activity. Place the transaction processing logic inside its body.
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator and the specified queue must exist in the configured folder.
+- `TransactionItem` gives access to the full `QueueItem` object including all metadata, `ExtractedQueueItem` gives direct access to the item's specific data.
+- The `FolderPath` property supports Orchestrator modern folder paths (e.g., `Finance/Invoices`).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RaiseAlert.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RaiseAlert.md
@@ -1,0 +1,48 @@
+# Raise Alert
+
+`UiPath.Core.Activities.RaiseAlert`
+
+Helps you add custom alerts in Orchestrator, with a selected severity.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Alerts
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Notification` | Notification | InArgument | `string` | Yes | — | The alert message text to display in Orchestrator. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Severity` | Severity | `AlertSeverity` | — | The severity level of the alert. Controls how it is displayed and filtered in Orchestrator. |
+
+### Enum Reference
+
+**AlertSeverity**
+
+| Value | Description |
+|-------|-------------|
+| `Info` | Informational alert. Used for general operational messages. |
+| `Warn` | Warning alert. Used for non-critical conditions that may require attention. |
+| `Error` | Error alert. Used for conditions that indicate a processing failure. |
+| `Fatal` | Fatal alert. Used for critical conditions that require immediate attention. |
+
+## XAML Example
+
+```xml
+<ui:RaiseAlert
+    Notification="&quot;Invoice processing completed with warnings.&quot;"
+    Severity="Warn"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- Alerts created by this activity appear in the **Alerts** section of Orchestrator and can trigger notification rules configured in Orchestrator.
+- This activity does not stop or affect workflow execution — it only sends the alert to Orchestrator.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReadListItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReadListItem.md
@@ -1,0 +1,51 @@
+# Read List Item
+
+`UiPath.Activities.System.Arrays.ReadListItem<T>`
+
+Retrieves the value of a specific item in a list.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Data.Lists
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| List | List | InArgument | `IList<T>` | Yes | — | The list from which to read the item. |
+| Index | Index | InArgument | `int` | Yes | — | The zero-based index of the item to retrieve. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Item | Item | OutArgument | `T` | The value at the specified index in the list. |
+
+## XAML Example
+
+```xml
+<!-- Read item at index 2 from a list of strings -->
+<ui:ReadListItem x:TypeArguments="x:String">
+  <ui:ReadListItem.List>
+    <InArgument x:TypeArguments="scg:IList(x:String)">[myStringList]</InArgument>
+  </ui:ReadListItem.List>
+  <ui:ReadListItem.Index>
+    <InArgument x:TypeArguments="x:Int32">2</InArgument>
+  </ui:ReadListItem.Index>
+  <ui:ReadListItem.Item>
+    <OutArgument x:TypeArguments="x:String">[itemValue]</OutArgument>
+  </ui:ReadListItem.Item>
+</ui:ReadListItem>
+```
+
+## Notes
+
+- This is a generic activity; the element type `T` is determined at design time.
+- An `ArgumentOutOfRangeException` is thrown if `Index` is negative or greater than or equal to the list's count.
+- Lists are zero-indexed: the first element is at index `0`.
+- Compatible with any `IList<T>` implementation, including `List<T>` and arrays.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReadStorageText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReadStorageText.md
@@ -1,0 +1,43 @@
+# Read Storage Text
+
+`UiPath.Core.Activities.Storage.ReadStorageText`
+
+Returns the text content of a certain file in an Orchestrator storage bucket.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Storage
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Path | InArgument | `string` | Yes | — | The path of the file within the storage bucket to read (e.g., `data/output.txt`). |
+| `Encoding` | Encoding | InArgument | `string` | No | `null` | The character encoding to use when reading the file (e.g., `"utf-8"`, `"utf-16"`). Defaults to UTF-8 when not specified. Can be set as a project-level default. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `string` | The text content of the file read from the storage bucket. |
+
+## XAML Example
+
+```xml
+<ui:ReadStorageText
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.Storage;assembly=UiPath.System.Activities"
+    DisplayName="Read Storage Text"
+    Path="[&quot;data/output.txt&quot;]"
+    Encoding="[&quot;utf-8&quot;]"
+    Result="{x:Reference fileContent}" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection with access to storage buckets.
+- The storage bucket name and folder path are configured in the Orchestrator connection context (via `StorageBucketName` and `FolderPath` inherited from the base storage activity class).
+- `Path` is the full file path within the bucket, including the file name and extension.
+- `Encoding` can be configured as a project-level setting (section `ReadTextFile`, property `Encoding`) so it applies consistently across the project without setting it on each activity instance.
+- If the file does not exist in the bucket, the activity throws a runtime error.
+- To write text content to a storage file, use **Write Storage Text**.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReadTextFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReadTextFile.md
@@ -1,0 +1,51 @@
+# Read Text File
+
+`UiPath.Core.Activities.ReadTextFile`
+
+Copies all the characters from a specified text file.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FileName` | Read Text File | `InArgument` | `string` | Yes* | — | Full path of the text file to read. Overload group: `FileName`. |
+| `File` | File | `InArgument` | `IResource` | Yes* | — | Resource reference to the file to read. Overload group: `File`. |
+| `Encoding` | Encoding | `InArgument` | `string` | No | `null` | The encoding to use when reading the file (e.g. `"utf-8"`, `"windows-1252"`). When `null`, the encoding is auto-detected. Configurable as a project setting. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Content` | Output | `OutArgument` | `string` | The full text content read from the file. |
+
+## Valid Configurations
+
+Two mutually exclusive overload groups determine how the file is specified:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Local path | `FileName` | String expression resolving to a local file path. |
+| Resource | `File` | `IResource` expression (e.g. from Create File or Get Local File or Folder). |
+
+## XAML Example
+
+```xml
+<ui:ReadTextFile
+    DisplayName="Read Text File"
+    FileName="&quot;C:\data\input.txt&quot;"
+    Encoding="&quot;utf-8&quot;"
+    Content="[fileContent]" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- The `Encoding` property can be set at project level via **Project Settings** (`Section.ReadTextFile, Property.Encoding`), avoiding repeated configuration across workflows.
+- When `Encoding` is left empty, the activity attempts to detect the encoding automatically using byte-order marks (BOM).
+- For large files, consider streaming alternatives to avoid high memory usage.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveDataColumn.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveDataColumn.md
@@ -1,0 +1,66 @@
+# Remove Data Column
+
+`UiPath.Core.Activities.RemoveDataColumn`
+
+Removes a DataColumn from a specified DataTable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| ColumnName | Column Name | InArgument | String | Yes* | — | The name of the column to remove. Mutually exclusive with **Column Number**. |
+| ColumnIndex | Column Number | InArgument | Int32 | Yes* | — | The zero-based index of the column to remove. Mutually exclusive with **Column Name**. |
+
+### Input/Output
+
+> These properties require a **variable** binding — the activity reads the incoming value and writes an updated value back. Do not use literal expressions.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | From Data Table | InOutArgument | DataTable | Yes | — | The DataTable from which the column will be removed. Modified in place. |
+
+\* Exactly one of `ColumnName` (overload group `ColumnName`) or `ColumnIndex` (overload group `ColumnIndex`) must be provided. `Column` (DataColumn object) exists in the source but is hidden in the designer (`isVisible: false`).
+
+## Valid Configurations
+
+| Mode | Required properties |
+|------|-------------------|
+| Remove by column name | `DataTable` + `ColumnName` |
+| Remove by column index | `DataTable` + `ColumnIndex` |
+
+## Notes
+
+- `Column` (DataColumn object overload) is present in the activity source but hidden in the designer (`isVisible: false`). Use `ColumnName` or `ColumnIndex` instead.
+- The DataTable variable is modified in place via `InOutArgument`. All rows lose the removed column's data.
+- Removing a column that does not exist throws an exception at runtime.
+
+## XAML Example
+
+```xml
+<!-- Remove column by name -->
+<ui:RemoveDataColumn DisplayName="Remove Data Column"
+                     xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:RemoveDataColumn.DataTable>
+    <InOutArgument x:TypeArguments="sd:DataTable">[myDataTable]</InOutArgument>
+  </ui:RemoveDataColumn.DataTable>
+  <ui:RemoveDataColumn.ColumnName>
+    <InArgument x:TypeArguments="x:String">"TempColumn"</InArgument>
+  </ui:RemoveDataColumn.ColumnName>
+</ui:RemoveDataColumn>
+
+<!-- Remove column by index -->
+<ui:RemoveDataColumn DisplayName="Remove Data Column"
+                     xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:RemoveDataColumn.DataTable>
+    <InOutArgument x:TypeArguments="sd:DataTable">[myDataTable]</InOutArgument>
+  </ui:RemoveDataColumn.DataTable>
+  <ui:RemoveDataColumn.ColumnIndex>
+    <InArgument x:TypeArguments="x:Int32">3</InArgument>
+  </ui:RemoveDataColumn.ColumnIndex>
+</ui:RemoveDataColumn>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveDataRow.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveDataRow.md
@@ -1,0 +1,60 @@
+# Remove Data Row
+
+`UiPath.Core.Activities.RemoveDataRow`
+
+Removes a DataRow from a specified DataTable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Row | Row | InArgument | DataRow | Yes* | — | The DataRow object to remove from the DataTable. Mutually exclusive with **Row Index**. |
+| RowIndex | Row Index | InArgument | Int32 | Yes* | — | The zero-based index of the row to remove. Mutually exclusive with **Row**. |
+
+### Input/Output
+
+> These properties require a **variable** binding — the activity reads the incoming value and writes an updated value back. Do not use literal expressions.
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InOutArgument | DataTable | Yes | — | The DataTable from which the row will be removed. The variable is updated in place. |
+
+\* Exactly one of `Row` or `RowIndex` must be provided (overload groups).
+
+## Valid Configurations
+
+| Mode | Required properties |
+|------|-------------------|
+| Remove by DataRow | `DataTable` + `Row` |
+| Remove by index | `DataTable` + `RowIndex` |
+
+## XAML Example
+
+```xml
+<!-- Remove by DataRow object -->
+<ui:RemoveDataRow DisplayName="Remove Data Row"
+                  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:RemoveDataRow.DataTable>
+    <InOutArgument x:TypeArguments="sd:DataTable">[myDataTable]</InOutArgument>
+  </ui:RemoveDataRow.DataTable>
+  <ui:RemoveDataRow.Row>
+    <InArgument x:TypeArguments="sd:DataRow">[rowToRemove]</InArgument>
+  </ui:RemoveDataRow.Row>
+</ui:RemoveDataRow>
+
+<!-- Remove by index -->
+<ui:RemoveDataRow DisplayName="Remove Data Row"
+                  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:RemoveDataRow.DataTable>
+    <InOutArgument x:TypeArguments="sd:DataTable">[myDataTable]</InOutArgument>
+  </ui:RemoveDataRow.DataTable>
+  <ui:RemoveDataRow.RowIndex>
+    <InArgument x:TypeArguments="x:Int32">[0]</InArgument>
+  </ui:RemoveDataRow.RowIndex>
+</ui:RemoveDataRow>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveDuplicateRows.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveDuplicateRows.md
@@ -1,0 +1,42 @@
+# Remove Duplicate Rows
+
+`UiPath.Core.Activities.RemoveDuplicateRows`
+
+Removes the duplicate rows from a specified DataTable, keeping only the first occurrence.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Data Table | InArgument | DataTable | Yes | — | The DataTable from which duplicate rows will be removed. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| OutputDataTable | Data Table | OutArgument | DataTable | A new DataTable containing only the unique rows, preserving the first occurrence of each duplicate group. |
+
+## Notes
+
+- Duplicate detection considers all columns. Two rows are duplicates if every column value is equal.
+- The original DataTable is not modified. The deduplicated result is placed in `OutputDataTable`.
+- Row order is preserved; the first occurrence of each unique row is kept.
+
+## XAML Example
+
+```xml
+<ui:RemoveDuplicateRows DisplayName="Remove Duplicate Rows"
+                        xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:RemoveDuplicateRows.DataTable>
+    <InArgument x:TypeArguments="sd:DataTable">[myDataTable]</InArgument>
+  </ui:RemoveDuplicateRows.DataTable>
+  <ui:RemoveDuplicateRows.OutputDataTable>
+    <OutArgument x:TypeArguments="sd:DataTable">[uniqueTable]</OutArgument>
+  </ui:RemoveDuplicateRows.OutputDataTable>
+</ui:RemoveDuplicateRows>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveFromCollection.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveFromCollection.md
@@ -1,0 +1,60 @@
+# Remove From Collection
+
+`UiPath.Activities.System.Collections.RemoveFromCollection`1``
+
+Remove the specified element from a collection.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Collection
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Collection` | Collection | `InArgument` | `ICollection<T>` | Yes | — | The collection from which to remove elements. |
+| `Item` | Item | `InArgument` | `T` | No | — | The element value to remove. Visible when **Action Type** is `Item`. Mutually exclusive with `Index` and `RemoveAllElements`. |
+| `Index` | Index | `InArgument` | `int` | No | — | The zero-based index of the element to remove. Visible when **Action Type** is `Index`. Mutually exclusive with `Item` and `RemoveAllElements`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `RemoveAllElements` | Remove All Elements | `bool` | `false` | When `true`, clears the entire collection. Controlled by the **Action Type** selector in the designer. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | `OutArgument` | `List<T>` | The collection after removal. When `Result` is not bound, the original collection object is mutated in-place. When `Result` is bound to a different variable, a new `List<T>` is returned. |
+
+## Valid Configurations
+
+The designer presents an **Action Type** selector that controls which properties are visible:
+
+| Action Type | Visible input properties | Behaviour |
+|-------------|--------------------------|-----------|
+| `Item` (default) | `Collection`, `Item` | Removes the first occurrence of the specified value. |
+| `Index` | `Collection`, `Index` | Removes the element at the specified zero-based index. |
+| `All` | `Collection` | Clears all elements from the collection. |
+
+Setting `RemoveAllElements = true` together with `Item` or `Index` is a validation error. Setting both `Item` and `Index` simultaneously is also a validation error.
+
+## XAML Example
+
+```xml
+<usc:RemoveFromCollection x:TypeArguments="x:String"
+    DisplayName="Remove From Collection"
+    Collection="[myList]"
+    Item="[&quot;hello&quot;]"
+    Result="[updatedList]"
+    xmlns:usc="clr-namespace:UiPath.Activities.System.Collections;assembly=UiPath.System.Activities"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" />
+```
+
+## Notes
+
+The type parameter `T` is inferred from the connected variable or argument.
+
+For `Index` removal, if the collection does not implement `IList`, the element at the given position is looked up with `ElementAt` and then removed by value. Only the first matching element is removed when using `Item` mode.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveLogFields.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RemoveLogFields.md
@@ -1,0 +1,40 @@
+# Remove Log Fields
+
+`UiPath.Core.Activities.RemoveLogFields`
+
+Removes custom log fields from each Log Message.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Logging
+
+## Properties
+
+### Input
+
+_No input arguments._
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| Fields | Fields | `List<InArgument<string>>` | — | A list of field name expressions whose entries should be removed from subsequent log messages. |
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:RemoveLogFields>
+  <ui:RemoveLogFields.Fields>
+    <InArgument x:TypeArguments="x:String">fieldName1</InArgument>
+    <InArgument x:TypeArguments="x:String">fieldName2</InArgument>
+  </ui:RemoveLogFields.Fields>
+</ui:RemoveLogFields>
+```
+
+## Notes
+
+- Only fields that were previously added via **Add Log Fields** can be removed here.
+- Field names are case-sensitive.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RenameFileX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RenameFileX.md
@@ -1,0 +1,59 @@
+# Rename File
+
+`UiPath.Core.Activities.RenameFileX`
+
+Renames the selected file.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File Path | `InArgument` | `string` | Yes* | — | Full path of the file to rename. Mutually exclusive with `FileResource`. |
+| `FileResource` | File Resource | `InArgument` | `IResource` | Yes* | — | Resource reference to the file to rename. Mutually exclusive with `FilePath`. |
+| `NewName` | New name | `InArgument` | `string` | Yes | — | The new name for the file. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `KeepExtension` | Keep extension | `bool` | `true` | When `true`, the original file extension is preserved even if `NewName` does not include one. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `OutputFileResource` | Renamed File | `OutArgument` | `IResource` | Reference to the renamed file. |
+
+## Valid Configurations
+
+The file to rename supports two mutually exclusive input modes:
+
+| Mode | Property | Overload group |
+|------|----------|----------------|
+| Local path | `FilePath` | `File` |
+| Resource | `FileResource` | `FileResource` |
+
+`FilePath` is visible by default when `FileResource` has no value. `FileResource` is shown when `FilePath` has no value.
+
+## XAML Example
+
+```xml
+<ui:RenameFileX
+    DisplayName="Rename File"
+    FilePath="&quot;C:\reports\old_name.xlsx&quot;"
+    NewName="&quot;new_name&quot;"
+    KeepExtension="True"
+    OutputFileResource="[renamedFile]" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- When `KeepExtension` is `true` and `NewName` omits the extension, the original extension is appended automatically.
+- When `KeepExtension` is `false`, `NewName` must include the desired extension explicitly.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RepeatNumberOfTimesX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RepeatNumberOfTimesX.md
@@ -1,0 +1,52 @@
+# Repeat Number of Times
+
+`UiPath.Core.Activities.RepeatNumberOfTimesX`
+
+Repeats a set of activities a specified number of times. Add the activities to repeat inside this activity.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `NumberOfTimes` | Number Of Times | `InArgument` | `int` | Yes | — | The total number of times to repeat the body activities. |
+| `StartAt` | Start at | `InArgument` | `int` | No | `1` | The starting value of the iteration counter variable. |
+
+## XAML Example
+
+```xml
+<ui:RepeatNumberOfTimesX
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Repeat Number of Times">
+  <ui:RepeatNumberOfTimesX.NumberOfTimes>
+    <InArgument x:TypeArguments="x:Int32">
+      <VisualBasicValue x:TypeArguments="x:Int32" ExpressionText="5" />
+    </InArgument>
+  </ui:RepeatNumberOfTimesX.NumberOfTimes>
+  <ui:RepeatNumberOfTimesX.StartAt>
+    <InArgument x:TypeArguments="x:Int32">
+      <VisualBasicValue x:TypeArguments="x:Int32" ExpressionText="1" />
+    </InArgument>
+  </ui:RepeatNumberOfTimesX.StartAt>
+  <ActivityAction x:TypeArguments="x:Int32">
+    <ActivityAction.Argument>
+      <DelegateInArgument x:TypeArguments="x:Int32" Name="currentIndex" />
+    </ActivityAction.Argument>
+    <Sequence DisplayName="Body">
+      <!-- child activities go here -->
+    </Sequence>
+  </ActivityAction>
+</ui:RepeatNumberOfTimesX>
+```
+
+## Notes
+
+- **Repeat Number of Times** is a container/scope activity. Child activities are placed inside the `ActivityAction` body.
+- The body receives the current iteration counter as a delegate argument (e.g. `currentIndex`). The counter starts at `StartAt` (default `1`) and increments by one on each iteration.
+- The activity iterates exactly `NumberOfTimes` times regardless of any conditions inside the body.
+- The iterator variable name is auto-suggested from the activity and can be renamed in the designer (configured via `Item` in the view model, display name `Current Index`).
+- Use a `Break` activity inside the body to exit the loop early; use `Continue` to skip to the next iteration.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Replace.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Replace.md
@@ -1,0 +1,54 @@
+# Replace Matching Patterns
+
+`UiPath.Core.Activities.Replace`
+
+Within a specified input string, replaces strings that match a regular expression pattern with a specified replacement string.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Input` | Text to replace | InArgument | `String` | Yes | — | The string in which to search for matches and perform replacements. |
+| `Pattern` | Pattern | InArgument | `String` | Yes | — | The regular expression pattern that identifies the substrings to replace. |
+| `Replacement` | Replace with text | InArgument | `String` | Yes | — | The replacement string. Supports regex substitution syntax (e.g. `$1` for capture group references). |
+| `TimeoutMS` | Timeout (ms) | InArgument | `Int32` | No | — | Maximum time in milliseconds allowed per match operation. Leave empty for no timeout. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `RegexOption` | Pattern options | `RegexOptions` | `IgnoreCase, Compiled` | Flags that control regular expression matching behavior. Multiple flags can be combined. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `String` | The resulting string after all pattern matches have been replaced. |
+
+### Enum Reference
+
+**`RegexOptions`** (flags, combinable): `None`, `IgnoreCase`, `Multiline`, `ExplicitCapture`, `Compiled`, `Singleline`, `IgnorePatternWhitespace`, `RightToLeft`, `ECMAScript`, `CultureInvariant`
+
+## XAML Example
+
+```xml
+<ui:Replace
+  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+  Input="[sourceText]"
+  Pattern="[&quot;\s+&quot;]"
+  Replacement="[&quot; &quot;]"
+  RegexOption="IgnoreCase, Compiled"
+  Result="[cleanedText]" />
+```
+
+## Notes
+
+- The `Replacement` string can reference captured groups using `$1`, `$2`, etc. or named groups using `${name}`.
+- If `TimeoutMS` is not set, the match timeout defaults to `Regex.InfiniteMatchTimeout`.
+- All occurrences of the pattern in `Input` are replaced; the original string is not modified (strings are immutable in .NET).
+- The activity uses the .NET `Regex.Replace` static method, which caches the 15 most recently used patterns automatically.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReportStatus.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ReportStatus.md
@@ -1,0 +1,36 @@
+# Report Status
+
+`UiPath.Core.Activities.ReportStatus`
+
+Displays a custom status in the UiPath Assistant for the process that is running.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Logging
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| StatusMessage | Status Message | InArgument | `string` | Yes | — | The message to display as the current job status in UiPath Assistant. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:ReportStatus StatusMessage="Extracting invoice data..." />
+```
+
+## Notes
+
+- Status messages appear in the UiPath Assistant job panel in real time while the robot is running.
+- This activity sends the status to Orchestrator, which relays it to the connected Assistant instance.
+- Has no effect when running outside of an Orchestrator-connected context.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ResetTimer.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ResetTimer.md
@@ -1,0 +1,40 @@
+# Reset Timer
+
+`UiPath.Core.Activities.ResetTimer`
+
+Resets the input timer provided as argument.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Timer
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Timer | Timer | InArgument | `UiPathTimer` | Yes | — | The timer object to reset. Must be a variable previously populated by a Start Timer activity. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:ResetTimer>
+  <ui:ResetTimer.Timer>
+    <InArgument x:TypeArguments="ui:UiPathTimer">[myTimer]</InArgument>
+  </ui:ResetTimer.Timer>
+</ui:ResetTimer>
+```
+
+## Notes
+
+- Resets the elapsed time on the timer back to zero.
+- The timer's running/stopped state is preserved; a running timer continues running from zero after reset.
+- To stop the timer before resetting, use Stop Timer first.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ResumeTimer.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ResumeTimer.md
@@ -1,0 +1,40 @@
+# Resume Timer
+
+`UiPath.Core.Activities.ResumeTimer`
+
+Resumes the input timer provided as argument.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Timer
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Timer | Timer | InArgument | `UiPathTimer` | Yes | — | The timer object to resume. Must be a variable previously populated by a Start Timer activity and stopped via Stop Timer. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:ResumeTimer>
+  <ui:ResumeTimer.Timer>
+    <InArgument x:TypeArguments="ui:UiPathTimer">[myTimer]</InArgument>
+  </ui:ResumeTimer.Timer>
+</ui:ResumeTimer>
+```
+
+## Notes
+
+- Resumes counting from the elapsed value at the point the timer was stopped.
+- Resuming a timer that is already running has no effect.
+- To restart the timer from zero instead, use Reset Timer followed by Start Timer.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RetryScope.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RetryScope.md
@@ -1,0 +1,48 @@
+# Retry Scope
+
+`UiPath.Core.Activities.RetryScope`
+
+Retries the contained activities as long as the condition is not met or an error is thrown.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | No | — | When `True`, the workflow continues execution even if the activity fails after all retries are exhausted. |
+| `NumberOfRetries` | Number of attempts | `InArgument` | `int` | No | `3` (project default) | The maximum number of retry attempts. Configurable via project settings (`Section.RetryScope`, `Property.NumberOfRetries`). |
+| `RetryInterval` | Retry interval | `InArgument` | `TimeSpan` | No | `5000` ms (project default) | The time to wait between retry attempts. Configurable via project settings (`Section.RetryScope`, `Property.RetryInterval`). |
+| `LogRetriedExceptions` | Log exceptions | `InArgument` | `bool` | No | `False` (project default) | When `True`, exceptions that trigger a retry are logged. Configurable via project settings (`Section.RetryScope`, `Property.LogRetriedExceptions`). |
+| `RetriedExceptionsLogLevel` | Log Level | `InArgument` | `LogLevel` | No | `Trace` (project default) | The log level used when logging retried exceptions. Configurable via project settings (`Section.RetryScope`, `Property.RetriedExceptionsLogLevel`). |
+
+## XAML Example
+
+```xml
+<ui:RetryScope
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Retry Scope">
+  <ui:RetryScope.NumberOfRetries>
+    <InArgument x:TypeArguments="x:Int32">
+      <VisualBasicValue x:TypeArguments="x:Int32" ExpressionText="3" />
+    </InArgument>
+  </ui:RetryScope.NumberOfRetries>
+  <ui:RetryScope.RetryInterval>
+    <InArgument x:TypeArguments="s:TimeSpan">
+      <VisualBasicValue x:TypeArguments="s:TimeSpan" ExpressionText="TimeSpan.FromSeconds(5)" />
+    </InArgument>
+  </ui:RetryScope.RetryInterval>
+  <!-- Try body -->
+  <!-- Condition body -->
+</ui:RetryScope>
+```
+
+## Notes
+
+- **Retry Scope** is a container/scope activity with two bodies: a **Try** body (the activities to attempt) and a **Condition** body (an activity returning `bool` that determines whether the attempt succeeded).
+- A retry is triggered if the Try body throws an exception **or** if the Condition body returns `False`.
+- `NumberOfRetries` and `RetryInterval` support project-level defaults and can be overridden per-instance via the properties panel.
+- The `ActivityBody` and `Condition` properties are hidden in the designer (`IsVisible = false`) — they are wired up through the visual canvas, not the properties panel.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Return.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/Return.md
@@ -1,0 +1,27 @@
+# Return
+
+`UiPath.Core.Activities.Return`
+
+Ends the current workflow and resumes the process immediately after the point where the workflow was invoked. Compatible with Robots version 23.8 and above.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow.Control
+
+## Properties
+
+No configurable properties.
+
+## XAML Example
+
+```xml
+<ui:Return DisplayName="Return"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+`Return` cancels the current workflow instance by calling `IWorkflowRuntime.CancelWorkflow`. Execution resumes in the parent process at the activity immediately following the `Invoke Workflow File` or equivalent invocation point.
+
+If the robot runtime does not support the `CancelWorkflow` feature (versions earlier than 23.8), the activity throws a `PlatformNotSupportedException`.
+
+Unlike `Break`, `Return` is not limited to loops — it exits the entire workflow regardless of nesting depth.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RunJob.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RunJob.md
@@ -1,0 +1,87 @@
+# Run Job
+
+`UiPath.Activities.System.Jobs.RunJob`
+
+Initiates any type of job (Agent, Agentic process, RPA workflows, API workflow, Testing process, etc.) via Orchestrator to be picked up by any available robots. It allows for flexible configuration of the execution mode (Do not wait, Wait for job completion or Suspend execution until job completion). It returns output arguments unless started in the Do not wait mode.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Run
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ProcessName` | Process name | InArgument | `string` | Yes | — | The name of the Orchestrator process to start. Supports auto-complete from available processes in the configured folder. |
+| `Machine` | Machine | InArgument | `string` | No | — | The machine on which the job will execute. If not specified, any available machine is used. |
+| `Account` | Account | InArgument | `string` | No | — | The account used to execute the job. If not specified, the default account associated with the machine is used. |
+| `TimeoutMS` | Timeout MS | InArgument | `int` | No | `600000` (10 min) | Maximum time in milliseconds to wait for the job to complete. Only applicable when `ExecutionMode` is `Busy` (Wait for job completion). Read-only for other modes. |
+| `ContinueOnError` | Continue On Error | InArgument | `bool` | No | `false` | When `True`, execution continues even if this activity encounters an error. Read-only when `ExecutionMode` is `None`. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ExecutionMode` | Execution mode | `JobExecutionMode` | `JobExecutionMode.Busy` | Determines how the initiated job is processed. See Valid Configurations below. |
+| `ContinueWhenFaulted` | Continue when job fails | `bool` | `false` (i.e., fail when faulted) | When `True`, a faulted job is ignored and execution continues. When `False`, a faulted job causes this activity to throw an error. Read-only when `ExecutionMode` is `None`. |
+| `FolderPath` | Folder Path | `string` | — | The Orchestrator folder containing the process. Leave empty to use the folder of the current process. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Job` | Job data | OutArgument | `OrchestratorJob` | An object containing information about the initiated job (e.g., Job ID, status, output arguments). Not populated when `ExecutionMode` is `None`. |
+
+## Valid Configurations
+
+The behavior and available properties depend on the `ExecutionMode` value:
+
+| `ExecutionMode` | Behavior | `TimeoutMS` | `ContinueOnError` | `ContinueWhenFaulted` | Output |
+|---|---|---|---|---|---|
+| `None` (Do not wait) | Starts the job and returns immediately without waiting. | Read-only | Read-only | Read-only | `Job` is populated with basic job info; no output arguments. |
+| `Busy` (Wait for job completion) | Starts the job and blocks the current robot until the job completes or times out. | Editable | Editable | Editable | `Job` is fully populated including output arguments. |
+| `Suspend` (Suspend until job completion) | Starts the job and suspends the current workflow (persistence required). Resumes when the job completes. | Read-only | Editable | Editable | `Job` is fully populated including output arguments on resume. |
+
+### Enum Reference
+
+**`JobExecutionMode`**
+
+| Value | Description |
+|-------|-------------|
+| `None` | Do not wait — fire and forget. |
+| `Busy` | Wait for job completion by blocking the robot thread. |
+| `Suspend` | Suspend the workflow until the job completes (requires persistence infrastructure). |
+
+## XAML Example
+
+```xml
+<!-- Wait for job completion -->
+<ui:RunJob
+    xmlns:ui="clr-namespace:UiPath.Activities.System.Jobs;assembly=UiPath.System.Activities"
+    DisplayName="Run Job"
+    ProcessName="[&quot;InvoiceProcessor&quot;]"
+    ExecutionMode="Busy"
+    TimeoutMS="[600000]"
+    ContinueWhenFaulted="False"
+    Job="{x:Reference jobData}" />
+```
+
+```xml
+<!-- Fire and forget -->
+<ui:RunJob
+    xmlns:ui="clr-namespace:UiPath.Activities.System.Jobs;assembly=UiPath.System.Activities"
+    DisplayName="Run Job"
+    ProcessName="[&quot;BackgroundReporter&quot;]"
+    ExecutionMode="None" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The process must be published and available in the specified (or current) Orchestrator folder.
+- **Suspend mode** requires a persistence-enabled environment. The calling workflow is suspended and resumed by the Orchestrator persistence infrastructure once the triggered job finishes. This allows the calling robot to be freed while waiting.
+- Input and output arguments for the triggered process are configured via the dynamic **Arguments** / **Input** / **Output** properties in the designer. The designer auto-imports the argument schema from the selected process when `ProcessName` is set to a literal string.
+- The input can be provided in three modes selectable via the designer menu: **Data Mapper** (structured schema), **Object** (single typed variable), or **Dictionary** (key-value pairs of arguments).
+- `ContinueWhenFaulted` is the inverse of the underlying `FailWhenFaulted` property: setting `ContinueWhenFaulted = True` sets `FailWhenFaulted = False`.
+- `Machine` and `Account` support auto-complete from Orchestrator-connected data sources. Leave empty to allow Orchestrator to assign automatically.
+- `FolderPath` supports Orchestrator modern folder paths (e.g., `Finance/Invoices`).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RuntimeContext.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/RuntimeContext.md
@@ -1,0 +1,32 @@
+# Manual Trigger
+
+`UiPath.Core.Activities.ManualTrigger`
+
+Contains job info such as Process name, Workflow name, User Name, User Email and Timestamp.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Triggers
+
+## Properties
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Get Current Job Info | `OutArgument` | `CurrentJobInfo` | An object containing runtime information about the current job, including process name, process version, workflow name, robot name, folder name, user email, and execution mode. |
+
+## XAML Example
+
+```xml
+<ui:ManualTrigger
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Manual Trigger"
+    Result="{x:Reference jobInfo}" />
+```
+
+## Notes
+
+- **Manual Trigger** is a scope/container activity. Place the automation logic to execute inside its body.
+- The trigger fires when a user manually starts the associated process from Orchestrator or the UiPath Assistant.
+- `ManualTrigger` inherits from `GetCurrentJobInfo` — the `Result` output is identical to the one produced by the **Get Current Job Info** activity.
+- No scheduling or queue configuration is required.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SendEmailNotification.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SendEmailNotification.md
@@ -1,0 +1,43 @@
+# Send Email Notification
+
+`UiPath.Activities.System.Orchestrator.Mail.SendEmailNotification`
+
+Sends an email notification via the Orchestrator API.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Alerts
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Subject` | Subject | InArgument | `string` | Yes | — | The subject line of the email notification. |
+| `Body` | Body | InArgument | `string` | No | — | The body content of the email. Supports rich text composition. |
+| `TimeoutMS` | Timeout (milliseconds) | InArgument | `int` | No | — | The maximum time in milliseconds to wait for the activity to complete before throwing an error. Defaults to 30000 ms (30 seconds). |
+| `ContinueOnError` | Continue on error | InArgument | `bool` | No | — | When true, execution continues even if the activity throws an error. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Recipients` | Recipients | `InArgument<IEnumerable<string>>` | — | The list of primary recipient email addresses (To). Required. |
+| `Cc` | Cc | `InArgument<IEnumerable<string>>` | — | The list of carbon-copy recipient email addresses. Optional. |
+
+## XAML Example
+
+```xml
+<ui:SendEmailNotification
+    Subject="&quot;Process Completed&quot;"
+    Body="&quot;The invoice processing run has finished successfully.&quot;"
+    xmlns:ui="clr-namespace:UiPath.Activities.System.Orchestrator.Mail;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- Email is delivered via the **Orchestrator Notification Service**. The Orchestrator instance must have email notifications configured (SMTP or SendGrid) for this activity to deliver messages.
+- Unlike a direct SMTP send, this activity does not require credentials in the workflow — authentication is handled entirely by Orchestrator.
+- `Recipients` is required and must contain at least one valid email address.
+- This activity does not support coded workflows (`codedWorkflowSupport` is false).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetAsset.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetAsset.md
@@ -1,0 +1,36 @@
+# Set Asset
+
+`UiPath.Core.Activities.SetAsset`
+
+Updates the value of an indicated asset, that is already available in Orchestrator, be it a global or a Per Robot asset.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Assets
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AssetName` | Asset Name | InArgument | `string` | Yes | — | The name of the Orchestrator asset to update. |
+| `Value` | Value | InArgument | `object` | Yes | — | The new value to assign to the asset. Must be compatible with the asset's type configured in Orchestrator (text, integer, or boolean). |
+
+## XAML Example
+
+```xml
+<ui:SetAsset
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Set Asset"
+    AssetName="[&quot;LastRunTimestamp&quot;]"
+    Value="[DateTime.Now.ToString()]" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The asset must already exist in Orchestrator; this activity updates an existing asset's value and cannot create new assets.
+- The asset type in Orchestrator determines which value types are accepted. Passing a value of the wrong type will cause a runtime error.
+- For **Per Robot** assets, the asset must be assigned to the robot running the process.
+- To update a credential asset (username and password), use **Set Credential** instead.
+- To update a secret asset, use **Set Secret** instead.
+- `FolderPath` is available via the Orchestrator connection context (inherited from the base activity class) and can be configured in the activity's Orchestrator scope.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetCredential.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetCredential.md
@@ -1,0 +1,57 @@
+# Set Credential
+
+`UiPath.Core.Activities.SetCredential`
+
+Updates the value of an indicated credential asset, that is already available in Orchestrator, be it a global or a Per Robot asset.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Assets
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `CredentialName` | Credential Asset Name | InArgument | `string` | Yes | — | The name of the Orchestrator credential asset to update. |
+| `UserName` | Username | InArgument | `string` | Yes | — | The new username value to store in the credential asset. |
+| `Password` | Password | InArgument | `string` | Yes (Normal password) | — | The new plaintext password value. Use this or `SecurePassword`, not both. |
+| `SecurePassword` | Secure Password | InArgument | `SecureString` | Yes (Secure password) | — | The new password as a `SecureString`. Use this or `Password`, not both. |
+
+## Valid Configurations
+
+`Password` and `SecurePassword` are mutually exclusive overload groups:
+
+| Configuration | Required properties |
+|---|---|
+| **Normal password** | `CredentialName`, `UserName`, `Password` |
+| **Secure password** | `CredentialName`, `UserName`, `SecurePassword` |
+
+## XAML Example
+
+```xml
+<!-- Using plaintext password -->
+<ui:SetCredential
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Set Credential"
+    CredentialName="[&quot;SAPLoginCredential&quot;]"
+    UserName="[newUsername]"
+    Password="[newPassword]" />
+```
+
+```xml
+<!-- Using SecureString password -->
+<ui:SetCredential
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Set Credential"
+    CredentialName="[&quot;SAPLoginCredential&quot;]"
+    UserName="[newUsername]"
+    SecurePassword="[newSecurePassword]" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The credential asset must already exist in Orchestrator.
+- For **Per Robot** credential assets, the asset must be assigned to the robot running the process.
+- Prefer `SecurePassword` over `Password` to avoid storing plaintext credentials in the workflow.
+- `FolderPath` is available via the Orchestrator connection context (inherited from the base activity class) and can be configured in the activity's Orchestrator scope.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetEnvironmentVariable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetEnvironmentVariable.md
@@ -1,0 +1,37 @@
+# Set Environment Variable
+
+`UiPath.Core.Activities.SetEnvironmentVariable`
+
+Sets the value of an environment variable.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Environment
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Name | Name | InArgument | `string` | Yes | — | The name of the environment variable to set. |
+| Value | Value | InArgument | `string` | Yes | — | The value to assign to the environment variable. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:SetEnvironmentVariable Name="MY_VAR" Value="HelloWorld" />
+```
+
+## Notes
+
+- Changes to Process-scoped variables are visible only within the current process and its children.
+- Setting a User or Machine variable requires the appropriate OS-level permissions; modifying Machine variables typically requires elevation.
+- To delete an environment variable, set its value to an empty string or `Nothing`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetSecret.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetSecret.md
@@ -1,0 +1,54 @@
+# Set Secret
+
+`UiPath.Core.Activities.SetSecret`
+
+Updates the value of an indicated secret asset, that is already available in Orchestrator, be it a global or a Per Robot asset.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Assets
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AssetName` | Secret asset name | InArgument | `string` | Yes | — | The name of the Orchestrator secret asset to update. |
+| `SecretValue` | Secret | InArgument | `string` | Yes (Normal secret) | — | The new plaintext secret value. Use this or `SecureSecretValue`, not both. |
+| `SecureSecretValue` | Secure secret | InArgument | `SecureString` | Yes (Secure secret) | — | The new secret value as a `SecureString`. Use this or `SecretValue`, not both. |
+
+## Valid Configurations
+
+`SecretValue` and `SecureSecretValue` are mutually exclusive overload groups:
+
+| Configuration | Required properties |
+|---|---|
+| **Normal secret** | `AssetName`, `SecretValue` |
+| **Secure secret** | `AssetName`, `SecureSecretValue` |
+
+## XAML Example
+
+```xml
+<!-- Using plaintext secret -->
+<ui:SetSecret
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Set Secret"
+    AssetName="[&quot;ApiToken&quot;]"
+    SecretValue="[newTokenValue]" />
+```
+
+```xml
+<!-- Using SecureString secret -->
+<ui:SetSecret
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Set Secret"
+    AssetName="[&quot;ApiToken&quot;]"
+    SecureSecretValue="[newSecureToken]" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The secret asset must already exist in Orchestrator.
+- For **Per Robot** secret assets, the asset must be assigned to the robot running the process.
+- Prefer `SecureSecretValue` over `SecretValue` to avoid storing plaintext sensitive values in the workflow.
+- `FolderPath` is available via the Orchestrator connection context (inherited from the base activity class) and can be configured in the activity's Orchestrator scope.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTaskStatus.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTaskStatus.md
@@ -1,0 +1,39 @@
+# Set Task Status
+
+`UiPath.Core.Activities.ProcessTracking.SetTaskStatus`
+
+Sets the status of a Task.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Process Tracking
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Status` | Status | InArgument | `TaskStatus` | Yes | — | The status value to assign to the task. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `TaskGuid` | Task | `string` | — | The identifier of the task to update. Selected via auto-complete from tasks visible in the current scope. If omitted, targets the current task within the enclosing Process Tracking Scope. |
+
+## XAML Example
+
+```xml
+<ui:SetTaskStatus
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.ProcessTracking;assembly=UiPath.System.Activities"
+    DisplayName="Set Task Status"
+    TaskGuid="myTaskScope"
+    Status="[TaskStatus.Completed]" />
+```
+
+## Notes
+
+- **Set Task Status** is typically placed inside a **Process Tracking Scope** to set the outcome of the task being tracked.
+- `TaskGuid` is selected from tasks defined by enclosing **Process Tracking Scope** activities using an auto-complete expression widget. It does not accept a free-form GUID string in normal usage.
+- `Status` accepts values from the `TaskStatus` enum provided by the UiPath.System.Activities package. Common values include `Completed`, `Failed`, and `Unfinished`.
+- Setting the task status does not automatically close the enclosing trace. To close the trace, use **Set Trace Status**.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTraceStatus.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTraceStatus.md
@@ -1,0 +1,40 @@
+# Set Trace Status
+
+`UiPath.Core.Activities.ProcessTracking.SetTraceStatus`
+
+Sets the status of the current Process Trace and close it. Do not set a status if the Process Trace extends beyond this Task scope.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Process Tracking
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Status` | Status | InArgument | `TraceStatus` | Yes | — | The status value to assign to the process trace, which also closes it. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `TraceGuid` | Trace | `string` | — | The identifier of the trace to update. Selected via auto-complete from traces visible in the current scope. If omitted, targets the current trace within the enclosing Process Tracking Scope. |
+
+## XAML Example
+
+```xml
+<ui:SetTraceStatus
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.ProcessTracking;assembly=UiPath.System.Activities"
+    DisplayName="Set Trace Status"
+    TraceGuid="myTraceScope"
+    Status="[TraceStatus.Completed]" />
+```
+
+## Notes
+
+- **Set Trace Status** closes the Process Mining trace and assigns it a final outcome status.
+- Use this activity only when the trace lifecycle ends within the current workflow. If the trace is expected to continue in a downstream automation (via `ExistingTrace` mode in a **Process Tracking Scope**), do not call this activity.
+- `TraceGuid` is selected from traces defined by enclosing **Process Tracking Scope** activities using an auto-complete expression widget.
+- `Status` accepts values from the `TraceStatus` enum provided by the UiPath.System.Activities package. Common values include `Completed`, `Failed`, and `Abandoned`.
+- To set only the task outcome without closing the trace, use **Set Task Status** instead.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTransactionProgress.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTransactionProgress.md
@@ -1,0 +1,34 @@
+# Set Transaction Progress
+
+`UiPath.Core.Activities.SetTransactionProgress`
+
+Helps you create custom progress statuses for your In Progress transactions.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `TransactionItem` | Transaction Item | InArgument | `QueueItem` | Yes | — | The transaction item whose progress is to be updated. Must be In Progress. |
+| `Progress` | Progress | InArgument | `string` | Yes | `""` | A free-text string describing the current processing stage. Visible in the Orchestrator queue item details. |
+| `FolderPath` | Folder Path | InArgument | `string` | No | — | The Orchestrator folder path to use. Overrides the robot's default folder. |
+
+## XAML Example
+
+```xml
+<ui:SetTransactionProgress
+    TransactionItem="[transactionItem]"
+    Progress="&quot;Extracting invoice data&quot;"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- The `TransactionItem` must have status **In Progress**.
+- This activity does not change the transaction's status — it only updates the progress string visible in Orchestrator. Use it to provide operational visibility into long-running transactions.
+- There is no limit imposed by this activity on the number of times progress can be updated for a single transaction.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTransactionStatus.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SetTransactionStatus.md
@@ -1,0 +1,82 @@
+# Set Transaction Status
+
+`UiPath.Core.Activities.SetTransactionStatus`
+
+Sets the status of a transaction item to Failed or Successful.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `TransactionItem` | Transaction Item | InArgument | `QueueItem` | Yes | — | The transaction item whose status is to be updated. Must be In Progress. |
+| `Status` | Status | InArgument | `ProcessingStatus` | No | Successful | The new status to assign to the transaction item. |
+| `Details` | Details | InArgument | `string` | No | null | Additional details about the failure. Visible in the Orchestrator queue item details. Only relevant when `Status` is Failed. |
+| `ErrorType` | ErrorType | InArgument | `ErrorType` | No | Business | The category of failure. Only relevant when `Status` is Failed. |
+| `Reason` | Reason | InArgument | `string` | No | — | The reason for the failure. Becomes required when `Status` is set to Failed. |
+| `AssociatedFilePath` | AssociatedFilePath | InArgument | `string` | No | null | Path to a file to attach to the failed transaction in Orchestrator. |
+| `TimeoutMS` | Timeout (milliseconds) | InArgument | `int` | No | — | The maximum time in milliseconds to wait before throwing an error. |
+| `ContinueOnError` | Continue On Error | InArgument | `bool` | No | false | When true, execution continues even if the activity throws an error. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Output` | Output | `Dictionary<string, InArgument>` | — | Inline key-value output data to attach to the transaction record in Orchestrator. |
+| `OutputVariable` | Output variable | `InArgument<Dictionary<string, object>>` | null | A variable dictionary of output data. Alternative to the inline `Output` dictionary. Toggle via the menu action on `Output`. |
+| `Analytics` | Analytics | `Dictionary<string, InArgument>` | — | Inline key-value analytics data to attach to the transaction record. |
+| `AnalyticsVariable` | Analytics variable | `InArgument<Dictionary<string, object>>` | null | A variable dictionary of analytics data. Alternative to the inline `Analytics` dictionary. Toggle via the menu action on `Analytics`. |
+
+## Valid Configurations
+
+- `Output` and `OutputVariable` are mutually exclusive display modes for the same underlying data. The designer menu action on `Output` ("Use Expression") switches to `OutputVariable`, and vice versa.
+- `Analytics` and `AnalyticsVariable` follow the same mutual exclusion pattern.
+- `Reason` becomes required when `Status` is `Failed`.
+- `Details`, `ErrorType`, `Reason`, and `AssociatedFilePath` are only meaningful when `Status` is `Failed`. They appear under the **Transaction Error** property category.
+
+### Enum Reference
+
+**ProcessingStatus**
+
+| Value | Description |
+|-------|-------------|
+| `Successful` | The transaction was processed successfully. |
+| `Failed` | The transaction failed. Requires `Reason` and optionally `ErrorType` and `Details`. |
+
+**ErrorType**
+
+| Value | Description |
+|-------|-------------|
+| `Business` | A business logic error (e.g. invalid invoice data). Does not trigger automatic retry by default. |
+| `Application` | A technical/application error (e.g. file not found, network timeout). Triggers automatic retry according to the queue's retry settings in Orchestrator. |
+
+## XAML Example
+
+```xml
+<!-- Successful -->
+<ui:SetTransactionStatus
+    TransactionItem="[transactionItem]"
+    Status="Successful"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+
+<!-- Failed with Application error -->
+<ui:SetTransactionStatus
+    TransactionItem="[transactionItem]"
+    Status="Failed"
+    ErrorType="Application"
+    Reason="&quot;Could not connect to SAP&quot;"
+    Details="[exception.Message]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- The `TransactionItem` must have status **In Progress**, typically obtained from **Get Transaction Item**, **Add Transaction Item**, or **Wait Queue Item**.
+- Choosing `ErrorType.Application` causes Orchestrator to re-queue the item for retry (subject to the queue's maximum retry count configuration).
+- Choosing `ErrorType.Business` marks the item as permanently failed with no automatic retry.
+- `FolderPath` is an advanced/hidden property that overrides the Orchestrator folder context.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ShouldStop.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/ShouldStop.md
@@ -1,0 +1,44 @@
+# Should Stop
+
+`UiPath.Core.Activities.ShouldStop`
+
+Checks if a Stop command was triggered in UiPath Orchestrator for the current job. Use this activity inside loops or long-running processes to implement a graceful stop: poll periodically and exit the workflow cleanly when the result is `True`.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Process
+
+## Properties
+
+No configurable input properties.
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `bool` | `True` if a Stop command has been issued for the current job in Orchestrator; `False` otherwise. |
+
+## XAML Example
+
+```xml
+<ui:ShouldStop DisplayName="Should Stop" Result="[shouldStop]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+Typical usage inside a loop:
+
+```xml
+<ui:ShouldStop DisplayName="Should Stop" Result="[shouldStop]" />
+<If Condition="[shouldStop]">
+  <If.Then>
+    <!-- clean up and exit -->
+    <ui:Return DisplayName="Return" />
+  </If.Then>
+</If>
+```
+
+## Notes
+
+- Returns `False` when the robot is not connected to Orchestrator (standalone execution).
+- Poll this activity at natural checkpoints in long-running loops rather than on every iteration, to avoid excess Orchestrator API calls.
+- Pair with `Return` or a loop exit condition to implement a graceful stop without throwing an exception.
+- A *Kill* stop (as opposed to *Soft Stop*) does not wait for `ShouldStop` to be checked — it terminates the process immediately.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SortDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SortDataTable.md
@@ -1,0 +1,68 @@
+# Sort Data Table
+
+`UiPath.Core.Activities.SortDataTable`
+
+Sorts a DataTable by ascending or descending order, based on the values of a specified column.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| DataTable | Ascending | InArgument | DataTable | Yes | — | The DataTable to sort. |
+| ColumnName | Name | InArgument | String | Yes* | — | The name of the column to sort by. Mutually exclusive with **Index** and **Column**. |
+| ColumnIndex | Index | InArgument | Int32? | Yes* | — | The zero-based index of the column to sort by. Mutually exclusive with **Name** and **Column**. |
+| DataColumn | Column | InArgument | DataColumn | Yes* | — | A DataColumn object identifying the column to sort by. Mutually exclusive with **Name** and **Index**. |
+
+\* Exactly one of `ColumnName`, `ColumnIndex`, or `DataColumn` must be provided. Providing none or more than one is a validation error.
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| SortOrder | Order | Property (SortOrder) | — | The sort direction. See **Enum Reference** below. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| OutputDataTable | Data Table | OutArgument | DataTable | A new DataTable containing the sorted rows. The original DataTable is not modified. |
+
+## Valid Configurations
+
+| Mode | Required properties |
+|------|-------------------|
+| Sort by column name | `DataTable` + `ColumnName` + `SortOrder` |
+| Sort by column index | `DataTable` + `ColumnIndex` + `SortOrder` |
+| Sort by DataColumn object | `DataTable` + `DataColumn` + `SortOrder` |
+
+## Enum Reference
+
+### SortOrder
+
+| Value | Description |
+|-------|-------------|
+| `Ascending` | Sorts rows from lowest to highest value. |
+| `Descending` | Sorts rows from highest to lowest value. |
+
+## XAML Example
+
+```xml
+<ui:SortDataTable DisplayName="Sort Data Table"
+                  SortOrder="Ascending"
+                  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:SortDataTable.DataTable>
+    <InArgument x:TypeArguments="sd:DataTable">[myDataTable]</InArgument>
+  </ui:SortDataTable.DataTable>
+  <ui:SortDataTable.ColumnName>
+    <InArgument x:TypeArguments="x:String">"LastName"</InArgument>
+  </ui:SortDataTable.ColumnName>
+  <ui:SortDataTable.OutputDataTable>
+    <OutArgument x:TypeArguments="sd:DataTable">[sortedTable]</OutArgument>
+  </ui:SortDataTable.OutputDataTable>
+</ui:SortDataTable>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SplitText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/SplitText.md
@@ -1,0 +1,49 @@
+# Split Text
+
+`UiPath.Activities.System.Text.SplitText`
+
+Split the source text into a list of substrings based on a specified separator.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Source` | Source | InArgument | `String` | Yes | — | The text to be split. |
+| `Separator` | Separator | InArgument | `String` | Yes | — | The character or text used to divide the source string. Supports a dropdown of common predefined separators. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `String` | The first substring produced by the split operation. |
+| `Results` | Results | OutArgument | `IEnumerable<String>` | All substrings produced by splitting the source text at every occurrence of the separator. |
+
+## Valid Configurations
+
+The `Separator` field supports a dropdown of predefined values as well as a free-form custom string. When a predefined separator is selected the internal `SeparatorKey` property is set automatically and is not exposed in the designer.
+
+### Enum Reference
+
+**`SeparatorOptions`**: `Custom`, `NewLine`, `Space`, `Tab`, `Comma`, `Colon`, `SemiColon`
+
+## XAML Example
+
+```xml
+<ucs:SplitText
+  xmlns:ucs="clr-namespace:UiPath.Activities.System.Text;assembly=UiPath.System.Activities.Standard"
+  Source="[csvLine]"
+  Separator="[&quot;,&quot;]"
+  Result="[firstField]"
+  Results="[allFields]" />
+```
+
+## Notes
+
+- The split is performed using `StringSplitOptions.None`, so consecutive separators produce empty-string entries in `Results`.
+- For the `NewLine` separator, the activity splits on `\r\n`, `\r`, and `\n` to handle all common line-ending conventions.
+- `Result` is a convenience output that holds only the first element of `Results`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StartJob.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StartJob.md
@@ -1,0 +1,68 @@
+# Start Job
+
+`UiPath.Core.Activities.StartJob`
+
+Initiates a new job via Orchestrator to be picked up by any available robots. It immediately continues the execution without waiting for the job to finish. It does not return output arguments.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Jobs
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ProcessName` | Process name | InArgument | `string` | Yes | — | The name of the process (release) to start in Orchestrator. |
+| `JobPriority` | Job Priority | InArgument | `StartProcessDtoJobPriority` | No | Normal | The priority of the started job in the Orchestrator queue. |
+| `NumberOfRobots` | Number Of Robots | InArgument | `int` | No | — | The number of robot instances to allocate for the job. |
+| `ModernFolder` | Modern Folder | InArgument | `bool` | No | true | Indicates whether the target process is in a modern (non-classic) Orchestrator folder. |
+| `ResumeOnSameContext` | Resume On Same Context | InArgument | `bool` | No | false | When true, the job will resume on the same robot/machine context if suspended. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Arguments` | Arguments | `Dictionary<string, Argument>` | `{}` | The inline collection of input arguments to pass to the started process. Keys must match the process's declared input argument names. |
+| `ArgumentsVariable` | Arguments Variable | `InArgument<Dictionary<string, object>>` | null | A variable dictionary of input arguments. Alternative to the inline `Arguments` dictionary. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `JobId` | Job Id | OutArgument | `string` | The numeric identifier of the started job in Orchestrator. |
+| `Key` | Key | OutArgument | `string` | The GUID key of the started job in Orchestrator. |
+
+## Valid Configurations
+
+- `Arguments` and `ArgumentsVariable` are two ways to supply input arguments. Use `Arguments` for inline design-time mapping and `ArgumentsVariable` to pass a dictionary variable at runtime.
+- `NumberOfRobots` controls the number of concurrent robot instances used to run the job.
+
+### Enum Reference
+
+**StartProcessDtoJobPriority**
+
+| Value | Description |
+|-------|-------------|
+| `Low` | The job is given lower scheduling priority than normal. |
+| `Normal` | Default scheduling priority. |
+| `High` | The job is given higher scheduling priority than normal. |
+
+## XAML Example
+
+```xml
+<ui:StartJob
+    ProcessName="&quot;InvoiceProcessing&quot;"
+    JobPriority="Normal"
+    JobId="[startedJobId]"
+    Key="[startedJobKey]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- This activity is **fire-and-forget**: it submits the job to Orchestrator and immediately continues without waiting for the job to complete. Use the **Get Jobs** activity to poll for the job's completion state if needed.
+- The started process does not return output arguments to the calling workflow.
+- `ProcessName` must exactly match the release name as configured in Orchestrator.
+- `FolderPath` is an advanced/hidden property (not shown in designer) that targets the process in a specific Orchestrator folder.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StartTimer.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StartTimer.md
@@ -1,0 +1,40 @@
+# Start Timer
+
+`UiPath.Core.Activities.StartTimer`
+
+Creates a new timer or restarts an existing one received as parameter.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Timer
+
+## Properties
+
+### Input
+
+_No input arguments._
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| Timer | Timer | OutArgument | `UiPathTimer` | The newly created (or restarted) timer object. Pass this variable to Stop Timer, Resume Timer, or Reset Timer. |
+
+## XAML Example
+
+```xml
+<ui:StartTimer>
+  <ui:StartTimer.Timer>
+    <OutArgument x:TypeArguments="ui:UiPathTimer">[myTimer]</OutArgument>
+  </ui:StartTimer.Timer>
+</ui:StartTimer>
+```
+
+## Notes
+
+- The returned `UiPathTimer` variable must be stored and passed to subsequent timer activities (Stop Timer, Resume Timer, Reset Timer).
+- Calling Start Timer on an existing timer variable restarts it from zero.
+- Timer precision is subject to .NET threading resolution (typically ~15 ms on Windows).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StopJob.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StopJob.md
@@ -1,0 +1,51 @@
+# Stop Job
+
+`UiPath.Core.Activities.StopJob`
+
+Stops or kills a job on Orchestrator.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Jobs
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Job` | Job | InArgument | `OrchestratorJob` | Yes | — | The Orchestrator job to stop. Typically obtained from **Get Jobs**. |
+| `Strategy` | Strategy | InArgument | `StopStrategy` | No | — | Controls how the job is stopped: gracefully or forcibly. |
+| `FolderPath` | Folder Path | InArgument | `string` | No | — | The Orchestrator folder path to use. Overrides the robot's default folder. |
+
+### Enum Reference
+
+**StopStrategy**
+
+| Value | Description |
+|-------|-------------|
+| `SoftStop` | Sends a stop signal to the robot. The robot will finish its current activity and then stop gracefully. |
+| `Kill` | Forcibly terminates the robot process immediately without waiting for it to finish. |
+
+## XAML Example
+
+```xml
+<!-- Soft stop -->
+<ui:StopJob
+    Job="[jobToStop]"
+    Strategy="SoftStop"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+
+<!-- Kill -->
+<ui:StopJob
+    Job="[jobToStop]"
+    Strategy="Kill"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- Use **Get Jobs** to retrieve an `OrchestratorJob` object to pass to the `Job` property.
+- `SoftStop` requests a graceful stop: the target robot will complete its currently executing activity before stopping. The job ends with status **Stopped**.
+- `Kill` forces immediate process termination. The job ends with status **Stopped** but the robot may not clean up resources properly. Use only when a graceful stop is not responding.
+- This activity does not wait for the job to actually stop — it only submits the stop request to Orchestrator. Poll with **Get Jobs** if you need to confirm the job has reached a terminal state.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StopTimer.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/StopTimer.md
@@ -1,0 +1,40 @@
+# Stop Timer
+
+`UiPath.Core.Activities.StopTimer`
+
+Stops the timer previously started using the Start Timer activity.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Timer
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Timer | Timer | InArgument | `UiPathTimer` | Yes | — | The timer object to stop. Must be a variable previously populated by a Start Timer activity. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:StopTimer>
+  <ui:StopTimer.Timer>
+    <InArgument x:TypeArguments="ui:UiPathTimer">[myTimer]</InArgument>
+  </ui:StopTimer.Timer>
+</ui:StopTimer>
+```
+
+## Notes
+
+- After stopping, the timer retains its elapsed value. Use Reset Timer to clear it back to zero.
+- Stopping a timer that is already stopped has no effect.
+- To resume a stopped timer from where it left off, use Resume Timer.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TextToLeftRight.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TextToLeftRight.md
@@ -1,0 +1,56 @@
+# Text to Left/Right
+
+`UiPath.Core.Activities.TextToLeftRight`
+
+Gets the text before and after the first occurrence of the indicated subtext.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Formatting
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FullText` | Text to split | InArgument | `String` | Yes | — | The full text to split at the separator. |
+| `Separator` | Separator | InArgument | `String` | Yes | — | The separator string used to split the text. Supports a dropdown of common predefined separators. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `CaseSensitiveSeparator` | Case sensitive separator | `Boolean` | `true` | If checked, the separator is case sensitive. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `TextToLeft` | Extracted text before the separator | OutArgument | `String` | The text that appears before the first occurrence of the separator. |
+| `TextToRight` | Extracted text after the separator | OutArgument | `String` | The text that appears after the first occurrence of the separator, including any additional occurrences joined back together. |
+
+## Valid Configurations
+
+The `Separator` field supports a dropdown of predefined values as well as a free-form custom string. When a predefined separator is selected the internal `SeparatorKey` property is set automatically and is not exposed in the designer.
+
+### Enum Reference
+
+**`DefaultSeparators`**: `Custom`, `NewLine`, `Space`, `Tab`, `Comma`, `Colon`, `SemiColon`, `EqualsSign`
+
+## XAML Example
+
+```xml
+<ui:TextToLeftRight
+  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+  FullText="[fullText]"
+  Separator="[&quot;,&quot;]"
+  CaseSensitiveSeparator="True"
+  TextToLeft="[leftPart]"
+  TextToRight="[rightPart]" />
+```
+
+## Notes
+
+- If the separator is not found in the text, `TextToLeft` receives the full original text and `TextToRight` is set to an empty string.
+- When the separator appears more than once, `TextToRight` contains everything after the first occurrence, with subsequent occurrences preserved.
+- When `CaseSensitiveSeparator` is `false`, matching is performed case-insensitively but the original casing of the source text is preserved in the output.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TimeTrigger.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TimeTrigger.md
@@ -1,0 +1,128 @@
+# Time Trigger
+
+`UiPath.Core.Activities.TimeTrigger`
+
+Schedule a recurrent time to start a job.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Triggers
+
+## Properties
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `Frequency` | Frequency | `TimeFrequency` | — | The scheduling frequency mode. Determines which other scheduling properties are shown. |
+| `TimeZone` | Time Zone | `string` | — | The time zone used to interpret scheduling times. Supports IANA and Windows time zone identifiers. |
+| `CronExpression` | Cron Expression | `string` | `"0 0 12 ? * MON-FRI *"` | A Quartz-style cron expression. Visible only when `Frequency` is `CronExpression`. |
+| `DailyRepeat` | Daily Repeat | `int?` | — | Repeat interval in days. Visible only when `Frequency` is `Daily`. |
+| `DailyStartingTime` | Daily Starting Time | `DateTime?` | — | The time of day to start when using the Daily frequency. Visible only when `Frequency` is `Daily`. |
+| `HourlyRepeat` | Hourly Repeat | `int?` | — | Repeat interval in hours. Visible only when `Frequency` is `Hourly`. |
+| `HourlyStartingMinutes` | Hourly Starting Minutes | `int?` | — | Minutes past the hour at which to start when using the Hourly frequency. Visible only when `Frequency` is `Hourly`. |
+| `MinuteByMinuteRepeat` | Minute By Minute Repeat | `int?` | — | Repeat interval in minutes. Visible only when `Frequency` is `MinuteByMinute`. |
+| `WeeklyDaysToRunOn` | Weekly Days To Run On | `List<DayOfWeek>` | — | Days of the week on which to trigger. Visible when `Frequency` is `Weekly`. |
+| `WeeklyStartingTime` | Weekly Starting Time | `DateTime?` | — | The time of day to start when using the Weekly frequency. Visible only when `Frequency` is `Weekly`. |
+| `MonthlyRepeat` | Monthly Repeat | `int?` | — | Repeat interval in months. Visible only when `Frequency` is `Monthly`. |
+| `MonthDaySelection` | Month Day Selection | `MonthDaySelectionType` | — | Controls whether to trigger on specific calendar days or on a weekday-of-month pattern. Visible only when `Frequency` is `Monthly`. |
+| `MonthlyDaysToRunOn` | Monthly Days To Run On | `List<DayOfWeek>` | — | Days of the week to use with the monthly weekday pattern. |
+| `DaysOfMonthToRunOn` | Days of the month | `List<string>` | — | Specific calendar day numbers of the month to trigger on. |
+| `MonthlyStartingTime` | Monthly Starting Time | `DateTime?` | — | The time of day to start when using the Monthly frequency. Visible only when `Frequency` is `Monthly`. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `CurrentJobInfo` | Runtime information about the triggered job, including Process name, Workflow name, User Name, User Email, and Timestamp. |
+
+## Valid Configurations
+
+The properties shown in the designer depend on the selected `Frequency` value:
+
+### Hourly
+
+Set `Frequency` to `Hourly`. Configure:
+- `HourlyRepeat` — run every N hours.
+- `HourlyStartingMinutes` — minutes past the hour when the trigger fires.
+
+### Daily
+
+Set `Frequency` to `Daily`. Configure:
+- `DailyRepeat` — run every N days.
+- `DailyStartingTime` — time of day (hour and minute) at which to fire.
+
+### Weekly
+
+Set `Frequency` to `Weekly`. Configure:
+- `WeeklyDaysToRunOn` — which days of the week to fire.
+- `WeeklyStartingTime` — time of day at which to fire on those days.
+
+### Monthly
+
+Set `Frequency` to `Monthly`. Configure:
+- `MonthlyRepeat` — run every N months.
+- `MonthDaySelection` — choose between specific calendar days (`DaysOfMonthToRunOn`) or a weekday-of-month pattern (`MonthlyDaysToRunOn`).
+- `MonthlyStartingTime` — time of day at which to fire.
+
+### Minute By Minute
+
+Set `Frequency` to `MinuteByMinute`. Configure:
+- `MinuteByMinuteRepeat` — run every N minutes.
+
+### Cron Expression
+
+Set `Frequency` to `CronExpression`. Configure:
+- `CronExpression` — a Quartz-style seven-field cron string (seconds, minutes, hours, day-of-month, month, day-of-week, year).
+- `TriggerEveryPlaceHolder` is displayed as a read-only hint when `Frequency` is `Weekly` or `CronExpression`.
+
+### Enum Reference
+
+**`TimeFrequency`**
+
+| Value | Description |
+|-------|-------------|
+| `Hourly` | Trigger every N hours |
+| `Daily` | Trigger every N days at a specified time |
+| `Weekly` | Trigger on specified days of the week |
+| `Monthly` | Trigger on specified days of the month |
+| `MinuteByMinute` | Trigger every N minutes |
+| `CronExpression` | Trigger according to a Quartz cron expression |
+
+**`MonthDaySelectionType`**
+
+| Value | Description |
+|-------|-------------|
+| `DayOfMonth` | Trigger on specific numbered days of the month |
+| `DayOfWeek` | Trigger on a named weekday occurrence within the month |
+
+## XAML Example
+
+```xml
+<!-- Daily at 09:00, every weekday -->
+<ui:TimeTrigger
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Time Trigger"
+    Frequency="Daily"
+    DailyRepeat="1"
+    DailyStartingTime="[New DateTime(2000,1,1,9,0,0)]"
+    TimeZone="UTC"
+    Result="{x:Reference jobInfo}" />
+```
+
+```xml
+<!-- Cron expression: every weekday at noon -->
+<ui:TimeTrigger
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="Time Trigger"
+    Frequency="CronExpression"
+    CronExpression="0 0 12 ? * MON-FRI *"
+    TimeZone="UTC"
+    Result="{x:Reference jobInfo}" />
+```
+
+## Notes
+
+- **Time Trigger** is a scope/container activity. Place the automation logic to execute on each scheduled firing inside its body.
+- The `Result` output provides a `CurrentJobInfo` object accessible within the trigger body for runtime context.
+- `TimeZone` accepts standard IANA time zone identifiers (e.g., `America/New_York`) or Windows time zone names (e.g., `Eastern Standard Time`).
+- Cron expressions follow the Quartz scheduler format with seven fields. The default `"0 0 12 ? * MON-FRI *"` fires at 12:00 noon every weekday.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TimeoutScope.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TimeoutScope.md
@@ -1,0 +1,45 @@
+# Timeout Scope
+
+`UiPath.Core.Activities.TimeoutScope`
+
+Creates a scope with limited execution time. It throws a `System.TimeoutException` in case of timeout.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System.Timer
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| ThrowExceptionAfter | Throw Exception After | InArgument | `TimeSpan` | Yes | — | The duration after which the scope throws a `System.TimeoutException` if the body has not completed. |
+| TimeoutMessage | Timeout Message | InArgument | `string` | No | — | The message included in the thrown `TimeoutException` when the time limit is exceeded. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties._
+
+## XAML Example
+
+```xml
+<ui:TimeoutScope>
+  <ui:TimeoutScope.ThrowExceptionAfter>
+    <InArgument x:TypeArguments="s:TimeSpan">[TimeSpan.FromSeconds(30)]</InArgument>
+  </ui:TimeoutScope.ThrowExceptionAfter>
+  <ui:TimeoutScope.TimeoutMessage>
+    <InArgument x:TypeArguments="x:String">Operation timed out after 30 seconds</InArgument>
+  </ui:TimeoutScope.TimeoutMessage>
+  <!-- child activities -->
+</ui:TimeoutScope>
+```
+
+## Notes
+
+- This is a container activity. Place the activities to be time-bounded inside its body.
+- When the timeout elapses, a `System.TimeoutException` is thrown from within the scope. Use a Try/Catch around the scope to handle this gracefully.
+- The `TimeoutMessage` value is surfaced as the exception `Message` property.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TrackObject.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/TrackObject.md
@@ -1,0 +1,42 @@
+# Track Object
+
+`UiPath.Core.Activities.ProcessTracking.TrackObject`
+
+Adds a new object to the task. This object will appear as metadata information on the task in Process Mining.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Process Tracking
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ObjectType` | Object Type | InArgument | `string` | Yes | — | The type label for the object being tracked (e.g., `"invoice"`, `"document"`, `"case"`). |
+| `ObjectId` | Object Id | InArgument | `string` | Yes | — | A unique identifier for the object being tracked (e.g., an invoice number or case ID). |
+| `ObjectInteraction` | Object Interaction | InArgument | `PTSObjectInteraction` | No | `null` | The type of interaction the current task has with the object (e.g., read, write, create). |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ObjectPropertiesV2` | Object Properties V2 | `InArgument<Dictionary<string, object>>` | — | A dictionary of additional key-value metadata properties to associate with the tracked object. |
+
+## XAML Example
+
+```xml
+<ui:TrackObject
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.ProcessTracking;assembly=UiPath.System.Activities"
+    DisplayName="Track Object"
+    ObjectType="[&quot;invoice&quot;]"
+    ObjectId="[invoiceNumber]"
+    ObjectInteraction="[PTSObjectInteraction.Read]" />
+```
+
+## Notes
+
+- **Track Object** must be used inside a **Process Tracking Scope** activity. It associates an object (identified by `ObjectType` and `ObjectId`) with the current task being tracked.
+- The tracked object and its metadata appear as enrichment data on the task in UiPath Process Mining dashboards.
+- `ObjectInteraction` describes how the automation interacted with the object (e.g., created it, read it, updated it). Refer to the `PTSObjectInteraction` enum values available in the UiPath.System.Activities package.
+- `ObjectPropertiesV2` allows attaching arbitrary key-value metadata. Keys and values must be serializable types.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/UpdateListItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/UpdateListItem.md
@@ -1,0 +1,50 @@
+# Update List Item
+
+`UiPath.Activities.System.Arrays.UpdateListItem<T>`
+
+Updates the value of a specific item in a list. Add a Read List Item activity after it to ensure you are using the updated value going forward.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Data.Lists
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| List | List | InArgument | `IList<T>` | Yes | — | The list containing the item to update. The list object is mutated in place (no reassignment needed). |
+| Index | Index | InArgument | `int` | Yes | — | The zero-based index of the item to update. |
+| Value | Value | InArgument | `T` | Yes | — | The new value to set at the specified index. |
+
+### Configuration
+
+_No configuration properties._
+
+### Output
+
+_No output properties. The list variable passed to `List` is updated in place._
+
+## XAML Example
+
+```xml
+<!-- Replace the item at index 1 in a list of strings -->
+<ui:UpdateListItem x:TypeArguments="x:String">
+  <ui:UpdateListItem.List>
+    <InArgument x:TypeArguments="scg:IList(x:String)">[myStringList]</InArgument>
+  </ui:UpdateListItem.List>
+  <ui:UpdateListItem.Index>
+    <InArgument x:TypeArguments="x:Int32">1</InArgument>
+  </ui:UpdateListItem.Index>
+  <ui:UpdateListItem.Value>
+    <InArgument x:TypeArguments="x:String">"updated value"</InArgument>
+  </ui:UpdateListItem.Value>
+</ui:UpdateListItem>
+```
+
+## Notes
+
+- This is a generic activity; the element type `T` is determined at design time.
+- `List` is an `InArgument` — the list is passed in by reference and mutated in place. No reassignment of the variable occurs.
+- An `ArgumentOutOfRangeException` is thrown if `Index` is out of the list's bounds.
+- Follow this activity with a **Read List Item** to obtain the updated value for use in downstream activities, as variables bound before the update will hold stale references in some workflow engines.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/UpdateRowItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/UpdateRowItem.md
@@ -1,0 +1,59 @@
+# Update Row Item
+
+`UiPath.Core.Activities.UpdateRowItem`
+
+Assigns the specified value into the indicated column of a DataTable row.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Programming > DataTable
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| Row | Row | InArgument | DataRow | Yes | — | The DataRow whose cell value will be updated. The row is modified in place within its parent DataTable. |
+| Value | Value | InArgument | Object | Yes | — | The new value to write into the cell. |
+| ColumnName | Column Name | InArgument | String | No* | — | The name of the column to update. |
+| ColumnIndex | Column Number | InArgument | Int32 | No* | — | The zero-based index of the column to update. |
+
+\* One of `ColumnName` or `ColumnIndex` must be provided to identify the target column.
+
+## Notes
+
+- The DataRow is updated in place. Because a DataRow holds a reference back to its parent DataTable, the change is reflected in the DataTable immediately without needing to re-assign it.
+- `Value` is typed as `Object`. Pass any value that is compatible with the column's data type.
+- There is no `Column` (DataColumn object) variant exposed in the designer for this activity.
+
+## XAML Example
+
+```xml
+<!-- Update by column name -->
+<ui:UpdateRowItem DisplayName="Update Row Item"
+                  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:UpdateRowItem.Row>
+    <InArgument x:TypeArguments="sd:DataRow">[CurrentRow]</InArgument>
+  </ui:UpdateRowItem.Row>
+  <ui:UpdateRowItem.ColumnName>
+    <InArgument x:TypeArguments="x:String">"Status"</InArgument>
+  </ui:UpdateRowItem.ColumnName>
+  <ui:UpdateRowItem.Value>
+    <InArgument x:TypeArguments="x:Object">"Processed"</InArgument>
+  </ui:UpdateRowItem.Value>
+</ui:UpdateRowItem>
+
+<!-- Update by column index -->
+<ui:UpdateRowItem DisplayName="Update Row Item"
+                  xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities">
+  <ui:UpdateRowItem.Row>
+    <InArgument x:TypeArguments="sd:DataRow">[CurrentRow]</InArgument>
+  </ui:UpdateRowItem.Row>
+  <ui:UpdateRowItem.ColumnIndex>
+    <InArgument x:TypeArguments="x:Int32">2</InArgument>
+  </ui:UpdateRowItem.ColumnIndex>
+  <ui:UpdateRowItem.Value>
+    <InArgument x:TypeArguments="x:Object">[newValue]</InArgument>
+  </ui:UpdateRowItem.Value>
+</ui:UpdateRowItem>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/UploadStorageFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/UploadStorageFile.md
@@ -1,0 +1,57 @@
+# Upload Storage File
+
+`UiPath.Core.Activities.Storage.UploadStorageFile`
+
+Uploads a local file to the Orchestrator storage, in a certain bucket and at a certain path.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Storage
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FileResource` | File Resource | InArgument | `IResource` | Yes (File overload) | — | A file resource object representing the local file to upload. Use this or `Path`, not both. |
+| `Path` | Path | InArgument | `string` | Yes (Path overload) | — | The local file system path of the file to upload. Use this or `FileResource`, not both. |
+| `Destination` | Destination | InArgument | `string` | Yes | — | The target directory path within the storage bucket where the file will be stored (e.g., `reports/2024`). |
+| `FileName` | File Name | InArgument | `string` | No | — | The name to use for the file in the storage bucket. If omitted, the name is derived automatically from `FileResource` or `Path`. |
+
+## Valid Configurations
+
+`FileResource` and `Path` are mutually exclusive overload groups:
+
+| Configuration | Required properties |
+|---|---|
+| **File** | `FileResource`, `Destination` |
+| **Path** | `Path`, `Destination` |
+
+## XAML Example
+
+```xml
+<!-- Upload using a local file path -->
+<ui:UploadStorageFile
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.Storage;assembly=UiPath.System.Activities"
+    DisplayName="Upload Storage File"
+    Path="[&quot;C:\Temp\report.pdf&quot;]"
+    Destination="[&quot;reports/2024&quot;]"
+    FileName="[&quot;report.pdf&quot;]" />
+```
+
+```xml
+<!-- Upload using a file resource -->
+<ui:UploadStorageFile
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.Storage;assembly=UiPath.System.Activities"
+    DisplayName="Upload Storage File"
+    FileResource="[myFileResource]"
+    Destination="[&quot;reports/2024&quot;]" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection with access to storage buckets.
+- The storage bucket name and folder path are configured in the Orchestrator connection context (via `StorageBucketName` and `FolderPath` inherited from the base storage activity class).
+- `Destination` is the directory path within the bucket (not including the file name). The file name is specified separately via `FileName`.
+- When `FileName` is left empty, the designer auto-populates it by deriving the name from `FileResource` or `Path`. If the `Destination` value previously included a filename (legacy format), it is automatically split into folder and filename parts during migration.
+- If a file with the same name already exists at the destination path in the bucket, it is overwritten.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/WaitQueueItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/WaitQueueItem.md
@@ -1,0 +1,61 @@
+# Wait Queue Item
+
+`UiPath.Core.Activities.WaitQueueItem`
+
+Waits for an item in the queue to be available so that you can process it (start the transaction) and sets its status to In Progress.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Queues
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `QueueName` | Queue name | InArgument | `string` | Yes | — | The name of the queue to monitor for available items. |
+| `Reference` | Reference | InArgument | `string` | No | — | Filters the item to wait for by reference value. Used together with `FilterStrategy`. |
+| `PollTimeMS` | PollTime (milliseconds) | InArgument | `int` | No | — | The interval in milliseconds between polling attempts while waiting for an item. |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `FilterStrategy` | Filter Strategy | `ReferenceFilterStrategy` | — | Determines how the `Reference` filter value is matched against queue item references. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `QueueItem` | The queue item that became available, now set to In Progress. |
+
+## Valid Configurations
+
+- `Reference` and `FilterStrategy` work together: only items whose reference matches the filter strategy are considered.
+- If `PollTimeMS` is not set, a default polling interval is used.
+
+### Enum Reference
+
+**ReferenceFilterStrategy**
+
+| Value | Description |
+|-------|-------------|
+| `StartsWith` | The item's reference must start with the specified value. |
+| `Equals` | The item's reference must exactly match the specified value. |
+
+## XAML Example
+
+```xml
+<ui:WaitQueueItem
+    QueueName="&quot;InvoiceProcessing&quot;"
+    PollTimeMS="[5000]"
+    Result="[transactionItem]"
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection. The robot must be connected to Orchestrator at runtime.
+- Unlike **Get Transaction Item**, this activity blocks execution until an item with status **New** becomes available in the queue. It will poll indefinitely unless a timeout is applied externally (e.g. via a wrapping **Parallel** or **Pick** activity).
+- The returned item is immediately set to status **In Progress**. Pass it to **Set Transaction Status** when processing is complete.
+- Use `PollTimeMS` to control how frequently Orchestrator is queried, balancing responsiveness against API load.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/While.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/While.md
@@ -1,0 +1,49 @@
+# While
+
+`UiPath.Core.Activities.InterruptibleWhile`
+
+Executes contained activities while the condition is True.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Workflow
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Condition` | Condition | `InArgument` | `bool` | No | — | The Boolean condition evaluated before each iteration. The loop continues while this is `True`. |
+| `MaxIterations` | Max Iterations | `InArgument` | `int` | No | — | Maximum number of iterations. A value of `0` means unlimited. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `CurrentIndex` | Current Index | `OutArgument` | `int` | The zero-based index of the current iteration. |
+
+## XAML Example
+
+```xml
+<ui:InterruptibleWhile
+    xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"
+    DisplayName="While">
+  <ui:InterruptibleWhile.Condition>
+    <InArgument x:TypeArguments="x:Boolean">
+      <VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="counter &lt; 10" />
+    </InArgument>
+  </ui:InterruptibleWhile.Condition>
+  <ui:InterruptibleWhile.Body>
+    <Sequence DisplayName="Body">
+      <!-- child activities go here -->
+    </Sequence>
+  </ui:InterruptibleWhile.Body>
+</ui:InterruptibleWhile>
+```
+
+## Notes
+
+- **While** is a container/scope activity. Child activities are placed inside its `Body`.
+- The `Condition` is evaluated **before** each iteration. If it is `False` on the first evaluation the body never executes.
+- Use a `Break` activity inside the body to exit the loop early; use `Continue` to skip to the next iteration.
+- Setting `MaxIterations` provides an upper bound to prevent infinite loops regardless of the condition value.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/WriteStorageText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/WriteStorageText.md
@@ -1,0 +1,38 @@
+# Write Storage Text
+
+`UiPath.Core.Activities.Storage.WriteStorageText`
+
+Saves an input String into a file in the Orchestrator storage, in a certain bucket and at a certain path.
+
+**Package:** `UiPath.System.Activities`
+**Category:** Storage
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Path` | Path | InArgument | `string` | Yes | — | The destination file path within the storage bucket (e.g., `data/output.txt`). |
+| `Text` | Text | InArgument | `string` | Yes | — | The string content to write into the storage file. |
+| `Encoding` | Encoding | InArgument | `string` | No | `null` | The character encoding to use when writing the text (e.g., `"utf-8"`, `"utf-16"`). Defaults to UTF-8 when not specified. Can be set as a project-level default. |
+
+## XAML Example
+
+```xml
+<ui:WriteStorageText
+    xmlns:ui="clr-namespace:UiPath.Core.Activities.Storage;assembly=UiPath.System.Activities"
+    DisplayName="Write Storage Text"
+    Path="[&quot;data/output.txt&quot;]"
+    Text="[reportContent]"
+    Encoding="[&quot;utf-8&quot;]" />
+```
+
+## Notes
+
+- Requires an active Orchestrator connection with access to storage buckets.
+- The storage bucket name and folder path are configured in the Orchestrator connection context (via `StorageBucketName` and `FolderPath` inherited from the base storage activity class).
+- `Path` is the full file path within the bucket, including the file name and extension.
+- If a file already exists at the specified `Path`, it is overwritten with the new content.
+- `Encoding` can be configured as a project-level setting (section `WriteTextFile`, property `Encoding`) so it applies consistently across the project without setting it on each activity instance.
+- To read the text content back from a storage file, use **Read Storage Text**.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/WriteTextFile.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/activities/WriteTextFile.md
@@ -1,0 +1,55 @@
+# Write Text File
+
+`UiPath.Core.Activities.WriteTextFile`
+
+Copies a text and pastes it in a text file replacing any existing data in the file.
+
+**Package:** `UiPath.System.Activities`
+**Category:** System > File
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FileName` | Write Text File | `InArgument` | `string` | Yes* | — | Full path of the text file to write. Overload group: `FileName`. |
+| `File` | File | `InArgument` | `ILocalResource` | Yes* | — | Local resource reference to the file to write. Overload group: `File`. |
+| `Text` | Text | `InArgument` | `string` | Yes | — | The text content to write to the file. |
+| `Encoding` | Encoding | `InArgument` | `string` | No | `null` | The encoding to use when writing the file (e.g. `"utf-8"`). When `null`, the system default encoding is used. Configurable as a project setting. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Output` | Output | `OutArgument` | `ILocalResource` | Reference to the written file. |
+
+## Valid Configurations
+
+Two mutually exclusive modes determine how the file is specified:
+
+| Mode | Property | Description |
+|------|----------|-------------|
+| Local path | `FileName` | String expression resolving to a local file path. Default mode. |
+| Resource | `File` | `ILocalResource` expression (e.g. from Create File). |
+
+The mode is toggled via a context menu action in Studio. Only one property is visible at a time.
+
+## XAML Example
+
+```xml
+<ui:WriteTextFile
+    DisplayName="Write Text File"
+    FileName="&quot;C:\output\result.txt&quot;"
+    Text="[reportText]"
+    Encoding="&quot;utf-8&quot;"
+    Output="[writtenFile]" />
+```
+
+`xmlns:ui="clr-namespace:UiPath.Core.Activities;assembly=UiPath.System.Activities"`
+
+## Notes
+
+- This activity **overwrites** all existing content in the target file. To append content instead, use the **Append Line** activity.
+- If the specified file does not exist, it is created automatically.
+- The `Encoding` property can be set at project level via **Project Settings** (`Section.WriteTextFile, Property.Encoding`).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/coded/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/coded/coded-api.md
@@ -1,0 +1,1293 @@
+# UiPath System Activities — Coded Workflow API
+
+`UiPath.System.Activities`
+
+Provides system-level automation capabilities for coded workflows: file and folder management, DataTable manipulation, text processing, date/time utilities, Orchestrator integration (jobs, queues, assets, credentials, storage buckets), and HTTP requests.
+
+**Service accessor:** `system` (type `ISystemService`)
+
+**Required package:** `"UiPath.System.Activities": "*"` in project.json dependencies
+
+## Auto-Imported Namespaces
+
+These namespaces are automatically available in coded workflows when this package is installed:
+
+```
+System
+System.Collections.Generic
+System.Data
+UiPath.Core
+UiPath.Core.Activities.Storage
+UiPath.Orchestrator.Client.Models
+UiPath.Activities.System.Jobs.Coded
+```
+
+## Service Overview
+
+The `system` service provides direct method calls — no handles, no `using` blocks. Methods cover:
+
+- **Process invocation** — invoke local processes or Orchestrator jobs synchronously or asynchronously
+- **File & folder operations** — create, copy, move, delete, read, and write files and folders
+- **Compression** — zip and unzip file archives
+- **DataTable operations** — add/remove rows and columns, sort, merge, deduplicate, lookup
+- **Text manipulation** — regex replace, extract patterns (emails, URLs, occurrences), split/join, case conversion
+- **Date & time** — parse dates from text, format dates, add/subtract time
+- **Orchestrator queues** — add, get, and manage queue items and transactions
+- **Orchestrator assets & credentials** — read/write assets and credential assets
+- **Storage buckets** — upload, download, list, read, and write Orchestrator storage files
+- **Orchestrator HTTP** — make arbitrary REST calls to Orchestrator APIs
+- **Alerts** — raise Orchestrator alerts
+
+---
+
+## Process Invocation
+
+### `(OrchestratorJob JobData, string OutputJson) RunJob(string processName, string orchestratorFolderPath = null, object inputArguments = null, bool doNotWait = false, RunJobOptionalParameters runJobOptionalParameters = null)`
+
+Runs a job in Orchestrator synchronously and returns the job data and output arguments.
+
+**Parameters:**
+- `processName` (`string`) — The name of the process to run
+- `orchestratorFolderPath` (`string`) — Orchestrator folder path where the process resides (default: `null`)
+- `inputArguments` (`object`) — Input arguments for the process; can be an anonymous object or dictionary (default: `null`)
+- `doNotWait` (`bool`) — If `true`, fires the job without waiting for completion (default: `false`)
+- `runJobOptionalParameters` (`RunJobOptionalParameters`) — Additional options: timeout, error handling (default: `null`)
+
+**Returns:** `(OrchestratorJob JobData, string OutputJson)` — Tuple with the Orchestrator job entity and the process output arguments serialized as a JSON string.
+
+---
+
+### `Task<(OrchestratorJob JobData, string OutputJson)> RunJobAsync(string processName, string orchestratorFolderPath = null, object inputArguments = null, bool doNotWait = false, RunJobOptionalParameters runJobOptionalParameters = null)`
+
+Asynchronous version of `RunJob`. Awaitable.
+
+**Parameters:** Same as `RunJob`.
+
+**Returns:** `Task<(OrchestratorJob JobData, string OutputJson)>` — Awaitable task yielding the same tuple as `RunJob`.
+
+---
+
+### `void InvokeProcess(string processName)`
+### `void InvokeProcess(string processName, string folderPath)`
+
+Invokes a process available on the current Robot. Blocking — returns only after the invoked process finishes.
+
+**Parameters:**
+- `processName` (`string`) — The name of the process to run
+- `folderPath` (`string`) — Orchestrator folder where the process resides
+
+**Returns:** `void` — Blocks until the invoked process completes.
+
+---
+
+### `Task<Dictionary<string, object>> InvokeProcessAsync(string processName)`
+### `Task<Dictionary<string, object>> InvokeProcessAsync(string processName, string folderPath)`
+### `Task<Dictionary<string, object>> InvokeProcessAsync(string processName, string folderPath = null, Dictionary<string, object> inArguments = null, Dictionary<string, object> inOutArguments = null, LogEntryType logEntry = LogEntryType.No, LogExitType logExit = LogExitType.No, UiPath.Core.Activities.LogLevel level = LogLevel.Info, InvokeProcessTargetSession targetSession = InvokeProcessTargetSession.Current, TimeSpan timeout = default)`
+
+Invokes a process available on the current Robot asynchronously.
+
+**Parameters (full overload):**
+- `processName` (`string`) — Name of the process to run
+- `folderPath` (`string`) — Orchestrator folder (default: `null`)
+- `inArguments` (`Dictionary<string, object>`) — Input arguments (default: `null`)
+- `inOutArguments` (`Dictionary<string, object>`) — In-out arguments; updated after execution (default: `null`)
+- `logEntry` (`LogEntryType`) — What to log on entry (default: `LogEntryType.No`)
+- `logExit` (`LogExitType`) — What to log on exit (default: `LogExitType.No`)
+- `level` (`UiPath.Core.Activities.LogLevel`) — Log level for entry/exit messages (default: `LogLevel.Info`)
+- `targetSession` (`InvokeProcessTargetSession`) — Session in which the child process starts (default: `InvokeProcessTargetSession.Current`)
+- `timeout` (`TimeSpan`) — Maximum wait time before aborting (default: `default`)
+
+**Returns:** `Task<Dictionary<string, object>>` — Awaitable task yielding the output arguments of the invoked process.
+
+---
+
+### `string StartJob(string processName)`
+### `string StartJob(string processName, string folderPath)`
+### `string StartJob(string processName, out string jobId)`
+### `string StartJob(string processName, out string jobId, string folderPath)`
+### `string StartJob(string processName, string folderPath, StartProcessDtoJobPriority jobPriority, bool resumeOnSameContext, out string jobId)`
+
+Starts an Orchestrator job without waiting for it to complete.
+
+**Parameters (full overload):**
+- `processName` (`string`) — Name of the process
+- `folderPath` (`string`) — Orchestrator folder
+- `jobPriority` (`StartProcessDtoJobPriority`) — Job execution priority
+- `resumeOnSameContext` (`bool`) — Whether to resume on the same context
+- `jobId` (`out string`) — Receives the started job's ID
+
+**Returns:** `string` — The Orchestrator job key/identifier.
+
+---
+
+### `void StopJob(OrchestratorJob job, StopStrategy strategy)`
+### `void StopJob(OrchestratorJob job, StopStrategy strategy, string folderPath)`
+### `void StopJob(OrchestratorJob job, StopStrategy strategy, string folderPath, int timeoutMS)`
+
+Stops a running Orchestrator job.
+
+**Parameters:**
+- `job` (`OrchestratorJob`) — The job to stop
+- `strategy` (`StopStrategy`) — How to stop the job (e.g., soft stop or kill)
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `IEnumerable<OrchestratorJob> GetJobs()`
+### `IEnumerable<OrchestratorJob> GetJobs(string filter, JobFilterSettings filterBuilder, string folderPath)`
+### `IEnumerable<OrchestratorJob> GetJobs(string filter, JobFilterSettings filterBuilder, string folderPath, int top, int skip, int timeoutMS)`
+
+Retrieves Orchestrator jobs matching the specified filter criteria.
+
+**Parameters (full overload):**
+- `filter` (`string`) — OData filter string
+- `filterBuilder` (`JobFilterSettings`) — Structured filter settings
+- `folderPath` (`string`) — Orchestrator folder
+- `top` (`int`) — Maximum number of results to return
+- `skip` (`int`) — Number of results to skip (paging)
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `IEnumerable<OrchestratorJob>` — Collection of matching job entities.
+
+---
+
+## File & Folder Operations
+
+### `void CopyFile(string path, string destination, bool overwrite)`
+
+Copies a file to another location.
+
+**Parameters:**
+- `path` (`string`) — Source file path
+- `destination` (`string`) — Destination path
+- `overwrite` (`bool`) — Whether to overwrite if destination exists
+
+**Returns:** `void`
+
+---
+
+### `void CopyFolder(string from, string to)`
+### `void CopyFolder(string from, string to, bool overwrite, bool includeSubfolder)`
+
+Copies a folder to another location.
+
+**Parameters:**
+- `from` (`string`) — Source folder path
+- `to` (`string`) — Destination folder path
+- `overwrite` (`bool`) — Whether to overwrite existing folders at the destination
+- `includeSubfolder` (`bool`) — Whether to include subfolders
+
+**Returns:** `void`
+
+---
+
+### `ILocalResource CreateFile(string name, string path)`
+
+Creates a new file at the specified location.
+
+**Parameters:**
+- `name` (`string`) — File name (including extension)
+- `path` (`string`) — Directory path where the file will be created
+
+**Returns:** `ILocalResource` — Resource handle for the newly created file, providing its `LocalPath`.
+
+---
+
+### `ILocalResource CreateFolder(string path)`
+
+Creates a new folder at the specified path.
+
+**Parameters:**
+- `path` (`string`) — Full path of the folder to create
+
+**Returns:** `ILocalResource` — Resource handle for the created folder.
+
+---
+
+### `void DeleteFileOrFolder(ILocalResource resourceFile)`
+
+Deletes the file or folder represented by the given resource.
+
+**Parameters:**
+- `resourceFile` (`ILocalResource`) — Resource pointing to the file or folder to delete
+
+**Returns:** `void`
+
+---
+
+### `void MoveFile(IResource pathResource, IResource destinationResource, bool overwrite)`
+
+Moves a file or folder to a new location.
+
+**Parameters:**
+- `pathResource` (`IResource`) — Source resource
+- `destinationResource` (`IResource`) — Destination resource
+- `overwrite` (`bool`) — Whether to overwrite if destination exists
+
+**Returns:** `void`
+
+---
+
+### `bool PathExists(string path)`
+### `bool PathExists(string path, PathType pathType)`
+### `bool PathExists(string path, out ILocalResource resource)`
+### `bool PathExists(string path, PathType pathType, out ILocalResource resource)`
+
+Checks whether a path exists on the file system.
+
+**Parameters:**
+- `path` (`string`) — Path to check
+- `pathType` (`PathType`) — Whether to check for a file, folder, or either
+- `resource` (`out ILocalResource`) — If the path exists, receives the corresponding resource
+
+**Returns:** `bool` — `true` if the path exists, `false` otherwise.
+
+---
+
+### `bool FileExists(string path)`
+
+Checks whether a file path exists.
+
+**Parameters:**
+- `path` (`string`) — Local file path to check
+
+**Returns:** `bool` — `true` if the file exists.
+
+---
+
+### `bool FolderExists(string path)`
+
+Checks whether a folder path exists.
+
+**Parameters:**
+- `path` (`string`) — Local folder path to check
+
+**Returns:** `bool` — `true` if the folder exists.
+
+---
+
+### `IResource GetResourceForLocalPath(string path, PathType pathType)`
+
+Constructs an `IResource` for the given local file or folder path.
+
+**Parameters:**
+- `path` (`string`) — Local path of the file or folder
+- `pathType` (`PathType`) — Whether the path is a file or folder
+
+**Returns:** `IResource` — Resource object wrapping the local path.
+
+---
+
+### `string ReadTextFile(IResource file)`
+### `string ReadTextFile(IResource file, string encoding)`
+
+Reads the contents of a text file.
+
+**Parameters:**
+- `file` (`IResource`) — The file to read
+- `encoding` (`string`) — Text encoding (e.g., `"UTF-8"`); uses system default when omitted
+
+**Returns:** `string` — The complete text content of the file.
+
+---
+
+### `void WriteTextFile(string text, ILocalResource file)`
+### `void WriteTextFile(string text, ILocalResource file, string encoding)`
+
+Writes text to a file, overwriting existing content.
+
+**Parameters:**
+- `text` (`string`) — Text to write
+- `file` (`ILocalResource`) — Target file resource
+- `encoding` (`string`) — Text encoding (e.g., `"UTF-8"`)
+
+**Returns:** `void`
+
+---
+
+### `void AppendLine(string text, ILocalResource file)`
+### `void AppendLine(string text, ILocalResource file, bool useDefaultEncoding, string encoding)`
+
+Appends a line of text to a file.
+
+**Parameters:**
+- `text` (`string`) — Text to append
+- `file` (`ILocalResource`) — Target file resource
+- `useDefaultEncoding` (`bool`) — Whether to use the system default encoding
+- `encoding` (`string`) — Explicit encoding to use when `useDefaultEncoding` is false
+
+**Returns:** `void`
+
+---
+
+### `Task<ILocalResource> DownloadFileFromURLAsync(string url, string fileName = default, FileConflictBehavior conflictResolution = FileConflictBehavior.Rename, int timeout = DownloadFileFromUrl.DefaultTimeout, CancellationToken cancellationToken = default, string userAgentHeaderValue = null)`
+
+Downloads a file from a URL asynchronously.
+
+**Parameters:**
+- `url` (`string`) — URL of the file to download
+- `fileName` (`string`) — Local file name to save as; auto-detected from URL if omitted (default: `default`)
+- `conflictResolution` (`FileConflictBehavior`) — What to do if the file already exists (default: `FileConflictBehavior.Rename`)
+- `timeout` (`int`) — Download timeout in milliseconds (default: `DownloadFileFromUrl.DefaultTimeout`)
+- `cancellationToken` (`CancellationToken`) — Cancellation token (default: `default`)
+- `userAgentHeaderValue` (`string`) — Custom User-Agent header (default: `null`)
+
+**Returns:** `Task<ILocalResource>` — Awaitable task yielding a resource pointing to the downloaded file.
+
+---
+
+## Compression
+
+### `ILocalResource[] ExtractUnzipFiles(IResource file)`
+### `ILocalResource[] ExtractUnzipFiles(IResource file, string destinationFolder)`
+### `ILocalResource[] ExtractUnzipFiles(IResource file, string destinationFolder, bool extractToADedicatedFolder, string password, CodePages codePage)`
+
+Extracts files from a ZIP archive.
+
+**Parameters (full overload):**
+- `file` (`IResource`) — The ZIP archive to extract
+- `destinationFolder` (`string`) — Folder where extracted files are placed
+- `extractToADedicatedFolder` (`bool`) — Whether to create a dedicated subfolder for the extracted contents
+- `password` (`string`) — Archive password, if protected
+- `codePage` (`CodePages`) — Code page for file name encoding
+
+**Returns:** `ILocalResource[]` — Array of resources for each extracted file.
+
+---
+
+### `ILocalResource CompressZipFiles(IEnumerable<IResource> resourcesToArchive, string compressedFileName)`
+### `ILocalResource CompressZipFiles(IEnumerable<IResource> resourcesToArchive, string compressedFileName, string password, ArchiveCompressionLevel compressionLevel, CodePages codePage, bool overrideExistingFile)`
+
+Compresses files into a ZIP archive.
+
+**Parameters (full overload):**
+- `resourcesToArchive` (`IEnumerable<IResource>`) — Files and folders to compress
+- `compressedFileName` (`string`) — Path and name of the output ZIP file
+- `password` (`string`) — Password to protect the archive
+- `compressionLevel` (`ArchiveCompressionLevel`) — Compression quality level
+- `codePage` (`CodePages`) — Code page for file name encoding
+- `overrideExistingFile` (`bool`) — Whether to overwrite an existing archive
+
+**Returns:** `ILocalResource` — Resource pointing to the created ZIP file.
+
+---
+
+## DataTable Operations
+
+### `void AddDataRow(ref DataTable dataTable, DataRow dataRow)`
+
+Adds a row to a DataTable.
+
+**Parameters:**
+- `dataTable` (`ref DataTable`) — The DataTable to modify
+- `dataRow` (`DataRow`) — The row to add
+
+**Returns:** `void`
+
+---
+
+### `void RemoveDataRow(ref DataTable dataTable, int rowIndex)`
+
+Removes a row at the specified index from a DataTable.
+
+**Parameters:**
+- `dataTable` (`ref DataTable`) — The DataTable to modify
+- `rowIndex` (`int`) — Zero-based index of the row to remove
+
+**Returns:** `void`
+
+---
+
+### `void ClearDataTable(ref DataTable dataTable)`
+
+Removes all rows from a DataTable.
+
+**Parameters:**
+- `dataTable` (`ref DataTable`) — The DataTable to clear
+
+**Returns:** `void`
+
+---
+
+### `void RemoveDataColumn(ref DataTable dataTable, string columnName)`
+
+Removes a column from a DataTable by name.
+
+**Parameters:**
+- `dataTable` (`ref DataTable`) — The DataTable to modify
+- `columnName` (`string`) — Name of the column to remove
+
+**Returns:** `void`
+
+---
+
+### `string OutputDataTable(DataTable dataTable)`
+
+Converts a DataTable to a string representation using CSV format.
+
+**Parameters:**
+- `dataTable` (`DataTable`) — The DataTable to convert
+
+**Returns:** `string` — String representation of the DataTable contents.
+
+---
+
+### `DataTable SortDataTable(DataTable dataTable, string columnName)`
+### `DataTable SortDataTable(DataTable dataTable, string columnName, SortOrder sortOrder)`
+
+Sorts a DataTable by a specified column.
+
+**Parameters:**
+- `dataTable` (`DataTable`) — The DataTable to sort
+- `columnName` (`string`) — Name of the column to sort by
+- `sortOrder` (`SortOrder`) — Ascending or descending (default: ascending when omitted)
+
+**Returns:** `DataTable` — A new sorted DataTable.
+
+---
+
+### `void MergeDataTable(DataTable sourceDataTable, ref DataTable destinationDataTable)`
+### `void MergeDataTable(DataTable sourceDataTable, ref DataTable destinationDataTable, MissingSchemaAction missingSchemaAction)`
+
+Merges a source DataTable into a destination DataTable.
+
+**Parameters:**
+- `sourceDataTable` (`DataTable`) — DataTable to merge from
+- `destinationDataTable` (`ref DataTable`) — DataTable to merge into (modified in place)
+- `missingSchemaAction` (`MissingSchemaAction`) — Specifies how to handle schema differences
+
+**Returns:** `void`
+
+---
+
+### `DataTable RemoveDuplicateRows(DataTable dataTable)`
+
+Removes duplicate rows from a DataTable, keeping only the first occurrence of each.
+
+**Parameters:**
+- `dataTable` (`DataTable`) — The DataTable to deduplicate
+
+**Returns:** `DataTable` — A new DataTable with duplicate rows removed.
+
+---
+
+### `void UpdateRowItem(object value, DataRow row, string columnName)`
+
+Sets the value of a cell in a DataRow by column name.
+
+**Parameters:**
+- `value` (`object`) — The value to set
+- `row` (`DataRow`) — The target DataRow
+- `columnName` (`string`) — Name of the column to update
+
+**Returns:** `void`
+
+---
+
+### `object GetRowItem(DataRow row, string columnName)`
+
+Gets the value of a cell from a DataRow by column name.
+
+**Parameters:**
+- `row` (`DataRow`) — The DataRow to read from
+- `columnName` (`string`) — Name of the column
+
+**Returns:** `object` — The value of the specified cell. Cast to the expected type as needed.
+
+---
+
+### `object LookupDataTable(DataTable dataTable, string lookupValue, string lookupColumnName, string targetColumnName)`
+### `object LookupDataTable(DataTable dataTable, string lookupValue, string lookupColumnName, string targetColumnName, out int rowIndex)`
+
+Searches for a value in a column and returns the corresponding cell value from a target column.
+
+**Parameters:**
+- `dataTable` (`DataTable`) — The DataTable to search
+- `lookupValue` (`string`) — Value to search for
+- `lookupColumnName` (`string`) — Column to search in
+- `targetColumnName` (`string`) — Column from which to return the matched row's value
+- `rowIndex` (`out int`) — Receives the zero-based index of the matching row
+
+**Returns:** `object` — Value from `targetColumnName` in the matched row. Returns `null` if `targetColumnName` is not set.
+
+---
+
+## Text Manipulation
+
+### `string Replace(string input, string pattern, string replacement)`
+### `string Replace(string input, string pattern, string replacement, RegexOptions regexOption)`
+
+Replaces occurrences of a regex pattern in a string.
+
+**Parameters:**
+- `input` (`string`) — The input string
+- `pattern` (`string`) — Regex pattern to find
+- `replacement` (`string`) — Replacement string
+- `regexOption` (`RegexOptions`) — Regex matching options (e.g., `RegexOptions.IgnoreCase`)
+
+**Returns:** `string` — The string with all matches replaced.
+
+---
+
+### `string FindAndReplace(string valueToFind, string source, string replaceWith, bool matchCase)`
+
+Finds and replaces a literal string (not regex) within a source string.
+
+**Parameters:**
+- `valueToFind` (`string`) — The string to find
+- `source` (`string`) — The source text
+- `replaceWith` (`string`) — The replacement text
+- `matchCase` (`bool`) — Whether the search is case-sensitive
+
+**Returns:** `string` — The resulting string after replacement.
+
+---
+
+### `IEnumerable<string> ExtractTextOccurrences(string source, string startingText, string endingText, bool ignoreDuplicates = false, bool matchCase = false)`
+
+Extracts all substrings between a pair of delimiter texts.
+
+**Parameters:**
+- `source` (`string`) — The text to search
+- `startingText` (`string`) — Opening delimiter
+- `endingText` (`string`) — Closing delimiter
+- `ignoreDuplicates` (`bool`) — Whether to omit duplicate matches (default: `false`)
+- `matchCase` (`bool`) — Whether delimiters are matched case-sensitively (default: `false`)
+
+**Returns:** `IEnumerable<string>` — All substrings found between the delimiters.
+
+---
+
+### `IEnumerable<string> ExtractEmails(string source, bool ignoreDuplicates = false)`
+
+Extracts all email addresses from a string.
+
+**Parameters:**
+- `source` (`string`) — The text to search
+- `ignoreDuplicates` (`bool`) — Whether to omit duplicate results (default: `false`)
+
+**Returns:** `IEnumerable<string>` — Collection of email address strings found in the source.
+
+---
+
+### `IEnumerable<string> ExtractUrls(string source, bool extractBaseURLOnly = false, bool ignoreDuplicates = false)`
+
+Extracts all URLs from a string.
+
+**Parameters:**
+- `source` (`string`) — The text to search
+- `extractBaseURLOnly` (`bool`) — Whether to return only the base URL (scheme + host) (default: `false`)
+- `ignoreDuplicates` (`bool`) — Whether to omit duplicate results (default: `false`)
+
+**Returns:** `IEnumerable<string>` — Collection of URL strings found in the source.
+
+---
+
+### `string ExtractTextFromHTML(string source)`
+
+Strips HTML tags and returns plain text content.
+
+**Parameters:**
+- `source` (`string`) — HTML string to process
+
+**Returns:** `string` — Plain text with HTML tags removed.
+
+---
+
+### `string CombineText(IEnumerable<string> source, string separator)`
+### `string CombineText(IEnumerable<string> source, SeparatorOptions separatorKey)`
+
+Joins a collection of strings into a single string.
+
+**Parameters:**
+- `source` (`IEnumerable<string>`) — Strings to join
+- `separator` (`string`) — Separator to place between items
+- `separatorKey` (`SeparatorOptions`) — Predefined separator (e.g., comma, newline)
+
+**Returns:** `string` — Single concatenated string.
+
+---
+
+### `IEnumerable<string> SplitText(string source, string separator)`
+### `IEnumerable<string> SplitText(string source, SeparatorOptions separatorKey)`
+
+Splits a string into a collection of substrings.
+
+**Parameters:**
+- `source` (`string`) — The string to split
+- `separator` (`string`) — Separator string
+- `separatorKey` (`SeparatorOptions`) — Predefined separator
+
+**Returns:** `IEnumerable<string>` — Collection of split substrings.
+
+---
+
+### `string ChangeCase(string source, ChangeCaseOptions changeCaseOptions)`
+
+Converts a string to a different case.
+
+**Parameters:**
+- `source` (`string`) — The input string
+- `changeCaseOptions` (`ChangeCaseOptions`) — Target case (e.g., upper, lower, title)
+
+**Returns:** `string` — The string in the target case.
+
+---
+
+## Date & Time
+
+### `IEnumerable<DateTime> ExtractDateAndTimeFromText(string format, string source, CultureInfo localizationCode)`
+
+Extracts date/time values from a string using a format pattern.
+
+**Parameters:**
+- `format` (`string`) — Date/time format string (e.g., `"MM/dd/yyyy"`)
+- `source` (`string`) — The text to search
+- `localizationCode` (`CultureInfo`) — Culture to use for parsing
+
+**Returns:** `IEnumerable<DateTime>` — All date/time values parsed from the source text.
+
+---
+
+### `string FormatDateAsText(DateTime source, string format, CultureInfo localizationCode)`
+
+Formats a `DateTime` value as a string.
+
+**Parameters:**
+- `source` (`DateTime`) — The date/time to format
+- `format` (`string`) — Format string (e.g., `"yyyy-MM-dd"`)
+- `localizationCode` (`CultureInfo`) — Culture for formatting
+
+**Returns:** `string` — The formatted date/time string.
+
+---
+
+### `DateTime AddOrSubtractFromDate(DateTime source, UnitsOfTime unitOfTime, int amountOfTime, UiPath.Activities.System.Date.AddOrSubtractFromDate.DateOperations selectedOperation)`
+
+Adds or subtracts a time amount from a `DateTime`.
+
+**Parameters:**
+- `source` (`DateTime`) — The starting date/time
+- `unitOfTime` (`UnitsOfTime`) — Time unit (e.g., days, months, years)
+- `amountOfTime` (`int`) — Number of units to add or subtract
+- `selectedOperation` (`DateOperations`) — Whether to add or subtract
+
+**Returns:** `DateTime` — The resulting date/time after the operation.
+
+---
+
+## Queue & Transaction Management
+
+### `void AddQueueItem(string queueType)`
+### `void AddQueueItem(string queueType, string folderPath)`
+### `void AddQueueItem(string queueType, string folderPath, Dictionary<string, object> itemInformationCollection)`
+### `void AddQueueItem(string queueType, string folderPath, DateTime dueDate, Dictionary<string, object> itemInformationCollection, DateTime deferDate, QueueItemPriority priority, string reference, int timeoutMS)`
+
+Adds a new queue item with status `New`.
+
+**Parameters (full overload):**
+- `queueType` (`string`) — Target queue name
+- `folderPath` (`string`) — Orchestrator folder
+- `dueDate` (`DateTime`) — The date before which the queue item should be processed. This is a prioritization criterion alongside Priority and Postpone
+- `itemInformationCollection` (`Dictionary<string, object>`) — Additional data stored on the item
+- `deferDate` (`DateTime`) — Earliest date the item may be processed
+- `priority` (`QueueItemPriority`) — Processing priority
+- `reference` (`string`) — Reference string for filtering
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `QueueItem AddTransactionItem(string queueType)`
+### `QueueItem AddTransactionItem(string queueType, string folderPath)`
+### `QueueItem AddTransactionItem(string queueType, string folderPath, string reference, Dictionary<string, object> transactionInformation, int timeoutMS)`
+
+Adds a new transaction item to an Orchestrator queue.
+
+**Parameters (full overload):**
+- `queueType` (`string`) — Target queue name
+- `folderPath` (`string`) — Orchestrator folder
+- `reference` (`string`) — Reference string
+- `transactionInformation` (`Dictionary<string, object>`) — Data stored on the transaction
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `QueueItem` — The created transaction item entity.
+
+---
+
+### `DataTable BulkAddQueueItems(DataTable queueItemsDataTable, string queueName)`
+### `DataTable BulkAddQueueItems(DataTable queueItemsDataTable, string queueName, string folderPath)`
+### `DataTable BulkAddQueueItems(DataTable queueItemsDataTable, string queueName, string folderPath, UiPath.Core.Activities.BulkAddQueueItems.CommitTypeEnum commitType, int timeoutMS)`
+
+Adds multiple queue items from a DataTable in a single operation.
+
+**Parameters (full overload):**
+- `queueItemsDataTable` (`DataTable`) — DataTable containing queue items to add
+- `queueName` (`string`) — Target queue name
+- `folderPath` (`string`) — Orchestrator folder
+- `commitType` (`CommitTypeEnum`) — Whether to commit all at once or per item
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `DataTable` — DataTable reflecting the result of the bulk operation (e.g., failed items).
+
+---
+
+### `QueueItem GetTransactionItem(string queueType)`
+### `QueueItem GetTransactionItem(string queueType, string folderPath)`
+### `QueueItem GetTransactionItem(string queueType, string folderPath, ReferenceFilterStrategy filterStrategy, string reference, int timeoutMS)`
+
+Gets an item from the queue and sets its status to `In Progress` (starts the transaction).
+
+**Parameters (full overload):**
+- `queueType` (`string`) — Source queue name
+- `folderPath` (`string`) — Orchestrator folder
+- `filterStrategy` (`ReferenceFilterStrategy`) — Strategy for filtering by reference
+- `reference` (`string`) — Reference value to filter by
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `QueueItem` — The retrieved transaction item, now in `In Progress` state. Returns `null` if no item is available.
+
+---
+
+### `QueueItem GetQueueItem(string queueType)`
+### `QueueItem GetQueueItem(string queueType, string folderPath)`
+### `QueueItem GetQueueItem(string queueType, string folderPath, ReferenceFilterStrategy filterStrategy, string reference, int timeoutMS)`
+
+Gets an item from the queue and sets its status to `In Progress`.
+
+**Parameters:** Same pattern as `GetTransactionItem`.
+
+**Returns:** `QueueItem` — The retrieved queue item.
+
+---
+
+### `IEnumerable<QueueItem> GetQueueItems(string queueName)`
+### `IEnumerable<QueueItem> GetQueueItems(string queueName, string folderPath)`
+### `IEnumerable<QueueItem> GetQueueItems(string queueName, string folderPath, int? duration, DateTime? from, int? priority, QueueItemStates queueItemStates, DateTime? to, ReferenceFilterStrategy filterStrategy, string reference, int skip, int top, int timeoutMS)`
+
+Retrieves a filtered collection of queue items without claiming them for processing.
+
+**Parameters (full overload):**
+- `queueName` (`string`) — Queue name
+- `folderPath` (`string`) — Orchestrator folder
+- `duration` (`int?`) — Filter by duration
+- `from` (`DateTime?`) — Start of date range filter
+- `priority` (`int?`) — Priority filter
+- `queueItemStates` (`QueueItemStates`) — Status filter
+- `to` (`DateTime?`) — End of date range filter
+- `filterStrategy` (`ReferenceFilterStrategy`) — Reference filter strategy
+- `reference` (`string`) — Reference value to filter by
+- `skip` (`int`) — Number of items to skip (paging)
+- `top` (`int`) — Maximum items to return
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `IEnumerable<QueueItem>` — Collection of queue items matching the filter.
+
+---
+
+### `QueueItem WaitQueueItem(string queueName)`
+### `QueueItem WaitQueueItem(string queueName, string folderPath)`
+### `QueueItem WaitQueueItem(string queueName, string folderPath, int pollTimeMS, ReferenceFilterStrategy filterStrategy, string reference, int timeoutMS)`
+
+Waits until an item becomes available in the queue, then returns it.
+
+**Parameters (full overload):**
+- `queueName` (`string`) — Queue name
+- `folderPath` (`string`) — Orchestrator folder
+- `pollTimeMS` (`int`) — Interval between polls in milliseconds
+- `filterStrategy` (`ReferenceFilterStrategy`) — Reference filter strategy
+- `reference` (`string`) — Reference value to filter by
+- `timeoutMS` (`int`) — Total timeout in milliseconds
+
+**Returns:** `QueueItem` — The first available queue item.
+
+---
+
+### `void DeleteQueueItems(IEnumerable<QueueItem> queueItems)`
+### `void DeleteQueueItems(IEnumerable<QueueItem> queueItems, string folderPath)`
+### `void DeleteQueueItems(IEnumerable<QueueItem> queueItems, string folderPath, int timeoutMS)`
+
+Deletes queue items from Orchestrator.
+
+**Parameters:**
+- `queueItems` (`IEnumerable<QueueItem>`) — Items to delete
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `void PostponeTransactionItem(QueueItem transactionItem, DateTime deferDate)`
+### `void PostponeTransactionItem(QueueItem transactionItem, DateTime deferDate, string folderPath)`
+### `void PostponeTransactionItem(QueueItem transactionItem, DateTime deferDate, string folderPath, DateTime dueDate, int timeoutMS)`
+
+Postpones a transaction item to a future date.
+
+**Parameters (full overload):**
+- `transactionItem` (`QueueItem`) — The item to postpone
+- `deferDate` (`DateTime`) — Earliest date the item may be processed again
+- `folderPath` (`string`) — Orchestrator folder
+- `dueDate` (`DateTime`) — Latest date the item should be processed
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `void SetTransactionProgress(QueueItem transactionItem, string progress)`
+### `void SetTransactionProgress(QueueItem transactionItem, string progress, string folderPath)`
+### `void SetTransactionProgress(QueueItem transactionItem, string progress, string folderPath, int timeoutMS)`
+
+Updates the progress text of a transaction item currently in progress.
+
+**Parameters:**
+- `transactionItem` (`QueueItem`) — The in-progress transaction item
+- `progress` (`string`) — Progress message to set
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `void SetTransactionStatus(QueueItem transactionItem, ProcessingStatus status)`
+### `void SetTransactionStatus(QueueItem transactionItem, ProcessingStatus status, string folderPath)`
+### `void SetTransactionStatus(QueueItem transactionItem, ProcessingStatus status, string folderPath, Dictionary<string, object> analytics, Dictionary<string, object> output, string details, ErrorType errorType, string reason, int timeoutMS)`
+
+Sets the final status of a transaction item (success, failure, or exception).
+
+**Parameters (full overload):**
+- `transactionItem` (`QueueItem`) — The transaction item to update
+- `status` (`ProcessingStatus`) — New status (e.g., Successful, Failed)
+- `folderPath` (`string`) — Orchestrator folder
+- `analytics` (`Dictionary<string, object>`) — Analytics data to attach
+- `output` (`Dictionary<string, object>`) — Output data to attach
+- `details` (`string`) — Status detail message
+- `errorType` (`ErrorType`) — Type of error (for failure statuses)
+- `reason` (`string`) — Failure reason
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+## Orchestrator Assets & Credentials
+
+### `object GetAsset(string assetName)`
+### `object GetAsset(string assetName, string folderPath)`
+### `object GetAsset(string assetName, string folderPath, CacheStrategyEnum cacheStrategy, int timeoutMS)`
+
+Retrieves an Orchestrator asset value.
+
+**Parameters (full overload):**
+- `assetName` (`string`) — Name of the asset
+- `folderPath` (`string`) — Orchestrator folder
+- `cacheStrategy` (`CacheStrategyEnum`) — Caching behavior
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `object` — The asset value. Cast to the expected type (e.g., `string`, `int`, `bool`).
+
+---
+
+### `void SetAsset(object value, string assetName)`
+### `void SetAsset(object value, string assetName, string folderPath)`
+### `void SetAsset(object value, string assetName, string folderPath, int timeoutMS)`
+
+Sets the value of an Orchestrator asset.
+
+**Parameters:**
+- `value` (`object`) — New value for the asset
+- `assetName` (`string`) — Name of the asset
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `(string userName, SecureString password) GetCredential(string assetName, string folderPath = null, int timeoutMS = 1000, CacheStrategyEnum cacheStrategy = CacheStrategyEnum.None)`
+
+Retrieves a credential asset as a username/password tuple.
+
+**Parameters:**
+- `assetName` (`string`) — Name of the credential asset
+- `folderPath` (`string`) — Orchestrator folder (default: `null`)
+- `timeoutMS` (`int`) — Timeout in milliseconds (default: `1000`)
+- `cacheStrategy` (`CacheStrategyEnum`) — Caching behavior (default: `CacheStrategyEnum.None`)
+
+**Returns:** `(string userName, SecureString password)` — Tuple containing the username string and the password as a `SecureString`.
+
+---
+
+### `string GetCredential(string assetName, string folderPath, out SecureString password, CacheStrategyEnum cacheStrategy, int timeoutMS)`
+
+Retrieves a credential asset, returning the username and providing the password via an `out` parameter.
+
+**Parameters:**
+- `assetName` (`string`) — Name of the credential asset
+- `folderPath` (`string`) — Orchestrator folder
+- `password` (`out SecureString`) — Receives the credential password
+- `cacheStrategy` (`CacheStrategyEnum`) — Caching behavior
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `string` — The username from the credential asset.
+
+---
+
+### `void SetCredential(string userName, string password, string credentialName)`
+### `void SetCredential(string userName, string password, string credentialName, string folderPath)`
+### `void SetCredential(string userName, string password, string credentialName, string folderPath, int timeoutMS)`
+
+Updates an Orchestrator credential asset with a new username and password.
+
+**Parameters:**
+- `userName` (`string`) — New username
+- `password` (`string`) — New password (plain text; stored securely by Orchestrator)
+- `credentialName` (`string`) — Name of the credential asset
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+## Storage Buckets
+
+### `void DeleteStorageFile(string path, string storageBucketName)`
+### `void DeleteStorageFile(string path, string storageBucketName, string folderPath)`
+### `void DeleteStorageFile(string path, string storageBucketName, string folderPath, int timeoutMS)`
+
+Deletes a file from an Orchestrator storage bucket.
+
+**Parameters:**
+- `path` (`string`) — Path of the file within the bucket
+- `storageBucketName` (`string`) — Name of the storage bucket
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `ILocalResource DownloadStorageFile(string path, string storageBucketName)`
+### `ILocalResource DownloadStorageFile(string path, string storageBucketName, string folderPath)`
+### `ILocalResource DownloadStorageFile(string path, string storageBucketName, string folderPath, string destination, int timeoutMS)`
+
+Downloads a file from an Orchestrator storage bucket to the local machine.
+
+**Parameters (full overload):**
+- `path` (`string`) — Path of the file within the bucket
+- `storageBucketName` (`string`) — Name of the storage bucket
+- `folderPath` (`string`) — Orchestrator folder
+- `destination` (`string`) — Local destination path
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `ILocalResource` — Resource pointing to the downloaded local file.
+
+---
+
+### `IEnumerable<StorageFileInfo> ListStorageFiles(string directory, string storageBucketName)`
+### `IEnumerable<StorageFileInfo> ListStorageFiles(string directory, string storageBucketName, string folderPath)`
+### `IEnumerable<StorageFileInfo> ListStorageFiles(string directory, string storageBucketName, string folderPath, bool recursive, string filter, int timeoutMS)`
+
+Lists files in a directory within an Orchestrator storage bucket.
+
+**Parameters (full overload):**
+- `directory` (`string`) — Directory path within the bucket (empty string for root)
+- `storageBucketName` (`string`) — Name of the storage bucket
+- `folderPath` (`string`) — Orchestrator folder
+- `recursive` (`bool`) — Whether to list files in subdirectories
+- `filter` (`string`) — File name filter pattern
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `IEnumerable<StorageFileInfo>` — Collection of file info objects with name, path, and size details.
+
+---
+
+### `void UploadStorageFile(string destination, IResource fileResource, string storageBucketName)`
+### `void UploadStorageFile(string destination, IResource fileResource, string storageBucketName, string folderPath)`
+### `void UploadStorageFile(string destination, IResource fileResource, string storageBucketName, string folderPath, int timeoutMS)`
+
+Uploads a local file to an Orchestrator storage bucket.
+
+**Parameters:**
+- `destination` (`string`) — Target path within the bucket
+- `fileResource` (`IResource`) — Local file resource to upload
+- `storageBucketName` (`string`) — Name of the storage bucket
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+### `string ReadStorageText(string path, string storageBucketName)`
+### `string ReadStorageText(string path, string storageBucketName, string folderPath)`
+### `string ReadStorageText(string path, string storageBucketName, string folderPath, string encoding, int timeoutMS)`
+
+Reads the text content of a file directly from an Orchestrator storage bucket.
+
+**Parameters (full overload):**
+- `path` (`string`) — File path within the bucket
+- `storageBucketName` (`string`) — Name of the storage bucket
+- `folderPath` (`string`) — Orchestrator folder
+- `encoding` (`string`) — Text encoding (e.g., `"UTF-8"`)
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `string` — Text content of the storage file.
+
+---
+
+### `void WriteStorageText(string path, string text, string storageBucketName)`
+### `void WriteStorageText(string path, string text, string storageBucketName, string folderPath)`
+### `void WriteStorageText(string path, string text, string storageBucketName, string folderPath, string encoding, int timeoutMS)`
+
+Writes text content directly to a file in an Orchestrator storage bucket.
+
+**Parameters (full overload):**
+- `path` (`string`) — Target file path within the bucket
+- `text` (`string`) — Text content to write
+- `storageBucketName` (`string`) — Name of the storage bucket
+- `folderPath` (`string`) — Orchestrator folder
+- `encoding` (`string`) — Text encoding (e.g., `"UTF-8"`)
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+## Orchestrator HTTP & Alerts
+
+### `int OrchestratorHTTPRequest(OrchestratorAPIHttpMethods method, string relativeEndpoint)`
+### `int OrchestratorHTTPRequest(OrchestratorAPIHttpMethods method, string relativeEndpoint, out Dictionary<string, string> responseHeaders, out string result)`
+### `int OrchestratorHTTPRequest(OrchestratorAPIHttpMethods method, string relativeEndpoint, string jSONPayload, string folderPath)`
+### `int OrchestratorHTTPRequest(OrchestratorAPIHttpMethods method, string relativeEndpoint, string jSONPayload, out Dictionary<string, string> responseHeaders, out string result, string folderPath)`
+### `int OrchestratorHTTPRequest(OrchestratorAPIHttpMethods method, string relativeEndpoint, string jSONPayload, string folderPath, out Dictionary<string, string> responseHeaders, out string result, int timeoutMS)`
+
+Makes an HTTP request to the Orchestrator API.
+
+**Parameters (full overload):**
+- `method` (`OrchestratorAPIHttpMethods`) — HTTP method: GET, POST, PUT, PATCH, or DELETE
+- `relativeEndpoint` (`string`) — API endpoint path relative to the Orchestrator base URL (e.g., `"/odata/Jobs"`)
+- `jSONPayload` (`string`) — Request body as a JSON string
+- `folderPath` (`string`) — Orchestrator folder for the X-UIPATH-OrganizationUnitId header
+- `responseHeaders` (`out Dictionary<string, string>`) — Receives the HTTP response headers
+- `result` (`out string`) — Receives the HTTP response body as a string
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `int` — HTTP status code (e.g., `200`, `201`, `404`).
+
+---
+
+### `void RaiseAlert(AlertSeverity severity, string notification)`
+### `void RaiseAlert(AlertSeverity severity, string notification, string folderPath)`
+### `void RaiseAlert(AlertSeverity severity, string notification, string folderPath, int timeoutMS)`
+
+Raises an alert in Orchestrator.
+
+**Parameters:**
+- `severity` (`AlertSeverity`) — Alert severity level
+- `notification` (`string`) — Alert message text
+- `folderPath` (`string`) — Orchestrator folder
+- `timeoutMS` (`int`) — Timeout in milliseconds
+
+**Returns:** `void`
+
+---
+
+## Options & Configuration Classes
+
+### `RunJobOptionalParameters`
+
+Additional optional parameters for `RunJob` and `RunJobAsync`. Namespace: `UiPath.Activities.System.Jobs.Coded` (auto-imported).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `TimeoutMS` | `int` | `600000` | Maximum time to wait for job completion in milliseconds (10 minutes) |
+| `ContinueOnError` | `bool` | `false` | Whether to continue workflow execution if the job fails |
+| `FailWhenJobFails` | `bool` | `false` | Whether to mark this workflow as failed if the job fails |
+
+---
+
+## Enum Reference
+
+**`OrchestratorAPIHttpMethods`**: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`
+
+**`InvokeProcessTargetSession`**: `Current`, `ProcessDefault`, `Main`, `Child`
+
+**`LogEntryType`**: `No`, `OnlyInvocation`, `WithArguments`
+
+**`LogExitType`**: `No`, `OnlySuccessfulReturn`, `WithArguments`
+
+**`AlertSeverity`**: `Info`, `Success`, `Warning`, `Error`, `Fatal`
+
+**`StopStrategy`**: `Stop`, `Kill`
+
+**`QueueItemStates`** (flags): `All`, `New`, `InProgress`, `Failed`, `Successful`, `Abandoned`, `Retried`, `Deleted`
+
+**`ReferenceFilterStrategy`**: `StartsWith`, `Equals`
+
+**`QueueItemPriority`**: `High`, `Normal`, `Low`
+
+**`ProcessingStatus`**: `Successful`, `Failed`
+
+**`ErrorType`**: `Business`, `Application`
+
+**`FileConflictBehavior`**: `Replace`, `Fail`, `Rename`
+
+**`ArchiveCompressionLevel`**: `None`, `Fast`, `Normal`, `Maximum`
+
+**`CodePages`**: Encoding identifiers (94 values). Common: `Default`, `UTF_8`, `UTF_16`, `WINDOWS_1252`, `ISO_8859_1`
+
+---
+
+## Common Patterns
+
+### Run an Orchestrator Job and Process Output
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var opts = new RunJobOptionalParameters
+    {
+        TimeoutMS = 120000,
+        FailWhenJobFails = true
+    };
+
+    var (jobData, outputJson) = system.RunJob(
+        processName: "DataProcessingProcess",
+        orchestratorFolderPath: "Finance/Automation",
+        inputArguments: new { Month = "March", Year = 2026 },
+        runJobOptionalParameters: opts
+    );
+
+    Log($"Job {jobData.Id} completed. Output: {outputJson}");
+}
+```
+
+---
+
+### Queue-Based Transaction Processing
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Get the next transaction item
+    var item = system.GetTransactionItem("InvoiceQueue", "Finance");
+    if (item == null) return;
+
+    try
+    {
+        // Process the transaction
+        var invoiceId = item.SpecificContent["InvoiceId"]?.ToString();
+        system.SetTransactionProgress(item, $"Processing invoice {invoiceId}");
+
+        // ... processing logic ...
+
+        system.SetTransactionStatus(item, ProcessingStatus.Successful);
+    }
+    catch (Exception ex)
+    {
+        system.SetTransactionStatus(
+            item,
+            ProcessingStatus.Failed,
+            folderPath: "Finance",
+            analytics: null,
+            output: null,
+            details: ex.Message,
+            errorType: ErrorType.Application,
+            reason: "Invoice processing error"
+        );
+    }
+}
+```
+
+---
+
+### File Operations: Read, Process, and Write
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Check if the source file exists
+    if (!system.FileExists(@"C:\Data\input.txt"))
+    {
+        Log("Input file not found");
+        return;
+    }
+
+    var resource = system.GetResourceForLocalPath(@"C:\Data\input.txt", PathType.File);
+    string content = system.ReadTextFile(resource);
+
+    // Process: extract emails and replace sensitive data
+    var emails = system.ExtractEmails(content, ignoreDuplicates: true);
+    string sanitized = system.Replace(content, @"\d{4}-\d{4}-\d{4}-\d{4}", "****-****-****-****");
+
+    // Write to output
+    var outputFile = system.CreateFile("output.txt", @"C:\Data");
+    system.WriteTextFile(sanitized, outputFile);
+
+    Log($"Found {emails.Count()} email addresses. Output written.");
+}
+```
+
+---
+
+### Storage Bucket Workflow
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    const string bucket = "ReportsBucket";
+    const string folder = "Finance";
+
+    // List available reports
+    var files = system.ListStorageFiles("reports/2026", bucket, folder, recursive: false, filter: "*.csv", timeoutMS: 30000);
+
+    foreach (var file in files)
+    {
+        // Download each report
+        var localFile = system.DownloadStorageFile(file.FileFullPath, bucket, folder);
+        Log($"Downloaded: {localFile.LocalPath}");
+
+        // Process the file content
+        string csvContent = system.ReadTextFile(localFile);
+        // ... processing ...
+
+        // Upload processed version
+        system.UploadStorageFile($"processed/{Path.GetFileName(file.FileFullPath)}", localFile, bucket, folder);
+    }
+}
+```
+
+---
+
+### Asset and Credential Retrieval
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Get a plain asset
+    string apiUrl = (string)system.GetAsset("ExternalAPIUrl", "SharedAssets");
+
+    // Get credentials
+    var (userName, password) = system.GetCredential("ExternalAPICredential", "SharedAssets");
+
+    // Use credentials to authenticate (SecureString → plain text conversion where required)
+    Log($"Connecting to {apiUrl} as {userName}");
+    // ... use credentials ...
+
+    // Update an asset after processing
+    system.SetAsset("2026-03-23", "LastRunDate", "SharedAssets");
+}
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/26.4/overview.md
@@ -1,0 +1,238 @@
+# UiPath System Activities
+
+`UiPath.System.Activities`
+
+Core general-purpose activities for every UiPath workflow. Covers file and folder operations, DataTable manipulation, text and date processing, collections, dialog boxes, credential management, environment interaction, workflow control, Orchestrator integration (queues, assets, jobs, storage), triggers, and scripting.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+
+## Activities
+
+### Workflow
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [While](activities/While.md) | `While.md` | Repeatedly executes contained activities while a condition is `True`. |
+| [Do While](activities/DoWhile.md) | `DoWhile.md` | Executes contained activities once, then repeats while a condition is `True`. |
+| [For Each](activities/ForEach.md) | `ForEach.md` | Iterates over each element in a collection. |
+| [Repeat Number of Times](activities/RepeatNumberOfTimesX.md) | `RepeatNumberOfTimesX.md` | Repeats contained activities a fixed number of times. |
+| [Else If](activities/ElseIf.md) | `ElseIf.md` | Multi-branch conditional — executes the first branch whose condition is `True`. |
+| [Retry Scope](activities/RetryScope.md) | `RetryScope.md` | Retries contained activities while a condition is not met or an error is thrown. |
+| [Invoke Workflow File](activities/InvokeWorkflow.md) | `InvokeWorkflow.md` | Invokes another XAML workflow file with optional arguments. |
+| [Invoke Process](activities/InvokeProcess.md) | `InvokeProcess.md` | Launches an external application or executable. |
+| [Run Parallel Process](activities/BeginProcess.md) | `BeginProcess.md` | Starts an Orchestrator process in the background without waiting for it to complete. |
+| [Evaluate Business Rule](activities/EvaluateBusinessRule.md) | `EvaluateBusinessRule.md` | Evaluates a DMN business rule file against input data. |
+| [Get Current Job Info](activities/GetCurrentJobInfo.md) | `GetCurrentJobInfo.md` | Returns information about the currently running Orchestrator job. |
+| [Comment](activities/Comment.md) | `Comment.md` | Design-time annotation; has no effect at runtime. |
+
+### Workflow Control
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Disabled Activities](activities/CommentOut.md) | `CommentOut.md` | Container whose contents are never executed at runtime. |
+| [Break](activities/Break.md) | `Break.md` | Exits the enclosing loop or Trigger Scope. |
+| [Continue](activities/Continue.md) | `Continue.md` | Skips the rest of the current loop iteration and starts the next. |
+| [Return](activities/Return.md) | `Return.md` | Immediately exits the current workflow. |
+| [Workflow Placeholder](activities/Placeholder.md) | `Placeholder.md` | Design-time placeholder for an activity to be added later. |
+
+### Workflow Checkpoint
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Check True](activities/CheckTrue.md) | `CheckTrue.md` | Asserts that a Boolean expression evaluates to `True`; throws on failure. |
+| [Check False](activities/CheckFalse.md) | `CheckFalse.md` | Asserts that a Boolean expression evaluates to `False`; throws on failure. |
+
+---
+
+### Collections
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Append Items to Collection](activities/AppendItemToCollection.md) | `AppendItemToCollection.md` | Appends one or more items to the end of a collection. |
+| [Build Collection](activities/BuildCollection.md) | `BuildCollection.md` | Creates a new collection from a set of provided items. |
+| [Collection to DataTable](activities/CollectionToDataTable.md) | `CollectionToDataTable.md` | Converts a collection to a DataTable. |
+| [Exists In Collection](activities/ExistsInCollection.md) | `ExistsInCollection.md` | Checks whether an item exists in a collection; returns its index. |
+| [Filter Collection](activities/FilterCollection.md) | `FilterCollection.md` | Filters a collection by a predicate, keeping or removing matching items. |
+| [Merge Collections](activities/MergeCollections.md) | `MergeCollections.md` | Combines two collections into one. |
+| [Remove From Collection](activities/RemoveFromCollection.md) | `RemoveFromCollection.md` | Removes an item, the item at an index, or all matching items from a collection. |
+| [Read List Item](activities/ReadListItem.md) | `ReadListItem.md` | Reads the item at a specified index from a list. |
+| [Update List Item](activities/UpdateListItem.md) | `UpdateListItem.md` | Updates the item at a specified index in a list. |
+
+---
+
+### DataTable
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [For Each Row in Data Table](activities/ForEachRow.md) | `ForEachRow.md` | Iterates over each row in a DataTable. |
+| [Add Data Row](activities/AddDataRow.md) | `AddDataRow.md` | Adds a row to a DataTable from an array or a DataRow object. |
+| [Remove Data Row](activities/RemoveDataRow.md) | `RemoveDataRow.md` | Removes a row from a DataTable by row object or index. |
+| [Add Data Column](activities/AddDataColumn.md) | `AddDataColumn.md` | Adds a column to a DataTable with a specified name and data type. |
+| [Remove Data Column](activities/RemoveDataColumn.md) | `RemoveDataColumn.md` | Removes a column from a DataTable by name or index. |
+| [Clear Data Table](activities/ClearDataTable.md) | `ClearDataTable.md` | Removes all rows from a DataTable. |
+| [Remove Duplicate Rows](activities/RemoveDuplicateRows.md) | `RemoveDuplicateRows.md` | Removes duplicate rows from a DataTable in-place. |
+| [Sort Data Table](activities/SortDataTable.md) | `SortDataTable.md` | Sorts a DataTable by a specified column in ascending or descending order. |
+| [Merge Data Table](activities/MergeDataTable.md) | `MergeDataTable.md` | Merges a source DataTable into a target DataTable. |
+| [Filter Data Table](activities/FilterDataTable.md) | `FilterDataTable.md` | Filters a DataTable rows by one or more conditions. |
+| [Join Data Tables](activities/JoinDataTables.md) | `JoinDataTables.md` | Joins two DataTables using Inner, Left, or Full join logic. |
+| [Lookup Data Table](activities/LookupDataTable.md) | `LookupDataTable.md` | Looks up a value in a DataTable and returns the cell value and row index. |
+| [Generate Data Table From Text](activities/GenerateDataTable.md) | `GenerateDataTable.md` | Parses delimited or fixed-width text into a DataTable. |
+| [Output Data Table as Text](activities/OutputDataTable.md) | `OutputDataTable.md` | Converts a DataTable to a formatted text string. |
+| [Get Row Item](activities/GetRowItem.md) | `GetRowItem.md` | Reads the value of a cell in a DataRow by column name or index. |
+| [Update Row Item](activities/UpdateRowItem.md) | `UpdateRowItem.md` | Sets the value of a cell in a DataRow by column name or index. |
+
+---
+
+### Text & Formatting
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Combine Text](activities/CombineText.md) | `CombineText.md` | Joins multiple text values with an optional separator. |
+| [Split Text](activities/SplitText.md) | `SplitText.md` | Splits a string by a delimiter into a collection of substrings. |
+| [Find and Replace](activities/FindAndReplace.md) | `FindAndReplace.md` | Finds and replaces all occurrences of a substring. |
+| [Change Case](activities/ChangeCase.md) | `ChangeCase.md` | Changes the case of a string (upper, lower, title, sentence). |
+| [Text to Left/Right](activities/TextToLeftRight.md) | `TextToLeftRight.md` | Extracts the text to the left or right of a delimiter. |
+| [Extract Text](activities/ExtractText.md) | `ExtractText.md` | Extracts text between anchors, from URLs, emails, or HTML. |
+| [Is Text Matching](activities/IsMatch.md) | `IsMatch.md` | Tests whether a string matches a regular expression pattern. |
+| [Find Matching Patterns](activities/Matches.md) | `Matches.md` | Finds all regex matches within a string. |
+| [Replace Matching Patterns](activities/Replace.md) | `Replace.md` | Replaces all regex matches in a string with a replacement. |
+| [Format Date as Text](activities/FormatDateAsText.md) | `FormatDateAsText.md` | Formats a `DateTime` value as a string using a format pattern. |
+| [Add or Subtract from Date](activities/AddOrSubtractFromDate.md) | `AddOrSubtractFromDate.md` | Adds or subtracts a duration from a date/time value. |
+| [Extract Date and Time from Text](activities/ExtractDateTime.md) | `ExtractDateTime.md` | Parses a `DateTime` from a string using a format or culture. |
+
+---
+
+### File System
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Copy File](activities/CopyFile.md) | `CopyFile.md` | Copies a file to a new location. |
+| [Move File](activities/MoveFile.md) | `MoveFile.md` | Moves a file to a new location. |
+| [Rename File](activities/RenameFileX.md) | `RenameFileX.md` | Renames a file. |
+| [Delete File or Folder](activities/Delete.md) | `Delete.md` | Deletes a file or folder at the specified path. |
+| [Create File](activities/CreateFile.md) | `CreateFile.md` | Creates a new file, optionally with initial content. |
+| [Copy Folder](activities/CopyFolderX.md) | `CopyFolderX.md` | Copies a folder and all its contents to a new location. |
+| [Create Folder](activities/CreateDirectory.md) | `CreateDirectory.md` | Creates a new directory at the specified path. |
+| [Get Local File or Folder](activities/PathExists.md) | `PathExists.md` | Opens a browse dialog to select a file or folder path. |
+| [Read Text File](activities/ReadTextFile.md) | `ReadTextFile.md` | Reads the entire content of a text file into a string. |
+| [Write Text File](activities/WriteTextFile.md) | `WriteTextFile.md` | Writes text to a file, overwriting or creating it. |
+| [Append Line](activities/AppendLine.md) | `AppendLine.md` | Appends a line of text to a file. |
+| [Compress/Zip Files](activities/CompressFiles.md) | `CompressFiles.md` | Compresses files or folders into a ZIP or GZip archive. |
+| [Extract/Unzip Files](activities/ExtractFiles.md) | `ExtractFiles.md` | Extracts files from a ZIP or GZip archive. |
+| [Download File from URL](activities/DownloadFileFromUrl.md) | `DownloadFileFromUrl.md` | Downloads a file from a URL to a local path. |
+| [Wait for Download](activities/GetLastDownloadedFile.md) | `GetLastDownloadedFile.md` | Waits for a file download to complete and returns the file path. **Windows only.** |
+
+---
+
+### System
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Message Box](activities/MessageBox.md) | `MessageBox.md` | Displays a dialog box with a message and configurable buttons. **Windows only.** |
+| [Get Username/Password](activities/GetUsernamePasswordX.md) | `GetUsernamePasswordX.md` | Displays a credential dialog and returns the entered username and password. **Windows only.** |
+| [Get Environment Variable](activities/GetEnvironmentVariable.md) | `GetEnvironmentVariable.md` | Reads the value of an environment variable. |
+| [Set Environment Variable](activities/SetEnvironmentVariable.md) | `SetEnvironmentVariable.md` | Sets the value of an environment variable. |
+| [Get Environment Folder](activities/GetEnvironmentFolder.md) | `GetEnvironmentFolder.md` | Returns the path of a special system folder (Desktop, Temp, etc.). |
+| [Beep](activities/Beep.md) | `Beep.md` | Plays the system beep sound. |
+| [Get Processes](activities/GetProcesses.md) | `GetProcesses.md` | Returns the list of currently running processes. |
+| [Kill Process](activities/KillProcess.md) | `KillProcess.md` | Terminates a running process by name or process object. |
+| [Invoke VBScript](activities/InvokeVBScript.md) | `InvokeVBScript.md` | Executes a VBScript file or inline script. **Windows only.** |
+| [Invoke Com Method](activities/InvokeComMethod.md) | `InvokeComMethod.md` | Invokes a method on a COM object. **Windows only.** |
+| [Invoke Code](activities/InvokeCode.md) | `InvokeCode.md` | Executes inline C# or VB.NET code within the workflow. |
+| [Change Type](activities/ChangeType.md) | `ChangeType.md` | Converts a value to a specified type `T`. |
+
+### Timers
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Timeout Scope](activities/TimeoutScope.md) | `TimeoutScope.md` | Executes contained activities within a time limit; throws on timeout. |
+| [Start Timer](activities/StartTimer.md) | `StartTimer.md` | Starts a new timer and returns a timer handle. |
+| [Stop Timer](activities/StopTimer.md) | `StopTimer.md` | Stops a running timer. |
+| [Resume Timer](activities/ResumeTimer.md) | `ResumeTimer.md` | Resumes a previously stopped timer. |
+| [Reset Timer](activities/ResetTimer.md) | `ResetTimer.md` | Resets a timer back to zero. |
+
+### Logging
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Log Message](activities/LogMessage.md) | `LogMessage.md` | Logs a message at a specified log level. |
+| [Add Log Fields](activities/AddLogFields.md) | `AddLogFields.md` | Adds structured fields to all subsequent log entries. |
+| [Remove Log Fields](activities/RemoveLogFields.md) | `RemoveLogFields.md` | Removes previously added structured log fields. |
+| [Report Status](activities/ReportStatus.md) | `ReportStatus.md` | Sends a status message to Orchestrator for the current job. |
+
+---
+
+### Orchestrator — Queues
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Add Queue Item](activities/AddQueueItem.md) | `AddQueueItem.md` | Adds a new item to an Orchestrator queue. |
+| [Add Transaction Item](activities/AddTransactionItem.md) | `AddTransactionItem.md` | Adds an item to a queue and immediately sets it to In Progress. |
+| [Bulk Add Queue Items](activities/BulkAddQueueItems.md) | `BulkAddQueueItems.md` | Adds multiple queue items from a DataTable in a single call. |
+| [Get Transaction Item](activities/GetQueueItem.md) | `GetQueueItem.md` | Retrieves the next available item from a queue for processing. |
+| [Get Queue Items](activities/GetQueueItems.md) | `GetQueueItems.md` | Retrieves a filtered list of queue items. |
+| [Delete Queue Items](activities/DeleteQueueItems.md) | `DeleteQueueItems.md` | Deletes queue items matching specified criteria. |
+| [Postpone Transaction Item](activities/PostponeTransactionItem.md) | `PostponeTransactionItem.md` | Postpones a transaction item to a future date. |
+| [Set Transaction Progress](activities/SetTransactionProgress.md) | `SetTransactionProgress.md` | Updates the progress notes on a transaction item. |
+| [Set Transaction Status](activities/SetTransactionStatus.md) | `SetTransactionStatus.md` | Marks a transaction item as Successful, Failed, or a Business Exception. |
+| [Wait Queue Item](activities/WaitQueueItem.md) | `WaitQueueItem.md` | Waits for a specific queue item (by reference) to become available. |
+| [New Item Added to Queue](activities/QueueTrigger.md) | `QueueTrigger.md` | Trigger scope that fires when a new item is added to a queue. |
+
+### Orchestrator — Assets & Credentials
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Get Asset](activities/GetRobotAsset.md) | `GetRobotAsset.md` | Retrieves an asset value from Orchestrator. |
+| [Set Asset](activities/SetAsset.md) | `SetAsset.md` | Updates an asset value in Orchestrator. |
+| [Get Credential](activities/GetRobotCredential.md) | `GetRobotCredential.md` | Retrieves a credential asset (username + password) from Orchestrator. |
+| [Set Credential](activities/SetCredential.md) | `SetCredential.md` | Updates a credential asset in Orchestrator. |
+| [Get Secret](activities/GetSecret.md) | `GetSecret.md` | Retrieves a secret value from Orchestrator. |
+| [Set Secret](activities/SetSecret.md) | `SetSecret.md` | Updates a secret value in Orchestrator. |
+
+### Orchestrator — Storage
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Upload Storage File](activities/UploadStorageFile.md) | `UploadStorageFile.md` | Uploads a local file to an Orchestrator storage bucket. |
+| [Download Storage File](activities/DownloadStorageFile.md) | `DownloadStorageFile.md` | Downloads a file from an Orchestrator storage bucket. |
+| [List Storage Files](activities/ListStorageFiles.md) | `ListStorageFiles.md` | Lists files in an Orchestrator storage bucket. |
+| [Delete Storage File](activities/DeleteStorageFile.md) | `DeleteStorageFile.md` | Deletes a file from an Orchestrator storage bucket. |
+| [Read Storage Text](activities/ReadStorageText.md) | `ReadStorageText.md` | Reads text content from an Orchestrator storage bucket. |
+| [Write Storage Text](activities/WriteStorageText.md) | `WriteStorageText.md` | Writes text content to an Orchestrator storage bucket. |
+
+### Orchestrator — Jobs
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Start Job](activities/StartJob.md) | `StartJob.md` | Starts an Orchestrator job (process execution) and returns job IDs. |
+| [Stop Job](activities/StopJob.md) | `StopJob.md` | Stops one or more running Orchestrator jobs. |
+| [Get Jobs](activities/GetJobs.md) | `GetJobs.md` | Retrieves a filtered list of Orchestrator jobs. |
+| [Run Job](activities/RunJob.md) | `RunJob.md` | Starts a job and suspends the workflow until it completes (requires persistence). |
+| [Should Stop](activities/ShouldStop.md) | `ShouldStop.md` | Checks whether a Stop command has been issued for the current job. |
+
+### Orchestrator — Alerts & API
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Raise Alert](activities/RaiseAlert.md) | `RaiseAlert.md` | Creates an alert in Orchestrator. |
+| [Send Email Notification](activities/SendEmailNotification.md) | `SendEmailNotification.md` | Sends an email via the Orchestrator Notification Service. |
+| [Orchestrator HTTP Request](activities/OrchestratorHttpRequest.md) | `OrchestratorHttpRequest.md` | Makes an authenticated HTTP request to the Orchestrator REST API. |
+
+### Orchestrator — Process Tracking
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Process Tracking Scope](activities/ProcessTrackingScope.md) | `ProcessTrackingScope.md` | Container scope for process/task tracking. |
+| [Track Object](activities/TrackObject.md) | `TrackObject.md` | Records a business object interaction in process tracking. |
+| [Set Task Status](activities/SetTaskStatus.md) | `SetTaskStatus.md` | Updates the status of a tracked task. |
+| [Set Trace Status](activities/SetTraceStatus.md) | `SetTraceStatus.md` | Updates the status of a process trace. |
+
+### Triggers
+
+| Activity | File | Description |
+|----------|------|-------------|
+| [Manual Trigger](activities/RuntimeContext.md) | `RuntimeContext.md` | Trigger scope that fires on manual job start. |
+| [Time Trigger](activities/TimeTrigger.md) | `TimeTrigger.md` | Trigger scope that fires on a cron schedule or simplified time interval. |
+| [New Item Added to Queue](activities/QueueTrigger.md) | `QueueTrigger.md` | Trigger scope that fires when a new item is added to a queue. |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/FindText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/FindText.md
@@ -1,0 +1,55 @@
+# Find Text
+
+`UiPath.Terminal.Advanced.Activities.TerminalFindTextInScreen`
+
+Searches the terminal screen for a text string, starting from an optional position, and returns the row and column coordinates where the text was found.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes | | The text string to search for. |
+| `StartRow` | StartRow | `InArgument` | `int` | | | Row to start searching from (1-based). Defaults to the beginning of the screen if not set. |
+| `StartColumn` | StartColumn | `InArgument` | `int` | | | Column to start searching from (1-based). Defaults to the beginning of the screen if not set. |
+| `IgnoreCase` | Ignore Case | `Property` | `bool` | | `false` | When `true`, the search is case-insensitive. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Row` | Row | `OutArgument` | `int` | The row where the text was found (1-based). |
+| `Column` | Column | `OutArgument` | `int` | The column where the text was found (1-based). |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before searching. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+- If the text is not found, the activity throws an `InvalidCoordinates` exception.
+- Use the output `Row` and `Column` values as inputs to other position-based activities.
+- To find text and move the cursor there in one step, use **Move Cursor to Text** instead.
+
+## XAML Example
+
+```xml
+<ta:TerminalFindTextInScreen DisplayName="Find Text"
+                              Text="[&quot;ERROR&quot;]"
+                              IgnoreCase="True"
+                              Row="[foundRow]"
+                              Column="[foundCol]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetColorAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetColorAtPosition.md
@@ -1,0 +1,49 @@
+# Get Color at Position
+
+`UiPath.Terminal.Advanced.Activities.TerminalGetColorAtPosition`
+
+Returns the foreground color of the character at the specified row and column on the terminal screen. Useful for detecting highlighted fields, error indicators, or status colors.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Position
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Row` | Row | `InArgument` | `int` | Yes | | The row of the character (1-based). |
+| `Column` | Column | `InArgument` | `int` | Yes | | The column of the character (1-based). |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `TerminalColor` | Color | `OutArgument` | `System.Drawing.Color` | The foreground color of the character at the specified position. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before reading. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+Color availability depends on the terminal provider and emulation type. Not all providers support color information (see BlueZone's `colorsAvailable` flag).
+
+## XAML Example
+
+```xml
+<ta:TerminalGetColorAtPosition DisplayName="Get Color at Position"
+                                Row="[3]"
+                                Column="[5]"
+                                TerminalColor="[charColor]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetCursorPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetCursorPosition.md
@@ -1,0 +1,38 @@
+# Get Cursor Position
+
+`UiPath.Terminal.Activities.TerminalGetCursorPosition`
+
+Returns the current row and column position of the terminal cursor.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Row` | Row | `OutArgument` | `int` | The current row of the cursor (1-based). |
+| `Column` | Column | `OutArgument` | `int` | The current column of the cursor (1-based). |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## XAML Example
+
+```xml
+<t:TerminalGetCursorPosition DisplayName="Get Cursor Position"
+                              Row="[cursorRow]"
+                              Column="[cursorCol]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetField.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetField.md
@@ -1,0 +1,65 @@
+# Get Field
+
+`UiPath.Terminal.Activities.TerminalGetField`
+
+Reads the text content of a specific input field on the terminal screen. The field is identified by a label that precedes it (`LabeledBy`), a label that follows it (`FollowedBy`), or both. When multiple fields match the label criteria, `Index` narrows the result.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Field
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `LabeledBy` | LabeledBy | `InArgument` | `string` | | | Text of the label that immediately precedes the target field. |
+| `Index` | Index | `InArgument` | `int` | | | Zero-based index used to disambiguate when multiple fields match the label criteria. Cannot be used without `LabeledBy` or `FollowedBy`. |
+| `FollowedBy` | FollowedBy | `InArgument` | `string` | | | Text of the label that immediately follows the target field. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Text` | Text | `OutArgument` | `string` | The text content read from the identified field. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before reading. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+- `NONE` — Do not wait; read immediately.
+- `READY` — Wait for the keyboard to be unlocked (screen ready for input).
+- `COMPLETE` — Wait for all data to arrive on the screen.
+
+## Notes
+
+At least one of `LabeledBy` or `FollowedBy` must be provided. Both can be specified together for a more precise match. `Index` is a secondary criterion used to disambiguate when multiple fields share the same label — it cannot be used alone without `LabeledBy` or `FollowedBy`.
+
+## XAML Example
+
+**By preceding label:**
+
+```xml
+<t:TerminalGetField DisplayName="Get Field"
+                    LabeledBy="[&quot;Username:&quot;]"
+                    Text="[usernameValue]" />
+```
+
+**By both labels with index to disambiguate:**
+
+```xml
+<t:TerminalGetField DisplayName="Get Field"
+                    LabeledBy="[&quot;Amount:&quot;]"
+                    FollowedBy="[&quot;USD&quot;]"
+                    Index="[1]"
+                    Text="[fieldValue]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetFieldAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetFieldAtPosition.md
@@ -1,0 +1,49 @@
+# Get Field at Position
+
+`UiPath.Terminal.Advanced.Activities.TerminalGetFieldAtPosition`
+
+Reads the content of the input field that starts at the specified row and column position on the terminal screen.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Position
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Row` | Row | `InArgument` | `int` | Yes | | The row of the field start (1-based). |
+| `Column` | Column | `InArgument` | `int` | Yes | | The column of the field start (1-based). |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Text` | Text | `OutArgument` | `string` | The text content of the field at the specified position. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before reading. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+Unlike **Get Text at Position** (which reads raw character data from a position), this activity reads the structured field at that position as defined by the terminal's field attributes.
+
+## XAML Example
+
+```xml
+<ta:TerminalGetFieldAtPosition DisplayName="Get Field at Position"
+                                Row="[7]"
+                                Column="[15]"
+                                Text="[fieldValue]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetScreenArea.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetScreenArea.md
@@ -1,0 +1,49 @@
+# Get Screen Area
+
+`UiPath.Terminal.Advanced.Activities.TerminalGetScreenArea`
+
+Reads all text within a rectangular region of the terminal screen, defined by a start position (Row/Column) and an end position (EndRow/EndColumn).
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Position
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Row` | Row | `InArgument` | `int` | Yes | | Starting row of the region (1-based). |
+| `Column` | Column | `InArgument` | `int` | Yes | | Starting column of the region (1-based). |
+| `EndRow` | EndRow | `InArgument` | `int` | Yes | | Ending row of the region (1-based, inclusive). |
+| `EndColumn` | EndColumn | `InArgument` | `int` | Yes | | Ending column of the region (1-based, inclusive). |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Text` | Text | `OutArgument` | `string` | The text read from the specified screen region. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before reading. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## XAML Example
+
+```xml
+<ta:TerminalGetScreenArea DisplayName="Get Screen Area"
+                           Row="[3]"
+                           Column="[1]"
+                           EndRow="[10]"
+                           EndColumn="[80]"
+                           Text="[areaText]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetText.md
@@ -1,0 +1,40 @@
+# Get Text
+
+`UiPath.Terminal.Activities.TerminalGetText`
+
+Reads the entire visible text content of the terminal screen and returns it as a string.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Text` | Text | `OutArgument` | `string` | The full text content of the terminal screen. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before reading. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+- `NONE` — Do not wait; read immediately.
+- `READY` — Wait for the keyboard to be unlocked (screen ready for input).
+- `COMPLETE` — Wait for all data to arrive on the screen.
+
+## XAML Example
+
+```xml
+<t:TerminalGetText DisplayName="Get Text"
+                   Text="[screenText]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetTextAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetTextAtPosition.md
@@ -1,0 +1,47 @@
+# Get Text at Position
+
+`UiPath.Terminal.Advanced.Activities.TerminalGetTextAtPosition`
+
+Reads text starting at a specific row and column position on the terminal screen. An optional `Length` parameter limits how many characters are read.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Position
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Row` | Row | `InArgument` | `int` | Yes | | The row to start reading from (1-based). |
+| `Column` | Column | `InArgument` | `int` | Yes | | The column to start reading from (1-based). |
+| `Length` | Length | `InArgument` | `int` | | | Number of characters to read. If not set, reads to the end of the line. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Text` | Text | `OutArgument` | `string` | The text read from the specified position. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before reading. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## XAML Example
+
+```xml
+<ta:TerminalGetTextAtPosition DisplayName="Get Text at Position"
+                               Row="[5]"
+                               Column="[10]"
+                               Length="[20]"
+                               Text="[fieldText]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursor.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursor.md
@@ -1,0 +1,38 @@
+# Move Cursor
+
+`UiPath.Terminal.Advanced.Activities.TerminalMoveCursor`
+
+Moves the terminal cursor to an exact row and column position on the screen.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Position
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Row` | Row | `InArgument` | `int` | Yes | | The target row (1-based). |
+| `Column` | Column | `InArgument` | `int` | Yes | | The target column (1-based). |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before moving. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## XAML Example
+
+```xml
+<ta:TerminalMoveCursor DisplayName="Move Cursor"
+                        Row="[5]"
+                        Column="[20]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursorToText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursorToText.md
@@ -1,0 +1,54 @@
+# Move Cursor to Text
+
+`UiPath.Terminal.Advanced.Activities.TerminalMoveCursorToText`
+
+Searches the terminal screen for a text string and moves the terminal cursor to the position where the text was found. Also returns the coordinates of the found text.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes | | The text string to search for. |
+| `StartRow` | StartRow | `InArgument` | `int` | | | Row to start searching from (1-based). Defaults to the beginning of the screen if not set. |
+| `StartColumn` | StartColumn | `InArgument` | `int` | | | Column to start searching from (1-based). Defaults to the beginning of the screen if not set. |
+| `IgnoreCase` | Ignore Case | `Property` | `bool` | | `false` | When `true`, the search is case-insensitive. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Row` | Row | `OutArgument` | `int` | The row where the text was found and the cursor moved to (1-based). |
+| `Column` | Column | `OutArgument` | `int` | The column where the text was found and the cursor moved to (1-based). |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before searching. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+- Combines a text search with a cursor move in a single activity. Equivalent to **Find Text** followed by **Move Cursor**.
+- If the text is not found, the activity throws an `InvalidCoordinates` exception.
+
+## XAML Example
+
+```xml
+<ta:TerminalMoveCursorToText DisplayName="Move Cursor to Text"
+                               Text="[&quot;Password:&quot;]"
+                               IgnoreCase="True"
+                               Row="[foundRow]"
+                               Column="[foundCol]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendControlKey.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendControlKey.md
@@ -1,0 +1,76 @@
+# Send Control Key
+
+`UiPath.Terminal.Activities.TerminalSendControlKey`
+
+Sends a single control key (such as Tab, Enter/Transmit, F1–F24, arrow keys, or terminal-specific function keys) to the terminal.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Key` | Key | `Property` | `ControlKey` | Yes | | The control key to send. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `1000` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before sending. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+**`ControlKey`** (selected values):
+
+| Value | Description |
+|-------|-------------|
+| `Transmit` | Submit / Enter (3270) |
+| `Tab` | Tab key |
+| `BackTab` | Reverse tab |
+| `Return` | Carriage return (VT) |
+| `Escape` | Escape key (VT) |
+| `F1`–`F24` | Function keys F1 through F24 |
+| `Shift_F1`–`Shift_F12` | Shift + function keys |
+| `Ctrl_F1`–`Ctrl_F12` | Ctrl + function keys |
+| `Alt_F1`–`Alt_F12` | Alt + function keys |
+| `PA1`, `PA2`, `PA3` | Program Attention keys (3270) |
+| `Clear` | Clear screen (3270) |
+| `Reset` | Reset (3270) |
+| `Attention` | Attention (3270) |
+| `BackSpace` | Backspace |
+| `Home` | Home key |
+| `End` | End key |
+| `Insert` | Insert key |
+| `Delete` | Delete key |
+| `PageUp`, `PageDown` | Page Up / Page Down |
+| `Up`, `Down`, `Left`, `Right` | Arrow keys |
+| `EraseEOF` | Erase end of field (3270) |
+| `EraseInput` | Erase input (3270) |
+| `Break` | Break (VT) |
+| `System` | System key (VT) |
+| `HoldScreen`, `NextScreen`, `PrevScreen` | VT screen navigation |
+| `Ctrl_A`–`Ctrl_Z` | Ctrl + letter (VT) |
+| `Wyse_Send`, `Wyse_Shift_Tab`, `Wyse_Shift_Enter` | Wyse terminal keys |
+| `CursorSelect` | Cursor Select (3270) |
+| `FieldPlus`, `FieldMinus`, `FieldExit` | AS400 field keys |
+| `Select` | Select (VT) |
+| `Do`, `End` | VT Do / End keys |
+| `Tandem_Next_Page`, `Tandem_Prev_Page` | Tandem page navigation |
+| `Tandem_Left`, `Tandem_Right` | Tandem directional keys |
+| `Tandem_Program_Reset`, `Tandem_Soft_Reset` | Tandem reset keys |
+| `Tandem_Shift_Next_Page`, `Tandem_Shift_Prev_Page` | Tandem shift page keys |
+
+## XAML Example
+
+```xml
+<t:TerminalSendControlKey DisplayName="Send Control Key"
+                           Key="Transmit" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeys.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeys.md
@@ -1,0 +1,40 @@
+# Send Keys
+
+`UiPath.Terminal.Advanced.Activities.TerminalSendKeys`
+
+Sends a raw text string or key sequence directly to the terminal. Use this activity to type text character by character into the terminal at the current cursor position.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Keys` | Keys | `InArgument` | `string` | Yes | | The text or key sequence to send to the terminal. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before sending. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+To send sensitive data such as passwords, use **Send Keys Secure** instead to avoid exposing the value as plain text in the workflow.
+
+## XAML Example
+
+```xml
+<ta:TerminalSendKeys DisplayName="Send Keys"
+                      Keys="[username]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeysSecure.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeysSecure.md
@@ -1,0 +1,41 @@
+# Send Keys Secure
+
+`UiPath.Terminal.Advanced.Activities.TerminalSendKeysSecure`
+
+Sends a `SecureString` value (such as a password) to the terminal without exposing it as plain text in the workflow. The secure string is converted to characters in memory and sent immediately, then the unmanaged memory buffer is zeroed out.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SecureText` | SecureText | `InArgument` | `SecureString` | Yes | | The secure string value to send. Typically sourced from an Asset, credential variable, or the `SSHPassword` output of a Get Credential activity. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before sending. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+- Uses `Marshal.SecureStringToGlobalAllocUnicode` internally; the unmanaged buffer is freed immediately after sending.
+- Do not use **Send Keys** for passwords — use this activity instead to prevent credential exposure in logs or workflow snapshots.
+
+## XAML Example
+
+```xml
+<ta:TerminalSendKeysSecure DisplayName="Send Keys Secure"
+                             SecureText="[passwordSecureString]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetField.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetField.md
@@ -1,0 +1,53 @@
+# Set Field
+
+`UiPath.Terminal.Activities.TerminalSetField`
+
+Writes text into a specific input field on the terminal screen. The field is identified by a label that precedes it (`LabeledBy`), a label that follows it (`FollowedBy`), or both. When multiple fields match the label criteria, `Index` narrows the result.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes | | The text to write into the field. |
+
+### Field
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `LabeledBy` | LabeledBy | `InArgument` | `string` | | | Text of the label that immediately precedes the target field. |
+| `Index` | Index | `InArgument` | `int` | | | Zero-based index used to disambiguate when multiple fields match the label criteria. Cannot be used without `LabeledBy` or `FollowedBy`. |
+| `FollowedBy` | FollowedBy | `InArgument` | `string` | | | Text of the label that immediately follows the target field. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before writing. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+- `NONE` — Do not wait; write immediately.
+- `READY` — Wait for the keyboard to be unlocked (screen ready for input).
+- `COMPLETE` — Wait for all data to arrive on the screen.
+
+## Notes
+
+At least one of `LabeledBy` or `FollowedBy` must be provided. Both can be specified together for a more precise match. `Index` is a secondary criterion used to disambiguate when multiple fields share the same label — it cannot be used alone without `LabeledBy` or `FollowedBy`.
+
+## XAML Example
+
+```xml
+<t:TerminalSetField DisplayName="Set Field"
+                    LabeledBy="[&quot;Username:&quot;]"
+                    Text="[username]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetFieldAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetFieldAtPosition.md
@@ -1,0 +1,52 @@
+# Set Field at Position
+
+`UiPath.Terminal.Advanced.Activities.TerminalSetFieldAtPosition`
+
+Writes text into the input field that starts at the specified row and column position on the terminal screen.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes | | The text to write into the field. |
+
+### Position
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Row` | Row | `InArgument` | `int` | Yes | | The row of the field start (1-based). |
+| `Column` | Column | `InArgument` | `int` | Yes | | The column of the field start (1-based). |
+
+### Options / Configuration
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `BackwardsCompatible` | Backwards Compatible | `Property` | `bool?` | `true` (existing workflows); `false` (newly added) | Controls cursor movement behavior after writing. When `true`, the cursor jumps back to the field start position after writing (legacy behavior). When `false`, the cursor stays at the end of the written text. |
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `5000` | Milliseconds to wait for the operation to complete. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen before writing. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+- `BackwardsCompatible` defaults to `true` for activities that were created with an older version of the package (detected via stack trace at design time). New activities added to a workflow default to `false`.
+- Set `BackwardsCompatible = false` for new workflows to get consistent cursor behavior after writing.
+
+## XAML Example
+
+```xml
+<ta:TerminalSetFieldAtPosition DisplayName="Set Field at Position"
+                                Row="[7]"
+                                Column="[15]"
+                                Text="[inputValue]"
+                                BackwardsCompatible="False" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/TerminalSession.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/TerminalSession.md
@@ -1,0 +1,102 @@
+# Terminal Session
+
+`UiPath.Terminal.Activities.TerminalSession`
+
+Container scope activity that establishes a terminal connection and provides it to all child activities. All other terminal activities must be placed inside a Terminal Session. Supports creating new connections (via connection string), reusing an existing open connection, and SSH authentication. Supported providers include BlueZone, IBM PCOMM, Attachmate, direct TCP/SSH (UiPathNew), EHLLAPI (Generic), and Tandem/NonStop via THLLAPI (TandemHLL).
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+
+## Properties
+
+### New Session
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ConnectionString` | Connection String | `InArgument` | `string` | | | Serialized connection string describing the terminal provider, host, port, and protocol. Use the **Connection Settings** button in the designer to build this value visually. |
+| `OutputConnection` | Output Connection | `OutArgument` | `TerminalConnection` | | | Stores the opened connection object so it can be reused in a later Terminal Session (via `ExistingConnection`). If not set, the connection is closed automatically when the scope ends. |
+
+### Use Existing Connection
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ExistingConnection` | Existing Connection | `InArgument` | `TerminalConnection` | | | A previously opened `TerminalConnection` object to reuse. When set, `ConnectionString` must not be set. |
+| `CloseConnection` | Close Connection | `Property` | `bool` | | `true` | When using an existing connection, controls whether the connection is closed when the scope exits. Automatically set to `false` if `OutputConnection` is provided. |
+
+### SSH Connection Properties
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SSHUserName` | SSH UserId | `InArgument` | `string` | | | SSH username for authentication. Only applies when the connection string specifies SSH protocol. |
+| `SSHPassword` | SSH Password | `InArgument` | `SecureString` | | | SSH password for authentication. Use a `SecureString` variable to avoid storing credentials as plain text. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `50000` | Milliseconds to wait for the terminal connection to be established. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `1000` | Milliseconds to wait after the connection is established before scheduling child activities. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue On Error | `InArgument` | `bool` | `false` | When `true`, the workflow continues execution even if this activity throws an error. |
+
+## Valid Configurations
+
+This activity supports two mutually exclusive connection modes. `ConnectionString` and `ExistingConnection` cannot both be set — a validation error is raised at design time.
+
+**Mode A — New Connection**: Set `ConnectionString`. The session opens a new connection. Optionally set `OutputConnection` to keep the connection alive after the scope exits.
+
+**Mode B — Existing Connection**: Set `ExistingConnection` with a previously opened `TerminalConnection` variable. Optionally set `CloseConnection = false` to leave it open after the scope.
+
+## Notes
+
+- All other terminal activities must be placed inside this scope.
+- If `OutputConnection` is set, `CloseConnection` is automatically forced to `false`.
+- The connection string must not reference the deprecated `UiPathInternal` provider type (validation error is raised).
+- For Tandem/NonStop sessions, use the `TandemHLL` provider type with `ConnectionType.LowLevel`. The connection uses the same EHLLAPI-style fields (`EhllDll`, `EhllSession`, etc.) but targets `THLLW3.DLL` or `THLLW6.DLL` (Attachmate Reflection 6530). Color information is not available for this provider.
+- SSH credentials are only used when the connection string's protocol is SSH. For non-SSH connections, `SSHUserName` and `SSHPassword` are ignored.
+- Use the **Connection Settings** button in the UiPath Studio designer to build the connection string visually (not available in Studio Web).
+- Use the **Run Wizard** button to launch the Terminal Recorder (not available in Studio Web, requires a literal connection string).
+
+## XAML Example
+
+**Mode A — New connection:**
+
+```xml
+<t:TerminalSession DisplayName="Terminal Session"
+                   ConnectionString="[connStr]"
+                   TimeoutMS="50000">
+  <t:TerminalSession.Body>
+    <ActivityAction x:TypeArguments="t:TerminalConnection">
+      <ActivityAction.Argument>
+        <DelegateInArgument x:TypeArguments="t:TerminalConnection" Name="terminalSession" />
+      </ActivityAction.Argument>
+      <Sequence DisplayName="Do">
+        <!-- child terminal activities here -->
+      </Sequence>
+    </ActivityAction>
+  </t:TerminalSession.Body>
+</t:TerminalSession>
+```
+
+**Mode B — Existing connection:**
+
+```xml
+<t:TerminalSession DisplayName="Terminal Session (Reuse)"
+                   ExistingConnection="[existingConn]"
+                   CloseConnection="False">
+  <t:TerminalSession.Body>
+    <ActivityAction x:TypeArguments="t:TerminalConnection">
+      <ActivityAction.Argument>
+        <DelegateInArgument x:TypeArguments="t:TerminalConnection" Name="terminalSession" />
+      </ActivityAction.Argument>
+      <Sequence DisplayName="Do">
+        <!-- child terminal activities here -->
+      </Sequence>
+    </ActivityAction>
+  </t:TerminalSession.Body>
+</t:TerminalSession>
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitFieldText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitFieldText.md
@@ -1,0 +1,51 @@
+# Wait Field Text
+
+`UiPath.Terminal.Activities.TerminalWaitFieldText`
+
+Waits until a specific input field on the terminal screen contains the expected text. The field is identified by a label that precedes it (`LabeledBy`), a label that follows it (`FollowedBy`), or both. When multiple fields match the label criteria, `Index` narrows the result.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes | | The text string to wait for in the field. |
+| `MatchCase` | MatchCase | `InArgument` | `bool` | | `false` | When `true`, the text comparison is case-sensitive. |
+
+### Field
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `LabeledBy` | LabeledBy | `InArgument` | `string` | | | Text of the label that immediately precedes the target field. |
+| `Index` | Index | `InArgument` | `int` | | | Zero-based index used to disambiguate when multiple fields match the label criteria. Cannot be used without `LabeledBy` or `FollowedBy`. |
+| `FollowedBy` | FollowedBy | `InArgument` | `string` | | | Text of the label that immediately follows the target field. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `30000` | Milliseconds to wait for the field text before throwing a timeout error. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+At least one of `LabeledBy` or `FollowedBy` must be provided. Both can be specified together for a more precise match. `Index` is a secondary criterion used to disambiguate when multiple fields share the same label — it cannot be used alone without `LabeledBy` or `FollowedBy`.
+
+## XAML Example
+
+```xml
+<t:TerminalWaitFieldText DisplayName="Wait Field Text"
+                          LabeledBy="[&quot;Status:&quot;]"
+                          Text="[&quot;OK&quot;]"
+                          TimeoutMS="[30000]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenReady.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenReady.md
@@ -1,0 +1,35 @@
+# Wait Screen Ready
+
+`UiPath.Terminal.Advanced.Activities.TerminalWaitScreenReady`
+
+Waits until the terminal keyboard is unlocked and the screen is ready to accept input. Use this activity after sending a command or key that triggers host-side processing, to ensure subsequent activities do not execute before the host responds.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `30000` | Milliseconds to wait for the screen to become ready before throwing a timeout error. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `0` | Milliseconds to wait after executing the activity. Defaults to 0 (no delay). |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | The wait mode; this activity always waits for the READY state regardless of this setting. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## Notes
+
+- This activity has `DelayMS = 0` by default (unlike most other activities which default to 300 ms).
+- Commonly placed after a **Send Control Key** (Transmit/Enter) to wait for the host to respond before reading or writing fields.
+
+## XAML Example
+
+```xml
+<ta:TerminalWaitScreenReady DisplayName="Wait Screen Ready"
+                              TimeoutMS="[30000]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenText.md
@@ -1,0 +1,42 @@
+# Wait Screen Text
+
+`UiPath.Terminal.Activities.TerminalWaitScreenText`
+
+Waits until a specified text string appears anywhere on the terminal screen. Useful for synchronizing with host-side processing that updates the screen.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes | | The text string to wait for on the screen. |
+| `MatchCase` | MatchCase | `InArgument` | `bool` | | `false` | When `true`, the text comparison is case-sensitive. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `30000` | Milliseconds to wait for the text to appear before throwing a timeout error. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+- `NONE` — Do not wait for screen ready; check for text immediately.
+- `READY` — Wait for the keyboard to be unlocked first.
+- `COMPLETE` — Wait for all data to arrive on the screen first.
+
+## XAML Example
+
+```xml
+<t:TerminalWaitScreenText DisplayName="Wait Screen Text"
+                           Text="[&quot;READY&quot;]"
+                           TimeoutMS="[30000]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitTextAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitTextAtPosition.md
@@ -1,0 +1,47 @@
+# Wait Text at Position
+
+`UiPath.Terminal.Advanced.Activities.TerminalWaitTextAtPosition`
+
+Waits until a specific row and column position on the terminal screen contains the expected text.
+
+**Package:** `UiPath.Terminal.Activities`  
+**Category:** App Integration.Terminals.Advanced  
+**Required Scope:** `TerminalSession`
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | `InArgument` | `string` | Yes | | The text string to wait for at the specified position. |
+| `MatchCase` | MatchCase | `InArgument` | `bool` | | `false` | When `true`, the text comparison is case-sensitive. |
+
+### Position
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Row` | Row | `InArgument` | `int` | Yes | | The row to check (1-based). |
+| `Column` | Column | `InArgument` | `int` | Yes | | The column to check (1-based). |
+
+### Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `TimeoutMS` | TimeoutMS | `InArgument` | `int` | `30000` | Milliseconds to wait for the text to appear before throwing a timeout error. |
+| `DelayMS` | DelayMS | `InArgument` | `int` | `300` | Milliseconds to wait after executing the activity. |
+| `WaitType` | WaitType | `Property` | `WaitMode` | `READY` | Determines how to wait for the terminal screen. |
+
+### Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+
+## XAML Example
+
+```xml
+<ta:TerminalWaitTextAtPosition DisplayName="Wait Text at Position"
+                                Row="[24]"
+                                Column="[1]"
+                                Text="[&quot;READY&quot;]"
+                                TimeoutMS="[30000]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/coded/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/coded/coded-api.md
@@ -1,0 +1,650 @@
+# Terminal Activities — Coded Workflow API
+
+`UiPath.Terminal.Activities`
+
+Coded workflow API for automating terminal emulation sessions. Provides methods to establish connections to IBM 3270/5250, VT, HP, ANSI, Wyse, and other legacy terminal systems via BlueZone, IBM PCOMM, Attachmate, or direct TCP/SSH connections, then interact with the terminal screen programmatically.
+
+**Service accessor:** `terminal` (type `ITerminalService`)
+**Required package:** `"UiPath.Terminal.Activities": "*"` in project.json dependencies
+
+## Auto-Imported Namespaces
+
+These namespaces are automatically available in coded workflows when this package is installed:
+
+```
+UiPath.Terminal
+UiPath.Terminal.Data
+UiPath.Terminal.Activities.API
+UiPath.Terminal.Enums
+```
+
+## Service Overview
+
+The `terminal` service provides factory methods that open a terminal connection and return a `TerminalConnection` object. The connection object is the API surface for all terminal operations — screen reads, field access, key sending, and waiting.
+
+This is a **connection-based API**:
+1. Call a service method (`GetConnection` / `GetSshConnection`) to open and connect.
+2. Use the returned `TerminalConnection` to perform terminal operations.
+3. Dispose the connection when done (or use a `using` statement).
+
+In coded workflow mode, all `TerminalConnection` methods **throw `TerminalConnectionException`** on failure instead of returning error codes. This means you do not need to check return values — just handle exceptions.
+
+---
+
+## Connection Methods
+
+### `TerminalConnection GetConnection(string connectionString)`
+
+Opens a terminal connection using a serialized connection string. The connection string encodes the provider type, host, port, protocol, and other settings. Use the **Terminal Session** XAML activity's Connection Settings dialog to generate a valid string.
+
+**Parameters:**
+- `connectionString` (`string`) — Serialized connection string. Example: obtained by configuring a Terminal Session activity and copying the `ConnectionString` property value.
+
+**Returns:** `TerminalConnection` — An open, connected terminal session. Implements `IDisposable`; use inside a `using` statement.
+
+**Throws:** `TerminalConnectionException` if the connection cannot be established within the timeout.
+
+---
+
+### `TerminalConnection GetConnection(ConnectionData connectionData)`
+
+Opens a terminal connection using a `ConnectionData` object, allowing programmatic configuration without a serialized connection string.
+
+**Parameters:**
+- `connectionData` (`ConnectionData`) — Configuration object specifying provider, host, port, protocol, and emulation settings.
+
+**Returns:** `TerminalConnection` — An open, connected terminal session.
+
+**Throws:** `TerminalConnectionException` if the connection cannot be established.
+
+---
+
+### `TerminalConnection GetSshConnection(ConnectionData connectionData, string sshUser, SecureString sshPassword)`
+
+Opens an SSH terminal connection with explicit credentials. The `connectionData` must specify `ProviderType = UiPathNew` and `ConnectionProtocol = SSH`.
+
+**Parameters:**
+- `connectionData` (`ConnectionData`) — Connection configuration. Must have `ProviderType = TerminalProviderType.UiPathNew` and `ConnectionProtocol = CommunicationType.SSH`.
+- `sshUser` (`string`) — SSH username.
+- `sshPassword` (`SecureString`) — SSH password. Use a `SecureString` variable (e.g., from Get Credential) to avoid plain-text exposure.
+
+**Returns:** `TerminalConnection` — An open, connected SSH terminal session.
+
+**Throws:** `TerminalConnectionException` if the connection fails, or `ArgumentException` if `ProviderType` or `ConnectionProtocol` is invalid.
+
+---
+
+## TerminalConnection
+
+`TerminalConnection` is the handle returned by all service methods. It provides all terminal interaction operations and implements `IDisposable`.
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` / `Shutdown()` explicitly. Disposing disconnects the session and terminates any host processes.
+
+### Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Connected` | `bool` | `true` if the session is currently connected to the host. |
+| `ConnectionString` | `string` | The serialized connection string used to establish this connection. |
+| `DefaultCmdOptions` | `CommandOptions` | Default timeout and wait-mode options applied to all operations when not explicitly overridden. |
+
+### Events
+
+| Event | Description |
+|-------|-------------|
+| `TerminalScreenChanged` | Raised when the terminal screen content changes. |
+| `TerminalFieldChanged` | Raised when a field value changes. |
+| `TerminalCursorChanged` | Raised when the cursor position changes. |
+| `TerminalConnectionChanged` | Raised when the connection status changes (e.g., connect/disconnect). |
+| `TerminalErrorRaised` | Raised when a terminal error occurs asynchronously. |
+
+### Screen Reading Methods
+
+#### `TerminalResultCode GetText(out string text, CommandOptions options = null)`
+
+Reads the entire visible text content of the terminal screen.
+
+**Parameters:**
+- `text` (`out string`) — Receives the full screen text.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode. Defaults to `DefaultCmdOptions`.
+
+**Returns:** `TerminalResultCode.Success` (or throws `TerminalConnectionException` on failure in coded workflow mode).
+
+---
+
+#### `TerminalResultCode GetTextAtPosition(TerminalField criteria, int? length, out string text, CommandOptions options = null)`
+
+Reads text from the screen starting at the position defined by `criteria`. Optionally limits the number of characters read.
+
+**Parameters:**
+- `criteria` (`TerminalField`) — Defines the start position via `RowStart` / `ColStart`.
+- `length` (`int?`, optional) — Number of characters to read. `null` reads to end of line.
+- `text` (`out string`) — Receives the text read from the position.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode GetScreenArea(TerminalField criteria, out string text, CommandOptions options = null)`
+
+Reads text from a rectangular region of the screen defined by `criteria`.
+
+**Parameters:**
+- `criteria` (`TerminalField`) — Defines the region using `RowStart`, `ColStart`, `RowEnd`, `ColEnd`.
+- `text` (`out string`) — Receives the text from the region.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode GetColorAtPosition(int row, int column, out Color color, CommandOptions options = null)`
+
+Gets the foreground color of the character at the specified position.
+
+**Parameters:**
+- `row` (`int`) — Row (1-based).
+- `column` (`int`) — Column (1-based).
+- `color` (`out Color`) — Receives the `System.Drawing.Color` value.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `ScreenData GetScreen(CommandOptions options = null)`
+
+Returns the raw screen data object including all field attributes and character data.
+
+**Parameters:**
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+**Returns:** `ScreenData` with screen content and field metadata, or `null` if not connected.
+
+---
+
+### Field Methods
+
+#### `TerminalResultCode GetField(TerminalField field, out string text, CommandOptions options = null)`
+
+Reads the text content of a field identified by its criteria (label, index, or coordinates).
+
+**Parameters:**
+- `field` (`TerminalField`) — Field identification. Set `LabeledBy`, `FollowedBy`, `Index`, or coordinate properties.
+- `text` (`out string`) — Receives the field text.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode SetField(TerminalField criteria, string text, CommandOptions options = null)`
+
+Writes text into the field matching the criteria.
+
+**Parameters:**
+- `criteria` (`TerminalField`) — Field identification. Set `LabeledBy`, `FollowedBy`, `Index`, or coordinate properties.
+- `text` (`string`) — Text to write.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+### Cursor Methods
+
+#### `TerminalResultCode GetCursorPosition(out CursorPosition cursorPosition, CommandOptions options = null)`
+
+Gets the current row and column of the terminal cursor.
+
+**Parameters:**
+- `cursorPosition` (`out CursorPosition`) — Receives the cursor position (`Row`, `Column`).
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode MoveCursor(int row, int column, CommandOptions options = null)`
+
+Moves the terminal cursor to the specified row and column.
+
+**Parameters:**
+- `row` (`int`) — Target row (1-based).
+- `column` (`int`) — Target column (1-based).
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode MoveCursor(CursorPosition cursor, CommandOptions options = null)`
+
+Moves the cursor using a `CursorPosition` object.
+
+**Parameters:**
+- `cursor` (`CursorPosition`) — Target position.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+### Key Sending Methods
+
+#### `TerminalResultCode SendKeys(string keys, CommandOptions options = null)`
+
+Sends a text string to the terminal at the current cursor position.
+
+**Parameters:**
+- `keys` (`string`) — Text to send.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode SendKeysSecure(SecureString keys, CommandOptions options = null)`
+
+Sends a `SecureString` to the terminal. The string is decrypted in-memory, sent, then the unmanaged buffer is zeroed. Use for passwords.
+
+**Parameters:**
+- `keys` (`SecureString`) — Secure text to send.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode SendControlKey(ControlKey key, CommandOptions options = null)`
+
+Sends a control key (Tab, F1–F24, Transmit/Enter, arrow keys, etc.) to the terminal.
+
+**Parameters:**
+- `key` (`ControlKey`) — The control key to send. See `ControlKey` enum.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode SendControlKey(ControlKey key, int delayMS, CommandOptions options = null)`
+
+Sends a control key then waits a specified number of milliseconds before returning. Useful when the host needs processing time after a key.
+
+**Parameters:**
+- `key` (`ControlKey`) — The control key to send.
+- `delayMS` (`int`) — Milliseconds to sleep after sending the key.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+### Wait Methods
+
+#### `TerminalResultCode WaitScreenReady(CommandOptions options = null)`
+
+Waits until the terminal keyboard is unlocked and the screen is ready for input.
+
+**Parameters:**
+- `options` (`CommandOptions`, optional) — Timeout and wait mode. Set `Timeout` to control how long to wait.
+
+---
+
+#### `TerminalResultCode WaitText(string text, TerminalField criteria = null, bool matchCase = true, CommandOptions options = null)`
+
+Waits until the specified text appears on the terminal screen (or in a specific field if `criteria` is provided).
+
+**Parameters:**
+- `text` (`string`) — Text to wait for.
+- `criteria` (`TerminalField`, optional) — When set, waits for the text in the specific field. When `null`, waits for the text anywhere on the screen.
+- `matchCase` (`bool`, optional) — Case-sensitive comparison. Default: `true`.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+#### `TerminalResultCode FindTextInScreen(string text, CursorPosition startPosition, bool ignoreCase, out CursorPosition position, CommandOptions options = null)`
+
+Searches the screen for a text string starting from `startPosition`.
+
+**Parameters:**
+- `text` (`string`) — Text to search for.
+- `startPosition` (`CursorPosition`) — Starting search position.
+- `ignoreCase` (`bool`) — Case-insensitive search.
+- `position` (`out CursorPosition`) — Receives the coordinates where text was found.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+**Returns:** `TerminalResultCode.Success` if found; throws (or returns `InvalidCoordinates`) if not found.
+
+---
+
+### Connection Lifecycle
+
+#### `TerminalResultCode Disconnect(CommandOptions options = null)`
+
+Disconnects from the host while keeping the connection object alive (does not dispose). Rarely needed — `Dispose()` handles cleanup.
+
+#### `void Shutdown()`
+
+Alias for `Dispose()`. Disconnects, shuts down host processes, and releases resources.
+
+#### `void Dispose()`
+
+Disconnects the session, terminates any host broker processes (x86/x64), and releases all managed and unmanaged resources.
+
+---
+
+### Advanced
+
+#### `TerminalResultCode OverrideScreenResolution(ScreenSize screenSize, CommandOptions options = null)`
+
+Overrides the terminal screen dimensions. Use when the host requires a non-standard screen size.
+
+**Parameters:**
+- `screenSize` (`ScreenSize`) — Target screen dimensions.
+- `options` (`CommandOptions`, optional) — Timeout and wait mode.
+
+---
+
+## Options & Configuration Classes
+
+### `CommandOptions`
+
+Controls timeout and screen-wait behavior for individual terminal operations.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Timeout` | `int` | `30000` | Milliseconds to wait before throwing a timeout error. When `0` or negative, falls back to the service default of 30000 ms. |
+| `WaitType` | `WaitMode` | `READY` | How to wait for the screen before executing the operation. |
+
+```csharp
+// Example: 10-second timeout, wait for screen ready
+var opts = new CommandOptions(WaitMode.READY, 10000);
+```
+
+### `ConnectionData`
+
+Programmatic configuration object for terminal connections. Used with `GetConnection(ConnectionData)` and `GetSshConnection()`.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `ProviderType` | `TerminalProviderType` | `UiPathNew` | Terminal emulator provider. Use `UiPathNew` for direct TCP/SSH connections. |
+| `ConnectionType` | `ConnectionType` | `Profile` | How the connection is established: `Address` (host/port — required for `UiPathNew`), `Profile` (provider profile file), `LowLevel` (EHLLAPI). |
+| `ConnectionProtocol` | `CommunicationType` | `TELNET` | Protocol: `TELNET`, `SSH`, or `HPVT`. |
+| `TerminalType` | `TerminalType` | `Terminal3270` | Terminal emulation type. |
+| `Host` | `string` | | Hostname or IP address of the target host. |
+| `Port` | `int` | `23` | TCP port. Default is 23 (Telnet); SSH typically uses 22. |
+| `ShowTerminal` | `bool` | `true` | Whether to display the terminal window (if supported by provider). |
+| `EnableSSL` | `bool` | `false` | Enable SSL/TLS for the connection. |
+| `Profile` | `string` | | Path to provider profile file (for profile-based providers: Attachmate, IBM, BlueZone, etc.). |
+| `InProcessMode` | `bool` | `false` | Run the terminal provider in-process (Generic/EHLLAPI only). |
+| `AttachExisting` | `bool` | `false` | Attach to an already-running terminal session. `true` value only available for the `Attachmate` provider| 
+| `ProxyType` | `ProxyType` | `None` | Proxy type (None, HTTP, SOCKS4, SOCKS5). |
+| `ProxyHost` | `string` | | Proxy server hostname. |
+| `ProxyPort` | `int` | | Proxy server port. |
+| `ProxyUser` | `string` | | Proxy authentication username. |
+| `ProxyPassword` | `string` | | Proxy authentication password. |
+| `InternalEncoding` | `string` | | Character encoding override (e.g., `"IBM037"` for EBCDIC). |
+| `EhllDll` | `string` | | Path to EHLLAPI DLL (Generic provider). |
+| `EhllFunction` | `string` | `"hllapi"` | EHLLAPI entry-point function name. |
+| `EhllSession` | `string` | `"A"` | EHLLAPI session identifier. |
+| `EhllEnhanced` | `bool` | `true` | Use enhanced EHLLAPI mode. |
+| `EhllEncoding` | `string` | | Character encoding used for EHLLAPI text communication (Generic provider). Defaults to the provider's configured encoding if not set or unrecognized. |
+| `EhllBasicMode` | `bool` | `false` | When `true`, disables field parsing on screen retrieval. Screen data is returned as raw text only, with no field metadata. Use for performance when field-level access is not needed (Generic provider). |
+| `LuName` | `string` | | For 3270/5250: the SNA Logical Unit (LU) name to request from the host. For VT/Wyse/Linux: the terminal answerback string (use `^M` for carriage return). Has no effect on non-SNA or non-VT connections. |
+| `TerminalModel` | `int` | `0` | Terminal model identifier. Use the enum value for the active `TerminalType`: `TerminalModes3270` (3270), `TerminalModes5250` (5250, defaults to `IBM_5250_3477_FC` when `0`), `TTVtTermId` (VT), `TerminalModesHP` (HP), `TerminalModesWyse` (Wyse), `TerminalModesLinux` (Linux). |
+
+### `TerminalField`
+
+Identifies a field or screen region for read/write operations.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `RowStart` | `int` | Start row (1-based, or -1 for unset). |
+| `ColStart` | `int` | Start column (1-based, or -1 for unset). |
+| `RowEnd` | `int` | End row for area operations (-1 for unset). |
+| `ColEnd` | `int` | End column for area operations (-1 for unset). |
+| `LabeledBy` | `string` | Text of the label that precedes the field. |
+| `FollowedBy` | `string` | Text of the label that follows the field. |
+| `Index` | `int` | Zero-based field index (-1 for unset). |
+
+### `CursorPosition`
+
+Represents a row/column location on the terminal screen.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Row` | `int` | Row (1-based). Default: `1`. |
+| `Column` | `int` | Column (1-based). Default: `1`. |
+
+---
+
+## Enum Reference
+
+**`WaitMode`**: `NONE`, `READY`, `COMPLETE`
+- `NONE` — Do not wait; execute immediately.
+- `READY` — Wait for keyboard unlock before executing.
+- `COMPLETE` — Wait for all screen data to arrive before executing.
+
+**`TerminalProviderType`**: `UiPathNew`, `Attachmate`, `IBM`, `BlueZone`, `Generic`, `AttachmateExtra`, `ReflectionUnix`, `ReflectionIBM`, `Rumba`, `TandemHLL`
+- `UiPathNew` — Direct TCP/SSH connection without a third-party emulator. Supports Telnet, SSH, and HPVT.
+- `TandemHLL` — Tandem/NonStop host sessions via THLLAPI (`THLLW3.DLL` / `THLLW6.DLL`, Attachmate Reflection 6530). Uses `ConnectionType.LowLevel` and the same `Ehll*` fields as `Generic`. Color attribute data is not supported; `GetColorAtPosition` always returns `Color.LightGreen`.
+
+**`CommunicationType`**: `TELNET`, `SSH`, `HPVT`
+
+**`ConnectionType`**: `Address`, `Profile`, `LowLevel`
+- `Address` — Connect by host/port. Required when using `ProviderType.UiPathNew`.
+- `Profile` — Connect using a provider-specific profile file (path set via `Profile`).
+- `LowLevel` — Connect via EHLLAPI (Generic provider) or THLLAPI (TandemHLL provider).
+
+**`TerminalType`**: `Terminal3270`, `Terminal5250`, `TerminalVT`, `TerminalHP`, `TerminalANSI`, `TerminalT653X`, `TerminalSCOANSI`, `TerminalWYSE`, `TerminalLinux`
+
+**`ControlKey`** (selected values): `Transmit`, `Tab`, `BackTab`, `Return`, `Escape`, `BackSpace`, `Home`, `End`, `Insert`, `Delete`, `PageUp`, `PageDown`, `Up`, `Down`, `Left`, `Right`, `F1`–`F24`, `Shift_F1`–`Shift_F12`, `Ctrl_F1`–`Ctrl_F12`, `Alt_F1`–`Alt_F12`, `PA1`–`PA3`, `Clear`, `Reset`, `Attention`, `EraseEOF`, `EraseInput`, `CursorSelect`, `FieldPlus`, `FieldMinus`, `FieldExit`, `Ctrl_A`–`Ctrl_Z`, `Tandem_Horizontal_Tab`, `Tandem_Vertical_Tab`
+
+**`TerminalModes3270`** (use with `TerminalType.Terminal3270`): `IBM_3270_3278_2` (0), `IBM_3270_3278_3` (1), `IBM_3270_3278_4` (2), `IBM_3270_3278_5` (3), `IBM_3270_3279_2` (4), `IBM_3270_3279_3` (5), `IBM_3270_3279_4` (6), `IBM_3270_3279_5` (7)
+
+**`TerminalModes5250`** (use with `TerminalType.Terminal5250`): `IBM_5250_3179_2` (54), `IBM_5250_3179_220` (60), `IBM_5250_3180_2` (52), `IBM_5250_3196_A1` (53), `IBM_5250_3477_FG` (61), `IBM_5250_3477_FC` (62), `IBM_5250_5251_1` (55), `IBM_5250_5251_11` (56), `IBM_5250_5252` (57), `IBM_5250_5291_1` (58), `IBM_5250_5292_2` (59), `IBM_5250_5555_C01` (64), `IBM_5250_5555_B01` (65), `IBM_5250_Printer` (63)
+
+**`TTVtTermId`** (use with `TerminalType.TerminalVT`): `VT100` (0), `VT101` (1), `VT102` (2), `VT220` (3), `VT240` (4), `VT320` (5), `VT340` (6), `VT420` (7), `VT100W` (10), `VT101W` (11), `VT102W` (12), `VT220w` (13), `VT240W` (14), `VT320W` (15), `VT340W` (16), `VT420W` (17), `VT100M` (20), `VT101M` (21), `VT102M` (22), `VT220M` (23), `VT240M` (24), `VT320M` (25), `VT340M` (26), `VT420M` (27)
+
+**`TerminalModesHP`** (use with `TerminalType.TerminalHP`): `HP_2372A` (0), `HP_70092` (1), `HP_70094` (2)
+
+**`TerminalModesWyse`** (use with `TerminalType.TerminalWYSE`): `WYSE_50_24_80` (0), `WYSE_50_24_132` (10), `WYSE_60_24_80` (1), `WYSE_60_24_132` (11), `WYSE_60_42_80` (41), `WYSE_60_42_132` (51), `WYSE_60_43_80` (61), `WYSE_60_43_132` (71), `WYSE_350_24_80` (2), `WYSE_350_24_132` (12)
+
+**`TerminalModesLinux`** (use with `TerminalType.TerminalLinux`): `Linux_24_80` (0), `Linux_24_132` (1), `Linux_36_80` (2), `Linux_36_132` (3), `Linux_48_80` (4), `Linux_48_132` (5)
+
+---
+
+## Common Patterns
+
+### Login to a 3270 host and read a field
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var connData = new ConnectionData
+    {
+        Host = "mainframe.corp.com",
+        Port = 23,
+        TerminalType = TerminalType.Terminal3270,
+        ProviderType = TerminalProviderType.UiPathNew,
+        ConnectionType = ConnectionType.Address,
+        ConnectionProtocol = CommunicationType.TELNET
+    };
+
+    using var conn = terminal.GetConnection(connData);
+
+    // Wait for login screen, then type credentials
+    conn.WaitText("ENTER USERID", options: new CommandOptions(WaitMode.READY, 30000));
+    conn.SetField(new TerminalField { LabeledBy = "USERID" }, "myuser");
+    conn.SetField(new TerminalField { LabeledBy = "PASSWORD" }, "mypassword");
+    conn.SendControlKey(ControlKey.Transmit);
+
+    // Wait for main menu
+    conn.WaitScreenReady(new CommandOptions(WaitMode.READY, 15000));
+
+    // Read data
+    conn.GetText(out string screen);
+    Log(screen);
+}
+```
+
+---
+
+### SSH connection with secure credentials
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var controlKeyDelayMS = 1000;
+    var connData = new ConnectionData
+    {
+        Host = "unix-server.corp.com",
+        Port = 22,
+        TerminalType = TerminalType.TerminalVT,
+        ProviderType = TerminalProviderType.UiPathNew,
+        ConnectionType = ConnectionType.Address,
+        ConnectionProtocol = CommunicationType.SSH
+    };
+
+    // sshPwd is a SecureString variable, e.g., from Get Credential activity
+    using var conn = terminal.GetSshConnection(connData, sshUser: "deploy", sshPassword: sshPwd);
+
+    conn.WaitText("$", options: new CommandOptions(WaitMode.NONE, 10000));
+    conn.SendKeys("ls -la /var/log");
+    conn.SendControlKey(ControlKey.Transmit, controlKeyDelayMS);
+
+    conn.GetText(out string output);
+    Log(output);
+}
+```
+
+---
+
+### Navigate a menu by field position (EHLLAPI / Generic provider)
+
+Use when automating a terminal session managed by a third-party emulator that exposes an EHLLAPI interface (e.g., a running IBM PCOMM or BlueZone session accessed via its EHLLAPI DLL).
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var connData = new ConnectionData
+    {
+        ProviderType = TerminalProviderType.Generic,
+        ConnectionType = ConnectionType.LowLevel,
+        EhllDll = @"C:\Program Files\IBM\Personal Communications\PCSHLL32.DLL",
+        EhllFunction = "hllapi",
+        EhllSession = "A",
+        EhllEnhanced = true
+    };
+
+    using var conn = terminal.GetConnection(connData);
+
+    // Move cursor to the Option field and type a menu choice
+    conn.MoveCursor(row: 4, column: 14);
+    conn.SendKeys("2");
+    conn.SendControlKey(ControlKey.Transmit);
+    conn.WaitScreenReady(new CommandOptions(WaitMode.READY, 20000));
+
+    // Read a region of the response screen (rows 5-20, full width)
+    var region = new TerminalField { RowStart = 5, ColStart = 1, RowEnd = 20, ColEnd = 80 };
+    conn.GetScreenArea(region, out string result);
+    Log(result);
+}
+```
+
+---
+
+### Wait for processing and read a result field (IBM Personal Communications / saved profile)
+
+Use when the connection is pre-configured in an IBM PCOMM workspace file (`.ws`). PCOMM must be installed on the robot machine.
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var connData = new ConnectionData
+    {
+        ProviderType = TerminalProviderType.IBM,
+        ConnectionType = ConnectionType.Profile,
+        Mode = ConnectionMode.Play,
+        ShowTerminal = true,
+        Profile = @"C:\PComm\Profiles\MainframeSession.ws"
+    };
+
+    using var conn = terminal.GetConnection(connData);
+
+    // Submit a transaction
+    conn.SetField(new TerminalField { LabeledBy = "TRAN CODE" }, "INQ01");
+    conn.SetField(new TerminalField { LabeledBy = "ACCOUNT  " }, accountNumber);
+    conn.SendControlKey(ControlKey.Transmit);
+
+    // Wait for either success or error indicator
+    var opts = new CommandOptions(WaitMode.READY, 30000);
+    conn.WaitScreenReady(opts);
+
+    // Check status field
+    conn.GetField(new TerminalField { LabeledBy = "STATUS   " }, out string status);
+    if (status.Trim() == "00")
+    {
+        conn.GetField(new TerminalField { LabeledBy = "BALANCE  " }, out string balance);
+        Log($"Balance: {balance}");
+    }
+    else
+    {
+        conn.GetText(out string screen);
+        throw new Exception($"Transaction failed. Status: {status}. Screen: {screen}");
+    }
+}
+```
+
+---
+
+### Detect a field color for conditional logic
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var conn = terminal.GetConnection(connectionString);
+    try
+    {
+        conn.WaitScreenReady(new CommandOptions(WaitMode.READY, 10000));
+
+        // Check if the status indicator at row 24, col 1 is red (error)
+        conn.GetColorAtPosition(24, 1, out Color statusColor);
+
+        if (statusColor == Color.Red)
+        {
+            conn.GetText(out string errorScreen);
+            Log($"Error screen detected: {errorScreen}");
+        }
+        else
+        {
+            conn.GetField(new TerminalField { Index = 0 }, out string firstField);
+            Log($"First field: {firstField}");
+        }
+    }
+    finally
+    {
+        conn.Dispose();
+    }
+}
+```
+
+
+---
+
+### Connect to a Tandem/NonStop host via THLLAPI
+
+Use when automating a Tandem/NonStop session running through Attachmate Reflection 6530. The `EhllFunction` entry point for THLLAPI is `"thllapi"` (not `"hllapi"`). Color attribute data is not available for this provider.
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var connData = new ConnectionData
+    {
+        ProviderType = TerminalProviderType.TandemHLL,
+        ConnectionType = ConnectionType.LowLevel,
+        EhllDll = @"C:\Program Files\Attachmate\Reflection\THLLW6.DLL",
+        EhllFunction = "thllapi",
+        EhllSession = "A"
+    };
+
+    using var conn = terminal.GetConnection(connData);
+
+    conn.WaitScreenReady(new CommandOptions(WaitMode.READY, 15000));
+
+    // Type a command and submit with Horizontal Tab to move between fields
+    conn.SetField(new TerminalField { LabeledBy = "LOGON:" }, "myuser");
+    conn.SendControlKey(ControlKey.Tandem_Horizontal_Tab);
+    conn.SetField(new TerminalField { LabeledBy = "PASSWORD:" }, "mypassword");
+    conn.SendControlKey(ControlKey.Return);
+
+    conn.WaitScreenReady(new CommandOptions(WaitMode.READY, 15000));
+    conn.GetText(out string screen);
+    Log(screen);
+}
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/overview.md
@@ -1,0 +1,42 @@
+# Terminal Activities
+
+`UiPath.Terminal.Activities`
+
+Terminal emulation activities for automating interactions with IBM 3270/5250, VT, HP, and other legacy terminal systems. Supports BlueZone, IBM PCOMM, Attachmate, and direct TCP/SSH connections.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+- [Coded Workflow API Reference](coded/coded-api.md) — Service API for coded C# workflows
+
+## Activities
+
+### App Integration.Terminals
+
+| Activity | Description |
+|----------|-------------|
+| [Terminal Session](activities/TerminalSession.md) | Container scope that establishes and manages a terminal connection for all child activities. |
+| [Get Text](activities/GetText.md) | Reads the entire visible text content of the terminal screen. |
+| [Get Field](activities/GetField.md) | Reads the text of a specific input field, identified by label, index, or adjacent label. |
+| [Set Field](activities/SetField.md) | Writes text into a specific input field, identified by label, index, or adjacent label. |
+| [Get Cursor Position](activities/GetCursorPosition.md) | Returns the current row and column of the terminal cursor. |
+| [Send Control Key](activities/SendControlKey.md) | Sends a control key (Tab, F1–F24, Enter, etc.) to the terminal. |
+| [Wait Screen Text](activities/WaitScreenText.md) | Waits until a specified text string appears anywhere on the terminal screen. |
+| [Wait Field Text](activities/WaitFieldText.md) | Waits until a specific input field contains the expected text. |
+
+### App Integration.Terminals.Advanced
+
+| Activity | Description |
+|----------|-------------|
+| [Move Cursor](activities/MoveCursor.md) | Moves the terminal cursor to an exact row/column position. |
+| [Send Keys](activities/SendKeys.md) | Sends a raw text string or key sequence directly to the terminal. |
+| [Send Keys Secure](activities/SendKeysSecure.md) | Sends a `SecureString` (e.g., a password) to the terminal without exposing it as plain text. |
+| [Wait Screen Ready](activities/WaitScreenReady.md) | Waits until the terminal keyboard is unlocked and the screen is ready for input. |
+| [Get Screen Area](activities/GetScreenArea.md) | Reads the text from a rectangular region of the terminal screen defined by start and end coordinates. |
+| [Get Text at Position](activities/GetTextAtPosition.md) | Reads text starting at a specific row/column, optionally limited to a given length. |
+| [Get Field at Position](activities/GetFieldAtPosition.md) | Reads the content of the field that starts at the specified row/column position. |
+| [Get Color at Position](activities/GetColorAtPosition.md) | Returns the foreground color of the character at the specified row/column. |
+| [Set Field at Position](activities/SetFieldAtPosition.md) | Writes text into the field at a specific row/column position. |
+| [Wait Text at Position](activities/WaitTextAtPosition.md) | Waits until a specific row/column position contains the expected text. |
+| [Find Text](activities/FindText.md) | Searches the screen for a text string, starting from an optional position, and returns the coordinates where it was found. |
+| [Move Cursor to Text](activities/MoveCursorToText.md) | Searches the screen for a text string and moves the terminal cursor to the location where it was found. |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/Address.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/Address.md
@@ -1,0 +1,42 @@
+# Generate Address
+
+Generates a random postal address and returns it as a `Dictionary<String, String>`. The dictionary contains keys: `Country`, `City`, `State`, `StreetNumber`, `StreetName`, `PostalCode`.
+
+**Class:** `UiPath.Testing.Activities.TestData.Address`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `AddressResult` | `OutArgument<Dictionary<String, String>>` | A dictionary containing address fields. Supported keys: `Country`, `City`, `State`, `StreetNumber`, `StreetName`, `PostalCode`. |
+
+---
+
+## Notes
+
+- The `Country` and `City` filter inputs are available in the designer via dropdowns, but they are not directly configurable as XAML expression arguments (they use non-browsable dropdown widgets).
+- The activity generates random addresses from a built-in dataset. Data is not fetched from any external API.
+
+---
+
+## XAML Example
+
+```xml
+<utad:Address
+  DisplayName="Generate Address"
+  AddressResult="[addressDict]" />
+```
+
+After execution, access individual fields:
+```vb
+addressDict("City")        ' e.g. "Chicago"
+addressDict("PostalCode")  ' e.g. "60601"
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/AttachDocument.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/AttachDocument.md
@@ -1,0 +1,44 @@
+# Attach Document
+
+Attaches a file to the currently running Test Case in Orchestrator. The attached document becomes accessible in the test case's execution details in Orchestrator, useful for including screenshots, reports, or evidence files.
+
+**Class:** `UiPath.Testing.Activities.AttachDocument`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `FilePath` | `InArgument<String>` | Yes | The full path to the file to attach to the test case. |
+| `Tags` | `InArgument<IEnumerable<String>>` | No | Optional tags to associate with the attached document in Orchestrator. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `ContinueOnError` | `InArgument<Boolean>` | No | `false` | If `true`, execution continues when the activity throws an error. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Attach a file without tags -->
+<uta:AttachDocument
+  DisplayName="Attach Document"
+  FilePath="&quot;C:\Reports\TestReport.pdf&quot;"
+  ContinueOnError="False" />
+
+<!-- Attach a file with tags -->
+<uta:AttachDocument
+  DisplayName="Attach Evidence Screenshot"
+  FilePath="[screenshotPath]"
+  Tags="[New String() {&quot;evidence&quot;, &quot;screenshot&quot;}]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/BulkAddTestDataQueue.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/BulkAddTestDataQueue.md
@@ -1,0 +1,40 @@
+# Bulk Add Test Data Queue Items
+
+Adds multiple test data items to a Test Data Queue in Orchestrator from a `DataTable`. Each row in the DataTable becomes one queue item; column names must match the queue's field schema.
+
+**Class:** `UiPath.Testing.Activities.BulkAddTestDataQueue`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Test Data Queues
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `QueueName` | `InArgument<String>` | Yes | The name of the Test Data Queue to add items to. |
+| `QueueItemsDataTable` | `InArgument<DataTable>` | Yes | DataTable where each row becomes a queue item. Column headers must match the queue's field names. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `FolderPath` | `InArgument<String>` | No | `null` | Orchestrator folder path. If not set, uses the folder of the running process. |
+| `ContinueOnError` | `InArgument<Boolean>` | No | `false` | If `true`, execution continues when the activity throws an error. |
+| `TimeoutMs` | `InArgument<Int32>` | No | — | Timeout in milliseconds for the Orchestrator API call. |
+
+---
+
+## XAML Example
+
+```xml
+<uta:BulkAddTestDataQueue
+  DisplayName="Bulk Add Test Data Queue Items"
+  QueueName="&quot;MyTestQueue&quot;"
+  QueueItemsDataTable="[dtItems]"
+  ContinueOnError="False" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/ComparePdfDocuments.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/ComparePdfDocuments.md
@@ -1,0 +1,102 @@
+# Compare PDF Documents
+
+Compares two PDF documents (baseline vs. target) to determine their equivalence. Supports text comparison at line/word/character granularity, optional inclusion of images/widgets, and comparison rules to exclude dynamic sections. Optionally uses Autopilot AI to interpret differences semantically.
+
+**Class:** `UiPath.Testing.Activities.ComparePdfDocuments`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Verification
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `BaselinePath` | `InArgument<IResource>` | Yes | — | The baseline (reference) PDF document. Accepts a file path or resource reference. |
+| `TargetPath` | `InArgument<IResource>` | Yes | — | The target PDF to compare against the baseline. |
+| `ComparisonType` | `ComparisonType` | Yes* | — | Granularity of text comparison: `Line`, `Word`, or `Character`. *Hidden when `InterpretDifferencesWithAutopilot` is `true`. |
+| `InterpretDifferencesWithAutopilot` | `Boolean` | No | `false` | If `true`, uses Autopilot AI to semantically interpret differences. When enabled, `ComparisonType` is hidden and `SemanticDifferences` is populated. |
+| `ContinueOnFailure` | `InArgument<Boolean>` | No | `true` | If `true`, the workflow continues even when differences are found. |
+| `IgnoreIdenticalItems` | `InArgument<Boolean>` | No | `true` | If `true`, identical content (lines/items) is excluded from the diff output. |
+| `IncludeImages` | `InArgument<Boolean>` | No | `true` | If `true`, images and URI widgets are included in the comparison. |
+| `IgnoreImagesLocation` | `InArgument<Boolean>` | No | `false` | If `true`, the position and page of images/URI widgets are ignored (only their presence is compared). Only relevant when `IncludeImages` is `true`. |
+| `OutputFolderPath` | `InArgument<String>` | Yes | `"."` | Directory path where output diff files will be saved. |
+| `Rules` | `List<InArgument<ComparisonRule>>` | No | — | *(Legacy)* Individual comparison rules added via the designer. |
+| `RulesList` | `InArgument<List<ComparisonRule>>` | No | — | A list of `ComparisonRule` objects (from **Create Comparison Rule**) to exclude dynamic sections. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Result` | `OutArgument<Boolean>` | `true` if documents are equivalent, `false` if differences were found. |
+| `Differences` | `OutArgument<IEnumerable<Difference>>` | List of text differences. Each `Difference` has `Operation` (`Equal`, `Inserted`, `Deleted`) and `Text`. Populated when `InterpretDifferencesWithAutopilot` is `false`. |
+| `SemanticDifferences` | `OutArgument<SemanticDifferences>` | Semantic interpretation from Autopilot. Only populated when `InterpretDifferencesWithAutopilot` is `true`. |
+
+---
+
+## Valid Configurations
+
+**Standard comparison** (`InterpretDifferencesWithAutopilot = false`):
+- `ComparisonType` must be set to `Line`, `Word`, or `Character`.
+- `Differences` output is populated; `SemanticDifferences` is not.
+
+**Autopilot-interpreted comparison** (`InterpretDifferencesWithAutopilot = true`):
+- `ComparisonType` is hidden and ignored.
+- `SemanticDifferences` output is populated; `Differences` is not.
+
+These two modes are mutually exclusive.
+
+---
+
+## Enum: `ComparisonType`
+
+| Value | Description |
+|-------|-------------|
+| `Line` | Compares extracted text line by line. |
+| `Word` | Compares extracted text word by word. |
+| `Character` | Compares extracted text character by character. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Standard line-by-line PDF comparison -->
+<uta:ComparePdfDocuments
+  DisplayName="Compare PDF Documents"
+  BaselinePath="&quot;Baseline\invoice_baseline.pdf&quot;"
+  TargetPath="[generatedPdfPath]"
+  ComparisonType="Line"
+  ContinueOnFailure="True"
+  IgnoreIdenticalItems="True"
+  IncludeImages="True"
+  IgnoreImagesLocation="False"
+  OutputFolderPath="&quot;Output\PDFDiff&quot;"
+  Result="[pdfCompareResult]"
+  Differences="[pdfDiffs]" />
+
+<!-- With comparison rules to ignore dynamic content -->
+<uta:ComparePdfDocuments
+  DisplayName="Compare PDF with Rules"
+  BaselinePath="&quot;Baseline\report.pdf&quot;"
+  TargetPath="[reportPath]"
+  ComparisonType="Line"
+  RulesList="[New List(Of ComparisonRule) From {dateRule, idRule}]"
+  OutputFolderPath="&quot;Output\PDFDiff&quot;"
+  Result="[pdfResult]"
+  Differences="[pdfDiffs]" />
+
+<!-- Autopilot semantic interpretation -->
+<uta:ComparePdfDocuments
+  DisplayName="Compare PDF (Autopilot)"
+  BaselinePath="&quot;Baseline\doc.pdf&quot;"
+  TargetPath="[targetDoc]"
+  InterpretDifferencesWithAutopilot="True"
+  OutputFolderPath="&quot;Output\PDFDiff&quot;"
+  Result="[pdfResult]"
+  SemanticDifferences="[semanticResult]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/CompareText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/CompareText.md
@@ -1,0 +1,98 @@
+# Compare Text
+
+Compares two text strings (baseline vs. target) and returns whether they are equivalent, along with a list of differences. Supports line-by-line, word-by-word, or character-by-character comparison. Accepts comparison rules (created via **Create Comparison Rule**) to exclude dynamic sections. Optionally uses Autopilot AI to interpret differences semantically.
+
+**Class:** `UiPath.Testing.Activities.CompareText`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Verification
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `BaselineText` | `InArgument<String>` | Yes | — | The reference text (the expected / golden content). |
+| `TargetText` | `InArgument<String>` | Yes | — | The text to compare against the baseline (the actual content). |
+| `ComparisonType` | `ComparisonType` | Yes* | — | Granularity of comparison: `Line`, `Word`, or `Character`. *Hidden when `InterpretDifferencesWithAutopilot` is `true`. |
+| `InterpretDifferencesWithAutopilot` | `Boolean` | No | `false` | If `true`, uses Autopilot AI to semantically interpret differences. When enabled, `ComparisonType` is hidden and `SemanticDifferences` is populated instead of `Differences`. |
+| `ContinueOnFailure` | `InArgument<Boolean>` | No | `true` | If `true`, the workflow continues even if the comparison finds differences (test case is still marked failed). |
+| `Rules` | `List<InArgument<ComparisonRule>>` | No | — | *(Legacy)* Individual comparison rules added via the designer. |
+| `RulesList` | `InArgument<List<ComparisonRule>>` | No | — | A list of `ComparisonRule` objects (from **Create Comparison Rule**) to exclude dynamic sections. Prefer this over `Rules` when building rules programmatically. |
+| `WordSeparators` | `InArgument<String>` | No | `".,!?:\n "` | Characters treated as word separators. Only visible when `ComparisonType` is `Word`. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Result` | `OutArgument<Boolean>` | `true` if texts are equivalent (no differences), `false` if differences were found. |
+| `OutputFilePath` | `InArgument<String>` | Path where the HTML diff output file is saved. Default: `"differences.html"`. |
+| `Differences` | `OutArgument<IEnumerable<Difference>>` | List of differences. Each `Difference` has `Operation` (`Equal`, `Inserted`, `Deleted`) and `Text`. Populated when `InterpretDifferencesWithAutopilot` is `false`. |
+| `SemanticDifferences` | `OutArgument<SemanticDifferences>` | Semantic interpretation of differences from Autopilot. Only populated when `InterpretDifferencesWithAutopilot` is `true`. |
+
+---
+
+## Valid Configurations
+
+**Standard comparison** (`InterpretDifferencesWithAutopilot = false`):
+- Set `ComparisonType` to `Line`, `Word`, or `Character`.
+- `WordSeparators` is only available when `ComparisonType = Word`.
+- `Differences` output is populated; `SemanticDifferences` is not.
+
+**Autopilot-interpreted comparison** (`InterpretDifferencesWithAutopilot = true`):
+- `ComparisonType` is hidden and ignored.
+- `SemanticDifferences` output is populated; `Differences` is not.
+
+These two modes are mutually exclusive.
+
+---
+
+## Enum: `ComparisonType`
+
+| Value | Description |
+|-------|-------------|
+| `Line` | Compares text line by line. |
+| `Word` | Compares text word by word (uses `WordSeparators` to tokenize). |
+| `Character` | Compares text character by character. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Standard line-by-line comparison with a rule to ignore dates -->
+<uta:CompareText
+  DisplayName="Compare Invoice Text"
+  BaselineText="[baselineContent]"
+  TargetText="[actualContent]"
+  ComparisonType="Line"
+  ContinueOnFailure="True"
+  RulesList="[New List(Of ComparisonRule) From {dateRule}]"
+  OutputFilePath="&quot;Output\diff.html&quot;"
+  Result="[compareResult]"
+  Differences="[diffs]" />
+
+<!-- Word comparison with custom separators -->
+<uta:CompareText
+  DisplayName="Compare Text (Word)"
+  BaselineText="[baseline]"
+  TargetText="[target]"
+  ComparisonType="Word"
+  WordSeparators="&quot; ,.\n&quot;"
+  OutputFilePath="&quot;Output\diff.html&quot;"
+  Result="[compareResult]" />
+
+<!-- Autopilot semantic interpretation -->
+<uta:CompareText
+  DisplayName="Compare Text (Autopilot)"
+  BaselineText="[baseline]"
+  TargetText="[target]"
+  InterpretDifferencesWithAutopilot="True"
+  OutputFilePath="&quot;Output\diff.html&quot;"
+  Result="[compareResult]"
+  SemanticDifferences="[semanticResult]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/CreateComparisonRule.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/CreateComparisonRule.md
@@ -1,0 +1,83 @@
+# Create Comparison Rule
+
+Creates a `ComparisonRule` object that can be passed to **Compare Text** or **Compare PDF Documents** to exclude dynamic sections of text from comparison. Rules match patterns using either wildcard or regex syntax, replacing matched portions with a placeholder in the diff output.
+
+**Class:** `UiPath.Testing.Activities.CreateComparisonRule`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Verification
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `RuleName` | `InArgument<String>` | No | — | A name for the rule. Used as the placeholder text in diff output when `UsePlaceholder` is `true`. |
+| `ComparisonRuleType` | `ComparisonRuleType` | No | `RegexRule` | The matching technique: `RegexRule` or `WildcardRule`. See enum below. |
+| `Pattern` | `InArgument<String>` | No | — | The pattern to match in the text. Use regex syntax for `RegexRule`, glob-style wildcards (`*`, `?`) for `WildcardRule`. |
+| `UsePlaceholder` | `InArgument<Boolean>` | No | `true` | If `true`, matched text in the diff is replaced by `[RuleName]`. If `false`, matched text is simply omitted. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ComparisonRule` | `OutArgument<ComparisonRule>` | The created comparison rule object. Pass this to the `Rules` or `RulesList` property of **Compare Text** or **Compare PDF Documents**. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `ContinueOnError` | `InArgument<Boolean>` | No | `false` | If `true`, execution continues when the activity throws an error. |
+
+---
+
+## Enum: `ComparisonRuleType`
+
+| Value | Description |
+|-------|-------------|
+| `RegexRule` | Pattern is a regular expression. Matches any text that satisfies the regex. |
+| `WildcardRule` | Pattern uses glob-style wildcards (`*` matches any sequence of characters, `?` matches a single character). |
+
+---
+
+## Notes
+
+- Create rules before calling **Compare Text** or **Compare PDF Documents**.
+- Multiple rules can be collected into a list and passed to those activities' `RulesList` property.
+- Typical use cases: excluding dates, timestamps, IDs, and other dynamic content from document comparisons.
+
+---
+
+## XAML Example
+
+```xml
+<!-- Rule to ignore date patterns like "01/15/2024" -->
+<uta:CreateComparisonRule
+  DisplayName="Create Date Rule"
+  RuleName="&quot;DatePattern&quot;"
+  ComparisonRuleType="RegexRule"
+  Pattern="&quot;\d{2}/\d{2}/\d{4}&quot;"
+  UsePlaceholder="True"
+  ComparisonRule="[dateRule]"
+  ContinueOnError="False" />
+
+<!-- Rule to ignore any order ID starting with "ORD-" -->
+<uta:CreateComparisonRule
+  DisplayName="Create Order ID Rule"
+  RuleName="&quot;OrderID&quot;"
+  ComparisonRuleType="WildcardRule"
+  Pattern="&quot;ORD-*&quot;"
+  UsePlaceholder="True"
+  ComparisonRule="[orderIdRule]" />
+```
+
+Then pass rules to **Compare Text**:
+```xml
+<uta:CompareText
+  ...
+  RulesList="[New List(Of ComparisonRule) From {dateRule, orderIdRule}]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/DeleteTestDataQueueItems.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/DeleteTestDataQueueItems.md
@@ -1,0 +1,38 @@
+# Delete Test Data Queue Items
+
+Deletes the specified test data queue items from Orchestrator. Accepts a list of `TestDataQueueItem` objects, typically obtained from a prior **Get Test Data Queue Items** activity.
+
+**Class:** `UiPath.Testing.Activities.DeleteTestDataQueueItems`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Test Data Queues
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `TestDataQueueItems` | `InArgument<List<TestDataQueueItem>>` | Yes | The list of test data queue items to delete. Typically the `TestDataQueueItems` output of **Get Test Data Queue Items**. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `FolderPath` | `InArgument<String>` | No | `null` | Orchestrator folder path. If not set, uses the folder of the running process. |
+| `ContinueOnError` | `InArgument<Boolean>` | No | `false` | If `true`, execution continues when the activity throws an error. |
+| `TimeoutMs` | `InArgument<Int32>` | No | — | Timeout in milliseconds for the Orchestrator API call. |
+
+---
+
+## XAML Example
+
+```xml
+<uta:DeleteTestDataQueueItems
+  DisplayName="Delete Test Data Queue Items"
+  TestDataQueueItems="[itemsToDelete]"
+  ContinueOnError="False" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/GetTestDataQueueItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/GetTestDataQueueItem.md
@@ -1,0 +1,49 @@
+# Get Test Data Queue Item
+
+Retrieves the next available test data item from a Test Data Queue in Orchestrator and returns its fields as a `Dictionary<String, Object>`. Optionally marks the item as consumed to prevent other test cases from claiming it.
+
+**Class:** `UiPath.Testing.Activities.GetTestDataQueueItem`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Test Data Queues
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `QueueName` | `InArgument<String>` | Yes | — | The name of the Test Data Queue to consume an item from. |
+| `MarkConsumed` | `Boolean` | No | `true` | If `true`, the retrieved item is marked as consumed in Orchestrator so it is not returned again by subsequent calls. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Output` | `OutArgument<Dictionary<String, Object>>` | The retrieved queue item as a key-value dictionary. Keys are the field names defined in the queue schema; values are the field values cast to `Object`. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `FolderPath` | `InArgument<String>` | No | `null` | Orchestrator folder path. If not set, uses the folder of the running process. |
+| `ContinueOnError` | `InArgument<Boolean>` | No | `false` | If `true`, execution continues when the activity throws an error. |
+| `TimeoutMs` | `InArgument<Int32>` | No | — | Timeout in milliseconds for the Orchestrator API call. |
+
+---
+
+## XAML Example
+
+```xml
+<uta:GetTestDataQueueItem
+  DisplayName="Get Test Data Queue Item"
+  QueueName="&quot;MyTestQueue&quot;"
+  MarkConsumed="True"
+  Output="[itemData]"
+  ContinueOnError="False" />
+```
+
+> After execution, access individual field values via `itemData("FieldName")`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/GetTestDataQueueItems.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/GetTestDataQueueItems.md
@@ -1,0 +1,79 @@
+# Get Test Data Queue Items
+
+Retrieves all items (or a filtered/paginated subset) from a Test Data Queue in Orchestrator. Returns a list of `TestDataQueueItem` objects that can be iterated or passed to **Delete Test Data Queue Items**.
+
+**Class:** `UiPath.Testing.Activities.GetTestDataQueueItems`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Test Data Queues
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `QueueName` | `InArgument<String>` | Yes | The name of the Test Data Queue to retrieve items from. |
+
+## Options
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `TestDataQueueItemStatus` | `TestDataQueueItemStatus` | No | `All` | Filter items by consumption status. See enum values below. |
+| `IdFilter` | `InArgument<String>` | No | — | Filter items by a specific item ID. |
+
+## Pagination
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `Skip` | `InArgument<Int32?>` | No | — | Number of items to skip (offset). Used for paging through large queues. |
+| `Top` | `InArgument<Int32?>` | No | — | Maximum number of items to return. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `TestDataQueueItems` | `OutArgument<List<TestDataQueueItem>>` | The retrieved list of test data queue items. Each item contains its field data and metadata (ID, status, etc.). |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `FolderPath` | `InArgument<String>` | No | `null` | Orchestrator folder path. If not set, uses the folder of the running process. |
+| `ContinueOnError` | `InArgument<Boolean>` | No | `false` | If `true`, execution continues when the activity throws an error. |
+| `TimeoutMs` | `InArgument<Int32>` | No | — | Timeout in milliseconds for the Orchestrator API call. |
+
+---
+
+## Enum: `TestDataQueueItemStatus`
+
+| Value | Description |
+|-------|-------------|
+| `All` | Return all items regardless of consumption status. |
+| `OnlyConsumed` | Return only items that have been marked as consumed. |
+| `OnlyNotConsumed` | Return only items that have not yet been consumed. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Get all unconsumed items -->
+<uta:GetTestDataQueueItems
+  DisplayName="Get Test Data Queue Items"
+  QueueName="&quot;MyTestQueue&quot;"
+  TestDataQueueItemStatus="OnlyNotConsumed"
+  TestDataQueueItems="[queueItems]"
+  ContinueOnError="False" />
+
+<!-- Paginated: get first 50 items, skipping 0 -->
+<uta:GetTestDataQueueItems
+  DisplayName="Get Test Data Queue Items (Page 1)"
+  QueueName="&quot;MyTestQueue&quot;"
+  Top="[50]"
+  Skip="[0]"
+  TestDataQueueItems="[queueItems]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/GivenName.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/GivenName.md
@@ -1,0 +1,29 @@
+# Generate Given Name
+
+Generates a random first name (given name) from a built-in dataset. Useful for creating realistic test data without real personal information.
+
+**Class:** `UiPath.Testing.Activities.TestData.GivenName`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `GivenNameResult` | `OutArgument<String>` | A randomly selected first name. |
+
+---
+
+## XAML Example
+
+```xml
+<utad:GivenName
+  DisplayName="Generate Given Name"
+  GivenNameResult="[firstName]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/LastName.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/LastName.md
@@ -1,0 +1,29 @@
+# Generate Last Name
+
+Generates a random surname (last name / family name) from a built-in dataset. Useful for creating realistic test data without real personal information.
+
+**Class:** `UiPath.Testing.Activities.TestData.LastName`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `LastNameResult` | `OutArgument<String>` | A randomly selected last name. |
+
+---
+
+## XAML Example
+
+```xml
+<utad:LastName
+  DisplayName="Generate Last Name"
+  LastNameResult="[lastName]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/NewAddTestDataQueueItem.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/NewAddTestDataQueueItem.md
@@ -1,0 +1,41 @@
+# Add Test Data Queue Item
+
+Adds a single test data item to a Test Data Queue in Orchestrator. The item is defined as a key-value dictionary of field names to expression values (`ItemInformation`). Requires an Orchestrator instance.
+
+**Class:** `UiPath.Testing.Activities.NewAddTestDataQueueItem`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Test Data Queues
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `QueueName` | `InArgument<String>` | Yes | The name of the Test Data Queue to add the item to. |
+| `ItemInformation` | `Dictionary<String, InArgument>` | Yes | Key-value pairs representing the item fields and their values. Keys must match the queue's column schema. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `FolderPath` | `InArgument<String>` | No | `null` | Orchestrator folder path. If not set, uses the folder of the running process. |
+| `ContinueOnError` | `InArgument<Boolean>` | No | `false` | If `true`, execution continues when the activity throws an error. |
+| `TimeoutMs` | `InArgument<Int32>` | No | — | Timeout in milliseconds for the Orchestrator API call. |
+
+---
+
+## XAML Example
+
+```xml
+<uta:NewAddTestDataQueueItem
+  DisplayName="Add Test Data Queue Item"
+  QueueName="&quot;MyTestQueue&quot;"
+  ContinueOnError="False" />
+```
+
+> **Note:** `ItemInformation` is configured through the activity designer's key-value editor. In XAML it is represented as a child collection — use the designer to configure individual fields.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomDate.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomDate.md
@@ -1,0 +1,38 @@
+# Generate Random Date
+
+Generates a random `DateTime` value within a specified range. The lower bound (`MinDate`) is inclusive; the upper bound (`MaxDate`) is exclusive.
+
+**Class:** `UiPath.Testing.Activities.TestData.RandomDate`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `MinDate` | `InArgument<DateTime>` | Yes | The inclusive lower bound of the date range. |
+| `MaxDate` | `InArgument<DateTime>` | Yes | The exclusive upper bound of the date range. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Output` | `OutArgument<DateTime>` | The randomly generated date within `[MinDate, MaxDate)`. |
+
+---
+
+## XAML Example
+
+```xml
+<utad:RandomDate
+  DisplayName="Generate Random Date"
+  MinDate="[New DateTime(2020, 1, 1)]"
+  MaxDate="[New DateTime(2025, 1, 1)]"
+  Output="[randomDate]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomNumber.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomNumber.md
@@ -1,0 +1,49 @@
+# Generate Random Number
+
+Generates a random numeric value between an optional minimum and maximum, with an optional number of decimal places. Returns a `Decimal`.
+
+**Class:** `UiPath.Testing.Activities.TestData.RandomNumber`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `Min` | `InArgument<Int64>` | No | `0` | The minimum value (inclusive). Default is `0`. |
+| `Max` | `InArgument<Int64>` | No | `Int64.MaxValue` | The maximum value (exclusive). Default is `long.MaxValue`. |
+| `Decimals` | `InArgument<Int32>` | No | `0` | Number of decimal places in the result. Default is `0` (integer). |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Output` | `OutArgument<Decimal>` | The randomly generated number. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Integer between 1 and 100 -->
+<utad:RandomNumber
+  DisplayName="Generate Random Number"
+  Min="[1]"
+  Max="[100]"
+  Decimals="[0]"
+  Output="[randomNum]" />
+
+<!-- Float with 2 decimal places between 0 and 1 -->
+<utad:RandomNumber
+  DisplayName="Generate Random Float"
+  Min="[0]"
+  Max="[1]"
+  Decimals="[2]"
+  Output="[randomFloat]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomString.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomString.md
@@ -1,0 +1,57 @@
+# Generate Random String
+
+Generates a random string of a specified length and casing. Useful for creating unique identifiers, test inputs, or password-like strings.
+
+**Class:** `UiPath.Testing.Activities.TestData.RandomString`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `Length` | `InArgument<Int32>` | Yes | — | The number of characters in the generated string. |
+| `Case` | `Case` | Yes | `LowerCase` | The casing style of the generated string. See enum values below. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Output` | `OutArgument<String>` | The randomly generated string. |
+
+---
+
+## Enum: `Case`
+
+| Value | Description |
+|-------|-------------|
+| `LowerCase` | All characters are lowercase (e.g., `abcdef`). |
+| `UpperCase` | All characters are uppercase (e.g., `ABCDEF`). |
+| `CamelCase` | CamelCase style (first letter of each word capitalized). |
+| `Mixed` | Random mix of upper and lowercase characters. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- 8-character lowercase string -->
+<utad:RandomString
+  DisplayName="Generate Random String"
+  Length="[8]"
+  Case="LowerCase"
+  Output="[randomStr]" />
+
+<!-- 12-character mixed-case string -->
+<utad:RandomString
+  DisplayName="Generate Mixed String"
+  Length="[12]"
+  Case="Mixed"
+  Output="[randomStr]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomValue.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/RandomValue.md
@@ -1,0 +1,44 @@
+# Generate Random Value
+
+Picks a random line from a single-column `.txt` or `.csv` file and returns it as a string. The file can contain up to ~2 billion lines. Useful for selecting random test values from a predefined list (e.g., product codes, user IDs, test inputs).
+
+**Class:** `UiPath.Testing.Activities.TestData.RandomValue`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Data
+
+```xml
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `FilePath` | `InArgument<String>` | Yes | The absolute or relative path to the `.txt` or `.csv` file. The file must contain one value per line. |
+
+## Output
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Value` | `OutArgument<String>` | The string from the randomly selected line in the file. |
+
+---
+
+## Notes
+
+- The file must be a single-column text file (one entry per line).
+- Both `.txt` and `.csv` formats are supported.
+- The random selection is uniformly distributed across all lines.
+
+---
+
+## XAML Example
+
+```xml
+<utad:RandomValue
+  DisplayName="Generate Random Value"
+  FilePath="&quot;Data\TestValues.txt&quot;"
+  Value="[randomVal]" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/VerifyExpression.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/VerifyExpression.md
@@ -1,0 +1,61 @@
+# Verify Expression
+
+Evaluates a Boolean expression and asserts that it is `true`. If the expression evaluates to `false`, the test case is marked as failed. Optionally captures screenshots on pass or fail and writes a formatted result message to the test report.
+
+**Class:** `UiPath.Testing.Activities.VerifyExpression`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Verification
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `Expression` | `InArgument<Boolean>` | Yes | The Boolean expression to verify. The assertion passes when this evaluates to `true`. |
+
+## Messages
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `OutputMessageFormat` | `InArgument<String>` | No | *(project setting)* | Custom format string for the result message written to the test report. Supported placeholders: `{Expression}`, `{Result}`. Example: `"{Expression} has result {Result}"`. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `TakeScreenshotInCaseOfFailingAssertion` | `InArgument<Boolean>` | No | `false` | If `true`, takes a screenshot when the assertion fails. |
+| `TakeScreenshotInCaseOfSucceedingAssertion` | `InArgument<Boolean>` | No | `false` | If `true`, takes a screenshot when the assertion passes. |
+
+---
+
+## Project Settings
+
+The `OutputMessageFormat` default is configurable in UiPath Studio under **Project Settings**:
+
+| Property | Setting Key | Description |
+|----------|-------------|-------------|
+| `OutputMessageFormat` | `VerifyActivitiesOutputFormat` / `VerifyExpressionOutputFormat` | Default message format for all Verify Expression instances in the project. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Basic assertion -->
+<uta:VerifyExpression
+  DisplayName="Verify Expression"
+  Expression="[actualValue = expectedValue]"
+  TakeScreenshotInCaseOfFailingAssertion="True" />
+
+<!-- With custom message format -->
+<uta:VerifyExpression
+  DisplayName="Verify Login Succeeded"
+  Expression="[isLoggedIn]"
+  OutputMessageFormat="&quot;Login check: {Expression} → {Result}&quot;"
+  TakeScreenshotInCaseOfFailingAssertion="True" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/VerifyExpressionWithOperator.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/VerifyExpressionWithOperator.md
@@ -1,0 +1,86 @@
+# Verify Expression with Operator
+
+Compares two expressions using a specified operator and asserts the comparison is true. Supports equality, inequality, relational comparisons, string containment, and regex matching. If the assertion fails, the test case is marked as failed.
+
+**Class:** `UiPath.Testing.Activities.VerifyExpressionWithOperator`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Verification
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `FirstExpression` | `InArgument<Object>` | Yes | The left-hand side of the comparison (the actual value). |
+| `Operator` | `Comparison` | Yes | The operator used to compare the two expressions. See enum values below. |
+| `SecondExpression` | `InArgument<Object>` | Yes | The right-hand side of the comparison (the expected value). |
+
+## Messages
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `OutputMessageFormat` | `InArgument<String>` | No | *(project setting)* | Custom format string for the result message. Supported placeholders: `{LeftExpression}`, `{LeftExpressionText}`, `{RightExpression}`, `{RightExpressionText}`, `{Result}`, `{Operator}`. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `TakeScreenshotInCaseOfFailingAssertion` | `InArgument<Boolean>` | No | `false` | If `true`, takes a screenshot when the assertion fails. |
+| `TakeScreenshotInCaseOfSucceedingAssertion` | `InArgument<Boolean>` | No | `false` | If `true`, takes a screenshot when the assertion passes. |
+
+---
+
+## Enum: `Comparison`
+
+| Value | Symbol | Description |
+|-------|--------|-------------|
+| `Equality` | `=` | Asserts `FirstExpression = SecondExpression`. |
+| `Inequality` | `<>` | Asserts `FirstExpression <> SecondExpression`. |
+| `GreaterThan` | `>` | Asserts `FirstExpression > SecondExpression`. |
+| `GreaterThanOrEqual` | `>=` | Asserts `FirstExpression >= SecondExpression`. |
+| `LessThan` | `<` | Asserts `FirstExpression < SecondExpression`. |
+| `LessThanOrEqual` | `<=` | Asserts `FirstExpression <= SecondExpression`. |
+| `Contains` | `Contains` | Asserts that `FirstExpression` contains `SecondExpression` (string containment). |
+| `RegexMatch` | `Regex-Match` | Asserts that `FirstExpression` matches the regex pattern in `SecondExpression`. |
+
+---
+
+## Project Settings
+
+| Property | Setting Key | Description |
+|----------|-------------|-------------|
+| `OutputMessageFormat` | `VerifyActivitiesOutputFormat` / `VerifyExpressionWithOperatorOutputFormat` | Default message format for all instances in the project. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Assert actual equals expected -->
+<uta:VerifyExpressionWithOperator
+  DisplayName="Verify Order Total"
+  FirstExpression="[actualTotal]"
+  Operator="Equality"
+  SecondExpression="[expectedTotal]"
+  TakeScreenshotInCaseOfFailingAssertion="True" />
+
+<!-- Assert string contains substring -->
+<uta:VerifyExpressionWithOperator
+  DisplayName="Verify Error Message"
+  FirstExpression="[errorMessage]"
+  Operator="Contains"
+  SecondExpression="&quot;Invalid input&quot;"
+  TakeScreenshotInCaseOfFailingAssertion="True" />
+
+<!-- Assert value matches regex -->
+<uta:VerifyExpressionWithOperator
+  DisplayName="Verify Email Format"
+  FirstExpression="[email]"
+  Operator="RegexMatch"
+  SecondExpression="&quot;^[^@]+@[^@]+\.[^@]+$&quot;" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/VerifyRange.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/activities/VerifyRange.md
@@ -1,0 +1,75 @@
+# Verify Range
+
+Verifies that a value falls within (or outside) a specified range defined by a lower and upper limit. If the assertion fails, the test case is marked as failed.
+
+**Class:** `UiPath.Testing.Activities.VerifyRange`
+**Assembly:** `UiPath.Testing.Activities`
+**Category:** Testing > Verification
+
+```xml
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Input
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `Expression` | `InArgument<Object>` | Yes | The value to verify against the range. |
+| `LowerLimit` | `InArgument<Object>` | Yes | The lower bound of the range (inclusive). |
+| `UpperLimit` | `InArgument<Object>` | Yes | The upper bound of the range (inclusive). |
+| `VerificationType` | `VerificationType` | Yes | Whether to assert the value is `IsWithin` or `IsNotWithin` the range. |
+
+## Messages
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `OutputMessageFormat` | `InArgument<String>` | No | *(project setting)* | Custom format string for the result message. Supported placeholders: `{LeftExpression}`, `{LeftExpressionText}`, `{RightExpression}`, `{RightExpressionText}`, `{Result}`, `{Operator}`. |
+
+## Common
+
+| Property | Type | Required | Default | Description |
+|----------|------|----------|---------|-------------|
+| `TakeScreenshotInCaseOfFailingAssertion` | `InArgument<Boolean>` | No | `false` | If `true`, takes a screenshot when the assertion fails. |
+| `TakeScreenshotInCaseOfSucceedingAssertion` | `InArgument<Boolean>` | No | `false` | If `true`, takes a screenshot when the assertion passes. |
+
+---
+
+## Enum: `VerificationType`
+
+| Value | Description |
+|-------|-------------|
+| `IsWithin` | Asserts the expression is within `[LowerLimit, UpperLimit]` (inclusive on both ends). |
+| `IsNotWithin` | Asserts the expression is outside the range. |
+
+---
+
+## Project Settings
+
+| Property | Setting Key | Description |
+|----------|-------------|-------------|
+| `OutputMessageFormat` | `VerifyActivitiesOutputFormat` / `VerifyRangeOutputFormat` | Default message format for all Verify Range instances in the project. |
+
+---
+
+## XAML Example
+
+```xml
+<!-- Assert value is within range [1, 100] -->
+<uta:VerifyRange
+  DisplayName="Verify Score In Range"
+  Expression="[score]"
+  LowerLimit="[1]"
+  UpperLimit="[100]"
+  VerificationType="IsWithin"
+  TakeScreenshotInCaseOfFailingAssertion="True" />
+
+<!-- Assert value is outside range (not within [-10, 0]) -->
+<uta:VerifyRange
+  DisplayName="Verify Positive Balance"
+  Expression="[balance]"
+  LowerLimit="[-10]"
+  UpperLimit="[0]"
+  VerificationType="IsNotWithin" />
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Testing.Activities/25.10/overview.md
@@ -1,0 +1,81 @@
+# UiPath.Testing.Activities — Activity Reference
+
+Activities for test case authoring, test data generation, test data queue management, and assertion-based verification. Requires UiPath Studio v2020.4+ and Orchestrator v2020.4+ for queue-based activities.
+
+**Package ID:** `UiPath.Testing.Activities`
+**Platform:** Cross-platform (Windows & Linux)
+
+---
+
+## XML Namespace Declarations
+
+```xml
+<!-- Main activities (most activities) -->
+xmlns:uta="clr-namespace:UiPath.Testing.Activities;assembly=UiPath.Testing.Activities"
+
+<!-- Test data generation activities -->
+xmlns:utad="clr-namespace:UiPath.Testing.Activities.TestData;assembly=UiPath.Testing.Activities"
+```
+
+---
+
+## Test Data Queues
+
+Interact with Orchestrator Test Data Queues to supply parameterized test data to test cases.
+
+| Activity | Class | Description |
+|----------|-------|-------------|
+| [Add Test Data Queue Item](activities/NewAddTestDataQueueItem.md) | `NewAddTestDataQueueItem` | Adds a single item (key-value dictionary) to a Test Data Queue. |
+| [Bulk Add Test Data Queue Items](activities/BulkAddTestDataQueue.md) | `BulkAddTestDataQueue` | Adds multiple items from a DataTable to a Test Data Queue. |
+| [Delete Test Data Queue Items](activities/DeleteTestDataQueueItems.md) | `DeleteTestDataQueueItems` | Deletes a list of test data queue items from Orchestrator. |
+| [Get Test Data Queue Item](activities/GetTestDataQueueItem.md) | `GetTestDataQueueItem` | Retrieves and optionally consumes the next item from a queue. Returns `Dictionary<String, Object>`. |
+| [Get Test Data Queue Items](activities/GetTestDataQueueItems.md) | `GetTestDataQueueItems` | Retrieves all items (or a filtered/paginated subset) from a queue. Returns `List<TestDataQueueItem>`. |
+
+---
+
+## Test Data
+
+Generate synthetic test data and attach evidence to test cases.
+
+| Activity | Class | Description |
+|----------|-------|-------------|
+| [Generate Address](activities/Address.md) | `Address` | Generates a random postal address as `Dictionary<String, String>`. Keys: `Country`, `City`, `State`, `StreetNumber`, `StreetName`, `PostalCode`. |
+| [Generate Given Name](activities/GivenName.md) | `GivenName` | Generates a random first name. |
+| [Generate Last Name](activities/LastName.md) | `LastName` | Generates a random last name. |
+| [Generate Random Date](activities/RandomDate.md) | `RandomDate` | Generates a random `DateTime` within a specified range. |
+| [Generate Random Number](activities/RandomNumber.md) | `RandomNumber` | Generates a random `Decimal` number with optional min, max, and decimal places. |
+| [Generate Random String](activities/RandomString.md) | `RandomString` | Generates a random string of a specified length and casing (`LowerCase`, `UpperCase`, `CamelCase`, `Mixed`). |
+| [Generate Random Value](activities/RandomValue.md) | `RandomValue` | Picks a random line from a `.txt` or `.csv` file and returns it as a string. |
+| [Attach Document](activities/AttachDocument.md) | `AttachDocument` | Attaches a file to the current test case in Orchestrator. |
+
+---
+
+## Verification
+
+Assert values, compare expressions, and compare text or PDF documents in test case workflows.
+
+| Activity | Class | Description |
+|----------|-------|-------------|
+| [Verify Expression](activities/VerifyExpression.md) | `VerifyExpression` | Asserts a Boolean expression is `true`. Marks the test case as failed if not. |
+| [Verify Expression with Operator](activities/VerifyExpressionWithOperator.md) | `VerifyExpressionWithOperator` | Compares two values using an operator (`=`, `<>`, `>`, `>=`, `<`, `<=`, `Contains`, `Regex-Match`). |
+| [Verify Range](activities/VerifyRange.md) | `VerifyRange` | Asserts a value is within (or outside) a lower/upper bound range. |
+| [Create Comparison Rule](activities/CreateComparisonRule.md) | `CreateComparisonRule` | Creates a `ComparisonRule` (regex or wildcard) for excluding dynamic sections in text/PDF comparisons. |
+| [Compare Text](activities/CompareText.md) | `CompareText` | Compares two text strings at line/word/character granularity. Supports rules to exclude dynamic content and optional Autopilot semantic interpretation. |
+| [Compare PDF Documents](activities/ComparePdfDocuments.md) | `ComparePdfDocuments` | Compares two PDF files for text and image equivalence. Supports comparison rules and Autopilot semantic interpretation. |
+
+---
+
+## Key Types
+
+| Type | Description |
+|------|-------------|
+| `TestDataQueueItem` | Represents a single item in a Test Data Queue. Contains item ID, status, and field data. |
+| `ComparisonRule` | A rule (regex or wildcard) that excludes matched text from comparisons. Created by **Create Comparison Rule**. |
+| `Difference` | A single diff entry with `Operation` (`Equal`, `Inserted`, `Deleted`) and `Text`. |
+| `SemanticDifferences` | AI-interpreted semantic diff result from Autopilot. |
+| `Comparison` | Enum of comparison operators: `Equality`, `Inequality`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`, `Contains`, `RegexMatch`. |
+| `ComparisonType` | Enum of text comparison granularities: `Line`, `Word`, `Character`. |
+| `VerificationType` | Enum: `IsWithin`, `IsNotWithin` (for Verify Range). |
+| `TestDataQueueItemStatus` | Enum: `All`, `OnlyConsumed`, `OnlyNotConsumed` (for Get Test Data Queue Items filter). |
+| `Case` | Enum of string casing: `LowerCase`, `UpperCase`, `CamelCase`, `Mixed` (for Generate Random String). |
+| `ComparisonRuleType` | Enum: `RegexRule`, `WildcardRule` (for Create Comparison Rule). |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/DeserializeJson.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/DeserializeJson.md
@@ -1,0 +1,56 @@
+# Deserialize JSON
+
+`UiPath.Web.Activities.DeserializeJson<T>`
+
+Deserializes a JSON string to a .NET object of the specified type `T`. By default, deserializes to `JObject`.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** JSON
+
+## When to use
+
+Use when you need a typed object from a JSON string for downstream activities.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `JsonString` | JSON string | InArgument | `string` | Yes | | | The JSON string to deserialize |
+| `JsonSample` | JSON sample | Property | `string` | | | | Optional sample JSON used at design time for custom type inference when supported by Studio features |
+| `Settings` | Serializer settings | InArgument | `JsonDeserializationSettings` | | | | Custom deserialization settings |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `JsonObject` | JSON object | OutArgument | `T` | The deserialized object. Type depends on the generic parameter (default: `JObject`) |
+
+## XAML Examples
+
+Deserialize to `JObject` (default):
+
+```xml
+<web:DeserializeJson x:TypeArguments="jn:JObject"
+  DisplayName="Deserialize JSON"
+  JsonString="[jsonString]"
+  JsonObject="[jsonResult]" />
+```
+
+Deserialize to a custom type:
+
+```xml
+<web:DeserializeJson x:TypeArguments="local:MyDataClass"
+  DisplayName="Deserialize to MyDataClass"
+  JsonString="[jsonString]"
+  JsonObject="[myDataObject]" />
+```
+
+## Notes
+
+- The generic type parameter `T` determines the output type. When used in XAML, specify the type via `x:TypeArguments`.
+- `JsonSample` is a design-time helper and may be hidden when type-inference features are not available.
+- Uses Newtonsoft.Json internally. Custom settings can control date handling, null value handling, etc.
+- Fails if `JsonString` is empty or invalid JSON.
+- The output type is determined by the activity's generic type argument.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/DeserializeJsonArray.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/DeserializeJsonArray.md
@@ -1,0 +1,41 @@
+# Deserialize JSON Array
+
+`UiPath.Web.Activities.DeserializeJsonArray`
+
+Deserializes a JSON array string to a `JArray` object.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** JSON
+
+## When to use
+
+Use when the response is a JSON array and you need a `JArray` for iteration or querying.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `JsonString` | JSON string | InArgument | `string` | Yes | | | The JSON array string to deserialize |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `JsonArray` | JSON array | OutArgument | `JArray` | The deserialized JSON array |
+
+## XAML Example
+
+```xml
+<web:DeserializeJsonArray
+  DisplayName="Deserialize JSON Array"
+  JsonString="[jsonArrayString]"
+  JsonArray="[resultArray]" />
+```
+
+## Notes
+
+- Input must be a valid JSON array (starting with `[`). For JSON objects, use **Deserialize JSON** instead.
+- Individual elements can be accessed by index on the resulting `JArray` (e.g., `resultArray(0)`).
+- Fails if `JsonString` is empty or invalid JSON.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/DeserializeXml.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/DeserializeXml.md
@@ -1,0 +1,40 @@
+# Deserialize XML
+
+`UiPath.Web.Activities.DeserializeXml`
+
+Deserializes an XML string to an `XDocument` object.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** XML
+
+## When to use
+
+Use when you need an `XDocument` for XPath queries or node inspection.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `XMLString` | XML String | InArgument | `string` | Yes | | | The XML string to deserialize |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `XMLDocument` | XMLDocument | OutArgument | `XDocument` | The parsed XML document |
+
+## XAML Example
+
+```xml
+<web:DeserializeXml
+  DisplayName="Deserialize XML"
+  XMLString="[xmlString]"
+  XMLDocument="[xmlDoc]" />
+```
+
+## Notes
+
+- The output `XDocument` (from `System.Xml.Linq`) can be queried using LINQ to XML or passed to **Execute XPath** and **Get XML Nodes** activities.
+- Fails if `XMLString` is empty or invalid XML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/ExecuteXPath.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/ExecuteXPath.md
@@ -1,0 +1,65 @@
+# Execute XPath
+
+`UiPath.Web.Activities.ExecuteXPath`
+
+Evaluates an XPath expression against an XML document or string and returns the result.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** XML
+
+## When to use
+
+Use when you need to query or extract data from XML via XPath.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `XPathExpression` | XPath Expression | InArgument | `string` | Yes | | | The XPath expression to evaluate |
+| `ExistingXML` | Existing XML | InArgument | `XDocument` | Yes* | | | An existing XML document to query. *Required if `XMLString` is not set (OverloadGroup: ExistingXML) |
+| `XMLString` | XML String | InArgument | `string` | Yes* | | | An XML string to query. *Required if `ExistingXML` is not set (OverloadGroup: XMLString) |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `object` | The XPath evaluation result. Type depends on the expression (string, number, boolean, or node set) |
+
+## Valid Configurations
+
+Provide XML input in one of two ways (mutually exclusive):
+
+**Mode A — Existing XML Document**: Set `ExistingXML` to a pre-parsed `XDocument` (e.g., from Deserialize XML).
+
+**Mode B — XML String**: Set `XMLString` to a raw XML string. The activity parses it internally.
+
+## XAML Examples
+
+Query using an existing `XDocument`:
+
+```xml
+<web:ExecuteXPath
+  DisplayName="Execute XPath on Document"
+  ExistingXML="[xmlDoc]"
+  XPathExpression="[&quot;//book[@category='fiction']/title&quot;]"
+  Result="[xpathResult]" />
+```
+
+Query using a raw XML string:
+
+```xml
+<web:ExecuteXPath
+  DisplayName="Execute XPath on String"
+  XMLString="[xmlString]"
+  XPathExpression="[&quot;count(//item)&quot;]"
+  Result="[itemCount]" />
+```
+
+## Notes
+
+- `ExistingXML` and `XMLString` are mutually exclusive (`[OverloadGroup]`). Set only one.
+- The result type depends on the XPath expression: string expressions return `string`, `count()` returns a number, boolean expressions return `bool`, and node selections return node sets.
+- Provide either `ExistingXML` or `XMLString`.
+- Fails if the XML is invalid or the expression is invalid.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/GetXMLNodeAttributes.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/GetXMLNodeAttributes.md
@@ -1,0 +1,42 @@
+# Get XML Node Attributes
+
+`UiPath.Web.Activities.GetXMLNodeAttributes`
+
+Gets the attributes of an XML node.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** XML
+
+## When to use
+
+Use when you already have a node and need its attribute list.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ExistingXMLNode` | ExistingXMLNode | InArgument | `XNode` | Yes | | | The XML node to extract attributes from |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Attributes` | Attributes | OutArgument | `IEnumerable<XAttribute>` | The collection of attributes on the node |
+
+## XAML Example
+
+```xml
+<web:GetXMLNodeAttributes
+  DisplayName="Get Node Attributes"
+  ExistingXMLNode="[xmlNode]"
+  Attributes="[nodeAttributes]" />
+```
+
+## Notes
+
+- The input `XNode` is typically obtained from the **Get XML Nodes** activity or by navigating an `XDocument`.
+- Each `XAttribute` in the output has `Name` and `Value` properties.
+- If the node has no attributes, the output collection is empty.
+- Only elements have attributes; other node types return none.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/GetXMLNodes.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/GetXMLNodes.md
@@ -1,0 +1,61 @@
+# Get XML Nodes
+
+`UiPath.Web.Activities.GetNodes`
+
+Deserializes XML into a list of XML nodes.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** XML
+
+## When to use
+
+Use when you need to enumerate the top-level XML nodes.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `ExistingXML` | Existing XML | InArgument | `XDocument` | Yes* | | | An existing XML document. *Required if `XMLString` is not set (OverloadGroup: Existing XML Document) |
+| `XMLString` | XML String | InArgument | `string` | Yes* | | | An XML string. *Required if `ExistingXML` is not set (OverloadGroup: XML Text) |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `XMLNodes` | XMLNodes | OutArgument | `IEnumerable<XNode>` | The collection of XML nodes extracted from the document |
+
+## Valid Configurations
+
+Provide XML input in one of two ways (mutually exclusive):
+
+**Mode A — Existing XML Document**: Set `ExistingXML` to a pre-parsed `XDocument`.
+
+**Mode B — XML String**: Set `XMLString` to a raw XML string.
+
+## XAML Examples
+
+From an existing document:
+
+```xml
+<web:GetNodes
+  DisplayName="Get XML Nodes from Document"
+  ExistingXML="[xmlDoc]"
+  XMLNodes="[nodeList]" />
+```
+
+From a string:
+
+```xml
+<web:GetNodes
+  DisplayName="Get XML Nodes from String"
+  XMLString="[xmlString]"
+  XMLNodes="[nodeList]" />
+```
+
+## Notes
+
+- `ExistingXML` and `XMLString` are mutually exclusive (`[OverloadGroup]`). Set only one.
+- Output nodes can be iterated with a **For Each** activity and passed to **Get XML Node Attributes** or further XPath queries.
+- For element-only enumeration, use the activity that returns element nodes from `Root`.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/HttpClient.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/HttpClient.md
@@ -1,0 +1,126 @@
+# HTTP Request (legacy)
+
+`UiPath.Web.Activities.HttpClient`
+
+> **Legacy activity** — Retained for existing workflow compatibility only. For new workflows, use **HTTP Request** (`NetHttpRequest`) instead.
+
+Composes a request to an endpoint URL, executes it and returns the response in a string format, saving the resource if specified. It has authentication capabilities allowing communication with secured endpoints. This is the legacy HTTP request activity; prefer the newer "HTTP Request" (`NetHttpRequest`) for new workflows.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** Web
+**Platform:** Cross-platform
+
+## When to use
+
+Use only to understand or maintain existing workflows that already depend on this activity. For new workflows or migrations, use the modern **HTTP Request** (`NetHttpRequest`) activity.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `EndPoint` | Request URL | InArgument | `string` | Yes | | | The URL endpoint to send the request to. |
+| `Method` | Request method | Property | `Method` | | | | HTTP method (GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH, MERGE). |
+| `AcceptFormat` | Accept Format | Property | `AcceptHeaderType` | | | | The Accept header format for the response. |
+| `Body` | Body | InArgument | `string` | | | | The request body content. |
+
+### Authentication (conditional on AuthenticationType)
+
+| Name | Display Name | Kind | Type | Visible When | Description |
+|------|-------------|------|------|------------|-------------|
+| `AuthenticationType` | Authentication Type | Property | `AuthType` | Always | The authentication method to use. |
+| `Username` | Username | InArgument | `string` | AuthenticationType = SimpleHttp | Username for basic authentication. OverloadGroup: SimpleAuthentication. |
+| `Password` | Password | InArgument | `string` | AuthenticationType = SimpleHttp AND NOT using secure | Password for basic authentication. OverloadGroup: SimpleAuthentication. |
+| `SecurePassword` | Secure password | InArgument | `SecureString` | AuthenticationType = SimpleHttp AND using secure | Secure password for basic authentication. OverloadGroup: SimpleAuthentication. |
+| `ConsumerKey` | ConsumerKey | InArgument | `string` | AuthenticationType = OAuth1 | OAuth1 consumer key. OverloadGroup: OAuth1. |
+| `ConsumerSecret` | ConsumerSecret | InArgument | `string` | AuthenticationType = OAuth1 | OAuth1 consumer secret. OverloadGroup: OAuth1. |
+| `OAuth1Token` | OAuth1Token | InArgument | `string` | AuthenticationType = OAuth1 | OAuth1 token. OverloadGroup: OAuth1. |
+| `OAuth1TokenSecret` | OAuth1TokenSecret | InArgument | `string` | AuthenticationType = OAuth1 | OAuth1 token secret. OverloadGroup: OAuth1. |
+| `OAuth2Token` | OAuth2Token | InArgument | `string` | AuthenticationType = OAuth2 | OAuth2 bearer token. OverloadGroup: OAuth2. |
+| `ClientCertificate` | ClientCertificate | InArgument | `string` | AuthenticationType = ClientCertificate | Path to the client certificate file. |
+| `ClientCertificatePassword` | ClientCertificatePassword | InArgument | `string` | AuthenticationType = ClientCertificate AND NOT using secure | Password for the client certificate. |
+| `SecureClientCertificatePassword` | SecureClientCertificatePassword | InArgument | `SecureString` | AuthenticationType = ClientCertificate AND using secure | Secure password for the client certificate. |
+
+### Options
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `BodyFormat` | Body Format | Property | `string` | The content type of the request body (e.g., `application/json`). |
+| `ResourcePath` | Filename for response attachment | InArgument | `string` | Path to save the response body as a file. |
+| `EnableSSLVerification` | Enable SSL certificate verification | InArgument | `bool` | Default: `True`. When enabled, validates the server SSL certificate. |
+| `Headers` | Headers | Property | `Dictionary<string, InArgument<string>>` | Custom HTTP headers to include in the request. |
+| `Parameters` | Parameters | Property | `Dictionary<string, InArgument<string>>` | URL query parameters to append to the request URL. |
+| `Cookies` | Cookies | Property | `Dictionary<string, InArgument<string>>` | Cookies to include in the request. |
+| `Attachments` | Attachments | Property | `Dictionary<string, InArgument<string>>` | File attachments to include in the request. |
+| `FileAttachments` | File Attachments | InArgument | `ICollection<ILocalResource>` | File resources to attach to the request. |
+| `UrlSegments` | URL Segments | Property | `Dictionary<string, InArgument<string>>` | URL segment replacements for parameterized URLs. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Response content | OutArgument | `string` | The response body returned as a string. |
+| `StatusCode` | Response status | OutArgument | `int` | The HTTP status code of the response. |
+| `ResponseHeaders` | Headers | OutArgument | `Dictionary<string, string>` | The response headers returned by the server. |
+| `ResponseAttachment` | Response attachment | OutArgument | `ILocalResource` | The saved response file attachment when `ResourcePath` is specified. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `ContinueOnError` | Continue on error | InArgument | `bool` | When set to `True`, the workflow continues executing even if the activity throws an error. |
+| `TimeoutMS` | Timeout (milliseconds) | InArgument | `int` | The maximum time (in milliseconds) to wait for the request to complete. |
+
+## Valid Configurations
+
+The activity supports five authentication modes controlled by the `AuthenticationType` property:
+
+1. **None** -- No authentication is applied to the request.
+2. **SimpleHttp** -- Basic HTTP authentication using a username and password (or secure password). `Password` and `SecurePassword` are mutually exclusive.
+3. **OAuth1** -- OAuth 1.0 authentication requiring a consumer key, consumer secret, token, and token secret.
+4. **OAuth2** -- OAuth 2.0 bearer token authentication.
+5. **ClientCertificate** -- Client certificate authentication with an optional certificate password. `ClientCertificatePassword` and `SecureClientCertificatePassword` are mutually exclusive.
+
+## Enum Reference
+
+**`Method`**: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `MERGE`
+
+**`AcceptHeaderType`**: `ANY`, `JSON`, `XML`, `CUSTOM`
+
+**`AuthType`**: `None`, `SimpleHttp`, `OAuth1`, `OAuth2`, `ClientCertificate`
+
+## XAML Examples
+
+A simple GET request:
+
+```xml
+<web:HttpClient
+  DisplayName="GET API Data"
+  EndPoint="[&quot;https://api.example.com/data&quot;]"
+  Method="GET"
+  AcceptFormat="JSON"
+  Result="[responseContent]"
+  StatusCode="[responseStatus]" />
+```
+
+A POST request with basic authentication:
+
+```xml
+<web:HttpClient
+  DisplayName="POST with Basic Auth"
+  EndPoint="[&quot;https://api.example.com/items&quot;]"
+  Method="POST"
+  AcceptFormat="JSON"
+  Body="[jsonBody]"
+  BodyFormat="application/json"
+  AuthenticationType="SimpleHttp"
+  Username="[apiUser]"
+  Password="[apiPassword]"
+  Result="[responseContent]"
+  StatusCode="[responseStatus]" />
+```
+
+## Notes
+
+This is the legacy HTTP Request activity that uses RestSharp internally. For new workflows, prefer the newer **HTTP Request** (`NetHttpRequest`) activity.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/NetHttpRequest.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/NetHttpRequest.md
@@ -1,0 +1,558 @@
+# HTTP Request
+
+`UiPath.Web.Activities.Http.NetHttpRequest`
+
+Configures and sends an HTTP request with customizable options for headers, authentication, cookies, retries, SSL, and request body formats. Includes flexible retry mechanisms and graceful handling of errors, with optional continuation on failure.
+
+> This activity has extensive runtime logic. For full understanding of defaults, side-effects, retry mechanics, and edge cases, read the [Observable Behavior](#nethttprequest--observable-behavior) section at the bottom of this document.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** Web
+**Platform:** Cross-platform
+
+## When to use
+
+Use for HTTP calls that require retries, authentication, file downloads, or rich response inspection.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `RequestUrl` | Request URL | InArgument | `string` | Yes | | | The URL to send the HTTP request to. |
+| `Method` | Request method | Property | `HttpMethod` | No | `GET` | | The HTTP method to use. |
+| `RequestBodyType` | Request body type | Property | `HttpRequestBodyType` | No | `None` | | The type of request body to send. |
+
+### Authentication (conditional)
+
+Properties in this group appear based on the value of `AuthenticationType`.
+
+| Name | Display Name | Kind | Type | Visible When | Default | Description |
+|------|-------------|------|------|------------|---------|-------------|
+| `AuthenticationType` | Authentication | Property | `AuthenticationType` | Always | `None` | The authentication method to use. |
+| `BasicAuthUsername` | Username | InArgument | `string` | `AuthenticationType = BasicUsernamePassword` | | The username for basic authentication. |
+| `BasicAuthPassword` | Password | InArgument | `string` | `AuthenticationType = BasicUsernamePassword` AND not using secure password | | The password for basic authentication. |
+| `BasicAuthSecurePassword` | Secure password | InArgument | `SecureString` | `AuthenticationType = BasicUsernamePassword` AND using secure password | | The password for basic authentication, stored as a secure string. |
+| `OAuthToken` | Bearer token | InArgument | `string` | `AuthenticationType = OAuthToken` | | The OAuth2 bearer token. |
+| `UseOsNegotiatedAuthCredentials` | Use operating system credentials | InArgument | `bool` | `AuthenticationType = NegotiatedAuthentication` | `True` | Whether to use operating system credentials for negotiated authentication. |
+| `CustomNegotiatedAuthCredentials` | Custom credentials | InArgument | `NetworkCredential` | `AuthenticationType = NegotiatedAuthentication` AND not using OS credentials | | Custom network credentials for negotiated authentication. |
+
+### Request Body (conditional)
+
+Properties in this group appear based on the value of `RequestBodyType`.
+
+| Name | Display Name | Kind | Type | Visible When | Default | Description |
+|------|-------------|------|------|------------|---------|-------------|
+| `TextPayload` | JSON payload | InArgument | `string` | `RequestBodyType = Text` | | The text or JSON body content. |
+| `TextPayloadContentType` | Text content type | InArgument | `string` | `RequestBodyType = Text` | `"application/json"` | The content type header for text payloads. |
+| `TextPayloadEncoding` | Text encoding | InArgument | `string` | `RequestBodyType = Text` | `"UTF-8"` | The encoding for text payloads. |
+| `BinaryPayload` | Binary payload | InArgument | `byte[]` | `RequestBodyType = Binary` | | The binary content to send. |
+| `FilePath` | Local file | InArgument | `string` | `RequestBodyType = Stream` AND using local file | | Path to a local file to stream as the request body. |
+| `PathResource` | Resource file | InArgument | `IResource` | `RequestBodyType = Stream` AND not using local file | | Resource file to stream as the request body. |
+| `FormData` | Url-encoded form data | InArgument | `Dictionary<string, string>` | `RequestBodyType = FormUrlEncoded` | | Form URL-encoded key-value data. |
+| `FormDataParts` | Form data parts | InArgument | `IEnumerable<FormDataPart>` | `RequestBodyType = MultipartFormData` | | Multipart form data parts. |
+| `LocalFiles` | Local files | InArgument | `IEnumerable<string>` | `RequestBodyType = MultipartFormData` | | Local file paths for multipart upload. |
+| `ResourceFiles` | Resource files | InArgument | `IEnumerable<IResource>` | `RequestBodyType = MultipartFormData` | | Resource files for multipart upload. |
+
+### Retry Policy (conditional)
+
+Properties in this group appear based on the value of `RetryPolicyType`.
+
+| Name | Display Name | Kind | Type | Visible When | Default | Description |
+|------|-------------|------|------|------------|---------|-------------|
+| `RetryPolicyType` | Retry policy type | Property | `RetryPolicyType` | Always | `Basic` | The retry strategy to use. |
+| `RetryCount` | Retry count | InArgument | `int` | `RetryPolicyType = Basic` or `ExponentialBackoff` | `3` | Number of retry attempts. |
+| `InitialDelay` | Initial delay | InArgument | `int` | `RetryPolicyType = Basic` or `ExponentialBackoff` | `500` | Initial delay in milliseconds before the first retry. |
+| `PreferRetryAfterValue` | Use Retry-After header | InArgument | `bool` | `RetryPolicyType = Basic` or `ExponentialBackoff` | `True` | Whether to respect the server's Retry-After header value. |
+| `MaxRetryAfterDelay` | Delay limit | InArgument | `int` | `RetryPolicyType = Basic` or `ExponentialBackoff` | `30000` | Maximum delay in milliseconds when using the Retry-After header. |
+| `RetryStatusCodes` | Retry status codes | InArgument | `IEnumerable<HttpStatusCode>` | `RetryPolicyType = Basic` or `ExponentialBackoff` | | HTTP status codes that should trigger a retry. |
+| `Multiplier` | Multiplier | InArgument | `double` | `RetryPolicyType = ExponentialBackoff` | `2` | Exponential backoff multiplier applied to the delay between retries. |
+| `UseJitter` | Use jitter | InArgument | `bool` | `RetryPolicyType = ExponentialBackoff` | `True` | Whether to add randomization to the delay between retries. |
+
+### Request Options
+
+| Name | Display Name | Kind | Type | Default | Placeholder | Description |
+|------|-------------|------|------|---------|-------------|-------------|
+| `FollowRedirects` | Follow redirects | InArgument | `bool` | `True` | | Whether to automatically follow HTTP redirects. |
+| `MaxRedirects` | Max redirects | InArgument | `int` | `3` | | Maximum number of redirects to follow. Only visible when `FollowRedirects` is `True`. |
+| `TimeoutInMiliseconds` | Request timeout | InArgument | `int?` | `10000` | | Request timeout in milliseconds. |
+| `Headers` | Headers | InArgument | `Dictionary<string, string>` | | Click to open | Custom HTTP headers to include in the request. |
+| `Parameters` | Parameters | InArgument | `Dictionary<string, string>` | | Click to open | URL query parameters to append to the request URL. |
+| `Cookies` | Additional cookies | InArgument | `Dictionary<string, string>` | | | Extra cookies to send with the request. |
+
+### Client Options
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `DisableSslVerification` | Disable SSL verification | InArgument | `bool` | `False` | Whether to skip SSL certificate validation. |
+| `TlsProtocol` | TLS protocol | InArgument | `SupportedTlsProtocols` | `Automatic` | The TLS protocol version to use. |
+| `EnableCookies` | Enable cookies | InArgument | `bool` | `True` | Whether to enable cookie handling. |
+| `ClientCertPath` | Client certificate | InArgument | `string` | | Path to a client certificate file. |
+| `ClientCertPassword` | Client certificate password | InArgument | `string` | | Plain-string password for the client certificate (available via menu action). |
+| `ClientCertSecurePassword` | Client certificate secure password | InArgument | `SecureString` | | Secure password for the client certificate. |
+| `ProxySetting` | Proxy settings | Property | `ProxySettingType` | `None` | Proxy usage configuration. |
+| `ProxyConfiguration` | Proxy configuration | InArgument | `WebProxyConfiguration` | | Custom proxy configuration. Only visible when `ProxySetting = Custom`. |
+
+### Response Options
+
+| Name | Display Name | Kind | Type | Default | Placeholder | Description |
+|------|-------------|------|------|---------|-------------|-------------|
+| `SaveResponseAsFile` | Always save response as file | InArgument | `bool` | `False` | | Whether to save the response body to a file. |
+| `OutputFileTargetFolder` | Output file target folder | InArgument | `string` | | Current project folder | Target folder path for the saved response file. |
+| `OutputFileName` | Output file name | InArgument | `string` | | Content-Disposition file name | Custom filename for the saved response file. |
+| `FileOverwrite` | If the file already exists | Property | `FileOverwriteOption` | `AutoRename` | | Behavior when the output file already exists. |
+| `SaveRawRequestResponse` | Enable debugging info | InArgument | `bool` | `False` | | Whether to save raw request and response data for debugging. |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `HttpResponseSummary` | The full HTTP response summary. |
+
+**`HttpResponseSummary` properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `StatusCode` | `HttpStatusCode` | The HTTP status code of the response. |
+| `TextContent` | `string` | The response body as text. |
+| `BinaryContent` | `byte[]` | The response body as a byte array. |
+| `File` | `ILocalResource` | The downloaded file resource, if the response was saved to a file. |
+| `Headers` | `IEnumerable<KeyValuePair<string, string>>` | The response headers. |
+| `ContentHeaders` | `IEnumerable<KeyValuePair<string, string>>` | Content-specific response headers. |
+| `RawRequestDebuggingInfo` | `string` | Raw request debug information, available when `SaveRawRequestResponse` is enabled. |
+
+### Common
+
+| Name | Display Name | Kind | Type | Default | Description |
+|------|-------------|------|------|---------|-------------|
+| `ContinueOnError` | Continue on error | InArgument | `bool` | `True` | Whether to continue workflow execution when an HTTP error occurs. |
+
+## Valid Configurations
+
+The activity uses conditional property groups where certain properties only appear based on the value of a controlling property.
+
+### Request Body modes (`RequestBodyType`)
+
+- **None** -- No request body is sent.
+- **Text** -- Shows `TextPayload`, `TextPayloadContentType`, and `TextPayloadEncoding`.
+- **FormUrlEncoded** -- Shows `FormData` for URL-encoded key-value pairs.
+- **MultipartFormData** -- Shows `FormDataParts`, `LocalFiles`, and `ResourceFiles` for multipart uploads.
+- **Binary** -- Shows `BinaryPayload` for raw binary content.
+- **Stream** -- Shows either `FilePath` (local file) or `PathResource` (resource file) to stream.
+
+### Authentication modes (`AuthenticationType`)
+
+- **None** -- No authentication is applied.
+- **BasicUsernamePassword** -- Shows `BasicAuthUsername` and either `BasicAuthPassword` or `BasicAuthSecurePassword`.
+- **Client certificate password mode** -- For certificate auth, the password can be entered as either `ClientCertPassword` or `ClientCertSecurePassword` (menu toggle in the designer).
+- **OAuthToken** -- Shows `OAuthToken` for a bearer token.
+- **NegotiatedAuthentication** -- Shows `UseOsNegotiatedAuthCredentials` and optionally `CustomNegotiatedAuthCredentials`.
+
+### Retry Policy modes (`RetryPolicyType`)
+
+- **None** -- No retries are performed.
+- **Basic** -- Shows `RetryCount`, `InitialDelay`, `PreferRetryAfterValue`, `MaxRetryAfterDelay`, and `RetryStatusCodes`.
+- **ExponentialBackoff** -- Shows the same properties as Basic plus `Multiplier` and `UseJitter`.
+
+### Proxy modes (`ProxySetting`)
+
+- **None** -- No proxy is used.
+- **SystemDefault** -- Uses the system default proxy.
+- **Custom** -- Shows `ProxyConfiguration` for a custom proxy setup.
+
+### Redirect handling
+
+- When `FollowRedirects` is `True`, the `MaxRedirects` property becomes visible.
+
+## Enum Reference
+
+| Enum | Values |
+|------|--------|
+| `HttpMethod` | `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `TRACE` |
+| `HttpRequestBodyType` | `None`, `Text`, `FormUrlEncoded`, `MultipartFormData`, `Binary`, `Stream` |
+| `AuthenticationType` | `None`, `BasicUsernamePassword`, `OAuthToken`, `NegotiatedAuthentication` |
+| `RetryPolicyType` | `None`, `Basic`, `ExponentialBackoff` |
+| `FileOverwriteOption` | `AutoRename`, `Replace`, `Discard` |
+| `ProxySettingType` | `None`, `SystemDefault`, `Custom` |
+| `SupportedTlsProtocols` | `Automatic`, `Tls12`, `Tls13` |
+
+## XAML Examples
+
+### GET request with basic authentication and retry
+
+```xml
+<nhr:NetHttpRequest
+  DisplayName="GET API Data"
+  RequestUrl="[&quot;https://api.example.com/data&quot;]"
+  Method="GET"
+  RequestBodyType="None"
+  AuthenticationType="BasicUsernamePassword"
+  BasicAuthUsername="[apiUser]"
+  BasicAuthPassword="[apiPassword]"
+  RetryPolicyType="Basic"
+  RetryCount="[3]"
+  TimeoutInMiliseconds="[10000]"
+  Result="[httpResponse]" />
+```
+
+### POST request with JSON body and OAuth token
+
+```xml
+<nhr:NetHttpRequest
+  DisplayName="POST JSON Data"
+  RequestUrl="[&quot;https://api.example.com/items&quot;]"
+  Method="POST"
+  RequestBodyType="Text"
+  TextPayload="[jsonPayload]"
+  TextPayloadContentType="[&quot;application/json&quot;]"
+  AuthenticationType="OAuthToken"
+  OAuthToken="[bearerToken]"
+  Result="[httpResponse]" />
+```
+
+## Notes
+
+- Cookies can persist across activity calls within the same workflow execution.
+- Only one of `TextContent`, `BinaryContent`, or `File` is meaningfully populated per response.
+
+## Use with other activities
+
+### Preparing inputs
+
+- Use **Serialize JSON** to convert a .NET object to a JSON string before assigning it to `TextPayload` (when `RequestBodyType = Text`).
+- Use **Serialize JSON** with custom `JsonSerializationSettings` for non-default serialization (date format, null handling, etc.) before sending.
+
+### Processing outputs
+
+- Use `StatusCode` to guard downstream parsing (for example, only deserialize on success codes you expect).
+- When `TextContent` contains JSON, use **Deserialize JSON** or **Deserialize JSON Array** to parse it before further processing.
+- When `TextContent` contains XML, use **Deserialize XML** followed by **Execute XPath**, **Get XML Nodes**, or **Get XML Node Attributes**.
+- When `File` is populated, treat it as the response payload for downstream file-based activities instead of using `TextContent` or `BinaryContent`.
+- Use `Headers` and `ContentHeaders` to capture server metadata needed for follow-up requests.
+
+---
+
+# NetHttpRequest — Observable Behavior
+
+This section describes **what it does**. Focus: side-effects, shared state, defaults, edge cases, and the output contract.
+
+## Runtime execution flow (high level)
+
+At runtime, request processing follows this sequence:
+
+1. Validate input values (including endpoint constraints).
+2. Normalize URL (adds `http://` when scheme is missing).
+3. Append query parameters to the URL.
+4. Create `HttpClient` using transport config, late-bound config, and timeout.
+5. Create `HttpRequestMessage` with method + final URL.
+6. Apply activity metadata.
+7. Apply cookies through the shared cookie manager.
+8. Resolve text encoding.
+9. Build request body from the selected body type.
+10. Add request headers (applied after body build, so explicit headers can override defaults such as `Content-Type`).
+11. Send request with `ResponseHeadersRead` and cancellation token.
+12. Build `HttpResponseSummary` using response options.
+
+Important implications:
+- URL normalization and parameter appending happen before length validation and send.
+- Header application happens after body construction.
+- Cancellation token is propagated through body preparation, send, and response processing.
+
+## Defaults
+
+See [Parameter Configuration Guide](#parameter-configuration-guide) for full details on how each property interacts with others and when to set it.
+
+| Property | Default | Notes |
+| --- | --- | --- |
+| Method | `GET` | |
+| EnableCookies | `true` | Cookies persist across calls (see below) |
+| TimeoutInMiliseconds | 10 000 ms | |
+| ContinueOnError | `true` | Network errors become 503 responses |
+| FollowRedirects | `true` | |
+| MaxRedirects | 3 | Only used when `FollowRedirects = true` |
+| RetryPolicyType | `Basic` | Constant-delay retries enabled by default |
+| RetryCount | 3 | Total attempts, not additional retries |
+| InitialDelay | 500 ms | |
+| Multiplier | 2.0 | Only used with `ExponentialBackoff` policy |
+| UseJitter | `true` | Adds 0–99 ms random noise per retry |
+| PreferRetryAfterValue | `true` | Honors server `Retry-After` header |
+| MaxRetryAfterDelay | 30 000 ms | Cap on server-suggested delay |
+| TextPayloadEncoding | UTF-8 | |
+| TextPayloadContentType | application/json | |
+| FileOverwrite | AutoRename | |
+| SaveResponseAsFile | `false` | |
+| SaveRawRequestResponse | `false` | |
+| URL scheme when omitted | `http://` | **Not** https |
+
+## Side-Effects and Shared State
+
+### Cookie Persistence (Workflow-Scoped)
+
+A **single cookie jar** is shared across every NetHttpRequest call in the same workflow execution.
+
+Observable effects:
+- Server-set cookies (`Set-Cookie` headers) from one call are automatically sent on subsequent calls to the same domain.
+- User-supplied cookies (`Cookies` property) are added to the same jar and accumulate — they are **never cleared**.
+- Even if a later call sets `EnableCookies = false`, the jar still holds cookies from earlier calls. The `false` flag only prevents the jar from being *read* for that specific request.
+
+When this matters:
+- Login flows: a first call authenticates, subsequent calls automatically carry the session cookie.
+- Browser-like cookie reuse: cookies set for `api.example.com` are sent on future calls to the same host, even from different parts of the workflow.
+
+### Connection Pooling (Automatic, Transparent)
+
+Requests with **identical transport settings** (SSL config, proxy, cookies, redirects, client cert, negotiated auth) share the same connection pool.
+
+Observable effects:
+- Subsequent requests to the same host reuse TCP connections (faster).
+- Idle connections close after ~30 seconds.
+- Connections recycle after ~5 minutes (picks up DNS changes).
+- Max 100 concurrent connections per server.
+
+When this matters:
+- High-throughput loops benefit automatically — no configuration needed.
+- Changing any transport setting (e.g., toggling `DisableSslVerification`) creates a separate pool; connections are not shared across pools.
+
+### File System Writes
+
+When a response is saved to disk (either `SaveResponseAsFile = true` or the response is detected as a file-type like image/pdf/etc.):
+
+- Files are written atomically: content streams to a temp file first, then moved to the final path. No partial files on failure.
+- `FileOverwrite` modes:
+  - **AutoRename** — appends ` 1`, ` 2`, etc. if the file already exists.
+  - **Replace** — deletes existing file, then writes.
+  - **Discard** — throws `IOException` immediately if file exists (before downloading the body).
+- Default target folder: `Environment.CurrentDirectory` if none specified.
+- Filename resolution order: user-supplied `OutputFileName` → server `Content-Disposition` header → auto-generated `downloaded_file_<GUID>`.
+
+### Automatic Decompression
+
+gzip, deflate, and brotli responses are **always** transparently decompressed. `TextContent` and `BinaryContent` contain the decompressed data. The `Content-Length` header in `ContentHeaders` may still reflect the compressed size.
+
+## Retry Behavior
+
+Retries are **enabled by default** (`Basic` policy, 3 attempts, 500 ms delay).
+
+### What triggers a retry
+
+- **Network failure** (`HttpRequestException`) — connection refused, DNS failure, etc.
+- **Retryable status code** — by default: `408`, `429`, `500`, `502`, `503`, `504`. Customizable via `RetryStatusCodes`.
+- Any other status code (e.g., `400`, `401`, `404`) does **not** trigger a retry — the response is returned immediately.
+
+### Retry policies
+
+| Policy | Delay pattern |
+| --- | --- |
+| `None` | No retries |
+| `Basic` | Same delay every time (`InitialDelay`) |
+| `ExponentialBackoff` | `delay = delay × Multiplier` each attempt, plus optional jitter (0–99 ms) |
+
+### Retry-After header
+
+When `PreferRetryAfterValue = true` (default) and the server sends a `Retry-After` header:
+- The server's suggested delay is used instead of the policy delay.
+- It is capped at `MaxRetryAfterDelay` (default 30 s).
+- For `ExponentialBackoff`: the server delay replaces the *wait* but the internal multiplier still progresses — so the next fallback delay is still doubled from where it was, not reset.
+
+### Exhausted retries
+
+If all attempts fail:
+- With `ContinueOnError = true` → a synthetic **503** response is returned.
+- With `ContinueOnError = false` → the last `HttpRequestException` propagates.
+
+## ContinueOnError Behavior
+
+When `ContinueOnError = true` (the default):
+
+| Error type | Caught? | Result |
+| --- | --- | --- |
+| Network failure (`HttpRequestException`) | Yes (on every attempt) | Each attempt is converted to a synthetic 503 response; the exception message is placed in `TextContent`. Retry handlers then decide whether to retry based on the 503 status code. |
+| Timeout (`TaskCanceledException`) | **No** | Exception propagates to the caller |
+| Validation error (null URL, etc.) | **No** | Exception propagates to the caller |
+| Response body read failure | **No** | Exception propagates to the caller |
+
+**Key gotcha:** Timeouts are **not** caught. A request that times out will throw even with `ContinueOnError = true`.
+
+Interaction with retries:
+- **With `ContinueOnError = true`**: `HttpRequestException` is caught by the `ContinueOnError` handler on **each** attempt and converted into a synthetic 503. The retry handlers see the 503 responses and retry based on status code (503 is retryable by default). After all retries are exhausted, the final 503 response is returned to the workflow.
+- **With `ContinueOnError = false`**: `HttpRequestException` is not converted to 503. It flows directly into the retry handlers, which may retry based on the exception according to the retry policy. If all retries are exhausted, the last `HttpRequestException` is propagated to the workflow.
+
+## Authentication
+
+| `AuthenticationType` | What happens |
+| --- | --- |
+| `None` | No auth header set. |
+| `BasicUsernamePassword` | `Authorization: Basic <base64(user:pass)>` added to every request. Use `BasicAuthUsername` with either `BasicAuthPassword` (string) or `BasicAuthSecurePassword` (secure string). Throws if username or password is empty. |
+| `OAuthToken` | `Authorization: Bearer <token>` added. Throws if token is empty. |
+| `NegotiatedAuthentication` | Windows/Kerberos negotiation at the connection level. Set `UseOsNegotiatedAuthCredentials = true` to use current Windows credentials. If `false`, provide `CustomNegotiatedAuthCredentials` (a `NetworkCredential` instance). |
+
+Auth headers are set **per request** — they are not cached or shared.
+
+## URL Handling
+
+- If the URL has no scheme (`example.com/api`), `http://` is prepended — **not** `https://`.
+- Query parameters from the `Parameters` dictionary are URI-escaped and appended.
+- Existing query strings in the URL are preserved; parameters are appended with `&`.
+- Final URL must be ≤ 2000 characters.
+
+## Request Body
+
+| `RequestBodyType` | What's sent | Content-Type set to |
+| --- | --- | --- |
+| `None` | No body | — |
+| `Text` | `StringContent` with the specified encoding | `TextPayloadContentType` (default `application/json`) |
+| `FormUrlEncoded` | Key-value pairs from `FormData` dictionary | `application/x-www-form-urlencoded` |
+| `MultipartFormData` | Files (`LocalFiles`, `ResourceFiles`) + fields (`FormData`, `FormDataParts`) | `multipart/form-data` (boundary auto-generated) |
+| `Binary` | Raw bytes from `BinaryPayload` | `application/octet-stream` |
+| `Stream` | File streamed from `FilePath` or `PathResource` | Auto-detected from file (see below) |
+
+A user-supplied `Content-Type` header in `Headers` overrides the auto-generated one when a body is present.
+
+### Which properties are used per body type
+
+| `RequestBodyType` | Required properties | Ignored properties |
+| --- | --- | --- |
+| `Text` | `TextPayload`, `TextPayloadContentType`, `TextPayloadEncoding` | `FormData`, `BinaryPayload`, `LocalFiles`, `ResourceFiles`, `FilePath`, `PathResource`, `FormDataParts` |
+| `FormUrlEncoded` | `FormData` | `TextPayload`, `BinaryPayload`, `LocalFiles`, `ResourceFiles`, `FilePath`, `PathResource`, `FormDataParts` |
+| `MultipartFormData` | At least one of: `FormData`, `LocalFiles`, `ResourceFiles`, `FormDataParts` | `TextPayload`, `BinaryPayload`, `FilePath`, `PathResource` |
+| `Binary` | `BinaryPayload` | Everything else |
+| `Stream` | `FilePath` **or** `PathResource` (not both) | Everything else |
+
+## Response Body Classification
+
+The activity decides how to populate the output based on the response:
+
+| Server response | Output field populated |
+| --- | --- |
+| Text content type (JSON, XML, text/*) | `TextContent` |
+| File-like (image/*, video/*, audio/*, attachment, most application/*) | `File` (saved to disk) |
+| Other binary | `BinaryContent` |
+| HEAD request or empty body | All empty, `StatusCode` reflects the actual status |
+| Null/no response (network error with ContinueOnError) | `StatusCode = 503`, error message in `TextContent` |
+
+Setting `SaveResponseAsFile = true` forces any response to be saved as a file regardless of content type.
+
+## Validation (Pre-Flight)
+
+These checks run before any network call:
+
+- `RequestUrl` must not be null or whitespace.
+- `MaxRedirects` ≥ 0.
+- `RetryCount` ≥ 0.
+- `InitialDelay` ≥ 0.
+- `MaxRetryAfterDelay` ≥ 0.
+- `Timeout` ≥ 0 (if set).
+
+Failures throw `ArgumentException` / `ArgumentOutOfRangeException` immediately.
+
+## Redirects
+
+- `FollowRedirects = true` (default): the activity follows up to `MaxRedirects` (default 3) HTTP redirects automatically.
+- `FollowRedirects = false`: redirect responses (3xx) are returned as-is.
+- Redirects are handled at the transport level — the `Authorization` header may be stripped by the underlying handler on cross-origin redirects (standard .NET behavior).
+
+## Debug Output
+
+When `SaveRawRequestResponse = true`, `RawRequestDebuggingInfo` contains a structured text dump designed for **machine consumption**. An agent can parse this output to understand what happened at runtime and make quick adjustments to request parameters (change headers, fix auth, tune retry, adjust timeout) without re-running a full test cycle.
+
+Sections in the output:
+
+- **Timing** — start UTC, end UTC, elapsed ms.
+- **Redirect** — whether a redirect occurred, initial vs. final URI.
+- **Transport** — SSL protocol, cookie mode, redirect config, proxy settings, client certificate path, auth type.
+- **Retry history** — for each attempt: status code, delay waited, whether `Retry-After` was honored (and the raw vs. clamped value), exception if any, start/end timestamps.
+- **Request headers** — all headers sent. `Authorization` and `Proxy-Authorization` values are **redacted** (scheme shown, value replaced with `***redacted***`).
+- **Request body preview** — content type, size, and text preview truncated at 2000 characters. Multipart requests list each part with its name, type, and size.
+- **Response headers** — all response + content headers.
+- **Response options** — file save settings, actual saved path and file size.
+- **Response body preview** — text truncated at 2000 chars; binary shows length only; file responses are not previewed.
+
+Use this output to:
+- Confirm which `Authorization` scheme was sent (even though the value is redacted, the scheme — `Basic`, `Bearer`, `Negotiate` — is visible).
+- See exact retry timing and whether the server's `Retry-After` was used.
+- Detect redirect chains and verify the final URL.
+- Inspect the actual `Content-Type` sent and received.
+- Verify file save path and size for download responses.
+
+If the debug assembly itself fails, the field contains an error message rather than crashing the activity.
+
+## Content Type and File Extension Detection
+
+### On requests (outbound)
+
+When the body type is `Stream` or `MultipartFormData`, the activity auto-detects the `Content-Type` for each file:
+
+1. **`IResource` files** (from `PathResource` or `ResourceFiles`) — the resource's own `MimeType` property is used if present. If `null`, falls back to step 2.
+2. **Local files** (from `FilePath` or `LocalFiles`) — the file extension is looked up in a built-in map. Recognized extensions include: `.jpg`, `.png`, `.gif`, `.pdf`, `.json`, `.xml`, `.csv`, `.zip`, `.mp4`, `.docx`, `.xlsx`, `.pptx`, and ~30 more. Unknown extensions default to `application/octet-stream`.
+3. **User override** — a `Content-Type` header in `Headers` overrides the auto-detected value for the main body (but not individual multipart parts).
+
+### On responses (inbound)
+
+The response `Content-Type` header drives two decisions:
+
+**Body classification** — determines which output field is populated:
+- **Text** if: `text/*`, `application/json`, `application/xml`, or any `application/*+json` / `application/*+xml` pattern, plus additional types like `application/javascript`, `application/yaml`, `application/sql`, `application/graphql`, `application/toml`, `application/markdown`.
+- **File** if: `Content-Disposition` has a filename or is `attachment`/`inline`, or content type is `image/*`, `video/*`, `audio/*`, or an `application/*` type that is not JSON/XML/form-urlencoded/octet-stream.
+- **Bytes** — everything else (including `application/octet-stream` without a filename).
+
+**Auto-generated file extension** — when saving to disk and no filename is available from the server:
+- Text responses get a mapped extension (e.g., `application/json` → `.json`, `text/html` → `.html`). Unknown text types get `.tmp`.
+- File/stream responses get a reverse-mapped extension from the content type (e.g., `image/png` → `.png`). Unknown types get `.tmp`.
+- Binary responses always get `.bin`.
+
+## Parameter Configuration Guide
+
+This section explains how to correctly configure each group of properties. Properties interact with each other — setting one may require or invalidate others. See [Defaults](#defaults) for the default value of each property.
+
+### Basic Input
+
+| Property | Type | How to use |
+| --- | --- | --- |
+| `Method` | Enum | `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `TRACE` |
+| `RequestUrl` | String | **Required.** Full URL or just host+path (scheme defaults to `http://`). Always set `https://` explicitly for secure APIs. |
+| `Parameters` | Dictionary | Query string key-value pairs. URI-escaped automatically. Appended to existing query strings. |
+| `Headers` | Dictionary | Request headers. Empty keys/values are silently skipped. `Content-Type` has special handling — see Request Body. |
+
+### Request Body
+
+Set `RequestBodyType` first — it determines which other properties are used.
+
+| If `RequestBodyType` is… | Then set… | And leave empty… |
+| --- | --- | --- |
+| `None` | Nothing else | All body properties |
+| `Text` | `TextPayload` (required), `TextPayloadContentType`, `TextPayloadEncoding` | `FormData`, `BinaryPayload`, file properties |
+| `FormUrlEncoded` | `FormData` (required) | `TextPayload`, `BinaryPayload`, file properties |
+| `MultipartFormData` | Any combination of: `FormData` (string fields), `LocalFiles` / `ResourceFiles` (file uploads), `FormDataParts` (typed parts with per-part content types and encoding) | `TextPayload`, `BinaryPayload`, `FilePath`, `PathResource` |
+| `Binary` | `BinaryPayload` (required) | Everything else |
+| `Stream` | `FilePath` **or** `PathResource` (one required, not both) | Everything else |
+
+Notes:
+- `TextPayloadContentType` defaults to `application/json`. Change it for XML (`application/xml`), plain text (`text/plain`), etc.
+- `TextPayloadEncoding` defaults to `UTF-8`. Override for legacy encodings.
+- `FormDataParts` allows typed parts (`TextFormDataPart`, `BinaryFormDataPart`, `FileFormDataPart`) with per-part content types and encoding. Parts marked `IsExample = true` are skipped at runtime.
+- For `Stream`, the `Content-Type` is auto-detected from the file extension (or `IResource.MimeType`). Override with a `Content-Type` header if needed.
+
+### Client Options (Transport)
+
+These affect the **connection pool** — changing any of these creates a separate pool (different connections than requests with different settings).
+
+| Property | How to use |
+| --- | --- |
+| `DisableSslVerification` | Set `true` only for testing against self-signed certs. **Never in production.** |
+| `TlsProtocol` | Leave as `Automatic` unless the server requires a specific version. `Tls13` requires server support. |
+| `EnableCookies` | `true` = cookies persist in shared jar. `false` = cookies sent via manual header only. |
+| `ProxySetting` | `None` = direct connection. `SystemDefault` = OS proxy. `Custom` = requires `ProxyConfiguration`. |
+| `ProxyConfiguration` | Only used when `ProxySetting = Custom`. Set `Address`, optionally `BypassOnLocal`, `BypassList`, `ProxyCredentials`. When switching away from `Custom`, clear this. |
+| `ClientCertPath` | Path to `.pfx`/`.p12` file, or a certificate subject name to find in the Windows Root store. |
+| `ClientCertPassword` / `ClientCertSecurePassword` | Password for the client certificate. Use one or the other, not both. Prefer `SecureString`. |
+
+### Proxy Configuration
+
+Use `ProxySetting` to choose how the request resolves proxy settings:
+
+- `SystemDefault`: Uses the operating system proxy configuration (WinINET). This matches browser behavior, including PAC scripts and system-level bypass lists.
+- `None`: Bypasses proxies entirely.
+- `Custom`: Uses the provided `ProxyConfiguration` object. Set the proxy `Address`, optional `BypassOnLocal`/`BypassList`, and `ProxyCredentials` when required.
+
+Switching proxy modes changes the underlying connection pool. If you move from `Custom` to `SystemDefault` or `None`, clear `ProxyConfiguration` to avoid confusion.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/SerializeJson.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/activities/SerializeJson.md
@@ -1,0 +1,42 @@
+# Serialize JSON
+
+`UiPath.Web.Activities.JSON.SerializeJson`
+
+Serializes the given object to a JSON string, optionally using custom serializer settings.
+
+**Package:** `UiPath.WebAPI.Activities`
+**Category:** JSON
+
+## When to use
+
+Use when you need to send or store JSON derived from an object.
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Placeholder | Description |
+|------|-------------|------|------|----------|---------|-------------|-------------|
+| `InputObject` | Input object | InArgument | `object` | Yes | | | The object to serialize to JSON |
+| `Settings` | Serializer settings | InArgument | `JsonSerializationSettings` | | | | Custom serialization settings (date format, null handling, etc.) |
+
+### Output
+
+| Name | Display Name | Kind | Type | Description |
+|------|-------------|------|------|-------------|
+| `Result` | Result | OutArgument | `string` | The serialized JSON string |
+
+## XAML Example
+
+```xml
+<json:SerializeJson
+  DisplayName="Serialize Object to JSON"
+  InputObject="[myObject]"
+  Result="[jsonString]" />
+```
+
+## Notes
+
+- Uses Newtonsoft.Json internally. Accepts any .NET object including `DataTable`, `JObject`, `Dictionary`, custom types, etc.
+- Custom `JsonSerializationSettings` can control indentation, null value handling, date formatting, and other serialization behaviors.
+- Fails if `InputObject` is null.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/coded-api.md
@@ -1,0 +1,809 @@
+# UiPath.Web.Activities - Coded Workflow API
+
+`UiPath.WebAPI.Activities`
+
+HTTP automation APIs for coded workflows, including request execution, convenience verb methods, payload helpers, multipart upload, and file transfer support.
+
+**Service accessor:** `http` (type `IHttpService`)  
+**Service accessor:** `soap` (type `ISoapService`)  
+**Service accessor:** `curl` (type `ICurlImportService`)  
+**Required package:** `"UiPath.WebAPI.Activities": "[2.5.0,)"` in project.json dependencies
+
+## Auto-Imported Namespaces
+
+These namespaces are automatically available in coded workflows when this package is installed:
+
+```csharp
+System
+System.Collections.Generic
+System.Net
+UiPath.Web.Activities.API
+UiPath.Web.Activities.API.Models
+UiPath.Web.Activities.Http.Models
+```
+
+## Agent Capabilities
+
+This package exposes three core services for HTTP/SOAP automation in coded workflows. Agents can invoke workflows based on the following scenario:
+
+### **Core Services**
+
+| Service | Type | Access | Capability |
+|---------|------|--------|-----------|
+| `http` | `IHttpService` | `http` service accessor | Send HTTP requests (GET/POST/PUT/DELETE/PATCH/etc.) with advanced options: authentication, retries, file upload/download, multipart forms, timeout, redirects. Returns `HttpResponseSummary` with response inspection helpers. |
+| `soap` | `ISoapService` | `soap` service accessor | Invoke SOAP operations via WSDL metadata. Requires endpoint, contract, method, and parameters. Returns `HttpResponseSummary` with XML content in `TextContent`. |
+| `curl` | `ICurlImportService` | `curl` service accessor | Parse raw cURL commands into structured `HttpRequestOptions`. Handles bash/cmd styles, auto-detects shell escaping, produces actionable warnings. |
+
+### **Agent Workflow Triggers**
+
+| User Intent | Agent Workflow | Entry Point |
+|---|---|---|
+| "Convert this cURL command" | cURL import + optional reconfiguration | [curl-import.md](curl-import.md) skill — parse cURL, handle warnings, execute with `http.SendRequestAsync()` |
+| "Call this URL but I don't know what it is" | Service discovery + auto-detection | [service-discovery.md](service-discovery.md) skill — probe for REST/SOAP, parse interface docs (OpenAPI/WSDL), map user goal, generate DTOs, iterate to success |
+| "Migrate from the old HTTP activity" | Legacy activity translation + verification | [http-request-upgrade.md](http-request-upgrade.md) skill — 5-phase capture→translate→compare workflow with safety gates |
+| "Send an HTTP GET/POST/etc. with auth, retry, file handling" | Direct API usage | Use `http.SendRequestAsync(HttpRequestOptions)` or convenience verb methods (`GetAsync`, `PostJsonAsync`, `PostMultipartAsync`, `DownloadFileAsync`, `UploadFileAsync`) |
+| "Parse/deserialize JSON response" | Native .NET methods | `Newtonsoft.Json.JsonConvert.DeserializeObject<T>(response.TextContent)` or `JsonConvert.DeserializeObject` + JArray.Parse for arrays |
+| "Parse/evaluate XML response or XPath" | Native .NET LINQ to XML | `System.Xml.Linq.XDocument.Parse(response.TextContent)` + `XElement`, `XPathEvaluate`, `Descendants`, etc. |
+
+### **Common Patterns**
+
+- **Request inspection:** Use `response.GetStatusCodeNumber()`, `response.IsSuccessStatusCode()`, `response.GetHeader(name)`, `response.GetMediaType()` to inspect responses without manual header parsing.
+- **Error handling:** Set `ContinueOnError = true` in options to get synthetic 503 responses instead of exceptions; inspect `response.TextContent` for error details.
+- **File operations:** Use `DownloadFileAsync(url, targetFolder, fileName)` or `UploadFileAsync(url, filePath)` for file transfer; `PostMultipartAsync(url, parts)` for multipart form uploads.
+- **Retries & timeout:** Configure `RetryPolicy` (Basic, ExponentialBackoff, None) and `TimeoutMilliseconds` in `HttpRequestOptions`.
+- **Authentication:** Use `.WithBasicAuth(user, pass)`, `.WithBearerToken(token)`, or set custom `Headers["Authorization"]` for other schemes.
+
+---
+
+## Skills & Related Workflows
+
+This API reference covers direct programmatic use of `IHttpService`, `ISoapService`, and `ICurlImportService`. For common workflows, refer to these companion agent skills:
+
+| Skill | Use case | Key workflow |
+|-------|----------|--------------|
+| [curl-import.md](curl-import.md) | Convert raw cURL commands to `HttpRequestOptions` | **Deterministic parsing + warning-driven reconfiguration.** Import a cURL, inspect warnings, adjust if needed, execute. Best for cURL → coded workflow conversion. |
+| [service-discovery.md](service-discovery.md) | Discover unknown service endpoints (REST/SOAP) and generate working requests | **Progressive probing + spec parsing + iterative execution.** Given a URL, auto-detect service type, parse interface docs (OpenAPI/WSDL), map user intent to operations, generate DTOs, and iterate until success. Best for green-field integration. |
+| [http-request-upgrade.md](http-request-upgrade.md) | Migrate from legacy `HttpClient` activity to modern `NetHttpRequest` in coded workflows | **High-risk 5-phase refactor with checkpoint gates.** Capture legacy baseline, translate inputs, compare outputs in test environment, verify downstream logic. One activity at a time with learnings carryover. |
+
+---
+
+## Service Overview
+
+The `http` service follows a direct-method API pattern. You can either:
+- Call convenience methods like `GetAsync`, `PostJsonAsync`, and `PostMultipartAsync`
+- Use `SendRequestAsync` with a fully configured `HttpRequestOptions` object for advanced control
+
+All methods return `Task<HttpResponseSummary>`, which contains status information, response content metadata, and diagnostic context for the request.
+
+The same package also exposes:
+- `soap` (`ISoapService`) for SOAP requests through `CallAsync(SoapRequestOptions options, CancellationToken cancellationToken = default)`
+- `curl` (`ICurlImportService`) for cURL-to-options conversion through `Import(string rawCurl, CurlImportOptions options = null)`
+
+## Response Extensions Quick Reference
+
+Use `HttpResponseSummaryExtensions` to inspect common response characteristics and metadata.
+
+| Extension method | Purpose |
+|------------------|---------|
+| `IsSuccessStatusCode()` | Returns `true` for 2xx responses. |
+| `IsClientError()` | Returns `true` for 4xx responses. |
+| `IsServerError()` | Returns `true` for 5xx responses. |
+| `IsRedirect()` | Returns `true` for 3xx responses. |
+| `GetStatusCodeNumber()` | Returns the numeric status code (for example, `200`, `404`). |
+| `GetHeader(string name)` | Returns the first matching response or content header value (case-insensitive). |
+| `GetContentType()` | Returns the full `Content-Type` value, if present. |
+| `GetMediaType()` | Returns the media type portion of `Content-Type` (for example, `application/json`). |
+| `GetCharset()` | Returns the charset from `Content-Type` when available. |
+
+For detailed runtime behavior, defaults, and cross-property interactions, see the NetHttpRequest activity reference documentation.
+
+## Core
+
+### `SendRequestAsync(HttpRequestOptions options, CancellationToken cancellationToken = default)`
+
+Sends an HTTP request with the specified options.
+
+**Parameters:**
+- `options` (`HttpRequestOptions`) - The HTTP request options.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result that contains the HTTP response summary for the executed request.
+
+## Basic Verbs (No Body)
+
+### `GetAsync(string url, CancellationToken cancellationToken = default)`
+
+Sends an HTTP GET request to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the GET operation.
+
+### `HeadAsync(string url, CancellationToken cancellationToken = default)`
+
+Sends an HTTP HEAD request to the specified URL to check resource availability without downloading the body.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing headers and status summary for the HEAD operation.
+
+### `DeleteAsync(string url, CancellationToken cancellationToken = default)`
+
+Sends an HTTP DELETE request to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the DELETE operation.
+
+### `OptionsAsync(string url, CancellationToken cancellationToken = default)`
+
+Sends an HTTP OPTIONS request to the specified URL to retrieve communication options.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing allowed methods and response summary for the OPTIONS operation.
+
+### `TraceAsync(string url, CancellationToken cancellationToken = default)`
+
+Sends an HTTP TRACE request to the specified URL for diagnostic purposes.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing diagnostic trace response information.
+
+## JSON Operations
+
+### `PostJsonAsync(string url, string jsonContent, CancellationToken cancellationToken = default)`
+
+Sends an HTTP POST request with a JSON body to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `jsonContent` (`string`) - The JSON string to send as the request body.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the JSON POST operation.
+
+### `PutJsonAsync(string url, string jsonContent, CancellationToken cancellationToken = default)`
+
+Sends an HTTP PUT request with a JSON body to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `jsonContent` (`string`) - The JSON string to send as the request body.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the JSON PUT operation.
+
+### `PatchJsonAsync(string url, string jsonContent, CancellationToken cancellationToken = default)`
+
+Sends an HTTP PATCH request with a JSON body to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `jsonContent` (`string`) - The JSON string to send as the request body.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the JSON PATCH operation.
+
+## Form Operations
+
+### `PostFormAsync(string url, Dictionary<string, string> formData, CancellationToken cancellationToken = default)`
+
+Sends an HTTP POST request with form-urlencoded data to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `formData` (`Dictionary<string, string>`) - The form data key-value pairs to send.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the form POST operation.
+
+### `PutFormAsync(string url, Dictionary<string, string> formData, CancellationToken cancellationToken = default)`
+
+Sends an HTTP PUT request with form-urlencoded data to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `formData` (`Dictionary<string, string>`) - The form data key-value pairs to send.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the form PUT operation.
+
+### `PatchFormAsync(string url, Dictionary<string, string> formData, CancellationToken cancellationToken = default)`
+
+Sends an HTTP PATCH request with form-urlencoded data to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `formData` (`Dictionary<string, string>`) - The form data key-value pairs to send.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the form PATCH operation.
+
+## Binary Operations
+
+### `PostBinaryAsync(string url, byte[] binaryContent, string contentType = null, CancellationToken cancellationToken = default)`
+
+Sends an HTTP POST request with binary content to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `binaryContent` (`byte[]`) - The binary data to send as the request body.
+- `contentType` (`string`) - The media type of the binary content. (default: `null`)
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the binary POST operation.
+
+### `PutBinaryAsync(string url, byte[] binaryContent, string contentType = null, CancellationToken cancellationToken = default)`
+
+Sends an HTTP PUT request with binary content to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `binaryContent` (`byte[]`) - The binary data to send as the request body.
+- `contentType` (`string`) - The media type of the binary content. (default: `null`)
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the binary PUT operation.
+
+### `PatchBinaryAsync(string url, byte[] binaryContent, string contentType = null, CancellationToken cancellationToken = default)`
+
+Sends an HTTP PATCH request with binary content to the specified URL.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `binaryContent` (`byte[]`) - The binary data to send as the request body.
+- `contentType` (`string`) - The media type of the binary content. (default: `null`)
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for the binary PATCH operation.
+
+## File Operations
+
+### `DownloadFileAsync(string url, string targetFolder, string fileName = null, CancellationToken cancellationToken = default)`
+
+Sends an HTTP GET request and saves the response to a file.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `targetFolder` (`string`) - The folder where the file will be saved.
+- `fileName` (`string`) - The output file name; if omitted, it is derived from the response. (default: `null`)
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing file transfer and response summary information.
+
+### `UploadFileAsync(string url, string filePath, CancellationToken cancellationToken = default)`
+
+Sends an HTTP POST request with a file streamed as the request body to the specified URL. For multipart/form-data uploads, use `PostMultipartAsync`.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `filePath` (`string`) - The local path of the file to upload.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for streamed file upload.
+
+### `PostMultipartAsync(string url, IEnumerable<FormDataPart> parts, CancellationToken cancellationToken = default)`
+
+Sends an HTTP POST request with multipart/form-data content to the specified URL. Supports mixed content including text fields, binary data, and file uploads in a single request.
+
+**Parameters:**
+- `url` (`string`) - The request URL.
+- `parts` (`IEnumerable<FormDataPart>`) - Multipart form-data parts (text, file, and/or binary parts).
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing the response summary for multipart uploads.
+
+## SOAP Service API
+
+### `CallAsync(SoapRequestOptions options, CancellationToken cancellationToken = default)`
+
+Invokes a SOAP operation using WSDL metadata and request options. The service resolves endpoint metadata, builds the SOAP envelope, and executes the request.
+
+**Parameters:**
+- `options` (`SoapRequestOptions`) - SOAP invocation configuration, including endpoint, contract, method, and parameter values.
+- `cancellationToken` (`CancellationToken`) - Token to cancel the asynchronous operation. (default: `default`)
+
+**Returns:** `Task<HttpResponseSummary>` - Asynchronous result containing status, headers, and SOAP response details.
+
+**Working with the result:**
+- `response.TextContent` holds the raw SOAP envelope (XML). Use `XDocument.Parse(response.TextContent)` then `Descendants(...)` or `XPathEvaluate` to extract payload fields, including namespace-qualified elements via `XNamespace`.
+- A SOAP Fault can be embedded inside an HTTP 200 response. Always check for a `<Fault>` element when `IsSuccessStatusCode()` returns `true`.
+- Use `HttpResponseSummaryExtensions` (`IsSuccessStatusCode()`, `IsClientError()`, `IsServerError()`, `GetHeader()`, `GetMediaType()`, `GetCharset()`) to inspect the HTTP transport layer without manual header parsing.
+
+## cURL Import API
+
+### `Import(string rawCurl, CurlImportOptions options = null)`
+
+Imports a raw cURL command and converts it to structured `HttpRequestOptions` that can be executed with `http.SendRequestAsync`.
+
+**Parameters:**
+- `rawCurl` (`string`) - Raw cURL command text.
+- `options` (`CurlImportOptions`) - Import behavior flags controlling mapping and normalization. (default: `null`)
+
+**Returns:** `CurlImportResult` - Parsed request options plus warnings generated during command interpretation.
+
+### `CurlImportResult` output model
+
+Represents the output returned by `curl.Import`.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `Options` | `HttpRequestOptions` | Parsed request options; `null` when import fails. |
+| `Warnings` | `IReadOnlyList<CurlImportWarning>` | Warnings and errors from parsing/normalization. |
+| `Raw` | `string` | Original cURL command text. |
+
+---
+
+## Options & Configuration Classes
+
+### `HttpRequestOptions`
+
+Options for configuring an HTTP request in coded workflows.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Method` | `HttpMethod` | `HttpMethod.GET` | HTTP method (GET, POST, PUT, DELETE, etc.). |
+| `Url` | `string` | `null` | Request URL. |
+| `Parameters` | `Dictionary<string, string>` | `null` | URL query parameters. |
+| `Headers` | `Dictionary<string, string>` | `null` | HTTP headers. |
+| `TimeoutMilliseconds` | `int` | `10_000` | Request timeout in milliseconds. |
+| `ContinueOnError` | `bool` | `false` | Continue execution when request fails. |
+| `FollowRedirects` | `bool` | `true` | Whether redirects are followed automatically. |
+| `MaxRedirects` | `int` | `3` | Maximum redirects to follow. |
+| `Authentication` | `AuthenticationOptions` | `null` | Authentication configuration. |
+| `Body` | `RequestBodyOptions` | `null` | Request body configuration. |
+| `RetryPolicy` | `RetryPolicyOptions` | `new RetryPolicyOptions()` | Retry policy configuration. |
+| `Client` | `ClientOptions` | `new ClientOptions()` | HTTP client configuration options. |
+| `ResponseOptions` | `ResponseOptions` | `new ResponseOptions()` | Response handling options. |
+| `Cookies` | `Dictionary<string, string>` | `null` | Cookies sent with the request. |
+
+### `SoapRequestOptions`
+
+Options for configuring SOAP requests in coded workflows.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `EndPoint` | `string` | `null` | WSDL endpoint URL. |
+| `ContractName` | `string` | `null` | WSDL contract (port type) name. |
+| `Method` | `string` | `null` | SOAP operation name to invoke. |
+| `Parameters` | `Dictionary<string, object>` | `null` | SOAP operation parameter name/value pairs. |
+| `Username` | `string` | `null` | Username for Basic authentication. |
+| `Password` | `string` | `null` | Password for Basic authentication. |
+| `SecurePassword` | `SecureString` | `null` | Secure password for Basic authentication. |
+| `UseWindowsCredentials` | `bool` | `false` | Use OS-level Negotiate/NTLM credentials. |
+| `ClientCertificatePath` | `string` | `null` | Path to client certificate file. |
+| `ClientCertificatePassword` | `string` | `null` | Password for the client certificate. |
+| `ClientCertificateSecurePassword` | `SecureString` | `null` | Secure password for the client certificate. |
+| `ContinueOnError` | `bool` | `false` | Continue workflow execution on SOAP errors. |
+
+### `CurlImportOptions`
+
+Options for controlling how raw cURL commands are translated into `HttpRequestOptions`.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `MapFileBodyToStream` | `bool` | `true` | Map file-based body content to stream/file-path form when possible. |
+| `InferJsonForTextPayload` | `bool` | `true` | Infer JSON content type for text payloads when applicable. |
+| `StripAuthorizationHeaderOnAuthMapping` | `bool` | `true` | Remove Authorization header if auth is mapped into typed authentication fields. |
+
+---
+
+## Enum Reference
+
+The following enums from `UiPath.Web.Activities.Http.Models` are used by the coded API options classes.
+
+### `HttpMethod`
+
+Used by `HttpRequestOptions.Method`.
+
+| Value | Description |
+|-------|-------------|
+| `GET` | HTTP GET method. |
+| `POST` | HTTP POST method. |
+| `PUT` | HTTP PUT method. |
+| `DELETE` | HTTP DELETE method. |
+| `HEAD` | HTTP HEAD method. |
+| `OPTIONS` | HTTP OPTIONS method. |
+| `PATCH` | HTTP PATCH method. |
+| `TRACE` | HTTP TRACE method. |
+
+### `AuthenticationType`
+
+Used by `AuthenticationOptions.Type`.
+
+| Value | Description |
+|-------|-------------|
+| `None` | No authentication. |
+| `BasicUsernamePassword` | Basic authentication with username and password. |
+| `OAuthToken` | OAuth bearer token authentication. |
+| `NegotiatedAuthentication` | OS-level Negotiate/NTLM authentication. |
+
+### `HttpRequestBodyType`
+
+Used by `RequestBodyOptions.Type`.
+
+| Value | Description |
+|-------|-------------|
+| `None` | No request body. |
+| `Text` | Text body (JSON, XML, plain text, etc.). |
+| `FormUrlEncoded` | URL-encoded form body. |
+| `MultipartFormData` | Multipart form data body. |
+| `Binary` | Binary body content. |
+| `Stream` | Streamed body content. |
+
+### `RetryPolicyType`
+
+Used by `RetryPolicyOptions.Type`.
+
+| Value | Description |
+|-------|-------------|
+| `None` | No retry policy. |
+| `Basic` | Fixed-interval retry. |
+| `ExponentialBackoff` | Exponential backoff retry. |
+
+### `SupportedTlsProtocols`
+
+Used by `ClientOptions.TlsProtocol`.
+
+| Value | Description |
+|-------|-------------|
+| `Automatic` | Automatically negotiate the TLS protocol version. |
+| `Tls12` | TLS 1.2. |
+| `Tls13` | TLS 1.3. |
+
+### `ProxySettingType`
+
+Used by `ClientOptions.ProxySetting`.
+
+| Value | Description |
+|-------|-------------|
+| `None` | No proxy. |
+| `SystemDefault` | Use the system default proxy. |
+| `Custom` | Use a custom proxy configuration. |
+
+### `FileOverwriteOption`
+
+Used by `ResponseOptions.FileOverwrite`.
+
+| Value | Description |
+|-------|-------------|
+| `AutoRename` | Automatically rename the file to avoid conflicts. |
+| `Replace` | Overwrite the existing file. |
+| `Discard` | Discard the download if the file already exists. |
+
+---
+
+## Related Activity Mappings
+
+- `Deserialize JSON` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.JsonConvert.DeserializeObject<T>(...)` in coded workflows.
+- `HTTP Request (Legacy)` is not exposed in coded workflows; use the `http` service (`IHttpService`) with `SendRequestAsync` instead. For behavioral differences versus the legacy activity, see [docs/activities/NetHttpRequest.md](UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md).
+- `Deserialize JSON Array` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.Linq.JArray.Parse(...)` in coded workflows.
+- `Serialize JSON` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.JsonConvert.SerializeObject(...)` in coded workflows.
+- `Deserialize XML` activity is not exposed as a dedicated coded API service method; use `System.Xml.Linq.XDocument.Parse(...)` in coded workflows.
+- `Execute XPath` activity is not exposed as a dedicated coded API service method; use `System.Xml.XPath.Extensions.XPathEvaluate(...)` (for example, `XDocument.XPathEvaluate(...)`) in coded workflows.
+- `Get XML Node Attributes` activity is not exposed as a dedicated coded API service method; cast to `System.Xml.Linq.XElement` and call `XElement.Attributes()` in coded workflows.
+- `Get XML Nodes` activity is not exposed as a dedicated coded API service method; use `System.Xml.Linq.XDocument.Nodes()` (or `XDocument.Root?.Nodes()` for element-only traversal) in coded workflows.
+
+---
+
+## Common Patterns
+
+### Basic GET request
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = http.GetAsync("https://httpbin.org/get").GetAwaiter().GetResult();
+    Log($"Status: {response.StatusCode}");
+}
+```
+
+### Advanced request with `HttpRequestOptions`
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var options = HttpRequestOptions.ForPost("https://httpbin.org/post")
+        .WithJsonBody("{\"name\":\"uipath\"}")
+        .WithHeader("X-Trace-Id", Guid.NewGuid().ToString())
+        .WithBearerToken("token-value")
+        .WithTimeout(30_000)
+        .WithRetry(3, 1_000);
+
+    var response = http.SendRequestAsync(options).GetAwaiter().GetResult();
+    Log($"Status: {response.StatusCode}");
+}
+```
+
+### Multipart upload with mixed content
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var parts = new List<FormDataPart>
+    {
+        new TextFormDataPart("Quarterly report", "title"),
+        new FileFormDataPart(@"C:\\Temp\\report.pdf", "document"),
+        new BinaryFormDataPart(new byte[] { 1, 2, 3, 4 }, "signature", "application/octet-stream")
+    };
+
+    var response = http.PostMultipartAsync("https://api.example.com/upload", parts)
+        .GetAwaiter()
+        .GetResult();
+
+    Log($"Upload status: {response.StatusCode}");
+}
+```
+
+### Download and save response as file
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = http.DownloadFileAsync(
+            "https://example.com/files/data.csv",
+            @"C:\\Temp\\Downloads",
+            "data.csv")
+        .GetAwaiter()
+        .GetResult();
+
+    Log($"Download status: {response.StatusCode}");
+}
+```
+
+### SOAP call using `SoapRequestOptions`
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var options = new SoapRequestOptions
+    {
+        EndPoint = "https://www.example.com/service?wsdl",
+        ContractName = "OrderService",
+        Method = "GetOrder",
+        Parameters = new Dictionary<string, object>
+        {
+            ["orderId"] = 42
+        }
+    };
+
+    var response = soap.CallAsync(options).GetAwaiter().GetResult();
+    Log($"SOAP status: {response.StatusCode}");
+}
+```
+
+### SOAP with Basic authentication
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = soap.CallAsync(new SoapRequestOptions
+    {
+        EndPoint = "https://secure.example.com/user-service?wsdl",
+        ContractName = "UserManagementService",
+        Method = "GetUserProfile",
+        Parameters = new Dictionary<string, object> { { "userId", "user123" } },
+        Username = "serviceaccount",
+        SecurePassword = GetSecurePassword()
+    }).GetAwaiter().GetResult();
+
+    if (response.IsSuccessStatusCode())
+    {
+        var profileXml = System.Xml.Linq.XDocument.Parse(response.TextContent);
+        Log(profileXml.ToString());
+    }
+}
+```
+
+### SOAP with Windows credentials
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = soap.CallAsync(new SoapRequestOptions
+    {
+        EndPoint = "https://crm.company.local/soap?wsdl",
+        ContractName = "CRMService",
+        Method = "FetchCustomer",
+        Parameters = new Dictionary<string, object> { { "customerId", "CUST-001" } },
+        UseWindowsCredentials = true
+    }).GetAwaiter().GetResult();
+
+    Log($"SOAP status: {response.GetStatusCodeNumber()}");
+}
+```
+
+### SOAP response parsing with XML namespaces
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = soap.CallAsync(new SoapRequestOptions
+    {
+        EndPoint = "https://api.example.com/weather-soap?wsdl",
+        ContractName = "WeatherService",
+        Method = "GetWeather",
+        Parameters = new Dictionary<string, object> { { "city", "New York" }, { "unit", "Celsius" } }
+    }).GetAwaiter().GetResult();
+
+    if (response.IsSuccessStatusCode())
+    {
+        var doc = System.Xml.Linq.XDocument.Parse(response.TextContent);
+        var ns = System.Xml.Linq.XNamespace.Get("http://api.example.com/weather");
+        var temperature = doc.Descendants(ns + "Temperature").FirstOrDefault()?.Value;
+        Log($"Temperature: {temperature}");
+    }
+}
+```
+
+### SOAP error handling — detecting HTTP errors and SOAP Faults
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = soap.CallAsync(new SoapRequestOptions
+    {
+        EndPoint = "https://api.example.com/validation?wsdl",
+        ContractName = "ValidationService",
+        Method = "ValidateData",
+        Parameters = new Dictionary<string, object> { { "data", "input" } },
+        ContinueOnError = true
+    }).GetAwaiter().GetResult();
+
+    if (response.IsSuccessStatusCode())
+    {
+        var doc = System.Xml.Linq.XDocument.Parse(response.TextContent);
+
+        // SOAP Fault can be embedded inside an HTTP 200 response.
+        var fault = doc.Descendants("Fault").FirstOrDefault();
+        if (fault != null)
+        {
+            var code = fault.Element("faultcode")?.Value;
+            var message = fault.Element("faultstring")?.Value;
+            Log($"SOAP Fault [{code}]: {message}");
+        }
+        else
+        {
+            var result = doc.Descendants("Result").FirstOrDefault()?.Value;
+            Log($"Result: {result}");
+        }
+    }
+    else if (response.IsClientError())
+    {
+        Log($"Client error {response.GetStatusCodeNumber()}: check endpoint/credentials.");
+    }
+    else if (response.IsServerError())
+    {
+        // HTTP 5xx — server-side transport fault (not a SOAP Fault).
+        Log($"Server error {response.GetStatusCodeNumber()}: {response.TextContent}");
+    }
+}
+```
+
+### Import cURL and execute as HTTP request
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var rawCurl = "curl https://api.example.com/items -H \"Authorization: Bearer token\" -H \"Accept: application/json\"";
+
+    var importResult = curl.Import(rawCurl, new CurlImportOptions
+    {
+        InferJsonForTextPayload = true,
+        MapFileBodyToStream = true,
+        StripAuthorizationHeaderOnAuthMapping = true
+    });
+
+    if (importResult.Options == null)
+    {
+        Log("cURL import failed. Review warnings for details.");
+        return;
+    }
+
+    var response = http.SendRequestAsync(importResult.Options).GetAwaiter().GetResult();
+    Log($"Imported request status: {response.StatusCode}");
+}
+```
+
+### Deserialize HTTP JSON response to a typed model
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = http.GetAsync("https://api.example.com/orders/42").GetAwaiter().GetResult();
+
+    // Deserialize JSON using Newtonsoft.Json in coded workflows.
+    var order = Newtonsoft.Json.JsonConvert.DeserializeObject<OrderModel>(response.TextContent);
+    Log($"Order id: {order?.Id}");
+}
+
+private sealed class OrderModel
+{
+    public int Id { get; set; }
+}
+```
+
+### Deserialize JSON array response for iteration
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var response = http.GetAsync("https://api.example.com/orders").GetAwaiter().GetResult();
+
+    var items = Newtonsoft.Json.Linq.JArray.Parse(response.TextContent);
+    foreach (var item in items)
+    {
+        Log($"Item: {item["id"]}");
+    }
+}
+```
+
+### Serialize object to JSON request body
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var payload = new
+    {
+        name = "sample",
+        count = 3
+    };
+
+    var json = Newtonsoft.Json.JsonConvert.SerializeObject(payload);
+    var response = http.PostJsonAsync("https://api.example.com/items", json).GetAwaiter().GetResult();
+    Log($"POST status: {response.StatusCode}");
+}
+```
+
+### Parse XML and evaluate XPath in coded workflows
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var xml = "<root><order id='42' status='ok'/></root>";
+    var doc = System.Xml.Linq.XDocument.Parse(xml);
+
+    var xpathResult = System.Xml.XPath.Extensions.XPathEvaluate(doc, "string(/root/order/@status)");
+    Log($"XPath status: {xpathResult}");
+
+    var firstElement = doc.Root?.Element("order");
+    if (firstElement != null)
+    {
+        foreach (var attribute in firstElement.Attributes())
+        {
+            Log($"Attr: {attribute.Name}={attribute.Value}");
+        }
+    }
+
+    foreach (var node in doc.Nodes())
+    {
+        Log($"Node type: {node.NodeType}");
+    }
+}
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/curl-import.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/curl-import.md
@@ -1,0 +1,207 @@
+# cURL Import � Converting cURL Commands to `HttpRequestOptions`
+
+An agent skill for converting raw cURL commands into a ready-to-use `HttpRequestOptions` object using the deterministic `ICurlImportService` parser.
+
+## Important instruction for agents
+
+**Do not parse cURL commands yourself.** The `ICurlImportService` (accessed as `curl` in coded workflows) is a deterministic parser that handles method, URL, headers, authentication, body types, proxy, TLS, cookies, retries, file output, and more. It automatically detects and correctly parses both **bash-style** and **cmd-style** cURL commands � there is no need to normalize shell syntax before importing.
+
+Manually parsing cURL is error-prone and unnecessary � the parser covers the vast majority of cURL flags and produces an `HttpRequestOptions` object that feeds directly into `http.SendRequestAsync()`.
+
+Read this file completely before generating code. The workflow is: **import ? act on warnings ? hand off `HttpRequestOptions`**.
+
+### Scope of this skill
+
+This skill is concerned **only** with producing a correct `HttpRequestOptions` from a cURL command. Once the object is ready, hand it off to `http.SendRequestAsync()`. Diagnosing HTTP responses, iterating on failures, and processing response content are handled by [NetHttpRequest.md](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) and [service-discovery.md](service-discovery.md).
+
+## When to use
+
+The user provides a cURL command and expects a coded workflow that reproduces the same HTTP request. Indicators:
+
+- The user message contains `curl ` followed by a URL or flags.
+- The user says "convert this cURL", "run this cURL", "make a workflow from this cURL", or similar.
+- The user pastes a command copied from browser DevTools, API documentation, or Postman.
+
+## Prerequisites
+
+- The coded workflow project must reference `UiPath.Web.Activities.API` (provides `ICurlImportService` and `IHttpService`).
+- The `curl` and `http` services are auto-imported via `WebRegistry` � no `using` statements needed for `UiPath.Web.Activities.API`, `UiPath.Web.Activities.API.Models`, or `UiPath.Web.Activities.Http.Models`.
+
+---
+
+## Phase 1 � Import the cURL command
+
+### Goal
+
+Use `curl.Import()` to parse the raw cURL string into structured `HttpRequestOptions`.
+
+### How it works
+
+`curl.Import(rawCurl)` returns a `CurlImportResult` with three fields:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `Options` | `HttpRequestOptions` | The parsed HTTP request options. `null` if the import failed (errors in `Warnings`). |
+| `Warnings` | `IReadOnlyList<CurlImportWarning>` | Warnings and errors from the parser. Each has `Code` (string), `Severity` (Info/Warning/Error), and `Args` (object[]). |
+| `Raw` | `string` | The original cURL string passed to the parser. |
+
+The parser automatically detects whether the input is bash-style (with `\` line continuations and single quotes) or cmd-style (with `^` line continuations and double quotes). Pass the cURL exactly as the user provided it.
+
+### What the parser handles
+
+The deterministic parser extracts and maps:
+
+| cURL concept | Mapped to `HttpRequestOptions` property |
+| --- | --- |
+| URL and query string | `Url`, `Parameters` |
+| `-X` / `--request` (method) | `Method` |
+| `-H` / `--header` | `Headers` |
+| `-d` / `--data` / `--data-raw` / `--json` | `Body` (Text with JSON or other content type) |
+| `--data-urlencode` | `Body` (FormUrlEncoded) |
+| `-F` / `--form` | `Body` (MultipartFormData with typed `FormDataPart` entries) |
+| `--data-binary` / `-T` (upload) | `Body` (Binary or Stream) |
+| `-u` / `--user` (user:pass) | `Authentication` (BasicUsernamePassword) |
+| `Authorization: Bearer` header | `Authentication` (OAuthToken) |
+| `Authorization: Basic` header | `Authentication` (BasicUsernamePassword, decoded) |
+| `--negotiate` / `--ntlm` | `Authentication` (NegotiatedAuthentication) |
+| `-b` / `--cookie` | `Cookies` |
+| `-L` / `--location` | `FollowRedirects` |
+| `--max-redirs` | `MaxRedirects` |
+| `--max-time` | `TimeoutMilliseconds` |
+| `--retry`, `--retry-delay`, `--retry-max-time`, `--retry-all-errors` | `RetryPolicy` |
+| `-k` / `--insecure` | `Client.DisableSslVerification` |
+| `--tlsv1.2`, `--tlsv1.3` | `Client.TlsProtocol` |
+| `--cert` / `--pass` | `Client.ClientCertificatePath`, `Client.ClientCertificatePassword` |
+| `-x` / `--proxy`, `-U` / `--proxy-user`, `--noproxy` | `Client.ProxySetting`, `Client.ProxyConfiguration` |
+| `-o` / `--output`, `-O` / `--remote-name` | `ResponseOptions` (SaveAsFile, FileName, TargetFolder) |
+| `--compressed` | Transparent (handled by transport) |
+
+### Optional import configuration
+
+`curl.Import()` accepts an optional `CurlImportOptions` parameter:
+
+| Option | Default | Effect |
+| --- | --- | --- |
+| `MapFileBodyToStream` | `true` | Maps `--data-binary @file` to a streaming body instead of loading into memory. |
+| `InferJsonForTextPayload` | `true` | When `-d` payload looks like JSON, sets `ContentType` to `application/json`. |
+| `StripAuthorizationHeaderOnAuthMapping` | `true` | Removes the raw `Authorization` header after mapping it to the `Authentication` property (avoids duplication). |
+
+For most use cases, the defaults are correct. Override only when needed.
+
+### Coded workflow � basic import
+
+```csharp
+var rawCurl = @"curl -X POST 'https://api.example.com/users' \
+  -H 'Authorization: Bearer eyJhbGciOi...' \
+  -H 'Content-Type: application/json' \
+  -d '{""name"":""John Doe"",""email"":""john@example.com""}'";
+
+var imported = curl.Import(rawCurl);
+
+if (imported.Options == null)
+{
+    // Import failed � check Phase 2 for how to handle errors
+    return;
+}
+
+// Options is ready � use with http.SendRequestAsync()
+var response = await http.SendRequestAsync(imported.Options);
+```
+
+---
+
+## Phase 2 � Act on warnings
+
+### Goal
+
+Inspect `CurlImportResult.Warnings` and react based on severity. The agent has two strategies for resolving issues:
+
+1. **Fix the cURL command and re-import** � preferred when the issue is in the cURL syntax itself (e.g., malformed quoting, missing URL). Fix the cURL string and call `curl.Import()` again.
+2. **Fill in the `HttpRequestOptions` directly** � when the parser produced a partial result and the warning tells the agent exactly what's missing (e.g., auth could not be decoded). Set the missing property on `imported.Options`.
+
+### Warning severity levels
+
+| Severity | Meaning | Agent action |
+| --- | --- | --- |
+| `Error` | The parser could not produce a valid `HttpRequestOptions`. `Options` is `null`. | If the fix is obvious (e.g., missing URL, broken quoting), correct the cURL and re-import. Otherwise, **ask the user** to clarify or fix the cURL. Do not guess. |
+| `Warning` | The parser produced an `HttpRequestOptions` but something was ambiguous or partially mapped. | Read the warning `Code` to understand what the parser could not resolve. Either fix the cURL and re-import, or fill the gap directly on `imported.Options`. |
+| `Info` | Informational � the parser made an automatic decision (e.g., stripped the `Authorization` header after mapping auth). | No action needed. Can log for transparency. |
+
+### Known warning codes
+
+| Code | Severity | Meaning | Agent response |
+| --- | --- | --- | --- |
+| `CURL_Import_DecodeBasicAuthFailed` | Warning | The Base64 payload in a `Basic` auth header could not be decoded. Auth is not mapped. | Fix the Base64 value in the cURL and re-import, **or** set `options.WithBasicAuth(username, password)` directly if the credentials are known. If neither is possible, ask the user. |
+| `CURL_Import_AmbiguousAuth_BearerPreferred` | Warning | Both Bearer and Basic credentials were detected. Bearer was used. | Inform the user which auth was chosen. If Basic was intended, either remove the Bearer header from the cURL and re-import, or replace with `options.WithBasicAuth(username, password)`. |
+| `CURL_Import_HeaderAuthorizationStripped` | Info | The raw `Authorization` header was removed after mapping to the `Authentication` property. | Expected when `StripAuthorizationHeaderOnAuthMapping = true` (default). No action needed. |
+
+### Handling unrecoverable errors
+
+If the parser returned `Options == null` and the error is not obvious to fix:
+
+1. **Do not invent a fix.** The cURL is the user's intent � guessing what they meant risks producing a request that does something different from what they expect.
+2. **Report the warnings** to the user with their codes.
+3. **Ask the user** to provide a corrected cURL or clarify what they intended.
+4. Once the user provides a fix, re-import.
+
+### Rules
+
+1. **Never re-parse the cURL yourself.** Always use `curl.Import()`.
+2. **React only to what the parser reported.** If the parser mapped a property without warnings, do not override it.
+3. **Prefer fixing the cURL and re-importing** over manually patching `HttpRequestOptions` � a clean re-import produces a fully consistent object.
+4. **When filling `HttpRequestOptions` directly**, use the fluent builder methods (`WithBasicAuth`, `WithBearerToken`, `WithHeader`, etc.) for setting new properties.
+5. **When the error is not clear, ask the user.** Do not try to over-correct a bad cURL by guessing.
+
+### Coded workflow � warning-driven fix
+
+```csharp
+var imported = curl.Import(rawCurl);
+
+if (imported.Options == null)
+{
+    // Import failed � report to user
+    foreach (var w in imported.Warnings)
+    {
+        Log($"cURL import {w.Severity}: {w.Code}");
+    }
+    // Ask user to fix the cURL
+    return;
+}
+
+// Act on warnings
+foreach (var w in imported.Warnings.Where(w => w.Severity == WarningSeverity.Warning))
+{
+    Log($"cURL import warning: {w.Code}");
+
+    if (w.Code == "CURL_Import_DecodeBasicAuthFailed")
+    {
+        // Parser couldn't decode Basic auth � fill in directly
+        imported.Options.WithBasicAuth("username", "password");
+    }
+}
+
+// Options is ready
+var response = await http.SendRequestAsync(imported.Options);
+```
+
+---
+
+## Anti-patterns
+
+| Do not | Why | Do instead |
+| --- | --- | --- |
+| Parse the cURL string yourself with regex or string splitting | Error-prone; misses quoting, escaping, flag ordering, multi-line continuations, cmd vs bash differences | Use `curl.Import()` |
+| Normalize bash cURL to cmd or vice versa before importing | The parser auto-detects shell style | Pass the cURL as-is |
+| Ignore warnings from the import result | May miss auth gaps, decode failures, or ambiguous mappings that need resolution | Always check `imported.Warnings` and act on entries where `Severity` is `Warning` or `Error` |
+| Override parser output that was mapped without warnings | The parser's mapping is tested and deterministic; overriding introduces drift | Only modify `HttpRequestOptions` when a warning tells you something is missing or ambiguous |
+| Guess what a broken cURL meant and silently fix it | May produce a request that differs from the user's intent | Ask the user to clarify or correct the cURL |
+| Build `HttpRequestOptions` from scratch when a cURL is available | Duplicates work the parser already does; risks transcription errors | Use `curl.Import()` and act only on warnings |
+
+---
+
+## See Also
+
+- [NetHttpRequest Activity](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) — modern HTTP activity behavior spec, inputs, outputs, and defaults
+- [HttpClient Activity (Legacy)](../../UiPath.Web.Activities.Package.Design/docs/activities/HttpClient.md) — legacy HTTP activity reference
+- [Service Discovery](service-discovery.md) — discovering unknown service endpoints and generating working requests
+- [HTTP Request Upgrade](http-request-upgrade.md) — migrating from the legacy HTTP Request activity

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/http-request-upgrade.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/http-request-upgrade.md
@@ -1,0 +1,686 @@
+﻿# HTTP Request Upgrade — Legacy to Modern Migration
+
+An agent skill for migrating workflows from the legacy HTTP Request activity (RestSharp-based) to the modern NetHttpRequest activity (.NET HttpClient-based).
+
+## Important instruction for agents
+
+Read this file **completely** before generating any code. The migration cannot be done with a simple property swap — the underlying HTTP clients differ (RestSharp vs .NET HttpClient), which causes behavioral divergences in header handling, encoding, redirect behavior, and body serialization. The skill uses a **capture → translate → verify** loop to ensure the migrated request produces the same result as the original.
+
+## When to use
+
+The user has an existing workflow (UI or coded) that uses the legacy `HttpClient` activity (class: `UiPath.Web.Activities.HttpClient`, display name: "HTTP Request") and wants to migrate it to the modern `NetHttpRequest` activity (display name: "HTTP Request").
+
+Indicators that the user is referring to the legacy activity:
+- The workflow XAML contains `<web:HttpClient` (namespace `UiPath.Web.Activities`).
+- Properties include `AcceptFormat`, `BodyFormat`, `Body`, `UrlSegments`, `Attachments`, `OAuth1Token`, `OAuth1TokenSecret`, `ConsumerKey`, `ConsumerSecret`.
+- The activity returns `Result` (string), `StatusCode` (int), `ResponseHeaders` (Dictionary), `ResponseAttachment` (ILocalResource).
+- The user mentions "RestSharp", "old HTTP activity", or "legacy HTTP Request".
+
+## Prerequisites
+
+- The target endpoint must be reachable from the runtime environment.
+- Authentication credentials used by the legacy activity must be available.
+- The coded workflow project must reference `UiPath.Web.Activities.API` (provides `IHttpService`).
+- `Newtonsoft.Json` is available for JSON serialization/deserialization.
+
+---
+
+## Caution and safety
+
+This migration changes the HTTP transport layer underneath an existing workflow. A mismatch — even a subtle one like a different `Content-Type` charset or a missing `Accept` header — can cause the server to return a different response, silently break downstream logic, or modify server-side state (for POST/PUT/DELETE/PATCH). The agent must treat this as a **high-risk refactor** and follow the rules below.
+
+### 1. Back up the project first
+
+Before any migration work begins, **tell the user to create a backup** of the project (copy the folder, commit to a branch, or create a snapshot). If the user declines, proceed only after explicit acknowledgment that they accept the risk.
+
+### 2. One activity at a time
+
+Never migrate multiple HTTP Request activities in a single step. The agent must:
+1. **Inventory** all legacy `HttpClient` activities in the workflow.
+2. **Propose a migration plan** to the user — a numbered list showing which activity will be migrated in which order.
+3. **Wait for user confirmation** before starting each activity's migration.
+4. **Complete the full Phase 0–5 cycle** for one activity before moving to the next.
+
+Prefer migrating **read-only (GET/HEAD/OPTIONS) activities first** — they don't modify server state, so comparison is safe. Save state-changing methods (POST/PUT/DELETE/PATCH) for later, after the pattern is established.
+
+### 3. Side-effect warning for mutating methods
+
+POST, PUT, DELETE, and PATCH requests may **create, modify, or delete data on the server**. Running the modern activity to compare against the legacy baseline means executing the request again — which may duplicate creates, double-delete, or produce different results if the server state changed.
+
+Before executing a mutating request with the modern activity:
+- **Warn the user** that re-executing the request will hit the server again.
+- **Ask if a test/sandbox environment is available** and suggest using it.
+- **If no safe environment exists**, ask the user whether to proceed or to accept the mapping from Phase 1 without runtime verification.
+
+### 4. Preserve the old activity until confirmed
+
+Do not delete or remove the legacy activity until the user confirms the modern replacement produces equivalent results. During migration:
+- **Comment out** or **disable** the legacy activity in the workflow (if UI workflow, set `IsEnabled = false`).
+- Keep it in place as a reference and rollback path.
+- Only remove it in Phase 5 after explicit user confirmation.
+
+### 5. Maintain a `learnings.md` file
+
+Create a `learnings.md` file in the project directory at the start of the first migration. This file accumulates discoveries, decisions, and fixes that apply across multiple activities in the same workflow. The agent must:
+- **Read `learnings.md`** at the start of each activity migration to reuse prior knowledge.
+- **Append to `learnings.md`** after each successful migration with what was learned.
+- **Reference specific learnings** when proposing mappings for subsequent activities.
+
+See [learnings.md format](#learningsmd-format) for the file structure.
+
+### 6. User checkpoints
+
+The agent must **stop and present results to the user** at these points — never auto-proceed:
+- After proposing the migration plan (rule 2).
+- After completing Phase 1 mapping — show the mapping and ask for confirmation before generating code.
+- After Phase 3 comparison — show the status code, response body diff, and any diagnosis before adjusting.
+- After Phase 4 output mapping — confirm the downstream variable assignments are correct.
+- Before Phase 5 finalization — confirm the user is ready to remove debug settings and the old activity.
+
+### 7. Scope lock
+
+During migration of one activity, **do not modify any other activity, variable, argument, or workflow logic** outside the scope of that specific activity. The only exception is updating `learnings.md`.
+
+### 8. Rollback guidance
+
+If migration fails (the modern activity cannot reproduce the legacy behavior after reasonable attempts):
+- **Re-enable the legacy activity** (uncomment or set `IsEnabled = true`).
+- **Remove the modern replacement code.**
+- **Record the failure reason in `learnings.md`** so future attempts can avoid the same path.
+- **Inform the user** with a clear explanation of what went wrong and whether a manual fix is possible.
+
+---
+
+## Phase 0 — Capture the legacy baseline
+
+### Goal
+
+Run the legacy activity and record its outputs so we have a ground truth to compare against after migration.
+
+### Why this matters
+
+The legacy activity uses RestSharp internally. RestSharp and .NET HttpClient differ in:
+- **Default headers** — RestSharp adds `Accept: application/json, text/json, text/x-json, text/javascript, application/xml, text/xml` by default for certain AcceptFormats; .NET HttpClient sends no Accept header by default.
+- **Body content type** — The legacy activity uses `BodyFormat` (a string like `"application/xml"` or `"application/json"`) which maps to RestSharp's body serializer; the modern activity uses `RequestBodyType` enum + `TextPayloadContentType`.
+- **URL segment interpolation** — The legacy activity supports `UrlSegments` (RestSharp's `{placeholder}` replacement in the URL); the modern activity does not — segments must be inlined into the URL.
+- **Cookie parsing** — The legacy activity parses cookie strings in `name=value;name2=value2` format from a `Dictionary<string, InArgument<string>>`; the modern activity accepts a flat `Dictionary<string, string>`.
+- **Redirect behavior** — RestSharp follows redirects by default with no limit; the modern activity follows up to 3 redirects by default.
+- **Timeout** — Legacy defaults to 6000 ms; modern defaults to 10000 ms.
+- **ContinueOnError** — Legacy defaults to `false`; modern defaults to `true`.
+- **Error shape** — Legacy throws or returns an empty `RestResponse`; modern returns a synthetic 503 with the exception message in `TextContent`.
+
+### What to capture
+
+From the legacy activity's execution, record:
+1. **Status code** (`StatusCode` output — an `int`).
+2. **Response body** (`Result` output — a `string`).
+3. **Response headers** (`ResponseHeaders` output — `Dictionary<string, string>`).
+4. **Response attachment** (`ResponseAttachment` output — if present, note the file path and content type).
+
+Also record the **inputs** that were configured:
+- `EndPoint`, `Method`, `AcceptFormat`, `BodyFormat`, `Body`
+- `Headers`, `Parameters`, `UrlSegments`, `Cookies`, `Attachments`, `FileAttachments`
+- `Username`, `Password` / `SecurePassword`
+- `ConsumerKey`, `ConsumerSecret`, `OAuth1Token`, `OAuth1TokenSecret`
+- `OAuth2Token`
+- `ClientCertificate`, `ClientCertificatePassword` / `SecureClientCertificatePassword`
+- `TimeoutMS`, `ContinueOnError`, `EnableSSLVerification`
+- `ResourcePath`
+
+### Agent action
+
+**Before anything else:**
+1. Remind the user to **back up the project** (see [Caution and safety](#caution-and-safety)).
+2. **Inventory all legacy activities** in the workflow and propose a migration plan — a numbered list showing the order of migration, with GET/HEAD/OPTIONS activities first.
+3. **Wait for user confirmation** of the plan before proceeding.
+4. **Read `learnings.md`** if it exists from a prior migration in this project.
+
+Then, for the current activity:
+
+If the legacy activity has already been run and the user can provide outputs → skip to Phase 1.
+
+If the user wants to run it first → the legacy activity is **not available in coded workflows**. It can only run in a UI workflow. Ask the user to run the existing workflow and share the outputs, or inspect the workflow XAML to extract the configured inputs.
+
+If the method is POST, PUT, DELETE, or PATCH → warn the user about side effects (see [Caution rule 3](#3-side-effect-warning-for-mutating-methods)) before capturing the baseline.
+
+---
+
+## Phase 1 — Map legacy inputs to modern inputs
+
+### Goal
+
+Translate every configured property of the legacy `HttpClient` activity to its equivalent on `NetHttpRequest` / `HttpRequestOptions`.
+
+### Static mapping table
+
+| Legacy property | Type | Modern property | Type | Notes |
+| --- | --- | --- | --- | --- |
+| `EndPoint` | `String` | `RequestUrl` / `Url` | `String` | Direct map. Both prepend `http://` if no scheme is present. |
+| `Method` | `Enum (GET,POST,PUT,DELETE,HEAD,OPTIONS,PATCH,MERGE)` | `Method` | `Enum (GET,POST,PUT,DELETE,HEAD,OPTIONS,PATCH,TRACE)` | `MERGE` has no equivalent — see [Special cases](#merge-method). |
+| `AcceptFormat` | `Enum (ANY,JSON,XML,CUSTOM)` | `Headers["Accept"]` | `String` | Map: `ANY` → omit or `*/*`, `JSON` → `application/json`, `XML` → `application/xml`, `CUSTOM` → copy from legacy `Headers["Accept"]`. |
+| `BodyFormat` | `String` | `TextPayloadContentType` | `String` | Legacy sets content type as a free-form string (e.g., `"application/json"`, `"application/xml"`). Map directly to `TextPayloadContentType`. |
+| `Body` | `String` | `TextPayload` | `String` | Direct map. Also set `RequestBodyType = Text`. |
+| `Headers` | `Dict<string, InArgument<string>>` | `Headers` | `Dict<string, string>` | Direct map (evaluate InArguments to strings). |
+| `Parameters` | `Dict<string, InArgument<string>>` | `Parameters` | `Dict<string, string>` | Direct map — both append as query string parameters. |
+| `UrlSegments` | `Dict<string, InArgument<string>>` | *(inline into URL)* | — | No equivalent. Replace `{key}` placeholders in the URL with their values before setting `RequestUrl`. |
+| `Cookies` | `Dict<string, InArgument<string>>` | `Cookies` | `Dict<string, string>` | Legacy parses `name=value;name2=value2` cookie strings. Modern accepts flat key-value pairs. Flatten before mapping. |
+| `Attachments` | `Dict<string, InArgument<string>>` | `LocalFiles` | `IEnumerable<string>` | Legacy maps `{name: filePath}`. Modern uses file paths in `LocalFiles` with `RequestBodyType = MultipartFormData`. Field names need `FormDataParts` with `FileFormDataPart` if the name matters. |
+| `FileAttachments` | `ICollection<ILocalResource>` | `ResourceFiles` | `IEnumerable<IResource>` | Direct map. Set `RequestBodyType = MultipartFormData`. |
+| `ResourcePath` | `String` | `OutputFileTargetFolder` + `OutputFileName` | `String` | Legacy writes response to this path. Modern splits into folder and filename. Also set `SaveResponseAsFile = true`. |
+| `Username` | `String` | `BasicAuthUsername` | `String` | Set `AuthenticationType = BasicUsernamePassword`. |
+| `Password` | `String` | `BasicAuthPassword` | `String` | Set `AuthenticationType = BasicUsernamePassword`. |
+| `SecurePassword` | `SecureString` | `BasicAuthSecurePassword` | `SecureString` | Set `AuthenticationType = BasicUsernamePassword`. |
+| `OAuth2Token` | `String` | `OAuthToken` | `String` | Set `AuthenticationType = OAuthToken`. |
+| `ConsumerKey` | `String` | — | — | **No equivalent.** OAuth 1.0 is not supported by the modern activity. See [Special cases](#oauth-10). |
+| `ConsumerSecret` | `String` | — | — | **No equivalent.** |
+| `OAuth1Token` | `String` | — | — | **No equivalent.** |
+| `OAuth1TokenSecret` | `String` | — | — | **No equivalent.** |
+| `ClientCertificate` | `String` | `ClientCertPath` | `String` | Direct map. |
+| `ClientCertificatePassword` | `String` | `ClientCertPassword` | `String` | Direct map. |
+| `SecureClientCertificatePassword` | `SecureString` | `ClientCertSecurePassword` | `SecureString` | Direct map. |
+| `TimeoutMS` | `Int32` (default 6000) | `TimeoutInMiliseconds` | `Int32?` (default 10000) | Carry the legacy value forward. |
+| `ContinueOnError` | `Boolean` (default false) | `ContinueOnError` | `Boolean` (default true) | **Carry the legacy value forward** to preserve behavior. |
+| `EnableSSLVerification` | `Boolean` (default true) | `DisableSslVerification` | `Boolean` (default false) | **Inverted logic.** `EnableSSLVerification = true` → `DisableSslVerification = false`. |
+
+### Special cases
+
+#### MERGE method
+
+The legacy activity supports `MERGE` (used in OData v3). The modern activity does not have a `MERGE` enum value. Options:
+1. If the server accepts `PATCH` instead of `MERGE` (OData v4), switch to `PATCH`.
+2. If `MERGE` is strictly required, the migration cannot proceed with the modern activity — inform the user.
+
+#### OAuth 1.0
+
+The modern activity does not support OAuth 1.0 (`ConsumerKey`, `ConsumerSecret`, `OAuth1Token`, `OAuth1TokenSecret`). Options:
+1. If the service also accepts OAuth 2.0 Bearer tokens, migrate to `OAuthToken`.
+2. If OAuth 1.0 is required, the user must construct the `Authorization` header manually (compute the OAuth 1.0 signature and set it in `Headers["Authorization"]`). Warn the user this is complex and error-prone.
+3. If neither is feasible, the migration cannot proceed — inform the user.
+
+#### Body with attachments
+
+The legacy activity has a special path: when both `Body` and `Attachments` are set, RestSharp sends a multipart request with the body as a form field. The modern activity requires using `RequestBodyType = MultipartFormData` with `FormDataParts` to achieve the same effect:
+
+```csharp
+var parts = new List<FormDataPart>
+{
+    new TextFormDataPart(legacyBody, "body", legacyBodyFormat), // Body as a text part
+    new FileFormDataPart(attachmentPath, attachmentName),       // Each attachment
+};
+var response = await http.PostMultipartAsync(url, parts);
+```
+
+#### UrlSegments
+
+Replace placeholders in the URL string before passing to the modern activity:
+
+```csharp
+// Legacy: EndPoint = "https://api.example.com/users/{userId}/orders/{orderId}"
+//         UrlSegments = { "userId": "123", "orderId": "456" }
+
+// Modern: inline the segments
+var url = "https://api.example.com/users/123/orders/456";
+```
+
+#### AcceptFormat to Header
+
+The legacy `AcceptFormat` enum maps to an `Accept` header:
+
+```csharp
+// Legacy: AcceptFormat = JSON
+// Modern: add an Accept header
+var options = HttpRequestOptions.ForGet(url)
+    .WithHeader("Accept", "application/json");
+```
+
+If `AcceptFormat = CUSTOM`, the user's `Headers["Accept"]` (case-insensitive) value is already in the headers dictionary and will carry over naturally.
+
+If `AcceptFormat = ANY`, the legacy activity sends `*/*`. The modern activity sends no `Accept` header by default, which servers treat as `*/*`. Typically safe to omit, but include `*/*` explicitly if the server is sensitive to it.
+
+---
+
+## Phase 2 — Generate the coded workflow
+
+### Goal
+
+Produce a coded workflow that calls the same URL with the same method, headers, body, and authentication — using `IHttpService` and `HttpRequestOptions`.
+
+### Strategy
+
+Always enable `SaveRawRequestResponse` so the agent can inspect the actual wire-level request and response for debugging:
+
+```csharp
+options.ResponseOptions.SaveRawRequestResponse = true;
+```
+
+Always set `ContinueOnError = true` during migration testing so failures return diagnostic info instead of throwing:
+
+```csharp
+options.ContinueOnError = true;
+```
+
+### Template — Simple GET migration
+
+```csharp
+// Legacy: HttpClient activity with Method=GET, EndPoint="https://api.example.com/data",
+//         AcceptFormat=JSON, TimeoutMS=6000
+
+var options = HttpRequestOptions.ForGet("https://api.example.com/data")
+    .WithHeader("Accept", "application/json")
+    .WithTimeout(6000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+```
+
+### Template — POST with JSON body migration
+
+```csharp
+// Legacy: Method=POST, EndPoint="https://api.example.com/items",
+//         BodyFormat="application/json", Body=jsonString, AcceptFormat=JSON
+
+var options = HttpRequestOptions.ForPost("https://api.example.com/items")
+    .WithJsonBody(jsonString)
+    .WithHeader("Accept", "application/json")
+    .WithTimeout(6000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+```
+
+### Template — POST with XML body migration
+
+```csharp
+// Legacy: Method=POST, BodyFormat="application/xml", Body=xmlString
+
+var options = HttpRequestOptions.ForPost("https://api.example.com/endpoint")
+    .WithTextBody(xmlString, "application/xml")
+    .WithTimeout(6000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+```
+
+### Template — Basic auth migration
+
+```csharp
+// Legacy: Username="user", Password="pass"
+
+var options = HttpRequestOptions.ForGet("https://api.example.com/secure")
+    .WithBasicAuth("user", "pass")
+    .WithTimeout(6000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+```
+
+### Template — OAuth2 Bearer token migration
+
+```csharp
+// Legacy: OAuth2Token = bearerToken
+
+var options = HttpRequestOptions.ForGet("https://api.example.com/protected")
+    .WithBearerToken(bearerToken)
+    .WithTimeout(6000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+```
+
+### Template — File download migration
+
+```csharp
+// Legacy: ResourcePath = @"C:\downloads\report.pdf"
+
+var options = HttpRequestOptions.ForGet("https://api.example.com/reports/latest")
+    .WithFileDownload(targetFolder: @"C:\downloads", fileName: "report.pdf")
+    .WithTimeout(6000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+if (response.HasFile())
+{
+    // response.File contains the saved ILocalResource
+}
+```
+
+### Template — Multipart with attachments migration
+
+```csharp
+// Legacy: Attachments = { "file1": @"C:\docs\a.pdf", "file2": @"C:\docs\b.pdf" }
+//         Body = metadataJson, BodyFormat = "application/json"
+
+var parts = new List<FormDataPart>
+{
+    new TextFormDataPart(metadataJson, "metadata", "application/json"),
+    new FileFormDataPart(@"C:\docs\a.pdf", "file1"),
+    new FileFormDataPart(@"C:\docs\b.pdf", "file2"),
+};
+
+var response = await http.PostMultipartAsync("https://api.example.com/upload", parts);
+```
+
+### Template — UrlSegments migration
+
+```csharp
+// Legacy: EndPoint = "https://api.example.com/users/{userId}/orders/{orderId}"
+//         UrlSegments = { "userId": "123", "orderId": "456" }
+
+// Inline the segments into the URL
+var url = $"https://api.example.com/users/{userId}/orders/{orderId}";
+var options = HttpRequestOptions.ForGet(url)
+    .WithTimeout(6000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+```
+
+---
+
+## Phase 3 — Execute and compare
+
+### Goal
+
+Run the modern activity and compare its output against the legacy baseline. Use `RawRequestDebuggingInfo` to diagnose differences.
+
+### Create or update `learnings.md`
+
+If this is the first activity being migrated in this project, create `learnings.md` in the project directory. If it already exists, read it before proceeding — prior learnings may prevent repeated mistakes.
+
+See [learnings.md format](#learningsmd-format) for the file structure.
+
+### Side-effect gate
+
+If the method is POST, PUT, DELETE, or PATCH:
+- **Do not execute the request** without user confirmation.
+- Remind the user that this will hit the server and may modify data.
+- Suggest using a test/sandbox environment if available.
+- If the user declines execution, accept the Phase 1 mapping as-is and skip to Phase 4 (mark comparison as "unverified" in `learnings.md`).
+
+### Comparison strategy
+
+```
+execute modern request
+compare status code with legacy baseline
+compare response body with legacy baseline
+if match → migration successful
+if mismatch → diagnose using debug info → adjust → retry
+```
+
+### Comparison criteria
+
+| Aspect | Match condition | Common mismatch causes |
+| --- | --- | --- |
+| **Status code** | Same numeric value | Different default headers, missing auth, different content type |
+| **Response body** | Semantically equivalent (same JSON/XML structure and values) | Encoding differences, whitespace changes, header-driven content negotiation |
+| **Response headers** | Key headers match (Content-Type, Set-Cookie, etc.) | Header casing differences (cosmetic, usually safe to ignore) |
+
+### Using RawRequestDebuggingInfo for diagnosis
+
+Enable via `options.ResponseOptions.SaveRawRequestResponse = true`, then inspect `response.RawRequestDebuggingInfo`.
+
+The debug dump contains sections that help diagnose divergences:
+
+1. **Request headers** — Compare the headers sent by the modern activity against what RestSharp would have sent. Look for:
+   - Missing `Accept` header (legacy had `AcceptFormat` which added it automatically).
+   - Different `Content-Type` (RestSharp may have added charset or boundary differently).
+   - Missing `User-Agent` (RestSharp sends `RestSharp/{version}` by default; .NET HttpClient does not).
+
+2. **Request body preview** — Verify the body content, encoding, and content type match the legacy request.
+
+3. **Response headers** — Check for `Set-Cookie`, `Location`, `WWW-Authenticate` that indicate the server responded differently.
+
+4. **Retry history** — The modern activity retries by default (3 attempts on 5xx/408/429). The legacy activity does **not** retry. If the server is flaky, the modern activity may succeed where legacy failed (or vice versa). Set `RetryPolicyType = None` during comparison testing to match legacy behavior:
+
+```csharp
+options.RetryPolicy = new RetryPolicyOptions { Type = RetryPolicyType.None };
+```
+
+### Diagnosis table
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| **Different status code** (e.g., legacy 200, modern 406) | Missing `Accept` header | Add `.WithHeader("Accept", "application/json")` (or the value from legacy's `AcceptFormat`) |
+| **Different status code** (e.g., legacy 200, modern 415) | Wrong `Content-Type` on request body | Check `TextPayloadContentType` matches legacy `BodyFormat`. Inspect debug dump's request headers. |
+| **Different status code** (e.g., legacy 200, modern 400) | Body encoding difference | RestSharp may encode form parameters differently. Check if `Parameters` in legacy were sent as query strings or form body (RestSharp puts them in the body for POST). See [Parameters as body](#parameters-as-post-body). |
+| **Different status code** (e.g., legacy 200, modern 401) | Auth header format difference | Compare `Authorization` header scheme in debug dump. RestSharp's Basic auth may differ in whitespace or encoding. |
+| **Same status code but different body** | Content negotiation — server returns different format based on `Accept` | Ensure `Accept` header matches exactly. |
+| **Same status code but different body** | Decompression difference | Modern activity auto-decompresses gzip/deflate/brotli. Legacy may return compressed data in `Result`. The decompressed content should be semantically equivalent. |
+| **Legacy returned file, modern returns text** | Response classification differs | If legacy used `ResourcePath` to force file save, set `SaveResponseAsFile = true` and configure `OutputFileTargetFolder`/`OutputFileName`. |
+| **Modern retries but legacy didn't** | Modern has retries enabled by default | Set `RetryPolicyType = None` to match legacy behavior, or keep retries for improved reliability. |
+| **Modern follows redirects differently** | Modern follows 3 redirects; legacy follows all | Increase `MaxRedirects` if needed, or set `FollowRedirects = false` to match legacy behavior when legacy didn't follow. |
+| **Timeout difference** | Legacy defaults to 6000 ms, modern to 10000 ms | Set `TimeoutInMiliseconds` to the legacy value. |
+
+### Parameters as POST body
+
+**Critical behavioral difference:** RestSharp sends `Parameters` in the request **body** (as form-urlencoded) for POST/PUT/PATCH requests when no explicit body is set. The modern activity **always** sends `Parameters` as query string parameters regardless of method.
+
+If the legacy activity uses `Parameters` with a POST method and no `Body`:
+- The server likely expects form-urlencoded body content.
+- Migrate `Parameters` to `FormData` with `RequestBodyType = FormUrlEncoded`:
+
+```csharp
+// Legacy: Method=POST, Parameters = { "key1": "value1", "key2": "value2" }
+// (RestSharp sends these as form-urlencoded body)
+
+// Modern: use FormData instead
+var formData = new Dictionary<string, string>
+{
+    { "key1", "value1" },
+    { "key2", "value2" }
+};
+var response = await http.PostFormAsync("https://api.example.com/endpoint", formData);
+```
+
+---
+
+## Phase 4 — Handle output mapping
+
+### Goal
+
+Map the modern activity's `HttpResponseSummary` output back to the variables the workflow expects, matching the legacy output shape.
+
+### Output mapping table
+
+| Legacy output | Type | Modern equivalent | Access pattern |
+| --- | --- | --- | --- |
+| `Result` | `String` | `response.TextContent` | Direct. Note: legacy always returns the response body as a string regardless of content type. Modern classifies responses and may populate `BinaryContent` or `File` instead. For text responses, `TextContent` is equivalent. |
+| `StatusCode` | `Int32` | `response.GetStatusCodeNumber()` | Extension method returns `int`. Or cast: `(int)response.StatusCode`. |
+| `ResponseHeaders` | `Dict<string, string>` | `response.Headers` + `response.ContentHeaders` | Modern separates response headers and content headers. Merge if needed: `response.Headers.Concat(response.ContentHeaders).ToDictionary(...)`. |
+| `ResponseAttachment` | `ILocalResource` | `response.File` | Available when response is classified as file or `SaveResponseAsFile = true`. |
+
+### Code example — reproducing legacy output shape
+
+```csharp
+var response = await http.SendRequestAsync(options);
+
+// Equivalent to legacy Result
+string result = response.TextContent;
+
+// Equivalent to legacy StatusCode
+int statusCode = response.GetStatusCodeNumber();
+
+// Equivalent to legacy ResponseHeaders (merged)
+var responseHeaders = new Dictionary<string, string>();
+if (response.Headers != null)
+{
+    foreach (var h in response.Headers)
+        responseHeaders[h.Key] = h.Value;
+}
+if (response.ContentHeaders != null)
+{
+    foreach (var h in response.ContentHeaders)
+        responseHeaders[h.Key] = h.Value;
+}
+
+// Equivalent to legacy ResponseAttachment
+var responseAttachment = response.File;
+```
+
+---
+
+## Phase 5 — Finalize and clean up
+
+### Goal
+
+Once the modern activity produces equivalent output, finalize the migration.
+
+### Checklist
+
+1. **Remove debug settings** — Set `SaveRawRequestResponse = false` (or remove the line) unless the user wants debug output in production.
+2. **Decide on ContinueOnError** — The legacy default was `false` (throw on error). The modern default is `true` (return synthetic 503). Set to match the user's intent, not the legacy default.
+3. **Decide on retries** — Legacy had no retry mechanism. Modern retries 3 times by default on 5xx/408/429. Keep retries for improved reliability, or set `RetryPolicyType = None` to match legacy behavior exactly.
+4. **Decide on timeout** — If the user had a specific `TimeoutMS`, carry it forward. Otherwise, the modern default (10s) is more generous than legacy (6s).
+5. **Confirm with the user** — Present the final migrated code and ask for explicit confirmation before removing the old activity.
+6. **Remove the legacy activity** from the workflow — only after user confirmation. If in a UI workflow, the activity was disabled in Phase 2; now delete it.
+7. **Update downstream logic** — If the workflow inspects `Result` (string), switch to `response.TextContent`. If it checks `StatusCode` (int), switch to `response.GetStatusCodeNumber()`.
+8. **Update `learnings.md`** — Append an entry for this activity recording the mapping decisions, any fixes discovered during Phase 3, and whether comparison was verified or unverified.
+
+### If migration failed
+
+Follow [rollback guidance](#8-rollback-guidance): re-enable the legacy activity, remove the modern replacement, record the failure in `learnings.md`, and inform the user.
+
+---
+
+## Summary — Agent decision flow
+
+```
+User identifies legacy HTTP Request activity
+       │
+       ▼
+  ┌─ SAFETY GATE ─────────────────────────────────────────┐
+  │ 1. Remind user to back up the project                 │
+  │ 2. Inventory all legacy activities                    │
+  │ 3. Propose migration plan (GET first, then mutating)  │
+  │ 4. Read learnings.md if it exists                     │
+  │ 5. Wait for user confirmation                         │
+  └───────────────────────────────────────────────────────┘
+       │
+       ▼
+  Phase 0: Capture legacy baseline (or accept user-provided outputs)
+       │  ⚠ If POST/PUT/DELETE/PATCH → warn about side effects
+       │
+       ▼
+  Phase 1: Map inputs using static mapping table
+       │
+       ├── OAuth 1.0 used? ──────────────► Warn user, offer manual header or stop
+       ├── MERGE method? ────────────────► Suggest PATCH or stop
+       ├── UrlSegments? ─────────────────► Inline into URL
+       ├── Parameters as POST body? ─────► Migrate to FormData
+       └── All inputs mapped ────────────► Continue
+       │
+       ▼
+  ┌─ USER CHECKPOINT ─┐
+  │ Show mapping,      │
+  │ ask to confirm     │
+  └────────────────────┘
+       │
+       ▼
+  Phase 2: Generate coded workflow with HttpRequestOptions
+       │  (legacy activity disabled, not deleted)
+       │
+       ▼
+  Phase 3: Execute with SaveRawRequestResponse = true
+       │  ⚠ If mutating method → confirm with user before executing
+       │  📝 Create/read learnings.md
+       │
+       ├── Status code matches? ──► Compare response body
+       │       ├── Body matches? ──► Phase 4: Map outputs
+       │       └── Body differs? ──► Diagnose with debug info → adjust → retry
+       └── Status code differs? ──► Diagnose with debug info → adjust → retry
+       │
+       ▼
+  ┌─ USER CHECKPOINT ─┐
+  │ Show comparison    │
+  │ results, ask to    │
+  │ confirm            │
+  └────────────────────┘
+       │
+       ▼
+  Phase 4: Map outputs to legacy shape
+       │
+       ▼
+  ┌─ USER CHECKPOINT ─┐
+  │ Confirm before     │
+  │ removing old       │
+  │ activity           │
+  └────────────────────┘
+       │
+       ▼
+  Phase 5: Finalize (remove debug, delete old activity, update learnings.md)
+       │
+       ├── Success ──► Update learnings.md ──► Next activity (repeat from Phase 0)
+       └── Failure ──► Rollback, record in learnings.md, inform user
+```
+
+## Known behavioral differences
+
+This section documents differences between RestSharp (legacy) and .NET HttpClient (modern) that **cannot** be eliminated by input mapping alone. The agent should be aware of these and inform the user when they are relevant.
+
+| Behavior | Legacy (RestSharp) | Modern (.NET HttpClient) | Impact |
+| --- | --- | --- | --- |
+| **Default User-Agent** | `RestSharp/{version}` | None | Some servers check User-Agent. Add `.WithHeader("User-Agent", "...")` if the server rejects requests without it. |
+| **Default Accept header** | Depends on `AcceptFormat` enum; `ANY` sends a long multi-type accept string | No Accept header unless explicitly set | Servers that require `Accept` will return 406 Not Acceptable. Always map `AcceptFormat` to an explicit header. |
+| **POST parameters** | Sent as form-urlencoded body | Sent as query string parameters | See [Parameters as POST body](#parameters-as-post-body). This is the most common migration-breaking difference. |
+| **Cookie format** | Parses `name=value;name2=value2` from dictionary values | Flat `Dictionary<string, string>` key-value pairs | Flatten cookie strings before mapping. |
+| **Redirect following** | Follows all redirects | Follows up to `MaxRedirects` (default 3) | Increase `MaxRedirects` for deeply redirecting URLs. |
+| **Timeout** | Default 6000 ms | Default 10000 ms | Carry forward the legacy value to preserve timing behavior. |
+| **Error handling** | `ContinueOnError` default false; throws exceptions | `ContinueOnError` default true; returns synthetic 503 | Set to match legacy behavior during migration. |
+| **Retries** | None | 3 retries on 5xx/408/429 by default | Set `RetryPolicyType = None` for exact behavioral parity, or keep for reliability. |
+| **SSL certificate path** | Looks up by path or subject name | Same — looks up by path or Windows Root store subject name | No change needed. |
+| **Response body** | Always returned as string in `Result` | Classified: text → `TextContent`, binary → `BinaryContent`, file → `File` | For text APIs, `TextContent` is equivalent. For file downloads, use `response.File`. |
+| **Decompression** | Depends on RestSharp version/config | Always decompresses gzip/deflate/brotli | Decompressed content should be equivalent. |
+| **OAuth 1.0** | Supported via RestSharp authenticator | Not supported | Must construct Authorization header manually or use OAuth 2.0. |
+
+## `learnings.md` format
+
+The `learnings.md` file lives in the project directory and is maintained across activity migrations.
+
+```markdown
+# HTTP Request Migration Learnings
+
+This file is auto-maintained by the migration agent. It records decisions and
+discoveries from each activity migration so subsequent migrations can reuse them.
+
+## Global learnings
+
+<!-- Patterns that apply to all activities in this workflow -->
+- (example) This server requires `Accept: application/json` header or returns 406.
+- (example) Parameters on POST must be sent as form body, not query string.
+
+## Activity migrations
+
+### Activity 1: GET /api/users (DisplayName: "Fetch Users")
+- **Status:** verified ✅
+- **Date:** 2024-01-15
+- **Mapping notes:** AcceptFormat=JSON → WithHeader("Accept", "application/json")
+- **Fixes during comparison:** Added User-Agent header — server returned 403 without it.
+- **Learnings for next activities:** Always include User-Agent for this server.
+
+### Activity 2: POST /api/orders (DisplayName: "Create Order")
+- **Status:** unverified ⚠️ (mutating method, user declined runtime comparison)
+- **Date:** 2024-01-15
+- **Mapping notes:** Parameters migrated to FormData (POST body). BodyFormat="application/json" → WithJsonBody().
+- **Fixes during comparison:** N/A — not executed.
+- **Learnings for next activities:** Same FormData pattern likely needed for other POST activities.
+```
+
+Rules:
+- **Never delete entries** — append only.
+- **Global learnings** accumulate patterns that apply across activities.
+- **Each activity entry** records status (verified/unverified/failed), mapping decisions, fixes, and forward-looking learnings.
+- The agent must **read the entire file** before starting each new activity migration.
+
+## See Also
+
+- [NetHttpRequest Activity](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) — modern HTTP activity behavior spec, inputs, outputs, and defaults
+- [HttpClient Activity (Legacy)](../../UiPath.Web.Activities.Package.Design/docs/activities/HttpClient.md) — legacy HTTP activity reference
+- [cURL Import Skills](curl-import.md) — converting raw cURL commands to HttpRequestOptions
+- [Service Discovery](service-discovery.md) — discovering unknown service endpoints and generating working requests

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/service-discovery.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/service-discovery.md
@@ -1,0 +1,506 @@
+﻿# Service Discovery
+
+An agent skill for progressively exploring an unknown service URL and producing a working coded workflow.
+
+## Important instruction for agents
+
+Read this file **completely** before generating any code. The workflow is sequential — each phase depends on the output of the previous one. Do **not** skip phases or assume the service type up front.
+
+### Hard rules — always enforced
+
+**RULE 1 — Never use bash, curl, or any shell tool for API exploration.**
+All HTTP probing must be done by writing a UiPath coded workflow using `http.SendRequestAsync` with `SaveRawRequestResponse = true`. Read `RawRequestDebuggingInfo` from the logs — it captures exact headers sent/received, redirect chains, retry history, timing, and body previews that external tools cannot replicate. Probe pattern:
+```csharp
+var options = HttpRequestOptions.ForGet(url);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+var response = http.SendRequestAsync(options).GetAwaiter().GetResult();
+Log(response.RawRequestDebuggingInfo);
+Log($"Status: {response.GetStatusCodeNumber()}  Media-Type: {response.GetMediaType()}");
+Log(response.TextContent);
+```
+
+**RULE 2 — Always add `using UiPath.Web.Activities.API` in every coded workflow.**
+`HttpResponseSummaryExtensions` — which provides `IsSuccessStatusCode()`, `IsServerError()`, `IsClientError()`, `IsRedirect()`, `HasTextContent()`, `HasFile()`, `GetStatusCodeNumber()`, `GetHeader()`, `GetMediaType()`, `GetContentType()`, `GetCharset()`, `GetWwwAuthenticate()`, `GetRedirectLocation()` — lives in `UiPath.Web.Activities.API` namespace, assembly `UiPath.Web.Activities.API.dll`. This is a separate assembly from `UiPath.Web.Activities.dll` where `HttpResponseSummary` itself lives. Omitting it causes all extension method calls to fail to compile. Required usings:
+```csharp
+using UiPath.Web.Activities.API;         // HttpResponseSummaryExtensions
+using UiPath.Web.Activities.API.Models;  // HttpRequestOptions, RetryPolicyOptions, etc.
+using UiPath.Web.Activities.Http.Models; // HttpResponseSummary, FormDataPart, etc.
+```
+
+**RULE 3 — Follow every phase in this skill in order. No shortcuts.**
+Do not skip phases, do not assume the service type up front, do not write the final workflow before completing the probe and spec-parse phases. Each phase gate must be passed before proceeding to the next.
+
+**RULE 4 — Use the full `HttpResponseSummaryExtensions` set on every response.**
+Prefer extension methods over raw property access: `GetStatusCodeNumber()` not `(int)response.StatusCode`, `IsSuccessStatusCode()` not manual status comparison, `HasTextContent()` before any JSON parsing, `GetMediaType()` for content-type checks. Always log `RawRequestDebuggingInfo` on every non-success path.
+
+## When to use
+
+The user provides a URL (or a base URL + a vague goal) and expects you to:
+
+1. Figure out whether it is a REST or SOAP service.
+2. Download and parse its interface definition (OpenAPI / Swagger / WSDL).
+3. Optionally map a user goal to a specific operation.
+4. Generate a coded workflow that calls the operation and reaches a **200 OK**.
+
+The user may have **zero knowledge** of the service. Treat every assumption as unverified until a response confirms it.
+
+## Prerequisites
+
+- The URL must be reachable from the runtime environment.
+- Authentication credentials, if required, must be supplied by the user (prompt when a 401/403 is received).
+- The coded workflow project must reference `UiPath.Web.Activities.API` (provides `IHttpService` and `ISoapService`).
+- `Newtonsoft.Json` is available in coded workflows for JSON serialization/deserialization.
+
+---
+
+## Phase 1 — Determine service type
+
+### Goal
+
+Classify the URL as **REST**, **SOAP**, or **Unknown** by probing for well-known interface documents.
+
+### Strategy
+
+Send lightweight GET requests using `IHttpService` with `ContinueOnError = true` and `SaveRawRequestResponse = true` so that failures return a synthetic 503 instead of throwing, and debug info is captured.
+
+Probe the following suffixes **in order** (stop as soon as one succeeds):
+
+#### REST / OpenAPI probes
+
+| Probe URL | Indicates |
+| --- | --- |
+| `{base}/swagger/v1/swagger.json` | ASP.NET default Swagger |
+| `{base}/swagger.json` | Common alternative |
+| `{base}/openapi.json` | OpenAPI 3.x convention |
+| `{base}/api-docs` | Swagger UI / SpringFox |
+| `{base}/v2/api-docs` | SpringFox v2 |
+| `{base}/v3/api-docs` | SpringDoc v3 |
+
+#### SOAP / WSDL probes
+
+| Probe URL | Indicates |
+| --- | --- |
+| `{base}?wsdl` | Standard WSDL query |
+| `{base}?WSDL` | Case-variant WSDL query |
+| `{base}?singleWsdl` | WCF single-file WSDL |
+
+#### Fallback: inspect the base URL
+
+If no suffix matches, GET the base URL itself and inspect:
+- `Content-Type` header via `response.GetMediaType()`:
+  - `application/json` or `text/html` → likely REST.
+  - `text/xml` or `application/xml` → likely SOAP (look for `<wsdl:` or `<soap:` in body).
+- Response body content for clues (HTML page with links, JSON payload, XML envelope).
+
+### Decision
+
+| Evidence | Classification |
+| --- | --- |
+| A probe returned valid JSON with `"openapi"` or `"swagger"` key | **REST** — proceed to Phase 2A |
+| A probe returned valid XML with `<wsdl:definitions>` or `<definitions>` root | **SOAP** — proceed to Phase 2B |
+| Base URL returned JSON or HTML but no interface doc found | **REST (no spec)** — proceed to Phase 2C |
+| Nothing useful returned (all 4xx/5xx or connection errors) | **Unknown** — report to user, ask for guidance |
+
+### Coded workflow example — probing
+
+```csharp
+var baseUrl = "https://example.com/api";
+
+// Try OpenAPI/Swagger first
+var probes = new[]
+{
+    $"{baseUrl}/swagger/v1/swagger.json",
+    $"{baseUrl}/swagger.json",
+    $"{baseUrl}/openapi.json",
+    $"{baseUrl}/api-docs",
+    $"{baseUrl}/v2/api-docs",
+    $"{baseUrl}/v3/api-docs",
+};
+
+HttpResponseSummary specResponse = null;
+string specUrl = null;
+
+foreach (var probe in probes)
+{
+    var options = HttpRequestOptions.ForGet(probe)
+        .WithTimeout(15_000);
+    options.ContinueOnError = true;
+    options.ResponseOptions.SaveRawRequestResponse = true;
+
+    var response = await http.SendRequestAsync(options);
+
+    if (response.IsSuccessStatusCode() && response.HasTextContent())
+    {
+        var mediaType = response.GetMediaType();
+        if (mediaType != null && mediaType.Contains("json"))
+        {
+            specResponse = response;
+            specUrl = probe;
+            break;
+        }
+    }
+}
+
+// If no REST spec found, try WSDL
+if (specResponse == null)
+{
+    var wsdlProbes = new[]
+    {
+        $"{baseUrl}?wsdl",
+        $"{baseUrl}?WSDL",
+        $"{baseUrl}?singleWsdl",
+    };
+
+    foreach (var probe in wsdlProbes)
+    {
+        var options = HttpRequestOptions.ForGet(probe)
+            .WithTimeout(15_000);
+        options.ContinueOnError = true;
+        options.ResponseOptions.SaveRawRequestResponse = true;
+
+        var response = await http.SendRequestAsync(options);
+
+        if (response.IsSuccessStatusCode() && response.HasTextContent())
+        {
+            var body = response.TextContent;
+            if (body.Contains("<wsdl:definitions") || body.Contains("<definitions"))
+            {
+                specResponse = response;
+                specUrl = probe;
+                break; // SOAP detected
+            }
+        }
+    }
+}
+```
+
+---
+
+## Phase 2A — Parse REST interface (OpenAPI / Swagger)
+
+### Goal
+
+Build an in-memory model of available endpoints, methods, parameters, and request/response shapes.
+
+### Steps
+
+1. Deserialize the spec JSON into a `JObject` using `Newtonsoft.Json.Linq.JObject.Parse(specResponse.TextContent)`.
+2. Extract:
+   - **basePath / servers** — the actual base URL for calls.
+   - **paths** — each path key + HTTP methods underneath.
+   - **parameters** — query, header, path, and body parameters for each operation.
+   - **requestBody / schemas** — expected request shapes (JSON Schema or `$ref` to `#/components/schemas/...`).
+   - **responses** — expected response status codes and shapes.
+3. Build a summary list: `operationId`, `method`, `path`, `summary`, `parameters`, `requestBodySchema`, `responseSchema`.
+
+### Presenting the model
+
+If the user has a specific goal → proceed to **Phase 3**.
+If the user has no specific goal → present a numbered list of operations with their summaries and ask the user to pick one, or offer to download the raw spec as a file:
+
+```csharp
+// Save the spec to a file for the user
+var downloadOptions = HttpRequestOptions.ForGet(specUrl)
+    .WithFileDownload(targetFolder: @"C:\temp", fileName: "openapi-spec.json");
+
+var fileResponse = await http.SendRequestAsync(downloadOptions);
+// fileResponse.File now contains the saved ILocalResource
+```
+
+---
+
+## Phase 2B — Parse SOAP interface (WSDL)
+
+### Goal
+
+Extract available contracts, operations, and message shapes from the WSDL document.
+
+### Steps
+
+1. Parse the WSDL XML using `System.Xml.Linq.XDocument.Parse(specResponse.TextContent)`.
+2. Extract:
+   - **Service name** — `<wsdl:service name="...">`.
+   - **Port types (contracts)** — `<wsdl:portType name="...">` → each contains `<wsdl:operation>` elements.
+   - **Operations per contract** — name, input message, output message.
+   - **Message schemas** — `<wsdl:types>` → inline XSD or imports.
+   - **Bindings** — SOAP 1.1 vs 1.2, transport URL.
+3. Build a summary list: `contractName`, `operationName`, `inputParameters`, `outputShape`.
+
+### Presenting the model
+
+Same logic as Phase 2A — if the user has a goal, proceed to Phase 3. Otherwise list operations or offer to save the WSDL:
+
+```csharp
+var downloadOptions = HttpRequestOptions.ForGet(specUrl)
+    .WithFileDownload(targetFolder: @"C:\temp", fileName: "service.wsdl");
+
+var fileResponse = await http.SendRequestAsync(downloadOptions);
+```
+
+---
+
+## Phase 2C — No spec available (REST heuristic exploration)
+
+### Goal
+
+When no interface document is found, explore the service by making requests and inspecting responses.
+
+### Steps
+
+1. GET the base URL — inspect the response body for links, API keys, or embedded documentation.
+2. Try common REST patterns: `{base}/api`, `{base}/api/v1`, `{base}/api/v2`.
+3. If the response is JSON, analyze its structure to infer available resources.
+4. If the response is HTML, look for `<a>` tags pointing to API endpoints or documentation.
+5. Report findings to the user and ask for guidance before proceeding.
+
+---
+
+## Phase 3 — Map user goal to an operation
+
+### Goal
+
+Given the user's stated intent (e.g., "get a list of users", "create an order"), find the best-matching operation from the model built in Phase 2.
+
+### Matching strategy
+
+1. **Exact match** — `operationId` or operation `summary` closely matches the user's words.
+2. **Semantic match** — HTTP method + path pattern implies the intent (e.g., `GET /users` for "list users", `POST /orders` for "create order").
+3. **Ambiguous** — multiple candidates match → present a short list and ask the user to confirm.
+
+Once an operation is selected, extract:
+- The full request URL (base + path, with path parameter placeholders).
+- Required and optional parameters (query, header, path, body).
+- The request body JSON schema (if applicable).
+- The expected success response shape.
+
+---
+
+## Phase 4 — Generate DTOs (if needed)
+
+### Goal
+
+When the selected operation has a structured request or response body, generate C# DTO classes in the project so the agent can use strongly-typed serialization.
+
+### When to generate DTOs
+
+- The request body schema defines an object with named properties.
+- The response schema defines an object the user will need to inspect or transform.
+- The user explicitly asks for typed models.
+
+### Rules
+
+- Place DTO files in the project directory, using a `Models` subfolder if one exists, or create one.
+- Name the file after the schema/class (e.g., `CreateOrderRequest.cs`, `UserResponse.cs`).
+- Use `Newtonsoft.Json` attributes (`[JsonProperty("...")]`) only when the JSON property name differs from the C# property name.
+- Keep DTOs simple — public properties with getters and setters, no business logic.
+- Use nullable types for optional fields.
+
+### Example DTO
+
+```csharp
+// Models/CreateOrderRequest.cs
+using Newtonsoft.Json;
+
+public class CreateOrderRequest
+{
+    [JsonProperty("product_id")]
+    public string ProductId { get; set; }
+
+    public int Quantity { get; set; }
+
+    [JsonProperty("shipping_address")]
+    public string ShippingAddress { get; set; }
+}
+```
+
+### Serialization in the workflow
+
+```csharp
+var requestBody = new CreateOrderRequest
+{
+    ProductId = "PROD-001",
+    Quantity = 2,
+    ShippingAddress = "123 Main St"
+};
+
+var json = JsonConvert.SerializeObject(requestBody);
+var response = await http.PostJsonAsync("https://api.example.com/orders", json);
+```
+
+### Deserialization of the response
+
+```csharp
+if (response.IsSuccessStatusCode() && response.HasTextContent())
+{
+    var order = JsonConvert.DeserializeObject<OrderResponse>(response.TextContent);
+}
+```
+
+---
+
+## Phase 5 — Progressive request execution
+
+### Goal
+
+Build and send the actual request, then iteratively fix issues until a **200 OK** (or the expected success code) is received.
+
+### Strategy
+
+Always enable debug output so each attempt produces diagnostic information:
+
+```csharp
+var options = HttpRequestOptions.ForPost("https://api.example.com/orders")
+    .WithJsonBody(json)
+    .WithTimeout(30_000);
+
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+```
+
+### Iteration loop
+
+```
+attempt = 0
+while not success and attempt < MAX_ATTEMPTS:
+    send request
+    inspect response.StatusCode, response.TextContent, response.RawRequestDebuggingInfo
+    diagnose failure
+    adjust request
+    attempt++
+```
+
+### Diagnosis table
+
+| Status | Likely cause | Agent action |
+| --- | --- | --- |
+| **401 Unauthorized** | Missing or invalid credentials | Check `response.GetWwwAuthenticate()` for the required auth scheme. Ask the user for credentials. Apply `.WithBearerToken()` or `.WithBasicAuth()`. |
+| **403 Forbidden** | Insufficient permissions | Report to user — credentials are valid but lack authorization for this operation. |
+| **404 Not Found** | Wrong URL or path parameters | Re-check the base URL, path, and any path parameters. Try alternative paths from the spec. |
+| **405 Method Not Allowed** | Wrong HTTP method | Check the `Allow` header via `response.GetHeader("Allow")` and switch to the correct method. |
+| **400 Bad Request** | Malformed body or missing parameters | Parse `response.TextContent` for validation error messages. Fix the request body or add missing parameters. |
+| **415 Unsupported Media Type** | Wrong `Content-Type` | Switch body content type (e.g., from `application/json` to `application/xml` or `application/x-www-form-urlencoded`). |
+| **422 Unprocessable Entity** | Validation failure | Parse error details from `response.TextContent`. Adjust field values or add missing required fields. |
+| **500 Internal Server Error** | Server-side issue | Inspect `response.TextContent` and `response.RawRequestDebuggingInfo` for clues. Report to user if the error is not actionable. |
+| **503 Service Unavailable** | Synthetic error from `ContinueOnError`, or server overloaded | Check `response.RawRequestDebuggingInfo` — if it contains a network exception, the service is unreachable. Otherwise retry after a delay. |
+| **3xx Redirect** | Service redirects to a different URL | Check `response.GetRedirectLocation()`. Update the base URL and retry. Consider enabling `FollowRedirects`. |
+
+### Using RawRequestDebuggingInfo
+
+The debug dump (enabled via `ResponseOptions.SaveRawRequestResponse = true`) contains the raw HTTP request and response as sent/received on the wire. Use it to:
+
+- Verify the exact URL, headers, and body that were sent.
+- Compare against the spec to find mismatches (wrong path, missing headers, malformed body).
+- Identify encoding issues or unexpected content transformations.
+- Present a concise diff to the user when asking for guidance.
+
+### Example — progressive iteration
+
+
+```csharp
+// First attempt — minimal request
+var options = HttpRequestOptions.ForGet("https://api.example.com/users")
+    .WithTimeout(15_000);
+options.ContinueOnError = true;
+options.ResponseOptions.SaveRawRequestResponse = true;
+
+var response = await http.SendRequestAsync(options);
+
+if (response.IsSuccessStatusCode())
+{
+    // Done — parse the response
+    var users = JsonConvert.DeserializeObject<List<UserResponse>>(response.TextContent);
+}
+else if (response.StatusCode == HttpStatusCode.Unauthorized)
+{
+    // Second attempt — add auth
+    var authScheme = response.GetWwwAuthenticate(); // e.g., "Bearer"
+    // Ask user for token, then retry:
+    options = HttpRequestOptions.ForGet("https://api.example.com/users")
+        .WithBearerToken(userProvidedToken)
+        .WithTimeout(15_000);
+    options.ContinueOnError = true;
+    options.ResponseOptions.SaveRawRequestResponse = true;
+
+    response = await http.SendRequestAsync(options);
+}
+else
+{
+    // Inspect debug info for diagnosis
+    var debugInfo = response.RawRequestDebuggingInfo;
+    var statusCode = response.GetStatusCodeNumber();
+    var errorBody = response.TextContent;
+    // Report and adjust...
+}
+```
+
+---
+
+## Phase 5B — Progressive SOAP execution
+
+For SOAP services, use `ISoapService.CallAsync` with the contract, method, and parameters discovered in Phase 2B:
+
+```csharp
+var response = await soap.CallAsync(new SoapRequestOptions
+{
+    EndPoint = specUrl,  // the WSDL URL
+    ContractName = "DiscoveredContractName",
+    Method = "DiscoveredMethodName",
+    Parameters = new Dictionary<string, object>
+    {
+        { "paramName", paramValue }
+    },
+    ContinueOnError = true
+});
+
+if (response.IsSuccessStatusCode())
+{
+    var xmlDoc = XDocument.Parse(response.TextContent);
+    // Extract results using LINQ to XML or XPath
+}
+else
+{
+    var statusCode = response.GetStatusCodeNumber();
+    var errorBody = response.TextContent;
+    // Diagnose and adjust parameters
+}
+```
+
+The same diagnosis table from Phase 5 applies. For SOAP-specific faults, parse the `<soap:Fault>` element from `response.TextContent` to extract `<faultcode>` and `<faultstring>`.
+
+---
+
+## Summary — Agent decision flow
+
+```
+User provides URL
+       │
+       ▼
+  Phase 1: Probe for spec
+       │
+       ├── REST spec found ──────► Phase 2A: Parse OpenAPI
+       ├── WSDL found ──────────► Phase 2B: Parse WSDL
+       ├── No spec, got response ► Phase 2C: Heuristic exploration
+       └── Nothing works ────────► Report to user, stop
+       │
+       ▼
+  User has a goal?
+       │
+       ├── Yes ──► Phase 3: Map goal to operation
+       └── No ───► List operations or download spec
+       │
+       ▼
+  Phase 4: Generate DTOs (if operation has structured body)
+       │
+       ▼
+  Phase 5/5B: Progressive execution until success
+       │
+       ▼
+  Return working coded workflow to user
+```
+
+## See Also
+
+- [NetHttpRequest Activity](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) — HTTP activity behavior spec, inputs, outputs, and defaults
+- [cURL Import](curl-import.md) — converting raw cURL commands to HttpRequestOptions
+- [HTTP Request Upgrade](http-request-upgrade.md) — migrating from legacy HTTP Request activity

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/overview.md
@@ -1,0 +1,35 @@
+# UiPath Web Activities
+
+`UiPath.WebAPI.Activities`
+
+Activities for making HTTP/REST requests and working with JSON and XML data. Includes modern HTTP Request with retry policies, authentication, and proxy support, plus JSON/XML serialization and parsing utilities.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+
+## Activities
+
+### Web
+
+| Activity | Description |
+|----------|-------------|
+| [HTTP Request](activities/NetHttpRequest.md) | Send HTTP requests with configurable authentication, retry policies, proxy, and SSL options. Returns a structured `HttpResponseSummary` |
+| [HTTP Request (legacy)](activities/HttpClient.md) | Legacy HTTP request activity using RestSharp. Prefer the newer HTTP Request for new workflows |
+
+### JSON
+
+| Activity | Description |
+|----------|-------------|
+| [Deserialize JSON](activities/DeserializeJson.md) | Deserialize a JSON string to a .NET object (`JObject` by default, or a custom type via generic parameter) |
+| [Deserialize JSON Array](activities/DeserializeJsonArray.md) | Deserialize a JSON array string to a `JArray` object |
+| [Serialize JSON](activities/SerializeJson.md) | Serialize a .NET object to a JSON string with optional custom settings |
+
+### XML
+
+| Activity | Description |
+|----------|-------------|
+| [Deserialize XML](activities/DeserializeXml.md) | Parse an XML string into an `XDocument` object |
+| [Execute XPath](activities/ExecuteXPath.md) | Evaluate an XPath expression against an XML document or string |
+| [Get XML Nodes](activities/GetXMLNodes.md) | Extract all XML nodes from a document or string |
+| [Get XML Node Attributes](activities/GetXMLNodeAttributes.md) | Get the attributes of an XML node |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/AddComment.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/AddComment.md
@@ -1,0 +1,148 @@
+# Add Comment
+
+`UiPath.Word.Activities.DocumentAddComment` (cross-platform)
+`UiPath.Word.Activities.WordAddComment` (Windows)
+
+Adds a comment to a Word document anchored to a text match, a named bookmark, or (Windows only) a tracked change revision.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Cross-Platform (`DocumentAddComment`)
+
+#### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Conditional | | Full path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Conditional | | A file resource reference to the Word document |
+| `CommentText` | Comment | InArgument | `string` | Yes | | The text content of the comment. |
+
+Mutually exclusive — provide exactly one of `FilePath` or `PathResource` (see Valid Configurations).
+
+#### Options
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AnchorType` | Search by | Property | `CommentAnchorType` | No | `Text` | The type of anchor for the comment. Cross-platform supports `Text` and `Bookmark` only. |
+| `AnchorText` | Text to comment | InArgument | `string` | Conditional | | The text to search for in the document. The comment will be anchored to this text. Required when anchor type is Text. |
+| `Bookmark` | Bookmark | InArgument | `string` | Conditional | | The name of the bookmark to anchor the comment to. Required when anchor type is Bookmark. |
+| `OccurrenceIndex` | Occurrence index | InArgument | `int?` | No | `1` | The occurrence of the anchor text to target. Default is 1 (first occurrence). |
+| `Author` | Author | InArgument | `string` | No | | The author name for the comment. If not specified, uses the current system user (cross-platform). |
+
+### Windows (`WordAddComment`)
+
+**Required Scope:** `WordApplicationScope`
+
+#### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `CommentText` | Comment | InArgument | `string` | Yes | | The text content of the comment. |
+
+#### Options
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `AnchorType` | Search by | Property | `CommentAnchorType` | No | `Text` | The type of anchor for the comment. Text anchors to a text match; Bookmark anchors to a named bookmark; Revision anchors to a tracked change. |
+| `AnchorText` | Text to comment | InArgument | `string` | Conditional | | The text to search for in the document. Required when anchor type is Text. |
+| `AnchorRevision` | Text to search in revisions | InArgument | `string` | Conditional | | The text to search for in the document's revisions. The comment will be anchored to this text. Required when anchor type is Revision. Windows only. |
+| `Bookmark` | Bookmark | InArgument | `string` | Conditional | | The name of the bookmark to anchor the comment to. Required when anchor type is Bookmark. |
+| `OccurrenceIndex` | Occurrence index | InArgument | `int?` | No | `1` | The occurrence of the anchor text or revision text to target. Default is 1 (first occurrence). |
+| `Author` | Author | InArgument | `string` | No | | The author name for the comment. If not specified, uses the current Word user. |
+
+#### CommentAnchorType Enum Values
+
+| Value | Platforms | Description |
+|-------|-----------|-------------|
+| `Text` | Both | Anchor the comment to a text match in the document. |
+| `Bookmark` | Both | Anchor the comment to a named bookmark in the document. |
+| `Revision` | Windows only | Anchor the comment to a tracked change (revision) in the document. |
+
+## Valid Configurations
+
+**Cross-platform document input:** Supports two input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Local Path**: Set `FilePath` to the document path.
+**Mode B — Resource**: Set `PathResource` to a file resource reference.
+
+Only one of `FilePath` or `PathResource` should be set.
+
+**Anchor type selection (both platforms):**
+
+| Anchor Type | Required Property | Optional Properties | Leave Empty |
+|-------------|-------------------|---------------------|-------------|
+| Text (default) | `AnchorText` | `OccurrenceIndex` | `Bookmark`, `AnchorRevision` |
+| Bookmark | `Bookmark` | | `AnchorText`, `OccurrenceIndex`, `AnchorRevision` |
+| Revision (Windows only) | `AnchorRevision` | `OccurrenceIndex` | `AnchorText`, `Bookmark` |
+
+## XAML Example
+
+**Cross-platform — anchor to text:**
+
+```xml
+<ui:DocumentAddComment
+    DisplayName="Add Comment"
+    FilePath="[documentPath]"
+    AnchorType="Text"
+    AnchorText="[textToComment]"
+    OccurrenceIndex="1"
+    CommentText="[commentText]"
+    Author="[authorName]" />
+```
+
+**Cross-platform — anchor to bookmark:**
+
+```xml
+<ui:DocumentAddComment
+    DisplayName="Add Comment"
+    FilePath="[documentPath]"
+    AnchorType="Bookmark"
+    Bookmark="[bookmarkName]"
+    CommentText="[commentText]" />
+```
+
+**Windows — anchor to text (inside Word Application Scope):**
+
+```xml
+<ui:WordAddComment
+    DisplayName="Add Comment"
+    AnchorType="Text"
+    AnchorText="[textToComment]"
+    OccurrenceIndex="1"
+    CommentText="[commentText]"
+    Author="[authorName]" />
+```
+
+**Windows — anchor to bookmark:**
+
+```xml
+<ui:WordAddComment
+    DisplayName="Add Comment"
+    AnchorType="Bookmark"
+    Bookmark="[bookmarkName]"
+    CommentText="[commentText]" />
+```
+
+**Windows — anchor to a tracked change revision:**
+
+```xml
+<ui:WordAddComment
+    DisplayName="Add Comment"
+    AnchorType="Revision"
+    AnchorRevision="[revisedText]"
+    OccurrenceIndex="1"
+    CommentText="[commentText]"
+    Author="[authorName]" />
+```
+
+## Notes
+
+- **Windows — Revision anchor:** Uses the separate `AnchorRevision` property (not `AnchorText`) to search within tracked changes. Matches revision text via case-sensitive substring search.
+- **Cross-platform:** Supports `Text` and `Bookmark` anchor types only. Setting `AnchorType` to `Revision` throws an exception.
+- `OccurrenceIndex` is 1-based. Defaults to 1 (first occurrence). Values less than 1 throw an exception.
+- `Author` defaults to the current Word user on Windows, or the current system user (`Environment.UserName`) on cross-platform.
+- Must be placed inside a **Word Application Scope** when using the Windows variant.
+- The cross-platform variant works on both Windows and Linux robots without requiring Microsoft Word to be installed.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DisableTrackChanges.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DisableTrackChanges.md
@@ -1,0 +1,79 @@
+# Disable Track Changes
+
+`UiPath.Word.Activities.DocumentDisableTrackChanges` (cross-platform)
+`UiPath.Word.Activities.WordDisableTrackChanges` (Windows)
+
+Disables track changes on a Word document. New edits will no longer be tracked as revisions.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Availability
+
+| Platform | Activity | Available |
+|----------|----------|-----------|
+| Windows | `WordDisableTrackChanges` | Yes |
+| Cross-platform | `DocumentDisableTrackChanges` | No (hidden — `browsable: false`) |
+
+The cross-platform variant is implemented but not yet exposed in UiPath Studio. It is hidden from the activity panel via `browsable: false` in the portable metadata. Only the Windows variant is available for use at this time.
+
+## Properties
+
+### Cross-Platform (`DocumentDisableTrackChanges`)
+
+#### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Conditional | | Full path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Conditional | | A file resource reference to the Word document |
+
+Mutually exclusive — provide exactly one (see Valid Configurations).
+
+No additional properties. Cross-platform simply removes tracking from the document settings.
+
+### Windows (`WordDisableTrackChanges`)
+
+**Required Scope:** `WordApplicationScope`
+
+#### Options
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Password` | Password | InArgument | `string` | No | | Password required to unprotect a document that was protected with TrackForEveryone. If the document is not protected, this property is ignored. |
+
+## Valid Configurations
+
+**Cross-platform:** Supports two input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Local Path**: Set `FilePath` to the document path.
+**Mode B — Resource**: Set `PathResource` to a file resource reference.
+
+Only one of `FilePath` or `PathResource` should be set.
+
+**Windows:** No mutually exclusive groups. `Password` is an independent optional property.
+
+## XAML Example
+
+**Cross-platform:**
+
+```xml
+<ui:DocumentDisableTrackChanges
+    DisplayName="Disable Track Changes"
+    FilePath="[documentPath]" />
+```
+
+**Windows (inside Word Application Scope):**
+
+```xml
+<ui:WordDisableTrackChanges
+    DisplayName="Disable Track Changes"
+    Password="[optionalPassword]" />
+```
+
+## Notes
+
+- **Windows:** If the document was protected with a password via Enable Track Changes (`TrackForEveryone`), provide the same password in `Password` to unprotect and disable tracking. Throws an exception if the document is protected and no password (or an incorrect password) is provided.
+- **Cross-platform:** Removes the `<w:trackRevisions>` element from the document's internal `settings.xml`. No password support.
+- Must be placed inside a **Word Application Scope** when using the Windows variant.
+- The cross-platform variant works on both Windows and Linux robots without requiring Microsoft Word to be installed.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentAddImage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentAddImage.md
@@ -1,0 +1,84 @@
+# Add Picture
+
+`UiPath.Word.Activities.DocumentAddImage`
+
+Adds an image to a Word document at a specified location relative to the document, a text match, or a bookmark.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes* | | The path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Yes* | | A file resource reference to the Word document |
+| `ImagePath` | Picture to insert | InArgument | `string` | Yes | | The file path of the image to insert |
+| `Text` | Text | InArgument | `string` | | | The text to search for when inserting relative to text. Visible only when `InsertRelativeTo` is `Text` |
+| `Bookmark` | Bookmark | InArgument | `string` | | | The bookmark name for positioning. Visible only when `InsertRelativeTo` is `Bookmark` |
+| `OccurrenceIndex` | OccurrenceIndex | InArgument | `int?` | | | The 1-based index of the specific occurrence. Visible only when `InsertRelativeTo` is `Text` and `Occurrence` is `Specific` |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertRelativeTo` | Insert Relative To | `InsertRelativeType` | `Document` | Determines the reference point for image insertion |
+| `Position` | Position | `Position` | `End` | Position relative to the reference point |
+| `Occurrence` | Occurrence | `Occurrence` | `All` | Which occurrence of the search text to target. Visible only when `InsertRelativeTo` is `Text` |
+
+## Valid Configurations
+
+This activity supports three insertion modes based on `InsertRelativeTo`:
+
+**Mode A — Relative to Document** (default): Set `InsertRelativeTo` to `Document`. Use `Position` (`Start` or `End`). The conditional properties (`Text`, `Bookmark`, `Occurrence`, `OccurrenceIndex`) are hidden; `FilePath`/`PathResource` and `ImagePath` remain visible.
+
+**Mode B — Relative to Text**: Set `InsertRelativeTo` to `Text`. Set `Text` to the search string. Use `Position` (`Before`/`After`/`Replace`). Set `Occurrence` and optionally `OccurrenceIndex`.
+
+**Mode C — Relative to Bookmark**: Set `InsertRelativeTo` to `Bookmark`. Set `Bookmark` to the bookmark name. Use `Position` (`Before`/`After`/`Replace`).
+
+Additionally, `FilePath` and `PathResource` are mutually exclusive (OverloadGroups).
+
+### Conditional Properties
+
+- **`Text`** (`string`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible (null or whitespace throws at runtime).
+- **`Bookmark`** (`string`) — Only visible when `InsertRelativeTo` is `Bookmark`. Required when visible (null or whitespace throws at runtime).
+- **`Occurrence`** (`Occurrence`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible.
+- **`OccurrenceIndex`** (`int?`) — Only visible when `InsertRelativeTo` is `Text` AND `Occurrence` is `Specific`. Required when visible and must be a 1-based index (>= 1); otherwise the activity throws at runtime.
+
+### Enum Reference
+
+**`InsertRelativeType`**: `Document`, `Bookmark`, `Text`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+**`Occurrence`**: `All`, `First`, `Last`, `Specific`
+
+## XAML Example
+
+**Insert at end of document:**
+```xml
+<ui:DocumentAddImage
+    DisplayName="Add Picture"
+    FilePath="[documentPath]"
+    ImagePath="[imagePath]"
+    InsertRelativeTo="Document"
+    Position="End" />
+```
+
+**Insert after specific text occurrence:**
+```xml
+<ui:DocumentAddImage
+    DisplayName="Add Picture"
+    FilePath="[documentPath]"
+    ImagePath="[imagePath]"
+    InsertRelativeTo="Text"
+    Text="[&quot;Figure 1&quot;]"
+    Occurrence="First"
+    Position="After" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentAppendText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentAppendText.md
@@ -1,0 +1,47 @@
+# Append Text
+
+`UiPath.Word.Activities.DocumentAppendText`
+
+Writes text at the end of a Word document.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes* | | The path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Yes* | | A file resource reference to the Word document |
+| `Text` | Text | InArgument | `string` | Yes | | The text to append to the document |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `NewLine` | New line | `bool` | `true` | Whether to insert a new line before appending the text |
+
+## Valid Configurations
+
+This activity supports two input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Local Path**: Set `FilePath` to the document path.
+**Mode B — Resource**: Set `PathResource` to a file resource reference.
+
+Only one of `FilePath` or `PathResource` should be set.
+
+## XAML Example
+
+```xml
+<ui:DocumentAppendText
+    DisplayName="Append Text"
+    FilePath="[documentPath]"
+    Text="[textToAppend]"
+    NewLine="True" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentCreateNew.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentCreateNew.md
@@ -1,0 +1,48 @@
+# Create New Document
+
+`UiPath.Word.Activities.DocumentCreateNew`
+
+Creates a new Word document at the specified file path.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | Path | InArgument | `string` | Yes | | The path where the new document will be created |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ConflictResolution` | Conflict Behavior | `ConflictBehavior` | `Replace` | Determines behavior when a file with the same name already exists |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Document` | Document | `IResource` | A resource reference to the newly created document. Can be passed to other activities that accept file resources |
+
+### Enum Reference
+
+**`ConflictBehavior`**: `Replace` (replaces the existing file), `Fail` (fails if file exists), `Skip` (skips creation, uses existing file)
+
+## XAML Example
+
+```xml
+<ui:DocumentCreateNew
+    DisplayName="Create New Document"
+    FilePath="[outputPath]"
+    ConflictResolution="Replace"
+    Document="[createdDocument]" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)
+- Unlike other Document* activities, this activity only accepts `FilePath` (not `PathResource`)
+- The `Document` output (`IResource`) can be passed as `PathResource` input to subsequent Document* activities

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentInsertDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentInsertDataTable.md
@@ -1,0 +1,84 @@
+# Insert DataTable in Document
+
+`UiPath.Word.Activities.DocumentInsertDataTable`
+
+Inserts a DataTable as a table in a Word document at a specified location relative to the document, a text match, or a bookmark.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes* | | The path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Yes* | | A file resource reference to the Word document |
+| `DataTable` | DataTable | InArgument | `DataTable` | Yes | | The DataTable to insert as a table in the document |
+| `Text` | Text | InArgument | `string` | | | The text to search for when inserting relative to text. Visible only when `InsertRelativeTo` is `Text` |
+| `Bookmark` | Bookmark | InArgument | `string` | | | The bookmark name for positioning. Visible only when `InsertRelativeTo` is `Bookmark` |
+| `OccurrenceIndex` | OccurrenceIndex | InArgument | `int?` | | | The 1-based index of the specific occurrence. Visible only when `InsertRelativeTo` is `Text` and `Occurrence` is `Specific` |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertRelativeTo` | Insert Relative To | `InsertRelativeType` | `Document` | Determines the reference point for table insertion |
+| `Position` | Position | `Position` | `End` | Position relative to the reference point |
+| `Occurrence` | Occurrence | `Occurrence` | `All` | Which occurrence of the search text to target. Visible only when `InsertRelativeTo` is `Text` |
+
+## Valid Configurations
+
+This activity supports three insertion modes based on `InsertRelativeTo`:
+
+**Mode A — Relative to Document** (default): Set `InsertRelativeTo` to `Document`. Use `Position` (`Start` or `End`). The conditional properties (`Text`, `Bookmark`, `Occurrence`, `OccurrenceIndex`) are hidden; `FilePath`/`PathResource` and `DataTable` remain visible.
+
+**Mode B — Relative to Text**: Set `InsertRelativeTo` to `Text`. Set `Text` to the search string. Use `Position` (`Before`/`After`/`Replace`). Set `Occurrence` and optionally `OccurrenceIndex`.
+
+**Mode C — Relative to Bookmark**: Set `InsertRelativeTo` to `Bookmark`. Set `Bookmark` to the bookmark name. Use `Position` (`Before`/`After`/`Replace`).
+
+Additionally, `FilePath` and `PathResource` are mutually exclusive (OverloadGroups).
+
+### Conditional Properties
+
+- **`Text`** (`string`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible (null or whitespace throws at runtime).
+- **`Bookmark`** (`string`) — Only visible when `InsertRelativeTo` is `Bookmark`. Required when visible (null or whitespace throws at runtime).
+- **`Occurrence`** (`Occurrence`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible.
+- **`OccurrenceIndex`** (`int?`) — Only visible when `InsertRelativeTo` is `Text` AND `Occurrence` is `Specific`. Required when visible and must be a 1-based index (>= 1); otherwise the activity throws at runtime.
+
+### Enum Reference
+
+**`InsertRelativeType`**: `Document`, `Bookmark`, `Text`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+**`Occurrence`**: `All`, `First`, `Last`, `Specific`
+
+## XAML Example
+
+**Insert at start of document:**
+```xml
+<ui:DocumentInsertDataTable
+    DisplayName="Insert DataTable in Document"
+    FilePath="[documentPath]"
+    DataTable="[myDataTable]"
+    InsertRelativeTo="Document"
+    Position="Start" />
+```
+
+**Insert at a bookmark:**
+```xml
+<ui:DocumentInsertDataTable
+    DisplayName="Insert DataTable in Document"
+    FilePath="[documentPath]"
+    DataTable="[myDataTable]"
+    InsertRelativeTo="Bookmark"
+    Bookmark="[&quot;TableLocation&quot;]"
+    Position="After" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)
+- DataTable column headers are used as the table header row

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentInsertHyperlink.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentInsertHyperlink.md
@@ -1,0 +1,90 @@
+# Add Hyperlink to Document
+
+`UiPath.Word.Activities.DocumentInsertHyperlink`
+
+Adds a hyperlink to a Word document at a specified location.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes* | | The path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Yes* | | A file resource reference to the Word document |
+| `TextToDisplay` | Text to display | InArgument | `string` | Yes | | The visible text of the hyperlink |
+| `Address` | Address | InArgument | `string` | Yes | | The URL or address the hyperlink points to |
+| `TextToSearchFor` | Text to search for | InArgument | `string` | | | The text to find in the document for positioning. Visible only when `InsertRelativeTo` is `Text` |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertRelativeTo` | Insert relative to | `InsertHyperlinkRelativeToType` | `Document` | The location reference for hyperlink insertion |
+| `Position` | Position where to insert | `Position` | `End` | Position relative to the reference point |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Result` | Found | `bool` | Indicates whether the hyperlink was successfully inserted |
+
+## Valid Configurations
+
+This activity supports two insertion modes based on `InsertRelativeTo`:
+
+**Mode A — Relative to Document** (default): Set `InsertRelativeTo` to `Document`. `TextToSearchFor` is hidden.
+
+- Supported `Position` values: `Start`, `End`
+- Using `Before`, `After`, or `Replace` with this mode will silently fail (returns `false`).
+
+**Mode B — Relative to Text**: Set `InsertRelativeTo` to `Text`. Set `TextToSearchFor` to locate the reference text.
+
+- Supported `Position` values: `Before`, `After`, `Replace`
+- Using `Start` or `End` with this mode will silently fail (returns `false`).
+
+Additionally, `FilePath` and `PathResource` are mutually exclusive (OverloadGroups).
+
+### Conditional Properties
+
+- **`TextToSearchFor`** (`string`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible.
+
+### Enum Reference
+
+**`InsertHyperlinkRelativeToType`**: `Document`, `Text`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+## XAML Example
+
+**Insert at end of document:**
+```xml
+<ui:DocumentInsertHyperlink
+    DisplayName="Add Hyperlink to Document"
+    FilePath="[documentPath]"
+    TextToDisplay="[&quot;Click here&quot;]"
+    Address="[&quot;https://example.com&quot;]"
+    InsertRelativeTo="Document"
+    Position="End"
+    Result="[insertResult]" />
+```
+
+**Insert after specific text:**
+```xml
+<ui:DocumentInsertHyperlink
+    DisplayName="Add Hyperlink to Document"
+    FilePath="[documentPath]"
+    TextToDisplay="[&quot;Learn more&quot;]"
+    Address="[&quot;https://example.com&quot;]"
+    InsertRelativeTo="Text"
+    TextToSearchFor="[&quot;For details&quot;]"
+    Position="After"
+    Result="[insertResult]" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentReadText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentReadText.md
@@ -1,0 +1,46 @@
+# Read Text
+
+`UiPath.Word.Activities.DocumentReadText`
+
+Reads all text content from a Word document.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes* | | The path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Yes* | | A file resource reference to the Word document |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Text` | Text | `string` | The full text content extracted from the document |
+
+## Valid Configurations
+
+This activity supports two input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Local Path**: Set `FilePath` to the document path.
+**Mode B — Resource**: Set `PathResource` to a file resource reference.
+
+Only one of `FilePath` or `PathResource` should be set.
+
+## XAML Example
+
+```xml
+<ui:DocumentReadText
+    DisplayName="Read Text"
+    FilePath="[documentPath]"
+    Text="[extractedText]" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)
+- Reads document content directly without requiring Microsoft Word installed

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentReplaceText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentReplaceText.md
@@ -1,0 +1,49 @@
+# Replace Text
+
+`UiPath.Word.Activities.DocumentReplaceText`
+
+Replaces all occurrences of a specified text within a Word document with another text.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes* | | The path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Yes* | | A file resource reference to the Word document |
+| `Search` | Search | InArgument | `string` | Yes | | The text to search for in the document |
+| `Replace` | Replace | InArgument | `string` | Yes | | The replacement text |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Found` | Found | `bool` | Indicates whether the search text was found and replaced |
+
+## Valid Configurations
+
+This activity supports two input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Local Path**: Set `FilePath` to the document path.
+**Mode B — Resource**: Set `PathResource` to a file resource reference.
+
+Only one of `FilePath` or `PathResource` should be set.
+
+## XAML Example
+
+```xml
+<ui:DocumentReplaceText
+    DisplayName="Replace Text"
+    FilePath="[documentPath]"
+    Search="[searchText]"
+    Replace="[replaceText]"
+    Found="[wasFound]" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentSetBookmarkContent.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/DocumentSetBookmarkContent.md
@@ -1,0 +1,43 @@
+# Set Bookmark Content
+
+`UiPath.Word.Activities.DocumentSetBookmarkContent`
+
+Sets the text content of a named bookmark in a Word document.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes* | | The path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Yes* | | A file resource reference to the Word document |
+| `BookmarkName` | Bookmark name | InArgument | `string` | Yes | | The name of the bookmark to update |
+| `BookmarkText` | Bookmark text | InArgument | `string` | Yes | | The text to set in the bookmark |
+
+## Valid Configurations
+
+This activity supports two input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Local Path**: Set `FilePath` to the document path.
+**Mode B — Resource**: Set `PathResource` to a file resource reference.
+
+Only one of `FilePath` or `PathResource` should be set.
+
+## XAML Example
+
+```xml
+<ui:DocumentSetBookmarkContent
+    DisplayName="Set Bookmark Content"
+    FilePath="[documentPath]"
+    BookmarkName="[&quot;CustomerName&quot;]"
+    BookmarkText="[customerName]" />
+```
+
+## Notes
+
+- Cross-platform activity (works on both Windows and Linux)
+- The bookmark must already exist in the document

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/EnableTrackChanges.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/EnableTrackChanges.md
@@ -1,0 +1,89 @@
+# Enable Track Changes
+
+`UiPath.Word.Activities.DocumentEnableTrackChanges` (cross-platform)
+`UiPath.Word.Activities.WordEnableTrackChanges` (Windows)
+
+Enables track changes on a Word document. All user edits will be tracked as revisions.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+
+## Availability
+
+| Platform | Activity | Available |
+|----------|----------|-----------|
+| Windows | `WordEnableTrackChanges` | Yes |
+| Cross-platform | `DocumentEnableTrackChanges` | No (hidden — `browsable: false`) |
+
+The cross-platform variant is implemented but not yet exposed in UiPath Studio. It is hidden from the activity panel via `browsable: false` in the portable metadata. Only the Windows variant is available for use at this time.
+
+## Properties
+
+### Cross-Platform (`DocumentEnableTrackChanges`)
+
+#### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Conditional | | Full path to the Word document file |
+| `PathResource` | File | InArgument | `IResource` | Conditional | | A file resource reference to the Word document |
+
+Mutually exclusive — provide exactly one (see Valid Configurations).
+
+No additional properties. Cross-platform always enables tracking for all users.
+
+### Windows (`WordEnableTrackChanges`)
+
+**Required Scope:** `WordApplicationScope`
+
+#### Options
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `TrackingScope` | Tracking scope | Property | `TrackingScope` | No | `TrackForEveryone` | Specifies the scope of track changes. TrackForEveryone protects the document so all users must track changes. TrackForMe enables tracking for the current user only. |
+| `Password` | Password | InArgument | `string` | No | | Optional password used to protect the document when TrackForEveryone scope is selected. |
+
+#### TrackingScope Enum Values
+
+| Value | Description |
+|-------|-------------|
+| `TrackForEveryone` | Protects the document so all users must track their changes. Optionally password-protected. |
+| `TrackForMe` | Enables tracking for the current user only, without document protection. |
+
+## Valid Configurations
+
+**Cross-platform:** Supports two input modes (mutually exclusive via OverloadGroups):
+
+**Mode A — Local Path**: Set `FilePath` to the document path.
+**Mode B — Resource**: Set `PathResource` to a file resource reference.
+
+Only one of `FilePath` or `PathResource` should be set.
+
+**Windows:** No mutually exclusive groups. `TrackingScope` and `Password` are independent optional configuration properties.
+
+## XAML Example
+
+**Cross-platform:**
+
+```xml
+<ui:DocumentEnableTrackChanges
+    DisplayName="Enable Track Changes"
+    FilePath="[documentPath]" />
+```
+
+**Windows (inside Word Application Scope):**
+
+```xml
+<ui:WordEnableTrackChanges
+    DisplayName="Enable Track Changes"
+    TrackingScope="TrackForEveryone"
+    Password="[optionalPassword]" />
+```
+
+## Notes
+
+- **Windows — TrackForEveryone:** Protects the document via `Document.Protect(wdAllowOnlyRevisions)` so all users must track changes. An optional `Password` can lock the protection.
+- **Windows — TrackForMe:** Sets `Document.TrackRevisions = true` for the current user only, without document protection.
+- **Cross-platform:** Modifies the document's internal `settings.xml` to add the `<w:trackRevisions>` element. Always tracks for everyone (no scope option). No `Password` support.
+- Must be placed inside a **Word Application Scope** when using the Windows variant.
+- The cross-platform variant works on both Windows and Linux robots without requiring Microsoft Word to be installed.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordAddImage.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordAddImage.md
@@ -1,0 +1,67 @@
+# Add Picture
+
+`UiPath.Word.Activities.WordAddImage`
+
+Adds a picture at a specified location in the Word document opened in the parent scope.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `ImagePath` | Picture to insert | InArgument | `string` | Yes | | The file path of the image to insert |
+| `Text` | Text | InArgument | `string` | | | The text to search for when inserting relative to text. Visible only when `InsertRelativeTo` is `Text` |
+| `Bookmark` | Bookmark | InArgument | `string` | | | The bookmark name for positioning. Visible only when `InsertRelativeTo` is `Bookmark` |
+| `OccurrenceIndex` | OccurrenceIndex | InArgument | `int?` | | | The 1-based index of the specific occurrence. Visible only when `InsertRelativeTo` is `Text` and `Occurrence` is `Specific` |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertRelativeTo` | Insert relative to | `InsertRelativeType` | `Document` | The location reference for image insertion |
+| `Position` | Position | `Position` | `End` | Position relative to the reference point |
+| `Occurrence` | Occurrence | `Occurrence` | `All` | Which occurrence of the text to target. Visible only when `InsertRelativeTo` is `Text` |
+
+## Valid Configurations
+
+**Mode A — Relative to Document** (default): Set `InsertRelativeTo` to `Document`. Use `Position` (`Start`/`End`). `Text`, `Bookmark`, `Occurrence`, `OccurrenceIndex` are hidden.
+
+**Mode B — Relative to Text**: Set `InsertRelativeTo` to `Text`. Set `Text` to the reference text. Use `Position` (`Before`/`After`/`Replace`). Set `Occurrence` and optionally `OccurrenceIndex`.
+
+**Mode C — Relative to Bookmark**: Set `InsertRelativeTo` to `Bookmark`. Set `Bookmark` to the bookmark name. Use `Position` (`Before`/`After`/`Replace`).
+
+### Conditional Properties
+
+- **`Text`** (`string`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible.
+- **`Bookmark`** (`string`) — Only visible when `InsertRelativeTo` is `Bookmark`. Required when visible.
+- **`Occurrence`** — Only visible when `InsertRelativeTo` is `Text`. Required when visible.
+- **`OccurrenceIndex`** (`int?`) — Only visible when `InsertRelativeTo` is `Text` and `Occurrence` is `Specific`. Required when visible and must be a 1-based index (>= 1); otherwise the activity throws at runtime.
+
+### Enum Reference
+
+**`InsertRelativeType`**: `Document`, `Text`, `Bookmark`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+**`Occurrence`**: `All`, `First`, `Last`, `Specific`
+
+## XAML Example
+
+```xml
+<ui:WordAddImage
+    DisplayName="Add Picture"
+    ImagePath="[imagePath]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- By default, inserts the image at the end of the document; use `InsertRelativeTo`, `Position`, `Occurrence`, and `OccurrenceIndex` for custom placement
+- For cross-platform scenarios (where Word is not available), use the `DocumentAddImage` activity

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordAddSensitivityLabel.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordAddSensitivityLabel.md
@@ -1,0 +1,35 @@
+# Add or Update Word Sensitivity Label
+
+`UiPath.Word.Activities.WordAddSensitivityLabel`
+
+Adds or updates a sensitivity label on the Word document opened in the parent scope.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `SensitivityLabel` | Sensitivity label | InArgument | `object` | Yes | | A sensitivity label ID (string) or an `IWordLabelObject` instance |
+| `Justification` | Justification | InArgument | `string` | | | Justification text for applying or changing the label |
+
+## XAML Example
+
+```xml
+<ui:WordAddSensitivityLabel
+    DisplayName="Add or Update Word Sensitivity Label"
+    SensitivityLabel="[sensitivityLabelId]"
+    Justification="[&quot;Business requirement&quot;]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- Requires Microsoft Information Protection (MIP) to be configured
+- `IWordLabelObject` has properties: `LabelId` (string) and `Justification` (string)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordAppendText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordAppendText.md
@@ -1,0 +1,38 @@
+# Append Text
+
+`UiPath.Word.Activities.WordAppendText`
+
+Appends text to the end of the Word document, optionally inserting a new line before the text.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | InArgument | `string` | Yes | | The text to append to the document |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `NewLine` | New line | `bool` | `true` | Whether to insert a new line before appending the text |
+
+## XAML Example
+
+```xml
+<ui:WordAppendText
+    DisplayName="Append Text"
+    Text="[textToAppend]"
+    NewLine="True" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordApplicationScope.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordApplicationScope.md
@@ -1,0 +1,56 @@
+# Word Application Scope
+
+`UiPath.Word.Activities.WordApplicationScope`
+
+Opens a Word document and provides a scope for other Word activities. When this activity ends, the document and the Word application are closed. If the specified file does not exist and `CreateNewFile` is enabled, a new document file is created.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes | | The path to the Word document to open |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `AutoSave` | Auto save | `bool` | `true` | Automatically saves the document when the scope ends |
+| `CreateNewFile` | Create if not exists | `bool` | `true` | Creates a new document if the file does not exist. Only supported for local file system paths |
+| `ReadOnly` | ReadOnly | `bool` | `false` | Opens the document in read-only mode |
+| `SensitivityOperation` | Sensitivity operation | `WordLabelOperation` | `None` | Sensitivity label operation to apply. Use `Add` with `SensitivityLabel` to set a label, or `Clear` to remove it |
+| `SensitivityLabel` | Sensitivity label | InArgument | `object` | Conditional | | A sensitivity label ID (string) or `IWordLabelObject` instance. Required when `SensitivityOperation` is `Add` (raises a validation error if missing) |
+
+### Enum Reference
+
+**`WordLabelOperation`**: `None` (no operation), `Add` (add or update label), `Clear` (remove label)
+
+## XAML Example
+
+```xml
+<ui:WordApplicationScope
+    DisplayName="Word Application Scope"
+    FilePath="[documentPath]"
+    AutoSave="True"
+    CreateNewFile="True">
+    <ui:WordApplicationScope.Body>
+        <ActivityAction x:TypeArguments="x:Object">
+            <Sequence>
+                <!-- Place Word activities here -->
+            </Sequence>
+        </ActivityAction>
+    </ui:WordApplicationScope.Body>
+</ui:WordApplicationScope>
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- This is a scope (container) activity. All Windows Word activities must be placed inside it
+- Opens a Word COM Interop session; the Word process is closed when the scope completes
+- Sensitivity label operations require Microsoft Information Protection (MIP) to be configured

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordExportToPdf.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordExportToPdf.md
@@ -1,0 +1,39 @@
+# Save Document as PDF
+
+`UiPath.Word.Activities.WordExportToPdf`
+
+Exports the Word document opened in the parent scope to a PDF file.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | File path | InArgument | `string` | Yes | | The output PDF file path |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ReplaceExisting` | Replace existing | `bool` | `true` | Whether to overwrite an existing PDF file at the target path |
+
+## XAML Example
+
+```xml
+<ui:WordExportToPdf
+    DisplayName="Save Document as PDF"
+    FilePath="[pdfOutputPath]"
+    ReplaceExisting="True" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- Uses Word's native PDF export functionality

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordGetSensitivityLabel.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordGetSensitivityLabel.md
@@ -1,0 +1,33 @@
+# Get Word Sensitivity Label
+
+`UiPath.Word.Activities.WordGetSensitivityLabel`
+
+Retrieves the sensitivity label from the Word document opened in the parent scope.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `SensitivityLabel` | Sensitivity label | `IWordLabelObject` | The sensitivity label retrieved from the document. Contains `LabelId` and `Justification` properties |
+
+## XAML Example
+
+```xml
+<ui:WordGetSensitivityLabel
+    DisplayName="Get Word Sensitivity Label"
+    SensitivityLabel="[retrievedLabel]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- Returns `null` if no sensitivity label is applied to the document
+- `IWordLabelObject` properties: `LabelId` (string), `Justification` (string)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordInsertDataTable.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordInsertDataTable.md
@@ -1,0 +1,68 @@
+# Insert DataTable in Document
+
+`UiPath.Word.Activities.WordInsertDataTable`
+
+Inserts a DataTable as a table in the Word document. Supports positional insertion relative to text or a bookmark.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `DataTable` | DataTable | InArgument | `DataTable` | Yes | | The DataTable to insert as a table |
+| `Text` | Text | InArgument | `string` | | | The text to search for when inserting relative to text. Visible only when `InsertRelativeTo` is `Text` |
+| `Bookmark` | Bookmark | InArgument | `string` | | | The bookmark name for positioning. Visible only when `InsertRelativeTo` is `Bookmark` |
+| `OccurrenceIndex` | OccurrenceIndex | InArgument | `int?` | | | The 1-based index of the specific occurrence. Visible only when `InsertRelativeTo` is `Text` and `Occurrence` is `Specific` |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertRelativeTo` | Insert relative to | `InsertRelativeType` | `Document` | The location reference for table insertion |
+| `Position` | Position | `Position` | `Start` | Position relative to the reference point |
+| `Occurrence` | Occurrence | `Occurrence` | `All` | Which occurrence of the text to target. Visible only when `InsertRelativeTo` is `Text` |
+
+## Valid Configurations
+
+**Mode A — Relative to Document** (default): Set `InsertRelativeTo` to `Document`. Use `Position` (`Start`/`End`). `Text`, `Bookmark`, `Occurrence`, `OccurrenceIndex` are hidden.
+
+**Mode B — Relative to Text**: Set `InsertRelativeTo` to `Text`. Set `Text` to the reference text. Use `Position` (`Before`/`After`/`Replace`). Set `Occurrence` and optionally `OccurrenceIndex`.
+
+**Mode C — Relative to Bookmark**: Set `InsertRelativeTo` to `Bookmark`. Set `Bookmark` to the bookmark name. Use `Position` (`Before`/`After`/`Replace`).
+
+### Conditional Properties
+
+- **`Text`** (`string`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible.
+- **`Bookmark`** (`string`) — Only visible when `InsertRelativeTo` is `Bookmark`. Required when visible.
+- **`Occurrence`** — Only visible when `InsertRelativeTo` is `Text`. Required when visible.
+- **`OccurrenceIndex`** (`int?`) — Only visible when `InsertRelativeTo` is `Text` and `Occurrence` is `Specific`. Required when visible and must be a 1-based index (>= 1); otherwise the activity throws at runtime.
+
+### Enum Reference
+
+**`InsertRelativeType`**: `Document`, `Text`, `Bookmark`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+**`Occurrence`**: `All`, `First`, `Last`, `Specific`
+
+## XAML Example
+
+```xml
+<ui:WordInsertDataTable
+    DisplayName="Insert DataTable in Document"
+    DataTable="[myDataTable]"
+    InsertRelativeTo="Document"
+    Position="Start" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- DataTable column headers are used as the table header row

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordInsertHyperlink.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordInsertHyperlink.md
@@ -1,0 +1,73 @@
+# Add Hyperlink to Document
+
+`UiPath.Word.Activities.WordInsertHyperlink`
+
+Adds a hyperlink to the Word document at a specified location.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `TextToDisplay` | Text to display | InArgument | `string` | Yes | | The visible text of the hyperlink |
+| `Address` | Address | InArgument | `string` | Yes | | The URL or address the hyperlink points to |
+| `TextToSearchFor` | Text to search for | InArgument | `string` | | | The text to find in the document for positioning. Only visible when `InsertRelativeTo` is `Text` |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `InsertRelativeTo` | Insert relative to | `InsertHyperlinkRelativeToType` | `Document` | The location reference for hyperlink insertion |
+| `Position` | Position where to insert | `Position` | `End` | Position relative to the reference point |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Found` | Found | `bool` | Indicates whether the reference text was found (when inserting relative to text) |
+
+## Valid Configurations
+
+**Mode A — Relative to Document** (default): Set `InsertRelativeTo` to `Document`. `TextToSearchFor` is hidden.
+
+- Supported `Position` values: `Start`, `End`
+- Using `Before`, `After`, or `Replace` with this mode will throw an error.
+
+**Mode B — Relative to Text**: Set `InsertRelativeTo` to `Text`. Set `TextToSearchFor` to the reference text.
+
+- Supported `Position` values: `Before`, `After`, `Replace`
+- Using `Start` or `End` with this mode is not supported.
+
+### Conditional Properties
+
+- **`TextToSearchFor`** (`string`) — Only visible when `InsertRelativeTo` is `Text`. Required when visible (throws if missing or empty).
+
+### Enum Reference
+
+**`InsertHyperlinkRelativeToType`**: `Document`, `Text`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+## XAML Example
+
+**Insert at end of document:**
+```xml
+<ui:WordInsertHyperlink
+    DisplayName="Add Hyperlink to Document"
+    TextToDisplay="[&quot;Visit website&quot;]"
+    Address="[&quot;https://example.com&quot;]"
+    InsertRelativeTo="Document"
+    Position="End"
+    Found="[wasFound]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordPasteFromClipboard.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordPasteFromClipboard.md
@@ -1,0 +1,73 @@
+# Paste Chart/Picture into Document
+
+`UiPath.Word.Activities.WordPasteFromClipboard`
+
+Pastes content from the clipboard into the Word document at a specified position. Commonly used with "Copy Excel Chart to Clipboard" to embed Excel charts in Word documents.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Text` | Text | InArgument | `string` | | | The text to search for when pasting relative to text |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `PasteOption` | Paste option | `PasteOptionType` | `Picture` | How the clipboard content is pasted |
+| `PasteRelativeTo` | Paste relative to | `PasteRelativeToType` | `Document` | The location reference for pasting |
+| `Position` | Position where to paste | `Position` | `End` | Position relative to the reference point |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Found` | Found | `bool` | Indicates whether the reference text was found (when pasting relative to text) |
+
+## Valid Configurations
+
+**Mode A — Relative to Document** (default): Set `PasteRelativeTo` to `Document`. The `Text` property is not used.
+
+- Supported `Position` values: `Start`, `End`
+- Using `Before`, `After`, or `Replace` with this mode will throw an error.
+
+**Mode B — Relative to Text**: Set `PasteRelativeTo` to `Text`. The `Text` property **must** be provided.
+
+- Supported `Position` values: `Before`, `After`, `Replace`
+- Using `Start` or `End` with this mode is not supported.
+
+### Conditional Properties
+
+- **`Text`** (`string`) — Only required when `PasteRelativeTo` is `Text`. Specifies the anchor text for positioning.
+
+### Enum Reference
+
+**`PasteOptionType`**: `EmbedData` (embeds a copy of the data), `LinkData` (links to the source data), `Picture` (pastes as a static image)
+
+**`PasteRelativeToType`**: `Document`, `Text`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+## XAML Example
+
+```xml
+<ui:WordPasteFromClipboard
+    DisplayName="Paste Chart/Picture into Document"
+    PasteOption="Picture"
+    PasteRelativeTo="Document"
+    Position="End" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- Typically used after copying an Excel chart to the clipboard
+- When `PasteRelativeTo` is `Text`, set the `Text` property to locate the insertion point

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordReadText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordReadText.md
@@ -1,0 +1,37 @@
+# Read Text
+
+`UiPath.Word.Activities.WordReadText`
+
+Reads all text from the Word document opened in the parent Word Application Scope.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Text` | Text | `string` | The full text content of the document |
+
+## XAML Example
+
+```xml
+<ui:WordApplicationScope DisplayName="Word Application Scope" FilePath="[documentPath]">
+    <ui:WordApplicationScope.Body>
+        <ActivityAction x:TypeArguments="x:Object">
+            <ui:WordReadText
+                DisplayName="Read Text"
+                Text="[extractedText]" />
+        </ActivityAction>
+    </ui:WordApplicationScope.Body>
+</ui:WordApplicationScope>
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordReplacePicture.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordReplacePicture.md
@@ -1,0 +1,35 @@
+# Replace Picture
+
+`UiPath.Word.Activities.WordReplacePicture`
+
+Replaces picture(s) in the Word document based on their Alt Text.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `PictureAltText` | Find pictures with Alt Text | InArgument | `string` | Yes | | All pictures with this Alt Text will be replaced. Case insensitive |
+| `PicturePath` | Replace with picture | InArgument | `string` | Yes | | The file path to the replacement image |
+
+## XAML Example
+
+```xml
+<ui:WordReplacePicture
+    DisplayName="Replace Picture"
+    PictureAltText="[&quot;CompanyLogo&quot;]"
+    PicturePath="[newLogoPath]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- Matches are case insensitive on the Alt Text
+- All pictures with matching Alt Text are replaced

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordReplaceText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordReplaceText.md
@@ -1,0 +1,47 @@
+# Replace Text
+
+`UiPath.Word.Activities.WordReplaceText`
+
+Replaces all occurrences of a text within the Word document with another text.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `Search` | Search | InArgument | `string` | Yes | | The text to search for |
+| `Replace` | Replace | InArgument | `string` | Yes | | The replacement text |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ReplaceAll` | Replace all | `bool` | `true` | If true, replaces all occurrences; otherwise only the first |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Found` | Found | `bool` | Indicates whether the search text was found |
+
+## XAML Example
+
+```xml
+<ui:WordReplaceText
+    DisplayName="Replace Text"
+    Search="[searchText]"
+    Replace="[replaceText]"
+    ReplaceAll="True"
+    Found="[wasFound]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordSaveAs.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordSaveAs.md
@@ -1,0 +1,44 @@
+# Save Document As
+
+`UiPath.Word.Activities.WordSaveAs`
+
+Saves the Word document opened in the parent scope as a different file, optionally in a different format.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `FilePath` | Save as file | InArgument | `string` | Yes | | The file path to save the document to |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `SaveAsFileType` | Save as type | `WordSaveAsType` | `XmlDocument` | The file format to save as |
+| `ReplaceExisting` | Replace existing | `bool` | `true` | Whether to overwrite an existing file at the target path |
+
+### Enum Reference
+
+**`WordSaveAsType`**: `XmlDocument` (.docx), `MacroEnabledDocument` (.docm), `OldDocument` (.doc), `WebPage` (.html), `FilteredWebPage` (filtered .html), `RichText` (.rtf), `PlainText` (.txt)
+
+## XAML Example
+
+```xml
+<ui:WordSaveAs
+    DisplayName="Save Document As"
+    FilePath="[outputPath]"
+    SaveAsFileType="XmlDocument"
+    ReplaceExisting="True" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordSetBookmarkContent.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordSetBookmarkContent.md
@@ -1,0 +1,34 @@
+# Set Bookmark Content
+
+`UiPath.Word.Activities.WordSetBookmarkContent`
+
+Sets the text content of a named bookmark in the Word document.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `BookmarkName` | Bookmark name | InArgument | `string` | Yes | | The name of the bookmark to update |
+| `BookmarkText` | Bookmark text | InArgument | `string` | Yes | | The text to set in the bookmark |
+
+## XAML Example
+
+```xml
+<ui:WordSetBookmarkContent
+    DisplayName="Set Bookmark Content"
+    BookmarkName="[&quot;CustomerName&quot;]"
+    BookmarkText="[customerName]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- The bookmark must already exist in the document

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordSetContentProperty.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/activities/WordSetContentProperty.md
@@ -1,0 +1,55 @@
+# Set Content Property
+
+`UiPath.Word.Activities.WordSetContentProperty`
+
+Sets the value of a content control in the Word document by matching its Text, Title, or Tag property.
+
+**Package:** `UiPath.Word.Activities`
+**Category:** Word
+**Required Scope:** `WordApplicationScope`
+**Platform:** Windows only
+
+## Properties
+
+### Input
+
+| Name | Display Name | Kind | Type | Required | Default | Description |
+|------|-------------|------|------|----------|---------|-------------|
+| `MatchBy` | Match by | InArgument | `MatchPropertyBy` | Yes | `Text` | Specifies the property to match content controls by |
+| `MatchTo` | Match to | InArgument | `string` | Yes | | The value to match against the selected property |
+| `Value` | Value | InArgument | `string` | Yes | | The text value to set in the matched content control |
+
+### Configuration
+
+| Name | Display Name | Type | Default | Description |
+|------|-------------|------|---------|-------------|
+| `ReplaceAll` | Replace all | `bool` | `false` | If true, replaces all matching content controls; otherwise only the first match |
+
+### Output
+
+| Name | Display Name | Type | Description |
+|------|-------------|------|-------------|
+| `Found` | Found | `bool` | Indicates whether at least one content control was found and updated |
+
+### Enum Reference
+
+**`MatchPropertyBy`**: `Text` (match by current text content), `Title` (match by control title), `Tag` (match by control tag)
+
+## XAML Example
+
+```xml
+<ui:WordSetContentProperty
+    DisplayName="Set Content Property"
+    MatchBy="[MatchPropertyBy.Title]"
+    MatchTo="[&quot;CompanyName&quot;]"
+    Value="[companyName]"
+    ReplaceAll="False"
+    Found="[wasFound]" />
+```
+
+## Notes
+
+- Windows only — requires Microsoft Word installed
+- Must be placed inside a Word Application Scope
+- Content controls are structured document elements in Word used for form fields and templates
+- Useful for filling in Word templates that use content controls as placeholders

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/coded-api.md
@@ -1,0 +1,558 @@
+# Word — Coded Workflow API
+
+`UiPath.Word.Activities`
+
+Provides coded workflow operations for creating, reading, and manipulating Word documents (.docx, .docm). Supports two runtime modes: a cross-platform (portable) API and a Windows-only API with additional features like sensitivity labels, content controls, and Save As.
+
+**Service accessor:** `word` (type `IWordService`)
+**Required package:** `"UiPath.Word.Activities": "*"` in project.json dependencies
+
+## Auto-Imported Namespaces
+
+These namespaces are automatically available in coded workflows when this package is installed:
+
+```
+System
+System.Collections.Generic
+System.Data
+UiPath.Word
+UiPath.Word.Activities
+UiPath.Word.Activities.API
+UiPath.Word.Activities.API.Models
+```
+
+## Service Overview
+
+The `word` service provides a handle-based API for Word document operations. You open a document via the service, receive a disposable handle, then call extension methods on the handle to read, write, and manipulate content.
+
+The API has two runtime variants:
+
+| Variant | Method | Handle Type | Availability |
+|---------|--------|-------------|-------------|
+| Portable (cross-platform) | `UseDocument` | `IWordDocumentHandle` | All platforms |
+| Windows (COM/Interop) | `UseWordDocument` | `IWordDocument` | Windows only |
+
+Both handles are `IDisposable` — always use them inside a `using` statement.
+
+---
+
+## Opening a Document (Portable)
+
+### `IWordDocumentHandle UseDocument(string documentPath, bool createNew = true)`
+
+Opens or creates a Word document using the cross-platform engine.
+
+**Parameters:**
+- `documentPath` (`string`) — Path of the Word document
+- `createNew` (`bool`) — If the document does not exist, determines whether a new document is created (default: `true`)
+
+**Returns:** `IWordDocumentHandle` — Disposable handle to the Word document. Use with `using` statement.
+
+### `IWordDocumentHandle UseDocument(DocumentOptions options)`
+
+Opens or creates a Word document with detailed options. When `CreateNew` is true, validates the file extension (.docx or .docm), handles conflict behavior, and creates the parent directory if needed.
+
+**Parameters:**
+- `options` (`DocumentOptions`) — Options controlling how the document is opened or created
+
+**Returns:** `IWordDocumentHandle` — Disposable handle to the Word document. Use with `using` statement.
+
+---
+
+## Opening a Document (Windows)
+
+### `IWordDocument UseWordDocument(string path)`
+
+Opens or creates a Word file using COM/Interop (Windows only).
+
+**Parameters:**
+- `path` (`string`) — The path of the Word file
+
+**Returns:** `IWordDocument` — Disposable handle for performing operations on the Word file. Use with `using` statement.
+
+### `IWordDocument UseWordDocument(WordUseOptions options)`
+
+Opens or creates a Word file with detailed options (Windows only).
+
+**Parameters:**
+- `options` (`WordUseOptions`) — Options controlling how the document is opened or created
+
+**Returns:** `IWordDocument` — Disposable handle for performing operations on the Word file. Use with `using` statement.
+
+---
+
+## Handle Types
+
+### `IWordDocumentHandle` (Portable)
+
+Disposable handle to a Word document opened via the portable (cross-platform) engine. Operations are available as extension methods in the `UiPath.Word.Activities.API.WordOperations` class and are called directly on the handle.
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` explicitly.
+
+#### Extension Methods
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `AppendText(string text, bool newLine = true)` | `void` | Appends text to the document. If `newLine` is true, appends on a new line. |
+| `AppendText(string text)` | `void` | Appends text to the document on a new line. |
+| `ReadText()` | `string` | Reads all text from the document. |
+| `ReplaceText(string search, string replace)` | `bool` | Searches and replaces text. Returns true if the searched text was found. |
+| `AddPicture(string imagePath)` | `bool` | Adds a picture at the end of the document. |
+| `AddPicture(string imagePath, Position position)` | `bool` | Adds a picture at the start or end of the document. |
+| `AddPicture(string imagePath, string bookmark, Position position)` | `bool` | Adds a picture relative to a bookmark. |
+| `AddPicture(string imagePath, string textToSearchFor, Occurrence occurrence, int? occurrenceIndex, Position position)` | `bool` | Adds a picture relative to a text occurrence. |
+| `InsertDataTable(DataTable dataTable)` | `bool` | Inserts a DataTable at the end of the document. |
+| `InsertDataTable(DataTable dataTable, Position position)` | `bool` | Inserts a DataTable at the start or end of the document. |
+| `InsertDataTable(DataTable dataTable, string bookmark, Position position)` | `bool` | Inserts a DataTable relative to a bookmark. |
+| `InsertDataTable(DataTable dataTable, string textToSearchFor, Occurrence occurrence, int? occurrenceIndex, Position position)` | `bool` | Inserts a DataTable relative to a text occurrence. |
+| `InsertHyperlink(string textToDisplay, string address)` | `bool` | Inserts a hyperlink at the end of the document. |
+| `InsertHyperlink(string textToDisplay, string address, Position position)` | `bool` | Inserts a hyperlink at the start or end of the document. |
+| `InsertHyperlink(string textToDisplay, string address, Position position, string textToSearchFor)` | `bool` | Inserts a hyperlink relative to a text. |
+| `InsertHyperlink(string textToDisplay, string address, InsertHyperlinkRelativeToType insertRelativeTo, Position position, string textToSearchFor)` | `bool` | Inserts a hyperlink with full control over positioning. |
+| `SetBookmarkContent(string bookmarkName, string bookmarkText)` | `bool` | Sets the text content of a bookmark. |
+| `EnableTrackChanges()` | `void` | Enables revision tracking on the document. Tracking applies to all users. |
+| `DisableTrackChanges()` | `void` | Disables revision tracking on the document. |
+| `AddComment(string commentText, string anchorText, int? occurrenceIndex = null, string author = null)` | `void` | Adds a comment anchored to a text match in the document. |
+| `AddComment(string commentText, string bookmark, string author = null)` | `void` | Adds a comment anchored to a bookmark in the document. |
+
+### `IWordDocument` (Windows)
+
+Disposable handle to a Word document opened via COM/Interop (Windows only). Operations are available as extension methods in the `UiPath.Word.Activities.API.WordOperations` class.
+
+> This type implements `IDisposable`. Always use inside a `using` statement or call `Dispose()` explicitly.
+
+> **Return type note:** Several methods that return `bool` in the portable API return `void` in the Windows API (e.g., `AddPicture`, `InsertDataTable`/`InsertDataTableInDocument`, `SetBookmarkContent`). Do not assume return types are the same across the two handle types.
+
+#### Extension Methods
+
+| Method | Return Type | Description |
+|--------|------------|-------------|
+| `AppendText(string text, bool addNewLineBeforeText = true)` | `void` | Appends text at the end of the document. |
+| `ReadText()` | `string` | Reads all text from the document. |
+| `ReplaceTextInDocument(string searchFor, string replaceWith, bool replaceAll = true)` | `bool` | Replaces first/all occurrences of text. Both `searchFor` and `replaceWith` max 255 chars. |
+| `AddPicture(string pictureToInsert)` | `void` | Adds a picture at the end of the document. |
+| `AddPicture(string pictureToInsert, Position positionWhereToInsert)` | `void` | Adds a picture at the start or end of the document. |
+| `AddPicture(string pictureToInsert, string bookmarkToSearchFor, Position positionWhereToInsert)` | `void` | Adds a picture relative to a bookmark. |
+| `AddPicture(string pictureToInsert, string textToSearchFor, Occurrence textOccurrence, int? occurenceIndex, Position positionWhereToInsert)` | `void` | Adds a picture relative to a text occurrence. |
+| `AddHyperlinkToDocument(string textToDisplay, string address)` | `bool` | Adds a hyperlink at the end of the document. |
+| `AddHyperlinkToDocument(string textToDisplay, string address, Position positionWhereToInsert)` | `bool` | Adds a hyperlink at the start or end of the document. |
+| `AddHyperlinkToDocument(string textToDisplay, string address, Position positionWhereToInsert, string textToSearchFor)` | `bool` | Adds a hyperlink relative to a text. |
+| `AddHyperlinkToDocument(string textToDisplay, string address, InsertHyperlinkRelativeToType insertRelativeTo, Position positionWhereToInsert, string textToSearchFor)` | `bool` | Adds a hyperlink with full control over positioning. |
+| `InsertDataTableInDocument(DataTable tableToInsert)` | `void` | Inserts a DataTable at the end of the document. |
+| `InsertDataTableInDocument(DataTable tableToInsert, Position positionWhereToInsert)` | `void` | Inserts a DataTable at the start or end of the document. |
+| `InsertDataTableInDocument(DataTable tableToInsert, string bookmarkToSearchFor, Position positionWhereToInsert)` | `void` | Inserts a DataTable relative to a bookmark. |
+| `InsertDataTableInDocument(DataTable tableToInsert, string textToSearchFor, Occurrence textOccurrence, int? occurenceIndex, Position positionWhereToInsert)` | `void` | Inserts a DataTable relative to a text occurrence. |
+| `SetBookmarkContent(string bookmarkName, string bookmarkText)` | `void` | Sets the text in a document bookmark. |
+| `SetContentControlProperty(MatchPropertyBy matchBy, string matchTo, string value, bool replaceAll = false)` | `bool` | Sets the value of a content control matched by text, title, or tag. |
+| `ReplacePicture(string findPicturesWithAltText, string replaceWithPicture)` | `void` | Replaces pictures by alt text. |
+| `PasteChartPictureIntoDocument(PasteRelativeToType pasteRelativeTo, Position positionWhereToPaste, string textToSearchFor, PasteOptionType pasteOption)` | `bool` | Pastes a chart/image from clipboard into the document. |
+| `SaveDocumentAs(WordSaveAsType saveAsType, string saveAsFile, bool replaceExisting = true)` | `void` | Saves the document as a different format. |
+| `SaveAsPDF(string filePathToSaveAs, bool replaceExisting = true)` | `void` | Exports the document to PDF. |
+| `AddSensitivityLabel(IWordLabelObject label)` | `void` | Adds a sensitivity label to the document. |
+| `GetSensitivityLabel()` | `IWordLabelObject` | Retrieves the sensitivity label from the document. |
+| `EnableTrackChanges(TrackingScope scope = TrackingScope.TrackForEveryone)` | `void` | Enables revision tracking on the document. When scope is `TrackForEveryone`, enforces tracking for all users. |
+| `DisableTrackChanges()` | `void` | Disables revision tracking on the document. |
+| `AddComment(string commentText, string anchorText, int? occurrenceIndex = null, string author = null)` | `void` | Adds a comment anchored to a text match in the document via COM Interop. |
+| `AddComment(string commentText, string bookmark, string author = null)` | `void` | Adds a comment anchored to a bookmark in the document via COM Interop. |
+| `AddCommentAtRevision(string commentText, string revisionText, int? occurrenceIndex = null, string author = null)` | `void` | Adds a comment anchored to a tracked change (revision) in the document. Windows only. |
+
+---
+
+## Options & Configuration Classes
+
+### `DocumentOptions`
+
+Options for opening or creating a Word document (portable API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Path` | `string` | — | Path of the Word document. |
+| `CreateNew` | `bool` | `true` | If the document does not exist, creates a new one. Validates file extension (.docx or .docm) and creates parent directory if needed. |
+| `ConflictBehavior` | `ConflictBehavior` | `Skip` | Behavior when a file already exists and `CreateNew` is true. |
+
+### `WordUseOptions`
+
+Options for opening or creating a Word document (Windows API).
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `Path` | `string` | — | Path of the Word file. |
+| `CreateIfNotExist` | `bool` | `true` | If true, the file is created when it does not exist. |
+| `ReadOnly` | `bool` | `false` | If true, the document is opened as read-only. |
+| `AutoSave` | `bool` | `true` | If true, saves changes after document operations. |
+| `SensitivityOperation` | `WordLabelOperation` | `None` | Sensitivity label operation to execute when opening/creating the file. |
+| `SensitivityLabel` | `IWordLabelObject` | — | Sensitivity label object to apply. Used only when `SensitivityOperation` is `Add`. |
+
+### `IWordLabelObject`
+
+Represents a sensitivity label to apply to a document.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `LabelId` | `string` | — | Sensitivity label ID. |
+| `Justification` | `string` | — | Justification for changing the label. |
+
+---
+
+## Enum Reference
+
+**`ConflictBehavior`**: `Replace`, `Fail`, `Skip`
+
+**`Position`**: `Start`, `End`, `Before`, `After`, `Replace`
+
+> **Note:** Valid `Position` values depend on the operation mode. For operations relative to the whole **Document**, only `Start` and `End` are supported. For operations relative to **Text** or a **Bookmark**, `Before`, `After`, and `Replace` are supported. Using unsupported combinations will result in validation failures or the operation returning `false`.
+
+**`Occurrence`**: `All`, `First`, `Last`, `Specific`
+
+**`InsertHyperlinkRelativeToType`**: `Document`, `Text`
+
+**`PasteRelativeToType`**: `Document`, `Text`
+
+**`PasteOptionType`**: `EmbedData`, `LinkData`, `Picture`
+
+**`MatchPropertyBy`**: `Text`, `Title`, `Tag`
+
+**`WordSaveAsType`**: `XmlDocument`, `MacroEnabledDocument`, `OldDocument`, `WebPage`, `FilteredWebPage`, `RichText`, `PlainText`
+
+**`WordLabelOperation`**: `None`, `Add`, `Clear`
+
+**`TrackingScope`**: `TrackForEveryone`, `TrackForMe`
+
+> **Note:** `TrackForEveryone` protects the document to enforce tracking for all users. `TrackForMe` enables tracking for the current user only without protection. Windows only.
+
+**`CommentAnchorType`**: `Text`, `Bookmark`, `Revision`
+
+> **Note:** `Text` anchors the comment to a text match. `Bookmark` anchors to a named bookmark. `Revision` anchors to a tracked change and is only available via `AddCommentAtRevision` on the Windows API — not available on the cross-platform API.
+
+---
+
+## Common Patterns
+
+### Read text from an existing document (portable)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var docPath = Path.Combine("Reports", "quarterly.docx");
+    using var doc = word.UseDocument(docPath, createNew: false);
+    var content = doc.ReadText();
+    Log(content);
+}
+```
+
+### Create a new document and append text (portable)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var doc = word.UseDocument(new DocumentOptions
+    {
+        Path = Path.Combine("Output", "report.docx"),
+        CreateNew = true,
+        ConflictBehavior = ConflictBehavior.Replace
+    });
+
+    doc.AppendText("Quarterly Report", newLine: false);
+    doc.AppendText("This report covers Q1 2025 performance metrics.");
+    doc.AppendText("Revenue increased by 15% compared to Q4 2024.");
+}
+```
+
+### Replace text and insert a picture (portable)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var templatePath = Path.Combine("Templates", "invoice.docx");
+    using var doc = word.UseDocument(templatePath, createNew: false);
+
+    doc.ReplaceText("{{CustomerName}}", "Acme Corp");
+    doc.ReplaceText("{{Date}}", DateTime.Now.ToString("yyyy-MM-dd"));
+    doc.AddPicture(Path.Combine("Assets", "logo.png"), "LogoBookmark", Position.Replace);
+}
+```
+
+### Fill bookmarks and export to PDF (Windows)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    using var doc = word.UseWordDocument(new WordUseOptions
+    {
+        Path = "C:\\Templates\\contract.docx",
+        CreateIfNotExist = false,
+        AutoSave = true
+    });
+
+    doc.SetBookmarkContent("ClientName", "Acme Corp");
+    doc.SetBookmarkContent("ContractDate", DateTime.Now.ToString("MMMM dd, yyyy"));
+    doc.SetBookmarkContent("Amount", "$50,000");
+    doc.SaveAsPDF("C:\\Output\\contract_signed.pdf");
+}
+```
+
+### Insert a DataTable from data (portable)
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    var table = new DataTable("Sales");
+    table.Columns.Add("Product", typeof(string));
+    table.Columns.Add("Revenue", typeof(string));
+    table.Rows.Add("Widget A", "$12,000");
+    table.Rows.Add("Widget B", "$8,500");
+
+    using var doc = word.UseDocument(Path.Combine("Reports", "sales.docx"));
+    doc.AppendText("Sales Summary", newLine: false);
+    doc.InsertDataTable(table, Position.End);
+}
+```
+
+---
+
+## Track Changes
+
+### Enable Track Changes (Portable)
+
+### `void EnableTrackChanges(this IWordDocumentHandle wordDocument)`
+
+Enables revision tracking on the document by adding the `trackRevisions` element to `word/settings.xml`. Tracking applies to all users (the cross-platform path does not support per-user scope).
+
+**Parameters:** None
+
+**Returns:** `void`
+
+---
+
+### Enable Track Changes (Windows)
+
+### `void EnableTrackChanges(this IWordDocument wordDocument, TrackingScope scope = TrackingScope.TrackForEveryone)`
+
+Enables revision tracking on the document. When scope is `TrackForEveryone`, the document is protected to enforce tracking for all users.
+
+**Parameters:**
+- `scope` (`TrackingScope`) — Tracking scope. Default: `TrackForEveryone`
+
+**Returns:** `void`
+
+---
+
+### Enable Track Changes with Password (Windows)
+
+### `void EnableTrackChanges(this IWordDocument wordDocument, TrackingScope scope, string password)`
+
+Enables revision tracking with password protection. The password prevents users from disabling track changes without providing the correct password.
+
+**Parameters:**
+- `scope` (`TrackingScope`) — Tracking scope
+- `password` (`string`) — Password to enforce track changes protection
+
+**Returns:** `void`
+
+---
+
+### Disable Track Changes (Portable)
+
+### `void DisableTrackChanges(this IWordDocumentHandle wordDocument)`
+
+Disables revision tracking by removing the `trackRevisions` element from `word/settings.xml`.
+
+**Parameters:** None
+
+**Returns:** `void`
+
+---
+
+### Disable Track Changes (Windows)
+
+### `void DisableTrackChanges(this IWordDocument wordDocument)`
+
+Disables revision tracking. If the document was protected via `TrackForEveryone`, it is unprotected first.
+
+**Parameters:** None
+
+**Returns:** `void`
+
+---
+
+### Disable Track Changes with Password (Windows)
+
+### `void DisableTrackChanges(this IWordDocument wordDocument, string password)`
+
+Disables revision tracking, removing password protection if it was set.
+
+**Parameters:**
+- `password` (`string`) — Password to remove track changes protection
+
+**Returns:** `void`
+
+---
+
+### Examples
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Portable: enable and disable track changes
+    using var doc = word.UseDocument("C:\\Documents\\report.docx", createNew: false);
+    doc.EnableTrackChanges();
+    doc.AppendText("This text will be tracked as an insertion.");
+    doc.DisableTrackChanges();
+}
+```
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Windows: enable track changes with scope control
+    using var doc = word.UseWordDocument("C:\\Documents\\report.docx");
+    doc.EnableTrackChanges(TrackingScope.TrackForEveryone);
+    doc.AppendText("This text will be tracked as an insertion.");
+    doc.DisableTrackChanges();
+}
+```
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Windows: enable track changes with password protection
+    using var doc = word.UseWordDocument("C:\\Documents\\report.docx");
+    doc.EnableTrackChanges(TrackingScope.TrackForEveryone, "secretPass");
+    doc.AppendText("Track changes cannot be disabled without the password.");
+    doc.DisableTrackChanges("secretPass");
+}
+```
+
+---
+
+## Comments
+
+### Add Comment at Text (Portable)
+
+### `void AddComment(this IWordDocumentHandle wordDocument, string commentText, string anchorText, int? occurrenceIndex = null, string author = null)`
+
+Adds a comment anchored to a text match in the document.
+
+**Parameters:**
+- `commentText` (`string`) — The comment body text
+- `anchorText` (`string`) — The text in the document to anchor the comment to
+- `occurrenceIndex` (`int?`) — Which occurrence of the anchor text to target (1-based). Default: first occurrence when `null`
+- `author` (`string`) — Comment author name. Default: current system user when `null` or empty
+
+**Returns:** `void`
+
+---
+
+### Add Comment at Bookmark (Portable)
+
+### `void AddComment(this IWordDocumentHandle wordDocument, string commentText, string bookmark, string author = null)`
+
+Adds a comment anchored to a bookmark in the document.
+
+**Parameters:**
+- `commentText` (`string`) — The comment body text
+- `bookmark` (`string`) — The bookmark name to anchor the comment to
+- `author` (`string`) — Comment author name. Default: current system user when `null` or empty
+
+**Returns:** `void`
+
+---
+
+### Add Comment at Text (Windows)
+
+### `void AddComment(this IWordDocument wordDocument, string commentText, string anchorText, int? occurrenceIndex = null, string author = null)`
+
+Adds a comment anchored to a text match in the document via COM Interop.
+
+**Parameters:**
+- `commentText` (`string`) — The comment body text
+- `anchorText` (`string`) — The text in the document to anchor the comment to
+- `occurrenceIndex` (`int?`) — Which occurrence of the anchor text to target (1-based). Default: first occurrence when `null`
+- `author` (`string`) — Comment author name. Default: current user when `null`
+
+**Returns:** `void`
+
+---
+
+### Add Comment at Bookmark (Windows)
+
+### `void AddComment(this IWordDocument wordDocument, string commentText, string bookmark, string author = null)`
+
+Adds a comment anchored to a bookmark in the document via COM Interop.
+
+**Parameters:**
+- `commentText` (`string`) — The comment body text
+- `bookmark` (`string`) — The bookmark name to anchor the comment to
+- `author` (`string`) — Comment author name. Default: current user when `null`
+
+**Returns:** `void`
+
+---
+
+### Add Comment at Revision (Windows only)
+
+### `void AddCommentAtRevision(this IWordDocument wordDocument, string commentText, string revisionText, int? occurrenceIndex = null, string author = null)`
+
+Adds a comment anchored to a tracked change (revision) in the document. Windows only — not available on the cross-platform API.
+
+**Parameters:**
+- `commentText` (`string`) — The comment body text
+- `revisionText` (`string`) — The text content of the tracked change to anchor the comment to
+- `occurrenceIndex` (`int?`) — Which matching revision to anchor to (1-based). Default: first match when `null`
+- `author` (`string`) — Comment author name. Default: current user when `null`
+
+**Returns:** `void`
+
+---
+
+### Examples
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Portable: add a comment anchored to text
+    using var doc = word.UseDocument("C:\\Documents\\report.docx", createNew: false);
+    doc.AddComment(
+        "Please review this paragraph.",
+        "quarterly results",
+        occurrenceIndex: 1,
+        author: "ReviewBot");
+}
+```
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Portable: add a comment at a bookmark
+    using var doc = word.UseDocument("C:\\Documents\\report.docx", createNew: false);
+    doc.AddComment(
+        "This section needs updating.",
+        "SummaryBookmark",
+        author: "ReviewBot");
+}
+```
+
+```csharp
+[Workflow]
+public void Execute()
+{
+    // Windows: add a comment at a tracked change (revision)
+    using var doc = word.UseWordDocument("C:\\Documents\\report.docx");
+    doc.EnableTrackChanges(TrackingScope.TrackForEveryone);
+    doc.AppendText("New content to review.");
+    doc.AddCommentAtRevision(
+        "Please verify this addition.",
+        "New content to review.",
+        author: "ReviewBot");
+}
+```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.6/overview.md
@@ -1,0 +1,106 @@
+# Word Activities
+
+`UiPath.Word.Activities`
+
+Activities for creating, reading, and manipulating Microsoft Word documents. Includes cross-platform activities using Xceed DocX and Windows-only activities using Word COM Interop.
+
+## Documentation
+
+- [XAML Activities Reference](activities/) — Per-activity documentation for XAML workflows
+
+## Activities
+
+### Cross-Platform
+
+These activities work on both Windows and Linux. They operate on document files directly via file path or resource reference, without requiring Microsoft Word to be installed.
+
+| Activity | Description |
+|----------|-------------|
+| [Create New Document](activities/DocumentCreateNew.md) | Creates a new Word document at the specified path |
+| [Read Text](activities/DocumentReadText.md) | Reads all text content from a Word document |
+| [Append Text](activities/DocumentAppendText.md) | Writes text at the end of a Word document |
+| [Replace Text](activities/DocumentReplaceText.md) | Replaces all occurrences of text within a document |
+| [Set Bookmark Content](activities/DocumentSetBookmarkContent.md) | Sets the text in a document bookmark |
+| [Add Hyperlink to Document](activities/DocumentInsertHyperlink.md) | Adds a hyperlink at a specified location in a document |
+| [Add Picture](activities/DocumentAddImage.md) | Adds an image at a specified location in a document |
+| [Insert DataTable in Document](activities/DocumentInsertDataTable.md) | Inserts a DataTable as a table in a document |
+| [Add Comment](activities/AddComment.md) | Adds a comment anchored to text or a bookmark in a document |
+| [Enable Track Changes](activities/EnableTrackChanges.md) | Enables revision tracking on a Word document *(not yet visible — `browsable: false`)* |
+| [Disable Track Changes](activities/DisableTrackChanges.md) | Disables revision tracking on a Word document *(not yet visible — `browsable: false`)* |
+
+### Windows Only
+
+These activities require Microsoft Word to be installed and must be placed inside a **Word Application Scope**. They use Word COM Interop for full-fidelity document manipulation.
+
+#### Scope
+
+| Activity | Description |
+|----------|-------------|
+| [Word Application Scope](activities/WordApplicationScope.md) | Opens a Word document and provides a scope for other Word activities |
+
+#### Text
+
+| Activity | Description |
+|----------|-------------|
+| [Read Text](activities/WordReadText.md) | Reads all text from the document in the parent scope |
+| [Append Text](activities/WordAppendText.md) | Appends text at the end of the document |
+| [Replace Text](activities/WordReplaceText.md) | Replaces text occurrences within the document |
+
+#### Bookmarks
+
+| Activity | Description |
+|----------|-------------|
+| [Set Bookmark Content](activities/WordSetBookmarkContent.md) | Sets the text in a document bookmark |
+
+#### Content Controls
+
+| Activity | Description |
+|----------|-------------|
+| [Set Content Property](activities/WordSetContentProperty.md) | Sets the value of a content control by matching Text, Title, or Tag |
+
+#### Images
+
+| Activity | Description |
+|----------|-------------|
+| [Add Picture](activities/WordAddImage.md) | Adds a picture at a specified location in the document |
+| [Replace Picture](activities/WordReplacePicture.md) | Replaces picture(s) by matching Alt Text |
+| [Paste Chart/Picture into Document](activities/WordPasteFromClipboard.md) | Pastes clipboard content (chart/picture) into the document |
+
+#### Tables
+
+| Activity | Description |
+|----------|-------------|
+| [Insert DataTable in Document](activities/WordInsertDataTable.md) | Inserts a DataTable as a table in the document |
+
+#### Hyperlinks
+
+| Activity | Description |
+|----------|-------------|
+| [Add Hyperlink to Document](activities/WordInsertHyperlink.md) | Adds a hyperlink at a specified location in the document |
+
+#### Save & Export
+
+| Activity | Description |
+|----------|-------------|
+| [Save Document As](activities/WordSaveAs.md) | Saves the document as a different file or format |
+| [Save Document as PDF](activities/WordExportToPdf.md) | Exports the document to PDF |
+
+#### Sensitivity Labels
+
+| Activity | Description |
+|----------|-------------|
+| [Add or Update Word Sensitivity Label](activities/WordAddSensitivityLabel.md) | Adds or updates a sensitivity label on the document |
+| [Get Word Sensitivity Label](activities/WordGetSensitivityLabel.md) | Retrieves the sensitivity label from the document |
+
+#### Track Changes
+
+| Activity | Description |
+|----------|-------------|
+| [Enable Track Changes](activities/EnableTrackChanges.md) | Enables revision tracking with scope control (TrackForMe or TrackForEveryone) |
+| [Disable Track Changes](activities/DisableTrackChanges.md) | Disables revision tracking, handling protected documents |
+
+#### Comments
+
+| Activity | Description |
+|----------|-------------|
+| [Add Comment](activities/AddComment.md) | Adds a comment anchored to text, a bookmark, or a tracked change |


### PR DESCRIPTION
## Summary
- Pulled latest activity documentation from `dev3/Activities` into `skills/uipath-rpa/references/activity-docs/`.
- UI Automation (`UiPath.UIAutomation.Activities`) excluded as requested.
- Only packages whose source has a populated `docs/` folder are touched.

## What's included

**New packages** (no prior version in skill):

| Package | Version |
|---|---|
| `UiPath.Callout.Activities` | 26.0 |
| `UiPath.Forms.Activities` | 26.0 |
| `UiPath.IntelligentOCR.StudioWeb.Activities` | 3.1 |
| `UiPath.MobileAutomation.Activities` | 25.10 |
| `UiPath.PDF.Activities` | 4.1 |
| `UiPath.Pipelines.Activities` | 3.0 |
| `UiPath.Terminal.Activities` | 2.10 |
| `UiPath.Web.Activities` | 2.5 |

**Bumped to latest version** (older version folder kept side-by-side):

| Package | New | Was |
|---|---|---|
| `UiPath.Excel.Activities` | 3.6 | 3.5 |
| `UiPath.Word.Activities` | 2.6 | 2.5 |
| `UiPath.Presentations.Activities` | 2.6 | 2.5 |
| `UiPath.System.Activities` | 26.4 | 25.10 |

**Updated in place**:
- `UiPath.Testing.Activities/25.10` — added `activities/` (19 files) and `overview.md` from source; existing `coded/` left untouched.

Versions were resolved from the package `*.build.props` files (`VersionPrefix` / `VersionMajor.VersionMinor`).

## Notes
- 397 files added, no existing files modified.
- CODEOWNERS already covers `skills/uipath-rpa/references/activity-docs/` — no update needed.
- Reviewer call: do we want to delete the now-superseded older version folders (3.5, 2.5, 25.10 for System) in this PR, or leave that for follow-up?

## Test plan
- [ ] Spot-check a handful of new files render correctly in markdown
- [ ] Confirm SKILL.md fallback path `references/activity-docs/{PackageId}/{closest}/` still resolves for affected packages
- [ ] Confirm no UI Automation content leaked in

🤖 Generated with [Claude Code](https://claude.com/claude-code)