### PR TITLE
fix(hitl): align maestro-flow skill and tests to v1.0 output variable path

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -22,7 +22,7 @@ uip maestro flow hitl add <path/to/file.flow> \
   --label "Invoice Review" \
   --priority High \
   --assignee finance-approvers \
-  --schema '{"inputs":[{"name":"invoiceId","binding":"fetchInvoice.result.invoiceId"}],"outputs":[{"name":"decision","required":true}],"outcomes":[{"name":"Approve"},{"name":"Reject"}]}' \
+  --schema '{"inputs":[{"name":"invoiceId","binding":"fetchInvoice.output.invoiceId"}],"outputs":[{"name":"decision","required":true}],"outcomes":[{"name":"Approve"},{"name":"Reject"}]}' \
   --output json
 ```
 
@@ -54,8 +54,8 @@ Handles full lifecycle: writes node, adds definition entry once, regenerates `va
     "priority": "Low"
   },
   "outputs": {
-    "result": { "type": "object", "description": "Task result data", "source": "=result", "var": "result" },
-    "status": { "type": "string", "description": "Task completion status", "source": "=status", "var": "status" }
+    "output": { "type": "object", "description": "Task result data", "source": "=result", "var": "output" },
+    "status": { "type": "string", "description": "Task completion status", "source": "=result.Action", "var": "status" }
   }
 }
 ```
@@ -65,9 +65,9 @@ BPMN type (`bpmn:UserTask`) and serviceType (`Actions.HITL`) come from the `uipa
 **Ports:** `input` (target) → `completed` (source)
 
 **Output variables:**
-- `$vars.{nodeId}.result` — object with all `output` / `inOut` fields the human filled in
-- `$vars.{nodeId}.result.{fieldName}` — individual field value
-- `$vars.{nodeId}.status` — `"completed"`
+- `$vars.{nodeId}.output` — object with all `output` / `inOut` fields the human filled in
+- `$vars.{nodeId}.output.{fieldName}` — individual field value
+- `$vars.{nodeId}.status` — selected outcome's action value (`"Continue"` or `"End"`)
 
 ---
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
@@ -41,9 +41,9 @@ Available: always — no `uip login` or registry pull required.
 
 ### Output Variables
 
-- `$vars.{nodeId}.result` — object containing all output and inOut fields the human filled in
-- `$vars.{nodeId}.result.{fieldName}` — individual field value
-- `$vars.{nodeId}.status` — `"completed"`
+- `$vars.{nodeId}.output` — object containing all output and inOut fields the human filled in
+- `$vars.{nodeId}.output.{fieldName}` — individual field value
+- `$vars.{nodeId}.status` — selected outcome's action value (`"Continue"` or `"End"`)
 
 ### Schema Design
 

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -183,7 +183,7 @@ uip maestro flow hitl add <path/to/file.flow> \
   --label "Invoice Review" \
   --priority High \
   --assignee finance-approvers \
