### PR TITLE
feat(uipath-maestro-flow): uip command checker and fixes

### DIFF
--- a/skills/uipath-maestro-flow/.maintenance/README.md
+++ b/skills/uipath-maestro-flow/.maintenance/README.md
@@ -168,7 +168,7 @@ Returns `plugins_checked=N missing_files=M`. Exits non-zero if any plugin folder
 
 ## Verifying `uip` command references
 
-Run the uip-command checker to verify every `uip ...` invocation in fenced code blocks resolves to a real command in the installed CLI:
+Run the uip-command checker to verify every `uip ...` invocation resolves to a real command in the installed CLI:
 
 ```bash
 bash .maintenance/check-uip-commands.sh
@@ -178,7 +178,8 @@ Returns `commands_checked=N unknown=M`. Exits non-zero if any referenced command
 
 The checker:
 
-- Scans only fenced code blocks tagged `bash`, `sh`, `shell`, `zsh`, `console`, or unlabelled. Inline backtick references like `` `uip maestro flow init` `` are skipped (out of scope for v1).
+- Scans `SKILL.md` and `references/**/*.md`. Skips `.maintenance/` and root-level scratch files (`PLAN.md`, `PR_BODY.md`).
+- Scans both **fenced code blocks** tagged `bash`, `sh`, `shell`, `zsh`, `console`, or unlabelled, **and inline backtick spans** like `` `uip maestro flow init` ``. Inline scanning catches doc-narrative drift that fenced-only scanning misses.
 - Stops the path at the first flag, placeholder (`<...>`), shell metachar, comment (`#`), path-literal, or non-kebab-case token — so positional args like `uip maestro flow registry search outlook` don't get mistreated as subcommands.
 - Treats trailing tokens after a leaf-with-positional-args (e.g. `uip maestro flow registry search <keyword>`) as arguments, not missing subcommands.
 - Falls back gracefully if `uip` is not installed: warns and exits 0. Pass `--strict` to fail in CI.
@@ -187,6 +188,20 @@ Pass specific files to scan only those (e.g. for pre-commit on staged files):
 
 ```bash
 bash .maintenance/check-uip-commands.sh references/shared/cli-commands.md
+```
+
+### Skipping intentional historical references
+
+Some docs reference removed commands on purpose — for example, a CLI version-comparison table that documents a pre-restructure prefix. Add `<!-- uip-check-skip -->` anywhere on the line to suppress checking for that line:
+
+```markdown
+> Replace `uip maestro flow` with `uip flow` if version < 0.3.4. <!-- uip-check-skip -->
+```
+
+For table rows, place the marker **inside a cell** so it doesn't break table structure (HTML comments render as nothing):
+
+```markdown
+| **< 0.3.4** | `uip flow` | `uip flow init MyProject` <!-- uip-check-skip --> |
 ```
 
 ## Running the full suite

--- a/skills/uipath-maestro-flow/.maintenance/README.md
+++ b/skills/uipath-maestro-flow/.maintenance/README.md
@@ -166,9 +166,32 @@ bash .maintenance/check-plugin-pairs.sh
 
 Returns `plugins_checked=N missing_files=M`. Exits non-zero if any plugin folder is missing a required file. Catches half-deleted plugins or new plugin folders that haven't been completed.
 
+## Verifying `uip` command references
+
+Run the uip-command checker to verify every `uip ...` invocation in fenced code blocks resolves to a real command in the installed CLI:
+
+```bash
+bash .maintenance/check-uip-commands.sh
+```
+
+Returns `commands_checked=N unknown=M`. Exits non-zero if any referenced command path is unknown to `uip`. Verification is **help-only** — the checker walks each command path with `uip <prefix> --help`, confirms the requested segment appears in the parent's `Subcommands` list, and never executes the command for real. Help responses are cached per prefix.
+
+The checker:
+
+- Scans only fenced code blocks tagged `bash`, `sh`, `shell`, `zsh`, `console`, or unlabelled. Inline backtick references like `` `uip maestro flow init` `` are skipped (out of scope for v1).
+- Stops the path at the first flag, placeholder (`<...>`), shell metachar, comment (`#`), path-literal, or non-kebab-case token — so positional args like `uip maestro flow registry search outlook` don't get mistreated as subcommands.
+- Treats trailing tokens after a leaf-with-positional-args (e.g. `uip maestro flow registry search <keyword>`) as arguments, not missing subcommands.
+- Falls back gracefully if `uip` is not installed: warns and exits 0. Pass `--strict` to fail in CI.
+
+Pass specific files to scan only those (e.g. for pre-commit on staged files):
+
+```bash
+bash .maintenance/check-uip-commands.sh references/shared/cli-commands.md
+```
+
 ## Running the full suite
 
