### PR TITLE
fix(maestro-case): unify binding shape docs, add output var dedup rule

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
@@ -225,7 +225,9 @@ The `body` input carries the actual task data from `input-values`:
 
 ### 3f. `data.outputs[]`
 
-Copy verbatim from `tasks describe` (Step 2). Set `elementId` to the task's elementId on each output. Copy `_jsonSchema` from Error output if present.
+Copy from `tasks describe` (Step 2). Set `elementId` to the task's elementId on each output. Copy `_jsonSchema` from Error output if present.
+
+**Dedup output `var`/`id`/`value`.** `tasks describe` returns generic names like `response` and `error` for every connector task. When multiple connector tasks exist in the same case, these collide. After copying, apply the [uniqueness rule](../../variables/global-vars/impl-json.md#uniqueness-rule): collect all existing output `var` values across every task already in `caseplan.json`; if a `var` already exists, append a counter suffix starting at 2 (e.g., `response` → `response2`, `error` → `error2`). Update `var`, `id`, `value`, and `target` (as `=<new var>`) with the suffixed name. `name`, `displayName`, and `source` stay unchanged.
 
 ### 3g. `data.bindings[]`
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/impl-json.md
@@ -40,7 +40,7 @@ Generate task ID (`t` + 8 alphanumeric chars) and elementId (`<stageId>-<taskId>
 - **`data.context[]`** — per [common §Context array](../../../connector-trigger-common.md#context-array)
 - **`data.context[].metadata`** — per [common §Metadata body](../../../connector-trigger-common.md#metadata-body) + [common §essentialConfiguration](../../../connector-trigger-common.md#essentialconfiguration)
 - **`data.inputs[]`** — per [common §Input body](../../../connector-trigger-common.md#input-body-from-tasksmd-values). **Include `elementId`** on each input.
-- **`data.outputs[]`** — copy verbatim from `tasks describe` (Step 2). Set `elementId` to the task's elementId. Copy `_jsonSchema` from Error output if present.
+- **`data.outputs[]`** — copy from `tasks describe` (Step 2). Set `elementId` to the task's elementId. Copy `_jsonSchema` from Error output if present. **Dedup:** apply the [uniqueness rule](../../variables/global-vars/impl-json.md#uniqueness-rule) — if a `var` value (`response`, `error`) already exists in any task in `caseplan.json`, suffix with a counter starting at 2. Update `var`, `id`, `value`, `target`; keep `name`, `displayName`, `source` unchanged.
 - **`data.bindings[]`** — empty array `[]`
 - **`entryConditions`** — do NOT auto-inject. Step 10 handles them.
 

--- a/skills/uipath-maestro-case/references/plugins/variables/bindings/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/bindings/impl-json.md
@@ -18,27 +18,11 @@ Root-level binding creation for `root.data.uipath.bindings[]`. Referenced by **a
 | case-management | `"process"` | `"CaseManagement"` | name + folderPath |
 | connector (activity/trigger) | `"Connection"` | — | ConnectionId + folderKey |
 
-## Non-Connector Binding Creation (name + folderPath)
+## Binding Creation
 
-For every non-connector task (process, action, agent, rpa, api-workflow, case-management), create **two** binding entries in `root.data.uipath.bindings[]`. Both bindings share the same `resourceKey`.
+For every task, create **two** binding entries in `root.data.uipath.bindings[]`. Both bindings share the same `resourceKey`. The shape is identical for all task types — only the field values differ per the Per Task Type table above.
 
-### Data sources
-
-| Field | Source |
-|---|---|
-| `name` | `tasks.md` `name` field (captured from registry during planning: `entry.name` for process types, `entry.deploymentTitle` for action) |
-| `folderPath` | `tasks.md` `folder-path` field (captured from registry during planning: `entry.folders[0].fullyQualifiedName` for process types, `entry.deploymentFolder.fullyQualifiedName` for action) |
-
-### resourceKey construction
-
-```
-resourceKey = "<folderPath>.<name>"
-```
-
-Examples:
-- folderPath `"Shared"`, name `"KYC"` → `"Shared.KYC"`
-- folderPath `"Shared/Finance"`, name `"InvoiceProcess"` → `"Shared/Finance.InvoiceProcess"`
-- folderPath `""` (empty), name `"ReviewHITL"` → `".ReviewHITL"`
+**Every binding entry MUST include all 7 fields:** `id`, `name`, `type`, `resource`, `resourceKey`, `default`, `propertyAttribute` (plus optional `resourceSubType`). Omitting `name` or `type` causes Studio Web to fail to render the case.
 
 ### Full binding shape (two entries per task)
 
@@ -67,9 +51,40 @@ Examples:
 ]
 ```
 
+> The `name` field mirrors `propertyAttribute` — for non-connector tasks the values are `"name"` and `"folderPath"`, for connector tasks `"ConnectionId"` and `"folderKey"`.
+
+### Data sources — non-connector tasks
+
+| Field | Source |
+|---|---|
+| `name` | `tasks.md` `name` field (captured from registry during planning: `entry.name` for process types, `entry.deploymentTitle` for action) |
+| `folderPath` | `tasks.md` `folder-path` field (captured from registry during planning: `entry.folders[0].fullyQualifiedName` for process types, `entry.deploymentFolder.fullyQualifiedName` for action) |
+
+### resourceKey construction — non-connector tasks
+
+```
+resourceKey = "<folderPath>.<name>"
+```
+
+Examples:
+- folderPath `"Shared"`, name `"KYC"` → `"Shared.KYC"`
+- folderPath `"Shared/Finance"`, name `"InvoiceProcess"` → `"Shared/Finance.InvoiceProcess"`
+- folderPath `""` (empty), name `"ReviewHITL"` → `".ReviewHITL"`
+
+### Data sources — connector tasks
+
+| Field | Source |
+|---|---|
+| `name` / `propertyAttribute` | First binding: `"ConnectionId"`. Second binding: `"folderKey"`. |
+| `default` (ConnectionId) | `connection-id` from `tasks.md` |
+| `default` (folderKey) | `folderKey` from `get-connection` (Step 1) |
+| `resourceKey` | `connection-id` from `tasks.md` |
+
 ### Task references
 
-After creating bindings, set `data.name` to `=bindings.<nameBindingId>` and `data.folderPath` to `=bindings.<folderPathBindingId>`. Do NOT use literal strings.
+Non-connector: set `data.name` to `=bindings.<nameBindingId>` and `data.folderPath` to `=bindings.<folderPathBindingId>`.
+Connector: set `data.context[].connection` to `=bindings.<connBindingId>` and `data.context[].folderKey` to `=bindings.<folderBindingId>`.
+Do NOT use literal strings.
 
 ## Deduplication
 


### PR DESCRIPTION
## Summary
- **Binding shape unification**: `bindings/impl-json.md` only documented the full JSON shape under a "Non-Connector" heading — connector tasks missed the mandatory `name` and `type` fields, causing Studio Web to fail to render the case. Replaced with a single "Binding Shape (all task types)" section that makes all 7 required fields explicit for every binding type.
- **Output var dedup rule**: connector-activity and connector-trigger `impl-json.md` said "copy outputs verbatim from tasks describe" — but `tasks describe` returns generic `var: "response"` / `var: "error"` for every connector task, causing var/id collisions when multiple connector tasks coexist. Added dedup rule referencing the existing uniqueness rule (counter suffix starting at 2).

## Test plan
- [ ] Build a case with 2+ connector tasks (e.g., connector-trigger + connector-activity sharing a connection) using the skill
- [ ] Verify root bindings include `name` and `type` fields on every entry
- [ ] Verify output `var`/`id` values are unique across tasks (e.g., `response`, `response2`)
- [ ] Upload to Studio Web and confirm FE canvas renders without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)