### PR TITLE
feat(uipath-platform): add traces_fetch smoke test + traces_e2e full round-trip test

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -220,6 +220,7 @@ jobs:
             echo "UIPATH_CLI_ORGANIZATION_ID=${{ secrets.UIPATH_ORG_ID }}"
             echo "UIPATH_CLI_TENANT_NAME=${{ secrets.UIPATH_TENANT_NAME }}"
             echo "UIPATH_CLI_TENANT_ID=${{ secrets.UIPATH_TENANT_ID }}"
+            echo "TRACES_SMOKE_PROCESS_KEY=${{ secrets.TRACES_SMOKE_PROCESS_KEY }}"
           } >> "$GITHUB_ENV"
           UIPATH_CLI_ENABLE_ENV_AUTH=true \
           UIPATH_CLI_AUTH_TOKEN="$TOKEN" \

--- a/tests/tasks/uipath-platform/check_traces_e2e.py
+++ b/tests/tasks/uipath-platform/check_traces_e2e.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python3
-"""Assert report.json has outcome=success and span_count >= 1."""
+"""Assert spans.json (raw uip traces spans get output) has Data with >= 1 span."""
 import json
 import sys
 from pathlib import Path
 
-report_path = Path("report.json")
-if not report_path.is_file():
-    sys.exit("FAIL: report.json not found")
+spans_path = Path("spans.json")
+if not spans_path.is_file():
+    sys.exit("FAIL: spans.json not found")
 
 try:
-    r = json.loads(report_path.read_text())
+    data = json.loads(spans_path.read_text())
 except json.JSONDecodeError as e:
-    sys.exit(f"FAIL: report.json is not valid JSON: {e}")
+    sys.exit(f"FAIL: spans.json is not valid JSON: {e}")
 
-if r.get("outcome") != "success":
-    sys.exit(f"FAIL: outcome={r.get('outcome')!r}, error={r.get('error')!r}")
+if data.get("Result") != "Success":
+    sys.exit(f"FAIL: Result={data.get('Result')!r}, Message={data.get('Message')!r}")
 
-count = r.get("span_count", 0)
-if not isinstance(count, int) or count < 1:
-    sys.exit(f"FAIL: span_count={count!r} — expected >= 1")
+spans = data.get("Data", [])
+if not isinstance(spans, list) or len(spans) < 1:
+    sys.exit(f"FAIL: span_count={len(spans)} — expected >= 1")
 
-print(f"OK: {count} spans returned for job {r.get('job_key')}")
+print(f"OK: {len(spans)} span(s) returned")