-Run all seven checkers in one invocation:
+Run all eight checkers in one invocation:
 
 ```bash
 bash .maintenance/check-all.sh
@@ -184,6 +207,7 @@ Continues running all checkers even when one fails — the goal is to surface ev
 - After deleting a doc — run `check-orphans.sh` to confirm nothing else became orphaned
 - Before adding a new capability — run `check-template.sh` against the new `CAPABILITY.md`
 - After adding a new plugin — run `check-plugin-pairs.sh` to confirm both `planning.md` and `impl.md` are present
+- After a `uip` CLI version bump — run `check-uip-commands.sh` to catch any commands that were renamed or removed
 
 The checkers are not currently wired into CI or pre-commit hooks. They are kept as lightweight tooling in this directory so future maintainers can run them on demand.
 

--- a/skills/uipath-maestro-flow/.maintenance/check-all.sh
+++ b/skills/uipath-maestro-flow/.maintenance/check-all.sh
@@ -17,6 +17,7 @@ CHECKERS=(
   "check-template.sh"
   "check-orphans.sh"
   "check-plugin-pairs.sh"
+  "check-uip-commands.sh"
 )
 
 overall=0

--- a/skills/uipath-maestro-flow/.maintenance/check-uip-commands.sh
+++ b/skills/uipath-maestro-flow/.maintenance/check-uip-commands.sh
@@ -53,9 +53,12 @@ if ! command -v python3 >/dev/null 2>&1; then
 fi
 
 if [ "${#FILES[@]}" -eq 0 ]; then
+  # Scan the skill's published surface only: SKILL.md + references/.
+  # Skips .maintenance/, scratch files at the skill root (PLAN.md, PR_BODY.md),
+  # and anything else that isn't part of what agents load.
   while IFS= read -r f; do
     FILES+=("$f")
-  done < <(/usr/bin/find . -type f -name '*.md' -not -path './.maintenance/*' 2>/dev/null | /usr/bin/sort)
+  done < <({ [ -f SKILL.md ] && echo "./SKILL.md"; /usr/bin/find ./references -type f -name '*.md' 2>/dev/null; } | /usr/bin/sort)
 fi
 
 if [ "${#FILES[@]}" -eq 0 ]; then
@@ -145,6 +148,16 @@ def verify_path(path):
 
 FENCE_RE = re.compile(r"^```([a-zA-Z0-9_+-]*)\s*$")
 ACCEPTED_LANGS = {"", "bash", "sh", "shell", "zsh", "console"}
+# Inline single-backtick spans. Greedy is fine: ` cannot appear inside a
+# single-backtick span by definition (use double-backtick spans for that, which
+# we deliberately don't scan — they're rare and usually contain code samples).
+INLINE_RE = re.compile(r"`([^`\n]+)`")
+# Per-line opt-out marker: `<!-- uip-check-skip -->` anywhere on the line
+# suppresses checking for that line. Used for intentional historical references
+# (e.g. CLI version-comparison tables that document a removed prefix). For
+# table rows, place the marker inside a cell (e.g. `| ... | ... <!-- uip-check-skip --> |`)
+# so it doesn't break table structure — HTML comments render as nothing.
+SKIP_MARKER = "<!-- uip-check-skip -->"
 
 
 SUBCOMMAND_RE = re.compile(r"^[a-z][a-z0-9-]*$")
@@ -161,6 +174,25 @@ def is_terminator(tok):
     if tok in {"|", ">", ">>", "<", "&&", "||", ";", "&", "$(", "`"}:
         return True
     return not SUBCOMMAND_RE.match(tok)
+
+
+def extract_path_from_uip_line(content):
+    """Tokenize a uip line and walk to extract the command path.
+
+    Returns the path list (possibly empty for bare `uip`).
+    Returns None if the line doesn't start with `uip`.
+    """
+    if content.startswith("$ "):
+        content = content[2:]
+    if not (content.startswith("uip ") or content.rstrip() == "uip"):
+        return None
+    tokens = content.split()
+    path = []
+    for tok in tokens[1:]:
+        if is_terminator(tok):
+            break
+        path.append(tok)
+    return path
 
 
 def extract_uip_commands(md_path):
@@ -184,24 +216,25 @@ def extract_uip_commands(md_path):
                 fence_lang = ""
             i += 1
             continue
