### PR TITLE
docs(uipath-agents): clean up guardrail.policies from tool resource templates [AL-409]

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -8,7 +8,7 @@ Two types exist:
 - **`custom`** — deterministic rules you define (word matching, number comparison, boolean checks, universal triggers)
 - **`builtInValidator`** — UiPath Guardrails API validators (PII detection, harmful content, prompt injection, IP protection, user prompt attacks)
 
-> **Tool-level `guardrail.policies`** is auto-populated by `uip agent validate` — it copies the root-level guardrails that target each tool (via `matchNames`) into the tool's `guardrail.policies` array. Do not manually edit `guardrail.policies` on tool resources. Always configure guardrails at the agent.json root `guardrails` array.
+> **All guardrails are configured at the agent.json root `guardrails` array.** Tool resource JSON files have a `guardrail` field (kept for schema compatibility) but its `policies` array is always empty — do not populate it. The `selector.scopes` and `selector.matchNames` fields on each guardrail in `agent.json` determine which tools and scopes a guardrail applies to.
 
 ## Guardrail Schema (Base Fields)
 
@@ -845,7 +845,7 @@ Add the `guardrails` array at the agent.json root level alongside `settings`, `m
 
 ## What NOT to Do
 
-> Canonical guardrail anti-patterns — discriminator omission (`$actionType` / `$parameterType` / `$ruleType` / `$selectorType`), lowercase scope values, manual `guardrail.policies` edits on tool resources, and UUID reuse — live in [../../critical-rules.md](../../critical-rules.md) § What NOT to Do. The validator-specific anti-patterns below extend (do not repeat) that canonical list.
+> Canonical guardrail anti-patterns — discriminator omission (`$actionType` / `$parameterType` / `$ruleType` / `$selectorType`), lowercase scope values, populating `guardrail.policies` on tool resources, and UUID reuse — live in [../../critical-rules.md](../../critical-rules.md) § What NOT to Do. The validator-specific anti-patterns below extend (do not repeat) that canonical list.
 
 1. **Do not use snake_case for PII entity names** — use PascalCase: `"Email"` not `"email_address"`, `"PhoneNumber"` not `"phone_number"`, `"USSocialSecurityNumber"` not `"us_ssn"`.
 2. **Do not add `prompt_injection` to Tool or Agent scope** — it only works with `"Llm"` scope, PreExecution stage.
@@ -941,7 +941,7 @@ Confirm the guardrails appear in the validated output without errors.
 
 ## References
 
-- [../../critical-rules.md](../../critical-rules.md) — canonical low-code rules and guardrail anti-patterns (discriminators, scope casing, manual `guardrail.policies` edits, UUID reuse)
+- [../../critical-rules.md](../../critical-rules.md) — canonical low-code rules and guardrail anti-patterns (discriminators, scope casing, populating `guardrail.policies` on tool resources, UUID reuse)
 - [../../project-lifecycle.md](../../project-lifecycle.md) § `uip agent guardrails list` — CLI reference for validator discovery
 - [../../agent-definition.md](../../agent-definition.md) § Guardrails — root-level placement in `agent.json`
 

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -8,7 +8,7 @@ Two types exist:
 - **`custom`** — deterministic rules you define (word matching, number comparison, boolean checks, universal triggers)
 - **`builtInValidator`** — UiPath Guardrails API validators (PII detection, harmful content, prompt injection, IP protection, user prompt attacks)
 
-> **All guardrails are configured at the agent.json root `guardrails` array.** Tool resource JSON files have a `guardrail` field (kept for schema compatibility) but its `policies` array is always empty — do not populate it. The `selector.scopes` and `selector.matchNames` fields on each guardrail in `agent.json` determine which tools and scopes a guardrail applies to.
+> **All guardrails are configured at the agent.json root `guardrails` array.** The `selector.scopes` and `selector.matchNames` fields on each guardrail determine which tools and scopes it applies to.
 
 ## Guardrail Schema (Base Fields)
 

--- a/skills/uipath-agents/references/lowcode/capabilities/integration-service/integration-service.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/integration-service/integration-service.md
@@ -76,7 +76,6 @@ IS tools differ structurally from Orchestrator-based tools:
   },
   "iconUrl": "<connector image URL — see rules below>",
   "settings": {},
-  "guardrail": { "policies": [] },
   "isPreview": false,
   "properties": {
     "toolPath": "<path from metadata, e.g. /v2/webSearch>",

--- a/skills/uipath-agents/references/lowcode/capabilities/integration-service/integration-service.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/integration-service/integration-service.md
@@ -76,7 +76,7 @@ IS tools differ structurally from Orchestrator-based tools:
   },
   "iconUrl": "<connector image URL — see rules below>",
   "settings": {},
-  "guardrail": { "policies": [] },     // Auto-populated by validate from root-level guardrails. Do not edit manually. See ../guardrails/guardrails.md.
+  "guardrail": { "policies": [] },     // Legacy field — always empty. Guardrails are configured in agent.json root `guardrails` array. See ../guardrails/guardrails.md.
   "isPreview": false,
   "properties": {
     "toolPath": "<path from metadata, e.g. /v2/webSearch>",

--- a/skills/uipath-agents/references/lowcode/capabilities/integration-service/integration-service.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/integration-service/integration-service.md
@@ -76,7 +76,7 @@ IS tools differ structurally from Orchestrator-based tools:
   },
   "iconUrl": "<connector image URL — see rules below>",
   "settings": {},
-  "guardrail": { "policies": [] },     // Legacy field — always empty. Guardrails are configured in agent.json root `guardrails` array. See ../guardrails/guardrails.md.
+  "guardrail": { "policies": [] },
   "isPreview": false,
   "properties": {
     "toolPath": "<path from metadata, e.g. /v2/webSearch>",

--- a/skills/uipath-agents/references/lowcode/capabilities/process/external.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/external.md
@@ -64,7 +64,7 @@ Extract from response (take first entry):
 - `InputArguments` → JSON Schema string → agent-level `inputSchema` (parse JSON)
 - `OutputArguments` → JSON Schema string → agent-level `outputSchema` (parse JSON)
 
-## Agent-Level Resource Shape
+## Tool resource.json Shape
 
 **Path:** `<AGENT_NAME>/resources/{ToolName}/resource.json`
 
@@ -89,9 +89,6 @@ Extract from response (take first entry):
     "processName": "MyProcess",
     "folderPath": "solution_folder",  // Always "solution_folder" — for both solution-internal and external
     "exampleCalls": []                // Required for external tools
-  },
-  "guardrail": {
-    "policies": []
   },
   "id": "<uuid>",              // Stable; generate once, never change
   "referenceKey": "<release-key-guid>", // For external: the release Key (lowercase GUID from /odata/Releases API). For solution-internal: leave empty, validate resolves it.
@@ -170,7 +167,7 @@ Then create the agent-level resource file:
 
 **Agent-level resource** — `<AGENT_NAME>/resources/<TOOL_NAME>/resource.json`
 
-Set `"location": "external"`, `"type"` directly from `resource list`'s `Type` field (`"process"`, `"agent"`, `"api"`, or `"processOrchestration"`), `"folderPath": "solution_folder"`, `"referenceKey"` to the release Key. Set `inputSchema`/`outputSchema` from the parsed `GetPackageEntryPointsV2` JSON Schema strings. Include `"exampleCalls": []` in `properties`. See § Agent-Level Resource Shape above for the full template.
+Set `"location": "external"`, `"type"` directly from `resource list`'s `Type` field (`"process"`, `"agent"`, `"api"`, or `"processOrchestration"`), `"folderPath": "solution_folder"`, `"referenceKey"` to the release Key. Set `inputSchema`/`outputSchema` from the parsed `GetPackageEntryPointsV2` JSON Schema strings. Include `"exampleCalls": []` in `properties`. See § Tool resource.json Shape above for the full template.
 
 ```bash
 # 5. Configure agent.json (system prompt, model, schemas)

