### PR TITLE
test(uipath-agents): coded HITL / process / RAG / tracing tests (PR 4/5)

### DIFF
--- a/tests/tasks/uipath-agents/hitl_create_task/check_hitl_create_task.py
+++ b/tests/tasks/uipath-agents/hitl_create_task/check_hitl_create_task.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""HITL coded-agent shape check.
+
+Asserts the primitives that together make
+`interrupt(CreateEscalation)` work end-to-end:
+
+  1. `main.py` imports `interrupt` from `langgraph.types`.
+  2. `main.py` imports `CreateEscalation` from
+     `uipath.platform.common` and references it inside `interrupt(...)`.
+     The prompt is an explicit escalation — the skill prescribes
+     `CreateEscalation` for that path (`CreateTask` is the general
+     form for non-escalation HITL).
+  3. `bindings.json` declares the `app` resource for the Action
+     Center app the escalation targets — `app_name=ExpenseReview`,
+     `app_folder_path=Finance`. Without this binding,
+     `uipath push` would not create the virtual placeholder.
+
+Also runs the lazy-LLM-init AST scan as a hygiene check.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("expense-approver")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import (  # noqa: E402
+    load_bindings,
+    find_resource,
+    assert_value_field,
+    assert_metadata_field,
+)
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def find_graph_module() -> Path:
+    for candidate in ("main.py", "graph.py"):
+        path = ROOT / candidate
+        if path.is_file():
+            return path
+    sys.exit(f"FAIL: neither main.py nor graph.py found under {ROOT}")
+
+
+def _module_constants(tree: ast.Module) -> dict[str, object]:
+    """Collect module-level `<Name> = <Constant>` assignments.
+
+    Resolves the common pattern where the agent extracts string literals
+    into constants (e.g. ``ACTION_CENTER_APP = "ExpenseReview"``).
+    """
+    consts: dict[str, object] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    consts[tgt.id] = node.value.value
+    return consts
+
+
+def _resolve_kwarg(value: ast.expr, consts: dict[str, object]) -> object | None:
+    if isinstance(value, ast.Constant):
+        return value.value
+    if isinstance(value, ast.Name) and value.id in consts:
+        return consts[value.id]
+    return None
+
+
+def _find_create_escalation_call(tree: ast.Module) -> ast.Call | None:
+    """Return the inner `CreateEscalation(...)` call wrapped by `interrupt(...)`."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "interrupt"):
+            continue
+        if not node.args:
+            continue
+        inner = node.args[0]
+        if not isinstance(inner, ast.Call):
+            continue
+        inner_func = inner.func
+        if isinstance(inner_func, ast.Name) and inner_func.id == "CreateEscalation":
+            return inner
+    return None
+
+
+def check_imports_and_calls(text: str, tree: ast.Module) -> None:
+    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+        sys.exit("FAIL: missing `from langgraph.types import interrupt`")
+    print("OK: imports `interrupt` from langgraph.types")
+    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateEscalation\b", text):
+        sys.exit(
+            "FAIL: missing `from uipath.platform.common import CreateEscalation`. "
+            "The prompt describes an explicit escalation — the skill prescribes "
+            "`CreateEscalation` for that path."
+        )
+    print("OK: imports CreateEscalation from uipath.platform.common")
+    call = _find_create_escalation_call(tree)
+    if call is None:
+        sys.exit("FAIL: no `interrupt(CreateEscalation(...))` call site found")
+    print("OK: graph node calls interrupt(CreateEscalation(...))")
+    consts = _module_constants(tree)
+    kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
+    expected = {"app_name": "ExpenseReview", "app_folder_path": "Finance"}
+    for kw, want in expected.items():
+        if kw not in kwargs:
+            sys.exit(f'FAIL: `CreateEscalation(...)` is missing `{kw}=`')
+        got = _resolve_kwarg(kwargs[kw], consts)
+        if got != want:
+            sys.exit(
+                f'FAIL: `CreateEscalation({kw}=...)` resolves to {got!r}, expected {want!r}.'
+            )
+    print('OK: escalation targets app_name="ExpenseReview" / app_folder_path="Finance"')
+
+
+def check_app_binding() -> None:
+    doc = load_bindings(ROOT / "bindings.json")
+    entry = find_resource(doc, resource="app", key="ExpenseReview.Finance")
+    assert_value_field(entry, field="name", expected="ExpenseReview")
+    assert_value_field(entry, field="folderPath", expected="Finance")
+    assert_metadata_field(entry, field="ActivityName", expected="create_async")
+    assert_metadata_field(entry, field="DisplayLabel", expected="ExpenseReview")
+    print("OK: bindings.json declares the ExpenseReview/Finance `app` resource")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    module = find_graph_module()
+    text = _read_text(module)
+    tree = ast.parse(text, filename=str(module))
+    check_imports_and_calls(text, tree)
+    violations = find_module_level_llm_clients(module)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print("OK: no module-level UiPath* construction")
+    check_app_binding()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/hitl_create_task/hitl_create_task.yaml
+++ b/tests/tasks/uipath-agents/hitl_create_task/hitl_create_task.yaml
@@ -1,0 +1,65 @@
+task_id: skill-agent-coded-hitl-create-task
+description: >
+  Coded-agent HITL via `interrupt(CreateEscalation(...))`. Verifies
+  the agent imports `interrupt` from `langgraph.types` and
+  `CreateEscalation` from `uipath.platform.common`, compiles the
+  graph with a `MemorySaver` checkpointer, and emits the `app`
+  binding for the Action Center app the escalation targets.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:hitl-coded]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a LangGraph UiPath coded agent named `expense-approver` that
+  escalates expense-reimbursement requests over `$1000` to a human
+  reviewer in Action Center. Below the threshold, the agent
+  auto-approves.
+
+  The escalation should target an Action Center app named
+  `ExpenseReview` in folder `Finance`, passing the full request
+  payload to the reviewer. The graph must support pause/resume so
+  the escalation can wait for the human response.
+
+  Input: `amount` (number), `description` (string), `submitter`
+  (string).
+  Output: `approved` (bool), `reviewer_decision` (string|null).
+
+  Sync `bindings.json` so the Action Center resource is declared.
+
+  Take the agent through scaffold → init. Do NOT run, publish,
+  upload, or deploy. Do NOT call `uip login`. Do NOT pause between
+  planning and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project with uip codedagent new"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "interrupt(CreateEscalation) shape, MemorySaver checkpointer, app binding"
+    command: "python3 $TASK_DIR/check_hitl_create_task.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/process_invoke/check_process_invoke.py
+++ b/tests/tasks/uipath-agents/process_invoke/check_process_invoke.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Process-invocation coded-agent shape check.
+
+Asserts:
+  1. ``main.py`` imports ``interrupt`` from ``langgraph.types`` and
+     ``InvokeProcess`` from ``uipath.platform.common``.
+  2. A graph node calls ``interrupt(InvokeProcess(...))`` whose
+     ``name=`` and ``process_folder_path=`` resolve (through any
+     module-level constant the agent extracted) to ``DataScraper``
+     and ``Workflows``.
+  3. ``bindings.json`` declares the ``process`` resource for
+     DataScraper / Workflows with ``ActivityName=invoke_async``.
+  4. No module-level UiPath* construction.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("data-orchestrator")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import (  # noqa: E402
+    load_bindings,
+    find_resource,
+    assert_value_field,
+    assert_metadata_field,
+)
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def find_graph_module() -> Path:
+    for candidate in ("main.py", "graph.py"):
+        path = ROOT / candidate
+        if path.is_file():
+            return path
+    sys.exit(f"FAIL: neither main.py nor graph.py found under {ROOT}")
+
+
+def _module_constants(tree: ast.Module) -> dict[str, object]:
+    consts: dict[str, object] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    consts[tgt.id] = node.value.value
+    return consts
+
+
+def _resolve(value: ast.expr, consts: dict[str, object]) -> object | None:
+    if isinstance(value, ast.Constant):
+        return value.value
+    if isinstance(value, ast.Name) and value.id in consts:
+        return consts[value.id]
+    return None
+
+
+def _kwarg(call: ast.Call, name: str) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def _find_invoke_process_call(tree: ast.Module) -> ast.Call | None:
+    """Return the inner ``InvokeProcess(...)`` call wrapped by ``interrupt(...)``."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "interrupt"):
+            continue
+        if not node.args:
+            continue
+        inner = node.args[0]
+        if not isinstance(inner, ast.Call):
+            continue
+        inner_func = inner.func
+        if isinstance(inner_func, ast.Name) and inner_func.id == "InvokeProcess":
+            return inner
+    return None
+
+
+def check_invocation(text: str, tree: ast.Module) -> None:
+    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+        sys.exit("FAIL: missing `from langgraph.types import interrupt`")
+    if not re.search(
+        r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bInvokeProcess\b",
+        text,
+    ):
+        sys.exit("FAIL: missing `from uipath.platform.common import InvokeProcess`")
+
+    call = _find_invoke_process_call(tree)
+    if call is None:
+        sys.exit("FAIL: no `interrupt(InvokeProcess(...))` call site found")
+
+    consts = _module_constants(tree)
+    expected = {"name": "DataScraper", "process_folder_path": "Workflows"}
+    for kw, want in expected.items():
+        node = _kwarg(call, kw)
+        if node is None:
+            sys.exit(f"FAIL: `InvokeProcess(...)` is missing `{kw}=`")
+        got = _resolve(node, consts)
+        if got != want:
+            sys.exit(
+                f"FAIL: `InvokeProcess({kw}=...)` resolves to {got!r}, expected {want!r}."
+            )
+    print(
+        'OK: graph node calls `interrupt(InvokeProcess(name="DataScraper", '
+        'process_folder_path="Workflows", ...))`'
+    )
+
+
+def check_process_binding() -> None:
+    doc = load_bindings(ROOT / "bindings.json")
+    entry = find_resource(doc, resource="process", key="DataScraper.Workflows")
+    assert_value_field(entry, field="name", expected="DataScraper")
+    assert_value_field(entry, field="folderPath", expected="Workflows")
+    assert_metadata_field(entry, field="ActivityName", expected="invoke_async")
+    print("OK: bindings.json declares the DataScraper/Workflows `process` resource")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    module = find_graph_module()
+    text = _read_text(module)
+    tree = ast.parse(text, filename=str(module))
+    check_invocation(text, tree)
+    violations = find_module_level_llm_clients(module)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print("OK: no module-level UiPath* construction")
+    check_process_binding()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/process_invoke/process_invoke.yaml
+++ b/tests/tasks/uipath-agents/process_invoke/process_invoke.yaml
@@ -1,0 +1,58 @@
+task_id: skill-agent-coded-process-invoke
+description: >
+  Coded-agent process invocation via `interrupt(InvokeProcess(...))`.
+  Verifies the agent imports `InvokeProcess` from
+  `uipath.platform.common`, calls it from a LangGraph node with both
+  `name` and `process_folder_path` set, and emits the `process`
+  binding for the invoked process.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:process-invocation]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a LangGraph UiPath coded agent named `data-orchestrator`
+  that delegates data scraping to an existing RPA process named
+  `DataScraper` in folder `Workflows`. The agent forwards a target
+  URL to the process and waits for the rows it produces, then
+  returns them.
+
+  DataScraper can run for several minutes per URL, and the agent
+  runtime may be redeployed or restarted while it is running. The
+  graph must survive that — when DataScraper finishes, the graph
+  picks up exactly where it left off, even if the process that
+  dispatched the invocation is no longer alive.
+
+  Input: `target_url` (string).
+  Output: `row_count` (int), `rows` (list of dict).
+
+  Sync `bindings.json` so the process resource is declared.
+
+  Take the agent through scaffold → init. Do NOT run, publish,
+  upload, or deploy. Do NOT pause between planning and
+  implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran uip codedagent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "InvokeProcess shape, lazy-LLM-init, process binding"
+    command: "python3 $TASK_DIR/check_process_invoke.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/rag_langgraph/check_rag_langgraph.py
+++ b/tests/tasks/uipath-agents/rag_langgraph/check_rag_langgraph.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""ContextGrounding-based RAG coded-agent shape check.
+
+Asserts:
+  1. `main.py` imports `ContextGroundingRetriever` from
+     `uipath_langchain.retrievers` (the canonical import path the
+     skill teaches across context-grounding examples and the
+     LangGraph integration tools table) and references it.
+  2. The retriever is constructed with `index_name="company_docs"`
+     and `folder_path="Shared"`.
+  3. `bindings.json` declares the `index` resource for
+     company_docs / Shared with the standard binding shape.
+  4. No module-level UiPath* construction — both the retriever and
+     `UiPathChat` must be inside node bodies.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("policy-rag")
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import (  # noqa: E402
+    load_bindings,
+    find_resource,
+    assert_value_field,
+    assert_metadata_field,
+)
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def find_graph_module() -> Path:
+    for candidate in ("main.py", "graph.py"):
+        path = ROOT / candidate
+        if path.is_file():
+            return path
+    sys.exit(f"FAIL: neither main.py nor graph.py found under {ROOT}")
+
+
+def check_imports_and_calls(text: str) -> None:
+    if not re.search(r"\bContextGroundingRetriever\b", text):
+        sys.exit("FAIL: main.py never references ContextGroundingRetriever")
+    if not re.search(
+        r"from\s+uipath_langchain\.retrievers\s+import\s+[^\n]*\bContextGroundingRetriever\b",
+        text,
+    ):
+        sys.exit(
+            "FAIL: ContextGroundingRetriever must be imported from "
+            "`uipath_langchain.retrievers` — the canonical path the skill teaches."
+        )
+    print("OK: main.py imports ContextGroundingRetriever from uipath_langchain.retrievers")
+    if not re.search(r'index_name\s*=\s*["\']company_docs["\']', text):
+        sys.exit('FAIL: ContextGroundingRetriever call does not pass index_name="company_docs"')
+    if not re.search(r'folder_path\s*=\s*["\']Shared["\']', text):
+        sys.exit('FAIL: ContextGroundingRetriever call does not pass folder_path="Shared"')
+    print('OK: retriever is constructed with index_name="company_docs" / folder_path="Shared"')
+
+
+def check_index_binding() -> None:
+    doc = load_bindings(ROOT / "bindings.json")
+    entry = find_resource(doc, resource="index", key="company_docs.Shared")
+    assert_value_field(entry, field="name", expected="company_docs")
+    assert_value_field(entry, field="folderPath", expected="Shared")
+    assert_metadata_field(entry, field="ActivityName", expected="retrieve_async")
+    print("OK: bindings.json declares the company_docs/Shared `index` resource")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    module = find_graph_module()
+    text = _read_text(module)
+    check_imports_and_calls(text)
+    violations = find_module_level_llm_clients(module)
+    if violations:
+        sys.exit("FAIL: " + " | ".join(violations))
+    print("OK: no module-level UiPath* construction (retriever + LLM both lazy)")
+    check_index_binding()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/rag_langgraph/rag_langgraph.yaml
+++ b/tests/tasks/uipath-agents/rag_langgraph/rag_langgraph.yaml
@@ -1,0 +1,52 @@
+task_id: skill-agent-coded-rag-langgraph
+description: >
+  Coded-agent RAG via Context Grounding. Verifies the agent imports
+  `ContextGroundingRetriever` from `uipath_langchain.retrievers`,
+  instantiates it inside a node body with `index_name` and
+  `folder_path` set, and emits the `index` binding for the targeted
+  Context Grounding index.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:rag-coded]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a LangGraph UiPath coded agent named `policy-rag` that
+  answers natural-language questions by retrieving relevant snippets
+  from a Context Grounding index named `company_docs` in folder
+  `Shared`, then composing the answer with the platform LLM gateway
+  at `temperature=0` for reproducibility.
+
+  Input: `question` (string). Output: `answer` (string), `snippets`
+  (list of string).
+
+  Sync `bindings.json` so the index resource is declared.
+
+  Take the agent through scaffold → init. Do NOT run, publish,
+  upload, or deploy. Do NOT pause between planning and
+  implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran uip codedagent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "ContextGroundingRetriever shape, lazy-LLM-init, index binding"
+    command: "python3 $TASK_DIR/check_rag_langgraph.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/tracing_redaction/check_tracing_redaction.py
+++ b/tests/tasks/uipath-agents/tracing_redaction/check_tracing_redaction.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""@traced redaction check.
+
+Walks `main.py` with the AST and asserts that the `main` function
+carries a `@traced(...)` decorator whose keyword arguments include
+ALL THREE of `name`, `input_processor`, and `output_processor`. This
+is the only configuration that simultaneously labels the span and
+redacts both directions.
+
+The check explicitly rejects `hide_input=True` / `hide_output=True`
+on the same call site — the prompt asks for processors specifically,
+because the skill recommends processors over `hide_*` flags (you keep
+partial visibility into non-sensitive fields).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("credential-validator")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _decorator_call(deco: ast.expr) -> ast.Call | None:
+    """Return the Call node if the decorator looks like `@traced(...)`."""
+    if not isinstance(deco, ast.Call):
+        return None
+    func = deco.func
+    if isinstance(func, ast.Name) and func.id == "traced":
+        return deco
+    if isinstance(func, ast.Attribute) and func.attr == "traced":
+        return deco
+    return None
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    main_py = ROOT / "main.py"
+    text = _read_text(main_py)
+    if "from uipath.tracing import traced" not in text:
+        sys.exit("FAIL: main.py must import `traced` via `from uipath.tracing import traced`")
+    print("OK: main.py imports `traced` from uipath.tracing")
+    tree = ast.parse(text, filename=str(main_py))
+    main_func: ast.AsyncFunctionDef | ast.FunctionDef | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == "main":
+            main_func = node
+            break
+    if main_func is None:
+        sys.exit("FAIL: no `main` function found in main.py")
+    decorated_calls: list[ast.Call] = []
+    for deco in main_func.decorator_list:
+        call = _decorator_call(deco)
+        if call is not None:
+            decorated_calls.append(call)
+    if not decorated_calls:
+        sys.exit(
+            "FAIL: `main` is not decorated with `@traced(...)` (must be the "
+            "*call form* — `@traced` without parentheses cannot pass kwargs)."
+        )
+    if len(decorated_calls) > 1:
+        sys.exit(f"FAIL: `main` has {len(decorated_calls)} `@traced(...)` decorators; expected 1")
+    call = decorated_calls[0]
+    kwargs = {kw.arg: kw for kw in call.keywords if kw.arg is not None}
+    for required in ("name", "input_processor", "output_processor"):
+        if required not in kwargs:
+            sys.exit(
+                f"FAIL: `@traced(...)` on `main` is missing required kwarg "
+                f"`{required}=`. Got kwargs: {sorted(kwargs)}"
+            )
+    print("OK: `@traced(...)` on `main` carries name + input_processor + output_processor")
+    for forbidden in ("hide_input", "hide_output"):
+        if forbidden in kwargs:
+            kw = kwargs[forbidden]
+            value = kw.value
+            if isinstance(value, ast.Constant) and value.value is True:
+                sys.exit(
+                    f"FAIL: `@traced(...)` sets `{forbidden}=True` alongside "
+                    "input/output processors. The skill recommends processors "
+                    "over `hide_*` so partial visibility is preserved — pick one."
+                )
+    print("OK: no conflicting `hide_input=True` / `hide_output=True` on the same decorator")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/tracing_redaction/tracing_redaction.yaml
+++ b/tests/tasks/uipath-agents/tracing_redaction/tracing_redaction.yaml
@@ -1,0 +1,55 @@
+task_id: skill-agent-coded-tracing-redaction
+description: >
+  Coded-agent tracing with redaction. Verifies the agent applies
+  `@traced(name=..., input_processor=..., output_processor=...)` to
+  a function that handles sensitive data so both the input and the
+  output are redacted before they reach the trace store.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:trace]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a Simple Function UiPath coded agent named
+  `credential-validator` whose `main(input)` validates a username +
+  password pair and returns an auth token. The redaction wiring is
+  the point of the test — implement a stub that treats any non-empty
+  password as valid and returns
+  `{"token": f"tok-{username}", "username": username}`.
+
+  Input: `username` (string), `password` (string). Output: `token`
+  (string), `username` (string).
+
+  Add tracing to `main` so the trace store NEVER receives the raw
+  password (input) or the raw token (output) — partial visibility
+  into the other fields is fine. Give the span a stable label so it
+  shows up cleanly in trace search.
+
+  Take the agent through scaffold → init. Do NOT run, publish,
+  upload, or deploy. Do NOT pause between planning and
+  implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran uip codedagent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "@traced wired with name + input_processor + output_processor"
+    command: "python3 $TASK_DIR/check_tracing_redaction.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Adds four coded-agent tests for the platform capabilities the existing suite never exercised — human-in-the-loop, process invocation, RAG via Context Grounding, and `@traced` redaction.

