### PR TITLE
test(uipath-agents): scaffold coded-test foundation (PR 1/5)

### DIFF
--- a/tests/tasks/uipath-agents/_shared/__init__.py
+++ b/tests/tasks/uipath-agents/_shared/__init__.py
@@ -1,0 +1,25 @@
+"""Shared helpers for uipath-agents tests.
+
+Used by check scripts under sibling directories of `_shared/` (e.g.
+`simple_echo/check_simple_echo.py`). Each check script imports from
+this package via:
+
+    import os
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from _shared.bindings_assertions import (  # noqa: E402
+        load_bindings,
+        find_resource,
+    )
+    from _shared.coded_project_factory import write_minimal_project  # noqa: E402
+    from _shared.ast_lazy_init_check import (  # noqa: E402
+        find_module_level_llm_clients,
+    )
+
+Coded-agent helpers are minimal: they mirror the on-disk shape that
+`uip codedagent init` would produce, the bindings.json schema documented
+in `references/coded/lifecycle/bindings-reference.md`, and the lazy-LLM
+init invariant called out in `references/coded/quickstart.md`.
+Inline-flow helpers (`inline_wiring.py`) cover the low-code agent-in-flow
+shape — see that module's docstring.
+"""

--- a/tests/tasks/uipath-agents/_shared/ast_lazy_init_check.py
+++ b/tests/tasks/uipath-agents/_shared/ast_lazy_init_check.py
@@ -1,0 +1,126 @@
+"""AST scan for the lazy-LLM-init invariant.
+
+`references/coded/quickstart.md` Critical Rule C4:
+
+  > Always instantiate `UiPath()` inside functions/nodes, never at
+  > module level.
+  > NEVER instantiate `UiPathAzureChatOpenAI`, `UiPathChat`,
+  > `UiPathChatOpenAI`, or any LLM client at module level — `uip
+  > codedagent init` imports the file and module-level LLM clients
+  > will fail because auth hasn't happened yet.
+
+This module finds module-level *call expressions* that look like LLM
+client construction (e.g. `llm = UiPathAzureChatOpenAI(...)` at column
+zero). Use it from check scripts to verify positive tests obey the rule
+and from anti-pattern tests to verify the agent refactored a known
+violation away.
+
+The check is conservative — it flags by class name only and does not
+attempt to follow imports. False negatives are possible if the agent
+aliases a class to a non-LLM-shaped name; false positives are rare in
+practice because `UiPath*Chat*` is a UiPath-specific convention.
+
+Usage:
+
+    from _shared.ast_lazy_init_check import find_module_level_llm_clients
+
+    violations = find_module_level_llm_clients(Path("main.py"))
+    if violations:
+        sys.exit("FAIL: " + ", ".join(violations))
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+DEFAULT_LLM_CLASS_NAMES = frozenset({
+    "UiPath",
+    "UiPathAzureChatOpenAI",
+    "UiPathChat",
+    "UiPathChatOpenAI",
+    "UiPathOpenAIEmbeddings",
+    "UiPathAzureOpenAIEmbeddings",
+})
+
+
+def _called_class_name(node: ast.Call) -> str | None:
+    """Return the class name being called, or None if it isn't a simple
+    Name/Attribute callable.
+
+    Examples:
+      `UiPath()` -> "UiPath"
+      `uipath.platform.UiPath()` -> "UiPath" (last attribute segment)
+      `factory()` -> "factory" (will be filtered out by class-name set)
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def find_module_level_llm_clients(
+    path: Path,
+    *,
+    class_names: frozenset[str] = DEFAULT_LLM_CLASS_NAMES,
+) -> list[str]:
+    """Return a list of human-readable violation descriptions.
+
+    A violation is any module-level *statement* (i.e. directly inside
+    `Module.body`, not nested inside a function/class) whose value is a
+    Call whose callable resolves to one of `class_names`.
+
+    Returns an empty list when the file obeys the lazy-init rule.
+    """
+    if not path.is_file():
+        return [f"{path} not found"]
+    try:
+        tree = ast.parse(path.read_text(), filename=str(path))
+    except SyntaxError as e:
+        return [f"{path} is not valid Python: {e}"]
+
+    violations: list[str] = []
+    for stmt in tree.body:
+        # Walk only the *direct* expressions in this statement — calls
+        # nested inside a function body are fine. Targets that count as
+        # "module-level instantiation":
+        #   - `llm = UiPathChat()`              (Assign)
+        #   - `llm: UiPathChat = UiPathChat()`  (AnnAssign)
+        #   - `UiPathChat()`                    (bare Expr)
+        candidate_calls: list[ast.Call] = []
+        if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
+            candidate_calls.append(stmt.value)
+        elif (
+            isinstance(stmt, ast.AnnAssign)
+            and stmt.value is not None
+            and isinstance(stmt.value, ast.Call)
+        ):
+            candidate_calls.append(stmt.value)
+        elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+            candidate_calls.append(stmt.value)
+        for call in candidate_calls:
+            name = _called_class_name(call)
+            if name in class_names:
+                violations.append(
+                    f"{path}:{call.lineno} module-level call to {name}() — "
+                    f"violates lazy-LLM-init Critical Rule (C4). Move this "
+                    f"into a function/node body."
+                )
+    return violations
+
+
+def assert_no_module_level_llm_clients(
+    path: Path,
+    *,
+    class_names: frozenset[str] = DEFAULT_LLM_CLASS_NAMES,
+) -> None:
+    """Print OK on pass, exit with FAIL on the first violation.
+
+    Designed for use as the entry of a sidecar check script."""
+    violations = find_module_level_llm_clients(path, class_names=class_names)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print(f"OK: {path} has no module-level LLM client construction")

