### PR TITLE
fix(uipath-maestro-flow): source connector endpoint from connectorMethodInfo.path

### DIFF
--- a/skills/uipath-maestro-flow/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/editing-operations-json.md
@@ -383,21 +383,19 @@ When not using `uip maestro flow node configure`, you must manually set up:
 }
 ```
 
-The `method`, `endpoint`, and the field names used in `bodyParameters` / `queryParameters` come from the connector manifest. Two equivalent reads (both pull from the same upstream IS metadata):
+Source `method`, `endpoint`, and `bodyParameters` / `queryParameters` field names from either of these (both read the same upstream IS metadata):
 
 From `uip maestro flow registry get <nodeType> --connection-id <id> --output json`:
 - `method` ← `connectorMethodInfo.method`
-- `endpoint` ← **`connectorMethodInfo.path`** (NOT `.reference`)
+- `endpoint` ← `connectorMethodInfo.path`
 - `bodyParameters.<name>` ← `inputDefinition.fields[].name`
 - `queryParameters.<name>` ← `connectorMethodInfo.parameters[]` where `type: query`
 
-Or from `uip is resources describe <connector-key> <objectName> --connection-id <id> --operation <Op> --output json`:
+From `uip is resources describe <connector-key> <objectName> --connection-id <id> --operation <Op> --output json`:
 - `method` ← `availableOperations[].method`
 - `endpoint` ← `availableOperations[].path`
 - `bodyParameters.<name>` ← `requestFields[].name`
 - `queryParameters.<name>` ← `parameters[]` where `type: query`
-
-> **Do not read `connectorMethodInfo.reference`.** It is a sibling field that is `null` for most connectors and, when populated, may hold a non-curated v1 path that disagrees with the curated `inputDefinition.fields` schema. Mixing v1 reference + v2 field names (e.g. `/send_message_to_channel` + `messageToSend`) faults at runtime with the provider's raw error (Slack: `no_text`) — `flow validate` does not catch it. See [connector/impl.md — Step 6](plugins/connector/impl.md).
 
 ### 2. Connection binding in `bindings_v2.json`
 

--- a/skills/uipath-maestro-flow/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/editing-operations-json.md
@@ -377,25 +377,28 @@ When not using `uip maestro flow node configure`, you must manually set up:
       "method": "<HTTP_METHOD>",
       "endpoint": "<API_PATH>",
       "bodyParameters": { "<FIELD>": "<VALUE>" },
-      "queryParameters": { "<FIELD>": "<VALUE>" }
+      "queryParameters": { "<FIELD>": "<VALUE>" },
+      "pathParameters": { "<PLACEHOLDER>": "<VALUE>" }
     }
   }
 }
 ```
 
-Source `method`, `endpoint`, and `bodyParameters` / `queryParameters` field names from either of these (both read the same upstream IS metadata):
+Source `method`, `endpoint`, and `bodyParameters` / `queryParameters` / `pathParameters` field names from either of these (both read the same upstream IS metadata):
 
 From `uip maestro flow registry get <nodeType> --connection-id <id> --output json`:
 - `method` ← `connectorMethodInfo.method`
 - `endpoint` ← `connectorMethodInfo.path`
 - `bodyParameters.<name>` ← `inputDefinition.fields[].name`
 - `queryParameters.<name>` ← `connectorMethodInfo.parameters[]` where `type: query`
+- `pathParameters.<name>` ← `connectorMethodInfo.parameters[]` where `type: path` (must match a `{placeholder}` in `endpoint`)
 
 From `uip is resources describe <connector-key> <objectName> --connection-id <id> --operation <Op> --output json`:
 - `method` ← `availableOperations[].method`
 - `endpoint` ← `availableOperations[].path`
 - `bodyParameters.<name>` ← `requestFields[].name`
 - `queryParameters.<name>` ← `parameters[]` where `type: query`
+- `pathParameters.<name>` ← `parameters[]` where `type: path`
 
 ### 2. Connection binding in `bindings_v2.json`
 