-        if in_fence and fence_lang in ACCEPTED_LANGS:
-            start = i
-            joined = line
-            while joined.rstrip().endswith("\\") and i + 1 < len(lines):
-                joined = joined.rstrip()[:-1] + " " + lines[i + 1]
-                i += 1
-            content = joined.lstrip()
-            if content.startswith("$ "):
-                content = content[2:]
-            if content.startswith("uip ") or content.rstrip() == "uip":
-                tokens = content.split()
-                path = []
-                for tok in tokens[1:]:
-                    if is_terminator(tok):
-                        break
-                    path.append(tok)
+        if SKIP_MARKER in line:
+            i += 1
+            continue
+        if in_fence:
+            if fence_lang in ACCEPTED_LANGS:
+                start = i
+                joined = line
+                while joined.rstrip().endswith("\\") and i + 1 < len(lines):
+                    joined = joined.rstrip()[:-1] + " " + lines[i + 1]
+                    i += 1
+                path = extract_path_from_uip_line(joined.lstrip())
                 if path:
                     yield (start + 1, path)
+        else:
+            # Inline backtick spans outside fenced blocks.
+            for match in INLINE_RE.finditer(line):
+                path = extract_path_from_uip_line(match.group(1).strip())
+                if path:
+                    yield (i + 1, path)
         i += 1
 
 

