### PR TITLE
fix(hitl): align maestro-flow HITL docs + tests to v1.0 schema (.output not .result)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -54,8 +54,8 @@ Handles full lifecycle: writes node, adds definition entry once, regenerates `va
     "priority": "Low"
   },
   "outputs": {
-    "result": { "type": "object", "description": "Task result data", "source": "=result", "var": "result" },
-    "status": { "type": "string", "description": "Task completion status", "source": "=status", "var": "status" }
+    "output": { "type": "object", "description": "Task result data", "source": "=result", "var": "output" },
+    "status": { "type": "string", "description": "Task completion status", "source": "=result.Action", "var": "status" }
   }
 }
 ```
@@ -64,10 +64,12 @@ BPMN type (`bpmn:UserTask`) and serviceType (`Actions.HITL`) come from the `uipa
 
 **Ports:** `input` (target) → `completed` (source)
 
-**Output variables:**
-- `$vars.{nodeId}.result` — object with all `output` / `inOut` fields the human filled in
-- `$vars.{nodeId}.result.{fieldName}` — individual field value
-- `$vars.{nodeId}.status` — `"completed"`
+**Output variables (v1.0 schema):**
+- `$vars.{nodeId}.output` — object with all `output` / `inOut` fields the human filled in
+- `$vars.{nodeId}.output.{fieldName}` — individual field value (e.g., `$vars.poReview1.output.decision`)
+- `$vars.{nodeId}.status` — outcome action (e.g., `"Continue"` / `"End"`)
+
+> **Note:** v1.0 (per [`uipath-human-in-the-loop` skill — hitl-node-quickform.md](../../../../../../uipath-human-in-the-loop/references/hitl-node-quickform.md)) uses `.output` for HITL output access — same pattern as every other plugin. Older flows that emit `var: "result"` and access via `.result.<field>` predate v1.0; new flows MUST use `.output`.
 
 ---
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
@@ -39,11 +39,13 @@ Available: always — no `uip login` or registry pull required.
 
 **The output port must be wired.** A node with no edge on `completed` blocks the flow indefinitely.
 
-### Output Variables
+### Output Variables (v1.0 schema)
 
-- `$vars.{nodeId}.result` — object containing all output and inOut fields the human filled in
-- `$vars.{nodeId}.result.{fieldName}` — individual field value
-- `$vars.{nodeId}.status` — `"completed"`
+- `$vars.{nodeId}.output` — object containing all output and inOut fields the human filled in
+- `$vars.{nodeId}.output.{fieldName}` — individual field value (e.g., `$vars.poReview1.output.decision`)
+- `$vars.{nodeId}.status` — outcome action (e.g., `"Continue"` / `"End"`)
+
+> **v1.0** (per [`uipath-human-in-the-loop` skill](../../../../../../uipath-human-in-the-loop/references/hitl-node-quickform.md)) uses `.output` for HITL value access. Older flows that emit `.result` predate v1.0 — new flows MUST use `.output`. When planning downstream consumers (decision/script/end nodes), reference values as `$vars.<hitlId>.output.<field>`.
 
 ### Schema Design
 
@@ -95,7 +97,7 @@ Trigger -> Process -> Decision (confidence ok?) ->
 
 In the node table:
 ```
