### PR TITLE
docs: add CEQL filter trees section for IS list activities

### DIFF
--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -122,6 +122,8 @@ uip maestro flow node configure <file> <nodeId> \
 
 The `method` and `endpoint` values come from `connectorMethodInfo` in the `registry get` response (Step 2). The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names.
 
+> **Server-side filtering (List All Records and similar list activities):** Pass a structured `filter` tree under `--detail` — the CLI compiles it to CEQL using the same logic Studio Web uses, so the activity round-trips cleanly. Tree shape, operator table, and examples live in [uipath-platform — Filter Trees (CEQL)](../../../../uipath-platform/references/integration-service/activities.md#filter-trees-ceql). **Do not pass a raw CEQL string in `filter`; do not use `filterExpression` (that is the trigger / JMESPath path — see [connector-trigger/impl.md](../connector-trigger/impl.md#filter-trees)).**
+
 > **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)" --output json`
 
 ---

--- a/skills/uipath-maestro-flow/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/plugins/connector/impl.md
@@ -112,6 +112,21 @@ The `<id>` in `--connection-id "<id>"` MUST be the connection bound to **this** 
 
 **Run `is resources describe` (Step 3) before this step.** The full metadata tells you which fields are required, what types they expect, and which need reference resolution. Do not guess field names or skip the metadata check — required fields missing from `--detail` cause runtime errors that `flow validate` does not catch.
 