--- a/skills/uipath-maestro-flow/.maintenance/check-uip-commands.sh
+++ b/skills/uipath-maestro-flow/.maintenance/check-uip-commands.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+# Verify every `uip` command referenced in this skill's markdown actually exists.
+# Usage: bash .maintenance/check-uip-commands.sh [--strict] [file1.md ...]
+# Output: BAD lines per unknown command, then "commands_checked=N unknown=M" summary.
+#
+# Scans fenced code blocks (```bash, ```sh, ```shell, ```zsh, ```console, or
+# unlabelled ```) under this skill for lines that begin with `uip `, extracts
+# the command path (tokens before the first flag, placeholder, or shell
+# metachar), and verifies it against `uip <path> --help`. Help output only —
+# no command is ever executed for real.
+#
+# How verification works: `uip <bogus> --help` silently falls back to the
+# parent's help, so exit code is not a reliable signal. Instead, we walk the
+# path level by level and confirm each next segment appears in the parent's
+# `Subcommands[].Name` list. Help responses are cached per prefix.
+#
+# Skips:
+# - Inline backtick references like `uip ...` (only fenced blocks are scanned)
+# - Files matching --skip-glob
+#
+# --strict: exit 2 if `uip` is not on PATH (CI mode). Default: warn and exit 0.
+#
+# Exits non-zero if any unknown command is referenced.
+
+set -e
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT" || exit 1
+
+STRICT=0
+FILES=()
+for arg in "$@"; do
+  case "$arg" in
+    --strict) STRICT=1 ;;
+    *) FILES+=("$arg") ;;
+  esac
+done
+
+if ! command -v uip >/dev/null 2>&1; then
+  if [ "$STRICT" -eq 1 ]; then
+    echo "uip not found on PATH (--strict)" >&2
+    exit 2
+  fi
+  echo "uip not found on PATH; skipping (use --strict to fail)" >&2
+  echo ""
+  echo "commands_checked=0 unknown=0"
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not found on PATH" >&2
+  exit 2
+fi
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  while IFS= read -r f; do
+    FILES+=("$f")
+  done < <(/usr/bin/find . -type f -name '*.md' -not -path './.maintenance/*' 2>/dev/null | /usr/bin/sort)
+fi
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo ""
+  echo "commands_checked=0 unknown=0"
+  exit 0
+fi
+
+export UIP_BIN="$(command -v uip)"
+export SKILL_ROOT="$ROOT"
+
+python3 - "${FILES[@]}" <<'PYEOF'
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+UIP = os.environ["UIP_BIN"]
+SKILL_ROOT = Path(os.environ["SKILL_ROOT"])
+files = [Path(p) for p in sys.argv[1:]]
+
+# Cache value: (subcommands_set, takes_positional_args) or None for invalid prefix
+_help_cache: dict[tuple, tuple[set, bool] | None] = {}
+
+
+def get_help(prefix):
+    if prefix in _help_cache:
+        return _help_cache[prefix]
+    # `--output json` is required: top-level `uip --help` defaults to plain
+    # text; other levels default to JSON but accept the flag too. Forcing it
+    # makes parsing deterministic.
+    cmd = [UIP, *prefix, "--help", "--output", "json"]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except Exception:
+        _help_cache[prefix] = None
+        return None
+    # uip prints non-JSON noise around the help payload — sometimes a banner
+    # before (e.g. `Tool factory already registered ...`), sometimes a human
+    # usage block after. Use raw_decode to grab the first complete JSON object.
+    out = proc.stdout
+    brace = out.find("{")
+    if brace < 0:
+        _help_cache[prefix] = None
+        return None
+    try:
+        data, _ = json.JSONDecoder().raw_decode(out[brace:])
+    except json.JSONDecodeError:
+        _help_cache[prefix] = None
+        return None
+    inner = data.get("Data", {})
+    resolved = inner.get("Command", "")
+    expected = prefix[-1] if prefix else "uip"
+    if resolved != expected:
+        _help_cache[prefix] = None
+        return None
+    subs = set()
+    for entry in inner.get("Subcommands", []) or []:
+        name = entry.get("Name", "")
+        leaf = name.split(None, 1)[0]
+        if leaf:
+            subs.add(leaf)
+    takes_args = bool(inner.get("Arguments"))
+    _help_cache[prefix] = (subs, takes_args)
+    return _help_cache[prefix]
+
+
+def verify_path(path):
+    prefix = ()
+    for seg in path:
+        info = get_help(prefix)
+        if info is None:
+            return False, prefix[-1] if prefix else seg, []
+        subs, takes_args = info
+        if seg not in subs:
+            # If the parent is a leaf (no subcommands) and accepts positional
+            # args, this token is an arg — path is valid up to here.
+            if not subs and takes_args:
+                return True, "", []
+            import difflib
+            return False, seg, difflib.get_close_matches(seg, sorted(subs), n=3, cutoff=0.5)
+        prefix = prefix + (seg,)
+    return True, "", []
+
+
+FENCE_RE = re.compile(r"^```([a-zA-Z0-9_+-]*)\s*$")
+ACCEPTED_LANGS = {"", "bash", "sh", "shell", "zsh", "console"}
+
+
+SUBCOMMAND_RE = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+def is_terminator(tok):
+    # A real uip subcommand is a lowercase kebab-case identifier. Anything else
+    # (flags, placeholders, paths, comments, quoted strings, shell metachars,
+    # positional args) ends the path.
+    if not tok:
+        return True
+    if tok.startswith("#"):
+        return True
+    if tok in {"|", ">", ">>", "<", "&&", "||", ";", "&", "$(", "`"}:
+        return True
+    return not SUBCOMMAND_RE.match(tok)
+
+
+def extract_uip_commands(md_path):
+    try:
+        text = md_path.read_text(encoding="utf-8")
+    except Exception:
+        return
+    lines = text.splitlines()
+    in_fence = False
+    fence_lang = ""
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = FENCE_RE.match(line.strip())
+        if m:
+            if not in_fence:
+                in_fence = True
+                fence_lang = m.group(1).lower()
+            else:
+                in_fence = False
+                fence_lang = ""
+            i += 1
+            continue
+        if in_fence and fence_lang in ACCEPTED_LANGS:
+            start = i
+            joined = line
+            while joined.rstrip().endswith("\\") and i + 1 < len(lines):
+                joined = joined.rstrip()[:-1] + " " + lines[i + 1]
+                i += 1
+            content = joined.lstrip()
+            if content.startswith("$ "):
+                content = content[2:]
+            if content.startswith("uip ") or content.rstrip() == "uip":
+                tokens = content.split()
+                path = []
+                for tok in tokens[1:]:
+                    if is_terminator(tok):
+                        break
+                    path.append(tok)
+                if path:
+                    yield (start + 1, path)
+        i += 1
+
+
+references = {}
+for md in files:
+    for line_no, path in extract_uip_commands(md):
+        references.setdefault(tuple(path), []).append((md, line_no))
+
+unknown = 0
+for path_tuple, locs in sorted(references.items()):
+    ok, bad, suggestions = verify_path(list(path_tuple))
+    if ok:
+        continue
+    idx = list(path_tuple).index(bad) if bad in path_tuple else 0
+    parent = "uip" + ("" if idx == 0 else " " + " ".join(path_tuple[:idx]))
+    cmd_str = "uip " + " ".join(path_tuple)
+    sug = f" (did you mean: {', '.join(suggestions)}?)" if suggestions else ""
+    for f, ln in locs:
+        try:
+            rel = f.relative_to(SKILL_ROOT).as_posix()
+        except ValueError:
+            rel = str(f)
+        print(f'BAD  {rel}:{ln}  {cmd_str} — "{bad}" not a subcommand of "{parent}"{sug}')
+        unknown += 1
+
+print()
+print(f"commands_checked={len(references)} unknown={unknown}")
+sys.exit(1 if unknown else 0)
+PYEOF

