### PR TITLE
wip ci(smoke): enable agent isolation on smoke runs

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -148,7 +148,13 @@ jobs:
   e2e:
     needs: detect
     if: needs.detect.outputs.skip != 'true'
-    runs-on: ubuntu-latest
+    # 24.04 ships bubblewrap 0.8+ (vs 22.04's 0.6.1, which the SDK's bwrap
+    # invocation engages but doesn't actually mask via mount overlays — the
+    # runner kernel CAN do mount overlays, but 0.6.1 is missing features the
+    # SDK relies on). 24.04's AppArmor restriction on unprivileged userns is
+    # relaxed via the sysctl + aa-disable steps below. Required for tasks
+    # that set `agent.isolation: true` in coder_eval.
+    runs-on: ubuntu-24.04
     # 18+ smoke tasks at ~1–2 min each + env setup. 60 min was getting
     # cancelled when the matrix grew + LLM reviewer was retrying on quota
     # exhaustion. 120 min covers worst-case reviewer-retry storms without
@@ -173,6 +179,22 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Install OS sandbox dependencies (bubblewrap + socat)
+        # Required for AgentConfig.isolation=true to engage on Linux. The
+        # bundled claude CLI silently falls back to no-sandbox if either is
+        # missing, which would let isolation probes pass without actually
+        # exercising bwrap.
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq --no-install-recommends bubblewrap socat
+          # Ubuntu 24.04 restricts unprivileged user namespaces by default;
+          # bwrap needs them to set up its mount/network namespaces. Relax
+          # the AppArmor sysctl and disable the per-binary bwrap profile.
+          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns || true
+          for prof in /etc/apparmor.d/bwrap-userns-restrict /etc/apparmor.d/bwrap; do
+            [ -f "$prof" ] && sudo aa-disable "$prof" || true
+          done
 
       - name: Install coder-eval
         working-directory: .coder_eval

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -167,6 +167,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: UiPath/coder_eval
+          ref: akshaya/sandbox
           token: ${{ secrets.GH_PAT }}
           path: .coder_eval
 
@@ -178,7 +179,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Install OS sandbox dependencies (bubblewrap + socat)
         # Required for AgentConfig.isolation=true to engage on Linux. The

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -18,6 +18,7 @@ defaults:
     # cutting before/after-hooks and coded-test-case off mid-task.
     max_turns: 40
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+    isolation: true
     plugins:
       - type: "local"
         path: "$SKILLS_REPO_PATH"


### PR DESCRIPTION
## Summary
- Set \`agent.isolation: true\` in \`tests/experiments/default.yaml\` so smoke tasks exercise coder_eval's filesystem-perimeter sandbox
- Pin the e2e smoke job to \`ubuntu-24.04\` and install \`bubblewrap\` + \`socat\` (with the AppArmor sysctl + \`aa-disable\` workarounds) so the SDK's bwrap sandbox actually engages instead of silently falling back to no-op

Mirrors UiPath/coder_eval#207.

## Test plan
- [ ] Smoke Skill Tests workflow passes on this PR
- [ ] Spot-check one task's \`sdk_options.json\` (or task.json) to confirm \`sandbox.enabled=true\` was sent to the SDK

🤖 Generated with [Claude Code](https://claude.com/claude-code)