### PR TITLE
fix(uipath-maestro-flow): bump hitl test budget; range-check wiki sum (MST-9301, MST-9302)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -8,7 +8,7 @@ tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, n
 agent:
   type: claude-code
   permission_mode: acceptEdits
-  max_turns: 25
+  max_turns: 47
   turn_timeout: 900
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
@@ -7,26 +7,23 @@ Usage: check_wiki_pageviews_flow.py {uipath_success|invalid_error}
 Success path — one HTTP call returns all daily view counts in the range,
 a Transform filter keeps days whose views exceed the hardcoded 500
 threshold, and the flow returns the **sum** of those views as an integer.
-UiPath article, 2024-01-01..2024-01-15 has exactly 6 days above 500
-(historical pageviews don't change), summing to 4130:
-  Jan  8 = 520
-  Jan  9 = 806
-  Jan 10 = 736
-  Jan 11 = 747
-  Jan 12 = 663
-  Jan 15 = 658
-  sum    = 4130
+For UiPath, 2024-01-01..2024-01-15 the originally observed sum was 4130
+(Jan 8/9/10/11/12/15 above 500). Wikimedia recomputes historical
+pageviews periodically, so the criterion checks that the output is a
+numeric leaf in SUCCESS_RANGE — wide enough to absorb any plausible
+recompute, narrow enough to rule out trivial / spurious passes (no day
+matched the filter, or the agent dumped the raw HTTP response). See
+https://uipath.atlassian.net/browse/MST-9302 for the rationale.
 
 The threshold is hardcoded because `core.action.transform.filter`'s
 `value` field is literal-only — it does not resolve `$vars.x`,
 `{$vars.x}`, or `=js:` expressions. Plumbing a dynamic threshold through
 Transform silently produces an empty filter output.
 
-The sum (not count) is picked to defeat a spurious-pass mode where the
-check's former regex fallback matched isolated digits inside HTTP
-error-dump leaves (ETag hex like `W/"...e5e6b4b0d..."` contains an
-isolated 6). With `assert_output_value` now strict-equality for numerics
-AND a 4-digit expected value, a wrong answer cannot match by accident.
+The numeric-leaf range check (rather than `assert_output_int_in_range`'s
+regex extraction) defeats a spurious-pass mode where digits embedded in
+HTTP error-dump leaves (e.g., ETag hex like `W/"...e5e6b4b0d..."`) could
+match the range. Same defense as `assert_output_value` for numerics.
 
 Error path — a bogus article makes the Wikimedia API return 404, which
 fails the HTTP node. The flow must wire the HTTP node's `error` output
@@ -43,14 +40,34 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,
+    collect_outputs,
     run_debug,
 )
 
+# Range chosen so a correct sum (originally 4130) sits comfortably inside,
+# while ruling out trivial outputs (single day at threshold ≈ 500) and
+# raw-dump cases (would carry totals well above 20k or non-numeric leaves).
+SUCCESS_RANGE = (1000, 20000)
+ERROR_STRING = "Article not found"
+
 CASES = {
-    # case: (article, date1, date2, expected_output_leaf)
-    "uipath_success": ("UiPath", "20240101", "20240115", 4130),
-    "invalid_error": ("ThisArticleDefinitelyDoesNotExist999", "20240101", "20240115", "Article not found"),
+    # case: (article, date1, date2)
+    "uipath_success": ("UiPath", "20240101", "20240115"),
+    "invalid_error": ("ThisArticleDefinitelyDoesNotExist999", "20240101", "20240115"),
 }
+
+
+def _find_numeric_leaf_in_range(payload, lo, hi):
+    """Return the first numeric leaf in [lo, hi] from the flow's declared
+    outputs, or None. Skips bools (which subclass int) and skips digit
+    extraction from string leaves — the latter is what makes this safer
+    than `assert_output_int_in_range` for HTTP-heavy flows."""
+    for v in collect_outputs(payload):
+        if isinstance(v, bool):
+            continue
+        if isinstance(v, (int, float)) and lo <= v <= hi:
+            return v
+    return None
 
 
 def main():
@@ -63,12 +80,22 @@ def main():
     # prefix) for the filter step.
     assert_flow_has_node_type(["core.action.http.v2", "core.action.transform"])
 
-    article, date1, date2, expected = CASES[case]
+    article, date1, date2 = CASES[case]
     inputs = {"article": article, "date1": date1, "date2": date2}