--- a/skills/uipath-maestro-flow/references/author/references/greenfield.md
+++ b/skills/uipath-maestro-flow/references/author/references/greenfield.md
@@ -31,7 +31,7 @@ For complex flows, produce a plan before building. Reference [planning-arch.md](
 
 ## Step 0 — Resolve the `uip` binary and detect command prefix
 
-See [shared/cli-conventions.md](../../shared/cli-conventions.md) for binary resolution, version detection, and the `uip maestro flow` vs `uip flow` command prefix rule. All commands below are written in the `uip maestro flow` form.
+See [shared/cli-conventions.md](../../shared/cli-conventions.md) for binary resolution, version detection, and the `uip maestro flow` vs `uip flow` command prefix rule. All commands below are written in the `uip maestro flow` form. <!-- uip-check-skip -->
 
 ## Step 1 — Check login status
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -80,15 +80,15 @@ Use when there is an existing deployed Action Center app that should serve as th
 **Published (tenant registry):**
 
 ```bash
-uip flow registry pull --force
-uip flow registry search "uipath.core.human-task" --output json
+uip maestro flow registry pull --force
+uip maestro flow registry search "uipath.core.human-task" --output json
 ```
 
 **In-solution (local, no login required):**
 
 ```bash
-uip flow registry list --local --output json
-uip flow registry get "<nodeType>" --local --output json
+uip maestro flow registry list --local --output json
+uip maestro flow registry get "<nodeType>" --local --output json
 ```
 
 Run from inside the flow project directory. Discovers sibling projects in the same `.uipx` solution.
@@ -97,10 +97,10 @@ Run from inside the flow project directory. Discovers sibling projects in the sa
 
 ```bash
 # Published (tenant registry)
-uip flow registry get "uipath.core.human-task.{key}" --output json
+uip maestro flow registry get "uipath.core.human-task.{key}" --output json
 
 # In-solution (local, no login required)
-uip flow registry get "uipath.core.human-task.{key}" --local --output json
+uip maestro flow registry get "uipath.core.human-task.{key}" --local --output json
 ```
 
 Confirm:
@@ -145,7 +145,7 @@ The instance carries only per-instance data (`inputs`, `outputs`, `display`). BP
 }
 ```
 
-> `resourceKey` takes the form `<FolderPath>.<AppName>` and `resourceSubType` is the app type — confirm both from `uip flow registry get` output. Both values come from the definition's `model.bindings`, never from the node instance.
+> `resourceKey` takes the form `<FolderPath>.<AppName>` and `resourceSubType` is the app type — confirm both from `uip maestro flow registry get` output. Both values come from the definition's `model.bindings`, never from the node instance.
 
 **Top-level `bindings[]` entries (sibling of `nodes`/`edges`/`definitions`):**
 
@@ -196,7 +196,7 @@ Manual Trigger -> RPA Process (extract) -> HITL (review) -> Decision (approved?)
 
 | Error | Cause | Fix |
 | --- | --- | --- |
-| Node type not found in registry (Option 2) | App not published or registry stale | If in same solution: `uip flow registry list --local`. Otherwise: `uip login` then `uip flow registry pull --force` |
+| Node type not found in registry (Option 2) | App not published or registry stale | If in same solution: `uip maestro flow registry list --local`. Otherwise: `uip login` then `uip maestro flow registry pull --force` |
 | Task never completes | Human hasn't submitted the form | Check task assignment in Orchestrator |
 | Output missing expected fields | App form doesn't match expected schema | Verify app form fields match what the flow expects |
 | `completed` port unwired (Option 1) | Missing edge on output handle | Wire the `completed` output handle — an unwired `completed` blocks the flow indefinitely |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
@@ -103,7 +103,7 @@ In the node table:
 ## Option 2 — `uipath.core.human-task.{key}` (App-Based)
 
 Node type: `uipath.core.human-task.{key}`
-Available: tenant-specific resource — requires `uip login` + `uip flow registry pull`.
+Available: tenant-specific resource — requires `uip login` + `uip maestro flow registry pull`.
 
 ### When to Select
 
@@ -125,15 +125,15 @@ Use when there is an existing coded app or Action Center app that should be the 
 **Published (tenant registry):**
 
 ```bash
-uip flow registry pull --force
-uip flow registry search "uipath.core.human-task" --output json
+uip maestro flow registry pull --force
+uip maestro flow registry search "uipath.core.human-task" --output json
 ```
 
 **In-solution (local, no login required):**
 
 ```bash
