### PR TITLE
docs(uipath-rpa): fix Terminal activity XAML examples

### DIFF
--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/FindText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/FindText.md
@@ -47,9 +47,11 @@ Searches the terminal screen for a text string, starting from an optional positi
 ## XAML Example
 
 ```xml
-<ta:TerminalFindTextInScreen DisplayName="Find Text"
+<uit:TerminalFindTextInScreen DisplayName="Find Text"
                               Text="[&quot;ERROR&quot;]"
                               IgnoreCase="True"
                               Row="[foundRow]"
-                              Column="[foundCol]" />
+                              Column="[foundCol]"
+                              WaitType="READY"
+                              DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetColorAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetColorAtPosition.md
@@ -42,8 +42,10 @@ Color availability depends on the terminal provider and emulation type. Not all 
 ## XAML Example
 
 ```xml
-<ta:TerminalGetColorAtPosition DisplayName="Get Color at Position"
+<uit:TerminalGetColorAtPosition DisplayName="Get Color at Position"
                                 Row="[3]"
                                 Column="[5]"
-                                TerminalColor="[charColor]" />
+                                TerminalColor="[charColor]"
+                                WaitType="READY"
+                                DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetCursorPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetCursorPosition.md
@@ -32,7 +32,9 @@ Returns the current row and column position of the terminal cursor.
 ## XAML Example
 
 ```xml
-<t:TerminalGetCursorPosition DisplayName="Get Cursor Position"
+<uit:TerminalGetCursorPosition DisplayName="Get Cursor Position"
                               Row="[cursorRow]"
-                              Column="[cursorCol]" />
+                              Column="[cursorCol]"
+                              WaitType="READY"
+                              DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetField.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetField.md
@@ -49,17 +49,21 @@ At least one of `LabeledBy` or `FollowedBy` must be provided. Both can be specif
 **By preceding label:**
 
 ```xml
-<t:TerminalGetField DisplayName="Get Field"
+<uit:TerminalGetField DisplayName="Get Field"
                     LabeledBy="[&quot;Username:&quot;]"
-                    Text="[usernameValue]" />
+                    Text="[usernameValue]"
+                    WaitType="READY"
+                    DelayMS="300" />
 ```
 
 **By both labels with index to disambiguate:**
 
 ```xml
-<t:TerminalGetField DisplayName="Get Field"
+<uit:TerminalGetField DisplayName="Get Field"
                     LabeledBy="[&quot;Amount:&quot;]"
                     FollowedBy="[&quot;USD&quot;]"
                     Index="[1]"
-                    Text="[fieldValue]" />
+                    Text="[fieldValue]"
+                    WaitType="READY"
+                    DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetFieldAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetFieldAtPosition.md
@@ -42,8 +42,10 @@ Unlike **Get Text at Position** (which reads raw character data from a position)
 ## XAML Example
 
 ```xml
-<ta:TerminalGetFieldAtPosition DisplayName="Get Field at Position"
+<uit:TerminalGetFieldAtPosition DisplayName="Get Field at Position"
                                 Row="[7]"
                                 Column="[15]"
-                                Text="[fieldValue]" />
+                                Text="[fieldValue]"
+                                WaitType="READY"
+                                DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetScreenArea.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetScreenArea.md
@@ -40,10 +40,12 @@ Reads all text within a rectangular region of the terminal screen, defined by a 
 ## XAML Example
 
 ```xml
-<ta:TerminalGetScreenArea DisplayName="Get Screen Area"
+<uit:TerminalGetScreenArea DisplayName="Get Screen Area"
                            Row="[3]"
                            Column="[1]"
                            EndRow="[10]"
                            EndColumn="[80]"
-                           Text="[areaText]" />
+                           Text="[areaText]"
+                           WaitType="READY"
+                           DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetText.md
@@ -35,6 +35,8 @@ Reads the entire visible text content of the terminal screen and returns it as a
 ## XAML Example
 
 ```xml
-<t:TerminalGetText DisplayName="Get Text"
-                   Text="[screenText]" />
+<uit:TerminalGetText DisplayName="Get Text"
+                   Text="[screenText]"
+                   WaitType="READY"
+                   DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetTextAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/GetTextAtPosition.md
@@ -39,9 +39,11 @@ Reads text starting at a specific row and column position on the terminal screen
 ## XAML Example
 
 ```xml