--- a/tests/tasks/uipath-platform/check_traces_e2e.py
+++ b/tests/tasks/uipath-platform/check_traces_e2e.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""Assert report.json has outcome=success and span_count >= 1."""
+import json
+import sys
+from pathlib import Path
+
+report_path = Path("report.json")
+if not report_path.is_file():
+    sys.exit("FAIL: report.json not found")
+
+try:
+    r = json.loads(report_path.read_text())
+except json.JSONDecodeError as e:
+    sys.exit(f"FAIL: report.json is not valid JSON: {e}")
+
+if r.get("outcome") != "success":
+    sys.exit(f"FAIL: outcome={r.get('outcome')!r}, error={r.get('error')!r}")
+
+count = r.get("span_count", 0)
+if not isinstance(count, int) or count < 1:
+    sys.exit(f"FAIL: span_count={count!r} — expected >= 1")
+
+print(f"OK: {count} spans returned for job {r.get('job_key')}")

--- a/tests/tasks/uipath-platform/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces_e2e.yaml
@@ -28,16 +28,8 @@ initial_prompt: |
 
   3. Extract the job Key (GUID) from Data[0].Key in the response.
 
-  4. Fetch LLM trace spans for the completed job:
-     `uip traces spans get --job-key <job_key> --output json`
-
-  5. Save your findings to report.json:
-     {
-       "job_key": "<guid>",
-       "outcome": "success" or "error",
-       "span_count": <number of spans returned, or 0>,
-       "error": "<error message if any, or null>"
-     }
+  4. Fetch LLM trace spans for the completed job and save the raw output:
+     `uip traces spans get --job-key <job_key> --output json > spans.json`
 
   Do NOT ask for approval or confirmation. Complete end-to-end in a single pass.
 
@@ -75,8 +67,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_exists
-    description: "report.json was written to the sandbox root"
-    path: "report.json"
+    description: "spans.json (raw CLI output) was written to the sandbox root"
+    path: "spans.json"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-platform/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces_e2e.yaml
@@ -1,0 +1,89 @@
+task_id: skill-platform-traces-e2e
+description: >
+  E2E test: agent uses the uipath-platform skill to start a pre-published
+  traces-smoke-agent job, wait for completion, fetch LLM trace spans, and
+  confirm at least one span is returned. Unlike traces_fetch.yaml (smoke),
+  this exercises the full round-trip against a real job and real traces.
+tags: [uipath-platform, e2e, lifecycle:discover]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  allowed_tools: ["Skill", "Bash", "Read", "Write"]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Use the uipath-platform skill.
+
+  1. Verify login: run `uip login status --output json`. Do NOT re-login —
+     use whatever tenant is currently active.
+
+  2. Start the pre-published traces-smoke-agent and wait for completion:
+     `uip or jobs start $TRACES_SMOKE_PROCESS_KEY \
+       --folder-path "Shared/uipath-platform" \
+       --wait-for-completion --timeout 120 --output json`
+
+  3. Extract the job Key (GUID) from Data[0].Key in the response.
+
+  4. Fetch LLM trace spans for the completed job:
+     `uip traces spans get --job-key <job_key> --output json`
+
+  5. Save your findings to report.json:
+     {
+       "job_key": "<guid>",
+       "outcome": "success" or "error",
+       "span_count": <number of spans returned, or 0>,
+       "error": "<error message if any, or null>"
+     }
+
+  Do NOT ask for approval or confirmation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent verified login status before starting job"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent started the job with --wait-for-completion"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+jobs\s+start.*--wait-for-completion'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched spans using uip traces spans get with --job-key"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+traces\s+spans\s+get.*--job-key'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was written to the sandbox root"
+    path: "report.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "span_count >= 1 — the real gate the smoke test lacks"
+    command: "python3 $TASK_DIR/check_traces_e2e.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces_e2e.yaml
@@ -16,32 +16,13 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Use the uipath-platform skill.
+  Use the `uipath-platform` skill.
 
-  1. Verify login: run `uip login status --output json`. Do NOT re-login —
-     use whatever tenant is currently active.
+  I want to verify that a published agent produces LLM trace spans. Start the agent at process key `$TRACES_SMOKE_PROCESS_KEY`, wait for it to complete, then fetch the trace spans and save them to spans.json.
 
-  2. Start the pre-published traces-smoke-agent and wait for completion:
-     `uip or jobs start $TRACES_SMOKE_PROCESS_KEY \
-       --folder-path "Shared/uipath-platform" \
-       --wait-for-completion --timeout 120 --output json`
-
-  3. Extract the job Key (GUID) from Data[0].Key in the response.
-
-  4. Fetch LLM trace spans for the completed job and save the raw output:
-     `uip traces spans get --job-key <job_key> --output json > spans.json`
-
-  Do NOT ask for approval or confirmation. Complete end-to-end in a single pass.
+  Use `--output json` on all uip commands.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent verified login status before starting job"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: command_executed
     description: "Agent started the job with --wait-for-completion"
     tool_name: "Bash"

--- a/tests/tasks/uipath-platform/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces_e2e.yaml
@@ -18,7 +18,7 @@ sandbox:
 initial_prompt: |
   Use the `uipath-platform` skill.
 
-  I want to verify that a published agent produces LLM trace spans. Start the agent at process key `$TRACES_SMOKE_PROCESS_KEY`, wait for it to complete, then fetch the trace spans and save them to spans.json.
+  Verify that the published agent at process key `$TRACES_SMOKE_PROCESS_KEY` produces LLM trace spans. Save the raw spans output to spans.json.
 
   Use `--output json` on all uip commands.
 

--- a/tests/tasks/uipath-platform/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces_fetch.yaml
@@ -1,0 +1,47 @@
+task_id: skill-platform-traces-fetch
+description: >
+  Smoke test: agent uses the uipath-platform skill to fetch LLM trace spans for a
+  given job key using the correct CLI command and flags. Verifies the agent knows
+  to call `uip traces spans get --job-key <guid> --output json` and summarize the
+  result in report.json. A 404 response (no traces for this job key) is an
+  acceptable outcome — this test checks command knowledge, not data availability.
+tags: [uipath-platform, smoke, lifecycle:discover]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Use the uipath-platform skill. Fetch the LLM trace spans for job key
+  `11111111-2222-3333-4444-555566667777` from the active UiPath tenant.
+  Write a report.json with at minimum:
+  {
+    "command": "<the exact uip command you ran>",
+    "outcome": "<success | 404 | error>",
+    "spans_count": <number of spans returned, or null>
+  }
+
+  Do NOT ask for approval or confirmation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched spans using uip traces spans get with --job-key flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+traces\s+spans\s+get.*--job-key'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was written to the sandbox root"
+    path: "report.json"
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces_fetch.yaml
@@ -2,7 +2,7 @@ task_id: skill-platform-traces-fetch
 description: >
   Smoke test: agent uses the uipath-platform skill to fetch LLM trace spans for a
   given job key against the live tenant. Verifies the agent knows to call
-  `uip traces spans get --job-key <guid> --output json` and record the result.
+  `uip traces spans get --job-key <guid> --output json`.
   A 404 response (no traces for this job key) is an acceptable outcome.
 tags: [uipath-platform, smoke, lifecycle:discover]
 
@@ -18,9 +18,6 @@ initial_prompt: |
 
   2. Fetch LLM trace spans for job key `11111111-2222-3333-4444-555566667777`:
      `uip traces spans get --job-key 11111111-2222-3333-4444-555566667777 --output json`
-
-  3. Save your findings to report.json — include the command you ran,
-     the outcome (success, 404, or error), and the span count (or null).
 
   Do NOT ask for approval or confirmation. Complete end-to-end in a single pass.
 
@@ -46,30 +43,5 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "report.json was written to the sandbox root"
-    path: "report.json"
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: json_check
-    description: "report.json records the command used"
-    path: "report.json"
-    assertions:
-      - expression: "command"
-        operator: contains
-        expected: "uip"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: json_check
-    description: "report.json records an outcome field"
-    path: "report.json"
-    assertions:
-      - expression: "outcome"
-        operator: exists
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces_fetch.yaml
@@ -1,10 +1,9 @@
 task_id: skill-platform-traces-fetch
 description: >
   Smoke test: agent uses the uipath-platform skill to fetch LLM trace spans for a
-  given job key using the correct CLI command and flags. Verifies the agent knows
-  to call `uip traces spans get --job-key <guid> --output json` and summarize the
-  result in report.json. A 404 response (no traces for this job key) is an
-  acceptable outcome — this test checks command knowledge, not data availability.
+  given job key against the live tenant. Verifies the agent knows to call
+  `uip traces spans get --job-key <guid> --output json` and record the result.
+  A 404 response (no traces for this job key) is an acceptable outcome.
 tags: [uipath-platform, smoke, lifecycle:discover]
 
 sandbox:
@@ -12,18 +11,28 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Use the uipath-platform skill. Fetch the LLM trace spans for job key
-  `11111111-2222-3333-4444-555566667777` from the active UiPath tenant.
-  Write a report.json with at minimum:
-  {
-    "command": "<the exact uip command you ran>",
-    "outcome": "<success | 404 | error>",
-    "spans_count": <number of spans returned, or null>
-  }
+  Use the uipath-platform skill.
+
+  1. Verify login: run `uip login status --output json`. Do NOT re-login —
+     use whatever tenant is currently active.
+
+  2. Fetch LLM trace spans for job key `11111111-2222-3333-4444-555566667777`:
+     `uip traces spans get --job-key 11111111-2222-3333-4444-555566667777 --output json`
+
+  3. Save your findings to report.json — include the command you ran,
+     the outcome (success, 404, or error), and the span count (or null).
 
   Do NOT ask for approval or confirmation. Complete end-to-end in a single pass.
 
 success_criteria:
+  - type: command_executed
+    description: "Agent verified login status before fetching"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent fetched spans using uip traces spans get with --job-key flag"
     tool_name: "Bash"
@@ -44,4 +53,23 @@ success_criteria:
     description: "report.json was written to the sandbox root"
     path: "report.json"
     weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json records the command used"
+    path: "report.json"
+    assertions:
+      - expression: "command"
+        operator: contains
+        expected: "uip"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json records an outcome field"
+    path: "report.json"
+    assertions:
+      - expression: "outcome"
+        operator: exists
+    weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces_fetch.yaml
@@ -11,25 +11,13 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Use the uipath-platform skill.
+  Use the `uipath-platform` skill.
 
-  1. Verify login: run `uip login status --output json`. Do NOT re-login —
-     use whatever tenant is currently active.
+  I want to inspect the LLM trace spans for a completed job. The job key is `11111111-2222-3333-4444-555566667777`. Fetch them.
 
-  2. Fetch LLM trace spans for job key `11111111-2222-3333-4444-555566667777`:
-     `uip traces spans get --job-key 11111111-2222-3333-4444-555566667777 --output json`
-
-  Do NOT ask for approval or confirmation. Complete end-to-end in a single pass.
+  Use `--output json` on all uip commands.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent verified login status before fetching"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: command_executed
     description: "Agent fetched spans using uip traces spans get with --job-key flag"
     tool_name: "Bash"


### PR DESCRIPTION
## Motivation

Adds two tests for \`uip traces spans get\` — the CLI command for fetching LLM trace spans from agent jobs.

## Summary

### \`traces_fetch.yaml\` — smoke (\`skill-platform-traces-fetch\`)
- Tags: \`[uipath-platform, smoke, lifecycle:discover]\`
- Goal-only prompt: agent fetches spans for a placeholder GUID; 404 is acceptable — tests command knowledge, not data
- 2 success criteria: correct command + \`--job-key\` flag, \`--output json\`

### \`traces_e2e.yaml\` + \`check_traces_e2e.py\` — full round-trip (\`skill-platform-traces-e2e\`)
- Tags: \`[uipath-platform, e2e, lifecycle:discover]\`
- Goal-only prompt: "Verify that the published agent produces LLM trace spans" — skill teaches start→wait→fetch
- **First test in the repo that proves the CLI returns real spans from a real job**
- Process key supplied via \`TRACES_SMOKE_PROCESS_KEY\` GitHub secret (no hardcoded GUIDs)
- 5 success criteria including \`run_command\` via \`check_traces_e2e.py\` (weight 5.0 — the real gate)

**Workflow change:** \`smoke-skills.yml\` now injects \`TRACES_SMOKE_PROCESS_KEY\` into \`$GITHUB_ENV\` so the agent sandbox picks it up at runtime.

**Prompt style:** Both prompts follow goal-statement style matching the repo pattern — no CLI commands, no procedural steps. Skill teaches the workflow.

## Test Results

### traces_e2e full round-trip — score 1.000 ✅

Verified 2026-05-05 locally against \`codereval/DefaultTenant\`:

```
status=SUCCESS  score=1.000  duration=73.1s  iterations=1  5/5 criteria passed

Job: traces-smoke-agent → State: Successful (8s)
Job key: 216e601d-59cd-42d3-8fce-f93262b1d307
Spans: 1 — "LLM call" (gpt-4.1-mini-2025-04-14, 35 tokens)
check_traces_e2e.py → OK: 1 span(s) returned
```

Agent discovered the process via \`uip or processes list\`, started the job, fetched spans — all from the skill, no procedure in the prompt.

### traces_fetch smoke — score 1.000 ✅

Verified locally — 2/2 criteria passed, ~20s.

## Test plan

- [x] \`traces_fetch\` smoke passes locally (score 1.000)
- [x] \`traces_e2e\` full round-trip passes locally (score 1.000, 5/5 criteria)
- [x] \`check_traces_e2e.py\` exits 0 with real data
- [x] No hardcoded GUIDs — process key via \`TRACES_SMOKE_PROCESS_KEY\` secret
- [x] Goal-only prompts — no CLI commands, no procedural steps (per review feedback)
- [x] Login criterion removed — CI always authenticates via env vars before tests run
- [ ] Both pass in CI on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)