### PR TITLE
docs(uipath-rpa): point cli-reference at UIA package CLI docs

### DIFF
--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -669,3 +669,9 @@ For RPA-specific connector workflow patterns (activity/resource discovery, conne
 ### inspect-package
 
 Inspect a NuGet package to discover its API surface (classes, methods, properties). See [coded/inspect-package-guide.md](coded/inspect-package-guide.md) for full usage.
+
+---
+
+## UI Automation Commands (`uip rpa uia ...`)
+
+UIA subcommands and flags are documented in the `UiPath.UIAutomation.Activities` package. See `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/cli-reference.md`.


### PR DESCRIPTION
## Summary
- Add a pointer section at the end of `skills/uipath-rpa/references/cli-reference.md` routing UIA subcommand/flag lookups to `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/cli-reference.md`.
- Honors the skill's boundary rule (`skills/uipath-rpa/CLAUDE.md`): UIA CLI syntax stays in the co-versioned UIA package docs, not duplicated in the RPA skill.

## Test plan
- [x] Verify the new section renders correctly at the bottom of `cli-reference.md`.
- [x] Confirm no UIA subcommands or flags are enumerated in the RPA skill (boundary rule).