### PR TITLE
feat(uipath-agents): add action schema validation for escalation guardrail apps

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -242,6 +242,8 @@ Example entry:
 
 A guardrail escalation app must expose a specific action schema contract. Validate **before** writing the guardrail JSON. If any check below fails, stop and report to the user: `<APP_NAME> does not have the required action schema configuration for tool guardrails.` (replace `<APP_NAME>` with the app's `Name` from Step 1).
 
+**SECURITY:** Never read `~/.uipath/.auth` directly — keep the token inside the shell. Always use a `bash -c` wrapper that sources the auth file and makes the API call in a single shell invocation, so Claude only sees the API response.
+
 2a. Look up `systemName` and `deployVersion` from the Apps API (use `Key` from Step 1 to filter client-side by `id`):
 
 ```bash

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -238,7 +238,45 @@ Example entry:
 
 > **Important:** Do NOT use `--kind Process` with `Type: "webApp"` to find Action Center apps. Those entries are the code-behind processes — their `Key` values are process release GUIDs, not app deployment IDs. Using them as `app.id` will cause runtime resolution failures.
 
-**Step 2 — Construct and add the escalate action** in `agent.json`'s `guardrails` array:
+**Step 2 — Validate the app's action schema**
+
+A guardrail escalation app must expose a specific action schema contract. Validate **before** writing the guardrail JSON. If any check below fails, stop and report to the user: `<APP_NAME> does not have the required action schema configuration for tool guardrails.` (replace `<APP_NAME>` with the app's `Name` from Step 1).
+
+2a. Look up `systemName` and `deployVersion` from the Apps API (use `Key` from Step 1 to filter client-side by `id`):
+
+```bash
+bash -c 'set -a; source ~/.uipath/.auth; set +a; curl -s \
+  "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-apps?state=deployed&pageNumber=0&limit=100" \
+  -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
+  -H "X-Uipath-Tenantid: $UIPATH_TENANT_ID" \
+  -H "Accept: application/json"'
+```
+
+From the entry whose `id` matches the `Key` from Step 1, extract `systemName` and `deployVersion`. If no entry matches → report error and stop.
+
+2b. Fetch the action schema:
+
+```bash
+bash -c 'set -a; source ~/.uipath/.auth; set +a; curl -s \
+  "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-schema?appSystemName=<SYSTEM_NAME>&version=<DEPLOY_VERSION>" \
+  -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
+  -H "X-Uipath-Tenantid: $UIPATH_TENANT_ID" \
+  -H "Accept: application/json"'
+```
+
+If the response is empty, not valid JSON, or missing the `inputs`/`outputs`/`outcomes` arrays → report error and stop.
+
+2c. Check required arguments by name. All three categories must pass — the app may have extra arguments beyond these, but must have at least:
+
+| Category | Required Names |
+|----------|---------------|
+| `inputs` (8) | `GuardrailName`, `GuardrailDescription`, `TenantName`, `AgentTrace`, `Tool`, `ExecutionStage`, `ToolInputs`, `ToolOutputs` |
+| `outputs` (3) | `ReviewedInputs`, `ReviewedOutputs`, `Reason` |
+| `outcomes` (2) | `Approve`, `Reject` |
+
+Validation is **name-only** — types, `required` flags, and `isList` are not checked. Verify every required name appears in the corresponding array's `name` fields. If any required name is missing → report error and stop.
+
+**Step 3 — Construct and add the escalate action** in `agent.json`'s `guardrails` array:
 
 ```json
 {
@@ -255,7 +293,7 @@ Example entry:
 
 `app.id` and `app.name` come from Step 1. `app.version` is always `"0"` and `app.folderName` is always `"solution_folder"` — these are fixed values for solution-embedded apps.
 
-**Step 3 — Generate solution resource files**
+**Step 4 — Generate solution resource files**
 
 Run these two commands from the solution root:
 
@@ -267,7 +305,7 @@ uip solution resource refresh --output json
 - `validate` generates `bindings_v2.json` with a `resource: "app"` binding for the escalation app.
 - `refresh` reads `bindings_v2.json`, fetches the app from the Resource Catalog Service by name, and generates all 4 solution-level resource files (`app/workflow Action/`, `appVersion/`, `package/`, `process/webApp/`) plus the `debug_overwrites.json` entries for both the app and its code-behind process.
 
-**Step 4 — Upload:**
+**Step 5 — Upload:**
 
 ```bash
 uip solution upload . --output json
@@ -860,6 +898,7 @@ Add the `guardrails` array at the agent.json root level alongside `settings`, `m
 11. **Do not use `--kind Process` (Type: `"webApp"`) to find escalation apps** — those entries are code-behind processes, not app deployments. Their `Key` values are process release GUIDs, not app IDs. Always use `--kind App` with `Type: "Workflow Action"`.
 12. **Do not use the remote `Folder`/`FolderKey` values from `resource list` as `app.folderName`/`app.folderId` in agent.json** — those point to the remote Shared deployment folder and break UI resolution. The correct agent.json values are `"folderName": "solution_folder"` and `"version": "0"`. Note: `FolderKey` from `resource list` IS correct to use in `debug_overwrites.json` entries, where it maps the solution-embedded resource to its real runtime location.
 13. **Do not use `source <(grep = ~/.uipath/.auth)` for Apps API calls in guardrail setup** — it fails to export variables to the surrounding shell in some environments. Use `set -a; source ~/.uipath/.auth; set +a` instead.
+14. **Do not skip action schema validation for escalation apps** — before writing a guardrail with `"$actionType": "escalate"`, fetch the app's action schema and verify all required inputs (8), outputs (3), and outcomes (2) are present by name. If any are missing, report `<APP_NAME> does not have the required action schema configuration for tool guardrails.` and do not proceed. See [§ Adding an escalation guardrail — Step 2](#adding-an-escalation-guardrail--step-by-step).
 
 ## Walkthrough
 

--- a/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
@@ -94,6 +94,14 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
+    description: "Agent validated the app's action schema via the Apps API"
+    tool_name: "Bash"
+    command_pattern: 'action-schema|action-apps'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
     description: "Agent used --output json on uip commands"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'

--- a/tests/tasks/uipath-agents/guardrail_escalation_app_validation/check_guardrail_escalation_app_validation.py
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app_validation/check_guardrail_escalation_app_validation.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Guardrail escalation app action schema validation check.
+
+Verifies the agent correctly rejected the incompatible "EscalationWorksApp"
+by NOT writing an escalate guardrail into agent.json. The app has:
+  - inputs: [input]           (missing all 8 required: GuardrailName, etc.)
+  - outputs: [output]         (missing all 3 required: ReviewedInputs, etc.)
+  - outcomes: [Submit, Reject] (missing Approve)
+
+The agent should have validated the action schema and reported the error
+instead of writing the guardrail.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "ValidationSol" / "ReviewAgent"
+AGENT = ROOT / "agent.json"
+
+
+def main() -> None:
+    if not AGENT.is_file():
+        # Agent may not have even gotten to writing agent.json if it
+        # stopped early after validation failure — that's acceptable.
+        print("OK: agent.json not found (agent may have stopped before writing)")
+        print("OK: incompatible app was not wired into a guardrail")
+        return
+
+    try:
+        agent = json.loads(AGENT.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: agent.json is not valid JSON: {e}")
+
+    guardrails = agent.get("guardrails")
+    if not isinstance(guardrails, list) or len(guardrails) == 0:
+        print("OK: no guardrails array (or empty) — agent did not write the escalate guardrail")
+        return
+
+    # Check that no guardrail uses EscalationWorksApp in an escalate action
+    for g in guardrails:
+        action = g.get("action")
+        if not isinstance(action, dict):
+            continue
+        if action.get("$actionType") != "escalate":
+            continue
+        app = action.get("app")
+        if not isinstance(app, dict):
+            continue
+        app_name = app.get("name", "")
+        if "EscalationWorksApp" in app_name:
+            sys.exit(
+                f"FAIL: agent wrote an escalate guardrail using EscalationWorksApp "
+                f"without validating the action schema. The app is incompatible — "
+                f"it has inputs=[input], outputs=[output], outcomes=[Submit,Reject] "
+                f"instead of the required 8 inputs, 3 outputs, and Approve/Reject outcomes. "
+                f"The agent should have reported: "
+                f"'EscalationWorksApp does not have the required action schema "
+                f"configuration for tool guardrails.'"
+            )
+
+    print("OK: no escalate guardrail references EscalationWorksApp")
+    print("OK: agent correctly rejected the incompatible app")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/guardrail_escalation_app_validation/guardrail_escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app_validation/guardrail_escalation_app_validation.yaml
@@ -1,0 +1,92 @@
+task_id: skill-agent-guardrail-escalation-app-validation
+description: >
+  Guardrail escalation app action schema validation. Asks the agent to add
+  an escalate guardrail using an incompatible Action Center app
+  ("EscalationWorksApp") that does NOT have the required guardrail schema
+  (missing 8 required inputs, 3 required outputs, wrong outcome names).
+  The agent must validate the action schema and reject the app with the
+  error message instead of writing the guardrail.
+tags: [uipath-agents, e2e, low-code]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+  max_turns: 40
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a UiPath solution "ValidationSol" containing a low-code agent
+  "ReviewAgent" that handles compliance review requests.
+  Then add a built-in PII detection guardrail that escalates violations
+  to a human reviewer instead of blocking.
+
+  Guardrail requirements:
+  - validatorType: pii_detection
+  - Detect Email entities, threshold 0.5
+  - Scope: Agent level
+  - Action: use $actionType "escalate"
+  - Escalation app name: "EscalationWorksApp"
+  - Recipient email: reviewer@example.com (type 3)
+
+  Use path-based commands from the working directory (no cd required):
+    uip solution new "ValidationSol" --output json
+    uip agent init "ValidationSol/ReviewAgent" --output json
+    uip solution project add "ValidationSol/ReviewAgent" --output json
+    uip agent guardrails list --output json
+    uip solution resource list --kind App --source remote --output json
+
+  You MUST validate the app's action schema before using it in the
+  escalate action. If the app does not have the required schema,
+  report the error and do NOT write the guardrail.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Do NOT write a plan file. Complete the entire task
+  end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the solution"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent scaffolded the agent project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent looked up the escalation app"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the action schema via the Apps API"
+    tool_name: "Bash"
+    command_pattern: 'action-schema|action-apps'
+    min_count: 1
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent rejected the incompatible app — no escalate guardrail written in agent.json"
+    command: "python3 $TASK_DIR/check_guardrail_escalation_app_validation.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- Adds action schema validation step (Step 2) to the escalation guardrail workflow in `guardrails.md` — agent must now verify the app exposes the required 8 inputs, 3 outputs, and 2 outcomes before writing the guardrail JSON
- Adds new test task `guardrail_escalation_app_validation` that verifies the agent correctly rejects an incompatible app instead of blindly wiring it
- Updates existing `guardrail_escalation_app` test to require action schema API calls

## Test plan
- [ ] Verify `guardrail_escalation_app_validation` task passes — agent fetches action schema and rejects incompatible app
- [ ] Verify existing `guardrail_escalation_app` task still passes with the new `action-schema` criterion
- [ ] Review guardrails.md step numbering is correct (Steps 1→5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)