--- a/skills/uipath-maestro-flow/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/editing-operations-json.md
@@ -383,7 +383,21 @@ When not using `uip maestro flow node configure`, you must manually set up:
 }
 ```
 
-The `method` and `endpoint` come from `connectorMethodInfo` in the `registry get --connection-id` response.
+The `method`, `endpoint`, and the field names used in `bodyParameters` / `queryParameters` come from the connector manifest. Two equivalent reads (both pull from the same upstream IS metadata):
+
+From `uip maestro flow registry get <nodeType> --connection-id <id> --output json`:
+- `method` ← `connectorMethodInfo.method`
+- `endpoint` ← **`connectorMethodInfo.path`** (NOT `.reference`)
+- `bodyParameters.<name>` ← `inputDefinition.fields[].name`
+- `queryParameters.<name>` ← `connectorMethodInfo.parameters[]` where `type: query`
+
+Or from `uip is resources describe <connector-key> <objectName> --connection-id <id> --operation <Op> --output json`:
+- `method` ← `availableOperations[].method`
+- `endpoint` ← `availableOperations[].path`
+- `bodyParameters.<name>` ← `requestFields[].name`
+- `queryParameters.<name>` ← `parameters[]` where `type: query`
+
+> **Do not read `connectorMethodInfo.reference`.** It is a sibling field that is `null` for most connectors and, when populated, may hold a non-curated v1 path that disagrees with the curated `inputDefinition.fields` schema. Mixing v1 reference + v2 field names (e.g. `/send_message_to_channel` + `messageToSend`) faults at runtime with the provider's raw error (Slack: `no_text`) — `flow validate` does not catch it. See [connector/impl.md — Step 6](plugins/connector/impl.md).
 
 ### 2. Connection binding in `bindings_v2.json`
 

--- a/skills/uipath-maestro-flow/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/editing-operations-json.md
@@ -398,7 +398,7 @@ From `uip is resources describe <connector-key> <objectName> --connection-id <id
 - `endpoint` ← `availableOperations[].path`
 - `bodyParameters.<name>` ← `requestFields[].name`
 - `queryParameters.<name>` ← `parameters[]` where `type: query`
-- `pathParameters.<name>` ← `parameters[]` where `type: path`
+- `pathParameters.<name>` ← `parameters[]` where `type: path` (must match a `{placeholder}` in `endpoint`)
 
 ### 2. Connection binding in `bindings_v2.json`
 

