### PR TITLE
test(uipath-rpa): re-pin Testing.Activities to 25.4.1, drop no-build guard

### DIFF
--- a/tests/tasks/uipath-rpa/coded_test_case.yaml
+++ b/tests/tasks/uipath-rpa/coded_test_case.yaml
@@ -21,14 +21,9 @@ initial_prompt: |
   Studio Desktop is NOT available — skip any CLI commands that require
   --use-studio. Focus on generating the correct files and project.json updates.
 
-  Do NOT run `uip rpa build` for this task. The grader checks files,
-  not build output. The TestAutomationProjectTemplate's default
-  `UiPath.Testing.Activities` `[25.10.x]` ships an auto-synthesized
-  bootloader workflow that fails to compile with CS0234 on this runner,
-  and the cached `.local/` artifacts persist across version edits — so
-  any attempt to "fix the build" will derail the run. Skip the build
-  entirely. `uip rpa get-errors` on individual `.cs` files is fine for
-  syntax sanity checks.
+  Use `UiPath.Testing.Activities` version `[25.4.1]` (newer 25.10.x
+  releases synthesize a bootloader that breaks the build on this
+  runner). Pin it in project.json before adding source files.
 
   Requirements:
   - Set up shared Before/After hooks that apply to ALL test cases:


### PR DESCRIPTION
## Summary
- Re-applies commit 95087cc6 (later reverted in 28cf5a54) on top of current main.
- With smoke-rpa CI now on stable `@uipath/rpa-tool` 0.9.2 (pinned via `>=0.9` to dodge the 1.0.0-alpha line), retry the 25.4.1 pin: tell the agent up front to use `UiPath.Testing.Activities [25.4.1]` instead of the template default `[25.10.2]`, which synthesizes a bootloader that fails to compile with CS0234 on the runner.
- Drops the "do NOT run `uip rpa build`" guard since `[25.4.1]` builds cleanly.

## Test plan
- [ ] `smoke-rpa-skills` workflow runs on this PR and the `skill-rpa-coded-test-case` task passes its weighted-score gate.
- [ ] Build is no longer skipped; agent completes the scaffold + hooks + test case end-to-end without burning turns on CS0234 recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)