### PR TITLE
test(uipath-agents): four coded-framework e2e tests (PR 2/5)

### DIFF
--- a/tests/tasks/uipath-agents/langgraph_classifier/check_langgraph_classifier.py
+++ b/tests/tasks/uipath-agents/langgraph_classifier/check_langgraph_classifier.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""LangGraph agent project-shape check.
+
+Asserts the lazy-LLM-init invariant (Critical Rule C4) and the
+schema-sync invariant (`entry-points.json` reflects the Pydantic
+Input/Output classes the agent declared).
+
+Checks performed:
+
+  1. `support-classifier/pyproject.toml` declares `uipath-langchain`
+     as a dependency, has `[project]` with `authors`, and contains NO
+     `[build-system]` section.
+  2. The project has either `langgraph.json` (Pattern A — recommended)
+     OR `uipath.json` with a `functions.graph` entry (Pattern B). Both
+     are valid per the LangGraph integration guide.
+  3. `main.py` (or `graph.py`) defines `GraphInput`/`GraphOutput`
+     Pydantic models, exports a top-level `graph` variable, and has
+     NO module-level UiPath* construction (`UiPathChat`,
+     `UiPathAzureChatOpenAI`, etc.).
+  4. `entry-points.json` has one entrypoint whose schemas mention
+     `text` (input) and `category` (output) — proves `uip codedagent
+     init` ran AFTER the Pydantic models were written.
+  5. `bindings.json` is the v2.0 envelope (resource count is not
+     asserted — the classifier itself uses no SDK resources).
+
+Exits 0 on PASS, with a `FAIL: ...` message on the first violation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import load_bindings  # noqa: E402
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("support-classifier")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Critical Rule C1 forbids it."
+        )
+    if "[project]" not in text or "authors" not in text:
+        sys.exit("FAIL: pyproject.toml is missing [project] or `authors`")
+    if "uipath-langchain" not in text:
+        sys.exit(
+            "FAIL: pyproject.toml does not declare `uipath-langchain` — "
+            "the LangGraph integration guide makes this dependency mandatory."
+        )
+    print("OK: pyproject.toml is hygienic and declares uipath-langchain")
+
+
+def find_graph_module() -> Path:
+    for candidate in ("main.py", "graph.py"):
+        path = ROOT / candidate
+        if path.is_file():
+            return path
+    sys.exit(
+        "FAIL: neither main.py nor graph.py found under "
+        f"{ROOT} — LangGraph integration guide requires one."
+    )
+
+
+def check_graph_module(path: Path) -> None:
+    text = _read_text(path)
+    for needle in ("GraphInput", "GraphOutput", "graph"):
+        if needle not in text:
+            sys.exit(f"FAIL: {path.name} is missing `{needle}`")
+    if "StateGraph" not in text and "CompiledStateGraph" not in text:
+        sys.exit(f"FAIL: {path.name} does not reference StateGraph / CompiledStateGraph")
+    print(f"OK: {path.name} defines GraphInput, GraphOutput, and a graph variable")
+    violations = find_module_level_llm_clients(path)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print(
+        f"OK: {path.name} has no module-level UiPath* construction "
+        "(lazy-LLM-init invariant holds)"
+    )
+
+
+def check_runtime_config() -> None:
+    langgraph_json = ROOT / "langgraph.json"
+    uipath_json = ROOT / "uipath.json"
+    if langgraph_json.is_file():
+        doc = _load_json(langgraph_json)
+        graphs = doc.get("graphs") or {}
+        if not graphs:
+            sys.exit("FAIL: langgraph.json has no `graphs` mapping")
+        target = next(iter(graphs.values()))
+        if not isinstance(target, str) or ":graph" not in target:
+            sys.exit(
+                f'FAIL: langgraph.json graphs entry should map to a `<file>:graph` '
+                f'reference, got {target!r}'
+            )
+        print(f"OK: langgraph.json registers a graph -> {target!r}")
+        return
+    if uipath_json.is_file():
+        doc = _load_json(uipath_json)
+        functions = doc.get("functions") or {}
+        graph_entry = functions.get("graph")
+        if not graph_entry or ":graph" not in graph_entry:
+            sys.exit(
+                "FAIL: neither langgraph.json nor uipath.json `functions.graph` "
+                "is present — the runtime cannot find the compiled graph."
+            )
+        print(f'OK: uipath.json registers functions.graph -> {graph_entry!r}')
+        return
+    sys.exit(
+        "FAIL: project has neither langgraph.json nor uipath.json — at "
+        "least one is required for `uip codedagent init` to succeed."
+    )
+
+
+def check_entry_points() -> None:
+    doc = _load_json(ROOT / "entry-points.json")
+    entrypoints = doc.get("entryPoints") or []
+    if not entrypoints:
+        sys.exit("FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully")
+    raw = json.dumps(entrypoints)
+    for field in ("text", "category"):
+        if field not in raw:
+            sys.exit(
+                f'FAIL: entry-points.json schemas do not mention `{field}`. '
+                f'Either `uip codedagent init` ran before the Pydantic models '
+                f'were written, or the models did not declare the expected '
+                f'fields. Got: {raw}'
+            )
+    print(
+        "OK: entry-points.json schemas reflect the GraphInput/GraphOutput "
+        "fields (text, category)"
+    )
+
+
+def check_bindings() -> None:
+    load_bindings(ROOT / "bindings.json")
+    print("OK: bindings.json envelope is well-formed")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    graph_module = find_graph_module()
+    check_graph_module(graph_module)
+    check_runtime_config()
+    check_entry_points()
+    check_bindings()
+    if not (ROOT / "run_marker.txt").is_file():
+        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+    print("OK: run_marker.txt exists (run completed cleanly)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/langgraph_classifier/langgraph_classifier.yaml
+++ b/tests/tasks/uipath-agents/langgraph_classifier/langgraph_classifier.yaml
@@ -1,0 +1,77 @@
+task_id: skill-agent-coded-langgraph-classifier
+description: >
+  LangGraph coded agent zero-to-running. Verifies the agent
+  scaffolds a LangGraph project (`uip codedagent new` →
+  `langgraph.json` + `main.py` exporting a compiled `graph`), keeps
+  LLM construction inside a node body (Critical Rule C4 —
+  module-level `UiPathChat()` breaks `uip codedagent init` with
+  `ImportError`), lets `uip codedagent init` regenerate the schema
+  from the actual code, and runs the classifier end-to-end via
+  `uip codedagent run agent`.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-langgraph, feature:schema-sync]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a LangGraph UiPath coded agent named `support-classifier` that
+  classifies a customer support ticket into one of three categories:
+  `billing`, `technical`, `general`.
+
+  Input: `text` (str). Output: `category` (str — one of the three
+  labels above) and `text` (str — the original text echoed back).
+
+  For deterministic test runs, pin the LLM to a low-cost gateway
+  model (e.g. `gpt-4o-mini-2024-07-18`) with `temperature=0`.
+
+  Take the agent end-to-end through scaffold → init → run. Run
+  against `'{"text": "I was charged twice for my last invoice."}'`
+  — the expected category is `billing`.
+
+  After the run succeeds, write `RAN_OK` to `run_marker.txt` in the
+  project root so the test harness can verify the run completed
+  cleanly.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded with uip codedagent new"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init to generate entry-points.json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent executed the agent locally with uip codedagent run"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run\s+agent'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "LangGraph project shape, lazy-LLM-init invariant, schema sync"
+    command: "python3 $TASK_DIR/check_langgraph_classifier.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/llamaindex_workflow/check_llamaindex_workflow.py
+++ b/tests/tasks/uipath-agents/llamaindex_workflow/check_llamaindex_workflow.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""LlamaIndex Workflow agent project-shape check.
+
+Checks performed:
+
+  1. `qna-workflow/pyproject.toml` declares `uipath-llamaindex`, has
+     `[project]` with `authors`, and contains NO `[build-system]`
+     section.
+  2. `llama_index.json` exists with a `workflows` mapping pointing to
+     a `<file>:workflow` (or any variable name) reference.
+  3. `main.py` defines `Question(StartEvent)`, `Answer(StopEvent)`,
+     a `Workflow` subclass, exports a top-level `workflow` variable,
+     and has NO module-level UiPath* construction.
+  4. `entry-points.json` reflects the StartEvent/StopEvent fields:
+     `question` (input), `answer` and `word_count` (output).
+  5. `bindings.json` is the v2.0 envelope.
+
+Exits 0 on PASS, with a `FAIL: ...` message on the first violation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import load_bindings  # noqa: E402
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("qna-workflow")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Critical Rule C1 forbids it."
+        )
+    if "[project]" not in text or "authors" not in text:
+        sys.exit("FAIL: pyproject.toml is missing [project] or `authors`")
+    if "uipath-llamaindex" not in text:
+        sys.exit(
+            "FAIL: pyproject.toml does not declare `uipath-llamaindex` — "
+            "the LlamaIndex integration guide makes this dependency "
+            "mandatory."
+        )
+    print("OK: pyproject.toml is hygienic and declares uipath-llamaindex")
+
+
+def check_llama_index_json() -> None:
+    doc = _load_json(ROOT / "llama_index.json")
+    workflows = doc.get("workflows") or {}
+    if not workflows:
+        sys.exit("FAIL: llama_index.json has no `workflows` mapping")
+    target = next(iter(workflows.values()))
+    if not isinstance(target, str) or ":" not in target:
+        sys.exit(
+            f'FAIL: llama_index.json workflows entry should map to a '
+            f'`<file>:<variable>` reference, got {target!r}'
+        )
+    print(f"OK: llama_index.json registers a workflow -> {target!r}")
+
+
+def check_main_py() -> None:
+    main = ROOT / "main.py"
+    text = _read_text(main)
+    for needle in ("StartEvent", "StopEvent", "Workflow", "@step", "workflow"):
+        if needle not in text:
+            sys.exit(f"FAIL: main.py is missing `{needle}`")
+    print(
+        "OK: main.py defines StartEvent/StopEvent subclasses, a Workflow, "
+        "a @step, and exports a workflow variable"
+    )
+    violations = find_module_level_llm_clients(main)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print(
+        "OK: main.py has no module-level UiPath* construction "
+        "(lazy-LLM-init invariant holds)"
+    )
+
+
+def check_entry_points() -> None:
+    doc = _load_json(ROOT / "entry-points.json")
+    entrypoints = doc.get("entryPoints") or []
+    if not entrypoints:
+        sys.exit("FAIL: entry-points.json has no entryPoints")
+    raw = json.dumps(entrypoints)
+    for field in ("question", "answer", "word_count"):
+        if field not in raw:
+            sys.exit(
+                f'FAIL: entry-points.json schemas do not mention `{field}`. '
+                f'StartEvent/StopEvent fields were not picked up by '
+                f'`uip codedagent init`. Got: {raw}'
+            )
+    print(
+        "OK: entry-points.json reflects StartEvent/StopEvent fields "
+        "(question, answer, word_count)"
+    )
+
+
+def check_bindings() -> None:
+    load_bindings(ROOT / "bindings.json")
+    print("OK: bindings.json envelope is well-formed")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    check_llama_index_json()
+    check_main_py()
+    check_entry_points()
+    check_bindings()
+    if not (ROOT / "run_marker.txt").is_file():
+        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+    print("OK: run_marker.txt exists (run completed cleanly)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/llamaindex_workflow/llamaindex_workflow.yaml
+++ b/tests/tasks/uipath-agents/llamaindex_workflow/llamaindex_workflow.yaml
@@ -1,0 +1,72 @@
+task_id: skill-agent-coded-llamaindex-workflow
+description: >
+  LlamaIndex coded agent zero-to-running. Verifies the agent
+  scaffolds a LlamaIndex Workflow project (`uip codedagent new` →
+  `llama_index.json` + `main.py` exporting a `Workflow` instance),
+  uses custom `StartEvent`/`StopEvent` subclasses for input/output
+  schemas, instantiates `UiPathOpenAI` lazily inside a step
+  (Critical Rule C4), and runs the workflow end-to-end via
+  `uip codedagent run`.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-llamaindex]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a LlamaIndex UiPath coded agent named `qna-workflow` that
+  takes a user question, generates a brief answer using the platform
+  LLM gateway, and reports both the answer and its word count.
+
+  Input: `question` (str). Output: `answer` (str), `word_count`
+  (int).
+
+  Take the agent end-to-end through scaffold → init → run. Run
+  against `'{"question": "What is Python in one sentence?"}'`.
+
+  After the run succeeds, write `RAN_OK` to `run_marker.txt` in the
+  project root so the test harness can verify the run completed
+  cleanly.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded with uip codedagent new"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init to generate entry-points.json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent executed the workflow locally with uip codedagent run"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run\s+agent'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "LlamaIndex project shape, lazy-LLM-init invariant, schema sync"
+    command: "python3 $TASK_DIR/check_llamaindex_workflow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/openai_agents_handoff/check_openai_agents_handoff.py
+++ b/tests/tasks/uipath-agents/openai_agents_handoff/check_openai_agents_handoff.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""OpenAI Agents agent project-shape check.
+
+The factory-function pattern (`def main() -> Agent`) is the load-bearing
+invariant for this framework — without it, `UiPathChatOpenAI(...)` and
+`_openai_shared.set_default_openai_client(...)` execute at module
+import time and `uip codedagent init` blows up before it can introspect
+the agent.
+
+Checks performed:
+
+  1. `triage-bot/pyproject.toml` declares `uipath-openai-agents`, has
+     `[project]` with `authors`, no `[build-system]`.
+  2. `openai_agents.json` exists with an `agents` mapping pointing at
+     `main.py:main` (factory pattern) — pointing at a top-level
+     `agent` variable would mean module-level `Agent[...]`
+     construction, which fails because the agent context type
+     resolution itself can pull in the LLM client.
+  3. `main.py` defines a `def main()` factory, declares a
+     `CustomerInput` Pydantic model with `customer_id`, has the
+     `_openai_shared.set_default_openai_client(...)` call INSIDE the
+     factory, configures three agents (`triage`, `billing`,
+     `technical`) with at least one `handoffs=` list, and has NO
+     module-level UiPath* construction.
+  4. `entry-points.json` reflects the `customer_id` context field
+     and the standard `messages` field every OpenAI Agent accepts.
+  5. `bindings.json` is the v2.0 envelope.
+
+Exits 0 on PASS, with a `FAIL: ...` message on the first violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import load_bindings  # noqa: E402
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("triage-bot")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Critical Rule C1 forbids it."
+        )
+    if "[project]" not in text or "authors" not in text:
+        sys.exit("FAIL: pyproject.toml is missing [project] or `authors`")
+    if "uipath-openai-agents" not in text:
+        sys.exit(
+            "FAIL: pyproject.toml does not declare `uipath-openai-agents` — "
+            "the OpenAI Agents integration guide makes this dependency "
+            "mandatory."
+        )
+    print("OK: pyproject.toml is hygienic and declares uipath-openai-agents")
+
+
+def check_openai_agents_json() -> None:
+    doc = _load_json(ROOT / "openai_agents.json")
+    agents = doc.get("agents") or {}
+    if not agents:
+        sys.exit("FAIL: openai_agents.json has no `agents` mapping")
+    target = next(iter(agents.values()))
+    if not isinstance(target, str) or ":main" not in target:
+        sys.exit(
+            f'FAIL: openai_agents.json should point at the factory function '
+            f'(`<file>:main`), got {target!r}. Pointing at a top-level '
+            f'variable would break the lazy-LLM-init invariant.'
+        )
+    print(f"OK: openai_agents.json registers an agent -> {target!r} (factory pattern)")
+
+
+def check_main_py() -> None:
+    main_path = ROOT / "main.py"
+    text = _read_text(main_path)
+    for needle in ("CustomerInput", "customer_id", "def main", "handoffs"):
+        if needle not in text:
+            sys.exit(f"FAIL: main.py is missing `{needle}`")
+    if "set_default_openai_client" not in text:
+        sys.exit(
+            "FAIL: main.py never calls `_openai_shared.set_default_openai_client(...)` — "
+            "without it the agents fall through to the default OpenAI client "
+            "instead of UiPath's gateway."
+        )
+    # Three named agents: triage, billing, technical
+    name_pattern = re.compile(r'name\s*=\s*"([^"]+)"')
+    declared_names = set(name_pattern.findall(text))
+    expected = {"triage", "billing", "technical"}
+    if not expected.issubset(declared_names):
+        missing = expected - declared_names
+        sys.exit(
+            f"FAIL: main.py is missing agent declarations for {sorted(missing)}. "
+            f"Found agent names: {sorted(declared_names)}"
+        )
+    print("OK: main.py declares triage / billing / technical agents with handoffs")
+    violations = find_module_level_llm_clients(main_path)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print(
+        "OK: main.py has no module-level UiPath* construction "
+        "(factory-function pattern preserved)"
+    )
+    # Confirm set_default_openai_client is INSIDE a function body — not at
+    # module level — by AST walk.
+    tree = ast.parse(text, filename=str(main_path))
+    for node in tree.body:
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            func = node.value.func
+            if isinstance(func, ast.Attribute) and func.attr == "set_default_openai_client":
+                sys.exit(
+                    f"FAIL: main.py:{node.lineno} `set_default_openai_client(...)` "
+                    "is at module level — it must run inside the factory "
+                    "function body to defer authentication until the runtime "
+                    "calls main()."
+                )
+    print("OK: set_default_openai_client(...) is inside the factory body")
+
+
+def check_entry_points() -> None:
+    doc = _load_json(ROOT / "entry-points.json")
+    entrypoints = doc.get("entryPoints") or []
+    if not entrypoints:
+        sys.exit("FAIL: entry-points.json has no entryPoints")
+    raw = json.dumps(entrypoints)
+    for field in ("customer_id", "messages"):
+        if field not in raw:
+            sys.exit(
+                f'FAIL: entry-points.json schemas do not mention `{field}`. '
+                f'`uip codedagent init` did not pick up the Agent[CustomerInput] '
+                f'context type. Got: {raw}'
+            )
+    print(
+        "OK: entry-points.json reflects the Agent[CustomerInput] context "
+        "(customer_id) and the standard `messages` field"
+    )
+
+
+def check_bindings() -> None:
+    load_bindings(ROOT / "bindings.json")
+    print("OK: bindings.json envelope is well-formed")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    check_openai_agents_json()
+    check_main_py()
+    check_entry_points()
+    check_bindings()
+    if not (ROOT / "run_marker.txt").is_file():
+        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+    print("OK: run_marker.txt exists (run completed cleanly)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/openai_agents_handoff/openai_agents_handoff.yaml
+++ b/tests/tasks/uipath-agents/openai_agents_handoff/openai_agents_handoff.yaml
@@ -1,0 +1,85 @@
+task_id: skill-agent-coded-openai-agents-handoff
+description: >
+  OpenAI Agents coded agent zero-to-running with a multi-agent
+  handoff. Verifies the agent scaffolds an OpenAI Agents project
+  (`uip codedagent new` → `openai_agents.json` + `main.py`
+  exporting an `Agent` factory function), uses the factory
+  function pattern (`def main() -> Agent`) so `UiPathChatOpenAI`
+  and `_openai_shared.set_default_openai_client` are deferred
+  (Critical Rule C4 — module-level setup breaks
+  `uip codedagent init`), and runs the triage agent end-to-end.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-openai-agents]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build an OpenAI Agents UiPath coded agent named `triage-bot` with
+  three agents:
+
+  - A `triage` agent (the top-level entrypoint) that reads the
+    customer's message and decides whether to hand off.
+  - A `billing` agent for invoice / payment questions.
+  - A `technical` agent for product / feature questions.
+
+  The triage agent must accept a typed customer context. Define
+  this context as a Pydantic model named `CustomerInput` with a
+  single `customer_id: str` field, and pass it as the typed context
+  on the triage `Agent[...]` so the entry-points schema picks it
+  up. Configure handoffs from triage to billing and technical.
+
+  Register the triage factory in `openai_agents.json` under the
+  entrypoint key `agent` (i.e. `{"agents": {"agent":
+  "main.py:main"}}`).
+
+  Take the agent end-to-end through scaffold → init → run. Run
+  with `uip codedagent run agent
+  '{"messages": "I think I was charged twice last month, can you check?", "customer_id": "C-101"}'`.
+
+  After the run succeeds, write `RAN_OK` to `run_marker.txt` in the
+  project root so the test harness can verify the run completed
+  cleanly.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded with uip codedagent new"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init to generate entry-points.json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent executed the agent locally with uip codedagent run agent"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run\s+agent'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "OpenAI Agents project shape, factory pattern, handoff wiring"
+    command: "python3 $TASK_DIR/check_openai_agents_handoff.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/simple_echo/check_simple_echo.py
+++ b/tests/tasks/uipath-agents/simple_echo/check_simple_echo.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Simple Function agent project-shape check.
+
+Verifies the artifacts a Simple Function scaffold MUST produce:
+
+  1. `echo-agent/pyproject.toml` exists, has `[project]` with `authors`,
+     and contains NO `[build-system]` section (Critical Rule C1).
+  2. `echo-agent/main.py` defines `Input` and `Output` Pydantic models
+     and an `async def main(input: Input) -> Output` entrypoint.
+  3. `echo-agent/main.py` does NOT instantiate any UiPath* class at
+     module level (Critical Rule C4 — lazy LLM init).
+  4. `echo-agent/uipath.json` has `functions.main == "main.py:main"`
+     (the simple-function entrypoint registration documented in
+     references/coded/lifecycle/setup.md).
+  5. `echo-agent/entry-points.json` has one entrypoint whose
+     `filePath` is `main` (or `main.py`) and whose input/output
+     JSON schemas mention the `message`/`repeat`/`echoed`/`length`
+     fields the agent declared.
+  6. `echo-agent/bindings.json` is the v2.0 envelope with zero
+     resources (the agent makes no SDK calls).
+
+Exits 0 on PASS, with a `FAIL: ...` message on the first violation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import load_bindings, count_resources_by_type  # noqa: E402
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("echo-agent")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Critical Rule C1 forbids it. UiPath agents do not use a build "
+            "system."
+        )
+    if "[project]" not in text:
+        sys.exit("FAIL: pyproject.toml has no [project] section")
+    if "authors" not in text:
+        sys.exit(
+            "FAIL: pyproject.toml has no `authors` entry — `uip codedagent "
+            "deploy` will reject the package with `Project authors cannot "
+            "be empty`."
+        )
+    print("OK: pyproject.toml has [project], `authors`, and no [build-system]")
+
+
+def check_main_py() -> None:
+    main = ROOT / "main.py"
+    text = _read_text(main)
+    for needle in ("class Input", "class Output", "def main"):
+        if needle not in text:
+            sys.exit(f"FAIL: main.py is missing `{needle}`")
+    print("OK: main.py defines Input, Output, and main()")
+    violations = find_module_level_llm_clients(main)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print("OK: main.py has no module-level UiPath* construction")
+
+
+def check_uipath_json() -> None:
+    doc = _load_json(ROOT / "uipath.json")
+    functions = doc.get("functions") or {}
+    main_entry = functions.get("main")
+    if main_entry not in ("main.py:main", "./main.py:main"):
+        sys.exit(
+            f'FAIL: uipath.json functions.main should be "main.py:main", '
+            f'got {main_entry!r}'
+        )
+    print(f'OK: uipath.json registers functions.main -> {main_entry!r}')
+
+
+def check_entry_points() -> None:
+    doc = _load_json(ROOT / "entry-points.json")
+    entrypoints = doc.get("entryPoints") or []
+    if not entrypoints:
+        sys.exit("FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully")
+    matches = [
+        ep for ep in entrypoints
+        if ep.get("filePath") in ("main", "main.py")
+    ]
+    if not matches:
+        paths = [ep.get("filePath") for ep in entrypoints]
+        sys.exit(f'FAIL: no entrypoint with filePath "main" or "main.py"; got {paths}')
+    ep = matches[0]
+    if not ep.get("uniqueId"):
+        sys.exit("FAIL: entrypoint is missing `uniqueId` — `uip codedagent init` did not generate it")
+    raw = json.dumps(ep)
+    for field in ("message", "repeat", "echoed", "length"):
+        if field not in raw:
+            sys.exit(
+                f'FAIL: entrypoint schema does not mention `{field}` — '
+                f'agent.json ↔ entry-points.json schema sync failed. '
+                f'Got: {raw}'
+            )
+    print(
+        "OK: entry-points.json has one `main` entrypoint with all four "
+        "schema fields (message / repeat / echoed / length)"
+    )
+
+
+def check_bindings() -> None:
+    doc = load_bindings(ROOT / "bindings.json")
+    total = sum(
+        count_resources_by_type(doc, t)
+        for t in ("asset", "queue", "process", "bucket", "app", "index", "connection", "mcpServer")
+    )
+    if total != 0:
+        sys.exit(
+            f"FAIL: simple-echo agent makes no SDK calls — bindings.json "
+            f"should have 0 resources, got {total}"
+        )
+    print("OK: bindings.json is the empty v2.0 envelope (no SDK calls expected)")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    check_main_py()
+    check_uipath_json()
+    check_entry_points()
+    check_bindings()
+    if not (ROOT / "run_marker.txt").is_file():
+        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+    print("OK: run_marker.txt exists (run completed cleanly)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/simple_echo/simple_echo.yaml
+++ b/tests/tasks/uipath-agents/simple_echo/simple_echo.yaml
@@ -1,0 +1,77 @@
+task_id: skill-agent-coded-simple-echo
+description: >
+  Simple Function coded agent zero-to-running. Verifies the agent
+  scaffolds via `uip codedagent new`, registers the function
+  entrypoint in `uipath.json`, runs `uip codedagent init` to emit
+  `entry-points.json` with Pydantic-derived schemas, then runs
+  `uip codedagent run main` to execute deterministically (no LLM,
+  no cloud auth needed).
+tags: [uipath-agents, smoke, coded, lifecycle:generate, lifecycle:execute, feature:framework-simple]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+  # Default smoke max_turns is 20, but the full scaffold -> init -> run
+  # loop (uv venv, uv sync, uip codedagent setup, uip codedagent new,
+  # rewrite main.py, init, run, write marker) lands at ~25 turns even
+  # without an LLM call. Bumping headroom to 40.
+  max_turns: 40
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a Simple Function UiPath coded agent named `echo-agent` whose
+  `main(input)` echoes `input.message` repeated `input.repeat` times
+  and reports the resulting length. No LLM calls — purely
+  deterministic Python.
+
+  Input fields: `message: str`, `repeat: int` (default 1).
+  Output fields: `echoed: str`, `length: int`.
+
+  Take the agent end-to-end through scaffold → init → run. After
+  `uip codedagent run main '{"message": "hi ", "repeat": 3}'`
+  succeeds, write `RAN_OK` to a file `run_marker.txt` in the project
+  root so the test harness can verify the run completed cleanly.
+
+  Do NOT publish, upload, or deploy. Do NOT call `uip login`. Do NOT
+  ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Complete the entire task end-to-end in
+  a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project with uip codedagent new"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init to generate entry-points.json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent executed the agent locally with uip codedagent run"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run\s+main'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Project shape, lazy-init, schema sync, and pyproject hygiene"
+    command: "python3 $TASK_DIR/check_simple_echo.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Adds four coded-agent end-to-end tests, one per framework the skill teaches. Each task is goal-only — the skill drives `uip codedagent new` → `init` → `run`.

| Task | Tier | What it covers |
|---|---|---|
| `skill-agent-coded-simple-echo` | smoke | Simple Function: Pydantic Input/Output, no LLM, deterministic; runs the agent locally and asserts echoed output. |
| `skill-agent-coded-langgraph-classifier` | e2e | LangGraph: StateGraph + lazy `UiPathChat()` inside a node, classifies a support ticket via the LLM Gateway. |
| `skill-agent-coded-llamaindex-workflow` | e2e | LlamaIndex: `Workflow` with `StartEvent`/`StopEvent` subclasses, lazy `UiPathOpenAI` inside a `@step`. |
| `skill-agent-coded-openai-agents-handoff` | e2e | OpenAI Agents: factory function returning `Agent[CustomerInput]` with handoffs to `billing` / `technical` specialists. |

## What each check script asserts

- `pyproject.toml` hygiene — `[project]` + `authors`, framework dep declared, no `[build-system]`.
- Runtime config file — `langgraph.json` / `llama_index.json` / `openai_agents.json` / `uipath.json` `functions`. OpenAI Agents check requires the factory pattern (`main.py:main`, not a top-level variable).
- Source-code shape — Pydantic models, framework-specific exports (`graph` / `workflow` / factory), expected agent declarations.
- **No module-level UiPath LLM client construction** — the AST scan catches the most common coded mistake (module-level `UiPathChat()` etc. fails `uip codedagent init` with `ImportError` at module-import time).
- `entry-points.json` mentions the declared field names, proving `uip codedagent init` ran after the Pydantic models were written.
- `bindings.json` is the v2.0 envelope.

Stacked on #472 (helpers under `coded/_shared/`). GitHub will retarget to `main` after #472 merges.

## Test plan

- [x] Each `check_*.py` dry-runs green against a synthetic well-formed project for its framework.
- [x] LangGraph check correctly fails when `main.py` has a module-level `UiPathChat()` (negative case for the AST scan).
- [x] All four task YAMLs parse and tag lists are consistent.