### PR TITLE
docs(uipath-platform): sync with CLI changes — users import, deploy auto-activate, project list, --name filter

### DIFF
--- a/skills/uipath-agents/references/lowcode/project-lifecycle.md
+++ b/skills/uipath-agents/references/lowcode/project-lifecycle.md
@@ -149,9 +149,11 @@ uip solution deploy run \
   --output json
 ```
 
-Creates folder, provisions resources, and activates. Polls until `DeploymentSucceeded`.
+Creates the folder, provisions resources, and activates the deployment in one call. A successful run returns `Status: DeploymentSucceeded` and `ActivationStatus: SuccessfulActivate`. Pass `--skip-activate` to opt out of auto-activation (legacy behaviour — leaves the deployment in `Inactive (Ready to activate)`).
 
 ### Activate Existing Deployment
+
+Run only when `--skip-activate` was passed during deploy, or to retry a failed auto-activation after fixing the underlying cause (e.g. missing config).
 
 ```bash
 uip solution deploy activate "<DEPLOYMENT_NAME>" --output json

--- a/skills/uipath-platform/references/orchestrator/setup-environment.md
+++ b/skills/uipath-platform/references/orchestrator/setup-environment.md
@@ -25,7 +25,7 @@ Create folders, assign users with roles, provision machines, and configure licen
 graph LR
     A[folders create] --> B[roles create-role]
     B --> C[roles edit-role<br/>add permissions]
-    C --> D[users create]
+    C --> D[users import]
     D --> E[users assign<br/>to folder + role]
     E --> F[machines create]
     F --> G[machines assign<br/>to folder]
@@ -102,21 +102,21 @@ Role types:
 - **Tenant** -- Applies across the entire tenant. Assigned via `uip or users assign-roles`.
 - **Folder** -- Applies only within specific folders. Assigned via `uip or users assign` or `uip or roles assign`.
 
-### Step 4: Create Users
+### Step 4: Import Users from Identity Service
 
-Create users at the tenant level. They exist tenant-wide but have no folder access until explicitly assigned.
+Users are managed in Identity Service (IS), not in Orchestrator. `users import` references an existing IS principal so the tenant can grant it folder access. (The legacy `users create` / `users delete` commands are gone — they called endpoints reserved for `ProvisionType=Manual`, which is not how cloud or IS-backed users are managed.)
 
 ```bash
-uip or users create --username "jane.doe@example.com" --output json
+uip or users import --username "jane.doe@example.com" --output json
 ```
 
 Key options:
-- `--role-keys <keys>` -- Comma-separated role GUIDs for tenant-level role assignment at creation time.
-- `--allow-unattended` -- Enable unattended job execution capability.
-- `--unattended-username <user>` / `--unattended-password <pass>` -- Windows credentials for unattended execution.
-- `--name <first>` / `--surname <last>` / `--email <email>` -- Profile fields.
+- `--directory-id <id>` -- Use the IS directory identifier (OIDC subject) instead of `--username`. Pass exactly one of the two.
+- `--domain <domain>` -- IS directory domain. Defaults to `default`. List configured domains via `GET /api/DirectoryService/GetDomains` if your tenant uses on-prem AD or a non-default IS realm.
+- `--type <type>` -- `DirectoryUser` (default) or `DirectoryGroup`.
+- `--folder-path <path>` / `--folder-key <key>` + `--role-keys <guids>` -- Optional. Imports the user **and** assigns folder roles in a single call. Both must be present together; pass neither for an import-only call. The next step covers folder assignment as a separate flow.
 
-Save the `Key` from the response for the next step.
+Save the `UserName` from the response and look up the `Key` via `users list` for the next step.
 
 ### Step 5: Assign Users to Folders
 
@@ -203,11 +203,9 @@ uip or roles edit-role r1r2r3r4-... \
   --add-permissions "Assets.View,Assets.Edit,Queues.View,Jobs.Create,Jobs.View,Processes.View" \
   --output json
 
-# 4. Create a user
-uip or users create --username "jane.doe@example.com" \
-  --name "Jane" --surname "Doe" --email "jane.doe@example.com" \
-  --allow-unattended --output json
-# Response: { "Data": { "Key": "u1u2u3u4-..." } }
+# 4. Import a user from Identity Service
+uip or users import --username "jane.doe@example.com" --output json
+# (Look up the assigned Key with: uip or users list --search "jane.doe")
 
 # 5. Assign user to folder with role
 uip or users assign \