-  --schema '{"inputs":[{"name":"invoiceId","binding":"fetchInvoice.result.invoiceId"},{"name":"amount","type":"number","binding":"fetchInvoice.result.amount"}],"outputs":[{"name":"decision","required":true}],"outcomes":[{"name":"Approve"},{"name":"Reject"}]}' \
+  --schema '{"inputs":[{"name":"invoiceId","binding":"fetchInvoice.output.invoiceId"},{"name":"amount","type":"number","binding":"fetchInvoice.output.amount"}],"outputs":[{"name":"decision","required":true}],"outcomes":[{"name":"Approve"},{"name":"Reject"}]}' \
   --position 474,144 \
   --output json
 ```
@@ -200,8 +200,8 @@ uip maestro flow hitl add <path/to/file.flow> \
 
 ```json
 {
-  "inputs":  [{ "name": "invoiceId", "binding": "fetchInvoice.result.invoiceId" },
-              { "name": "amount", "type": "number", "binding": "fetchInvoice.result.amount" }],
+  "inputs":  [{ "name": "invoiceId", "binding": "fetchInvoice.output.invoiceId" },
+              { "name": "amount", "type": "number", "binding": "fetchInvoice.output.amount" }],
   "outputs": [{ "name": "decision", "required": true },
               { "name": "notes" }],
   "inOuts":  [{ "name": "emailBody" }],
@@ -209,7 +209,7 @@ uip maestro flow hitl add <path/to/file.flow> \
 }
 ```
 
-- `inputs` — read-only context fields shown to the reviewer; `binding` is the full `$vars` path (e.g. `fetchInvoice.result.invoiceId`)
+- `inputs` — read-only context fields shown to the reviewer; `binding` is the full `$vars` path (e.g. `fetchInvoice.output.invoiceId`)
 - `outputs` — fields the human fills in; `variable` defaults to the field name
 - `inOuts` — pre-filled editable fields (human can modify before submitting)
 - `outcomes` — button labels; first is primary (Approve path); subsequent ones end the flow unless you re-wire them

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -1,0 +1,182 @@
+task_id: skill-flow-e2e-devcon-expense-approval
+description: >
+  DevCon end-to-end scenario: developer gives a vague expense approval requirement.
+  Agent must detect the HITL need, design a sensible schema with correct field types,
+  build the full flow (trigger → script → HITL → script → end), wire edges correctly
+  including the completed handle, and validate. Tests that both the maestro-flow and
+  human-in-the-loop skills work together across the full authoring lifecycle.
+tags: [uipath-maestro-flow, uipath-human-in-the-loop, e2e, integration, devcon]
+
+agent:
+  type: claude-code
+  max_turns: 120
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I want to automate our expense approval workflow. Here's the rough idea:
+
+  Employees submit expense reports through our internal system. We need a flow that:
+  - Pulls the expense details (let's mock this as a script for now — expense amount,
+    who submitted it, what category like "Travel" or "Equipment", and an expense ID)
+  - Sends it to a manager for review. The manager needs to see the details and either
+    approve or reject. If they reject, they should be able to add a reason. The
+    manager group is "expense-approvers".
+  - After the manager decides, we log the outcome in another script node — it should
+    read the manager's decision and their rejection reason if they rejected it.
+
+  I'm not sure exactly what all the fields should be, but the key ones are: the
+  amount (it's a number), the submitter's name (text), and the category (text).
+  The manager fills in their decision (approved yes/no) and optionally a reason.
+
+  Build the complete flow as a UiPath Flow project called "ExpenseApproval" in a
+  solution of the same name. Wire everything end-to-end and validate it.
+
+  After building, save a summary to report.json:
+  {
+    "solution": "ExpenseApproval",
+    "flow_file": "<relative path to the .flow file>",
+    "hitl_node_id": "<id of the HITL node>",
+    "hitl_schema": {
+      "input_fields": ["<list of field IDs shown to the manager>"],
+      "output_fields": ["<list of field IDs the manager fills in>"],
+      "outcomes": ["<list of outcome names>"]
+    },
+    "decision_access_path": "<$vars path used in the downstream logging script to read the manager's decision>",
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created a solution"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+solution\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent initialized a Flow project"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used uip maestro flow hitl add to add the HITL node"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+hitl\s+add'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow file exists at correct double-nested path"
+    command: "test -f ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "HITL node is present with correct type"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"uipath.human-in-the-loop"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "HITL node uses v1.0 schema (typeVersion 1.0)"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"typeVersion": "1.0"'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Amount field uses number type (not text)"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"number"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Decision/approval field uses boolean type"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"boolean"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Completed handle is wired"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"completed"'
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Input fields are bound to upstream script output using correct v1.0 .output path"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - '"binding": "=js:$vars.'
+      - '.output.'
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Downstream script accesses HITL output via $vars.<nodeId>.output path"
+    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+    includes:
+      - "$vars."
+      - ".output."
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow validates successfully"
+    command: "uip maestro flow validate ExpenseApproval/ExpenseApproval/ExpenseApproval.flow --output json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json confirms correct HITL schema and access path"
+    path: "report.json"
+    assertions:
+      - expression: "solution"
+        operator: equals
+        expected: "ExpenseApproval"
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+      - expression: "length(hitl_schema.input_fields)"
+        operator: gte
+        expected: 2
+      - expression: "length(hitl_schema.output_fields)"
+        operator: gte
+        expected: 1
+      - expression: "length(hitl_schema.outcomes)"
+        operator: gte
+        expected: 2
+      - expression: "decision_access_path"
+        operator: contains
+        expected: ".output."
+    weight: 3.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -89,11 +89,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "result_variable references $vars.<nodeId>.result"
+    description: "result_variable references $vars.<nodeId>.output"
     path: "report.json"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -1,8 +1,8 @@
 task_id: skill-flow-hitl-quality-result-downstream
 description: >
   Quality test: agent correctly references the HITL node's output via
-  $vars.<nodeId>.result in a downstream node. Tests that the agent knows
-  the result variable path and wires it into a decision or script node.
+  $vars.<nodeId>.output in a downstream node. Tests that the agent knows
+  the output variable path and wires it into a decision or script node.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
 agent:
@@ -36,7 +36,7 @@ initial_prompt: |
   Save a summary to report.json:
   {
     "hitl_node_id": "<id>",
-    "result_path": "<full variable path used in the script, e.g. $vars.hitlReview1.result.approved>",
+    "result_path": "<full variable path used in the script, e.g. $vars.hitlReview1.output.approved>",
     "validation_passed": true
   }
 
@@ -58,11 +58,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Flow references the HITL result variable"
+    description: "Flow references the HITL output variable"
     path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 3.0
     pass_threshold: 1.0
 
@@ -75,11 +75,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "report.json result_path references $vars and .result"
+    description: "report.json result_path references $vars and .output"
     path: "report.json"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -2,7 +2,7 @@ task_id: skill-flow-hitl-quality-boolean-decision
 description: >
   Quality test: agent correctly wires a boolean HITL output field into a
   Decision node condition using the exact runtime path
-  $vars.<nodeId>.result.<fieldName>. Tests field-level variable access
+  $vars.<nodeId>.output.<fieldName>. Tests field-level variable access
   and that both Decision branches are wired to distinct downstream nodes.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
@@ -32,14 +32,14 @@ initial_prompt: |
   Wire: Trigger → Script → HITL →|completed| Decision → (two branches) → End
 
   The Decision node condition MUST use the exact field-level runtime variable
-  path — not just $vars.<nodeId>.result but specifically the approved field.
+  path — not just $vars.<nodeId>.output but specifically the approved field.
 
   Do NOT run flow debug. Validate after building.
 
   Save a summary to report.json:
   {
     "hitl_node_id": "<id>",
-    "decision_condition": "<full expression used, e.g. $vars.complianceReview1.result.approved>",
+    "decision_condition": "<full expression used, e.g. $vars.complianceReview1.output.approved>",
     "result_path_used": "<same or equivalent path referenced in the Decision>",
     "validation_passed": true
   }
@@ -63,11 +63,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Decision node condition references field-level HITL result"
+    description: "Decision node condition references field-level HITL output"
     path: "VendorApproval/VendorApproval/VendorApproval.flow"
     includes:
       - "$vars."
-      - ".result.approved"
+      - ".output.approved"
     weight: 3.0
     pass_threshold: 1.0
 
@@ -85,7 +85,7 @@ success_criteria:
     path: "report.json"
     includes:
       - "$vars."
-      - ".result.approved"
+      - ".output.approved"
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -31,7 +31,7 @@ initial_prompt: |
   Wire: Trigger → HITL →|completed| Decision → both branches → Script → End
 
   The Decision node condition must reference the HITL result using the
-  correct runtime variable path ($vars.<nodeId>.result.<fieldName>).
+  correct runtime variable path ($vars.<nodeId>.output.<fieldName>).
 
   Do NOT run flow debug. Validate after building.
 
@@ -39,7 +39,7 @@ initial_prompt: |
   {
     "hitl_node_id": "<id>",
     "decision_node_id": "<id of the Decision node>",
-    "decision_expression": "<full expression used, e.g. $vars.hitl1.result.approved>",
+    "decision_expression": "<full expression used, e.g. $vars.hitl1.output.approved>",
     "validation_passed": true
   }
 
@@ -69,11 +69,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Decision node references HITL result variable"
+    description: "Decision node references HITL output variable"
     path: "LeaveRequest/LeaveRequest/LeaveRequest.flow"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 2.5
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

Updates `skills/uipath-maestro-flow` and `tests/tasks/uipath-maestro-flow` to use `$vars.<nodeId>.output` (not `.result`) and `status source =result.Action` following the v1.0 HITL node schema rename.

> **Note**: HITL skill docs (`uipath-human-in-the-loop/`) and their eval tests are handled in a separate PR (#529) owned by @dushyant-uipath.

## Files changed

- `skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md` — Quick Reference JSON fixed: `outputs.output` (not `result`), `status.source = "=result.Action"`
- `skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md`
- `skills/uipath-maestro-flow/references/shared/cli-commands.md`
- `tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml`
- `tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml`
- `tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml`
- `tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml`
- `tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml` (**new**) — DevCon end-to-end scenario: vague expense approval requirement, agent builds full flow with HITL using both maestro-flow and HITL skills

## Test plan

- [ ] `quality_01`, `quality_02`, `quality_03`, `smoke_03` pass with updated `.output` paths
- [ ] `devcon_expense_approval` passes end-to-end: solution creation, flow init, hitl add, validate