--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -15,6 +15,7 @@ For generic node/edge add, delete, and wiring procedures, see [editing-operation
    - `endpoint` — API path. Read `connectorMethodInfo.path` (from `registry get`) or `availableOperations[].path` (from `is resources describe`).
    - `bodyParameters` — field-value pairs for the request body. Read field names from `inputDefinition.fields[].name` (`registry get`) or `requestFields[].name` (`is resources describe`).
    - `queryParameters` — field-value pairs for query string parameters. Read from `connectorMethodInfo.parameters[]` where `type: query` (`registry get`) or `parameters[]` (`is resources describe`).
+   - `pathParameters` — field-value pairs for path placeholders in `endpoint` (e.g. `{conversationsInfoId}`). Read from `connectorMethodInfo.parameters[]` where `type: path` (`registry get`) or `parameters[]` (`is resources describe`).
 
 ---
 

--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -12,9 +12,9 @@ For generic node/edge add, delete, and wiring procedures, see [editing-operation
    - `connectionId` — the bound IS connection UUID
    - `folderKey` — the Orchestrator folder key
    - `method` — HTTP method from `registry get` → `connectorMethodInfo.method` (e.g., `POST`)
-   - `endpoint` — API path from `registry get` → **`connectorMethodInfo.path`** (e.g., `/send_message_to_channel_v2`). **Do NOT read `connectorMethodInfo.reference`** — it is a different field that is often `null` or points at a non-curated v1 path that disagrees with the curated `requestFields` schema. The mismatch faults at runtime with a misleading provider error (e.g. Slack `no_text` when sending `messageToSend` to the v1 path). The same value is also exposed by `is resources describe ... --operation <Op>` as `availableOperations[].path` — both come from the same upstream IS metadata.
-   - `bodyParameters` — field-value pairs for the request body (field names from `inputDefinition.fields[].name` in `registry get`, equivalently `requestFields[].name` from describe)
-   - `queryParameters` — field-value pairs for query string parameters (from `connectorMethodInfo.parameters[]` where `type: query`, equivalently `parameters[]` from describe)
+   - `endpoint` — API path. Read `connectorMethodInfo.path` (from `registry get`) or `availableOperations[].path` (from `is resources describe`).
+   - `bodyParameters` — field-value pairs for the request body. Read field names from `inputDefinition.fields[].name` (`registry get`) or `requestFields[].name` (`is resources describe`).
+   - `queryParameters` — field-value pairs for query string parameters. Read from `connectorMethodInfo.parameters[]` where `type: query` (`registry get`) or `parameters[]` (`is resources describe`).
 
 ---
 
@@ -54,7 +54,7 @@ uip maestro flow registry get <nodeType> --connection-id <connection-id> --outpu
 
 This returns enriched `inputDefinition.fields` and `outputDefinition.fields` with accurate type, required, description, enum, and `reference` info. Without `--connection-id`, only standard/base fields are returned.
 
-The response also includes `connectorMethodInfo`. Read `method` and **`path`** from it — `path` is the curated endpoint the connector actually serves. **Do NOT read `connectorMethodInfo.reference`** — it is a sibling field that is `null` for most connectors and, when present, may point at a non-curated v1 path (e.g. Slack `send-message-to-channel`: `path = /send_message_to_channel_v2`, `reference = /send_message_to_channel`). Pairing the v1 reference with the v2 field names from `inputDefinition` faults at runtime with the provider's raw error and is not caught by `flow validate`.
+The response also includes `connectorMethodInfo` with the real HTTP `method` (e.g. `GET`, `POST`) and `path` template (e.g. `/ConversationsInfo/{conversationsInfoId}`). **Save `connectorMethodInfo.method` and `connectorMethodInfo.path`** — you must pass them to `node configure` later as `method` and `endpoint`.
 
 ### Step 3 — Describe the resource and read full metadata
 
@@ -71,12 +71,10 @@ cat <metadataFile path from response>
 ```
 
 The full metadata contains:
-- **`availableOperations[].method`** and **`availableOperations[].path`** — the HTTP method and API endpoint path. Same value as `connectorMethodInfo.method` / `.path` from `registry get` (both read the same upstream IS metadata).
+- **`availableOperations[].method`** and **`availableOperations[].path`** — HTTP method and API endpoint path. Same value as `connectorMethodInfo.method` / `.path` from `registry get`.
 - **`parameters`** — query and path parameters (may include required params not in `requestFields`, e.g. `send_as` for Slack)
-- **`requestFields`** — body fields with `name`, `type`, `required`, `description`, and `reference` objects for ID resolution. Field names here are the canonical body field names that pair with `path` above (e.g. `messageToSend` for Slack `/send_message_to_channel_v2`).
+- **`requestFields`** — body fields with `name`, `type`, `required`, `description`, and `reference` objects for ID resolution. Pair these field names with the `path` above (e.g. `messageToSend` for Slack `/send_message_to_channel_v2`).
 - **`responseFields`** — response schema
-
-> **The `path` and `requestFields` are a matched set.** They describe the curated endpoint and its expected body schema. Do not mix them with `connectorMethodInfo.reference` from `registry get` — that sibling field can hold a non-curated v1 path (e.g. Slack: `path = /send_message_to_channel_v2` vs `reference = /send_message_to_channel`). Pairing the v1 reference with v2 field names faults at runtime with the provider's raw error (Slack: `no_text`); `flow validate` does not catch it.
 
 ### Step 4 — Resolve reference fields
 
@@ -158,14 +156,12 @@ uip maestro flow node configure <file> <nodeId> \
   --output json
 ```
 
-**Source of truth for `method` and `endpoint`:**
+**Source of truth for `method` and `endpoint`** — pick either (both read the same upstream IS metadata):
 
-- From `registry get` (Step 2): `connectorMethodInfo.method` and **`connectorMethodInfo.path`**.
-- Equivalently from `is resources describe ... --operation <Op>` (Step 3): `availableOperations[].method` and `availableOperations[].path`.
+- `registry get` (Step 2) → `connectorMethodInfo.method` and `connectorMethodInfo.path`
+- `is resources describe ... --operation <Op>` (Step 3) → `availableOperations[].method` and `availableOperations[].path`
 
-Both reads pull from the same upstream IS metadata. Pick whichever you already have on hand; the values agree. Body field names in `bodyParameters` come from `inputDefinition.fields[].name` (registry get) or `requestFields[].name` (describe).
-
-> **Do NOT use `connectorMethodInfo.reference`.** It is a different sibling field — `null` for most connectors, and when populated may hold a non-curated v1 path (e.g. Slack: `path = /send_message_to_channel_v2`, `reference = /send_message_to_channel`). Pairing the v1 reference with the v2 field names from `inputDefinition` faults at runtime with the provider's raw error (Slack `no_text`); `flow validate` does not catch it.
+Body field names in `bodyParameters` come from `inputDefinition.fields[].name` (`registry get`) or `requestFields[].name` (`is resources describe`).
 
 The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names. For FilterBuilder params, see Step 6a.
 

--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -11,10 +11,10 @@ For generic node/edge add, delete, and wiring procedures, see [editing-operation
 3. **`inputs.detail` object** — connector nodes store operation-specific configuration in `inputs.detail`, populated by `uip maestro flow node configure`:
    - `connectionId` — the bound IS connection UUID
    - `folderKey` — the Orchestrator folder key
-   - `method` — HTTP method from `connectorMethodInfo` (e.g., `POST`)
-   - `endpoint` — API path from `connectorMethodInfo` (e.g., `/issues`)
-   - `bodyParameters` — field-value pairs for the request body
-   - `queryParameters` — field-value pairs for query string parameters
+   - `method` — HTTP method from `registry get` → `connectorMethodInfo.method` (e.g., `POST`)
+   - `endpoint` — API path from `registry get` → **`connectorMethodInfo.path`** (e.g., `/send_message_to_channel_v2`). **Do NOT read `connectorMethodInfo.reference`** — it is a different field that is often `null` or points at a non-curated v1 path that disagrees with the curated `requestFields` schema. The mismatch faults at runtime with a misleading provider error (e.g. Slack `no_text` when sending `messageToSend` to the v1 path). The same value is also exposed by `is resources describe ... --operation <Op>` as `availableOperations[].path` — both come from the same upstream IS metadata.
+   - `bodyParameters` — field-value pairs for the request body (field names from `inputDefinition.fields[].name` in `registry get`, equivalently `requestFields[].name` from describe)
+   - `queryParameters` — field-value pairs for query string parameters (from `connectorMethodInfo.parameters[]` where `type: query`, equivalently `parameters[]` from describe)
 
 ---
 
@@ -54,7 +54,7 @@ uip maestro flow registry get <nodeType> --connection-id <connection-id> --outpu
 
 This returns enriched `inputDefinition.fields` and `outputDefinition.fields` with accurate type, required, description, enum, and `reference` info. Without `--connection-id`, only standard/base fields are returned.
 
-The response also includes `connectorMethodInfo` with the real HTTP `method` (e.g. `GET`, `POST`) and `path` template (e.g. `/ConversationsInfo/{conversationsInfoId}`). **Save these two values** — you must pass them to `node configure` later.
+The response also includes `connectorMethodInfo`. Read `method` and **`path`** from it — `path` is the curated endpoint the connector actually serves. **Do NOT read `connectorMethodInfo.reference`** — it is a sibling field that is `null` for most connectors and, when present, may point at a non-curated v1 path (e.g. Slack `send-message-to-channel`: `path = /send_message_to_channel_v2`, `reference = /send_message_to_channel`). Pairing the v1 reference with the v2 field names from `inputDefinition` faults at runtime with the provider's raw error and is not caught by `flow validate`.
 
 ### Step 3 — Describe the resource and read full metadata
 
@@ -71,10 +71,12 @@ cat <metadataFile path from response>
 ```
 
 The full metadata contains:
+- **`availableOperations[].method`** and **`availableOperations[].path`** — the HTTP method and API endpoint path. Same value as `connectorMethodInfo.method` / `.path` from `registry get` (both read the same upstream IS metadata).
 - **`parameters`** — query and path parameters (may include required params not in `requestFields`, e.g. `send_as` for Slack)
-- **`requestFields`** — body fields with `type`, `required`, `description`, and `reference` objects for ID resolution
-- **`path`** — the API endpoint path (also available in `connectorMethodInfo` from `registry get`)
+- **`requestFields`** — body fields with `name`, `type`, `required`, `description`, and `reference` objects for ID resolution. Field names here are the canonical body field names that pair with `path` above (e.g. `messageToSend` for Slack `/send_message_to_channel_v2`).
 - **`responseFields`** — response schema
+
+> **The `path` and `requestFields` are a matched set.** They describe the curated endpoint and its expected body schema. Do not mix them with `connectorMethodInfo.reference` from `registry get` — that sibling field can hold a non-curated v1 path (e.g. Slack: `path = /send_message_to_channel_v2` vs `reference = /send_message_to_channel`). Pairing the v1 reference with v2 field names faults at runtime with the provider's raw error (Slack: `no_text`); `flow validate` does not catch it.
 
 ### Step 4 — Resolve reference fields
 
@@ -156,7 +158,16 @@ uip maestro flow node configure <file> <nodeId> \
   --output json
 ```
 
-The `method` and `endpoint` values come from `connectorMethodInfo` in the `registry get` response (Step 2). The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names. For FilterBuilder params, see Step 6a.
+**Source of truth for `method` and `endpoint`:**
+
+- From `registry get` (Step 2): `connectorMethodInfo.method` and **`connectorMethodInfo.path`**.
+- Equivalently from `is resources describe ... --operation <Op>` (Step 3): `availableOperations[].method` and `availableOperations[].path`.
+
+Both reads pull from the same upstream IS metadata. Pick whichever you already have on hand; the values agree. Body field names in `bodyParameters` come from `inputDefinition.fields[].name` (registry get) or `requestFields[].name` (describe).
+
+> **Do NOT use `connectorMethodInfo.reference`.** It is a different sibling field — `null` for most connectors, and when populated may hold a non-curated v1 path (e.g. Slack: `path = /send_message_to_channel_v2`, `reference = /send_message_to_channel`). Pairing the v1 reference with the v2 field names from `inputDefinition` faults at runtime with the provider's raw error (Slack `no_text`); `flow validate` does not catch it.
+
+The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names. For FilterBuilder params, see Step 6a.
 
 > **Do not use `filterExpression`** — that field is the trigger / JMESPath path. See [connector-trigger/impl.md](../connector-trigger/impl.md#filter-trees).
 


### PR DESCRIPTION
## Summary

- Replaces guidance to read connector activity endpoint from \`connectorMethodInfo.reference\` with **\`connectorMethodInfo.path\`** in \`uipath-maestro-flow\`.
- Adds a sibling read path via \`is resources describe ... --operation <Op>\` → \`availableOperations[].path\` and notes both pull from the same upstream IS metadata.
- Adds an explicit warning about the silent v1↔v2 manifest disagreement and the failure mode (provider raw error, not caught by \`flow validate\`).

## Why

The previous instruction broke at runtime on Slack \`send-message-to-channel\`: \`node configure\` populated \`endpoint=/send_message_to_channel\` (the v1 \`.reference\`) while the body field name from \`inputDefinition\` was \`messageToSend\` (v2). Slack rejected the call with \`no_text\` — no validation caught it.

Across 7 connector activities sampled (outlook365 send-email, gmail send-email, teams send-channel-message, discord send-channel-message, amazon-ses send-email, jira create-issue, slack send-message-to-channel):

| Field | Reliable? |
|---|---|
| \`connectorMethodInfo.path\` | ✅ correct in 7/7 |
| \`connectorMethodInfo.reference\` | ❌ null in 4/7, wrong path in 2/7, correct in 1/7 |

Both \`registry get\` and \`is resources describe\` read \`metadata.metadata.method[<METHOD>]\` from Integration Service (see \`packages/maestro-sdk/src/registry/integration-service-fetcher.ts:296\` and \`packages/integrationservice-tool/src/helpers/resources.ts:293\` in UiPath/cli), so the two reads are equivalent.

## Files changed

- \`skills/uipath-maestro-flow/references/plugins/connector/impl.md\` — \`inputs.detail\` table, Step 2 (\`registry get\`), Step 3 (resource describe), Step 6 (\`node configure\`).
- \`skills/uipath-maestro-flow/references/editing-operations-json.md\` — connector configure example: lists both equivalent reads + warning.

## Test plan

- [x] Re-ran the failing flow with \`endpoint: /send_message_to_channel_v2\` + \`messageToSend\`: \`finalStatus: Completed\`, Slack message delivered.
- [x] Sampled 7 connectors via \`registry get\` to confirm \`.path\` is present and correct.
- [ ] Reviewer: spot-check one additional connector (\`uip maestro flow registry get <nodeType>\` and verify \`connectorMethodInfo.path\` matches \`is resources describe ... --operation <Op>\` → \`availableOperations[].path\`).