### PR TITLE
fix(uipath-maestro-flow): source connector endpoint from connectorMethodInfo.path

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -377,13 +377,28 @@ When not using `uip maestro flow node configure`, you must manually set up:
       "method": "<HTTP_METHOD>",
       "endpoint": "<API_PATH>",
       "bodyParameters": { "<FIELD>": "<VALUE>" },
-      "queryParameters": { "<FIELD>": "<VALUE>" }
+      "queryParameters": { "<FIELD>": "<VALUE>" },
+      "pathParameters": { "<PLACEHOLDER>": "<VALUE>" }
     }
   }
 }
 ```
 
-The `method` and `endpoint` come from `connectorMethodInfo` in the `registry get --connection-id` response.
+Source `method`, `endpoint`, and `bodyParameters` / `queryParameters` / `pathParameters` field names from either of these (both read the same upstream IS metadata):
+
+From `uip maestro flow registry get <nodeType> --connection-id <id> --output json`:
+- `method` ← `connectorMethodInfo.method`
+- `endpoint` ← `connectorMethodInfo.path`
+- `bodyParameters.<name>` ← `inputDefinition.fields[].name`
+- `queryParameters.<name>` ← `connectorMethodInfo.parameters[]` where `type: query`
+- `pathParameters.<name>` ← `connectorMethodInfo.parameters[]` where `type: path` (must match a `{placeholder}` in `endpoint`)
+
+From `uip is resources describe <connector-key> <objectName> --connection-id <id> --operation <Op> --output json`:
+- `method` ← `availableOperations[].method`
+- `endpoint` ← `availableOperations[].path`
+- `bodyParameters.<name>` ← `requestFields[].name`
+- `queryParameters.<name>` ← `parameters[]` where `type: query`
+- `pathParameters.<name>` ← `parameters[]` where `type: path` (must match a `{placeholder}` in `endpoint`)
 
 ### 2. Connection binding in `bindings_v2.json`
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -11,10 +11,11 @@ For generic node/edge add, delete, and wiring procedures, see [editing-operation
 3. **`inputs.detail` object** — connector nodes store operation-specific configuration in `inputs.detail`, populated by `uip maestro flow node configure`:
    - `connectionId` — the bound IS connection UUID
    - `folderKey` — the Orchestrator folder key
-   - `method` — HTTP method from `connectorMethodInfo` (e.g., `POST`)
-   - `endpoint` — API path from `connectorMethodInfo` (e.g., `/issues`)
-   - `bodyParameters` — field-value pairs for the request body
-   - `queryParameters` — field-value pairs for query string parameters
+   - `method` — HTTP method from `registry get` → `connectorMethodInfo.method` (e.g., `POST`)
+   - `endpoint` — API path. Read `connectorMethodInfo.path` (from `registry get`) or `availableOperations[].path` (from `is resources describe`).
+   - `bodyParameters` — field-value pairs for the request body. Read field names from `inputDefinition.fields[].name` (`registry get`) or `requestFields[].name` (`is resources describe`).
+   - `queryParameters` — field-value pairs for query string parameters. Read from `connectorMethodInfo.parameters[]` where `type: query` (`registry get`) or `parameters[]` (`is resources describe`).
+   - `pathParameters` — field-value pairs for path placeholders in `endpoint` (e.g. `{conversationsInfoId}`). Read from `connectorMethodInfo.parameters[]` where `type: path` (`registry get`) or `parameters[]` (`is resources describe`).
 
 ---
 
@@ -54,7 +55,7 @@ uip maestro flow registry get <nodeType> --connection-id <connection-id> --outpu
 
 This returns enriched `inputDefinition.fields` and `outputDefinition.fields` with accurate type, required, description, enum, and `reference` info. Without `--connection-id`, only standard/base fields are returned.
 
-The response also includes `connectorMethodInfo` with the real HTTP `method` (e.g. `GET`, `POST`) and `path` template (e.g. `/ConversationsInfo/{conversationsInfoId}`). **Save these two values** — you must pass them to `node configure` later.
+The response also includes `connectorMethodInfo` with the real HTTP `method` (e.g. `GET`, `POST`) and `path` template (e.g. `/ConversationsInfo/{conversationsInfoId}`). **Save `connectorMethodInfo.method` and `connectorMethodInfo.path`** — you must pass them to `node configure` later as `method` and `endpoint`.
 
 ### Step 3 — Describe the resource and read full metadata
 
@@ -71,9 +72,9 @@ cat <metadataFile path from response>
 ```
 
 The full metadata contains:
+- **`availableOperations[].method`** and **`availableOperations[].path`** — HTTP method and API endpoint path. Same value as `connectorMethodInfo.method` / `.path` from `registry get`.
 - **`parameters`** — query and path parameters (may include required params not in `requestFields`, e.g. `send_as` for Slack)
-- **`requestFields`** — body fields with `type`, `required`, `description`, and `reference` objects for ID resolution
-- **`path`** — the API endpoint path (also available in `connectorMethodInfo` from `registry get`)
+- **`requestFields`** — body fields with `name`, `type`, `required`, `description`, and `reference` objects for ID resolution. Pair these field names with the `path` above (e.g. `messageToSend` for Slack `/send_message_to_channel_v2`).
 - **`responseFields`** — response schema
 
 ### Step 4 — Resolve reference fields
@@ -156,7 +157,14 @@ uip maestro flow node configure <file> <nodeId> \
   --output json
 ```
 
-The `method` and `endpoint` values come from `connectorMethodInfo` in the `registry get` response (Step 2). The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names. For FilterBuilder params, see Step 6a.
+**Source of truth for `method` and `endpoint`** — pick either (both read the same upstream IS metadata):
+
+- `registry get` (Step 2) → `connectorMethodInfo.method` and `connectorMethodInfo.path`
+- `is resources describe ... --operation <Op>` (Step 3) → `availableOperations[].method` and `availableOperations[].path`
+
+Body field names in `bodyParameters` come from `inputDefinition.fields[].name` (`registry get`) or `requestFields[].name` (`is resources describe`).
+
+The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names. For FilterBuilder params, see Step 6a.
 
 > **Do not use `filterExpression`** — that field is the trigger / JMESPath path. See [connector-trigger/impl.md](../connector-trigger/impl.md#filter-trees).
 


### PR DESCRIPTION
## Summary
- Document `method`/`endpoint`/`bodyParameters`/`queryParameters`/`pathParameters` field-name sources from both `uip maestro flow registry get` and `uip is resources describe`
- Add `pathParameters` to the `inputs.detail` JSON example in `editing-operations-json.md` with a note that keys must match `{placeholder}` tokens in `endpoint`
- Replace vague "comes from `connectorMethodInfo`" with explicit `connectorMethodInfo.method` / `connectorMethodInfo.path` references
- Rebased onto the post-#505 capability restructure (`references/` moved under `author/references/`)

Replaces #488 (which targeted the pre-restructure paths).

## Test plan
- [ ] Verify the `pathParameters` example placeholder syntax is consistent with existing examples elsewhere in the skill
- [ ] Skim `editing-operations-json.md` Direct JSON section end-to-end — confirm no broken references after the additions
- [ ] Skim `plugins/connector/impl.md` Steps 2, 3, 6 — confirm the source-of-truth notes reinforce (rather than contradict) each other