-    print(f"[{case}] Injecting inputs: {inputs} (expect {expected!r})")
-    payload = run_debug(inputs=inputs, timeout=300)
-    assert_output_value(payload, expected)
-    print(f"OK: [{case}] output contains {expected!r}")
+
+    if case == "uipath_success":
+        lo, hi = SUCCESS_RANGE
+        print(f"[{case}] Injecting inputs: {inputs} (expect numeric leaf in [{lo}, {hi}])")
+        payload = run_debug(inputs=inputs, timeout=300)
+        match = _find_numeric_leaf_in_range(payload, lo, hi)
+        if match is None:
+            sys.exit(f"FAIL: No numeric output in [{lo}, {hi}]\nOutputs: {list(collect_outputs(payload))}")
+        print(f"OK: [{case}] output {match} in [{lo}, {hi}]")
+    else:
+        print(f"[{case}] Injecting inputs: {inputs} (expect {ERROR_STRING!r})")
+        payload = run_debug(inputs=inputs, timeout=300)
+        assert_output_value(payload, ERROR_STRING)
+        print(f"OK: [{case}] output contains {ERROR_STRING!r}")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -48,7 +48,7 @@ success_criteria:
 
   # ── Execution checks — success path (transform filter + sum) + error path (http error port) ─────
   - type: run_command
-    description: "UiPath 2024-01-01..15: debug returns 4130 (sum of views on days above 500)"
+    description: "UiPath 2024-01-01..15: debug returns numeric sum of pageviews on days above 500 (range-tolerant of Wikimedia recomputes)"
     command: "python3 $TASK_DIR/check_wiki_pageviews_flow.py uipath_success"
     timeout: 600
     expected_exit_code: 0


### PR DESCRIPTION
## Summary

Two test-infra fixes from coder_eval run `2026-05-01_08-14-42`:

- **[MST-9301](https://uipath.atlassian.net/browse/MST-9301)** — `skill-flow-hitl-quality-result-downstream`: bump `max_turns` 25 → 47 to match observed workload.
- **[MST-9302](https://uipath.atlassian.net/browse/MST-9302)** — `skill-flow-wiki-pageviews`: replace brittle hardcoded `4130` expected value with a numeric-leaf range check that absorbs Wikimedia recomputes.

## MST-9301 — methodology

Per the quantitative-budget protocol: pulled blob samples from `coderevaltests/runs/`, ran 3 local samples at `--max-turns 150`, computed combined SUCCESS distribution after right-censoring.

```
Production samples (aws_bedrock):    [34, 36, 40, 42, 43, 45]   N=6 SUCCESS, 1 censored
Local samples     (anthropic_direct): [24, 40]                  N=2 SUCCESS at --max-turns 150, 1 FAILURE excluded
Combined SUCCESS:                     [24, 34, 36, 40, 40, 42, 43, 45]   N=8
                                      min=24  max=45  mean=38.0  stdev=6.7
stdev/mean = 17.6% (below 25% threshold) → use simple max+5% rule
Budget = round(45 * 1.05) = 47
```

## MST-9302 — fix design

The previous `assert_output_value(payload, 4130)` was a 4-digit strict-equality check chosen to defeat a spurious-pass mode where the helper's former regex fallback could match isolated digits inside HTTP error-dump leaves (e.g., ETag hex `W/"...e5e6b4b0d..."` containing `6`). Wikimedia recomputes historical pageviews periodically, so `4130` will drift even when the upstream blockers (MST-9299, MST-9258) are resolved.

This PR replaces it with `SUCCESS_RANGE = (1000, 20000)` and a strict numeric-leaf scan (no regex extraction over stringified outputs) — the same defense as `assert_output_value` for numerics. Lower bound rules out trivial / single-day passes; upper bound rules out raw-dump cases.

## Test plan

- [x] `validate_yaml.py` passes on both edited YAMLs
- [x] `_shared/test_flow_check.py` 19/19 pass
- [ ] Re-run failing tasks once merged: `coder-eval run --filter skill-flow-hitl-quality-result-downstream --replicates 3`
- [ ] Re-run wiki_pageviews after MST-9299 + MST-9258 land: `coder-eval run --filter skill-flow-wiki-pageviews --replicates 3`

## Out of scope

- MST-9299 (FolderKey) and MST-9258 (stale `\$vars`) — upstream blockers for `skill-flow-wiki-pageviews`. This PR does not change runtime behavior; the checker only verifies the agent's emitted sum if the upstream succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-9301]: https://uipath.atlassian.net/browse/MST-9301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MST-9302]: https://uipath.atlassian.net/browse/MST-9302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