+#### Step 6a — Detect FilterBuilder parameters
+
+Before writing `--detail`, scan the operation's `parameters[]` (from Step 3 / `registry get`) for any entry with `design.component === "FilterBuilder"`. This applies to **any** operation, not only List operations — connectors render the FilterBuilder UI for any param flagged this way.
+
+For every match:
+
+- That parameter's `name` is the connector-specific filter input — most commonly `where`, sometimes `q` (Salesforce), sometimes another name. Do not assume `where`.
+- **Pass a structured filter tree under `--detail.filter`** — the CLI compiles it into both halves of the contract: the runtime CEQL string at `inputs.detail.queryParameters.<name>` *and* the design-time tree at `inputs.detail.configuration.essentialConfiguration.savedFilterTrees.<name>`. Studio Web reads the latter to render the FilterBuilder UI; only `--detail.filter` populates that side.
+- **Do not pass a raw CEQL string under `--detail.queryParameters.<name>`.** It populates only the runtime half — debug runs succeed but the FilterBuilder UI shows `undefined` when the activity is reopened in SW. The CLI rejects this at configure time.
+- Tree shape, operator table, examples → [uipath-platform — Filter Trees (CEQL)](../../../../uipath-platform/references/integration-service/activities.md#filter-trees-ceql).
+
+If the operation has no FilterBuilder parameter, server-side filtering is not supported — pass no `filter` and filter downstream (e.g. with a Script node).
+
+#### Step 6b — Run configure
+
 After adding the node with `uip maestro flow node add`, configure it with the resolved connection and field values:
 
 ```bash
@@ -120,9 +135,9 @@ uip maestro flow node configure <file> <nodeId> \
   --output json
 ```
 
-The `method` and `endpoint` values come from `connectorMethodInfo` in the `registry get` response (Step 2). The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names.
+The `method` and `endpoint` values come from `connectorMethodInfo` in the `registry get` response (Step 2). The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names. For FilterBuilder params, see Step 6a.
 
-> **Server-side filtering (List All Records and similar list activities):** Pass a structured `filter` tree under `--detail` — the CLI compiles it to CEQL using the same logic Studio Web uses, so the activity round-trips cleanly. Tree shape, operator table, and examples live in [uipath-platform — Filter Trees (CEQL)](../../../../uipath-platform/references/integration-service/activities.md#filter-trees-ceql). **Do not pass a raw CEQL string in `filter`; do not use `filterExpression` (that is the trigger / JMESPath path — see [connector-trigger/impl.md](../connector-trigger/impl.md#filter-trees)).**
+> **Do not use `filterExpression`** — that field is the trigger / JMESPath path. See [connector-trigger/impl.md](../connector-trigger/impl.md#filter-trees).
 
 > **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)" --output json`
 
@@ -332,6 +347,8 @@ For connector-trigger flows, the same pattern applies — top-level `bindings[]`
 | `connectorMethodInfo` missing method/path | Used `registry get` without `--connection-id` | Re-run with `--connection-id` for enriched metadata (Step 2) |
 | `bindings_v2.json` malformed or stale | It was hand-edited (the CLI overwrites edits on next debug/pack) | Never edit `bindings_v2.json` directly — author bindings in the top-level `.flow` `bindings[]` instead. Compare your top-level `bindings[]` against the schema and examples in the Bindings section above |
 | Connector key not found | Wrong key name | Run `uip is connectors list --output json` — keys are often prefixed with `uipath-` |
+| FilterBuilder UI shows `undefined` when activity is reopened in Studio Web; flow runs at debug | A raw `queryParameters.<filterParamName>` string was passed instead of a structured filter tree, so `essentialConfiguration.savedFilterTrees.<filterParamName>` is empty. The runtime side works but Studio Web has no tree to render. | Re-run `uip maestro flow node configure` with `--detail '{"filter": {...tree...}}'` — the CLI populates both halves. See Step 6a above and [uipath-platform — Filter Trees (CEQL)](../../../../uipath-platform/references/integration-service/activities.md#filter-trees-ceql). |
+| `node configure` fails with `'<name>' is a FilterBuilder parameter — pass a structured filter tree under --detail.filter` | Same root cause — raw string under `queryParameters` for a FilterBuilder param | Move the value into `--detail.filter` as a structured tree. The CLI catches this at configure time so it never reaches Studio Web. |
 
 ### Debug Tips
 

--- a/skills/uipath-platform/references/integration-service/activities.md
+++ b/skills/uipath-platform/references/integration-service/activities.md
@@ -56,7 +56,7 @@ The **Operation** field on trigger activities indicates the trigger type:
 
 Some IS activities — most notably **List All Records** and other list/query operations — accept a server-side filter expressed in **CEQL** (Connector Expression Query Language). As with trigger filters (which compile to JMESPath), CEQL filters are authored as a **structured filter tree** and the CLI compiles them to a CEQL string. Authoring as a tree keeps the CLI and Studio Web in lockstep so the activity round-trips cleanly when re-opened in SW.
 
-> **Status:** the CLI ships the `CeqlHelper` compiler in `@uipath/integrationservice-sdk` (`dap/helpers/filter-builder/ceql-helper.ts`). Activity-side `--detail.filter` validation is rolling out per [ENGCE-57404](https://uipath.atlassian.net/browse/ENGCE-57404); until your installed CLI advertises it, fall back to the connector's literal `$filter` parameter.
+The CLI delivers the compiled CEQL to the runtime via **`queryParameters.where`** on the activity detail — the IS connector reads the `where` query parameter when executing list/query operations. Pass `filter` (the structured tree) and the CLI populates `queryParameters.where` for you; passing both `filter` and `queryParameters.where` is rejected at validation time.
 
 ### Tree shape
 

--- a/skills/uipath-platform/references/integration-service/activities.md
+++ b/skills/uipath-platform/references/integration-service/activities.md
@@ -56,7 +56,12 @@ The **Operation** field on trigger activities indicates the trigger type:
 
 Some IS activities — most notably **List All Records** and other list/query operations — accept a server-side filter expressed in **CEQL** (Connector Expression Query Language). As with trigger filters (which compile to JMESPath), CEQL filters are authored as a **structured filter tree** and the CLI compiles them to a CEQL string. Authoring as a tree keeps the CLI and Studio Web in lockstep so the activity round-trips cleanly when re-opened in SW.
 
-The CLI delivers the compiled CEQL to the runtime via **`queryParameters.where`** on the activity detail — the IS connector reads the `where` query parameter when executing list/query operations. Pass `filter` (the structured tree) and the CLI populates `queryParameters.where` for you; passing both `filter` and `queryParameters.where` is rejected at validation time.
+The CLI persists both halves of the contract from a single `filter` input:
+
+- **Runtime side** — the compiled CEQL string lands at `inputs.detail.queryParameters.where`. The IS connector reads `queryParameters.where` when executing List All Records and similar list/query operations.
+- **Design-time side** — the structured tree is embedded under `inputs.detail.configuration`'s `essentialConfiguration.savedFilterTrees.where`. Studio Web reads this on open to re-render the filter widget; without it the filter UI shows up empty even though the runtime call still works.
+
+Pass `filter` (the structured tree) and the CLI emits both halves in lockstep. Passing both `filter` and `queryParameters.where` is rejected at validation time — single source of truth.
 
 ### Tree shape
 

--- a/skills/uipath-platform/references/integration-service/activities.md
+++ b/skills/uipath-platform/references/integration-service/activities.md
@@ -49,3 +49,133 @@ The **Operation** field on trigger activities indicates the trigger type:
 - **Resources** = data objects with CRUD (e.g., "Account"). Discovered via `is resources list`. Executed via `is resources execute <verb>`.
 
 > After listing activities, present the available actions to the user. Activities provide context for what a connector can do — use this to guide which resource operations, triggers, or workflow actions to pursue.
+
+---
+
+## Filter Trees (CEQL)
+
+Some IS activities — most notably **List All Records** and other list/query operations — accept a server-side filter expressed in **CEQL** (Connector Expression Query Language). As with trigger filters (which compile to JMESPath), CEQL filters are authored as a **structured filter tree** and the CLI compiles them to a CEQL string. Authoring as a tree keeps the CLI and Studio Web in lockstep so the activity round-trips cleanly when re-opened in SW.
+
+> **Status:** the CLI ships the `CeqlHelper` compiler in `@uipath/integrationservice-sdk` (`dap/helpers/filter-builder/ceql-helper.ts`). Activity-side `--detail.filter` validation is rolling out per [ENGCE-57404](https://uipath.atlassian.net/browse/ENGCE-57404); until your installed CLI advertises it, fall back to the connector's literal `$filter` parameter.
+
+### Tree shape
+
+Identical to the trigger filter tree — the same `FilterTree` / `Filter` / `WorkflowValue` types are used; only the compiler output (CEQL vs JMESPath) differs.
+
+```jsonc
+{
+  "groupOperator": 0,             // 0 = And, 1 = Or — combines sibling filters/groups
+  "index": 0,                     // ordering index within parent (root is 0)
+  "filters": [                    // leaf conditions at this level
+    {
+      "id": "<fieldName>",        // resource field name from `is resources describe`
+      "operator": "<Operator>",   // PascalCase, see operator table below
+      "value": {
+        "value": <typed value>,   // string / number / boolean / ISO-8601 date-time / array
+        "rawString": "\"...\"",   // verbatim user-entered text (with quotes for strings)
+        "isLiteral": true         // literals only — expression values are not yet supported
+      }
+    }
+  ],
+  "groups": []                    // optional: nested subgroups (same shape as root)
+}
+```
+
+A no-op filter — used when the user wants to list all records without restriction — is `null` or `{"groupOperator": null, "index": 0, "filters": []}`. Prefer **omitting** the `filter` field entirely.
+
+### Compiled CEQL output
+
+The CLI compiles each leaf to `<field> <op> <value>` (or `<field> <function>` for null checks) and joins siblings with the group operator. String values are wrapped in single quotes; booleans, numerics, and enums are passed bare.
+
+| Operator | CEQL token | Notes |
+|---|---|---|
+| `Equals` | `=` | |
+| `NotEquals` | `!=` | |
+| `LessThan` / `LessThanOrEqual` / `GreaterThan` / `GreaterThanOrEqual` | `<` / `<=` / `>` / `>=` | Numeric / date-time |
+| `Contains` / `NotContains` | `Contains` / `Not Contains` | Substring (string) |
+| `StartsWith` / `NotStartsWith` / `EndsWith` / `NotEndsWith` | `Starts With` / `Not Starts With` / `Ends With` / `Not Ends With` | String |
+| `Like` / `NotLike` | `Like` / `Not Like` | Pattern match (connector-specific) |
+| `In` / `NotIn` | `In` / `Not In` | Membership — `value.value` is a list; rendered as `(v1, v2, …)` |
+| `IsNull` / `IsNotNull` | `Is Null` / `Is Not Null` | No `value` needed |
+| `Is` / `IsNot` | `=` against literal `true` / `false` | Boolean shortcut |
+
+Logical operators between siblings:
+
+| `groupOperator` | CEQL token |
+|---|---|
+| `0` (And) | ` AND ` |
+| `1` (Or) | ` OR ` |
+
+### Examples
+
+**Active accounts only:**
+
+```json
+{
+  "groupOperator": 0, "index": 0,
+  "filters": [
+    { "id": "Status", "operator": "Equals",
+      "value": { "value": "Active", "rawString": "\"Active\"", "isLiteral": true } }
+  ]
+}
+```
+→ CEQL: `Status = 'Active'`
+
+**Score ≥ 80 AND Region in (EMEA, APAC):**
+
+```json
+{
+  "groupOperator": 0, "index": 0,
+  "filters": [
+    { "id": "Score", "operator": "GreaterThanOrEqual",
+      "value": { "value": 80, "rawString": "80", "isLiteral": true } },
+    { "id": "Region", "operator": "In",
+      "value": { "value": ["EMEA", "APAC"], "rawString": "[\"EMEA\",\"APAC\"]", "isLiteral": true } }
+  ]
+}
+```
+→ CEQL: `Score >= 80 AND Region In ('EMEA', 'APAC')`
+
+**Subject contains "urgent" AND (owner = me OR owner is null):**
+
+```json
+{
+  "groupOperator": 0, "index": 0,
+  "filters": [
+    { "id": "Subject", "operator": "Contains",
+      "value": { "value": "urgent", "rawString": "\"urgent\"", "isLiteral": true } }
+  ],
+  "groups": [
+    {
+      "groupOperator": 1, "index": 1,
+      "filters": [
+        { "id": "OwnerId", "operator": "Equals",
+          "value": { "value": "${me.id}", "rawString": "\"${me.id}\"", "isLiteral": false } },
+        { "id": "OwnerId", "operator": "IsNull" }
+      ]
+    }
+  ]
+}
+```
+→ CEQL: `Subject Contains 'urgent' AND (OwnerId = ${me.id} OR OwnerId Is Null)`. Non-literal values (`isLiteral: false`) are emitted as `${expression}` placeholders for runtime resolution.
+
+### How to build a CEQL filter tree
+
+1. Run `uip is resources describe "<connector-key>" "<objectName>" --connection-id "<id>" --operation List` to read the resource's filterable fields (`requestFields` / `parameters` flagged as filterable).
+2. For each user-intent condition, pick a matching field `name` from that response — using an unknown field name will be rejected by the CLI at configure time.
+3. Choose an operator based on the field type (see operator table). Date-time fields take ISO-8601 strings; enums take the literal enum value.
+4. Build one leaf per condition; place multiple conditions under the same `groupOperator` (0 for AND, 1 for OR).
+5. If you need mixed AND/OR logic, use nested `groups`.
+6. Wrap values in a `WorkflowValue` object with `value`, `rawString`, `isLiteral`. Strings, numbers, booleans, dates, and arrays are all valid `value` types; only `isLiteral: true` is currently supported by activity-side compilation.
+7. If the resource doesn't expose filterable fields, the activity does not support server-side filtering — omit `filter` and filter downstream in the flow (e.g. with a Script node).
+
+### What NOT to generate
+
+| Invalid input | Why it fails | Valid replacement |
+|---|---|---|
+| `"filter": "Status = 'Active'"` | Bare CEQL string — `filter` must be an object. | Structured tree with `filters: [...]`. |
+| `"filterExpression": "..."` | That field is reserved for the trigger (JMESPath) path. | Use `filter` (CEQL tree) for activities. |
+| `{ "operator": "equals", ... }` | Operator is case-sensitive. | `"operator": "Equals"` |
+| `{ "value": "Active" }` on a leaf | Bare string — must be wrapped in the `WorkflowValue` object. | `{ "value": { "value": "Active", "rawString": "\"Active\"", "isLiteral": true } }` |
+| `{ "id": "fields.Status", ... }` | `fields.` prefix — use the bare field name from `is resources describe`. | `{ "id": "Status", ... }` |
+| `In` operator with a single value not in a list | `In` expects an array `value`. | Use `Equals`, or pass `value: ["one"]`. |

--- a/skills/uipath-platform/references/integration-service/activities.md
+++ b/skills/uipath-platform/references/integration-service/activities.md
@@ -56,12 +56,20 @@ The **Operation** field on trigger activities indicates the trigger type:
 
 Some IS activities — most notably **List All Records** and other list/query operations — accept a server-side filter expressed in **CEQL** (Connector Expression Query Language). As with trigger filters (which compile to JMESPath), CEQL filters are authored as a **structured filter tree** and the CLI compiles them to a CEQL string. Authoring as a tree keeps the CLI and Studio Web in lockstep so the activity round-trips cleanly when re-opened in SW.
 
-The CLI persists both halves of the contract from a single `filter` input:
+### Contract — three signals from IS metadata
 
-- **Runtime side** — the compiled CEQL string lands at `inputs.detail.queryParameters.where`. The IS connector reads `queryParameters.where` when executing List All Records and similar list/query operations.
-- **Design-time side** — the structured tree is embedded under `inputs.detail.configuration`'s `essentialConfiguration.savedFilterTrees.where`. Studio Web reads this on open to re-render the filter widget; without it the filter UI shows up empty even though the runtime call still works.
+The CLI reads the live IS metadata response and uses three signals to wire the filter:
 
-Pass `filter` (the structured tree) and the CLI emits both halves in lockstep. Passing both `filter` and `queryParameters.where` is rejected at validation time — single source of truth.
+1. **The activity supports CEQL** when one of its `parameters` declares `design.component === "FilterBuilder"`. That parameter's `name` is the connector-specific key the compiled CEQL string is sent under — most commonly `where`, but **not always** (e.g. Salesforce uses `q`). Activities with no such parameter do not support server-side filtering — pass no `filter` and filter downstream.
+2. **A field is filterable** when its IS metadata entry has `searchable: true`. Type alone does not gate it — the connector flags fields explicitly. Fields without `searchable: true` are rejected by the CLI even if they look like primitives.
+3. **Permitted operators** for the field are listed under `searchableOperators`. **Connector-side identifier** for the field in CEQL is `searchableNames[0]` when present (some connectors expose a friendly `name` but require a different identifier in the query string).
+
+### What the CLI persists from a single `filter` input
+
+- **Runtime side** — the compiled CEQL string lands at `inputs.detail.queryParameters.<filterParamName>` where `<filterParamName>` is the FilterBuilder parameter's name from the IS metadata (often `where`).
+- **Design-time side** — the structured tree is embedded under `inputs.detail.configuration`'s `essentialConfiguration.savedFilterTrees.<filterParamName>`. Studio Web reads this on open to re-render the filter widget; without it the filter UI shows up empty even though the runtime call still works.
+
+Pass `filter` (the structured tree) and the CLI emits both halves in lockstep. Passing both `filter` and `queryParameters.<filterParamName>` is rejected at validation time — single source of truth.
 
 ### Tree shape
 
@@ -166,13 +174,13 @@ Logical operators between siblings:
 
 ### How to build a CEQL filter tree
 
-1. Run `uip is resources describe "<connector-key>" "<objectName>" --connection-id "<id>" --operation List` to read the resource's filterable fields (`requestFields` / `parameters` flagged as filterable).
-2. For each user-intent condition, pick a matching field `name` from that response — using an unknown field name will be rejected by the CLI at configure time.
-3. Choose an operator based on the field type (see operator table). Date-time fields take ISO-8601 strings; enums take the literal enum value.
-4. Build one leaf per condition; place multiple conditions under the same `groupOperator` (0 for AND, 1 for OR).
-5. If you need mixed AND/OR logic, use nested `groups`.
-6. Wrap values in a `WorkflowValue` object with `value`, `rawString`, `isLiteral`. Strings, numbers, booleans, dates, and arrays are all valid `value` types; only `isLiteral: true` is currently supported by activity-side compilation.
-7. If the resource doesn't expose filterable fields, the activity does not support server-side filtering — omit `filter` and filter downstream in the flow (e.g. with a Script node).
+1. Run `uip is resources describe "<connector-key>" "<objectName>" --connection-id "<id>" --operation List` to read the resource's metadata.
+2. **Confirm CEQL is supported** for this operation: at least one entry under `parameters` must carry `design.component === "FilterBuilder"`. If none does, the activity does not support server-side filtering — omit `filter` and filter downstream (e.g. with a Script node).
+3. **Pick filterable fields** from `fields[]` where `searchable: true`. Other fields will be rejected by the CLI at configure time even if they look like primitives.
+4. For each leaf, pick an operator from the field's `searchableOperators` list (when present). Date-time fields take ISO-8601 strings; enums take the literal enum value.
+5. Use the field's `name` as the leaf `id`. The CLI rewrites it to `searchableNames[0]` when emitting CEQL if the connector declares one — you don't need to use the alias yourself.
+6. Build one leaf per condition; place multiple conditions under the same `groupOperator` (0 for AND, 1 for OR). Use nested `groups` for mixed AND/OR.
+7. Wrap values in a `WorkflowValue` object with `value`, `rawString`, `isLiteral`. Strings, numbers, booleans, dates, and arrays are all valid `value` types; only `isLiteral: true` is currently supported by activity-side compilation.
 
 ### What NOT to generate
 
@@ -183,4 +191,6 @@ Logical operators between siblings:
 | `{ "operator": "equals", ... }` | Operator is case-sensitive. | `"operator": "Equals"` |
 | `{ "value": "Active" }` on a leaf | Bare string — must be wrapped in the `WorkflowValue` object. | `{ "value": { "value": "Active", "rawString": "\"Active\"", "isLiteral": true } }` |
 | `{ "id": "fields.Status", ... }` | `fields.` prefix — use the bare field name from `is resources describe`. | `{ "id": "Status", ... }` |
+| `{ "id": "<field without searchable: true>", ... }` | The CLI checks `searchable` on the IS metadata entry; non-searchable fields are rejected even if their type looks filterable. | Pick a field where `searchable: true`. |
+| `"queryParameters": { "where": "..." }` alongside `filter` | Hardcoding `where` assumes that's the FilterBuilder param name — it isn't always (Salesforce uses `q`, etc.). | Pass `filter` only; the CLI discovers the right param name from `design.component === "FilterBuilder"`. |
 | `In` operator with a single value not in a list | `In` expects an array `value`. | Use `Equals`, or pass `value: ["one"]`. |


### PR DESCRIPTION
## Jira Ticket
[ENGCE-57404](https://uipath.atlassian.net/browse/ENGCE-57404)

## Summary
- Adds a **Filter Trees (CEQL)** section to `skills/uipath-platform/references/integration-service/activities.md` covering the structured tree shape (mirrors the trigger filter tree), operator → CEQL-token mappings, group-operator semantics, worked examples (Equals, In + numeric AND, nested AND/OR with non-literal value and IsNull), build-from-`is resources describe` steps, and a \"What NOT to generate\" table.
- Cross-references the new section from the Maestro Flow connector plugin doc (`skills/uipath-maestro-flow/references/plugins/connector/impl.md`, Step 6) and explicitly contrasts CEQL \`filter\` with the trigger-side JMESPath \`filterExpression\` so authors don't cross-wire the two paths.

## Depends on
- [UiPath/cli#1194](https://github.com/UiPath/cli/pull/1194) — restores the \`CeqlHelper\` compiler in \`@uipath/integrationservice-sdk\`. Activity-side \`--detail.filter\` validation is still rolling out per ENGCE-57404; the doc is marked preview accordingly. **Merge this PR only after the CLI side wires CEQL into activity \`--detail.filter\`** so we're not telling agents to use an API their installed CLI doesn't yet support.

## Test plan
- [x] Cross-reference link from `connector/impl.md` resolves to the new anchor.
- [x] Trigger doc's `#filter-trees` anchor still exists for the contrast link.
- [x] Spot-check rendering in the skill viewer.
- [ ] Add a smoke eval mirroring `tests/tasks/uipath-maestro-flow/...trigger_with_filter.yaml` once the CLI activity validator lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENGCE-57404]: https://uipath.atlassian.net/browse/ENGCE-57404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