--- a/skills/uipath-platform/references/resources/triggers-and-webhooks.md
+++ b/skills/uipath-platform/references/resources/triggers-and-webhooks.md
@@ -59,13 +59,19 @@ uip resource triggers create --type time \
   --name "WeekdayInvoiceRun" \
   --release-key <process-key> \
   --cron "0 0 9 ? * 1-5" \
-  --time-zone "UTC" \
+  --time-zone "Europe/Bucharest" \
   --runtime-type Unattended \
   --job-priority Normal \
   --folder-path "Finance" --output json
 ```
 
-Additional options: `--calendar-key` (skip holidays, from `uip or calendars list`), `--stop-strategy` (`SoftStop`|`Kill`), `--input-arguments` (JSON).
+`--time-zone` takes an IANA time zone ID (e.g. `UTC`, `Europe/Bucharest`, `America/Los_Angeles`).
+
+Additional options:
+- `--disabled` — create the trigger in disabled state (default is enabled). Useful when you want to stage triggers ahead of activation, then enable them in bulk via `triggers enable`.
+- `--calendar-key` — skip holidays, from `uip or calendars list`.
+- `--stop-strategy` — `SoftStop` or `Kill`.
+- `--input-arguments` — JSON-encoded input arguments map.
 
 ### Queue Trigger
 

--- a/skills/uipath-platform/references/solution/activate-and-manage.md
+++ b/skills/uipath-platform/references/solution/activate-and-manage.md
@@ -31,7 +31,11 @@ graph LR
 
 ## Step 1: Activate a Deployment
 
-Activate a deployment that was deployed without auto-activation. Activation provisions all solution components (processes, queues, assets, etc.) in the target folder:
+`solution deploy run` activates by default. Use `deploy activate` only when:
+- the deploy was started with `--skip-activate`, or
+- the previous activation failed (e.g. missing config) and you've fixed the cause and want to retry without redeploying.
+
+Activation provisions all solution components (processes, queues, assets, etc.) in the target folder:
 
 ```bash
 uip solution deploy activate "MyDeployment" --output json
@@ -86,6 +90,9 @@ uip solution packages list --output json
 
 # Paginate and sort
 uip solution packages list --take 20 --order-by "Name" --order-direction "asc" --output json
+
+# Filter by name (server-side substring match on the package name)
+uip solution packages list --name "Invoice" --output json
 ```
 
 | Option | Description | Default |

--- a/skills/uipath-platform/references/solution/develop-solution.md
+++ b/skills/uipath-platform/references/solution/develop-solution.md
@@ -68,7 +68,21 @@ Unregister a project from the `.uipx` manifest. Does NOT delete files from disk.
 uip solution project remove ./InvoiceAutomation/OldProject --output json
 ```
 
-## Step 5: List Resources
+## Step 5: List Projects
+
+Enumerate the projects registered in the local `.uipx` manifest. Reads only on-disk metadata — no backend call, so safe to use offline or in CI checks.
+
+```bash
+# from inside the solution dir
+uip solution project list --output json
+
+# or with an explicit solution folder
+uip solution project list --solution-folder ./InvoiceAutomation --output json
+```
+
+`Name` is read from each project's `project.uiproj`, falling back to the directory basename if the manifest is missing or unreadable. Empty solutions return `Data: []`.
+
+## Step 6: List Resources
 
 Show resources declared in the solution, available in Orchestrator, or both. Run from inside the solution directory (default), or pass `--solution-folder <path>` to target another location.
 
@@ -90,7 +104,7 @@ uip solution resource list --solution-folder ./InvoiceAutomation --output json
 | `--source <source>` | `all`, `local`, `remote` | `all` |
 | `--login-validity <minutes>` | Minimum minutes left on token before refresh | `10` |
 
-## Step 6: Refresh Resources
+## Step 7: Refresh Resources
 
 Re-scan all projects and sync resource declarations from their `bindings_v2.json` files. Refresh is the only way to reconcile a solution's local artefacts with cloud entities — run it after adding/importing projects, after editing `bindings_v2.json`, or before any `pack` / `upload`.
 
@@ -137,7 +151,7 @@ When a name (e.g. `orders` queue) exists in multiple cloud folders, refresh pref
 
 The placeholder `solution_folder` (and `.`) in a binding's folder field means "no folder" / tenant scope — they're not real cloud folders.
 
-## Step 7: Get a Single Resource Configuration
+## Step 8: Get a Single Resource Configuration
 
 Fetch the full configuration (`spec`, `apiVersion`, `isOverridable`, `resourceOverwrite`) for a specific resource by key. Useful when you need the resolved server state for a binding — e.g., constructing a deploy override, resolving an entry-point ID, inspecting a connection's authentication mode.
 