--- a/skills/uipath-agents/references/lowcode/capabilities/process/external.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/external.md
@@ -91,7 +91,7 @@ Extract from response (take first entry):
     "exampleCalls": []                // Required for external tools
   },
   "guardrail": {
-    "policies": []              // Legacy field — always empty. Guardrails are configured in agent.json root `guardrails` array. See ../guardrails/guardrails.md.
+    "policies": []
   },
   "id": "<uuid>",              // Stable; generate once, never change
   "referenceKey": "<release-key-guid>", // For external: the release Key (lowercase GUID from /odata/Releases API). For solution-internal: leave empty, validate resolves it.

--- a/skills/uipath-agents/references/lowcode/capabilities/process/external.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/external.md
@@ -91,7 +91,7 @@ Extract from response (take first entry):
     "exampleCalls": []                // Required for external tools
   },
   "guardrail": {
-    "policies": []              // Auto-populated by `uip agent validate` from root-level guardrails. Do not edit manually. See ../guardrails/guardrails.md.
+    "policies": []              // Legacy field — always empty. Guardrails are configured in agent.json root `guardrails` array. See ../guardrails/guardrails.md.
   },
   "id": "<uuid>",              // Stable; generate once, never change
   "referenceKey": "<release-key-guid>", // For external: the release Key (lowercase GUID from /odata/Releases API). For solution-internal: leave empty, validate resolves it.

