### PR TITLE
feat(case-tool): add troubleshooting step for failed cases

### DIFF
--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -84,6 +84,7 @@ Re-read `tasks.md` AND `caseplan.json` (Step 9.6). Then:
 | Edit caseplan.json directly | [references/case-editing-operations.md](references/case-editing-operations.md) |
 | Case JSON schema | [references/case-schema.md](references/case-schema.md) |
 | Surviving CLI commands (registry, validate, debug, runtime) | [references/case-commands.md](references/case-commands.md) |
+| Troubleshoot a failed case | [references/troubleshooting-guide.md](references/troubleshooting-guide.md) |
 | Resolve task types from registry | [references/registry-discovery.md](references/registry-discovery.md) |
 | Wire inputs/outputs + cross-task refs + expression prefixes | [references/bindings-and-expressions.md](references/bindings-and-expressions.md) |
 | Configure connector activity / trigger / event | [references/connector-integration.md](references/connector-integration.md) |

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -228,6 +228,16 @@ Requires `uip login`. Uploads to Studio Web, runs in Orchestrator, streams resul
 
 When a debug or process run fails, read **[troubleshooting-guide.md](troubleshooting-guide.md)**. Diagnostic priority: incidents → runtime variables → caseplan.json correlation → traces (last resort).
 
+**Diagnose → fix → re-run loop.** After each diagnostic pass, classify the root cause and act:
+
+1. **Fixable in `caseplan.json`** (wrong binding, missing condition, malformed expression, incorrect input value): apply the targeted fix via the matching plugin's `impl-json.md`, re-run `uip maestro case validate`, then re-run Step 14 debug.
+2. **Fixable outside `caseplan.json`** (missing/expired connection, unregistered task type, missing Orchestrator asset, permissions): halt agent edits. Report exact resource + remediation steps to the user via **AskUserQuestion** with options — `Resource fixed, re-run debug`, `Abort`.
+3. **Inconclusive** (no actionable cause): proceed to next round per retry policy.
+
+**Retry policy.** Up to 3 troubleshoot → fix → debug rounds per failed run. Each round must add new context (different element ID, broader scope, fallback command) or apply a different fix — do not repeat identical commands or re-apply the same fix. Track round count.
+
+After the 3rd inconclusive round (or 3rd debug failure post-fix), halt and ask the user with **AskUserQuestion**. Report: instance ID, folder key, incident IDs/messages, faulting element ID, variable snapshot, what was tried each round. Options — `Provide additional context` (user supplies hints; run one more targeted round), `Pause for manual investigation`, `Abort`. Do not propose `caseplan.json` edits without confirmed cause.
+
 ## Step 15 — Optional: Publish to Studio Web
 
 **Default publish target.** Uploads the case to Studio Web for visualization and editing.

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -226,7 +226,7 @@ Requires `uip login`. Uploads to Studio Web, runs in Orchestrator, streams resul
 
 ## Step 14a — Troubleshoot failed case
 
-When a debug or process run fails, read **[references/troubleshooting-guide.md](references/troubleshooting-guide.md)**. Diagnostic priority: incidents → runtime variables → caseplan.json correlation → traces (last resort).
+When a debug or process run fails, read **[troubleshooting-guide.md](troubleshooting-guide.md)**. Diagnostic priority: incidents → runtime variables → caseplan.json correlation → traces (last resort).
 
 ## Step 15 — Optional: Publish to Studio Web
 

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -224,6 +224,10 @@ uip maestro case debug "<directory>/<solutionName>/<projectName>" --log-level de
 
 Requires `uip login`. Uploads to Studio Web, runs in Orchestrator, streams results.
 