@@ -181,7 +195,7 @@ If you need the full server spec for a resource that's already in the solution (
 
 `list --source remote` returns entities from RCS that are **visible to your user** — including ones not bound to this solution. `get` is solution-context-aware: it considers anything in your `.uipx`'s solution_folder as "local", and falls back to RCS for everything else. A key shown by `list --source remote` that isn't bound to the solution will resolve via the FPS fallback.
 
-## Step 8: Upload to Studio Web
+## Step 9: Upload to Studio Web
 
 Upload the solution for browser-based editing. Accepts a directory, `.uipx` file, or `.uis` archive.
 
@@ -191,7 +205,7 @@ uip solution upload ./InvoiceAutomation --output json
 
 If the `SolutionId` in `.uipx` matches an existing Studio Web solution, the upload overwrites it.
 
-## Step 9: Delete from Studio Web
+## Step 10: Delete from Studio Web
 
 Remove a solution from Studio Web by its UUID (returned by `upload`).
 

--- a/skills/uipath-platform/references/solution/pack-and-deploy.md
+++ b/skills/uipath-platform/references/solution/pack-and-deploy.md
@@ -22,10 +22,11 @@ graph LR
     A[solution pack] --> B[solution publish]
     B --> C[deploy config get]
     C --> D[config set / link]
-    D --> E[deploy run]
+    D --> E["deploy run<br/>(auto-activate by default)"]
     B --> E
     E --> F[deploy status]
     E --> G[deploy list]
+    E -->|--skip-activate| H[deploy activate]
 ```
 
 ---
@@ -75,12 +76,20 @@ This uploads to Studio Web for collaborative editing. It does **not** place the 
 
 ## Step 4: Deploy to Orchestrator
 
-Deploy the published package. This creates a new Orchestrator folder and provisions all solution resources inside it:
+Deploy the published package. By default this creates a new Orchestrator folder, provisions all solution resources, **and activates the deployment** in one call:
 
 ```bash
 uip solution deploy run -n "InvoiceAutomation-v2" \
   --package-name "MySolution" --package-version "2.0.0" \
   --folder-name "MySolutionFolder" --output json
+```
+
+A successful run returns `Status: DeploymentSucceeded` and `ActivationStatus: SuccessfulActivate`. If the package requires configuration before it can activate, deploy still succeeds but activation surfaces an explicit error pointing at `deploy activate <name>` — fix the config and retry the activate.
+
+To skip auto-activation (legacy behaviour — leaves the deployment in `Inactive (Ready to activate)`):
+
+```bash
+uip solution deploy run … --skip-activate --output json
 ```
 
 Key options:
@@ -94,8 +103,9 @@ Key options:
 | `--folder-path <path>` | Parent folder under which the new folder is created | -- |
 | `--folder-key <key>` | Parent folder key (GUID, alternative to `--folder-path`) | -- |
 | `--config-file <path>` | Configuration file from `deploy config get` | -- |
-| `--timeout <seconds>` | Polling timeout | 360 |
-| `--poll-interval <ms>` | Polling interval | 5000 |
+| `--skip-activate` | Skip the post-deploy activation; leaves the deployment in `Inactive (Ready to activate)` | (off — auto-activate) |
+| `--timeout <seconds>` | Polling timeout, applied per phase (deploy and, when not skipped, activate) | 360 |
+| `--poll-interval <ms>` | Polling interval used during both phases | 5000 |
 | `-t, --tenant <name>` | Tenant override | Current tenant |
 
 ## Step 5: Check Deployment Status
@@ -106,12 +116,7 @@ The `deploy run` command returns a pipeline deployment ID. Use it to check progr
 uip solution deploy status <pipeline-deployment-id> --output json
 ```
 
-> **Heads up:** `deploy run`'s polling is unreliable for long-running deployments. The CLI may print
-> `Result: Failure / Deployment polling failed: Response returned an error code` and `deploy status`
-> may then return `HTTP 404 Pipeline deployment not found` even when the deployment **succeeded**
-> server-side (the pipeline record can expire shortly after completion). Always cross-check with
-> `solution deploy list` and look up the deployment by name before treating a polling failure as a
-> real error.
+The CLI also falls back to the persistent `searchSearchDeployments22` record if the pipeline service has already recycled the in-flight tracking ID — so a deployment that finishes while the CLI is between polls is still surfaced as `DeploymentSucceeded` rather than a polling failure.
 
 ## Step 6: List Deployments
 