--- a/skills/uipath-agents/references/lowcode/capabilities/process/solution-agent.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/solution-agent.md
@@ -43,9 +43,6 @@ No remote discovery needed — the tool agent is another project in the same sol
     "processName": "ToolAgent",
     "folderPath": "solution_folder"
   },
-  "guardrail": {
-    "policies": []
-  },
   "id": "<uuid>",
   "referenceKey": "",           // Leave empty; validate resolves it and writes it back to disk
   "isEnabled": true,
@@ -116,9 +113,6 @@ Create a tool resource file at `AgentA/resources/Agent B/resource.json`:
   "properties": {
     "processName": "Agent B",
     "folderPath": "solution_folder"  // ← always solution_folder for solution resources
-  },
-  "guardrail": {
-    "policies": []                  // Auto-populated by validate from root-level guardrails. Do not edit manually. See ../guardrails/guardrails.md.
   },
   "argumentProperties": {}
 }

--- a/skills/uipath-agents/references/lowcode/capabilities/process/solution-agent.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/solution-agent.md
@@ -44,7 +44,7 @@ No remote discovery needed — the tool agent is another project in the same sol
     "folderPath": "solution_folder"
   },
   "guardrail": {
-    "policies": []              // Legacy field — always empty. Guardrails are configured in agent.json root `guardrails` array. See ../guardrails/guardrails.md.
+    "policies": []
   },
   "id": "<uuid>",
   "referenceKey": "",           // Leave empty; validate resolves it and writes it back to disk

--- a/skills/uipath-agents/references/lowcode/capabilities/process/solution-agent.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/solution-agent.md
@@ -44,7 +44,7 @@ No remote discovery needed — the tool agent is another project in the same sol
     "folderPath": "solution_folder"
   },
   "guardrail": {
-    "policies": []              // Auto-populated by validate from root-level guardrails. Do not edit manually. See ../guardrails/guardrails.md.
+    "policies": []              // Legacy field — always empty. Guardrails are configured in agent.json root `guardrails` array. See ../guardrails/guardrails.md.
   },
   "id": "<uuid>",
   "referenceKey": "",           // Leave empty; validate resolves it and writes it back to disk

--- a/skills/uipath-agents/references/lowcode/critical-rules.md
+++ b/skills/uipath-agents/references/lowcode/critical-rules.md
@@ -36,7 +36,7 @@ These rules are the canonical source for low-code agent authoring. Capability fi
 
 16. **Never invoke other skills automatically.** If the user needs flow operations, tell them to use the `uipath-maestro-flow` skill.
 
-17. **Read [capabilities/guardrails/guardrails.md](capabilities/guardrails/guardrails.md) before authoring guardrail JSON.** The schema uses discriminator fields (`$guardrailType`, `$actionType`, `$parameterType`, `$ruleType`, `$selectorType`) that cannot be guessed. Configure guardrails at the agent.json root `guardrails` array; never edit `guardrail.policies` on tool resources by hand.
+17. **Read [capabilities/guardrails/guardrails.md](capabilities/guardrails/guardrails.md) before authoring guardrail JSON.** The schema uses discriminator fields (`$guardrailType`, `$actionType`, `$parameterType`, `$ruleType`, `$selectorType`) that cannot be guessed. Configure guardrails at the agent.json root `guardrails` array; never populate `guardrail.policies` on tool resources — that field is a legacy schema artifact and must remain empty `[]`.
 
 ## What NOT to Do (17)
 
@@ -55,5 +55,5 @@ These rules are the canonical source for low-code agent authoring. Capability fi
 13. **Do not pass `--for-low-code-agents` to `uip is connectors list` or `uip is activities list`** — this flag has been removed. Run the commands without it and filter yourself if needed.
 14. **Do not omit discriminator fields in guardrails** — every action needs `$actionType` (not `type`), every validator parameter needs `$parameterType` and `id` (not `name`), every custom rule needs `$ruleType`, every field selector needs `$selectorType`. Missing any discriminator causes `uip agent validate` to fail.
 15. **Do not use lowercase scope values in guardrails** — use `"Agent"`, `"Llm"`, `"Tool"` (PascalCase), not `"agent"`, `"llm"`, `"tool"`.
