### PR TITLE
Fix 3 IS connection tests (slack, outlook) in flow test suite

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -25,6 +25,10 @@ initial_prompt: |
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
+  Test connections for this task live in Orchestrator folder "Shared/uipath-maestro-flow".
+  Resolve its key with `uip or folders get "Shared/uipath-maestro-flow" -o json`
+  and pass `--folder-key <key>` on every `uip is connections list` call.
+
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -24,6 +24,10 @@ initial_prompt: |
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
+  Test connections for this task live in Orchestrator folder "Shared/uipath-maestro-flow".
+  Resolve its key with `uip or folders get "Shared/uipath-maestro-flow" -o json`
+  and pass `--folder-key <key>` on every `uip is connections list` call.
+
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes"

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -24,7 +24,7 @@ import sys
 
 CONNECTOR_KEY = "uipath-microsoft-outlook365"
 TRIGGER_TYPE_MARKER = "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"
-SHARED_FOLDER_PATH = "Shared"
+TEST_FOLDER_PATH = "Shared/uipath-maestro-flow"
 
 
 def _uip_json(args: list[str]) -> dict:
@@ -55,18 +55,18 @@ def _read_flow() -> tuple[dict, str]:
         return json.load(f), flows[0]
 
 
-def _find_shared_folder_key() -> str:
-    folders = _uip_json(["uip", "or", "folders", "list", "--output", "json"]).get("Data", [])
-    for f in folders:
-        if f.get("Path") == SHARED_FOLDER_PATH:
-            return f["Key"]
-    sys.exit(f"FAIL: no '{SHARED_FOLDER_PATH}' folder in Orchestrator")
+def _find_test_folder_key() -> str:
+    resp = _uip_json(["uip", "or", "folders", "get", TEST_FOLDER_PATH, "--output", "json"])
+    key = resp.get("Data", {}).get("Key")
+    if not key:
+        sys.exit(f"FAIL: no '{TEST_FOLDER_PATH}' folder in Orchestrator")
+    return key
 
 
 def _find_default_outlook_connection() -> tuple[str, str, str]:
     """Return (connection_id, folder_key, connection_name) for the default
-    enabled Outlook connection in Shared."""
-    folder_key = _find_shared_folder_key()
+    enabled Outlook connection in the test folder."""
+    folder_key = _find_test_folder_key()
     conns_raw = _uip_json(
         [
             "uip", "is", "connections", "list", CONNECTOR_KEY,
@@ -75,7 +75,7 @@ def _find_default_outlook_connection() -> tuple[str, str, str]:
     ).get("Data", [])
     if not isinstance(conns_raw, list) or not conns_raw:
         sys.exit(
-            f"FAIL: no {CONNECTOR_KEY} connection in folder {SHARED_FOLDER_PATH}. "
+            f"FAIL: no {CONNECTOR_KEY} connection in folder {TEST_FOLDER_PATH}. "
             f"Provision an Outlook connection in the test tenant first."
         )
     defaults = [c for c in conns_raw if c.get("IsDefault") == "Yes" and c.get("State") == "Enabled"]

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -41,6 +41,10 @@ initial_prompt: |
   Step 3 for resolving the `parentFolderId` reference field against the bound
   connection. Do not reuse any folder ID you may have seen before.
 
+  Test connections for this task live in Orchestrator folder "Shared/uipath-maestro-flow".
+  Resolve its key with `uip or folders get "Shared/uipath-maestro-flow" -o json`
+  and pass `--folder-key <key>` on every `uip is connections list` call.
+
 success_criteria:
   # ── Structural: flow builds and validates ──────────────────────────────
   - type: run_command


### PR DESCRIPTION
The three connector-driven flow tasks were failing because the test connections live in `Shared/uipath-maestro-flow`, but the prompts and the Outlook post-check assumed `Shared`. Added a one-paragraph folder hint to the three task YAMLs and updated `check_outlook_trigger_inbox.py` to look in the right folder.

## Test results

| Task | Before | After |
|---|---|---|
| `skill-flow-outlook-trigger-inbox` | ERROR (timeout) | SUCCESS 1.000 (463s) |
| `skill-flow-slack-channel-description` | FAILURE 0.250 | SUCCESS 1.000 (567s) |
| `skill-flow-slack-weather-pipeline` | FAILURE 0.000 | SUCCESS 1.000 (1004s) |