-uip flow registry list --local --output json
-uip flow registry get "<nodeType>" --local --output json
+uip maestro flow registry list --local --output json
+uip maestro flow registry get "<nodeType>" --local --output json
 ```
 
 Run from inside the flow project directory. Discovers sibling projects in the same `.uipx` solution.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
@@ -96,7 +96,7 @@ uip maestro flow node configure <ProjectName>.flow <nodeId> \
 
 Template literals with `${...}` interpolation work because the whole expression is evaluated as JavaScript — `$vars` is a global in the `=js:` context. Plain string concatenation (`'Bearer ' + $vars.token`) works the same way.
 
-When calling `uip flow node configure --detail`, pass the `=js:` string verbatim — the CLI stores it in `inputs.detail.bodyParameters` unchanged:
+When calling `uip maestro flow node configure --detail`, pass the `=js:` string verbatim — the CLI stores it in `inputs.detail.bodyParameters` unchanged:
 
 ```bash
 uip maestro flow node configure <Project>.flow <nodeId> \

--- a/skills/uipath-maestro-flow/references/diagnose/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/diagnose/CAPABILITY.md
@@ -18,7 +18,7 @@ Capability index for postmortem on a failed `flow debug` or deployed process run
 ## Critical rules
 
 1. **Investigate in priority order — incidents → variables → flow correlation → traces.** Each step adds context; stop when you have enough to identify the root cause. Skipping ahead to traces is the most common mistake — they are verbose and last-resort. See [troubleshooting-guide.md](references/troubleshooting-guide.md).
