### PR TITLE
test(uipath-maestro-case): add single-node tests for non-connector ta…

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,6 +53,7 @@
 
 # Case Management skill
 /skills/uipath-maestro-case/ @charlesliu9 @song-zhao-25 @jundayin
+/tests/tasks/uipath-maestro-case/ @charlesliu9 @song-zhao-25 @jundayin
 
 # Coded Apps skill
 /skills/uipath-coded-apps/ @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -1,0 +1,89 @@
+"""Shared helpers for uipath-maestro-case single-node e2e checks.
+
+Locates the generated `caseplan.json`, runs ``uip maestro case validate``,
+and asserts that a task of the expected ``type`` exists somewhere in the
+case definition. ``case-management`` tasks are allowed to land as skeletons
+(empty ``data``) when the referenced sub-case isn't published on the tenant
+— the test only cares that the task ``type`` was written correctly.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import subprocess
+import sys
+from typing import Any
+
+
+def find_caseplan(pattern: str = "**/caseplan.json") -> str:
+    matches = sorted(
+        p for p in glob.glob(pattern, recursive=True) if "/.venv/" not in p
+    )
+    if not matches:
+        _fail(f"No caseplan.json found matching {pattern}")
+    if len(matches) > 1:
+        joined = "\n  - ".join(matches)
+        _fail(f"Multiple caseplan.json files match {pattern!r}:\n  - {joined}")
+    return matches[0]
+
+
+def read_caseplan(path: str | None = None) -> dict:
+    p = path or find_caseplan()
+    with open(p) as f:
+        return json.load(f)
+
+
+def iter_tasks(plan: dict):
+    """Yield every task dict from every Stage / ExceptionStage node."""
+    for node in plan.get("nodes") or []:
+        node_type = node.get("type") or ""
+        if not node_type.endswith("Stage") and "Stage" not in node_type:
+            continue
+        lanes = ((node.get("data") or {}).get("tasks")) or []
+        for lane in lanes:
+            for task in lane or []:
+                yield task
+
+
+def find_tasks_of_type(plan: dict, task_type: str) -> list[dict]:
+    return [t for t in iter_tasks(plan) if t.get("type") == task_type]
+
+
+def assert_validate_passes(caseplan_path: str, *, timeout: int = 60) -> None:
+    cmd = ["uip", "maestro", "case", "validate", caseplan_path, "--output", "json"]
+    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if r.returncode != 0:
+        _fail(
+            f"uip maestro case validate exit {r.returncode}\n"
+            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+
+
+def assert_task_type_present(task_type: str, *, caseplan_path: str | None = None) -> dict:
+    plan = read_caseplan(caseplan_path)
+    matches = find_tasks_of_type(plan, task_type)
+    if not matches:
+        types_seen = sorted({t.get("type", "?") for t in iter_tasks(plan)})
+        _fail(
+            f"No task with type={task_type!r} found in caseplan. "
+            f"Task types seen: {types_seen}"
+        )
+    return matches[0]
+
+
+def task_is_skeleton(task: dict) -> bool:
+    data = task.get("data") or {}
+    if not data:
+        return True
+    context = data.get("context") or {}
+    return not context.get("taskTypeId")
+
+
+def _stringify(v: Any) -> str:
+    return json.dumps(v, default=str)
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -5,6 +5,13 @@ and asserts that a task of the expected ``type`` exists somewhere in the
 case definition. ``case-management`` tasks are allowed to land as skeletons
 (empty ``data``) when the referenced sub-case isn't published on the tenant
 — the test only cares that the task ``type`` was written correctly.
+
+For tasks whose referenced resource is published on the tenant (e.g. the
+RPA / Agent / API-workflow single-node tests), this module also provides
+``run_debug``: runs ``uip solution resource refresh`` then
+``uip maestro case debug`` and returns the parsed JSON payload so callers
+can assert on declared output values. Mirrors the uipath-maestro-flow
+``flow_check.run_debug`` shape.
 """
 
 from __future__ import annotations
@@ -12,9 +19,10 @@ from __future__ import annotations
 import glob
 import json
 import os
+import re
 import subprocess
 import sys
-from typing import Any
+from typing import Any, Iterable, Sequence
 
 
 def find_caseplan(pattern: str = "**/caseplan.json") -> str:
@@ -87,3 +95,237 @@ def _stringify(v: Any) -> str:
 
 def _fail(msg: str):
     sys.exit(f"FAIL: {msg}")