--- a/tests/tasks/uipath-agents/_shared/bindings_assertions.py
+++ b/tests/tasks/uipath-agents/_shared/bindings_assertions.py
@@ -1,0 +1,168 @@
+"""Reusable bindings.json assertions for coded-agent check scripts.
+
+The schema is documented in
+`skills/uipath-agents/references/coded/lifecycle/bindings-reference.md`.
+These helpers exit the process with a `FAIL: ...` message on any
+assertion failure (so they pair naturally with `run_command` success
+criteria in task YAMLs — exit code 0 means PASS, anything else FAIL).
+
+Print one `OK: ...` line per passing assertion so eval transcripts make
+the diagnostic chain obvious.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def load_bindings(path: Path | str = "bindings.json") -> dict:
+    """Load and validate the bindings.json envelope.
+
+    Asserts `version == "2.0"` and `resources` is a list, then returns
+    the whole document.
+    """
+    p = Path(path)
+    if not p.is_file():
+        sys.exit(f"FAIL: Missing {p}")
+    try:
+        doc = json.loads(p.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {p} is not valid JSON: {e}")
+    version = doc.get("version")
+    if version != "2.0":
+        sys.exit(f'FAIL: bindings.json version should be "2.0", got {version!r}')
+    resources = doc.get("resources")
+    if not isinstance(resources, list):
+        sys.exit(f"FAIL: bindings.json resources must be a list, got {type(resources).__name__}")
+    print(f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)')
+    return doc
+
+
+def find_resource(
+    doc: dict,
+    *,
+    resource: str,
+    key: str,
+) -> dict:
+    """Return the unique resource entry matching `resource` + `key`.
+
+    Exits with FAIL if zero or more than one match is found — duplicate
+    keys are a known authoring failure mode and should never pass.
+    """
+    resources = doc.get("resources") or []
+    matches = [
+        r for r in resources
+        if isinstance(r, dict)
+        and r.get("resource") == resource
+        and r.get("key") == key
+    ]
+    if not matches:
+        sys.exit(
+            f'FAIL: no resource with resource=="{resource}" and key=="{key}" '
+            f"in bindings.json. Got: {json.dumps(resources, indent=2)}"
+        )
+    if len(matches) > 1:
+        sys.exit(
+            f'FAIL: expected exactly one resource with resource=="{resource}" '
+            f'and key=="{key}", got {len(matches)}'
+        )
+    print(f'OK: found {resource} entry with key="{key}"')
+    return matches[0]
+
+
+def assert_value_field(
+    entry: dict,
+    *,
+    field: str,
+    expected: Any,
+    inner: str = "defaultValue",
+) -> None:
+    """Assert `entry["value"][field][inner] == expected`.
+
+    Default `inner="defaultValue"` matches the standard binding shape
+    (`"name": {"defaultValue": ..., "isExpression": false, ...}`). Pass
+    `inner="displayName"` to assert the displayName label, etc.
+    """
+    value = entry.get("value")
+    if not isinstance(value, dict):
+        sys.exit(f"FAIL: entry value must be an object, got {value!r}")
+    block = value.get(field)
+    if not isinstance(block, dict):
+        sys.exit(f'FAIL: entry value.{field} must be an object, got {block!r}')
+    actual = block.get(inner)
+    if actual != expected:
+        sys.exit(
+            f'FAIL: value.{field}.{inner} should be {expected!r}, got {actual!r}'
+        )
+    print(f'OK: value.{field}.{inner} == {expected!r}')
+
+
+def assert_metadata_field(entry: dict, *, field: str, expected: Any) -> None:
+    """Assert `entry["metadata"][field] == expected`."""
+    metadata = entry.get("metadata")
+    if not isinstance(metadata, dict):
+        sys.exit(f"FAIL: entry metadata must be an object, got {metadata!r}")
+    actual = metadata.get(field)
+    if actual != expected:
+        sys.exit(
+            f'FAIL: metadata.{field} should be {expected!r}, got {actual!r}'
+        )
+    print(f'OK: metadata.{field} == {expected!r}')
+
+
+def assert_entrypoint_link(
+    entry: dict,
+    *,
+    unique_id: str,
+    file_path: str,
+) -> None:
+    """Assert the resource is bound to an entrypoint via
+    `EntryPointUniqueId` (preferred) with `displayName == file_path`.
+
+    Falls back to `EntryPointPath` only if `EntryPointUniqueId` is
+    absent — matches the resolver rules in `bindings-reference.md`
+    Step 4.
+    """
+    value = entry.get("value") or {}
+    uid_block = value.get("EntryPointUniqueId")
+    if isinstance(uid_block, dict):
+        if uid_block.get("defaultValue") != unique_id:
+            sys.exit(
+                f'FAIL: EntryPointUniqueId.defaultValue should be {unique_id!r}, '
+                f'got {uid_block.get("defaultValue")!r}'
+            )
+        if uid_block.get("displayName") != file_path:
+            sys.exit(
+                f'FAIL: EntryPointUniqueId.displayName must equal the entrypoint '
+                f'filePath ({file_path!r}), got {uid_block.get("displayName")!r}'
+            )
+        print(
+            f'OK: entry bound to entrypoint uniqueId={unique_id!r} '
+            f'(displayName={file_path!r})'
+        )
+        return
+    path_block = value.get("EntryPointPath")
+    if isinstance(path_block, dict):
+        if path_block.get("defaultValue") != file_path:
+            sys.exit(
+                f'FAIL: EntryPointPath.defaultValue should be {file_path!r}, '
+                f'got {path_block.get("defaultValue")!r}'
+            )
+        print(f'OK: entry bound to entrypoint filePath={file_path!r} (fallback)')
+        return
+    sys.exit(
+        f'FAIL: entry has neither EntryPointUniqueId nor EntryPointPath; expected '
+        f'a binding to entrypoint uniqueId={unique_id!r} (filePath={file_path!r})'
+    )
+
+
+def count_resources_by_type(doc: dict, resource_type: str) -> int:
+    """Return the number of entries with `resource == resource_type`."""
+    resources = doc.get("resources") or []
+    return sum(
+        1 for r in resources
+        if isinstance(r, dict) and r.get("resource") == resource_type
+    )

--- a/tests/tasks/uipath-agents/_shared/coded_project_factory.py
+++ b/tests/tasks/uipath-agents/_shared/coded_project_factory.py
@@ -1,0 +1,153 @@
+"""Coded-agent project scaffolding factory.
+
+Emits the minimum file set a coded-agent task needs *before* the agent
+runs `uip codedagent init` — `pyproject.toml`, `uipath.json`,
+`entry-points.json`, and a `bindings.json` skeleton. The shape mirrors
+`assets/templates/pyproject.toml` and the project layout documented in
+`references/coded/lifecycle/setup.md`.
+
+This is *not* a substitute for `uip codedagent new` / `init`. It is the
+seed used by tests that aren't *about* scaffolding (e.g. bindings-only
+tests, anti-pattern negative tests) so they can skip straight to the
+behavior under test. Tests that exercise the scaffold lifecycle itself
+(PR 2 framework end-to-end tests) MUST call `uip codedagent new` from
+the agent prompt — never call this factory.
+
+Critical Rule (`references/coded/quickstart.md`): NEVER add a
+`[build-system]` section. The factory enforces this — `pyproject.toml`
+is `[project]` + `[dependency-groups]` only.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from textwrap import dedent
+from typing import Iterable
+
+PYPROJECT_TEMPLATE = dedent(
+    """\
+    [project]
+    name = "{name}"
+    version = "0.0.1"
+    description = "{description}"
+    authors = [{{ name = "Agent Developer" }}]
+    requires-python = ">=3.11"
+    dependencies = [
+        "uipath",{extra_deps}
+    ]
+
+    [dependency-groups]
+    dev = [
+        "uipath-dev",
+    ]
+    """
+)
+
+
+def write_pyproject(
+    root: Path,
+    *,
+    name: str,
+    description: str = "Test fixture",
+    extra_dependencies: Iterable[str] = (),
+) -> Path:
+    """Write `pyproject.toml`. No `[build-system]` — Critical Rule C1.
+
+    `extra_dependencies` is for framework deps (e.g. `uipath-langchain`).
+    They are appended to the base `["uipath"]` list.
+    """
+    extras = list(extra_dependencies)
+    extra_block = ""
+    if extras:
+        extra_block = "\n" + "\n".join(f'    "{dep}",' for dep in extras)
+    content = PYPROJECT_TEMPLATE.format(
+        name=name,
+        description=description,
+        extra_deps=extra_block,
+    )
+    path = root / "pyproject.toml"
+    path.write_text(content)
+    return path
+
+
+def write_uipath_json(root: Path, *, functions: dict | None = None) -> Path:
+    """Write `uipath.json` in the shape `uip codedagent init` produces.
+
+    `functions` maps entrypoint name to `<file>.py:<func>` per the
+    simple-function convention in `setup.md`. Pass `None` to omit the
+    `functions` key entirely (LangGraph / LlamaIndex / OpenAI Agents
+    auto-discover from their own config files).
+    """
+    payload: dict = {
+        "$schema": "https://cloud.uipath.com/draft/2024-12/uipath",
+        "runtimeOptions": {"isConversational": False},
+        "packOptions": {
+            "fileExtensionsIncluded": [],
+            "filesIncluded": [],
+            "filesExcluded": [],
+            "directoriesExcluded": [],
+            "includeUvLock": True,
+        },
+    }
+    if functions is not None:
+        payload["functions"] = functions
+    path = root / "uipath.json"
+    path.write_text(json.dumps(payload, indent=2))
+    return path
+
+
+def write_entry_points(
+    root: Path,
+    *,
+    entrypoints: list[dict] | None = None,
+) -> Path:
+    """Write `entry-points.json`.
+
+    Each entry must include at minimum `filePath` and `uniqueId`. Pass
+    `entrypoints=None` to write an empty list (sufficient for some
+    bindings-sync tests — see `bindings_sync.yaml`).
+    """
+    payload = {
+        "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+        "$id": "entry-points.json",
+        "entryPoints": list(entrypoints or []),
+    }
+    path = root / "entry-points.json"
+    path.write_text(json.dumps(payload, indent=2))
+    return path
+
+
+def write_empty_bindings(root: Path) -> Path:
+    """Write the v2.0 bindings.json skeleton (see `bindings-reference.md`)."""
+    path = root / "bindings.json"
+    path.write_text(json.dumps({"version": "2.0", "resources": []}, indent=2))
+    return path
+
+
+def write_minimal_project(
+    root: Path,
+    *,
+    name: str = "test-agent",
+    description: str = "Test fixture",
+    functions: dict | None = None,
+    entrypoints: list[dict] | None = None,
+    extra_dependencies: Iterable[str] = (),
+) -> dict:
+    """Emit the four-file minimum: pyproject.toml, uipath.json,
+    entry-points.json, bindings.json.
+
+    Returns a dict of the absolute paths for downstream assertions.
+    """
+    root.mkdir(parents=True, exist_ok=True)
+    return {
+        "pyproject": write_pyproject(
+            root,
+            name=name,
+            description=description,
+            extra_dependencies=extra_dependencies,
+        ),
+        "uipath_json": write_uipath_json(root, functions=functions),
+        "entry_points": write_entry_points(root, entrypoints=entrypoints),
+        "bindings": write_empty_bindings(root),
+    }

