### PR TITLE
docs(skills): front-load identity in descriptions, add when_to_use

### DIFF
--- a/.claude/rules/skill-review.md
+++ b/.claude/rules/skill-review.md
@@ -20,13 +20,13 @@ Does the skill follow the canonical layout and conventions?
 - `description` is under 1024 characters (repo cap; Claude Code's hard truncation for `description` + `when_to_use` is 1,536 chars — run `hooks/validate-skill-descriptions.sh` to verify)
 - `description` front-loads the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters
 - `description` includes compact `→` redirects for commonly confused sibling skills (e.g., `For XAML→uipath-rpa`)
-- `description` starts with `[PREVIEW]` for new/unstable skills
+- `description` starts with the brand/domain identity (e.g., `UiPath`, `UiPath RPA`) — NOT a metadata tag like `[PREVIEW]`. Preview status belongs in the SKILL.md body
 - SKILL.md body follows the expected section order: Title, When to Use, Critical Rules, Workflow/Quick Start, Reference Navigation, Anti-patterns
 - Reference files use kebab-case naming with `-guide.md` / `-template.md` suffixes
 - Folder organization is logical (references/, assets/, scripts/)
 - No orphaned files (every file is reachable from SKILL.md)
 
-**Red flags:** missing frontmatter fields, name mismatch, description over 1024 chars, verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files.
+**Red flags:** missing frontmatter fields, name mismatch, description over 1024 chars, description prefixed with `[PREVIEW]` or other metadata tags (displaces high-value matching tokens), verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files.
 
 ### 2. Consistency (1-5)
 

--- a/.claude/rules/skill-structure.md
+++ b/.claude/rules/skill-structure.md
@@ -30,10 +30,11 @@ description: "<identity> (<unique signal>). <core actions>. For <confusing-case>
 
 - `name` MUST exactly match the parent folder name
 - `description` MUST be under 1024 characters. Claude Code truncates `description` + `when_to_use` at 1,536 chars in the skill listing ([source](https://code.claude.com/docs/en/skills.md)); 1024 is the repo cap to keep descriptions focused and leave headroom
-- `description` MUST start with `[PREVIEW]` when the skill is first created. Remove the tag only when the skill is considered stable
-- `description` MUST front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters
+- `description` MUST front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters — the first ~100 chars carry the most matching signal
+- `description` MUST start with the brand or domain identity (e.g., `UiPath`, `UiPath RPA`, `UiPath Maestro Flow`). Do NOT prefix with metadata tags like `[PREVIEW]`, `[BETA]`, etc. — those displace high-value matching tokens and semantically de-prioritize the skill
+- Preview / beta status MUST be indicated in the SKILL.md body (e.g., a `> **Preview**` callout under the H1), NOT in the frontmatter description
 - `description` MUST include compact redirects for commonly confused sibling skills using `→` notation (e.g., `For XAML→uipath-rpa`)
-- `description` MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — these waste characters and get truncated
+- `description` MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — these waste characters and get truncated. Use `→` redirects for sibling disambiguation instead
 - All frontmatter fields (`allowed-tools`, `user-invocable`, etc.) MUST be at the top level — NOT nested under a `metadata:` key (Claude Code only reads top-level fields)
 - Frontmatter MUST be valid YAML (no tabs, proper quoting of strings with colons)
 

--- a/skills/uipath-coded-apps/SKILL.md
+++ b/skills/uipath-coded-apps/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: uipath-coded-apps
-description: "[PREVIEW] UiPath Coded Web Apps & Coded Action Apps (uip codedapp, app.config.json, action-schema.json, @uipath/uipath-typescript SDK). Scaffold, build, debug, deploy. For .cs/XAML→uipath-rpa, Python→uipath-agents."
+description: "UiPath Coded Web Apps & Coded Action Apps (`uip codedapp`, app.config.json, action-schema.json, @uipath/uipath-typescript SDK). Scaffold, build, debug, deploy. For .cs/XAML→uipath-rpa, Python→uipath-agents."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
 # UiPath Coded Apps
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps using the `uip codedapp` CLI and `@uipath/uipath-typescript` SDK.
 

--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: uipath-data-fabric
-description: "[PREVIEW] Data Fabric entity/record CRUD via uip df. Create entities, insert/query/update/delete records, CSV import, file attachments. For Orchestrator→uipath-platform. For Integration Service→uipath-platform."
+description: "UiPath Data Fabric entity/record CRUD via `uip df`. Create entities, insert/query/update/delete records, CSV import, file attachments. For Orchestrator→uipath-platform. For Integration Service→uipath-platform."
 ---
 
 # UiPath Data Fabric — Agent Skill
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Data Fabric is UiPath's structured data store. Entities are typed schemas;
 records are rows; file fields store binary attachments.

--- a/skills/uipath-feedback/SKILL.md
+++ b/skills/uipath-feedback/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: uipath-feedback
-description: "Send bug reports or improvement suggestions to UiPath via uip feedback send. TRIGGER: 'report issue', 'feedback', 'something is wrong', /uipath-feedback."
+description: "Send UiPath bug reports or improvement suggestions via `uip feedback send`. Use for 'report issue', 'feedback', 'something is wrong', or the /uipath-feedback command."
+when_to_use: "User says 'this is broken', 'this isn't working', 'report a bug', 'send feedback', 'something is wrong', 'file an issue', 'this crashed', 'wrong result' about a UiPath product, CLI, or skill. Also fires on the /uipath-feedback slash command."
 allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion
 user-invocable: true
 ---

--- a/skills/uipath-gov-access-policy/SKILL.md
+++ b/skills/uipath-gov-access-policy/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: uipath-gov-access-policy
-description: "[PREVIEW] UiPath access policies (`uip gov access-policy`): govern tool-use when an Actor Process invokes a child Resource. Selection + Actor Process + Actor Identity rules. For product settings→uipath-gov-aops-policy."
+description: "UiPath access policies (`uip gov access-policy`): govern tool-use when an Actor Process invokes a child Resource. Selection + Actor Process + Actor Identity rules. For product settings→uipath-gov-aops-policy."
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 
 # UiPath Access Policy Governance
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Skill for authoring UiPath **access policies** of type `ToolUsePolicy` via the `uip gov access-policy` CLI. The `ToolUsePolicy` type **governs tool-use / resource-use** inside Agents and workflow automations: when an Actor Process tries to invoke a child Resource/Tool, the policy decides whether the call is allowed. The `uip gov access-policy` surface returns other policy types as well, but they are out of scope for this skill.
 

--- a/skills/uipath-gov-aops-policy/SKILL.md
+++ b/skills/uipath-gov-aops-policy/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: uipath-gov-aops-policy
-description: "[PREVIEW] UiPath AOps governance — enforce rules (\"block/restrict/require X\") by mapping intent to a Product policy via `uip gov aops-policy`. Create/update/delete/list/deploy policies to users, groups, tenants. For platform ops→uipath-platform."
+description: "UiPath AOps governance — enforce rules (\"block/restrict/require X\") by mapping intent to a Product policy via `uip gov aops-policy`. Create/update/delete/list/deploy policies to users, groups, tenants. For platform ops→uipath-platform."
 allowed-tools: Bash, Read, Write, Grep, Glob
 ---
 
 # UiPath AOps Governance
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Skill for managing AOps governance policies and deploying them to users, groups, or tenants via the `uip gov aops-policy` CLI.
 

--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: uipath-human-in-the-loop
-description: "[PREVIEW] Add Human-in-the-Loop node to a Flow, Maestro, or Coded Agent. Triggers on approval gates, escalations, write-back validation, data enrichment — even without user saying 'HITL'. Designs schema, writes JSON directly."
+description: "UiPath Human-in-the-Loop node for Flow, Maestro, or Coded Agent. Approval gates, escalations, write-back validation, data enrichment — even without user saying 'HITL'. Designs task schema, writes JSON directly."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # UiPath Human-in-the-Loop Assistant
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Recognizes when a business process needs a human decision point, designs the task schema through conversation, and wires the HITL node into the automation — Flow, Maestro, or Coded Agent.
 

--- a/skills/uipath-interact/SKILL.md
+++ b/skills/uipath-interact/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: uipath-interact
-description: "[PREVIEW] Inspect and interact with live desktop/browser apps -- click buttons, type text, read values, take screenshots, inspect UI state, verify behavior, fill forms, navigate menus, and extract table data from running applications."
+description: "UiPath UI interaction (`uip rpa uia`) — drive live desktop/browser apps: click, type, read values, screenshot, inspect UI state, verify behavior, fill forms, navigate menus, extract table data from running applications."
+when_to_use: "User wants to drive or inspect a live running app (Windows desktop or browser) — 'click the button', 'fill this form', 'read the value from the screen', 'screenshot the dialog', 'extract this table', 'verify the UI shows X', 'walk through this app'. Live execution only — NOT for authoring XAML/coded selectors at design time (use uipath-rpa)."
 allowed-tools: Bash(uip:*), Read, Grep
 ---
 
 # UI Interaction via "uip rpa uia"
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Drive live desktop applications and browser tabs via the `uip rpa uia` CLI: discover applications and interact with elements using stable refs.
 

--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: uipath-maestro-case
-description: "[PREVIEW] Case Management authoring from sdd.md. Produces tasks.md plan, writes caseplan.json directly via per-plugin JSON recipes. For .xaml→uipath-rpa, .flow→uipath-maestro-flow."
+description: "UiPath Case Management authoring (caseplan.json) from sdd.md. Produces tasks.md plan, writes caseplan.json via per-plugin JSON recipes. For .xaml→uipath-rpa, .flow→uipath-maestro-flow."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
 # UiPath Case Management Authoring Assistant
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Builds UiPath Case Management definitions from `sdd.md`. Generates `tasks.md` plan, then writes `caseplan.json` directly via per-plugin JSON recipes. CLI is reserved for read-only metadata fetches (registry, validate, debug, tasks describe, is describe) and solution boundary operations (`uip solution new` / `project add` / `upload`).
 

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -1,10 +1,12 @@
 ---
 name: uipath-maestro-flow
-description: "[PREVIEW] ALWAYS invoke for .flow / UiPath Maestro Flow tasks (read, edit, author, debug, or Q&A) — spec evolves. Leverages uip CLI: nodes, edges, subflows, scripts, variables, triggers, End nodes, registry."
+description: "UiPath Maestro Flow (.flow) — read, edit, author, debug. `uip` CLI: nodes, edges, subflows, scripts, variables, triggers, End nodes, registry. For C#/XAML→uipath-rpa. For agents→uipath-agents."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # UiPath Flow Authoring Assistant
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Comprehensive guide for creating, editing, validating, and debugging UiPath Flow projects using the `uip` CLI and `.flow` file format.
 

--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: uipath-planner
 description: "UiPath task planner — elicits preferences, plans multi-skill execution, detects project type (.cs, .xaml, .flow, .py). Triggers for non-trivial or ambiguous UiPath requests. Simple single-skill tasks→specialist directly."
+when_to_use: "User makes an ambiguous or multi-product UiPath request — 'help me automate this', 'build a UiPath solution for X', 'what's the right approach for Y', 'set up a process from scratch'. Skip when the project type (.cs/.xaml/.flow/.py) and scope are already clear — invoke the specialist skill directly."
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, EnterPlanMode, ExitPlanMode
 ---
 

--- a/skills/uipath-rpa-legacy/SKILL.md
+++ b/skills/uipath-rpa-legacy/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: uipath-rpa-legacy
-description: "[PREVIEW] Legacy UiPath RPA (.NET Framework 4.6.1, XAML) via uip rpa-legacy CLI. TRIGGER: project.json targetFramework 'Legacy' or absent; user mentions legacy. For Windows/cross-platform→uipath-rpa."
+description: "Legacy UiPath RPA (.NET Framework 4.6.1, XAML) via `uip rpa-legacy`. Activates when project.json targetFramework='Legacy' or missing, or user mentions legacy. For Windows/cross-platform→uipath-rpa."
 ---
 
 # Legacy RPA Workflow Architect
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Legacy UiPath RPA projects: .NET Framework 4.6.1, VB.NET expressions, classic activities (no "X" suffix). Uses `uip rpa-legacy` CLI (standalone, no Studio IPC needed).
 

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: uipath-rpa
 description: "UiPath RPA — create, edit, build, run, debug `.cs` coded workflows and `.xaml` workflows. UI automation with Object Repository selectors, test case authoring, Integration Service connector calls. Deploy→uipath-platform. Test reports→uipath-test. Agents→uipath-agents. Legacy→uipath-rpa-legacy."
+when_to_use: "User wants to create, edit, debug, or run a UiPath automation — '.cs' coded workflows or '.xaml' files. Triggers: 'build a workflow', 'automate Excel/email/web/PDF/queue items', 'add a try-catch', 'fix this XAML error', 'scrape this site', 'process invoices', 'create a test case', or project.json shows UiPath dependencies. NOT for '.flow' files (→uipath-maestro-flow), Python agents (→uipath-agents), legacy .NET 4.6.1 projects (→uipath-rpa-legacy)."
 ---
 
 # UiPath RPA Assistant

--- a/skills/uipath-solution-design/SKILL.md
+++ b/skills/uipath-solution-design/SKILL.md
@@ -1,9 +1,11 @@
 ---
 name: uipath-solution-design
-description: "[PREVIEW] PDD→SDD: analyze PDDs (PDF/docx/md), pick scope (single product or multi-project Solution: RPA/Flow/Case/Agents/Apps/API Workflows), generate implementation-ready SDD. For project setup→uipath-platform."
+description: "UiPath PDD→SDD: analyze PDDs (PDF/docx/md), pick scope (single product or multi-project Solution: RPA/Flow/Case/Agents/Apps/API Workflows), generate implementation-ready SDD. For project setup→uipath-platform."
 ---
 
 # UiPath Solution Design
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Transform a Process Design Document (PDD) into an implementation-ready Solution Design Document (SDD) that a coding agent can build from. Select the right UiPath scope — either a single product (RPA Process/Library/Test Auto, Maestro Flow, Case Management, Agents, Coded Apps, or API Workflows) or a multi-project Solution composing several of them — based on PDD signals.
 

--- a/skills/uipath-tasks/SKILL.md
+++ b/skills/uipath-tasks/SKILL.md
@@ -1,10 +1,13 @@
 ---
 name: uipath-tasks
-description: "[PREVIEW] Manage UiPath Action Center tasks via CLI. Use when: list/assign/complete tasks, or user mentions 'Action Center'/'tasks'/'uip tasks'. For Orchestrator→uipath-platform, codedapp→uipath-coded-apps. Skip Document Understanding."
+description: "UiPath Action Center human-in-the-loop tasks via `uip tasks` — list, assign, complete approval/validation tasks. For Orchestrator→uipath-platform, codedapp→uipath-coded-apps. Skip Document Understanding."
+when_to_use: "User says 'approve task', 'pending approval', 'pending action item', 'review action', 'list my tasks', 'reassign task' in an Orchestrator/Action Center context. NOT for TaskCreate/TaskUpdate (general session-task tracking) or Document Understanding validation."
 user-invocable: true
 ---
 
 # UiPath Tasks (Action Center) — Agent Skill
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Action Center is UiPath's human-in-the-loop platform. Tasks represent work items
 that require human input — form approvals, document validation, data labeling, and more.

--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: uipath-test
-description: "[PREVIEW] UiPath Test Manager — manage test projects, cases, sets, executions; generate reports. TRIGGER when: test ops, reports, results. DO NOT TRIGGER: Orchestrator → uipath-platform; test automation → uipath-rpa."
+description: "UiPath Test Manager — manage test projects, cases, sets, executions; generate reports. For Orchestrator→uipath-platform. For test automation→uipath-rpa."
 allowed-tools: Bash, Read, Write, Glob, Grep
 user-invocable: true
 ---
 
 # UiPath Test Assistant
+
+> **Preview** — skill is under active development; surface and behavior may change.
 
 Manage UiPath Test Manager resources (projects, test cases, test sets, executions) and generate persona-tailored shareable test reports.
 


### PR DESCRIPTION
## Summary

Skill descriptions weren't matching reliably because `[PREVIEW]` prefixes displaced high-value identity tokens in the first ~100 chars (where Claude does most of its skill-selection matching). Plus a contradictory rule in `skill-structure.md` told us to do exactly that. This PR fixes both.

- **Strip `[PREVIEW]` from frontmatter on 12 skills.** Moved to a `> **Preview**` callout under the H1 in each SKILL.md body. Affected: coded-apps, data-fabric, gov-access-policy, gov-aops-policy, human-in-the-loop, interact, maestro-case, maestro-flow, rpa-legacy, solution-design, tasks, test.
- **Replace `TRIGGER:` / `DO NOT TRIGGER:` prose** with the `→` redirect style already used elsewhere. Affected: feedback, rpa-legacy, test.
- **Strengthen brand front-loading** on tasks (`UiPath Action Center…` — disambiguates from generic "tasks" colliding with TaskCreate/TaskUpdate) and interact (now leads with `UiPath` instead of generic "Inspect and interact…"). Minor tightening on data-fabric, solution-design, human-in-the-loop.
- **Add `when_to_use` field** to the 5 skills most affected by ambiguous matching: `uipath-rpa`, `uipath-tasks`, `uipath-feedback`, `uipath-planner`, `uipath-interact`. Trigger phrases now live there instead of bloating `description`. `description` + `when_to_use` are concatenated in the listing and capped at 1,536 chars combined — every skill stays well under (max is 762).
- **Update repo rules** (`.claude/rules/skill-structure.md`, `.claude/rules/skill-review.md`) to match — preview status belongs in the SKILL.md body, not the frontmatter description. No metadata-tag prefixes on `description`.

## Why

The matching algorithm weights early tokens. `[PREVIEW] UiPath…` gives Claude 10 chars of zero matching value before the actual domain identity appears, and semantically reads as "experimental, don't pick me." Front-loading `UiPath` / `UiPath RPA` / `UiPath Maestro Flow` recovers those chars and puts the strongest signal where it matters.

`when_to_use` is the documented field for trigger phrases — using it keeps `description` focused on identity and gives us another ~1,200 chars of headroom per skill before the hard cap.

## Test plan

- [x] `hooks/validate-skill-descriptions.sh` passes on all 18 skills (range 158–303 chars, well under 1024 cap)
- [x] Combined description + when_to_use stays under 1,536 cap (max: rpa at 762)
- [x] No `[PREVIEW]` / `TRIGGER:` / `DO NOT TRIGGER:` tokens left in any frontmatter description
- [ ] Reload Claude Code and verify skills auto-invoke on realistic prompts (manual smoke test)
- [ ] Skill owners confirm the new descriptions and `when_to_use` triggers match their intent (see Slack thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)