+
+
+# ── Debug helpers ───────────────────────────────────────────────────────────
+
+
+def find_project_dir(pattern: str = "**/project.uiproj") -> str:
+    """Return the directory holding the Case `project.uiproj`. Filters by
+    ``ProjectType`` so a sibling Agent / RPA / Coded project in the same
+    solution does not collide with the Case project we want to debug.
+    """
+    candidates = sorted(
+        p for p in glob.glob(pattern, recursive=True) if "/.venv/" not in p
+    )
+    if not candidates:
+        _fail(f"No project.uiproj found matching {pattern}")
+    case_projects = [p for p in candidates if _is_case_project(p)]
+    if not case_projects:
+        joined = "\n  - ".join(candidates)
+        _fail(
+            f"No Case project.uiproj found matching {pattern} — "
+            f"candidates exist but none declare ProjectType=\"CaseManagement\":"
+            f"\n  - {joined}"
+        )
+    if len(case_projects) > 1:
+        joined = "\n  - ".join(case_projects)
+        _fail(
+            f"Multiple Case projects match {pattern!r} — refusing to guess:"
+            f"\n  - {joined}"
+        )
+    return os.path.dirname(case_projects[0])
+
+
+def find_solution_dir(pattern: str = "**/*.uipx") -> str:
+    """Return the directory holding the ``*.uipx`` solution manifest.
+    Used as ``--solution-folder`` for ``uip solution resource refresh``.
+    """
+    matches = sorted(
+        p for p in glob.glob(pattern, recursive=True) if "/.venv/" not in p
+    )
+    if not matches:
+        _fail(f"No solution manifest found matching {pattern}")
+    if len(matches) > 1:
+        joined = "\n  - ".join(matches)
+        _fail(f"Multiple solution manifests match {pattern!r}:\n  - {joined}")
+    return os.path.dirname(matches[0])
+
+
+def run_debug(
+    *,
+    timeout: int = 540,
+    project_glob: str = "**/project.uiproj",
+    solution_glob: str = "**/*.uipx",
+    refresh_timeout: int = 120,
+) -> dict:
+    """Locate the case project, refresh solution resources, run
+    ``uip maestro case debug --output json``, and return the parsed
+    ``Data`` payload. Exits on any step failing or ``finalStatus`` not
+    being ``Completed``.
+
+    Resource refresh is mandatory per the maestro-case skill: without it
+    Studio Web cannot resolve connector resources and the debug call
+    surfaces a "Resource is not configured" warning instead of running.
+    """
+    project_dir = find_project_dir(project_glob)
+    solution_dir = find_solution_dir(solution_glob)
+
+    refresh_cmd = [
+        "uip", "solution", "resource", "refresh",
+        "--solution-folder", solution_dir,
+        "--output", "json",
+    ]
+    r = subprocess.run(refresh_cmd, capture_output=True, text=True, timeout=refresh_timeout)
+    if r.returncode != 0:
+        _fail(
+            f"solution resource refresh exit {r.returncode}\n"
+            f"stdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+
+    debug_cmd = [
+        "uip", "maestro", "case", "debug", project_dir,
+        "--log-level", "debug", "--output", "json",
+    ]
+    r = subprocess.run(debug_cmd, capture_output=True, text=True, timeout=timeout)
+    if r.returncode != 0:
+        _fail(
+            f"case debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}"
+        )
+    data = _parse_json(r.stdout)
+    if data is None:
+        _fail(f"Could not parse JSON from case debug\n{r.stdout}")
+    payload = data.get("Data") if isinstance(data, dict) and "Data" in data else data
+    status = (payload or {}).get("finalStatus")
+    if status != "Completed":
+        _fail(f"Case did not complete (finalStatus={status})\n{r.stdout}")
+    return payload
+
+
+# Keys that hold runtime metadata, not task outputs. Excluded from
+# output extraction so GUID / timestamp / status digits do not falsely
+# match small expected values (e.g. an integer in [0, 120] would match
+# any 1-3 digit chunk of an instanceId UUID).
+_METADATA_KEYS = frozenset({
+    "jobKey", "instanceId", "runId", "solutionId", "finalStatus",
+    "status", "studioWebUrl", "createdAt", "startedAt", "endedAt",
+    "elementId", "id", "uniqueId", "projectId", "tenantId", "folderId",
+    "uipathActivityTypeId", "taskTypeId", "elementInstanceId",
+    "timestamp", "occurredAt",
+})
+
+
+def collect_outputs(payload: dict) -> list[Any]:
+    """Return the declared output values from a case debug payload.
+
+    The case runtime exposes outputs under a few paths depending on
+    schema version — we walk all of them and ignore well-known metadata
+    keys. Nested dicts/lists are flattened to leaf values.
+    """
+    out: list[Any] = []
+
+    variables = payload.get("variables") or {}
+    for val in (variables.get("globals") or {}).values():
+        out.extend(_leaves(val))
+    for v in variables.get("globalVariables") or []:
+        if isinstance(v, dict) and "value" in v:
+            out.extend(_leaves(v.get("value")))
+    for section in ("outputs", "inputOutputs"):
+        for v in variables.get(section) or []:
+            if isinstance(v, dict) and "value" in v:
+                out.extend(_leaves(v.get("value")))
+
+    for task in _iter_runtime_tasks(payload):
+        for out_var in task.get("outputs") or []:
+            if isinstance(out_var, dict) and "value" in out_var:
+                out.extend(_leaves(out_var.get("value")))
+
+    return out
+
+
+def _iter_runtime_tasks(payload: dict):
+    """Yield runtime task execution dicts from anywhere in the payload.
+
+    Case debug nests task executions under stage / lane structures. We
+    walk defensively so changes to the runtime shape don't silently
+    break the output extraction.
+    """
+    seen_ids: set[int] = set()
+    stack: list[Any] = [payload]
+    while stack:
+        node = stack.pop()
+        if id(node) in seen_ids:
+            continue
+        seen_ids.add(id(node))
+        if isinstance(node, dict):
+            if "outputs" in node and (
+                "displayName" in node or "taskTypeId" in node or "type" in node
+            ):
+                yield node
+            stack.extend(node.values())
+        elif isinstance(node, (list, tuple)):
+            stack.extend(node)
+
+
+def _leaves(v: Any):
+    if isinstance(v, dict):
+        for k, nested in v.items():
+            if k in _METADATA_KEYS:
+                continue
+            yield from _leaves(nested)
+    elif isinstance(v, (list, tuple)):
+        for item in v:
+            yield from _leaves(item)
+    else:
+        yield v
+
+
+def assert_outputs_contain(
+    payload: dict, needles: str | Sequence[str], *, require_all: bool = True
+) -> None:
+    """Assert the stringified outputs contain the given needle(s)."""
+    if isinstance(needles, str):
+        needles = [needles]
+    haystack = _stringify_leaves(collect_outputs(payload))
+    present = [n for n in needles if n.lower() in haystack]
+    missing = [n for n in needles if n.lower() not in haystack]
+    ok = len(missing) == 0 if require_all else len(present) > 0
+    if not ok:
+        mode = "all of" if require_all else "any of"
+        _fail(
+            f"Outputs missing {mode} {list(needles)}; present={present}; "
+            f"missing={missing}\nOutputs: {haystack[:1000]}"
+        )
+
+
+def assert_output_int_in_range(payload: dict, lo: int, hi: int) -> int:
+    """Assert at least one integer in [lo, hi] appears in the outputs.
+
+    Pulls integers from output values only (metadata keys excluded by
+    ``collect_outputs``), so GUIDs in jobKey / instanceId can't satisfy
+    the range.
+    """
+    haystack = _stringify_leaves(collect_outputs(payload))
+    hits = [int(m) for m in re.findall(r"-?\d+", haystack) if lo <= int(m) <= hi]
+    if not hits:
+        _fail(
+            f"No integer in [{lo}, {hi}] found in outputs\n"
+            f"Outputs: {haystack[:1000]}"
+        )
+    return hits[0]
+
+
+def _stringify_leaves(values: Iterable[Any]) -> str:
+    return json.dumps(list(values), default=str).lower()
+
+
+def _parse_json(stdout: str) -> dict | None:
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError:
+        for i, line in enumerate(stdout.split("\n")):
+            if line.strip().startswith("{"):
+                try:
+                    return json.loads("\n".join(stdout.split("\n")[i:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def _is_case_project(path: str) -> bool:
+    try:
+        with open(path, encoding="utf-8") as f:
+            manifest = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return False
+    return manifest.get("ProjectType") == "CaseManagement"

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -82,11 +82,23 @@ def assert_task_type_present(task_type: str, *, caseplan_path: str | None = None
 
 
 def task_is_skeleton(task: dict) -> bool:
+    """True when the task's resource hasn't been wired into ``data``.
+
+    v20 caseplan markers for a populated task:
+    - ``execute-connector-activity`` / ``wait-for-connector``: ``data.typeId`` AND ``data.connectionId``
+    - ``action``: ``data.inputs`` present (bare ``taskTitle`` / ``priority`` is still skeleton-equivalent)
+    - everything else (``process`` / ``agent`` / ``rpa`` / ``api-workflow`` / ``case-management``):
+      ``data.name`` AND ``data.folderPath`` (both as ``=bindings.<id>`` refs)
+    """
     data = task.get("data") or {}
     if not data:
         return True
-    context = data.get("context") or {}
-    return not context.get("taskTypeId")
+    task_type = task.get("type")
+    if task_type in {"execute-connector-activity", "wait-for-connector"}:
+        return not (data.get("typeId") and data.get("connectionId"))
+    if task_type == "action":
+        return "inputs" not in data
+    return not (data.get("name") and data.get("folderPath"))
 
 
 def _stringify(v: Any) -> str:

--- a/tests/tasks/uipath-maestro-case/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-case/init_validate.yaml
@@ -6,7 +6,7 @@ description: >
   — CLI (`uip solution new` + `uip solution project add`) or the JSON
   strategy (writing project files directly). The test asserts on the
   resulting artifacts and the validate step, not on the scaffolding method.
-tags: [uipath-maestro-case, smoke, init, validate]
+tags: [uipath-maestro-case, init, validate]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-case/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   explore available case task resources via the registry. Tests whether the
   skill teaches the correct discovery workflow (pull + direct cache-file
   inspection at ~/.uip/case-resources/, not relying on registry search).
-tags: [uipath-maestro-case, smoke, registry]
+tags: [uipath-maestro-case, registry]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -1,0 +1,62 @@
+task_id: skill-case-single-agent
+description: >
+  Build a Case Management definition from an sdd.md whose only task is an
+  AGENT. Exercises the agent plugin, registry resolution via
+  agent-index.json, and direct caseplan.json write of a `type: "agent"`
+  task. Validates the resulting case file.
+tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Case Management project named "AgentSingleCase" from the
+  sdd.md below. Write the sdd.md to disk first, then build from it.
+
+  ```
+  # AgentSingleCase
+
+  ## Trigger
+  - Manual trigger — user-initiated start of the case.
+
+  ## Stages
+  - Classify (regular stage) — receives the case after the manual trigger.
+
+  ## Tasks
+  - Run CountLetters (AGENT) — placed in the "Classify" stage.
+    - Agent Reference: Name "CountLetters", Folder "Shared".
+    - Component type: AGENT.
+  ```
+
+  Treat the generated tasks.md plan as pre-approved — do NOT block on the
+  HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
+  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
+  in a single pass and finish with `uip maestro case validate` passing on the
+  resulting caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the generated caseplan.json"
+    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Caseplan contains a task with type=\"agent\""
+    command: "python3 $TASK_DIR/check_agent_case.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -18,8 +18,9 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Build a UiPath Case Management project named "AgentSingleCase" from the
-  sdd.md below. Write the sdd.md to disk first, then build from it.
+  Build a UiPath Case Management solution named "AgentSingleCase" containing
+  a project also named "AgentSingleCase" from the sdd.md below. Write the
+  sdd.md to disk first, then build from it.
 
   ```
   # AgentSingleCase
@@ -47,7 +48,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro case validate passes on the generated caseplan.json"
-    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    command: "uip maestro case validate AgentSingleCase/AgentSingleCase/caseplan.json --output json"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -3,7 +3,9 @@ description: >
   Build a Case Management definition from an sdd.md whose only task is an
   AGENT. Exercises the agent plugin, registry resolution via
   agent-index.json, and direct caseplan.json write of a `type: "agent"`
-  task. Validates the resulting case file.
+  task. Validates the resulting case file and runs `uip maestro case debug`
+  end-to-end, asserting the CountLetters agent returns the expected 'r'
+  letter count.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
@@ -23,25 +25,92 @@ initial_prompt: |
   sdd.md to disk first, then build from it.
 
   ```
-  # AgentSingleCase
+  # SDD — AgentSingleCase
 
-  ## Trigger
-  - Manual trigger — user-initiated start of the case.
+  Single-stage, single-task case exercising the agent task plugin end-to-end.
 
-  ## Stages
-  - Classify (regular stage) — receives the case after the manual trigger.
+  ## Section 1: Case Definition
 
-  ## Tasks
-  - Run CountLetters (AGENT) — placed in the "Classify" stage.
-    - Agent Reference: Name "CountLetters", Folder "Shared".
-    - Component type: AGENT.
+  ### 1.1 Case Metadata
+  | Property | Value |
+  |---|---|
+  | Case Name | AgentSingleCase |
+  | Case Description | Single-node case that runs the CountLetters agent on a fixed input word. |
+  | Case Identifier | Prefix: ASC, Type: constant |
+  | Priority | Choiceset: Low, Medium, High - Default: Medium |
+  | Case-Level SLA | 1 d |
+  | SLA Type | Static |
+
+  ### 1.3 Triggers
+  | Trigger Type | Source | Configuration | Initial Variable Mapping |
+  |---|---|---|---|
+  | manual | User-initiated start of the case | - | - |
+
+  ### 1.4 Case Completion Conditions
+  | WHEN | IF | THEN | Marks Case Complete |
+  |---|---|---|---|
+  | required-stages-completed | - | Case marked complete | Yes |
+
+  ### 1.5 Case Variables
+  | Variable | Category | Type | Default | Description | Produced By | Consumed By |
+  |---|---|---|---|---|---|---|
+  | word | input | string | arrow | Input word the CountLetters agent counts | trigger:Manual | classify.runCountLetters |
+  | letterCount | implementation | number | - | Count of the letter 'r' returned by CountLetters | classify.runCountLetters | - |
+
+  ## Section 2: Stages & Tasks
+
+  ### Stage 1: Classify (`classify`)
+  **Type:** Stage
+  **Description:** Invoke the CountLetters agent on the input word.
+  **Required for Case Completion:** Yes
+
+  #### Stage Entry Conditions
+  | WHEN | IF | Interrupting |
+  |---|---|---|
+  | case-entered | - | No |
+
+  #### Stage Completion Conditions
+  | WHEN | IF | Exit Type | Marks Stage Complete |
+  |---|---|---|---|
+  | required-tasks-completed | - | exit-only | Yes |
+
+  #### Stage Task Summary
+  | # | Task ID | Task | Type | Owner |
+  |---|---|---|---|---|
+  | 1 | `classify.runCountLetters` | Run CountLetters agent | agent | System |
+
+  ##### Task 1.1: Run CountLetters agent (`classify.runCountLetters`)
+
+  **Type:** agent
+  **Description:** Invoke the CountLetters agent to count occurrences of the letter 'r' in the input word.
+
+  **Entry Condition**
+
+  | WHEN | IF |
+  |---|---|
+  | current-stage-entered | - |
+
+  | Field | Value |
+  |---|---|
+  | Agent Reference | Name "CountLetters", Folder "Shared" |
+  | Component Type | AGENT |
+
+  **Input Schema**
+  | Field | Type | Binding | Required |
+  |---|---|---|---|
+  | word | string | "arrow" | Yes |
+
+  **Output Schema**
+  | Field | Type | Binding |
+  |---|---|---|
+  | letterCount | number | -> count |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the
   HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
-  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
-  in a single pass and finish with `uip maestro case validate` passing on the
-  resulting caseplan.json.
+  debug` yourself — the test harness runs it. Do NOT ask for approval,
+  confirmation, or feedback. Build end-to-end in a single pass and finish
+  with `uip maestro case validate` passing on the resulting caseplan.json.
   Before starting, load the uipath-maestro-case skill. Read and follow its
   workflow steps exactly.
 
@@ -55,9 +124,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan contains a task with type=\"agent\""
+    description: "Caseplan has an agent task and debug returns the 'r' letter count for 'arrow'"
     command: "python3 $TASK_DIR/check_agent_case.py"
-    timeout: 30
+    timeout: 900
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -13,8 +13,11 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 80
-  turn_timeout: 1200
+
+run_limits:
+  task_timeout: 1500
+  max_turns: 120
+  turn_timeout: 1500
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -13,6 +13,7 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 80
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -4,8 +4,7 @@ description: >
   AGENT. Exercises the agent plugin, registry resolution via
   agent-index.json, and direct caseplan.json write of a `type: "agent"`
   task. Validates the resulting case file and runs `uip maestro case debug`
-  end-to-end, asserting the CountLetters agent returns the expected 'r'
-  letter count.
+  end-to-end, asserting only that the case finalStatus is `Completed`.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
@@ -128,7 +127,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan has an agent task and debug returns the 'r' letter count for 'arrow'"
+    description: "Caseplan has an agent task and debug completes successfully"
     command: "python3 $TASK_DIR/check_agent_case.py"
     timeout: 900
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""AgentSingleCase: caseplan.json contains a task whose type is "agent"."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+
+
+def main():
+    task = assert_task_type_present("agent")
+    skeleton = task_is_skeleton(task)
+    print(
+        f"OK: agent task present (displayName={task.get('displayName')!r}, "
+        f"skeleton={skeleton})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
@@ -1,19 +1,33 @@
 #!/usr/bin/env python3
-"""AgentSingleCase: caseplan.json contains a task whose type is "agent"."""
+"""AgentSingleCase: an agent task is wired and debug returns the occurrence of the letter 'r' in the input word 'arrow' (2: r, r)."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+from _shared.case_check import (  # noqa: E402
+    assert_output_int_in_range,
+    assert_task_type_present,
+    run_debug,
+    task_is_skeleton,
+)
 
 
 def main():
     task = assert_task_type_present("agent")
-    skeleton = task_is_skeleton(task)
+    if task_is_skeleton(task):
+        sys.exit(
+            "FAIL: agent task is a skeleton — debug requires a resolved "
+            "CountLetters registry entry with a real taskTypeId"
+        )
+    payload = run_debug(timeout=600)
+    # CountLetters returns the count of the letter 'r' for the input word.
+    # 'arrow' → 2. Tight range so a stray digit
+    # outside the task output cannot satisfy the assertion.
+    hit = assert_output_int_in_range(payload, 2, 2)
     print(
-        f"OK: agent task present (displayName={task.get('displayName')!r}, "
-        f"skeleton={skeleton})"
+        f"OK: agent task wired (displayName={task.get('displayName')!r}); "
+        f"debug returned 'r' letter count {hit} for 'arrow'"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""AgentSingleCase: an agent task is wired and debug returns the occurrence of the letter 'r' in the input word 'arrow' (2: r, r)."""
+"""AgentSingleCase: an agent task is wired and debug completes successfully."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
-    assert_output_int_in_range,
     assert_task_type_present,
     run_debug,
     task_is_skeleton,
@@ -20,14 +19,10 @@ def main():
             "FAIL: agent task is a skeleton — debug requires a resolved "
             "CountLetters registry entry with a real taskTypeId"
         )
-    payload = run_debug(timeout=600)
-    # CountLetters returns the count of the letter 'r' for the input word.
-    # 'arrow' → 2. Tight range so a stray digit
-    # outside the task output cannot satisfy the assertion.
-    hit = assert_output_int_in_range(payload, 2, 2)
+    run_debug(timeout=600)
     print(
         f"OK: agent task wired (displayName={task.get('displayName')!r}); "
-        f"debug returned 'r' letter count {hit} for 'arrow'"
+        f"debug finalStatus=Completed"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -1,0 +1,62 @@
+task_id: skill-case-single-api-workflow
+description: >
+  Build a Case Management definition from an sdd.md whose only task is an
+  API workflow. Exercises the api-workflow plugin, registry resolution via
+  api-index.json, and direct caseplan.json write of a `type: "api-workflow"`
+  task. Validates the resulting case file.
+tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Case Management project named "ApiWorkflowSingleCase"
+  from the sdd.md below. Write the sdd.md to disk first, then build from it.
+
+  ```
+  # ApiWorkflowSingleCase
+
+  ## Trigger
+  - Manual trigger — user-initiated start of the case.
+
+  ## Stages
+  - Lookup (regular stage) — receives the case after the manual trigger.
+
+  ## Tasks
+  - Lookup Age (API_WORKFLOW) — placed in the "Lookup" stage.
+    - API Workflow Reference: Name "name-to-age", Folder "Shared".
+    - Component type: API_WORKFLOW.
+  ```
+
+  Treat the generated tasks.md plan as pre-approved — do NOT block on the
+  HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
+  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
+  in a single pass and finish with `uip maestro case validate` passing on the
+  resulting caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the generated caseplan.json"
+    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Caseplan contains a task with type=\"api-workflow\""
+    command: "python3 $TASK_DIR/check_api_workflow_case.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -18,8 +18,9 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Build a UiPath Case Management project named "ApiWorkflowSingleCase"
-  from the sdd.md below. Write the sdd.md to disk first, then build from it.
+  Build a UiPath Case Management solution named "ApiWorkflowSingleCase"
+  containing a project also named "ApiWorkflowSingleCase" from the sdd.md
+  below. Write the sdd.md to disk first, then build from it.
 
   ```
   # ApiWorkflowSingleCase
@@ -47,7 +48,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro case validate passes on the generated caseplan.json"
-    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    command: "uip maestro case validate ApiWorkflowSingleCase/ApiWorkflowSingleCase/caseplan.json --output json"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -12,8 +12,11 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 80
-  turn_timeout: 1200
+
+run_limits:
+  task_timeout: 1500
+  max_turns: 120
+  turn_timeout: 1500
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -129,7 +129,7 @@ success_criteria:
   - type: run_command
     description: "Caseplan has an api-workflow task and debug completes successfully"
     command: "python3 $TASK_DIR/check_api_workflow_case.py"
-    timeout: 600
+    timeout: 720
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -12,6 +12,7 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 80
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -4,7 +4,7 @@ description: >
   API workflow. Exercises the api-workflow plugin, registry resolution via
   api-index.json, and direct caseplan.json write of a `type: "api-workflow"`
   task. Validates the resulting case file and runs `uip maestro case debug`
-  end-to-end, asserting the NameToAgeFixed2 API workflow returns an integer age.
+  end-to-end, asserting only that the case finalStatus is `Completed`.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
@@ -127,7 +127,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan has an api-workflow task and debug returns an integer age for 'tomasz'"
+    description: "Caseplan has an api-workflow task and debug completes successfully"
     command: "python3 $TASK_DIR/check_api_workflow_case.py"
     timeout: 600
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -3,7 +3,8 @@ description: >
   Build a Case Management definition from an sdd.md whose only task is an
   API workflow. Exercises the api-workflow plugin, registry resolution via
   api-index.json, and direct caseplan.json write of a `type: "api-workflow"`
-  task. Validates the resulting case file.
+  task. Validates the resulting case file and runs `uip maestro case debug`
+  end-to-end, asserting the NameToAgeFixed2 API workflow returns an integer age.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
@@ -23,25 +24,92 @@ initial_prompt: |
   below. Write the sdd.md to disk first, then build from it.
 
   ```
-  # ApiWorkflowSingleCase
+  # SDD — ApiWorkflowSingleCase
 
-  ## Trigger
-  - Manual trigger — user-initiated start of the case.
+  Single-stage, single-task case exercising the api-workflow task plugin end-to-end.
 
-  ## Stages
-  - Lookup (regular stage) — receives the case after the manual trigger.
+  ## Section 1: Case Definition
 
-  ## Tasks
-  - Lookup Age (API_WORKFLOW) — placed in the "Lookup" stage.
-    - API Workflow Reference: Name "name-to-age", Folder "Shared".
-    - Component type: API_WORKFLOW.
+  ### 1.1 Case Metadata
+  | Property | Value |
+  |---|---|
+  | Case Name | ApiWorkflowSingleCase |
+  | Case Description | Single-node case that invokes the NameToAgeFixed2 API workflow with a fixed name. |
+  | Case Identifier | Prefix: AWS, Type: constant |
+  | Priority | Choiceset: Low, Medium, High - Default: Medium |
+  | Case-Level SLA | 1 d |
+  | SLA Type | Static |
+
+  ### 1.3 Triggers
+  | Trigger Type | Source | Configuration | Initial Variable Mapping |
+  |---|---|---|---|
+  | manual | User-initiated start of the case | - | - |
+
+  ### 1.4 Case Completion Conditions
+  | WHEN | IF | THEN | Marks Case Complete |
+  |---|---|---|---|
+  | required-stages-completed | - | Case marked complete | Yes |
+
+  ### 1.5 Case Variables
+  | Variable | Category | Type | Default | Description | Produced By | Consumed By |
+  |---|---|---|---|---|---|---|
+  | name | input | string | tomasz | Input name passed to the NameToAgeFixed2 API workflow | trigger:Manual | lookup.lookupAge |
+  | age | implementation | number | - | Predicted age returned by the API workflow | lookup.lookupAge | - |
+
+  ## Section 2: Stages & Tasks
+
+  ### Stage 1: Lookup (`lookup`)
+  **Type:** Stage
+  **Description:** Invoke the NameToAgeFixed2 API workflow on the input name.
+  **Required for Case Completion:** Yes
+
+  #### Stage Entry Conditions
+  | WHEN | IF | Interrupting |
+  |---|---|---|
+  | case-entered | - | No |
+
+  #### Stage Completion Conditions
+  | WHEN | IF | Exit Type | Marks Stage Complete |
+  |---|---|---|---|
+  | required-tasks-completed | - | exit-only | Yes |
+
+  #### Stage Task Summary
+  | # | Task ID | Task | Type | Owner |
+  |---|---|---|---|---|
+  | 1 | `lookup.lookupAge` | Lookup age via NameToAgeFixed2 API workflow | api-workflow | System |
+
+  ##### Task 1.1: Lookup age via NameToAgeFixed2 API workflow (`lookup.lookupAge`)
+
+  **Type:** api-workflow
+  **Description:** Call the NameToAgeFixed2 API workflow and return the predicted age.
+
+  **Entry Condition**
+
+  | WHEN | IF |
+  |---|---|
+  | current-stage-entered | - |
+
+  | Field | Value |
+  |---|---|
+  | API Workflow Reference | Name "NameToAgeFixed2", Folder "Shared" |
+  | Component Type | API_WORKFLOW |
+
+  **Inputs**
+  | Variable | Type | Binding |
+  |---|---|---|
+  | name | string | "tomasz" |
+
+  **Outputs**
+  | Variable | Type | Binding |
+  |---|---|---|
+  | age | number | -> EstimatedAge |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the
   HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
-  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
-  in a single pass and finish with `uip maestro case validate` passing on the
-  resulting caseplan.json.
+  debug` yourself — the test harness runs it. Do NOT ask for approval,
+  confirmation, or feedback. Build end-to-end in a single pass and finish
+  with `uip maestro case validate` passing on the resulting caseplan.json.
   Before starting, load the uipath-maestro-case skill. Read and follow its
   workflow steps exactly.
 
@@ -55,9 +123,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan contains a task with type=\"api-workflow\""
+    description: "Caseplan has an api-workflow task and debug returns an integer age for 'tomasz'"
     command: "python3 $TASK_DIR/check_api_workflow_case.py"
-    timeout: 30
+    timeout: 600
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""ApiWorkflowSingleCase: caseplan.json contains a task whose type is "api-workflow"."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+
+
+def main():
+    task = assert_task_type_present("api-workflow")
+    skeleton = task_is_skeleton(task)
+    print(
+        f"OK: api-workflow task present (displayName={task.get('displayName')!r}, "
+        f"skeleton={skeleton})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
@@ -1,13 +1,12 @@
 #!/usr/bin/env python3
-"""ApiWorkflowSingleCase: an api-workflow task is wired and debug returns
-an integer age in [0, 120] for the input name='tomasz'."""
+"""ApiWorkflowSingleCase: an api-workflow task is wired and debug completes
+successfully."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
-    assert_output_int_in_range,
     assert_task_type_present,
     run_debug,
     task_is_skeleton,
@@ -21,11 +20,10 @@ def main():
             "FAIL: api-workflow task is a skeleton — debug requires a "
             "resolved name-to-age registry entry with a real taskTypeId"
         )
-    payload = run_debug(timeout=540)
-    age = assert_output_int_in_range(payload, 0, 120)
+    run_debug(timeout=540)
     print(
         f"OK: api-workflow task wired (displayName={task.get('displayName')!r}); "
-        f"debug returned age={age} for 'tomasz'"
+        f"debug finalStatus=Completed"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
@@ -1,19 +1,31 @@
 #!/usr/bin/env python3
-"""ApiWorkflowSingleCase: caseplan.json contains a task whose type is "api-workflow"."""
+"""ApiWorkflowSingleCase: an api-workflow task is wired and debug returns
+an integer age in [0, 120] for the input name='tomasz'."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+from _shared.case_check import (  # noqa: E402
+    assert_output_int_in_range,
+    assert_task_type_present,
+    run_debug,
+    task_is_skeleton,
+)
 
 
 def main():
     task = assert_task_type_present("api-workflow")
-    skeleton = task_is_skeleton(task)
+    if task_is_skeleton(task):
+        sys.exit(
+            "FAIL: api-workflow task is a skeleton — debug requires a "
+            "resolved name-to-age registry entry with a real taskTypeId"
+        )
+    payload = run_debug(timeout=540)
+    age = assert_output_int_in_range(payload, 0, 120)
     print(
-        f"OK: api-workflow task present (displayName={task.get('displayName')!r}, "
-        f"skeleton={skeleton})"
+        f"OK: api-workflow task wired (displayName={task.get('displayName')!r}); "
+        f"debug returned age={age} for 'tomasz'"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -19,8 +19,9 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Build a UiPath Case Management project named "ParentCaseSingle" from the
-  sdd.md below. Write the sdd.md to disk first, then build from it.
+  Build a UiPath Case Management solution named "ParentCaseSingle" containing
+  a project also named "ParentCaseSingle" from the sdd.md below. Write the
+  sdd.md to disk first, then build from it.
 
   ```
   # ParentCaseSingle
@@ -50,7 +51,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro case validate passes on the generated caseplan.json"
-    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    command: "uip maestro case validate ParentCaseSingle/ParentCaseSingle/caseplan.json --output json"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -1,0 +1,65 @@
+task_id: skill-case-single-case-management
+description: >
+  Build a Case Management definition from an sdd.md whose only task is a
+  nested case (CASE_MANAGEMENT). The referenced sub-case will not be
+  published on the tenant, so the agent must emit a skeleton task per the
+  skill's unresolved-resource rules — `type: "case-management"` set, no
+  fabricated taskTypeId. Validates the resulting case file.
+tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Case Management project named "ParentCaseSingle" from the
+  sdd.md below. Write the sdd.md to disk first, then build from it.
+
+  ```
+  # ParentCaseSingle
+
+  ## Trigger
+  - Manual trigger — user-initiated start of the case.
+
+  ## Stages
+  - Delegate (regular stage) — receives the case after the manual trigger.
+
+  ## Tasks
+  - Spawn ChildOnboardingCase (CASE_MANAGEMENT) — placed in the "Delegate" stage.
+    - Case Reference: Name "ChildOnboardingCase", Folder "Shared".
+    - Component type: CASE_MANAGEMENT.
+  ```
+
+  Treat the generated tasks.md plan as pre-approved — do NOT block on the
+  HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
+  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
+  in a single pass. If the referenced sub-case isn't in the registry, leave
+  it as a skeleton task (`<UNRESOLVED>`) per the skill's rules — do NOT
+  fabricate a taskTypeId. Finish with `uip maestro case validate` passing
+  on the resulting caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the generated caseplan.json"
+    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Caseplan contains a task with type=\"case-management\""
+    command: "python3 $TASK_DIR/check_case_management_case.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -12,8 +12,11 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 80
-  turn_timeout: 1200
+
+run_limits:
+  task_timeout: 1500
+  max_turns: 120
+  turn_timeout: 1500
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -12,6 +12,7 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 80
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -24,18 +24,74 @@ initial_prompt: |
   sdd.md to disk first, then build from it.
 
   ```
-  # ParentCaseSingle
+  # SDD — ParentCaseSingle
 
-  ## Trigger
-  - Manual trigger — user-initiated start of the case.
+  Single-stage, single-task case exercising the case-management (nested case) task plugin.
 
-  ## Stages
-  - Delegate (regular stage) — receives the case after the manual trigger.
+  ## Section 1: Case Definition
 
-  ## Tasks
-  - Spawn ChildOnboardingCase (CASE_MANAGEMENT) — placed in the "Delegate" stage.
-    - Case Reference: Name "ChildOnboardingCase", Folder "Shared".
-    - Component type: CASE_MANAGEMENT.
+  ### 1.1 Case Metadata
+  | Property | Value |
+  |---|---|
+  | Case Name | ParentCaseSingle |
+  | Case Description | Single-node case that spawns a child ChildOnboardingCase as a nested case task. |
+  | Case Identifier | Prefix: PCS, Type: constant |
+  | Priority | Choiceset: Low, Medium, High - Default: Medium |
+  | Case-Level SLA | 1 d |
+  | SLA Type | Static |
+
+  ### 1.3 Triggers
+  | Trigger Type | Source | Configuration | Initial Variable Mapping |
+  |---|---|---|---|
+  | manual | User-initiated start of the case | - | - |
+
+  ### 1.4 Case Completion Conditions
+  | WHEN | IF | THEN | Marks Case Complete |
+  |---|---|---|---|
+  | required-stages-completed | - | Case marked complete | Yes |
+
+  ### 1.5 Case Variables
+  | Variable | Category | Type | Default | Description | Produced By | Consumed By |
+  |---|---|---|---|---|---|---|
+  | childCaseSpawned | implementation | boolean | false | ChildOnboardingCase spawn flag | delegate.spawnChildOnboardingCase | - |
+
+  ## Section 2: Stages & Tasks
+
+  ### Stage 1: Delegate (`delegate`)
+  **Type:** Stage
+  **Description:** Spawn the ChildOnboardingCase nested case.
+  **Required for Case Completion:** Yes
+
+  #### Stage Entry Conditions
+  | WHEN | IF | Interrupting |
+  |---|---|---|
+  | case-entered | - | No |
+
+  #### Stage Completion Conditions
+  | WHEN | IF | Exit Type | Marks Stage Complete |
+  |---|---|---|---|
+  | required-tasks-completed | - | exit-only | Yes |
+
+  #### Stage Task Summary
+  | # | Task ID | Task | Type | Owner |
+  |---|---|---|---|---|
+  | 1 | `delegate.spawnChildOnboardingCase` | Spawn ChildOnboardingCase | case-management | System |
+
+  ##### Task 1.1: Spawn ChildOnboardingCase (`delegate.spawnChildOnboardingCase`)
+
+  **Type:** case-management
+  **Description:** Spawn the ChildOnboardingCase as a nested case task.
+
+  **Entry Condition**
+
+  | WHEN | IF |
+  |---|---|
+  | current-stage-entered | - |
+
+  | Field | Value |
+  |---|---|
+  | Case Reference | Name "ChildOnboardingCase", Folder "Shared" |
+  | Component Type | CASE_MANAGEMENT |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""ParentCaseSingle: caseplan.json contains a task whose type is "case-management"."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+
+
+def main():
+    task = assert_task_type_present("case-management")
+    skeleton = task_is_skeleton(task)
+    print(
+        f"OK: case-management task present (displayName={task.get('displayName')!r}, "
+        f"skeleton={skeleton})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""ProcessSingleCase: caseplan.json contains a task whose type is "process"."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+
+
+def main():
+    task = assert_task_type_present("process")
+    skeleton = task_is_skeleton(task)
+    print(
+        f"OK: process task present (displayName={task.get('displayName')!r}, "
+        f"skeleton={skeleton})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
@@ -1,19 +1,28 @@
 #!/usr/bin/env python3
-"""ProcessSingleCase: caseplan.json contains a task whose type is "process"."""
+"""ProcessSingleCase: a process task is wired and debug completes successfully."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+from _shared.case_check import (  # noqa: E402
+    assert_task_type_present,
+    run_debug,
+    task_is_skeleton,
+)
 
 
 def main():
     task = assert_task_type_present("process")
-    skeleton = task_is_skeleton(task)
+    if task_is_skeleton(task):
+        sys.exit(
+            "FAIL: process task is a skeleton — debug requires a resolved "
+            "ProcurementProcess registry entry with a real taskTypeId"
+        )
+    run_debug(timeout=720)
     print(
-        f"OK: process task present (displayName={task.get('displayName')!r}, "
-        f"skeleton={skeleton})"
+        f"OK: process task wired (displayName={task.get('displayName')!r}); "
+        f"debug finalStatus=Completed"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -1,0 +1,64 @@
+task_id: skill-case-single-process
+description: >
+  Build a Case Management definition from an sdd.md whose only task is a
+  PROCESS. Exercises the process plugin, registry resolution via
+  process-index.json, and direct caseplan.json write of a `type: "process"`
+  task. Validates the resulting case file.
+tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Case Management project named "ProcessSingleCase" from the
+  sdd.md below. Write the sdd.md to disk first, then build from it.
+
+  ```
+  # ProcessSingleCase
+
+  ## Trigger
+  - Manual trigger — user-initiated start of the case.
+
+  ## Stages
+  - Run Process (regular stage) — receives the case after the manual trigger.
+
+  ## Tasks
+  - Run InvoiceApproval (PROCESS) — placed in the "Run Process" stage.
+    - Process Reference: Name "InvoiceApproval", Folder "Shared".
+    - Component type: PROCESS.
+  ```
+
+  Treat the generated tasks.md plan as pre-approved — do NOT block on the
+  HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
+  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
+  in a single pass and finish with `uip maestro case validate` passing on the
+  resulting caseplan.json. If the process is not in the registry, leave it
+  as a skeleton task (`<UNRESOLVED>`) per the skill's rules — do not fabricate
+  a taskTypeId.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the generated caseplan.json"
+    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Caseplan contains a task with type=\"process\""
+    command: "python3 $TASK_DIR/check_process_case.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -18,8 +18,9 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Build a UiPath Case Management project named "ProcessSingleCase" from the
-  sdd.md below. Write the sdd.md to disk first, then build from it.
+  Build a UiPath Case Management solution named "ProcessSingleCase" containing
+  a project also named "ProcessSingleCase" from the sdd.md below. Write the
+  sdd.md to disk first, then build from it.
 
   ```
   # ProcessSingleCase
@@ -49,7 +50,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro case validate passes on the generated caseplan.json"
-    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    command: "uip maestro case validate ProcessSingleCase/ProcessSingleCase/caseplan.json --output json"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -13,8 +13,11 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 80
-  turn_timeout: 1200
+
+run_limits:
+  task_timeout: 1500
+  max_turns: 120
+  turn_timeout: 1500
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -13,6 +13,7 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 80
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -2,8 +2,10 @@ task_id: skill-case-single-process
 description: >
   Build a Case Management definition from an sdd.md whose only task is a
   PROCESS. Exercises the process plugin, registry resolution via
-  process-index.json, and direct caseplan.json write of a `type: "process"`
-  task. Validates the resulting case file.
+  processOrchestration-index.json, and direct caseplan.json write of a
+  `type: "process"` task. Validates the resulting case file and runs
+  `uip maestro case debug` end-to-end, asserting only that the case
+  finalStatus is `Completed`.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
@@ -23,27 +25,81 @@ initial_prompt: |
   sdd.md to disk first, then build from it.
 
   ```
-  # ProcessSingleCase
+  # SDD — ProcessSingleCase
 
-  ## Trigger
-  - Manual trigger — user-initiated start of the case.
+  Single-stage, single-task case exercising the process task plugin end-to-end.
 
-  ## Stages
-  - Run Process (regular stage) — receives the case after the manual trigger.
+  ## Section 1: Case Definition
 
-  ## Tasks
-  - Run InvoiceApproval (PROCESS) — placed in the "Run Process" stage.
-    - Process Reference: Name "InvoiceApproval", Folder "Shared".
-    - Component type: PROCESS.
+  ### 1.1 Case Metadata
+  | Property | Value |
+  |---|---|
+  | Case Name | ProcessSingleCase |
+  | Case Description | Single-node case that runs the ProcurementProcess process. |
+  | Case Identifier | Prefix: PSC, Type: constant |
+  | Priority | Choiceset: Low, Medium, High - Default: Medium |
+  | Case-Level SLA | 1 d |
+  | SLA Type | Static |
+
+  ### 1.3 Triggers
+  | Trigger Type | Source | Configuration | Initial Variable Mapping |
+  |---|---|---|---|
+  | manual | User-initiated start of the case | - | - |
+
+  ### 1.4 Case Completion Conditions
+  | WHEN | IF | THEN | Marks Case Complete |
+  |---|---|---|---|
+  | required-stages-completed | - | Case marked complete | Yes |
+
+  ### 1.5 Case Variables
+  | Variable | Category | Type | Default | Description | Produced By | Consumed By |
+  |---|---|---|---|---|---|---|
+  | procurementCompleted | implementation | boolean | false | ProcurementProcess completion flag | runProcess.runProcurementProcess | - |
+
+  ## Section 2: Stages & Tasks
+
+  ### Stage 1: Run Process (`runProcess`)
+  **Type:** Stage
+  **Description:** Execute the ProcurementProcess process.
+  **Required for Case Completion:** Yes
+
+  #### Stage Entry Conditions
+  | WHEN | IF | Interrupting |
+  |---|---|---|
+  | case-entered | - | No |
+
+  #### Stage Completion Conditions
+  | WHEN | IF | Exit Type | Marks Stage Complete |
+  |---|---|---|---|
+  | required-tasks-completed | - | exit-only | Yes |
+
+  #### Stage Task Summary
+  | # | Task ID | Task | Type | Owner |
+  |---|---|---|---|---|
+  | 1 | `runProcess.runProcurementProcess` | Run ProcurementProcess process | process | System |
+
+  ##### Task 1.1: Run ProcurementProcess process (`runProcess.runProcurementProcess`)
+
+  **Type:** process
+  **Description:** Run the ProcurementProcess process.
+
+  **Entry Condition**
+
+  | WHEN | IF |
+  |---|---|
+  | current-stage-entered | - |
+
+  | Field | Value |
+  |---|---|
+  | Process Reference | Name "ProcurementProcess", Folder "Shared/uipath-agents" |
+  | Component Type | PROCESS |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the
   HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
-  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
-  in a single pass and finish with `uip maestro case validate` passing on the
-  resulting caseplan.json. If the process is not in the registry, leave it
-  as a skeleton task (`<UNRESOLVED>`) per the skill's rules — do not fabricate
-  a taskTypeId.
+  debug` yourself — the test harness runs it. Do NOT ask for approval,
+  confirmation, or feedback. Build end-to-end in a single pass and finish
+  with `uip maestro case validate` passing on the resulting caseplan.json.
   Before starting, load the uipath-maestro-case skill. Read and follow its
   workflow steps exactly.
 
@@ -57,9 +113,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan contains a task with type=\"process\""
+    description: "Caseplan has a process task and debug completes successfully"
     command: "python3 $TASK_DIR/check_process_case.py"
-    timeout: 30
+    timeout: 900
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+"""RpaSingleCase: caseplan.json contains exactly one task whose type is "rpa"."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+
+
+def main():
+    task = assert_task_type_present("rpa")
+    skeleton = task_is_skeleton(task)
+    print(
+        f"OK: rpa task present (displayName={task.get('displayName')!r}, "
+        f"skeleton={skeleton})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
-"""RpaSingleCase: an rpa task is wired and debug returns the problem title."""
+"""RpaSingleCase: an rpa task is wired and debug completes successfully."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
-    assert_outputs_contain,
     assert_task_type_present,
     run_debug,
     task_is_skeleton,
@@ -20,11 +19,10 @@ def main():
             "FAIL: rpa task is a skeleton — debug requires a resolved "
             "ProjectEuler registry entry with a real taskTypeId"
         )
-    payload = run_debug(timeout=720)
-    assert_outputs_contain(payload, "prime square remainders")
+    run_debug(timeout=720)
     print(
         f"OK: rpa task wired (displayName={task.get('displayName')!r}); "
-        f"debug returned the problem 123 title"
+        f"debug finalStatus=Completed"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
@@ -1,19 +1,30 @@
 #!/usr/bin/env python3
-"""RpaSingleCase: caseplan.json contains exactly one task whose type is "rpa"."""
+"""RpaSingleCase: an rpa task is wired and debug returns the problem title."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+from _shared.case_check import (  # noqa: E402
+    assert_outputs_contain,
+    assert_task_type_present,
+    run_debug,
+    task_is_skeleton,
+)
 
 
 def main():
     task = assert_task_type_present("rpa")
-    skeleton = task_is_skeleton(task)
+    if task_is_skeleton(task):
+        sys.exit(
+            "FAIL: rpa task is a skeleton — debug requires a resolved "
+            "ProjectEuler registry entry with a real taskTypeId"
+        )
+    payload = run_debug(timeout=720)
+    assert_outputs_contain(payload, "prime square remainders")
     print(
-        f"OK: rpa task present (displayName={task.get('displayName')!r}, "
-        f"skeleton={skeleton})"
+        f"OK: rpa task wired (displayName={task.get('displayName')!r}); "
+        f"debug returned the problem 123 title"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -1,0 +1,62 @@
+task_id: skill-case-single-rpa
+description: >
+  Build a Case Management definition from an sdd.md whose only task is an
+  RPA workflow. Exercises planning, RPA-task plugin, registry resolution
+  via process-index.json, and direct caseplan.json write of a `type: "rpa"`
+  task. Validates the resulting case file.
+tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Case Management project named "RpaSingleCase" from the
+  sdd.md below. Write the sdd.md to disk first, then build from it.
+
+  ```
+  # RpaSingleCase
+
+  ## Trigger
+  - Manual trigger — user-initiated start of the case.
+
+  ## Stages
+  - Run RPA (regular stage) — receives the case after the manual trigger.
+
+  ## Tasks
+  - Run ProjectEuler (RPA) — placed in the "Run RPA" stage.
+    - Process Reference: Name "ProjectEuler", Folder "Shared".
+    - Component type: RPA.
+  ```
+
+  Treat the generated tasks.md plan as pre-approved — do NOT block on the
+  HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
+  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
+  in a single pass and finish with `uip maestro case validate` passing on the
+  resulting caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the generated caseplan.json"
+    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Caseplan contains a task with type=\"rpa\""
+    command: "python3 $TASK_DIR/check_rpa_case.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -18,8 +18,9 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Build a UiPath Case Management project named "RpaSingleCase" from the
-  sdd.md below. Write the sdd.md to disk first, then build from it.
+  Build a UiPath Case Management solution named "RpaSingleCase" containing
+  a project also named "RpaSingleCase" from the sdd.md below. Write the
+  sdd.md to disk first, then build from it.
 
   ```
   # RpaSingleCase
@@ -47,7 +48,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro case validate passes on the generated caseplan.json"
-    command: "uip maestro case validate $(find . -type f -name caseplan.json -not -path '*/.venv/*' | head -n 1) --output json"
+    command: "uip maestro case validate RpaSingleCase/RpaSingleCase/caseplan.json --output json"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -3,7 +3,8 @@ description: >
   Build a Case Management definition from an sdd.md whose only task is an
   RPA workflow. Exercises planning, RPA-task plugin, registry resolution
   via process-index.json, and direct caseplan.json write of a `type: "rpa"`
-  task. Validates the resulting case file.
+  task. Validates the resulting case file and runs `uip maestro case debug`
+  end-to-end, asserting the RPA task returns the expected problem title.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
@@ -23,25 +24,92 @@ initial_prompt: |
   sdd.md to disk first, then build from it.
 
   ```
-  # RpaSingleCase
+  # SDD — RpaSingleCase
 
-  ## Trigger
-  - Manual trigger — user-initiated start of the case.
+  Single-stage, single-task case exercising the rpa task plugin end-to-end.
 
-  ## Stages
-  - Run RPA (regular stage) — receives the case after the manual trigger.
+  ## Section 1: Case Definition
 
-  ## Tasks
-  - Run ProjectEuler (RPA) — placed in the "Run RPA" stage.
-    - Process Reference: Name "ProjectEuler", Folder "Shared".
-    - Component type: RPA.
+  ### 1.1 Case Metadata
+  | Property | Value |
+  |---|---|
+  | Case Name | RpaSingleCase |
+  | Case Description | Single-node case that runs the ProjectEuler RPA workflow on a fixed problem number. |
+  | Case Identifier | Prefix: RSC, Type: constant |
+  | Priority | Choiceset: Low, Medium, High - Default: Medium |
+  | Case-Level SLA | 1 d |
+  | SLA Type | Static |
+
+  ### 1.3 Triggers
+  | Trigger Type | Source | Configuration | Initial Variable Mapping |
+  |---|---|---|---|
+  | manual | User-initiated start of the case | - | - |
+
+  ### 1.4 Case Completion Conditions
+  | WHEN | IF | THEN | Marks Case Complete |
+  |---|---|---|---|
+  | required-stages-completed | - | Case marked complete | Yes |
+
+  ### 1.5 Case Variables
+  | Variable | Category | Type | Default | Description | Produced By | Consumed By |
+  |---|---|---|---|---|---|---|
+  | in_ProblemNumber | input | number | 123 | Project Euler problem number to solve | trigger:Manual | runRpa.runProjectEuler |
+  | problemTitle | implementation | string | - | Problem title returned by the ProjectEuler RPA workflow | runRpa.runProjectEuler | - |
+
+  ## Section 2: Stages & Tasks
+
+  ### Stage 1: Run RPA (`runRpa`)
+  **Type:** Stage
+  **Description:** Execute the ProjectEuler RPA workflow on the input problem number.
+  **Required for Case Completion:** Yes
+
+  #### Stage Entry Conditions
+  | WHEN | IF | Interrupting |
+  |---|---|---|
+  | case-entered | - | No |
+
+  #### Stage Completion Conditions
+  | WHEN | IF | Exit Type | Marks Stage Complete |
+  |---|---|---|---|
+  | required-tasks-completed | - | exit-only | Yes |
+
+  #### Stage Task Summary
+  | # | Task ID | Task | Type | Owner |
+  |---|---|---|---|---|
+  | 1 | `runRpa.runProjectEuler` | Run ProjectEuler RPA workflow | rpa | System |
+
+  ##### Task 1.1: Run ProjectEuler RPA workflow (`runRpa.runProjectEuler`)
+
+  **Type:** rpa
+  **Description:** Run the ProjectEuler RPA workflow to fetch the problem title for the given problem number.
+
+  **Entry Condition**
+
+  | WHEN | IF |
+  |---|---|
+  | current-stage-entered | - |
+
+  | Field | Value |
+  |---|---|
+  | Process Reference | Name "ProjectEuler", Folder "Shared" |
+  | Component Type | RPA |
+
+  **Inputs**
+  | Variable | Type | Binding |
+  |---|---|---|
+  | in_ProblemNumber | number | 123 |
+
+  **Outputs**
+  | Variable | Type | Binding |
+  |---|---|---|
+  | problemTitle | string | -> problemTitle |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the
   HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
-  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
-  in a single pass and finish with `uip maestro case validate` passing on the
-  resulting caseplan.json.
+  debug` yourself — the test harness runs it. Do NOT ask for approval,
+  confirmation, or feedback. Build end-to-end in a single pass and finish
+  with `uip maestro case validate` passing on the resulting caseplan.json.
   Before starting, load the uipath-maestro-case skill. Read and follow its
   workflow steps exactly.
 
@@ -55,9 +123,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan contains a task with type=\"rpa\""
+    description: "Caseplan has an rpa task and debug returns the problem 123 title"
     command: "python3 $TASK_DIR/check_rpa_case.py"
-    timeout: 30
+    timeout: 900
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -12,8 +12,11 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 80
-  turn_timeout: 1200
+
+run_limits:
+  task_timeout: 1500
+  max_turns: 120
+  turn_timeout: 1500
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -12,6 +12,7 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 80
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -4,7 +4,7 @@ description: >
   RPA workflow. Exercises planning, RPA-task plugin, registry resolution
   via process-index.json, and direct caseplan.json write of a `type: "rpa"`
   task. Validates the resulting case file and runs `uip maestro case debug`
-  end-to-end, asserting the RPA task returns the expected problem title.
+  end-to-end, asserting only that the case finalStatus is `Completed`.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
@@ -127,7 +127,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan has an rpa task and debug returns the problem 123 title"
+    description: "Caseplan has an rpa task and debug completes successfully"
     command: "python3 $TASK_DIR/check_rpa_case.py"
     timeout: 900
     expected_exit_code: 0


### PR DESCRIPTION
Adds e2e tests covering agent, api_workflow, case_management, process, and rpa task types, plus a shared case_check helper that locates the generated caseplan.json, runs `uip maestro case validate`, and asserts the expected task type is present.