### PR TITLE
feat(case-skill): document CLI mutation commands + hitl add opt-in

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -1,5 +1,7 @@
 # action task — Implementation (Direct JSON Write)
 
+> **Use the `uipath-human-in-the-loop` skill for HITL action tasks.** It owns the full implementation reference for Case HITL — JSON shape, field schema design, CLI opt-in (`uip case hitl add`), and downstream output access. See [hitl-casetask-action.md](../../../../../uipath-human-in-the-loop/references/hitl-casetask-action.md). The guide below covers the raw JSON shape for direct writes.
+
 > **Phase split.** Phase 2 writes shape with empty input values. Phase 3 binds values per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md). See [phased-execution.md](../../../phased-execution.md).
 
 ## Task JSON Shape

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
@@ -2,6 +2,8 @@
 
 A human-in-the-loop (HITL) action task. Assigns a task to a user or group for manual review, approval, or data entry via the Actions app.
 
+> **Use the `uipath-human-in-the-loop` skill for HITL tasks.** It handles schema design, field type selection, assignee configuration, and the full JSON + CLI implementation for Case action tasks. Full reference: [hitl-casetask-action.md](../../../../../uipath-human-in-the-loop/references/hitl-casetask-action.md). The notes below cover Case-specific planning only.
+
 ## When to Use
 
 Pick this plugin when the sdd.md describes a `HITL` task, or any task requiring manual user interaction: approval, review, sign-off, correction, classification by a person.


### PR DESCRIPTION
## Summary

- **case-commands.md**: Revised intro, added Case Plan Mutation Commands section documenting `cases add/get/edit`, `stages add/edit/get/remove`, `tasks add/edit/get/remove/enrich/add-connector`, and `hitl add` (CLI PR #1207).
- **action/impl-json.md**: Added CLI opt-in callout pointing to `uip maestro case hitl add`.

## Motivation

Demo scripts (Health Claims, Commercial Lending, Mortgage Loan Origination) build case plans via CLI. Without these commands in the skill reference, coding agents default to direct JSON writes only.

## Notes

`hitl add` is gated on CLI PR #1207 merging. All other mutation commands are already shipped.

CODEOWNERS: @baishalighosh @dushyant-uipath @maestro-cli-team