### PR TITLE
feat(uipath-maestro-flow): frontmatter description include all capabilities

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-maestro-flow
-description: "UiPath Maestro Flow (.flow) — read, edit, author, debug. `uip` CLI: nodes, edges, subflows, scripts, variables, triggers, End nodes, registry. For C#/XAML→uipath-rpa. For agents→uipath-agents."
+description: "UiPath Maestro Flow (.flow) — build, edit, run, debug, fix. Create, connect nodes/edges; connector, approval, script, subflow; triggers, schedules; validate. Upload, publish, manage runs. Diagnose errors and traces. `uip maestro flow` CLI."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
@@ -42,7 +42,7 @@ Comprehensive guide for creating, editing, validating, debugging, publishing, an
 | Create a new flow or edit an existing one                    | [references/author/CAPABILITY.md](references/author/CAPABILITY.md)                               |
 | Publish, deploy, debug, or manage a flow's lifecycle         | [references/operate/CAPABILITY.md](references/operate/CAPABILITY.md)                             |
 | Diagnose a failed or misbehaving flow run                    | [references/diagnose/CAPABILITY.md](references/diagnose/CAPABILITY.md)                           |
-| Look up CLI command syntax                                   | [references/shared/cli-commands.md](references/shared/cli-commands.md)                                   |
+| Look up CLI command syntax                                   | [references/shared/cli-commands.md](references/shared/cli-commands.md)                           |
 | Look up CLI conventions (`--output json`, login, FOLDER_KEY) | [references/shared/cli-conventions.md](references/shared/cli-conventions.md)                     |
 | Understand the `.flow` JSON format                           | [references/shared/file-format.md](references/shared/file-format.md)                             |
 | Understand variables and `=js:` expressions                  | [references/shared/variables-and-expressions.md](references/shared/variables-and-expressions.md) |

--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-maestro-flow
-description: "UiPath Maestro Flow (.flow) — build, edit, run, debug, fix. Create, connect nodes/edges; connector, approval, script, subflow; triggers, schedules; validate. Upload, publish, manage runs. Diagnose errors and traces. `uip maestro flow` CLI."
+description: "UiPath Maestro Flow (.flow) — build, edit, run, debug, fix. Create, connect nodes; connector, approval, script, subflow; triggers, schedules; validate. Upload, publish, manage runs, instances. Diagnose errors, incidents, traces. `uip maestro flow` CLI. For C#/XAML→uipath-rpa. For agents→uipath-agents."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 


### PR DESCRIPTION
## Summary

Refines the `uipath-maestro-flow` SKILL.md frontmatter `description` to improve plugin matcher signal and align with how users actually describe their work.

## Before

UiPath Maestro Flow (.flow) — read, edit, author, debug. uip CLI: nodes, edges, subflows, scripts, variables, triggers, End nodes, registry. For C#/XAML→uipath-rpa. For agents→uipath-agents.



## After

UiPath Maestro Flow (.flow) — build, edit, run, debug, fix. Create, connect nodes; connector, approval, script, subflow; triggers, schedules; validate. Upload, publish, manage runs, instances. Diagnose errors, incidents, traces. uip maestro flow CLI.



245 chars, under the 250 cap.

## Changes

### Surfaces all three capabilities
Previous description only covered authoring (`read, edit, author, debug`). New description signals all three capability areas the skill actually owns: **Author** (create, connect, validate), **Operate** (upload, publish, manage runs/instances), **Diagnose** (errors, incidents, traces).

### Removes unnecessary redirects
- Dropped `For C#/XAML→uipath-rpa` — the file/domain tokens (`.flow`, `Maestro`, `nodes`, `subflow`, `connector`) are distinctive enough that an RPA author wouldn't say any of them.
- Dropped `For agents→uipath-agents` — the `uipath-agents` skill has its own front-loaded identity; the redirect was doing little work.

### Replaces jargon with user vocabulary, but keeps UI nouns
| Before | After | Why |
|--------|-------|-----|
| `wire nodes/edges` | `connect nodes` | Users say "connect Salesforce to Slack", not "wire" |
| `HITL` | `approval` | Users say "approval step", not the acronym |
| `incidents` (only) | `errors, incidents` | Pair conversational verb with UI label users see in Studio Web |
| `instances` (only) | `runs, instances` | Pair conversational verb with UI label users see in Orchestrator |
| `init` | `create` | CLI jargon → natural verb |

### Adds missing user-intent signals
- **`fix`** — high-volume user phrase ("fix my flow", "why isn't this working")
- **`triggers, schedules`** — "trigger when an email arrives", "run every Monday" weren't represented
- **`errors`** — covers the most common Diagnose entry phrase ("my flow failed/broke/crashed")

### Tightens CLI signal
- `\`uip\` CLI` → `\`uip maestro flow\` CLI` — `uip` alone is generic across all UiPath skills; `uip maestro flow` is the actual command surface and a much stronger matching token.

### Drops internal capability labels
Removed `Author:` / `Operate:` / `Diagnose:` prefixes. They cost ~24 chars, aren't user vocabulary, and the matcher doesn't need the structural cue. Freed space for more user-language verbs and UI nouns.