-2. **Always include `--folder-key <FOLDER_KEY>` (`-f` shorthand) on `instance` and `incident get` commands.** Without it the command rejects the request before reaching the API. Get the folder key from `uip orchestrator folder list --output json` or from the job/process context. See [shared/cli-conventions.md](../shared/cli-conventions.md#5---folder-key-requirement).
+2. **Always include `--folder-key <FOLDER_KEY>` (`-f` shorthand) on `instance` and `incident get` commands.** Without it the command rejects the request before reaching the API. Get the folder key from `uip or folders list --output json` or from the job/process context. See [shared/cli-conventions.md](../shared/cli-conventions.md#5---folder-key-requirement).
 3. **Never call the underlying APIs directly — always use `uip` CLI commands.** The `instance` and `incident` subcommands are the supported diagnostic surface; direct API calls are not.
 4. **When the local `.flow` may differ from the deployed BPMN, fetch the deployed asset.** Use `uip maestro flow instance asset <INSTANCE_ID> --folder-key <FOLDER_KEY> --output json` to see what actually ran. Do not assume your local file matches.
 

--- a/skills/uipath-maestro-flow/references/diagnose/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-flow/references/diagnose/references/troubleshooting-guide.md
@@ -2,7 +2,7 @@
 
 Diagnostic workflow for failed debug runs and deployed process runs. All commands require `uip login`.
 
-> **`--folder-key` is required.** All `instance` and `incident get` commands require `--folder-key <FOLDER_KEY>`. Get the folder key from `uip orchestrator folder list --output json` or from the job/process context.
+> **`--folder-key` is required.** All `instance` and `incident get` commands require `--folder-key <FOLDER_KEY>`. Get the folder key from `uip or folders list --output json` or from the job/process context.
 
 ## Diagnostic priority
 

--- a/skills/uipath-maestro-flow/references/operate/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/operate/CAPABILITY.md
@@ -20,7 +20,7 @@ Capability index for the lifecycle of a flow as a deployed asset. Operate owns e
 
 1. **Always run `uip solution resource refresh <SolutionDir>` before `solution upload` or `flow debug`.** Stale resource declarations cause runtime binding failures even when the local `.flow` is correct. The refresh syncs connection and process resource declarations from the project's `bindings_v2.json` files into the solution.
 2. **Default to Studio Web when the user says "publish" without specifier.** "Publish" → `uip solution upload <SolutionDir>`. Only run `uip maestro flow pack` + `uip solution publish` when the user explicitly asks to deploy to Orchestrator. The Orchestrator path bypasses Studio Web — the user cannot visualize or edit the flow there.
-3. **Always include `--folder-key <FOLDER_KEY>` (`-f` shorthand) on `instance` commands.** Without it the command rejects the request before reaching the API. Get the folder key from `uip orchestrator folder list --output json` or from the job/process context. See [shared/cli-conventions.md](../shared/cli-conventions.md#5---folder-key-requirement).
+3. **Always include `--folder-key <FOLDER_KEY>` (`-f` shorthand) on `instance` commands.** Without it the command rejects the request before reaching the API. Get the folder key from `uip or folders list --output json` or from the job/process context. See [shared/cli-conventions.md](../shared/cli-conventions.md#5---folder-key-requirement).
 4. **Always report Studio Web URL and Instance ID as the first two lines of any debug summary.** Parse `Data.studioWebUrl` and `Data.instanceId` from the JSON output. Use `<not returned by CLI>` if missing — never omit the line. Users need these immediately, not buried below status text.
 
 ## Workflow

--- a/skills/uipath-maestro-flow/references/operate/references/manage.md
+++ b/skills/uipath-maestro-flow/references/operate/references/manage.md
@@ -7,7 +7,7 @@ Intervene in a running or faulted Flow instance: pause, resume, cancel, retry. A
 ## Pre-flight
 
 1. **Logged in.** `uip login status --output json` returns success.
-2. **Folder key resolved.** Get it from `uip orchestrator folder list --output json` or from the job/process context. See [shared/cli-conventions.md — `--folder-key` requirement](../../shared/cli-conventions.md#5---folder-key-requirement).
+2. **Folder key resolved.** Get it from `uip or folders list --output json` or from the job/process context. See [shared/cli-conventions.md — `--folder-key` requirement](../../shared/cli-conventions.md#5---folder-key-requirement).
 3. **Instance ID known.** From a debug run (`Data.instanceId`), `flow job status` response, or `instance list`.
 
 ## Lifecycle commands

--- a/skills/uipath-maestro-flow/references/shared/cli-conventions.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-conventions.md
@@ -22,9 +22,9 @@ If `npm install -g` fails with a permission error, prompt the user to re-run wit
 ### Command prefix by version
 
 | Installed version | Command prefix | Example |
-|---|---|---|
+| --- | --- | --- |
 | **≥ 0.3.4** | `uip maestro flow` | `uip maestro flow init MyProject` |
-| **< 0.3.4** | `uip flow` | `uip flow init MyProject` |
+| **< 0.3.4** | `uip flow` | `uip flow init MyProject` <!-- uip-check-skip --> |
 
 ```bash
 MIN_VERSION="0.3.4"
@@ -36,7 +36,7 @@ fi
 echo "Using: $FLOW_CMD (CLI version $CURRENT)"
 ```
 
-> **All commands across this skill are written as `uip maestro flow ...` (the ≥ 0.3.4 form).** If version detection above returns < 0.3.4, replace `uip maestro flow` with `uip flow`. Arguments and flags are identical — only the prefix differs. See UiPath/cli#841 for background on the restructuring.
+> **All commands across this skill are written as `uip maestro flow ...` (the ≥ 0.3.4 form).** If version detection above returns < 0.3.4, replace `uip maestro flow` with `uip flow`. Arguments and flags are identical — only the prefix differs. See UiPath/cli#841 for background on the restructuring. <!-- uip-check-skip -->
 
 ## 2. Always use `--output json`
 

--- a/skills/uipath-maestro-flow/references/shared/cli-conventions.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-conventions.md
@@ -98,7 +98,7 @@ All `uip maestro flow instance` and `uip maestro flow incident get` commands req
 Get the folder key:
 
 ```bash
-uip orchestrator folder list --output json
+uip or folders list --output json
 ```
 
 Or pull it from the job/process context (e.g., `Data.folderKey` on a job status response, or from the debug output's surrounding metadata).

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -273,11 +273,11 @@ Without a wired error edge, any of these fails the whole flow with `finalStatus:
 
 ```bash
 # Confirm the node supports error handling
-uip flow registry get <nodeType> --output json \
+uip maestro flow registry get <nodeType> --output json \
   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['Data']['Node'].get('supportsErrorHandling'))"
 
 # Add an outgoing edge with sourcePort: "error"
-uip flow edge add <Project>.flow <actionNodeId> <errorHandlerId> \
+uip maestro flow edge add <Project>.flow <actionNodeId> <errorHandlerId> \
   --source-port error --target-port input --output json
 ```
 


### PR DESCRIPTION
# `uip` command checker + 18 stale-reference fixes

## Summary

Adds a new maintenance checker, `check-uip-commands.sh`, that scans this skill's markdown — both fenced code blocks **and** inline backtick spans — for `uip ...` invocations and verifies each command path exists in the installed CLI. The checker is help-only — no command is ever executed for real. Wires it into `check-all.sh` as the eighth checker.

Iteration history during PR review:

1. v1 scanned only fenced blocks. First run surfaced 13 stale references in fenced blocks across 4 files.
2. PR review caught 5 more drift cases that lived in inline backtick references — outside v1's scan scope.
3. v2 (this version) extends scanning to inline backticks. Verified by injecting drift into a previously-clean file and confirming the checker flags it. A `<!-- uip-check-skip -->` marker is honored for intentional historical references (e.g. CLI version-comparison tables that document a removed prefix).

All 18 stale references are fixed — left over from a prior `uip` CLI restructure (`uip flow ...` → `uip maestro flow ...`) and a separate orchestrator-command rename (`uip orchestrator folder list` → `uip or folders list`).

## What changed

### Checker infrastructure

| File | Change |
|------|--------|
| `.maintenance/check-uip-commands.sh` | **New.** Skill-scoped command-existence checker. |
| `.maintenance/check-all.sh` | Wires `check-uip-commands.sh` into the suite. |
| `.maintenance/README.md` | Documents the new checker, when to run it, and bumps the suite count to eight. |

### Doc fixes — fenced code blocks (caught by v1)

| File | Change |
|------|--------|
| `references/author/references/plugins/hitl/impl.md` | 6 × `uip flow registry ...` → `uip maestro flow registry ...` |
| `references/author/references/plugins/hitl/planning.md` | 4 × `uip flow registry ...` → `uip maestro flow registry ...` |
| `references/shared/file-format.md` | `uip flow registry get` and `uip flow edge add` → `uip maestro flow ...` |
| `references/shared/cli-conventions.md` | `uip orchestrator folder list` → `uip or folders list` |

### Doc fixes — inline backtick references (caught by manual review; v2 catches these too)

| File | Change |
|------|--------|
| `references/operate/CAPABILITY.md` | `uip orchestrator folder list` → `uip or folders list` |
| `references/operate/references/manage.md` | `uip orchestrator folder list` → `uip or folders list` |
| `references/diagnose/CAPABILITY.md` | `uip orchestrator folder list` → `uip or folders list` |
| `references/diagnose/references/troubleshooting-guide.md` | `uip orchestrator folder list` → `uip or folders list` |
| `references/author/references/plugins/http/impl.md` | `uip flow node configure` → `uip maestro flow node configure` |

The intentional historical reference at `references/shared/cli-conventions.md:27` (a CLI-version comparison table that documents the **pre-0.3.4** prefix `uip flow`) is preserved and marked with `<!-- uip-check-skip -->` so the checker honors it. Same marker added to two related lines: a blockquote in `cli-conventions.md` and a prose mention in `greenfield.md`.

## How the checker works

**Scope:** scans `SKILL.md` and `references/**/*.md`. Skips `.maintenance/` and root-level scratch files.

**Extraction:** in fenced blocks tagged `bash`/`sh`/`shell`/`zsh`/`console`/unlabelled, scan lines starting with `uip`. Outside fenced blocks, scan inline single-backtick spans whose content starts with `uip`.

**Tokenization:** walk left-to-right collecting tokens until the first one that isn't a kebab-case identifier — that ends the command path. This stops at flags, `<placeholders>`, paths, `#` comments, shell metacharacters, and positional args. Bare `` `uip` `` (path empty) is skipped.

**Verification:** walk the path level by level against the installed CLI: call `uip <prefix> --help --output json`, parse the response, and confirm the next segment appears in `Data.Subcommands[].Name`. Cache one help response per prefix.

**Positional args:** if a token isn't a known subcommand AND the parent has no subcommands AND the parent accepts positional args, treat the token as an argument (success). Otherwise report a failure with file:line + a `did you mean: ...` suggestion.

**Opt-out:** add `<!-- uip-check-skip -->` to any line to suppress checking for that line. Inside table rows, place the marker inside a cell so it doesn't break table structure.

### Quirks of `uip` help that drove the design

- `uip --help` (top level) defaults to **plain text**; subcommand help defaults to JSON. Forcing `--output json` makes parsing deterministic.
- A bogus subcommand silently falls back to the parent's help (e.g., `uip rpa run --help` returns `Data.Command = "rpa"`, not `"run"`). Exit code stays 0, so we verify by walking the path and confirming the resolved `Command` matches each leaf.
- Some help payloads have noise — a banner before the JSON, a usage block after. We use `JSONDecoder().raw_decode()` from the first `{` to grab the first complete object.

## How to run

```bash
# This skill only (default)
bash .maintenance/check-uip-commands.sh

# Single file (e.g. for staged-file checks)
bash .maintenance/check-uip-commands.sh references/shared/cli-commands.md

# CI mode — fail if uip is not on PATH
bash .maintenance/check-uip-commands.sh --strict

# Full suite (this checker plus the other seven)
bash .maintenance/check-all.sh
```

## Test plan

- [x] Full check suite passes locally — 8/8 green, `commands_checked=57 unknown=0`.
- [x] Bogus-command fixture produces the expected failure: a fixture with `uip rpa runn` and `uip nope` exits 1, names file:line, and offers `did you mean: run-file?`.
- [x] Pre-fix run on this skill reported 13 unknown commands; post-fix run reports 0.
- [x] Manual `grep -rn "uip flow \|uip orchestrator"` sweep returns only the intentional version-comparison row.
- [x] All seven previously existing checkers still pass — no regressions.
