### PR TITLE
fix(hitl): align HITL skill and tests to v1.0 node schema

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -38,6 +38,7 @@ See [references/hitl-patterns.md](references/hitl-patterns.md) for the full busi
 6. **The definition entry is added once.** Check `workflow.definitions` — if `uipath.human-in-the-loop` is already there, do not add it again.
 7. **Check existing node IDs before generating a new one.** Read `workflow.nodes[*].id` from the `.flow` file and pick the next available suffix (e.g. `invoiceReview1`, then `invoiceReview2`).
 8. **Never report a failed validation as done.** If `uip maestro flow validate` returns errors, diagnose from the JSON output and fix before reporting to the user.
+9. **Output fields are accessed by `field.id`, not `field.variable`.** The runtime result object uses field IDs as keys — `$vars.<nodeId>.output.<fieldId>`. The `variable` property creates a separate workflow-global variable (`$vars.{variable}`) but does NOT change the key used in the output object.
 
 ---
 
@@ -285,7 +286,7 @@ After completing the wiring:
 1. **What was inserted** — node ID, label, insertion point
 2. **Schema summary** — what the human will see (input-direction fields), fill in (output/inOut-direction fields), and click (outcomes). For deployed action app show the actionSchema from the retrieve-configuration api response here.
 3. **Edges wired** — which handles were connected and to which nodes; any handles left unwired
-4. **Runtime variables** — `$vars.<nodeId>.result` (object) and `$vars.<nodeId>.status` (string) and how to reference them downstream
+4. **Runtime variables** — `$vars.<nodeId>.output` (object) and `$vars.<nodeId>.status` (string) and how to reference them downstream
 5. **Validation result** — pass or errors to fix
 6. **Production readiness note:**
    - **QuickForm**: ready to deploy once the solution is packaged. No additional build steps.