-16. **Do not manually edit `guardrail.policies` on tool resources** — it is auto-populated by `uip agent validate` from root-level guardrails. Configure guardrails at the agent.json root `guardrails` array only.
+16. **Do not populate `guardrail.policies` on tool resource JSON files** — that field is a legacy schema artifact from when guardrails were tool-only scoped. All guardrails are now configured at the agent.json root `guardrails` array with `selector.scopes` and `selector.matchNames`. Tool resource `guardrail.policies` must always remain empty `[]`.
 17. **Do not expect `uip solution resource refresh` to wire non-StorageBucket index data sources** — GoogleDrive/OneDrive/Dropbox/Confluence/Attachments indexes, `attachments` contexts, and `datafabricentityset` contexts are not auto-generated. Refresh warns + skips them; any solution-level files for these must be hand-authored. See [capabilities/context/index.md](capabilities/context/index.md).

--- a/skills/uipath-agents/references/lowcode/critical-rules.md
+++ b/skills/uipath-agents/references/lowcode/critical-rules.md
@@ -36,7 +36,7 @@ These rules are the canonical source for low-code agent authoring. Capability fi
 
 16. **Never invoke other skills automatically.** If the user needs flow operations, tell them to use the `uipath-maestro-flow` skill.
 
-17. **Read [capabilities/guardrails/guardrails.md](capabilities/guardrails/guardrails.md) before authoring guardrail JSON.** The schema uses discriminator fields (`$guardrailType`, `$actionType`, `$parameterType`, `$ruleType`, `$selectorType`) that cannot be guessed. Configure guardrails at the agent.json root `guardrails` array; never populate `guardrail.policies` on tool resources — that field is a legacy schema artifact and must remain empty `[]`.
+17. **Read [capabilities/guardrails/guardrails.md](capabilities/guardrails/guardrails.md) before authoring guardrail JSON.** The schema uses discriminator fields (`$guardrailType`, `$actionType`, `$parameterType`, `$ruleType`, `$selectorType`) that cannot be guessed. Configure guardrails at the agent.json root `guardrails` array only.
 
 ## What NOT to Do (17)
 


### PR DESCRIPTION
## What changed?

Cleaned up incorrect and misleading `guardrail.policies` guidance across the low-code agent skills.

**Root cause:** Earlier docs incorrectly stated that `guardrail.policies` on tool resource JSON files is auto-populated by \`uip agent validate\`. In reality, \`guardrail.policies\` is a legacy schema artifact from when guardrails were tool-scoped only. All guardrails are configured at the agent.json root \`guardrails\` array; tool resource files must not include \`guardrail.policies\` at all.

**Changes by file:**

- **`capabilities/guardrails/guardrails.md`** — Overview note rewritten: removed "auto-populated by validate" claim; states plainly that all guardrails go in the agent.json root \`guardrails\` array and \`selector.scopes\`/\`selector.matchNames\` control targeting. Cross-references updated accordingly.
- **`critical-rules.md`** — Rule 17 simplified (no more "never edit by hand" phrasing). What NOT to Do #16 expanded to correctly describe \`guardrail.policies\` as a legacy field that must always remain absent from tool resource files.
- **`capabilities/integration-service/integration-service.md`** — Removed \`"guardrail": { "policies": [] }\` from IS tool resource template.
- **`capabilities/process/external.md`** — Renamed section heading "Agent-Level Resource Shape" → "Tool resource.json Shape" (was confusingly named); removed \`"guardrail": { "policies": [] }\` from template; updated Walkthrough cross-reference.
- **`capabilities/process/solution-agent.md`** — Removed \`"guardrail": { "policies": [] }\` from both tool resource templates (main shape and agent-to-agent example).

## How has this been tested?

End-to-end flow run against a fresh `JokeAgentEscalation2` solution: created solution, configured `agent.json` with PII escalation guardrail (no `guardrail.policies` on any tool resource), ran `uip agent validate` + `uip solution resource refresh`, confirmed 4 solution-level resource files generated and `debug_overwrites.json` populated, uploaded successfully.

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] None
- [ ] DB migrations
- [ ] API removals/changes
- [ ] Other