-| hitlReview | Invoice Review | human-task | uipath.human-in-the-loop | inputs: [invoiceId, amount] outputs: [decision] outcomes: [Approve, Reject] | result, status |
+| hitlReview | Invoice Review | human-task | uipath.human-in-the-loop | inputs: [invoiceId, amount] outputs: [decision] outcomes: [Approve, Reject] | output, status |
 ```
 
 ---

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -42,7 +42,7 @@ initial_prompt: |
       "outcomes":      ["<outcome names>"]
     },
     "priority": "<priority set>",
-    "result_variable": "<how the decision node reads the officer's decision>",
+    "result_variable": "<how the decision node reads the officer's decision — must reference an output field value, not the outcome status>",
     "validation_passed": true
   }
 
@@ -89,11 +89,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "result_variable references $vars.<nodeId>.result"
+    description: "result_variable references $vars.<nodeId>.output (v1.0 access pattern)"
     path: "report.json"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -1,8 +1,9 @@
 task_id: skill-flow-hitl-quality-result-downstream
 description: >
   Quality test: agent correctly references the HITL node's output via
-  $vars.<nodeId>.result in a downstream node. Tests that the agent knows
-  the result variable path and wires it into a decision or script node.
+  $vars.<nodeId>.output in a downstream node (v1.0 access pattern). Tests
+  that the agent knows the output variable path and wires it into a
+  decision or script node.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
 agent:
@@ -36,7 +37,7 @@ initial_prompt: |
   Save a summary to report.json:
   {
     "hitl_node_id": "<id>",
-    "result_path": "<full variable path used in the script, e.g. $vars.hitlReview1.result.approved>",
+    "result_path": "<full variable path used in the script, e.g. $vars.hitlReview1.output.approved>",
     "validation_passed": true
   }
 
@@ -58,11 +59,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Flow references the HITL result variable"
+    description: "Flow references the HITL output variable (v1.0 access pattern)"
     path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 3.0
     pass_threshold: 1.0
 
@@ -75,11 +76,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "report.json result_path references $vars and .result"
+    description: "report.json result_path references $vars and .output (v1.0 access pattern)"
     path: "report.json"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -24,7 +24,7 @@ initial_prompt: |
        - Reviewer sees: expense amount, requester name, category (all read-only)
        - Reviewer fills in: approved (boolean), comments (text, optional)
        - Outcomes: Approve (primary), Reject
-  3. Script node — reads the reviewer's decision from the HITL result and
+  3. Script node — reads the reviewer's decision from the HITL output and
      logs: "Decision: <approved value>, Comments: <comments value>"
      The script must reference the HITL output via the correct runtime variable path.
   4. End node

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -2,8 +2,9 @@ task_id: skill-flow-hitl-quality-boolean-decision
 description: >
   Quality test: agent correctly wires a boolean HITL output field into a
   Decision node condition using the exact runtime path
-  $vars.<nodeId>.result.<fieldName>. Tests field-level variable access
-  and that both Decision branches are wired to distinct downstream nodes.
+  $vars.<nodeId>.output.<fieldName> (v1.0 access pattern). Tests field-level
+  variable access and that both Decision branches are wired to distinct
+  downstream nodes.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
 agent:
@@ -25,21 +26,21 @@ initial_prompt: |
        - Sees (read-only): vendor name, credit score
        - Fills in: approved (boolean, required), risk_notes (text, optional)
        - Outcomes: Approve (primary), Reject
-  4. Decision node — branches on the `approved` boolean from the HITL result:
+  4. Decision node — branches on the `approved` boolean from the HITL output:
        - true  → Script node that logs "Vendor onboarded" → End
        - false → Script node that logs "Vendor rejected" → End
 
   Wire: Trigger → Script → HITL →|completed| Decision → (two branches) → End
 
   The Decision node condition MUST use the exact field-level runtime variable
-  path — not just $vars.<nodeId>.result but specifically the approved field.
+  path — not just $vars.<nodeId>.output but specifically the approved field.
 
   Do NOT run flow debug. Validate after building.
 
   Save a summary to report.json:
   {
     "hitl_node_id": "<id>",
-    "decision_condition": "<full expression used, e.g. $vars.complianceReview1.result.approved>",
+    "decision_condition": "<full expression used, e.g. $vars.complianceReview1.output.approved>",
     "result_path_used": "<same or equivalent path referenced in the Decision>",
     "validation_passed": true
   }
@@ -63,11 +64,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Decision node condition references field-level HITL result"
+    description: "Decision node condition references field-level HITL output (v1.0 access pattern)"
     path: "VendorApproval/VendorApproval/VendorApproval.flow"
     includes:
       - "$vars."
-      - ".result.approved"
+      - ".output.approved"
     weight: 3.0
     pass_threshold: 1.0
 
@@ -81,11 +82,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "report.json decision_condition references field-level variable"
+    description: "report.json decision_condition references field-level variable (v1.0 access pattern)"
     path: "report.json"
     includes:
       - "$vars."
-      - ".result.approved"
+      - ".output.approved"
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -23,15 +23,15 @@ initial_prompt: |
        - Reviewer sees (read-only): employee name, number of days
        - Reviewer fills in: approved (boolean)
        - Outcomes: Approve (primary), Reject
-  3. Decision node — branches on the reviewer's approved field from the HITL result
+  3. Decision node — branches on the reviewer's approved field from the HITL output
   4. true branch  → Script node that logs "Leave approved" → End
   5. false branch → Script node that logs "Leave rejected" → End
 
   Use the inline quickform HITL node (uipath.human-in-the-loop).
   Wire: Trigger → HITL →|completed| Decision → both branches → Script → End
 
-  The Decision node condition must reference the HITL result using the
-  correct runtime variable path ($vars.<nodeId>.result.<fieldName>).
+  The Decision node condition must reference the HITL output using the
+  correct runtime variable path ($vars.<nodeId>.output.<fieldName>).
 
   Do NOT run flow debug. Validate after building.
 
@@ -39,7 +39,7 @@ initial_prompt: |
   {
     "hitl_node_id": "<id>",
     "decision_node_id": "<id of the Decision node>",
-    "decision_expression": "<full expression used, e.g. $vars.hitl1.result.approved>",
+    "decision_expression": "<full expression used, e.g. $vars.hitl1.output.approved>",
     "validation_passed": true
   }
 
@@ -69,11 +69,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Decision node references HITL result variable"
+    description: "Decision node references HITL output variable (v1.0 access pattern)"
     path: "LeaveRequest/LeaveRequest/LeaveRequest.flow"
     includes:
       - "$vars."
-      - ".result"
+      - ".output"
     weight: 2.5
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

Follow-up to #529 — that PR migrated `uipath-human-in-the-loop` to v1.0 (`output`, not `result`) for HITL value access, but left the maestro-flow plugin docs and 3 maestro-flow HITL test criteria on the stale `.result` pattern. The two doc surfaces contradicted each other, so agents flip-flopped between `.result` and `.output` depending on which doc dominated their context window.

This PR realigns the maestro-flow side to v1.0:

- **Docs**: `skills/uipath-maestro-flow/.../hitl/{impl,planning}.md` — outputs JSON, "Output Variables" section, planner annotation now use `.output` (matching #529's `hitl-node-quickform.md`). Added v1.0 transition notes.
- **Tests**: 4 maestro-flow HITL test YAMLs — criterion includes + prompt examples `.result`→`.output`. `quality_01` placeholder also disambiguates field-value access vs outcome-status access (the latter drove a residual stochastic miss during verification).

## Tickets resolved

- **[MST-9345](https://uipath.atlassian.net/browse/MST-9345)** (HITL value-access drift in `quality_01_schema_design`) — primary subject of this PR.
- **[MST-9301](https://uipath.atlassian.net/browse/MST-9301)** (`quality_02_result_downstream` "max_turns shortfall") — turned out to be the same stale-criterion drift, not a budget issue. Resolves without any budget bump.
- Partially helps **[MST-9346](https://uipath.atlassian.net/browse/MST-9346)** (`smoke_03_multi_outcome_routing` turn_timeout + `core.control.end` validator). The criterion-side stale `.result` is fixed here; the validator inconsistency remains for a separate follow-up.

## Root cause (deep dive)

In coder_eval run `2026-05-04_04-05-27`, the 6 maestro-flow HITL tasks split roughly 50/50 between agents emitting `.result` (matching the stale maestro-flow `hitl/impl.md`) and `.output` (matching the canonical v1.0 `hitl-node-quickform.md`). Same agent, same docs, same flow shape — different outcome depending on which doc the agent attended to.

| task_id | HITL access pattern | Pre-fix result |
|---|---|---|
| `skill-flow-hitl-quality-boolean-decision` | `$vars.complianceReview1.result.approved` | PASS 1.0 (stale criterion) |
| `skill-flow-hitl-quality-schema-design` | `$vars.poReview1.output.decision` | **FAIL 0.93** (criterion expected `.result`) |
| `skill-flow-hitl-quality-result-downstream` | `$vars.expenseReview1.output.approved` | **FAIL 0.80** (criterion expected `.result`) |

The criterion was the wrong artifact, not the agent.

## Test plan

- [x] `coder-eval run quality_01_schema_design.yaml --repeats 5 --experiment tests/experiments/e2e.yaml` → 5/5 SUCCESS, all emitted `$vars.poReview1.output.decision`.
- [x] `coder-eval run quality_02_result_downstream.yaml --repeats 2` → 2/2 SUCCESS at 1.0 (was MST-9301, resolves with no budget bump).
- [x] `coder-eval run quality_03_boolean_decision.yaml --repeats 2` → 2/2 SUCCESS (regression check — passed before, still passes after).
- [x] `coder-eval run smoke_03_multi_outcome_routing.yaml --repeats 2` → 2/2 SUCCESS.
- [x] Total: 11/11 SUCCESS post-fix on the affected surface.
- [ ] CI smoke-skills + smoke-rpa-skills checks pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-9345]: https://uipath.atlassian.net/browse/MST-9345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MST-9301]: https://uipath.atlassian.net/browse/MST-9301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