### PR TITLE
chore: add code owners for guardrails capability docs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,6 +28,9 @@
 # Agents skill (coded + low-code)
 /skills/uipath-agents/ @gabrielavaduva @AlvinStanescu @Adrian-badea @cosmyo @AlexandruCGhimisi @andreibalas-uipath @al3xanndru
 
+# Guardrails capability docs
+/skills/uipath-agents/references/lowcode/capabilities/guardrails/ @apetraru-uipath @valentinabojan @ctiliescuuipath
+
 # Planner skill
 /skills/uipath-planner/ @RaduAna-Maria
 


### PR DESCRIPTION
## Summary
- Adds `@apetraru-uipath`, `@valentinabojan`, and `@ctiliescuuipath` as code owners for `/skills/uipath-agents/references/lowcode/capabilities/guardrails/`

## Test plan
- [ ] Verify CODEOWNERS entry is correctly picked up by GitHub for the guardrails folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)