--- a/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
@@ -345,19 +345,17 @@ Same definition as QuickForm — see [hitl-node-quickform.md](hitl-node-quickfor
 
 ## Edge Wiring
 
-Identical to QuickForm. Wire `completed`, `cancelled`, `timeout`:
+Identical to QuickForm. Only the `completed` handle is available — there are no `cancelled` or `timeout` handles in v1.0:
 
 ```json
-{ "id": "invoiceReview1-completed-nextNode1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "nextNode1", "targetPort": "input" },
-{ "id": "invoiceReview1-cancelled-end1-input",      "sourceNodeId": "invoiceReview1", "sourcePort": "cancelled", "targetNodeId": "end1",      "targetPort": "input" },
-{ "id": "invoiceReview1-timeout-end2-input",        "sourceNodeId": "invoiceReview1", "sourcePort": "timeout",   "targetNodeId": "end2",      "targetPort": "input" }
+{ "id": "invoiceReview1-completed-nextNode1-input", "sourceNodeId": "invoiceReview1", "sourcePort": "completed", "targetNodeId": "nextNode1", "targetPort": "input" }
 ```
 
 ---
 
 ## `variables.nodes` — Regenerate After Adding
 
-Same rule as QuickForm — add `result` and `status` entries for the new node, then replace the entire `variables.nodes` array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
+Same rule as QuickForm — add `output` and `status` entries for the new node, then replace the entire `variables.nodes` array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
 
 ---
 
@@ -367,5 +365,5 @@ Same as QuickForm:
 
 | Variable | What it contains |
 |---|---|
-| `$vars.<nodeId>.result` | Outputs the human filled in via the app |
-| `$vars.<nodeId>.status` | `"completed"`, `"cancelled"`, or `"timeout"` |
+| `$vars.<nodeId>.output` | Outputs the human filled in via the app |
+| `$vars.<nodeId>.status` | Selected outcome's action value (`"Continue"` or `"End"`) |

--- a/skills/uipath-human-in-the-loop/references/hitl-node-coded-action-app.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-coded-action-app.md
@@ -320,9 +320,9 @@ All values below come directly from the `ParsedActionSchema` assembled in Step 4
 
 **Definition entry** — same as QuickForm. See [hitl-node-quickform.md](hitl-node-quickform.md) for the full definition block. Add once to `workflow.definitions`, deduplicated by `nodeType`.
 
-**Edge wiring** — wire `completed`, `cancelled`, `timeout`. See [hitl-node-quickform.md](hitl-node-quickform.md) for edge format.
+**Edge wiring** — wire `completed` (only handle available in v1.0). See [hitl-node-quickform.md](hitl-node-quickform.md) for edge format.
 
-**`variables.nodes` regeneration** — add `result` and `status` entries for the new node, then replace the entire array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
+**`variables.nodes` regeneration** — add `output` and `status` entries for the new node, then replace the entire array. See [hitl-node-quickform.md](hitl-node-quickform.md) for the regeneration algorithm.
 
 ---
 
@@ -330,5 +330,5 @@ All values below come directly from the `ParsedActionSchema` assembled in Step 4
 
 | Variable | Contents |
 |---|---|
-| `$vars.<nodeId>.result` | Outputs the human filled in via the app form |
-| `$vars.<nodeId>.status` | `"completed"`, `"cancelled"`, or `"timeout"` |
+| `$vars.<nodeId>.output` | Outputs the human filled in via the app form |
+| `$vars.<nodeId>.status` | Selected outcome's action value (`"Continue"` or `"End"`) |

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -1,6 +1,6 @@
 # HITL QuickForm Node — Direct JSON Reference
 
-The agent writes the `uipath.human-in-the-loop` node directly into the `.flow` file as JSON. **Direct JSON is the default.** A CLI opt-in is also available when the user explicitly requests it — see [flow-commands.md — uip maestro flow hitl add](../../../../uipath-maestro-flow/references/flow-commands.md#uip-maestro-flow-hitl-add).
+The agent writes the `uipath.human-in-the-loop` node directly into the `.flow` file as JSON. **Direct JSON is the default.** A CLI opt-in is also available when the user explicitly requests it — see [cli-commands.md — uip maestro flow hitl add](../../../../uipath-maestro-flow/references/shared/cli-commands.md#uip-maestro-flow-hitl-add).
 
 ---
 
@@ -42,11 +42,11 @@ The `id` field is the `$vars` path — `fetchInvoice.output` → `$vars.fetchInv
 |---|---|---|
 | HTTP node | `output` | `$vars.{nodeId}.output.body.{field}` |
 | Script node | `output` | `$vars.{nodeId}.output.{field}` |
-| Prior HITL node | `result`, `status` | `$vars.{nodeId}.result.{field}` |
+| Prior HITL node | `output`, `status` | `$vars.{nodeId}.output.{field}` |
 | Agent node | `output` | `$vars.{nodeId}.output.content` |
 | Trigger (manual) | `output` | `$vars.start.output.{field}` |
 
-For the full variable system, see → [uipath-maestro-flow — variables-and-expressions.md](../../../../uipath-maestro-flow/references/variables-and-expressions.md)
+For the full variable system, see → [uipath-maestro-flow — variables-and-expressions.md](../../../../uipath-maestro-flow/references/shared/variables-and-expressions.md)
 
 ---
 
@@ -146,14 +146,14 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
 ```json
 {
   "nodeType": "uipath.human-in-the-loop",
-  "version": "1.0.0",
+  "version": "1.0",
   "category": "human-task",
   "tags": ["human-task", "hitl", "human-in-the-loop", "approval"],
   "sortOrder": 50,
   "display": {
     "label": "Human in the Loop",
     "icon": "users",
-    "shape": "rectangle"
+    "shape": "square"
   },
   "handleConfiguration": [
     {
@@ -162,11 +162,7 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
         {
           "id": "input",
           "type": "target",
-          "handleType": "input",
-          "constraints": {
-            "forbiddenSourceCategories": ["trigger"],
-            "validationMessage": "Human tasks cannot be directly triggered"
-          }
+          "handleType": "input"
         }
       ],
       "visible": true
@@ -195,8 +191,8 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
     "priority": "Normal"
   },
   "outputDefinition": {
-    "result": { "type": "object", "description": "Task result data", "source": "=result", "var": "result" },
-    "status": { "type": "string", "description": "Task completion status", "source": "=status", "var": "status" }
+    "output": { "type": "object", "description": "Task result data", "source": "=result", "var": "output" },
+    "status": { "type": "string", "description": "Task completion status", "source": "=result.Action", "var": "status" }
   }
 }
 ```
@@ -217,15 +213,15 @@ Wire the `completed` output handle to the downstream node. Edge ID format: `{sou
 
 ## `variables.nodes` — Regenerate After Every Node Add/Remove
 
-The HITL node exposes two outputs (`result`, `status`). After adding it, **completely replace** `workflow.variables.nodes` by iterating all nodes and collecting their outputs:
+The HITL node exposes two outputs (`output`, `status`). After adding it, **completely replace** `workflow.variables.nodes` by iterating all nodes and collecting their outputs:
 
 ```json
 "variables": {
   "nodes": [
     {
-      "id": "invoiceReview1.result",
+      "id": "invoiceReview1.output",
       "type": "object",
-      "binding": { "nodeId": "invoiceReview1", "outputId": "result" }
+      "binding": { "nodeId": "invoiceReview1", "outputId": "output" }
     },
     {
       "id": "invoiceReview1.status",
@@ -251,7 +247,7 @@ The agent translates the user's business description into the `fields[]` and `ou
 | field `id` | lowercase label, spaces→`-`, strip non-alphanumeric. `"Invoice ID"` → `"invoiceid"`, `"Due Date"` → `"due-date"` |
 | `direction` | `inputs[]` items → `"input"`, `outputs[]` → `"output"`, `inOuts[]` → `"inOut"` |
 | field `type` | `"string"` → `"text"`, `"number"` → `"number"`, `"boolean"` → `"boolean"`, `"date"` → `"date"` |
-| `binding` | Read `variables.nodes` to find `{nodeId}.{outputId}` for the upstream node, then construct `"=js:$vars.<nodeId>.<outputId>.<varName>"`. The outputId is `output` for HTTP/script/agent/trigger nodes, `result` for a prior HITL node — do not assume `.result.` universally |
+| `binding` | Read `variables.nodes` to find `{nodeId}.{outputId}` for the upstream node, then construct `"=js:$vars.<nodeId>.<outputId>.<varName>"`. The outputId is `output` for HTTP/script/agent/trigger nodes and for a prior HITL node (v1.0) — always read `variables.nodes` to confirm, never assume |
 | `variable` | output/inOut variable name — defaults to `id` if not specified |
 | `required` | omit if false; set `true` for mandatory outputs |
 | `outcomes[0]` | `isPrimary: true`, `outcomeType: "Positive"`, `action: "Continue"` |
@@ -330,14 +326,17 @@ After the HITL node, downstream nodes can reference:
 
 | Variable | Type | What it contains |
 |---|---|---|
-| `$vars.<nodeId>.result` | object | All `output` and `inOut` fields the human filled in |
-| `$vars.<nodeId>.result.<fieldVariable>` | varies | Individual field value (e.g. `$vars.invoiceReview1.result.decision`) |
-| `$vars.<nodeId>.status` | string | `"completed"` when the human submits the task |
+| `$vars.<nodeId>.output` | object | All `output` and `inOut` fields the human filled in, keyed by **field `id`** |
+| `$vars.<nodeId>.output.<fieldId>` | varies | Individual field value using the field's `id` property (e.g. `$vars.invoiceReview1.output.decision`) |
+| `$vars.<nodeId>.status` | string | Selected outcome's action value (`"Continue"` for primary, `"End"` for secondary) |
+
+> **`fieldId` not `variable`**: The output object properties are keyed by the field's `id` (e.g. `"decision"`), not by the `variable` property. The `variable` property creates a separate workflow-global variable (`$vars.{variable}`) — it does not change the key used in the output object. If a field has `"id": "dec1"` and `"variable": "approvalResult"`, access it as `$vars.nodeId.output.dec1`, not `.approvalResult`.
 
 **In a downstream script node:**
 ```javascript
-const result = $vars.invoiceReview1.result;
-if ($vars.invoiceReview1.status === "completed") {
-  await updateSystem(result.vendorName, result.costCenter);
+const output = $vars.invoiceReview1.output;
+// Access by field ID, not variable name
+if ($vars.invoiceReview1.status === "Continue") {
+  await updateSystem(output.vendorName, output.costCenter);
 }
 ```

--- a/tests/tasks/uipath-human-in-the-loop/TEST_PLAN.md
+++ b/tests/tasks/uipath-human-in-the-loop/TEST_PLAN.md
@@ -4,7 +4,7 @@
 |---|---|
 | **Surface** | `uipath-human-in-the-loop` skill |
 | **Repo** | `UiPath/skills` |
-| **Status** | Draft — Apr 2026 |
+| **Status** | Active — May 2026 |
 
 ---
 
@@ -26,12 +26,52 @@ Agent-facing test scenarios for the `uipath-human-in-the-loop` skill — detects
 
 ---
 
+## Node v1.0 — What the Tests Verify
+
+All tests target `uipath.human-in-the-loop` v1.0 (the current manifest). Key invariants:
+
+| Property | v1.0 value | Common mistake |
+|---|---|---|
+| Output variable | `$vars.<nodeId>.output` | Using `.result` (v1.0.0 behavior) |
+| Output access key | field `id` property | Using field `variable` property |
+| Status variable | `$vars.<nodeId>.status` | Expecting `"completed"` string |
+| Status value | outcome `action` value (`"Continue"` / `"End"`) | Comparing to `"completed"` |
+| Available handles | `completed` only | Wiring `cancelled` or `timeout` (removed in v1.0) |
+| Definition shape | `version: "1.0"`, `shape: "square"` | `"1.0.0"` / `"rectangle"` |
+
+---
+
+## Variable Binding Accuracy
+
+The two most common developer mistakes around HITL variable binding:
+
+### 1. fieldId vs variable property
+
+The HITL runtime result object keys are the field's **`id`** property, not the `variable` property.
+
+```json
+{ "id": "dec1", "variable": "approvalResult", "direction": "output" }
+```
+
+Correct access: `$vars.nodeId.output.dec1`
+Wrong access: `$vars.nodeId.output.approvalResult`
+
+The `variable` property creates a separate workflow-global variable (`$vars.approvalResult`) — this is a different access path, not the output object property.
+
+### 2. binding on input vs output fields
+
+- **Input fields** (`"direction": "input"`): MUST have `binding` pointing to upstream node output. Read from `variables.nodes` to construct `"=js:$vars.<nodeId>.output.<field>"`.
+- **Output fields** (`"direction": "output"`): MUST NOT have `binding`. The human fills these in.
+- **InOut fields** (`"direction": "inOut"`): MUST have `binding` (pre-fills from upstream) AND appear in `$vars.<nodeId>.output` after the human submits (same as output fields).
+
+---
+
 ## Test Structure
 
 | Tier | Purpose | Cadence |
 |---|---|---|
 | **Smoke** | Skill-trigger routing, negative guards — offline, tempdir sandbox | Every PR |
-| **Quality** | Schema design accuracy, handle wiring, options, confirm-before-CLI rule | Every PR |
+| **Quality** | Schema design accuracy, variable binding, handle wiring, options | Every PR |
 | **E2E** | Full authoring lifecycle: Discover → Plan → Build → Verify — no step-by-step guidance | Pre-release |
 
 **Scenario types:**
@@ -60,25 +100,29 @@ Agent-facing test scenarios for the `uipath-human-in-the-loop` skill — detects
 | ✅ Present | [smoke_07_neg_automated.yaml](smoke_07_neg_automated.yaml) | `skill-hitl-smoke-neg-automated` | Fully automated single-supplier pipeline with explicit no-review sign-off → `hitl_needed: false` | 🔴 Negative |
 | ✅ Present | [smoke_08_neg_admin.yaml](smoke_08_neg_admin.yaml) | `skill-hitl-smoke-neg-admin` | Action Center reassignment question (runtime admin) → `hitl_authoring_needed: false`, no flow authoring | 🔴 Negative |
 
-### Quality — 4 of 7 present, **3 gaps confirmed** ❌
+### Quality — 8 of 11 present ✅ (3 pending)
 
 | Status | File | Task ID | What it tests | Type |
 |---|---|---|---|---|
 | ✅ Present | [quality_01_approval_gate_schema.yaml](quality_01_approval_gate_schema.yaml) | `skill-hitl-quality-approval-gate-schema` | Invoice approval schema design (inputs/outputs/outcomes); agent must produce schema and stop — no CLI commands before user approves | 🟤 Brown |
-| ❌ **Missing** | `quality_02_escalation_schema.yaml` | — | **Not created** — see proposed spec below | — |
-| ❌ **Missing** | `quality_03_inouts_data_enrichment_schema.yaml` | — | **Not created** — see proposed spec below | — |
-| ✅ Present | [quality_04_all_handles.yaml](quality_04_all_handles.yaml) | `skill-hitl-quality-completed-handle-and-result` | Wire `completed` handle → downstream script node; agent references `$vars.<id>.result`; validate | 🟢 Green |
-| ✅ Present | [quality_05_priority_and_timeout.yaml](quality_05_priority_and_timeout.yaml) | `skill-hitl-quality-priority-timeout` | HIGH priority + `PT48H` timeout (ISO 8601); validate `FinanceCompliance` flow | 🟤 Brown |
-| ❌ **Missing** | `quality_06_confirm_before_cli_rule.yaml` | — | **Not created** — see proposed spec below | — |
-| ✅ Present | [quality_07_runtime_vars.yaml](quality_07_runtime_vars.yaml) | `skill-hitl-quality-runtime-vars` | Both `$vars.<id>.result` AND `$vars.<id>.status` referenced in downstream script; validate `ReviewAndRoute` | 🟢 Green |
+| ❌ **Missing** | `quality_02_escalation_schema.yaml` | — | Escalation chain: 3+ outcomes (Approve/Escalate/Reject); agent designs schema and stops before CLI | — |
+| ❌ **Missing** | `quality_03_inouts_data_enrichment_schema.yaml` | — | inOut vs output distinction: human sees+fills vs human fills from scratch | — |
+| ✅ Present | [quality_04_all_handles.yaml](quality_04_all_handles.yaml) | `skill-hitl-quality-completed-handle-and-result` | Wire `completed` handle → downstream script node; agent references `$vars.<id>.output` by field ID; validate | 🟢 Green |
+| ✅ Present | [quality_05_priority_and_timeout.yaml](quality_05_priority_and_timeout.yaml) | `skill-hitl-quality-priority-timeout` | HIGH priority + `PT48H` timeout duration (ISO 8601); validate `FinanceCompliance` flow | 🟤 Brown |
+| ❌ **Missing** | `quality_06_confirm_before_cli_rule.yaml` | — | Adversarial: user says "skip the review" — agent must still propose schema and withhold CLI | — |
+| ✅ Present | [quality_07_runtime_vars.yaml](quality_07_runtime_vars.yaml) | `skill-hitl-quality-runtime-vars` | Both `$vars.<id>.output` AND `$vars.<id>.status` referenced in downstream script; validate `ReviewAndRoute` | 🟢 Green |
+| ✅ Present | [quality_08_variable_binding_fieldid.yaml](quality_08_variable_binding_fieldid.yaml) | `skill-hitl-quality-variable-binding-fieldid` | Agent uses field `id` (not `variable`) to access output fields; `$vars.nodeId.output.approved` not `.legalApproval` | 🟢 Green |
+| ✅ Present | [quality_09_dev_mistake_wrong_type.yaml](quality_09_dev_mistake_wrong_type.yaml) | `skill-hitl-quality-dev-mistake-wrong-type` | Agent infers correct types from description: boolean for yes/no, number for amounts, date for deadlines | 🟢 Green |
+| ✅ Present | [quality_10_dev_mistake_binding_direction.yaml](quality_10_dev_mistake_binding_direction.yaml) | `skill-hitl-quality-dev-mistake-binding-direction` | Input fields get binding from upstream; output fields get NO binding; bindings use `variables.nodes` paths | 🟢 Green |
+| ✅ Present | [quality_11_inout_field_access.yaml](quality_11_inout_field_access.yaml) | `skill-hitl-quality-inout-field-access` | inOut fields: pre-filled via binding AND appear in `$vars.nodeId.output` after submit (same as output) | 🟢 Green |
 
 ### E2E — 7 of 7 present (1 skipped) ✅⏭
 
 | Status | File | Task ID | What it tests | Type |
 |---|---|---|---|---|
-| ✅ Present | [e2e_01_invoice_approval_greenfield.yaml](e2e_01_invoice_approval_greenfield.yaml) | `skill-hitl-e2e-invoice-approval-greenfield` | SharePoint → HITL → SAP; full Discover→Plan→Build→Verify; wires `completed`, captures `$vars.result` | 🟤 Brown |
+| ✅ Present | [e2e_01_invoice_approval_greenfield.yaml](e2e_01_invoice_approval_greenfield.yaml) | `skill-hitl-e2e-invoice-approval-greenfield` | SharePoint → HITL → SAP; full Discover→Plan→Build→Verify; wires `completed`, captures `$vars.output` | 🟤 Brown |
 | ✅ Present | [e2e_02_ai_escalation_brownfield.yaml](e2e_02_ai_escalation_brownfield.yaml) | `skill-hitl-e2e-ai-escalation-brownfield` | Inserts HITL escalation node into existing `ComplaintTriage` flow on low-confidence path; wires `completed` | 🟤 Brown |
-| ✅ Present | [e2e_03_gdpr_compliance_greenfield.yaml](e2e_03_gdpr_compliance_greenfield.yaml) | `skill-hitl-e2e-gdpr-compliance-greenfield` | GDPR deletion flow from scratch; 7-day timeout (ISO 8601); wires both `completed` and `timeout` handles | 🟢 Green |
+| ✅ Present | [e2e_03_gdpr_compliance_greenfield.yaml](e2e_03_gdpr_compliance_greenfield.yaml) | `skill-hitl-e2e-gdpr-compliance-greenfield` | GDPR deletion flow from scratch; P7D timeout duration (ISO 8601); wires `completed` | 🟢 Green |
 | ✅ Present | [e2e_04_multi_hitl_brownfield.yaml](e2e_04_multi_hitl_brownfield.yaml) | `skill-hitl-e2e-multi-hitl-brownfield` | Inserts **two** HITL nodes into `HROnboarding` flow (doc review + IT access); both completed handles wired | 🟤 Brown |
 | ✅ Present | [e2e_05_expense_approval_brownfield.yaml](e2e_05_expense_approval_brownfield.yaml) | `skill-hitl-e2e-expense-approval-brownfield` | Inserts single HITL node between two existing nodes in minimal `ExpenseApproval` flow; wires `completed` | 🟤 Brown |
 | ✅ Present | [e2e_06_invoice_approval_greenfield_simple.yaml](e2e_06_invoice_approval_greenfield_simple.yaml) | `skill-hitl-e2e-invoice-approval-greenfield-simple` | Creates `InvoiceApproval` project from scratch (`uip solution new` + `flow init`); wires `completed`; validates | 🟢 Green |
@@ -86,20 +130,37 @@ Agent-facing test scenarios for the `uipath-human-in-the-loop` skill — detects
 
 ---
 
+## Coverage Map — Real-World Optimization
+
+Each quality test targets a specific failure pattern observed in agent behavior:
+
+| Test | Developer mistake / skill gap it guards against | Real-world consequence if uncaught |
+|---|---|---|
+| `quality_04` | Agent forgets to wire `completed` handle | Flow blocks indefinitely at the HITL step in production |
+| `quality_07` | Agent references wrong variable path or wrong output key | Downstream scripts crash at runtime with undefined variable errors |
+| `quality_08` | Agent uses `variable` property instead of field `id` for output access | `$vars.nodeId.output.legalApproval` is undefined; actual value is at `output.approved` |
+| `quality_09` | Agent defaults all fields to `text` type | Boolean comparisons fail (`"true" !== true`); numbers compared as strings |
+| `quality_10` | Agent adds `binding` to output fields, or forgets it on input fields | Blank form fields for reviewer (missing binding), or human input is silently ignored (binding on output overwrites) |
+| `quality_11` | Agent uses `"output"` direction for editable+pre-filled fields instead of `"inOut"` | Human sees empty field (no pre-fill) or cannot edit it (treated as read-only input) |
+
+---
+
 ## Coverage Gaps
 
 | Capability | Smoke | Quality | E2E |
 |---|---|---|---|
-| Schema — `inOuts` for fill-in fields (data enrichment) | ✅ [smoke_06](smoke_06_data_enrichment.yaml) | ❌ **quality_03 missing** | — |
-| Schema — escalation chain (3+ outcomes) | — | ❌ **quality_02 missing** | ✅ [e2e_02](e2e_02_ai_escalation_brownfield.yaml) |
-| Confirm-before-CLI rule (adversarial — user says "skip") | — | ❌ **quality_06 missing** | — |
-| Wire `timeout` handle | — | ❌ **no quality test** | ✅ [e2e_03](e2e_03_gdpr_compliance_greenfield.yaml) |
-| Negative: broken / empty schema passed to CLI | — | ❌ **quality_03 missing** | — |
+| Schema — `inOuts` for fill-in fields (data enrichment) | ✅ [smoke_06](smoke_06_data_enrichment.yaml) | ❌ **quality_03 pending** | — |
+| Schema — escalation chain (3+ outcomes) | — | ❌ **quality_02 pending** | ✅ [e2e_02](e2e_02_ai_escalation_brownfield.yaml) |
+| Confirm-before-CLI rule (adversarial) | — | ❌ **quality_06 pending** | — |
+| Variable binding: fieldId access | — | ✅ [quality_08](quality_08_variable_binding_fieldid.yaml) | — |
+| Variable binding: type accuracy | — | ✅ [quality_09](quality_09_dev_mistake_wrong_type.yaml) | — |
+| Variable binding: input vs output direction | — | ✅ [quality_10](quality_10_dev_mistake_binding_direction.yaml) | — |
+| inOut pre-fill + downstream access | ✅ [smoke_06](smoke_06_data_enrichment.yaml) | ✅ [quality_11](quality_11_inout_field_access.yaml) | — |
 | Negative: invalid flow path | ❌ **no smoke test** | — | — |
 
 ---
 
-## Gap Priority
+## Remaining Gap Priority
 
 #### 🔴 `quality_06_confirm_before_cli_rule.yaml`
 [quality_01](quality_01_approval_gate_schema.yaml) only checks the cooperative case where the user asks for a schema review first. This test covers the adversarial case: user says "just do it, skip the review" — agent must still propose the schema and withhold `uip flow node add` until confirmed.
@@ -109,9 +170,6 @@ Agent-facing test scenarios for the `uipath-human-in-the-loop` skill — detects
 
 #### 🔴 `quality_03_inouts_data_enrichment_schema.yaml`
 [smoke_06](smoke_06_data_enrichment.yaml) checks detection only. At quality depth, the agent must use `inOuts` (not `outputs`) for fields the human both sees and fills in, author the node, and validate — confirming the distinction survives actual CLI authoring.
-
-#### 🟠 `quality_08_timeout_handle.yaml`
-`timeout` handle wiring is only tested in [e2e_03](e2e_03_gdpr_compliance_greenfield.yaml) as part of a full business scenario. A focused quality test should verify the agent wires the `timeout` handle to a downstream node and sets a valid ISO 8601 duration in isolation.
 
 #### 🟠 `smoke_09_neg_invalid_flow_path.yaml`
 No test covers what happens when the agent tries to add a HITL node to a `.flow` file that doesn't exist. Agent must surface the CLI error cleanly and must not create a blank `.flow` file as a workaround.

--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -89,10 +89,10 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Agent captured the runtime result variable"
+    description: "Agent captured the runtime output variable"
     path: "report.json"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -5,9 +5,9 @@ task_id: skill-hitl-e2e-gdpr-compliance-greenfield
 description: >
   Authoring E2E golden scenario (green field): agent builds a GDPR deletion
   request flow with a privacy officer sign-off checkpoint. Tests proactive
-  compliance pattern detection, schema design with Reject path, timeout wiring.
-  Real business use case. Full Discover -> Plan -> Build -> Verify loop.
-  Does not deploy or run the flow.
+  compliance pattern detection, schema design with Reject path, and timeout
+  duration configuration. Real business use case. Full Discover -> Plan ->
+  Build -> Verify loop. Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, green-field, compliance, gdpr]
 
 agent:
@@ -34,8 +34,8 @@ initial_prompt: |
       "outputs": ["<what they fill in>"],
       "outcomes": ["<their choices>"]
     },
-    "timeout_configured": "<ISO 8601 duration used>",
-    "handles_wired": ["<list of handles wired>"],
+    "timeout_configured": "<ISO 8601 duration used, e.g. P7D>",
+    "handles_wired": ["completed"],
     "validation_passed": true
   }
 
@@ -74,10 +74,10 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Timeout handle is wired"
+    description: "completed handle is wired"
     path: "report.json"
     includes:
-      - "timeout"
+      - "completed"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
@@ -1,7 +1,7 @@
 task_id: skill-hitl-quality-completed-handle-and-result
 description: >
   Quality test: agent must wire the completed handle to a downstream node
-  and demonstrate how to read the human's decision using $vars.<nodeId>.result
+  and demonstrate how to read the human's decision using $vars.<nodeId>.output
   in the next script node. Tests C5, C6, F2.
 tags: [uipath-human-in-the-loop, integration, edge-wiring]
 
@@ -22,13 +22,13 @@ initial_prompt: |
 
   Wire the completed handle from the HITL node to processResult. In the
   processResult script node body, show how to read the human's decision using
-  $vars.<hitl-node-id>.result.
+  $vars.<hitl-node-id>.output.
 
   Validate after adding and wiring. Save results to report.json:
   {
     "hitl_node_id": "<id>",
     "handles_wired": ["completed"],
-    "result_variable_expression": "$vars.<hitl-node-id>.result",
+    "result_variable_expression": "$vars.<hitl-node-id>.output",
     "commands_used": ["<list>"],
     "validation_passed": true
   }
@@ -72,10 +72,10 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "report.json references $vars result expression"
+    description: "report.json references $vars output expression"
     path: "report.json"
     includes:
       - "$vars"
-      - ".result"
+      - ".output"
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
@@ -1,7 +1,7 @@
 task_id: skill-hitl-quality-runtime-vars
 description: >
   Quality test: after adding a HITL node, agent must wire a downstream
-  script node that correctly references $vars.<NodeId>.result and
+  script node that correctly references $vars.<NodeId>.output and
   $vars.<NodeId>.status. Tests G1 and G2.
 tags: [uipath-human-in-the-loop, integration, runtime-variables]
 
@@ -25,7 +25,7 @@ initial_prompt: |
   Save results to report.json — use the actual node ID that was generated:
   {
     "hitl_node_id": "<the actual id of the HITL node>",
-    "result_variable": "$vars.<hitl_node_id>.result",
+    "result_variable": "$vars.<hitl_node_id>.output",
     "status_variable": "$vars.<hitl_node_id>.status",
     "validation_passed": true
   }
@@ -48,11 +48,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "report.json references a $vars result variable"
+    description: "report.json references a $vars output variable"
     path: "report.json"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
@@ -1,0 +1,113 @@
+task_id: skill-hitl-quality-variable-binding-fieldid
+description: >
+  Quality test: agent correctly uses field ID (not the variable property) when
+  accessing HITL output fields downstream. The output object is keyed by
+  field.id — $vars.<nodeId>.output.<fieldId>. Tests that the agent does not
+  confuse the variable property with the access key.
+tags: [uipath-human-in-the-loop, integration, variable-binding]
+
+agent:
+  type: claude-code
+  max_turns: 75
+  turn_timeout: 900
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "ContractReview" for legal contract approval:
+
+  1. Manual trigger
+  2. Script node — sets contract context (mock: contractId = "CTR-2026-001", value = 85000)
+  3. HITL node — legal reviewer approves the contract:
+       - Sees (read-only): contract ID, contract value
+       - Fills in: approved (boolean, required), comments (text, optional)
+       - The approved field must have id "approved" and variable "legalApproval"
+       - The comments field must have id "reviewcomments" and variable "legalNotes"
+       - Outcomes: Approve (primary), Reject
+  4. Script node — reads the reviewer's decision and logs:
+       "Approved: <approved value>, Comments: <comments value>"
+     The script MUST access the fields using the correct runtime variable path
+     based on field IDs ($vars.<nodeId>.output.approved and
+     $vars.<nodeId>.output.reviewcomments), NOT the variable property names.
+  5. End node
+
+  Wire: Trigger → Script → HITL →|completed| Script (log) → End
+
+  Use the inline quickform node (uipath.human-in-the-loop).
+  Do NOT run flow debug. Validate after building.
+
+  Save a summary to report.json:
+  {
+    "hitl_node_id": "<id>",
+    "approved_access_path": "<full path used to read approved field>",
+    "comments_access_path": "<full path used to read comments field>",
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip maestro flow validate ContractReview/ContractReview/ContractReview.flow --output json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "HITL node has approved field with correct id and variable"
+    path: "ContractReview/ContractReview/ContractReview.flow"
+    includes:
+      - '"id": "approved"'
+      - '"variable": "legalApproval"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "HITL node has comments field with id reviewcomments"
+    path: "ContractReview/ContractReview/ContractReview.flow"
+    includes:
+      - '"id": "reviewcomments"'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Downstream script references output by field ID .approved"
+    path: "ContractReview/ContractReview/ContractReview.flow"
+    includes:
+      - ".output.approved"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Downstream script references output by field ID .reviewcomments"
+    path: "ContractReview/ContractReview/ContractReview.flow"
+    includes:
+      - ".output.reviewcomments"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Script does NOT reference .output.legalApproval or .output.legalNotes (variable names, not field IDs)"
+    command: "grep -L legalApproval ContractReview/ContractReview/ContractReview.flow"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json access paths use field IDs not variable names"
+    path: "report.json"
+    assertions:
+      - expression: "approved_access_path"
+        operator: contains
+        expected: ".output.approved"
+      - expression: "comments_access_path"
+        operator: contains
+        expected: ".output.reviewcomments"
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+    weight: 3.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
@@ -1,0 +1,95 @@
+task_id: skill-hitl-quality-dev-mistake-wrong-type
+description: >
+  Developer mistake test: agent must infer and apply correct field types from
+  the business description, not default everything to text. Tests that the agent
+  uses boolean for yes/no decisions, number for amounts, and date for deadlines —
+  even when the developer's schema description is vague or uses wrong types.
+tags: [uipath-human-in-the-loop, integration, schema-design, developer-mistake]
+
+agent:
+  type: claude-code
+  max_turns: 75
+  turn_timeout: 900
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "ExpenseReview" for expense claim approval:
+
+  1. Manual trigger
+  2. Script node — sets expense context (mock: amount = 1250.50, submittedDate = "2026-04-01")
+  3. HITL node — finance reviewer checks the expense:
+       - Sees (read-only): expense amount (should be a NUMBER), submission date (should be a DATE)
+       - Fills in:
+           - approved: a yes/no decision (should be BOOLEAN, not text)
+           - rejection_reason: optional explanation if rejected (text)
+           - approved_amount: the amount actually approved, may differ from requested (should be NUMBER)
+       - Outcomes: Approve (primary), Reject
+  4. Script node — logs: "Approved: <approved>, Amount: <approved_amount>"
+  5. End node
+
+  Wire: Trigger → Script → HITL →|completed| Script (log) → End
+
+  Use the inline quickform node (uipath.human-in-the-loop).
+  Do NOT run flow debug. Validate after building.
+
+  Save a summary to report.json:
+  {
+    "hitl_node_id": "<id>",
+    "field_types": {
+      "amount": "<type used>",
+      "submittedDate": "<type used>",
+      "approved": "<type used>",
+      "approved_amount": "<type used>"
+    },
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip maestro flow validate ExpenseReview/ExpenseReview/ExpenseReview.flow --output json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "approved field uses boolean type"
+    path: "ExpenseReview/ExpenseReview/ExpenseReview.flow"
+    includes:
+      - '"boolean"'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "amount fields use number type"
+    path: "ExpenseReview/ExpenseReview/ExpenseReview.flow"
+    includes:
+      - '"number"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json confirms correct types were used"
+    path: "report.json"
+    assertions:
+      - expression: "field_types.approved"
+        operator: equals
+        expected: "boolean"
+      - expression: "field_types.amount"
+        operator: equals
+        expected: "number"
+      - expression: "field_types.approved_amount"
+        operator: equals
+        expected: "number"
+      - expression: "field_types.submittedDate"
+        operator: equals
+        expected: "date"
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+    weight: 3.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
@@ -1,0 +1,120 @@
+task_id: skill-hitl-quality-dev-mistake-binding-direction
+description: >
+  Developer mistake test: agent must correctly wire upstream variable bindings
+  on input-direction fields and must NOT add binding on output-direction fields.
+  Tests that the agent reads variables.nodes to construct bindings, uses the
+  correct fieldId-based outputId path, and never puts binding on an output field.
+tags: [uipath-human-in-the-loop, integration, variable-binding, developer-mistake]
+
+agent:
+  type: claude-code
+  max_turns: 90
+  turn_timeout: 900
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "SupplierOnboarding" for supplier vetting:
+
+  1. Manual trigger
+  2. Script node (id suggestion: "fetchSupplier") — sets supplier data:
+       output.supplierName = "Acme Corp"
+       output.riskScore = 72
+       output.country = "DE"
+  3. HITL node — compliance officer reviews the supplier:
+       Input fields (read-only, MUST be bound to upstream script output):
+         - Supplier Name: bound to fetchSupplier node's supplierName output
+         - Risk Score:    bound to fetchSupplier node's riskScore output (number)
+         - Country:       bound to fetchSupplier node's country output
+       Output fields (filled by the officer, NO binding — the officer fills these in):
+         - approved (boolean, required)
+         - risk_notes (text, optional)
+       Outcomes: Approve (primary), Reject
+  4. Decision node — routes on approved field:
+       - true  → Script node that logs "Supplier approved: <supplierName>"
+       - false → Script node that logs "Supplier rejected"
+  5. End nodes for both branches
+
+  Wire: Trigger → Script → HITL →|completed| Decision → both branches → End
+
+  Use the inline quickform node (uipath.human-in-the-loop).
+  Read variables.nodes before writing input field bindings — use the exact
+  $vars path from the node's outputId entry.
+  Output fields must NOT have a binding property.
+  Do NOT run flow debug. Validate after building.
+
+  Save a summary to report.json:
+  {
+    "hitl_node_id": "<id>",
+    "supplier_name_binding": "<full binding expression used>",
+    "risk_score_binding": "<full binding expression used>",
+    "approved_has_binding": false,
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip maestro flow validate SupplierOnboarding/SupplierOnboarding/SupplierOnboarding.flow --output json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Input fields have binding expressions pointing to upstream script output"
+    path: "SupplierOnboarding/SupplierOnboarding/SupplierOnboarding.flow"
+    includes:
+      - '"binding": "=js:$vars.'
+      - "fetchSupplier"
+      - ".output.supplierName"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Risk score field is bound and uses number type"
+    path: "SupplierOnboarding/SupplierOnboarding/SupplierOnboarding.flow"
+    includes:
+      - ".output.riskScore"
+      - '"number"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "HITL has boolean output field for approved"
+    path: "SupplierOnboarding/SupplierOnboarding/SupplierOnboarding.flow"
+    includes:
+      - '"direction": "output"'
+      - '"boolean"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Decision node references HITL output by field ID"
+    path: "SupplierOnboarding/SupplierOnboarding/SupplierOnboarding.flow"
+    includes:
+      - "$vars."
+      - ".output.approved"
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json confirms bindings and approved has no binding"
+    path: "report.json"
+    assertions:
+      - expression: "supplier_name_binding"
+        operator: contains
+        expected: "=js:$vars."
+      - expression: "supplier_name_binding"
+        operator: contains
+        expected: "fetchSupplier"
+      - expression: "approved_has_binding"
+        operator: equals
+        expected: false
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+    weight: 3.0
+    pass_threshold: 0.75

--- a/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
@@ -1,0 +1,108 @@
+task_id: skill-hitl-quality-inout-field-access
+description: >
+  Quality test: agent correctly uses inOut direction for fields the human both
+  sees and can modify (write-back validation pattern). Verifies that inOut fields
+  appear in $vars.<nodeId>.output (same as output fields), and that the binding
+  pre-fills the value while still allowing the human to edit it.
+tags: [uipath-human-in-the-loop, integration, schema-design, inout, variable-binding]
+
+agent:
+  type: claude-code
+  max_turns: 90
+  turn_timeout: 900
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath Flow named "RCAReview" for AI-generated root cause analysis review:
+
+  1. Manual trigger
+  2. Script node (id suggestion: "generateRCA") — sets AI-generated output:
+       output.ticketId = "INC-5521"
+       output.rcaDraft = "Network timeout caused by misconfigured firewall rule"
+       output.confidence = 0.68
+  3. HITL node — support lead reviews the RCA:
+       Input fields (read-only, bound to upstream):
+         - Ticket ID: bound to generateRCA.output.ticketId (text)
+         - Confidence Score: bound to generateRCA.output.confidence (number)
+       InOut fields (pre-filled from upstream but human CAN edit before submitting):
+         - RCA Text: pre-filled from generateRCA.output.rcaDraft, human can correct it
+           (direction must be "inOut", NOT "output" and NOT "input")
+       Output fields (human fills in from scratch):
+         - severity (text, required): agent's severity assessment
+       Outcomes: Approve (primary), Request Changes
+  4. Script node — logs the final RCA:
+       References $vars.<hitl-node-id>.output.rcatext (using field ID)
+       References $vars.<hitl-node-id>.output.severity
+  5. End node
+
+  Wire: Trigger → Script → HITL →|completed| Script (log) → End
+
+  Use the inline quickform node (uipath.human-in-the-loop).
+  Do NOT run flow debug. Validate after building.
+
+  Save a summary to report.json:
+  {
+    "hitl_node_id": "<id>",
+    "rca_field_direction": "<direction value used for the RCA text field>",
+    "rca_field_has_binding": true,
+    "rca_access_path": "<$vars path used in downstream script>",
+    "validation_passed": true
+  }
+
+success_criteria:
+  - type: run_command
+    description: "uip flow validate passes"
+    command: "uip maestro flow validate RCAReview/RCAReview/RCAReview.flow --output json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "RCA text field has inOut direction"
+    path: "RCAReview/RCAReview/RCAReview.flow"
+    includes:
+      - '"direction": "inOut"'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "inOut field is pre-filled with upstream binding"
+    path: "RCAReview/RCAReview/RCAReview.flow"
+    includes:
+      - '"direction": "inOut"'
+      - "generateRCA"
+      - ".output.rcaDraft"
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Downstream script accesses RCA via output object (inOut fields appear in output)"
+    path: "RCAReview/RCAReview/RCAReview.flow"
+    includes:
+      - "$vars."
+      - ".output."
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json confirms inOut direction and correct access path"
+    path: "report.json"
+    assertions:
+      - expression: "rca_field_direction"
+        operator: equals
+        expected: "inOut"
+      - expression: "rca_field_has_binding"
+        operator: equals
+        expected: true
+      - expression: "rca_access_path"
+        operator: contains
+        expected: ".output."
+      - expression: "validation_passed"
+        operator: equals
+        expected: true
+    weight: 3.0
+    pass_threshold: 0.75


### PR DESCRIPTION
## Summary

- **`output` not `result`**: Updates all skill docs and eval tests to use `$vars.<nodeId>.output` (v1.0 renamed the outputId from `result` to `output`)
- **`cancelled`/`timeout` handles removed**: Cleaned up all references to non-existent handles; v1.0 exposes only `completed`
- **`fieldId` vs `variable` rule documented**: Added Critical Rule 9 to SKILL.md and a callout in hitl-node-quickform.md — output object keys are the field `id`, not `field.variable`
- **4 new developer-mistake quality tests** guarding the most common HITL authoring errors:
  - `quality_08`: agent uses field ID (not variable name) for output access
  - `quality_09`: agent infers correct types (boolean/number/date) instead of defaulting to text
  - `quality_10`: binding on input fields only — output fields must have no binding
  - `quality_11`: inOut fields are pre-filled via binding AND appear in `$vars.<nodeId>.output` after submit
- **TEST_PLAN.md rewritten** with v1.0 invariants table, variable binding accuracy section, real-world consequence coverage map

## Files changed

All files are under `skills/uipath-human-in-the-loop/` and `tests/tasks/uipath-human-in-the-loop/` (Dushyant-owned).

## Test plan

- [ ] `quality_08` — ContractReview: field ID vs variable name access
- [ ] `quality_09` — ExpenseReview: boolean/number/date type inference
- [ ] `quality_10` — SupplierOnboarding: binding direction correctness
- [ ] `quality_11` — RCAReview: inOut pre-fill + downstream output access
- [ ] Existing `quality_04`, `quality_07`, `e2e_01`, `e2e_03` pass with updated `.output` paths