### PR TITLE
test(uipath-agents): coded anti-pattern + bindings sweep tests (PR 5/5)

### DIFF
--- a/tests/tasks/uipath-agents/antipattern_build_system/antipattern_build_system.yaml
+++ b/tests/tasks/uipath-agents/antipattern_build_system/antipattern_build_system.yaml
@@ -1,0 +1,82 @@
+task_id: skill-agent-coded-antipattern-build-system
+description: >
+  Negative test for Coded Critical Rule C1 — `pyproject.toml` MUST
+  NOT carry a `[build-system]` section. The prompt seeds a violating
+  pyproject (with `hatchling` declared as the build backend), and
+  the skill must drive the agent to detect the violation and remove
+  the section before any further work.
+tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I have an existing UiPath coded agent project under `legacy-port`
+  that I'm getting ready for deployment. Recreate the project with
+  these files exactly, then review and fix anything that would
+  prevent the project from packaging cleanly with `uip codedagent
+  pack`.
+
+  **legacy-port/pyproject.toml**:
+  ```toml
+  [project]
+  name = "legacy-port"
+  version = "0.0.1"
+  description = "Ported from a legacy Python service"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+
+  [build-system]
+  requires = ["hatchling>=1.0"]
+  build-backend = "hatchling.build"
+  ```
+
+  **legacy-port/main.py**:
+  ```python
+  from pydantic import BaseModel
+  from uipath.tracing import traced
+
+  class Input(BaseModel):
+      message: str
+
+  class Output(BaseModel):
+      echoed: str
+
+  @traced()
+  async def main(input: Input) -> Output:
+      return Output(echoed=input.message)
+  ```
+
+  After recreating those files, review them for any UiPath coded-
+  agent anti-patterns and fix them in place. Do NOT keep the
+  pyproject as written if it violates a rule.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "pyproject.toml exists under legacy-port/"
+    path: "legacy-port/pyproject.toml"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "pyproject.toml has no [build-system] section after the fix"
+    command: "python3 $TASK_DIR/check_antipattern_build_system.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/antipattern_build_system/check_antipattern_build_system.py
+++ b/tests/tasks/uipath-agents/antipattern_build_system/check_antipattern_build_system.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""C1 anti-pattern check — `[build-system]` must be gone after the fix."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "legacy-port"
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def main() -> None:
+    if not PYPROJECT.is_file():
+        sys.exit(f"FAIL: missing {PYPROJECT}")
+    text = PYPROJECT.read_text(encoding="utf-8")
+    # `[build-system]` must be removed entirely. A line-anchored regex is the
+    # right precision — substring search would false-flag a comment.
+    if re.search(r"^\s*\[build-system\]", text, re.M):
+        sys.exit(
+            "FAIL: pyproject.toml still has a [build-system] section. "
+            "Critical Rule C1: UiPath coded agents do not use a build "
+            "system; remove the section entirely."
+        )
+    # Sanity: `[project]` survived the edit.
+    if not re.search(r"^\s*\[project\]", text, re.M):
+        sys.exit(
+            "FAIL: pyproject.toml lost its [project] section while removing "
+            "[build-system]. Only the build-system block should be removed."
+        )
+    print("OK: pyproject.toml has [project] and no [build-system] section")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/antipattern_module_level_llm/antipattern_module_level_llm.yaml
+++ b/tests/tasks/uipath-agents/antipattern_module_level_llm/antipattern_module_level_llm.yaml
@@ -1,0 +1,97 @@
+task_id: skill-agent-coded-antipattern-module-level-llm
+description: >
+  Negative test for Coded Critical Rule C4 — LLM clients must be
+  instantiated lazily, never at module level. The prompt seeds a
+  LangGraph `main.py` with `llm = UiPathChat(...)` at column zero,
+  and the skill must drive the agent to refactor the construction
+  inside a node body before `uip codedagent init` is run.
+tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I'm porting an existing LangGraph agent into UiPath. Recreate the
+  project under `legacy-classifier` exactly as below, then review
+  for any UiPath coded-agent anti-patterns and fix them in place.
+
+  **legacy-classifier/pyproject.toml**:
+  ```toml
+  [project]
+  name = "legacy-classifier"
+  version = "0.0.1"
+  description = "Ported classifier"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath", "uipath-langchain"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **legacy-classifier/main.py**:
+  ```python
+  from langgraph.graph import StateGraph, START, END
+  from langgraph.types import Command
+  from uipath_langchain.chat.models import UiPathChat
+  from pydantic import BaseModel
+  from typing import TypedDict
+
+  llm = UiPathChat(model="gpt-4o-mini-2024-07-18", temperature=0)
+
+  class GraphInput(BaseModel):
+      text: str
+
+  class GraphOutput(BaseModel):
+      category: str
+      text: str
+
+  class GraphState(TypedDict):
+      text: str
+      category: str | None
+
+  async def classify(state):
+      result = await llm.ainvoke(f"Classify: {state['text']}")
+      return Command(update={"category": str(result), "text": state["text"]})
+
+  builder = StateGraph(GraphState, input=GraphInput, output=GraphOutput)
+  builder.add_node("classify", classify)
+  builder.add_edge(START, "classify")
+  builder.add_edge("classify", END)
+  graph = builder.compile()
+  ```
+
+  **legacy-classifier/langgraph.json**:
+  ```json
+  {"graphs": {"agent": "./main.py:graph"}}
+  ```
+
+  After recreating those files, review for anti-patterns and fix
+  them in place. The graph must still compile and `graph` must
+  remain exported.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "main.py exists under legacy-classifier/"
+    path: "legacy-classifier/main.py"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No module-level UiPath* construction; graph still exports `graph`"
+    command: "python3 $TASK_DIR/check_antipattern_module_level_llm.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/antipattern_module_level_llm/check_antipattern_module_level_llm.py
+++ b/tests/tasks/uipath-agents/antipattern_module_level_llm/check_antipattern_module_level_llm.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""C4 anti-pattern check — module-level UiPath* must be gone after the fix."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "legacy-classifier"
+MAIN = ROOT / "main.py"
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+
+
+def main() -> None:
+    if not MAIN.is_file():
+        sys.exit(f"FAIL: missing {MAIN}")
+    violations = find_module_level_llm_clients(MAIN)
+    if violations:
+        sys.exit(
+            "FAIL: main.py still has module-level UiPath* construction — "
+            "Critical Rule C4 violation. Move the LLM client into a node body. "
+            + " | ".join(violations)
+        )
+    print("OK: main.py has no module-level UiPath* construction")
+    text = MAIN.read_text(encoding="utf-8")
+    # The graph variable must survive the refactor — it's what
+    # `uip codedagent init` looks for via langgraph.json.
+    if not re.search(r"^\s*graph\s*=\s*", text, re.M):
+        sys.exit(
+            "FAIL: main.py no longer exports a top-level `graph =` variable. "
+            "Refactor must preserve the compiled graph export."
+        )
+    print("OK: top-level `graph` variable still exported")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
+++ b/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
@@ -1,0 +1,77 @@
+task_id: skill-agent-coded-antipattern-wrong-sdk-import
+description: >
+  Negative test for Coded Critical Rule C4 (correct SDK import path)
+  — `from uipath import UiPath` is wrong and raises `ImportError`
+  at module-import time. The correct path is `from uipath.platform
+  import UiPath`. The skill must drive the agent to fix the import.
+tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I have an existing UiPath coded agent that I'm trying to run.
+  Recreate the project under `bad-import` exactly as below, then
+  review for any UiPath coded-agent anti-patterns and fix them in
+  place.
+
+  **bad-import/pyproject.toml**:
+  ```toml
+  [project]
+  name = "bad-import"
+  version = "0.0.1"
+  description = "Has the wrong SDK import path"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **bad-import/main.py**:
+  ```python
+  from uipath import UiPath  # this import path does not exist
+  from pydantic import BaseModel
+
+  class Input(BaseModel):
+      asset_name: str
+
+  class Output(BaseModel):
+      value: str
+
+  async def main(input: Input) -> Output:
+      sdk = UiPath()
+      asset = await sdk.assets.retrieve_async(input.asset_name, folder_path="Shared")
+      return Output(value=str(asset))
+  ```
+
+  After recreating those files, review for anti-patterns and fix
+  them in place. The agent should still call `sdk.assets.retrieve_
+  async` with the same arguments.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "main.py exists under bad-import/"
+    path: "bad-import/main.py"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "main.py imports UiPath from uipath.platform; no `from uipath import UiPath`"
+    command: "python3 $TASK_DIR/check_antipattern_wrong_sdk_import.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/check_antipattern_wrong_sdk_import.py
+++ b/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/check_antipattern_wrong_sdk_import.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""C4 (correct SDK import path) anti-pattern check.
+
+Asserts the wrong import has been removed and the correct one is in
+place. Importantly, both regexes are line-anchored and require the
+imported name to be exactly `UiPath` so a member-list import like
+`from uipath.platform import UiPath, foo` still passes while
+`from uipath import UiPath` is rejected.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "bad-import"
+MAIN = ROOT / "main.py"
+
+WRONG = re.compile(r"^\s*from\s+uipath\s+import\s+(?:[^,\n]*,\s*)*UiPath(?:\s*,|$)", re.M)
+RIGHT = re.compile(r"^\s*from\s+uipath\.platform\s+import\s+(?:[^,\n]*,\s*)*UiPath\b", re.M)
+
+
+def main() -> None:
+    if not MAIN.is_file():
+        sys.exit(f"FAIL: missing {MAIN}")
+    text = MAIN.read_text(encoding="utf-8")
+    if WRONG.search(text):
+        sys.exit(
+            "FAIL: main.py still has `from uipath import UiPath`. "
+            "Critical Rule C4: the correct import is `from uipath.platform "
+            "import UiPath`."
+        )
+    if not RIGHT.search(text):
+        sys.exit(
+            "FAIL: main.py does not import UiPath from `uipath.platform`. "
+            "Add `from uipath.platform import UiPath`."
+        )
+    print("OK: main.py imports UiPath from `uipath.platform` (no `from uipath import UiPath`)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/bindings_asset_subtypes/bindings_asset_subtypes.yaml
+++ b/tests/tasks/uipath-agents/bindings_asset_subtypes/bindings_asset_subtypes.yaml
@@ -1,0 +1,102 @@
+task_id: skill-agents-bindings-asset-subtypes
+description: >
+  Asset SubType inference from Python type annotations. The agent
+  scans a project where three different `sdk.assets.retrieve_async`
+  call sites are annotated as `str`, `int`, and `bool` respectively.
+  The bindings sync should produce three `asset` entries — and where
+  the inference is high-confidence, emit `metadata.SubType` matching
+  the type annotation (`stringAsset` / `integerAsset` /
+  `booleanAsset`).
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Hand-author a UiPath coded agent project — do NOT scaffold via
+  the CLI. Inside the working directory create:
+
+  **pyproject.toml**:
+  ```toml
+  [project]
+  name = "asset-subtypes"
+  version = "0.0.1"
+  description = "Three asset retrieves with different annotations"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **uipath.json**:
+  ```json
+  {"projectType": "CodedAgent", "functions": {"main": "main.py:main"}}
+  ```
+
+  **entry-points.json**:
+  ```json
+  {
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+      {
+        "filePath": "main",
+        "uniqueId": "cc111111-2222-3333-4444-555566667777",
+        "type": "agent",
+        "input": {"type": "object", "properties": {}, "required": []},
+        "output": {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}
+      }
+    ]
+  }
+  ```
+
+  **main.py**:
+  ```python
+  from uipath.platform import UiPath
+
+  async def main(input):
+      sdk = UiPath()
+      api_key: str = await sdk.assets.retrieve_async("api_key", folder_path="Shared")
+      max_retries: int = await sdk.assets.retrieve_async("max_retries", folder_path="Shared")
+      feature_enabled: bool = await sdk.assets.retrieve_async("feature_enabled", folder_path="Shared")
+      return {"ok": True, "api_key": api_key, "max_retries": max_retries, "feature_enabled": feature_enabled}
+  ```
+
+  **bindings.json** (start empty):
+  ```json
+  {"version": "2.0", "resources": []}
+  ```
+
+  Then sync `bindings.json` so it reflects all three asset retrieves.
+  Each one must produce a separate binding entry. Where the type
+  annotation lets you infer the SubType with high confidence, emit
+  `metadata.SubType` accordingly. If a SubType cannot be inferred
+  cleanly, omitting it is acceptable per the bindings reference.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "bindings.json exists"
+    path: "bindings.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Three asset bindings, correct keys, SubType either matches the annotation or is omitted"
+    command: "python3 $TASK_DIR/check_bindings_asset_subtypes.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/bindings_asset_subtypes/check_bindings_asset_subtypes.py
+++ b/tests/tasks/uipath-agents/bindings_asset_subtypes/check_bindings_asset_subtypes.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Asset SubType inference check.
+
+Three asset retrieves at the call site, each annotated with a
+different concrete type. The check requires:
+
+  1. All three asset bindings exist with the right keys
+     (`<name>.Shared`).
+  2. Each binding's `metadata.SubType` is EITHER the matching SubType
+     for the annotation (`stringAsset` / `integerAsset` /
+     `booleanAsset`) OR absent. Per the bindings reference, omitting
+     the SubType is always safe — `uipath push` falls back to the
+     base `kind` and the asset still works. The annotation-driven
+     inference is the high-confidence path; we accept either.
+  3. No SubType is set to a *wrong* value (e.g. `credentialAsset`
+     on a non-credential retrieve, or `integerAsset` on a `str` site).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import (  # noqa: E402
+    load_bindings,
+    find_resource,
+    assert_value_field,
+    count_resources_by_type,
+)
+
+EXPECTED = {
+    "api_key": "stringAsset",
+    "max_retries": "integerAsset",
+    "feature_enabled": "booleanAsset",
+}
+
+
+def main() -> None:
+    doc = load_bindings(ROOT / "bindings.json")
+    n = count_resources_by_type(doc, "asset")
+    if n != 3:
+        sys.exit(f"FAIL: expected exactly 3 asset bindings, got {n}")
+    print("OK: three asset bindings present")
+    for name, expected_subtype in EXPECTED.items():
+        entry = find_resource(doc, resource="asset", key=f"{name}.Shared")
+        assert_value_field(entry, field="name", expected=name)
+        assert_value_field(entry, field="folderPath", expected="Shared")
+        metadata = entry.get("metadata") or {}
+        actual = metadata.get("SubType")
+        if actual is None:
+            print(f'OK: {name} asset binding has no SubType (acceptable fallback)')
+            continue
+        if actual == expected_subtype:
+            print(f'OK: {name} asset binding has SubType={actual!r} (high-confidence inference)')
+            continue
+        sys.exit(
+            f'FAIL: {name} asset binding has SubType={actual!r}, expected '
+            f'either {expected_subtype!r} (from annotation) or omitted. '
+            f'Wrong SubType is worse than no SubType — `uipath push` would '
+            f'create the wrong placeholder kind.'
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
+++ b/tests/tasks/uipath-agents/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
@@ -1,0 +1,118 @@
+task_id: skill-agents-bindings-multi-entrypoint
+description: >
+  Bindings sync over a project with two entrypoints. Per the
+  bindings-reference Step 4, when `entry-points.json` has multiple
+  entrypoints the resolver must either ask which entrypoint each
+  resource binds to (`AskUserQuestion`) or leave the entrypoint
+  field off the binding. The check accepts any consistent outcome —
+  the load-bearing assertion is that no binding ends up with a
+  fabricated `EntryPointUniqueId` that doesn't match either real
+  entrypoint.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Hand-author a UiPath coded agent project — do NOT scaffold via
+  the CLI. Inside the working directory create:
+
+  **pyproject.toml**:
+  ```toml
+  [project]
+  name = "multi-ep"
+  version = "0.0.1"
+  description = "Project with two entrypoints"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **uipath.json**:
+  ```json
+  {"projectType": "CodedAgent"}
+  ```
+
+  **entry-points.json**:
+  ```json
+  {
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+      {
+        "filePath": "main",
+        "uniqueId": "11111111-aaaa-bbbb-cccc-222222222222",
+        "type": "agent",
+        "input": {"type": "object", "properties": {}, "required": []},
+        "output": {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}
+      },
+      {
+        "filePath": "report",
+        "uniqueId": "33333333-aaaa-bbbb-cccc-444444444444",
+        "type": "agent",
+        "input": {"type": "object", "properties": {}, "required": []},
+        "output": {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}
+      }
+    ]
+  }
+  ```
+
+  **main.py**:
+  ```python
+  from uipath.platform import UiPath
+
+  async def main(input):
+      sdk = UiPath()
+      bucket = await sdk.buckets.retrieve_async(name="reports-bucket", folder_path="Reports")
+      return {"ok": True, "bucket": str(bucket)}
+  ```
+
+  **report.py**:
+  ```python
+  from uipath.platform import UiPath
+
+  async def main(input):
+      sdk = UiPath()
+      asset = await sdk.assets.retrieve_async("report_email", folder_path="Reports")
+      return {"ok": True, "email": str(asset)}
+  ```
+
+  **bindings.json** (start empty):
+  ```json
+  {"version": "2.0", "resources": []}
+  ```
+
+  Then sync `bindings.json`. Two entrypoints exist; the bindings
+  reference allows either binding each resource to a chosen
+  entrypoint or leaving the entrypoint field off the resource
+  entirely. Whatever you choose, every entrypoint id you write must
+  match one of the two real entrypoints in `entry-points.json`.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "bindings.json exists"
+    path: "bindings.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Two bindings; any EntryPointUniqueId references a real entrypoint"
+    command: "python3 $TASK_DIR/check_bindings_multi_entrypoint.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
+++ b/tests/tasks/uipath-agents/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Multi-entrypoint binding resolution check.
+
+The project has two entrypoints (`main` / `report`) and two SDK
+calls (one per file). The bindings reference allows the agent to
+either link each binding to a chosen entrypoint via
+`EntryPointUniqueId` or leave the field off entirely (the user
+might have chosen "None" in the disambiguation prompt). The wrong
+outcome is fabricating an entrypoint id that matches neither real
+entrypoint — that would silently break runtime resource resolution.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import (  # noqa: E402
+    load_bindings,
+    find_resource,
+    assert_value_field,
+    count_resources_by_type,
+)
+
+
+def _real_entrypoint_uids() -> set[str]:
+    path = ROOT / "entry-points.json"
+    if not path.is_file():
+        sys.exit(f"FAIL: missing {path}")
+    doc = json.loads(path.read_text(encoding="utf-8"))
+    uids = {ep.get("uniqueId") for ep in (doc.get("entryPoints") or [])}
+    uids.discard(None)
+    if len(uids) < 2:
+        sys.exit(f"FAIL: expected ≥2 entrypoints, got uniqueIds={sorted(uids)}")
+    return uids
+
+
+def main() -> None:
+    real = _real_entrypoint_uids()
+    print(f"OK: entry-points.json declares {len(real)} entrypoint(s)")
+    doc = load_bindings(ROOT / "bindings.json")
+    bucket_n = count_resources_by_type(doc, "bucket")
+    asset_n = count_resources_by_type(doc, "asset")
+    if bucket_n != 1:
+        sys.exit(f"FAIL: expected exactly 1 bucket binding, got {bucket_n}")
+    if asset_n != 1:
+        sys.exit(f"FAIL: expected exactly 1 asset binding, got {asset_n}")
+    print("OK: one bucket + one asset binding present")
+    bucket = find_resource(doc, resource="bucket", key="reports-bucket.Reports")
+    assert_value_field(bucket, field="name", expected="reports-bucket")
+    assert_value_field(bucket, field="folderPath", expected="Reports")
+    asset = find_resource(doc, resource="asset", key="report_email.Reports")
+    assert_value_field(asset, field="name", expected="report_email")
+    assert_value_field(asset, field="folderPath", expected="Reports")
+    # Validate any EntryPointUniqueId references a real entrypoint.
+    for entry in (bucket, asset):
+        value = entry.get("value") or {}
+        ep = value.get("EntryPointUniqueId")
+        if not isinstance(ep, dict):
+            print(f"OK: {entry.get('resource')} binding has no EntryPointUniqueId (acceptable)")
+            continue
+        uid = ep.get("defaultValue")
+        if uid not in real:
+            sys.exit(
+                f'FAIL: {entry.get("resource")} binding references '
+                f'EntryPointUniqueId={uid!r}, which is not one of the real '
+                f'entrypoints {sorted(real)}.'
+            )
+        print(
+            f"OK: {entry.get('resource')} binding's EntryPointUniqueId "
+            f"resolves to a real entrypoint ({uid!r})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/bindings_queue_app_index/bindings_queue_app_index.yaml
+++ b/tests/tasks/uipath-agents/bindings_queue_app_index/bindings_queue_app_index.yaml
@@ -1,0 +1,106 @@
+task_id: skill-agents-bindings-queue-app-index
+description: >
+  Bindings sync covering five resource types in one project —
+  queue, app, index, connection, mcpServer. The agent runs the
+  bindings-sync workflow over a hand-authored project; the check
+  verifies one binding entry per resource with the right key
+  construction (`<name>.<folder_path>` for most, bare
+  `<connection_key>` for connections) and metadata fields.
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Hand-author a UiPath coded agent project — do NOT scaffold via
+  the CLI. Inside the working directory create:
+
+  **pyproject.toml**:
+  ```toml
+  [project]
+  name = "five-bindings"
+  version = "0.0.1"
+  description = "Five binding types in one project"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **uipath.json**:
+  ```json
+  {"projectType": "CodedAgent", "functions": {"main": "main.py:main"}}
+  ```
+
+  **entry-points.json**:
+  ```json
+  {
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+      {
+        "filePath": "main",
+        "uniqueId": "bb111111-2222-3333-4444-555566667777",
+        "type": "agent",
+        "input": {"type": "object", "properties": {}, "required": []},
+        "output": {"type": "object", "properties": {"ok": {"type": "boolean"}}, "required": ["ok"]}
+      }
+    ]
+  }
+  ```
+
+  **main.py**:
+  ```python
+  from uipath.platform import UiPath
+
+  async def main(input):
+      sdk = UiPath()
+      # queue
+      await sdk.queues.create_item_async(item={"Name": "OrderQueue", "SpecificContent": {"id": "1"}})
+      # app (Action Center)
+      await sdk.tasks.create_async(title="Review", data={"id": "1"}, app_name="ReviewApp", app_folder_path="Ops")
+      # index (Context Grounding)
+      await sdk.context_grounding.retrieve_async(name="kb_index", folder_path="Shared")
+      # connection (Integration Service)
+      await sdk.connections.retrieve_async("salesforce-prod-conn")
+      # mcpServer
+      await sdk.mcp.retrieve_async(slug="weather-mcp", folder_path="Tools")
+      return {"ok": True}
+  ```
+
+  **bindings.json** (start empty):
+  ```json
+  {"version": "2.0", "resources": []}
+  ```
+
+  Then sync `bindings.json` so it reflects all five resource calls.
+  Each resource must produce one binding entry: queue, app, index,
+  connection, mcpServer.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "bindings.json exists"
+    path: "bindings.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "All five bindings present with correct keys, value blocks, and metadata"
+    command: "python3 $TASK_DIR/check_bindings_queue_app_index.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/bindings_queue_app_index/check_bindings_queue_app_index.py
+++ b/tests/tasks/uipath-agents/bindings_queue_app_index/check_bindings_queue_app_index.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Five-binding-type sweep check.
+
+Asserts the hand-authored project produced exactly the five bindings
+expected by the bindings-reference tables — one each for queue, app,
+index, connection, mcpServer — with the right key construction
+(`<name>.<folder>` for most, bare `<key>` for connections) and the
+load-bearing metadata fields (`ActivityName`, `DisplayLabel`).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd())
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bindings_assertions import (  # noqa: E402
+    load_bindings,
+    find_resource,
+    assert_value_field,
+    assert_metadata_field,
+    count_resources_by_type,
+)
+
+
+def main() -> None:
+    doc = load_bindings(ROOT / "bindings.json")
+    # queue — the `create_item_async` call site has no folder_path,
+    # so per bindings-reference "No folder_path" rule the key is just
+    # the queue name (no trailing dot).
+    queue = find_resource(doc, resource="queue", key="OrderQueue")
+    assert_value_field(queue, field="name", expected="OrderQueue")
+    assert_metadata_field(queue, field="ActivityName", expected="create_item_async")
+    # app (Action Center)
+    app = find_resource(doc, resource="app", key="ReviewApp.Ops")
+    assert_value_field(app, field="name", expected="ReviewApp")
+    assert_value_field(app, field="folderPath", expected="Ops")
+    assert_metadata_field(app, field="ActivityName", expected="create_async")
+    assert_metadata_field(app, field="DisplayLabel", expected="ReviewApp")
+    # index (Context Grounding)
+    index = find_resource(doc, resource="index", key="kb_index.Shared")
+    assert_value_field(index, field="name", expected="kb_index")
+    assert_value_field(index, field="folderPath", expected="Shared")
+    # The reference says ALL methods bind via the same `retrieve_async`
+    # ActivityName, even when the call site is `search_async`.
+    assert_metadata_field(index, field="ActivityName", expected="retrieve_async")
+    # connection
+    connection = find_resource(doc, resource="connection", key="salesforce-prod-conn")
+    assert_value_field(connection, field="ConnectionId", expected="salesforce-prod-conn")
+    assert_metadata_field(connection, field="UseConnectionService", expected="True")
+    # mcpServer
+    mcp = find_resource(doc, resource="mcpServer", key="weather-mcp.Tools")
+    assert_value_field(mcp, field="name", expected="weather-mcp")
+    assert_value_field(mcp, field="folderPath", expected="Tools")
+    assert_metadata_field(mcp, field="ActivityName", expected="retrieve_async")
+    # Deduplication / no-extras: each kind has exactly one entry.
+    for kind in ("queue", "app", "index", "connection", "mcpServer"):
+        n = count_resources_by_type(doc, kind)
+        if n != 1:
+            sys.exit(f"FAIL: expected exactly 1 `{kind}` binding entry, got {n}")
+    print("OK: each of queue/app/index/connection/mcpServer has exactly one binding entry")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds seven coded-agent tests — four anti-pattern smokes that verify the skill catches the most expensive coded mistakes, plus three bindings-sweep tests that close the binding-resource and entrypoint-resolution gaps.

### Anti-pattern tests (smoke)

Each task seeds a violating project layout in the prompt; the skill must drive the agent to detect and fix the violation in place.

| Task | What it covers |
|---|---|
| `skill-agent-coded-antipattern-build-system` | Pre-seeded `pyproject.toml` with `[build-system]` (hatchling). Check verifies the section is removed and `[project]` survives. |
| `skill-agent-coded-antipattern-module-level-llm` | Pre-seeded LangGraph `main.py` with `llm = UiPathChat(...)` at module level. Check verifies no module-level UiPath* construction remains and the top-level `graph` variable is preserved. |
| `skill-agent-coded-antipattern-wrong-sdk-import` | Pre-seeded `from uipath import UiPath` (raises `ImportError`). Check verifies the import was switched to `from uipath.platform import UiPath`. |
| `skill-agent-coded-antipattern-login-no-tenant` | Goal-only auth prompt with environment / org / tenant. Asserts `uip login --output json` and `uip login tenant set "MyTenant"` were both run. |

### Bindings sweep tests (e2e)

| Task | What it covers |
|---|---|
| `skill-agents-bindings-queue-app-index` | Five binding types in one project — `queue`, `app`, `index`, `connection`, `mcpServer`. Asserts one entry per resource with the correct key (bare for connections; bare for the no-folder queue), value block, and metadata (`ActivityName`, `DisplayLabel`, `UseConnectionService`). |
| `skill-agents-bindings-asset-subtypes` | Three asset retrieves annotated `str` / `int` / `bool`. Asserts three asset bindings; per-binding `metadata.SubType` either matches the annotation (`stringAsset` / `integerAsset` / `booleanAsset`) OR is omitted. A *wrong* SubType fails — that would mis-place the resource at `uipath push` time. |
| `skill-agents-bindings-multi-entrypoint` | `entry-points.json` with two entrypoints, two SDK calls across two source files. Asserts each binding's `EntryPointUniqueId` references one of the real entrypoints (or has no entrypoint link at all); fabricated UUIDs fail. |

Stacked on #475.

## Test plan

- [x] All six sidecar `check_*.py` scripts dry-run green against synthetic well-formed projects (the seventh task, `antipattern-login-no-tenant`, has no sidecar — pure `command_executed` checks).
- [x] Negative cases verified: leaving `[build-system]` in fails the build-system check; `from uipath import UiPath` fails the import check; a fabricated entrypoint UUID fails the multi-entrypoint check; `SubType="credentialAsset"` on a `str`-annotated retrieve fails the asset-subtypes check.
- [x] All nineteen task YAMLs in `coded/` parse and tag lists are consistent.