-<ta:TerminalGetTextAtPosition DisplayName="Get Text at Position"
+<uit:TerminalGetTextAtPosition DisplayName="Get Text at Position"
                                Row="[5]"
                                Column="[10]"
                                Length="[20]"
-                               Text="[fieldText]" />
+                               Text="[fieldText]"
+                               WaitType="READY"
+                               DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursor.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursor.md
@@ -32,7 +32,9 @@ Moves the terminal cursor to an exact row and column position on the screen.
 ## XAML Example
 
 ```xml
-<ta:TerminalMoveCursor DisplayName="Move Cursor"
+<uit:TerminalMoveCursor DisplayName="Move Cursor"
                         Row="[5]"
-                        Column="[20]" />
+                        Column="[20]"
+                        WaitType="READY"
+                        DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursorToText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/MoveCursorToText.md
@@ -46,9 +46,11 @@ Searches the terminal screen for a text string and moves the terminal cursor to 
 ## XAML Example
 
 ```xml
-<ta:TerminalMoveCursorToText DisplayName="Move Cursor to Text"
+<uit:TerminalMoveCursorToText DisplayName="Move Cursor to Text"
                                Text="[&quot;Password:&quot;]"
                                IgnoreCase="True"
                                Row="[foundRow]"
-                               Column="[foundCol]" />
+                               Column="[foundCol]"
+                               WaitType="READY"
+                               DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendControlKey.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendControlKey.md
@@ -71,6 +71,8 @@ Sends a single control key (such as Tab, Enter/Transmit, F1–F24, arrow keys, o
 ## XAML Example
 
 ```xml
-<t:TerminalSendControlKey DisplayName="Send Control Key"
-                           Key="Transmit" />
+<uit:TerminalSendControlKey DisplayName="Send Control Key"
+                           Key="Transmit"
+                           WaitType="READY"
+                           DelayMS="1000" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeys.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeys.md
@@ -35,6 +35,8 @@ To send sensitive data such as passwords, use **Send Keys Secure** instead to av
 ## XAML Example
 
 ```xml
-<ta:TerminalSendKeys DisplayName="Send Keys"
-                      Keys="[username]" />
+<uit:TerminalSendKeys DisplayName="Send Keys"
+                      Keys="[username]"
+                      WaitType="READY"
+                      DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeysSecure.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SendKeysSecure.md
@@ -36,6 +36,8 @@ Sends a `SecureString` value (such as a password) to the terminal without exposi
 ## XAML Example
 
 ```xml
-<ta:TerminalSendKeysSecure DisplayName="Send Keys Secure"
-                             SecureText="[passwordSecureString]" />
+<uit:TerminalSendKeysSecure DisplayName="Send Keys Secure"
+                             SecureText="[passwordSecureString]"
+                             WaitType="READY"
+                             DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetField.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetField.md
@@ -47,7 +47,9 @@ At least one of `LabeledBy` or `FollowedBy` must be provided. Both can be specif
 ## XAML Example
 
 ```xml
-<t:TerminalSetField DisplayName="Set Field"
+<uit:TerminalSetField DisplayName="Set Field"
                     LabeledBy="[&quot;Username:&quot;]"
-                    Text="[username]" />
+                    Text="[username]"
+                    WaitType="READY"
+                    DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetFieldAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/SetFieldAtPosition.md
@@ -44,9 +44,11 @@ Writes text into the input field that starts at the specified row and column pos
 ## XAML Example
 
 ```xml
-<ta:TerminalSetFieldAtPosition DisplayName="Set Field at Position"
+<uit:TerminalSetFieldAtPosition DisplayName="Set Field at Position"
                                 Row="[7]"
                                 Column="[15]"
                                 Text="[inputValue]"
-                                BackwardsCompatible="False" />
+                                BackwardsCompatible="False"
+                                WaitType="READY"
+                                DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/TerminalSession.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/TerminalSession.md
@@ -66,37 +66,41 @@ This activity supports two mutually exclusive connection modes. `ConnectionStrin
 **Mode A — New connection:**
 
 ```xml
-<t:TerminalSession DisplayName="Terminal Session"
+<uit:TerminalSession DisplayName="Terminal Session"
                    ConnectionString="[connStr]"
-                   TimeoutMS="50000">
-  <t:TerminalSession.Body>
-    <ActivityAction x:TypeArguments="t:TerminalConnection">
+                   TimeoutMS="50000"
+                   CloseConnection="True"
+                   DelayMS="1000">
+  <uit:TerminalSession.Body>
+    <ActivityAction x:TypeArguments="uit:TerminalConnection">
       <ActivityAction.Argument>
-        <DelegateInArgument x:TypeArguments="t:TerminalConnection" Name="terminalSession" />
+        <DelegateInArgument x:TypeArguments="uit:TerminalConnection" Name="terminalSession" />
       </ActivityAction.Argument>
       <Sequence DisplayName="Do">
         <!-- child terminal activities here -->
       </Sequence>
     </ActivityAction>
-  </t:TerminalSession.Body>
-</t:TerminalSession>
+  </uit:TerminalSession.Body>
+</uit:TerminalSession>
 ```
 
 **Mode B — Existing connection:**
 
 ```xml
-<t:TerminalSession DisplayName="Terminal Session (Reuse)"
+<uit:TerminalSession DisplayName="Terminal Session (Reuse)"
                    ExistingConnection="[existingConn]"
-                   CloseConnection="False">
-  <t:TerminalSession.Body>
-    <ActivityAction x:TypeArguments="t:TerminalConnection">
+                   CloseConnection="False"
+                   TimeoutMS="50000"
+                   DelayMS="1000">
+  <uit:TerminalSession.Body>
+    <ActivityAction x:TypeArguments="uit:TerminalConnection">
       <ActivityAction.Argument>
-        <DelegateInArgument x:TypeArguments="t:TerminalConnection" Name="terminalSession" />
+        <DelegateInArgument x:TypeArguments="uit:TerminalConnection" Name="terminalSession" />
       </ActivityAction.Argument>
       <Sequence DisplayName="Do">
         <!-- child terminal activities here -->
       </Sequence>
     </ActivityAction>
-  </t:TerminalSession.Body>
-</t:TerminalSession>
+  </uit:TerminalSession.Body>
+</uit:TerminalSession>
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitFieldText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitFieldText.md
@@ -44,8 +44,10 @@ At least one of `LabeledBy` or `FollowedBy` must be provided. Both can be specif
 ## XAML Example
 
 ```xml
-<t:TerminalWaitFieldText DisplayName="Wait Field Text"
+<uit:TerminalWaitFieldText DisplayName="Wait Field Text"
                           LabeledBy="[&quot;Status:&quot;]"
                           Text="[&quot;OK&quot;]"
-                          TimeoutMS="[30000]" />
+                          TimeoutMS="[30000]"
+                          WaitType="READY"
+                          DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenReady.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenReady.md
@@ -30,6 +30,8 @@ Waits until the terminal keyboard is unlocked and the screen is ready to accept 
 ## XAML Example
 
 ```xml
-<ta:TerminalWaitScreenReady DisplayName="Wait Screen Ready"
-                              TimeoutMS="[30000]" />
+<uit:TerminalWaitScreenReady DisplayName="Wait Screen Ready"
+                              TimeoutMS="[30000]"
+                              WaitType="READY"
+                              DelayMS="0" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenText.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitScreenText.md
@@ -36,7 +36,9 @@ Waits until a specified text string appears anywhere on the terminal screen. Use
 ## XAML Example
 
 ```xml
-<t:TerminalWaitScreenText DisplayName="Wait Screen Text"
+<uit:TerminalWaitScreenText DisplayName="Wait Screen Text"
                            Text="[&quot;READY&quot;]"
-                           TimeoutMS="[30000]" />
+                           TimeoutMS="[30000]"
+                           WaitType="READY"
+                           DelayMS="300" />
 ```

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitTextAtPosition.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Terminal.Activities/2.10/activities/WaitTextAtPosition.md
@@ -39,9 +39,11 @@ Waits until a specific row and column position on the terminal screen contains t
 ## XAML Example
 
 ```xml
-<ta:TerminalWaitTextAtPosition DisplayName="Wait Text at Position"
+<uit:TerminalWaitTextAtPosition DisplayName="Wait Text at Position"
                                 Row="[24]"
                                 Column="[1]"
                                 Text="[&quot;READY&quot;]"
-                                TimeoutMS="[30000]" />
+                                TimeoutMS="[30000]"
+                                WaitType="READY"
+                                DelayMS="300" />
 ```


### PR DESCRIPTION
- Replace incorrect namespace prefixes (`t:`, `ta:`) with `uit:` across all 20 activity docs
- Add missing `WaitType` and `DelayMS` properties to every XAML example
- Add constructor-defaulted properties (`CloseConnection`, `TimeoutMS`, `DelayMS`) to TerminalSession examples