--- a/skills/uipath-platform/references/solution/pack-and-deploy.md
+++ b/skills/uipath-platform/references/solution/pack-and-deploy.md
@@ -260,10 +260,6 @@ These are different commands with different destinations:
 
 On `deploy run`, `--folder-path` is the **parent** folder, not the deployment folder itself. The deployment folder is `--folder-name`, created inside `--folder-path`. To produce a nested layout like `Shared/Nica/Solution`, pre-create `Shared/Nica` (or use a previous deploy to make it) and pass `--folder-path "Shared/Nica" --folder-name "Solution"`.
 
-### Polling false-positives on `deploy run`
-
-`deploy run` may report `Failure / Deployment polling failed` even when the deployment succeeded — the pipeline ID expires after completion and `deploy status` then 404s. Always verify with `solution deploy list` (look up the deployment by name + check `OperationStatus`) before treating it as a real error. CI scripts should fall back to `deploy list` on polling failure rather than failing the pipeline.
-
 ### Config `link` Connects to Existing Resources
 
 `config link` does not copy or move a resource. It tells the deployment to use an existing Orchestrator resource instead of creating a new one. The linked resource must already exist in the specified folder.

--- a/skills/uipath-platform/references/solution/solution.md
+++ b/skills/uipath-platform/references/solution/solution.md
@@ -37,8 +37,8 @@ graph LR
     B --> C[resource refresh]
     C --> D[pack]
     D --> E[publish]
-    E --> F[deploy run]
-    F --> G[activate]
+    E --> F["deploy run<br/>(auto-activate by default)"]
+    F -->|--skip-activate| G[activate]
     C --> H[upload]
 ```
 
@@ -62,16 +62,17 @@ uip solution
   ├── project
   │     ├── add <projectPath> [solutionFile]    Register an existing subfolder in .uipx
   │     ├── remove <projectPath> [solutionFile] Unregister a project from .uipx
-  │     └── import --source <path>              Copy external project into solution and register
+  │     ├── import --source <path>              Copy external project into solution and register
+  │     └── list                                List projects registered in the local .uipx (no backend call)
   ├── resource
   │     ├── list                          List local, remote, or all resources (--solution-folder, default cwd)
   │     ├── refresh                       Sync resource declarations from project bindings (--solution-folder, default cwd)
   │     └── get <resource-key>            Get full configuration for a single resource — local or remote (--solution-folder, default cwd)
   ├── deploy
-  │     ├── run -n <name>                 Deploy a published solution package
+  │     ├── run -n <name>                 Deploy a published solution package (auto-activates by default; pass --skip-activate to opt out)
   │     ├── status <id>                   Check deployment status
   │     ├── list                          List deployments
-  │     ├── activate <name>               Activate a deployment
+  │     ├── activate <name>               Activate a deployment (only needed after --skip-activate or to retry a failed auto-activation)
   │     ├── uninstall <name>              Uninstall a deployment
   │     └── config
   │           ├── get <package-name>      Fetch default deploy config


### PR DESCRIPTION
## Summary

Sync the `uipath-platform` skill references with two recent CLI changes:

- **[UiPath/cli#1365](https://github.com/UiPath/cli/pull/1365)** — easy-wins batch (timezone IANA, triggers `--disabled`, queues retention enum, `solution project list`, `solution packages list --name`, `solution deploy run` auto-activate by default + polling fix).
- **[UiPath/cli#1423](https://github.com/UiPath/cli/pull/1423)** (OR-92643) — replaces legacy `users create`/`delete` with `users import` (calls `AssignDirectoryUser` endpoint, references an existing IS principal).

## Files changed

| File | Change |
|---|---|
| `setup-environment.md` | `users create` → `users import` (text, mermaid, complete-example block); add option list with `--directory-id` / `--domain` / `--type` / folder + role flags |
| `pack-and-deploy.md` | `deploy run` activates by default; document `--skip-activate`; drop the stale "polling is unreliable" warning (now fixed via search-API fallback); update flow diagram |
| `activate-and-manage.md` | Clarify `deploy activate` is needed only after `--skip-activate` or to retry a failed auto-activation; add `packages list --name <pattern>` server-side filter |
| `develop-solution.md` | New "Step 5: List Projects" section for `solution project list`; renumber subsequent steps |
| `triggers-and-webhooks.md` | Document new `--disabled` flag on `triggers create`; change example `--time-zone` from `UTC` to `Europe/Bucharest` so IANA expectation is obvious |

## Notes

- Queues retention action documentation in `process-queues.md` was already correct (lists `Delete, Archive, None` with default) — no change needed.
- Other resource-tool / agent-tool / solution-design skills had no references to the changed commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)