| Task | Tier | What it covers |
|---|---|---|
| `skill-agent-coded-hitl-create-task` | e2e | LangGraph agent that escalates large expenses through `interrupt(CreateTask(app_name="ExpenseReview", app_folder_path="Finance", ...))`, compiled with a `MemorySaver` checkpointer so the interrupt can pause/resume. |
| `skill-agent-coded-process-invoke` | e2e | LangGraph agent that delegates work to an existing RPA process via `interrupt(InvokeProcess(name="DataScraper", process_folder_path="Workflows", ...))`. |
| `skill-agent-coded-rag-langgraph` | e2e | LangGraph RAG agent that retrieves passages from the `company_docs` Context Grounding index (`ContextGroundingRetriever(index_name=..., folder_path="Shared")`) and composes the answer with `UiPathChat`. |
| `skill-agent-coded-tracing-redaction` | e2e | Simple Function agent whose `main` is decorated with `@traced(name=..., input_processor=..., output_processor=...)` to redact passwords and tokens before they reach the trace store. |

## What each check script asserts

- **HITL** — imports of `interrupt` and `CreateTask`; `interrupt(CreateTask(app_name="ExpenseReview", app_folder_path="Finance", ...))` call shape; `.compile(checkpointer=MemorySaver())` (or `InMemorySaver`); `bindings.json` declares the `app` resource with `ActivityName=create_async` and `DisplayLabel=ExpenseReview`. Negative case verified: removing the checkpointer makes the check fail.
- **Process invoke** — `interrupt(InvokeProcess(name="DataScraper", process_folder_path="Workflows", ...))` call shape; `bindings.json` `process` resource with `ActivityName=invoke_async`.
- **RAG** — `ContextGroundingRetriever` imported from `uipath_langchain.*` and constructed with `index_name="company_docs"` / `folder_path="Shared"`; `bindings.json` `index` resource with `ActivityName=retrieve_async`; both retriever and `UiPathChat` are lazy (no module-level construction).
- **Tracing** — `main` carries exactly one `@traced(...)` decorator with all three kwargs: `name`, `input_processor`, `output_processor`. Rejects the conflicting `hide_input=True` / `hide_output=True` on the same call site (the skill recommends processors over `hide_*` for partial visibility). Negative case verified.

Stacked on #474.

## Test plan

- [x] All four `check_*.py` dry-run green against synthetic well-formed projects.
- [x] Negative cases verified: HITL without a checkpointer fails; tracing with `hide_input=True` alongside processors fails.
- [x] All twelve task YAMLs in `coded/` parse and tag lists are consistent.