+## Step 14a — Troubleshoot failed case
+
+When a debug or process run fails, read **[references/troubleshooting-guide.md](references/troubleshooting-guide.md)**. Diagnostic priority: incidents → runtime variables → caseplan.json correlation → traces (last resort).
+
 ## Step 15 — Optional: Publish to Studio Web
 
 **Default publish target.** Uploads the case to Studio Web for visualization and editing.

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -236,6 +236,8 @@ When a debug or process run fails, read **[troubleshooting-guide.md](troubleshoo
 
 **Retry policy.** Up to 3 troubleshoot → fix → debug rounds per failed run. Each round must add new context (different element ID, broader scope, fallback command) or apply a different fix — do not repeat identical commands or re-apply the same fix. Track round count.
 
+**Per-round timeout.** If a debug run exceeds 10 minutes wall-clock, treat the round as inconclusive and advance to the next round (counts toward the 3-round limit). Advisory — do not hard-kill the subprocess; classify by elapsed time and move on.
+
 After the 3rd inconclusive round (or 3rd debug failure post-fix), halt and ask the user with **AskUserQuestion**. Report: instance ID, folder key, incident IDs/messages, faulting element ID, variable snapshot, what was tried each round. Options — `Provide additional context` (user supplies hints; run one more targeted round), `Pause for manual investigation`, `Abort`. Do not propose `caseplan.json` edits without confirmed cause.
 
 ## Step 15 — Optional: Publish to Studio Web

--- a/skills/uipath-maestro-case/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-case/references/troubleshooting-guide.md
@@ -23,6 +23,8 @@ uip maestro case job status <JOB_KEY> --output json
 
 Parse the instance ID and folder key from the response.
 
+> **No instance ID / `job status` fails →** halt. Report job key to user; downstream steps need the instance ID.
+
 ## Step 2 — Fetch incidents
 
 Failed cases always have an incident. Start here — incidents give you the error category, message, and the faulting element.
@@ -49,6 +51,8 @@ For all incidents on a specific case process:
 uip maestro case processes incidents <PROCESS_KEY> --folder-key <FOLDER_KEY> --output json
 ```
 
+> **Empty incidents →** skip to Step 3. **Invalid instance ID error →** recheck Step 1 output.
+
 ## Step 3 — Fetch runtime variable state
 
 Get the variable values at the time of failure to understand what data each stage/task was working with:
@@ -63,6 +67,8 @@ Scope to a specific element (stage or task):
 uip maestro case instance variables <INSTANCE_ID> --folder-key <FOLDER_KEY> --parent-element-id <ELEMENT_ID> --output json
 ```
 
+> **Empty variables →** skip to Step 4.
+
 ## Step 4 — Correlate with the case definition
 
 Use the incident's faulting element ID and the variable state to locate the failure point in `caseplan.json`. Map the element ID to the corresponding stage, task, edges etc., check its `data.inputs[]`, upstream edges, and the variable values flowing into it.
@@ -72,6 +78,8 @@ If the local `caseplan.json` may differ from what was deployed, fetch the deploy
 ```bash
 uip maestro case instance asset <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json
 ```
+
+> **`instance asset` fails →** fall back to local `caseplan.json`.
 
 Additional instance inspection commands:
 
@@ -90,6 +98,14 @@ uip maestro case job traces <JOB_KEY> --pretty                  # human-readable
 ```
 
 > **Always use CLI commands for troubleshooting — never call the underlying APIs directly.**
+
+## Stop conditions
+
+1. **Stop early on root cause.** Once a step yields actionable cause (error + faulting element + variable state), stop. Skip remaining steps.
+2. **Empty result → next step.** If a step returns empty/missing data, move to the next step. Do not retry the same command.
+3. **One retry on transient failure** (auth, network). Second failure: halt that step, continue.
+4. **Max one full pass through Steps 1–5.** No looping.
+5. **Escalate to user** if Steps 1–5 yield no root cause, or all paths blocked. Report: instance ID, folder key, incident IDs/messages, faulting element ID, variable snapshot. Do not propose `caseplan.json` edits without confirmed cause.
 
 ## CLI command reference
 

--- a/skills/uipath-maestro-case/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-case/references/troubleshooting-guide.md
@@ -1,0 +1,143 @@
+# Troubleshooting Failed Cases
+
+Diagnostic workflow for failed debug runs and deployed case process runs. All commands require `uip login`.
+
+> **`--folder-key` is required for `incident get`.** Most `instance` subcommands accept `--folder-key <FOLDER_KEY>` and auto-detect from the authenticated folder if omitted, but `incident get` requires it explicitly. Get the folder key from `uip orchestrator folder list --output json` or from the job/process context.
+
+## Diagnostic priority
+
+Investigate in this order — each step adds context, stop when you have enough to diagnose the root cause:
+
+1. Incidents (error message + faulting element)
+2. Runtime variables (data state at failure)
+3. Case definition correlation (map element to `caseplan.json` node)
+4. Traces (last resort — verbose full timeline)
+
+## Step 1 — Get the instance ID
+
+The debug output (`Data.instanceId`) or `job status` response contains the instance ID. If you only have a job key:
+
+```bash
+uip maestro case job status <JOB_KEY> --output json
+```
+
+Parse the instance ID and folder key from the response.
+
+## Step 2 — Fetch incidents
+
+Failed cases always have an incident. Start here — incidents give you the error category, message, and the faulting element.
+
+```bash
+uip maestro case instance incidents <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json
+```
+
+Drill into a specific incident for full detail:
+
+```bash
+uip maestro case incident get <INCIDENT_ID> --folder-key <FOLDER_KEY> --output json
+```
+
+To get a cross-process incident overview:
+
+```bash
+uip maestro case incident summary --output json
+```
+
+For all incidents on a specific case process:
+
+```bash
+uip maestro case processes incidents <PROCESS_KEY> --folder-key <FOLDER_KEY> --output json
+```
+
+## Step 3 — Fetch runtime variable state
+
+Get the variable values at the time of failure to understand what data each stage/task was working with:
+
+```bash
+uip maestro case instance variables <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json
+```
+
+Scope to a specific element (stage or task):
+
+```bash
+uip maestro case instance variables <INSTANCE_ID> --folder-key <FOLDER_KEY> --parent-element-id <ELEMENT_ID> --output json
+```
+
+## Step 4 — Correlate with the case definition
+
+Use the incident's faulting element ID and the variable state to locate the failure point in `caseplan.json`. Map the element ID to the corresponding stage, task, edges etc., check its `data.inputs[]`, upstream edges, and the variable values flowing into it.
+
+If the local `caseplan.json` may differ from what was deployed, fetch the deployed case definition:
+
+```bash
+uip maestro case instance asset <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json
+```
+
+Additional instance inspection commands:
+
+```bash
+uip maestro case instance element-executions <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json  # per-element execution details
+uip maestro case instance cursors <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json             # current execution cursor positions
+```
+
+## Step 5 — Traces (last resort)
+
+Traces are verbose but contain the full execution timeline. Use them only when incidents and variables are insufficient:
+
+```bash
+uip maestro case job traces <JOB_KEY> --output json
+uip maestro case job traces <JOB_KEY> --pretty                  # human-readable form
+```
+
+> **Always use CLI commands for troubleshooting — never call the underlying APIs directly.**
+
+## CLI command reference
+
+### uip maestro case instance
+
+Inspect and manage Case process instances. **Requires `uip login`.** Most subcommands accept `--folder-key <FOLDER_KEY>` (`-f` shorthand) and auto-detect the folder when omitted.
+
+```bash
+uip maestro case instance list --output json                                                        # list all instances
+uip maestro case instance get <INSTANCE_ID> -f <FOLDER_KEY> --output json                           # get instance details
+uip maestro case instance incidents <INSTANCE_ID> -f <FOLDER_KEY> --output json                     # get incidents for a failed instance
+uip maestro case instance variables <INSTANCE_ID> -f <FOLDER_KEY> --output json                     # get runtime variable values
+uip maestro case instance variables <INSTANCE_ID> -f <FOLDER_KEY> --parent-element-id <ELEMENT_ID> --output json  # scope to a specific element
+uip maestro case instance element-executions <INSTANCE_ID> -f <FOLDER_KEY> --output json            # get per-element execution details
+uip maestro case instance asset <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # get the deployed Case JSON definition
+uip maestro case instance cursors <INSTANCE_ID> -f <FOLDER_KEY> --output json                       # get current execution cursor positions
+```
+
+Instance lifecycle commands:
+
+```bash
+uip maestro case instance pause <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # pause a running instance
+uip maestro case instance resume <INSTANCE_ID> -f <FOLDER_KEY> --output json                        # resume a paused instance
+uip maestro case instance cancel <INSTANCE_ID> -f <FOLDER_KEY> --output json                        # cancel an instance
+uip maestro case instance retry <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # retry a faulted instance
+uip maestro case instance migrate <INSTANCE_ID> <NEW_VERSION> -f <FOLDER_KEY> --output json         # migrate to a new package version
+uip maestro case instance goto <INSTANCE_ID> '[{"sourceElementId":"A","targetElementId":"B"}]' -f <FOLDER_KEY> --output json  # move execution cursor
+```
+
+### uip maestro case incident
+
+Get incident details for failed cases. **Requires `uip login`.**
+
+```bash
+uip maestro case incident summary --output json                                     # get incident summaries across all processes
+uip maestro case incident get <INCIDENT_ID> --folder-key <FOLDER_KEY> --output json # get full details for a specific incident
+```
+
+Use `instance incidents <INSTANCE_ID>` to get incidents scoped to a specific run, then `incident get <INCIDENT_ID>` for full detail on a specific incident. Use `processes incidents <PROCESS_KEY>` for all incidents on a process across all runs.
+
+### uip maestro case job
+
+Monitor case jobs. **Requires `uip login`.**
+
+```bash
+uip maestro case job status <JOB_KEY> --output json                                 # get job status (parse instanceId, folderKey)
+uip maestro case job status <JOB_KEY> --detailed --output json                      # full response with all fields
+uip maestro case job traces <JOB_KEY> --output json                                 # stream raw execution traces
+uip maestro case job traces <JOB_KEY> --pretty                                      # human-readable trace output
+uip maestro case job traces <JOB_KEY> --poll-interval 5000                          # adjust poll interval (ms)
+```

--- a/skills/uipath-maestro-case/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-case/references/troubleshooting-guide.md
@@ -93,51 +93,11 @@ uip maestro case job traces <JOB_KEY> --pretty                  # human-readable
 
 ## CLI command reference
 
-### uip maestro case instance
+For full flag tables and all subcommands, see [case-commands.md](case-commands.md):
 
-Inspect and manage Case process instances. **Requires `uip login`.** Most subcommands accept `--folder-key <FOLDER_KEY>` (`-f` shorthand) and auto-detect the folder when omitted.
+- `uip maestro case instance` — list/get/incidents/variables/asset/cursors/element-executions and lifecycle (pause/resume/cancel/retry/migrate/goto)
+- `uip maestro case incident` — `summary`, `get`
+- `uip maestro case processes incidents <PROCESS_KEY>` — all incidents on a process
+- `uip maestro case job` — `status`, `traces`
 
-```bash
-uip maestro case instance list --output json                                                        # list all instances
-uip maestro case instance get <INSTANCE_ID> -f <FOLDER_KEY> --output json                           # get instance details
-uip maestro case instance incidents <INSTANCE_ID> -f <FOLDER_KEY> --output json                     # get incidents for a failed instance
-uip maestro case instance variables <INSTANCE_ID> -f <FOLDER_KEY> --output json                     # get runtime variable values
-uip maestro case instance variables <INSTANCE_ID> -f <FOLDER_KEY> --parent-element-id <ELEMENT_ID> --output json  # scope to a specific element
-uip maestro case instance element-executions <INSTANCE_ID> -f <FOLDER_KEY> --output json            # get per-element execution details
-uip maestro case instance asset <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # get the deployed Case JSON definition
-uip maestro case instance cursors <INSTANCE_ID> -f <FOLDER_KEY> --output json                       # get current execution cursor positions
-```
-
-Instance lifecycle commands:
-
-```bash
-uip maestro case instance pause <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # pause a running instance
-uip maestro case instance resume <INSTANCE_ID> -f <FOLDER_KEY> --output json                        # resume a paused instance
-uip maestro case instance cancel <INSTANCE_ID> -f <FOLDER_KEY> --output json                        # cancel an instance
-uip maestro case instance retry <INSTANCE_ID> -f <FOLDER_KEY> --output json                         # retry a faulted instance
-uip maestro case instance migrate <INSTANCE_ID> <NEW_VERSION> -f <FOLDER_KEY> --output json         # migrate to a new package version
-uip maestro case instance goto <INSTANCE_ID> '[{"sourceElementId":"A","targetElementId":"B"}]' -f <FOLDER_KEY> --output json  # move execution cursor
-```
-
-### uip maestro case incident
-
-Get incident details for failed cases. **Requires `uip login`.**
-
-```bash
-uip maestro case incident summary --output json                                     # get incident summaries across all processes
-uip maestro case incident get <INCIDENT_ID> --folder-key <FOLDER_KEY> --output json # get full details for a specific incident
-```
-
-Use `instance incidents <INSTANCE_ID>` to get incidents scoped to a specific run, then `incident get <INCIDENT_ID>` for full detail on a specific incident. Use `processes incidents <PROCESS_KEY>` for all incidents on a process across all runs.
-
-### uip maestro case job
-
-Monitor case jobs. **Requires `uip login`.**
-
-```bash
-uip maestro case job status <JOB_KEY> --output json                                 # get job status (parse instanceId, folderKey)
-uip maestro case job status <JOB_KEY> --detailed --output json                      # full response with all fields
-uip maestro case job traces <JOB_KEY> --output json                                 # stream raw execution traces
-uip maestro case job traces <JOB_KEY> --pretty                                      # human-readable trace output
-uip maestro case job traces <JOB_KEY> --poll-interval 5000                          # adjust poll interval (ms)
-```
+Append `--output json` to any command whose output you parse.


### PR DESCRIPTION
Adds references/troubleshooting-guide.md covering the diagnostic priority
(incidents → variables → caseplan correlation → traces) and the CLI
reference for `uip maestro case instance`, `incident`, and `job`. Links
the guide from SKILL.md's reference table and from implementation.md's
Step 14a.
