### PR TITLE
fix(hooks): silence happy-path stderr in ensure-uip SessionStart hook

### DIFF
--- a/hooks/ensure-uip.sh
+++ b/hooks/ensure-uip.sh
@@ -76,18 +76,22 @@ UIPATH_REGISTRY_FLAG="--@uipath:registry=https://registry.npmjs.org/"
 # npm install -g always re-downloads and re-installs, even if the same version
 # is already present. This is slow for a synchronous session hook and also
 # re-triggers package lifecycle scripts. Check first, install only when needed.
+# Stay silent on the happy path: Claude Code surfaces ANY stderr from an
+# exit-0 SessionStart hook as "Failed with non-blocking status code",
+# which is misleading. Capture install output and only emit on failure.
 ensure_npm_package() {
   local pkg="$1"
 
   if npm ls -g "$pkg" --depth=0 &>/dev/null \
      && [ -z "$(npm outdated -g "$pkg" $UIPATH_REGISTRY_FLAG 2>/dev/null)" ]; then
-    echo "$pkg is already installed and up to date." >&2
     return
   fi
 
-  echo "Installing or updating $pkg globally..." >&2
-  if ! npm install -g $UIPATH_REGISTRY_FLAG "$pkg" 2>&1; then
-    echo "Failed to install $pkg. Please run: npm install -g $UIPATH_REGISTRY_FLAG $pkg" >&2
+  local output
+  if ! output="$(npm install -g $UIPATH_REGISTRY_FLAG "$pkg" 2>&1)"; then
+    echo "Failed to install $pkg:" >&2
+    echo "$output" >&2
+    echo "Please run manually: npm install -g $UIPATH_REGISTRY_FLAG $pkg" >&2
     exit 2
   fi
 }


### PR DESCRIPTION
## Summary
- Claude Code surfaces any stderr from an exit-0 SessionStart hook as `Failed with non-blocking status code: <text>`. Users were seeing `"@uipath/cli is already installed and up to date."` formatted as a hook failure even though `ensure-uip.sh` was exiting 0 cleanly.
- Drop the two informational `echo … >&2` lines on the happy path and capture `npm install -g` output so it is only emitted when the install actually fails. Real errors still write a multi-line stderr explanation and `exit 2`.
- Added an inline comment so a future reader does not innocently re-add helpful echoes and reintroduce the warning.

## Test plan
- [x] Run `bash hooks/ensure-uip.sh` with `@uipath/cli` and `@uipath/rpa-tool` already installed → exit 0, empty stdout, empty stderr.
- [ ] Start a fresh Claude Code session with the plugin loaded → confirm no `Failed with non-blocking status code` message appears.
- [ ] Force the install branch (e.g. `npm uninstall -g @uipath/cli` then re-run hook) → confirm install completes silently on success and that a forced failure still surfaces clear stderr + exit 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)