--- a/tests/tasks/uipath-agents/_shared/project_root.py
+++ b/tests/tasks/uipath-agents/_shared/project_root.py
@@ -1,0 +1,32 @@
+"""Resolve the on-disk project root for a coded-agent test.
+
+The skill's `references/coded/lifecycle/setup.md` teaches `mkdir
+<PROJECT_NAME> && cd <PROJECT_NAME>` as the canonical scaffolding
+step, but in practice agents sometimes work directly in the
+sandbox cwd (no subdir) — especially when the prompt doesn't
+emphasise the mkdir step. To stay durable across both behaviours
+without flipping check scripts every time, this helper finds the
+project root by looking for `pyproject.toml`:
+
+  1. If `<cwd>/pyproject.toml` exists → return `<cwd>` (flat layout).
+  2. Else if `<cwd>/<default_subdir>/pyproject.toml` exists →
+     return that subdir.
+  3. Else fall back to `<cwd>/<default_subdir>` so downstream
+     checks surface a clear "Missing <expected file>" diagnostic
+     against the canonical layout.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def find_project_root(default_subdir: str) -> Path:
+    cwd = Path(os.getcwd())
+    if (cwd / "pyproject.toml").is_file():
+        return cwd
+    nested = cwd / default_subdir
+    if (nested / "pyproject.toml").is_file():
+        return nested
+    return nested

--- a/tests/tasks/uipath-agents/bindings_sync.yaml
+++ b/tests/tasks/uipath-agents/bindings_sync.yaml
@@ -4,7 +4,7 @@ description: >
   all Python files in a project (including helper modules), resolve module-level
   constants, and produce a correct bindings.json. Tests that the skill teaches
   scanning beyond main.py and constant resolution.
-tags: [uipath-agents, smoke, bindings]
+tags: [uipath-agents, smoke, coded, bindings]
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
## Summary

Foundation helpers for upcoming coded-agent tests under `tests/tasks/uipath-agents/coded/`. No tests yet — these modules are imported by the sidecar `check_*.py` scripts in follow-up PRs.

## Changes

- `coded/_shared/coded_project_factory.py` — `write_minimal_project()` emits a four-file scaffold (`pyproject.toml` without `[build-system]`, `uipath.json`, `entry-points.json`, empty `bindings.json`) for tests where scaffolding isn't the focus.
- `coded/_shared/bindings_assertions.py` — common shape checks for `bindings.json`: envelope load, resource lookup by `(resource, key)`, `value.<field>.defaultValue` / `metadata.<field>` assertions, entrypoint-link verification.
- `coded/_shared/ast_lazy_init_check.py` — AST scan that flags module-level construction of UiPath LLM client classes (`UiPath`, `UiPathChat`, `UiPathAzureChatOpenAI`, `UiPathChatOpenAI`, `UiPathOpenAIEmbeddings`, `UiPathAzureOpenAIEmbeddings`). Used to verify the lazy-init invariant in coded-agent code.
- `bindings_sync.yaml` — add `coded` tag so `make tags TAGS="uipath-agents coded"` matches it (the test already exercises coded-agent bindings sync).

## Test plan

- [x] Each helper imports cleanly and round-trips: factory writes the four files; bindings assertions accept a valid envelope and reject a wrong version; AST scan flags `llm = UiPath()` at module level and ignores `UiPath()` inside a function body.