### PR TITLE
fix(uipath-maestro-flow): document display as required on every node (MST-9346)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -213,6 +213,8 @@ Use `Edit` to map every `out` variable in `variables.globals` on every reachable
 {
   "id": "doneSuccess",
   "type": "core.control.end",
+  "typeVersion": "1.0.0",
+  "display": { "label": "Done" },
   "inputs": {},
   "outputs": {
     "<VARIABLE_ID>": {

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -73,6 +73,8 @@ Before editing the `.flow` file, ensure each of the following is handled. These 
 }
 ```
 
+> **`display` is required on every node** — including control-flow nodes (`core.control.end`, `core.logic.terminate`) where it may feel optional. Omitting it produces a vague `[(root)] Schema validation failed: Invalid input: expected object, received undefined` from `uip maestro flow validate`, which does NOT pinpoint the missing field. Always include `"display": { "label": "<label>" }` on every node, even bare end nodes. See [file-format.md — Node instance](../../shared/file-format.md#node-instance) and [MST-9368](https://uipath.atlassian.net/browse/MST-9368) for the validator-error-clarity follow-up.
+
 > **Node outputs are required.** Every node that produces data for downstream `$vars` references must include an `outputs` block. See [file-format.md — Node outputs](../../shared/file-format.md#node-outputs) for the standard patterns by node category (action nodes get `output` + `error`; trigger nodes get `output` only; end/terminate nodes do not use this pattern).
 
 > **No `model` block on nodes.** BPMN type, serviceType, event definition, and binding/context templates are provided by the definition in `definitions[]` (copied verbatim from the registry). Instance-specific identity fields live under `inputs`: `entryPointId`/`isDefaultEntryPoint` for triggers, `source` for inline agents, `color`/`content` for sticky notes. See [file-format.md — Instance-specific fields that live in `inputs`](../../shared/file-format.md#instance-specific-fields-that-live-in-inputs).

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -64,7 +64,15 @@ The `.flow` file is a JSON document at `<ProjectName>.flow` in the project root.
 }
 ```
 
-**Required fields**: `id`, `type`, `typeVersion`
+**Required fields on every node**: `id`, `type`, `typeVersion`, **`display`** (with at least a `label`). This includes control-flow nodes that "feel" trivial — `core.control.end`, `core.logic.terminate`, etc. all require `display: { "label": "..." }`. The schema does not exempt them.
+
+> **Gotcha — vague schema-validation error on missing `display`.** Omitting `display` on any node produces:
+>
+> ```
+> [error] [(root)] Schema validation failed: Invalid input: expected object, received undefined
+> ```
+>
+> The error path is `(root)` and does NOT pinpoint which node or which field is missing. If you see this error after editing a `.flow` file, audit every node for a `display` block before doing anything else. (Improving the validator's path specificity is tracked in [MST-9368](https://uipath.atlassian.net/browse/MST-9368).)
 
 > **No `model` block on nodes.** BPMN type, serviceType, event definition, and binding/context templates all live in the node's **definition** (the manifest copied from the registry into `definitions[]`). The runtime hydrates them from the definition at serialization time — instances carry only per-instance data (`inputs`, `outputs`, `display`).
 >

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -64,7 +64,7 @@ The `.flow` file is a JSON document at `<ProjectName>.flow` in the project root.
 }
 ```
 
-**Required fields on every node**: `id`, `type`, `typeVersion`, **`display`** (with at least a `label`). This includes control-flow nodes that "feel" trivial — `core.control.end`, `core.logic.terminate`, etc. all require `display: { "label": "..." }`. The schema does not exempt them.
+**Required fields on every node**: `id`, `type`, `typeVersion`, **`display`** (with at least a `label`). This applies to **every** node — triggers (`core.trigger.manual`, `core.trigger.scheduled`, connector triggers), action nodes, control-flow nodes (`core.control.end`, `core.logic.terminate`), and human-task nodes. The Zod `nodeSchema` declares `display: displayConfigSchema` without `.optional()`, so no node type is exempt — even ones that "feel" trivial.
 
 > **Gotcha — vague schema-validation error on missing `display`.** Omitting `display` on any node produces:
 >
@@ -96,6 +96,7 @@ Example — manual start trigger:
   "id": "start",
   "type": "core.trigger.manual",
   "typeVersion": "1.0.0",
+  "display": { "label": "Manual trigger" },
   "inputs": {
     "entryPointId": "3d4a8c34-5682-4ebe-a6bc-d92a18830bb5"
   },
@@ -318,6 +319,7 @@ Replace `<uuid>` with any generated UUID (e.g. `crypto.randomUUID()` in Node.js,
       "id": "start",
       "type": "core.trigger.manual",
       "typeVersion": "1.0.0",
+      "display": { "label": "Manual trigger" },
       "inputs": {
         "entryPointId": "<uuid>"
       },
@@ -357,6 +359,7 @@ Replace `<uuid>` with any generated UUID (e.g. `crypto.randomUUID()` in Node.js,
       "id": "end",
       "type": "core.logic.terminate",
       "typeVersion": "1.0.0",
+      "display": { "label": "End" },
       "inputs": {}
     }
   ],

--- a/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
+++ b/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
@@ -279,6 +279,7 @@ Workflow output variables (`direction: "out"`) must be mapped on End nodes. The 
   "id": "end1",
   "type": "core.control.end",
   "typeVersion": "1.0.0",
+  "display": { "label": "End" },
   "inputs": {},
   "outputs": {
     "totalAmount": {
@@ -605,6 +606,7 @@ A flow with input, state, and output variables:
       "id": "start",
       "type": "core.trigger.manual",
       "typeVersion": "1.0.0",
+      "display": { "label": "Manual trigger" },
       "inputs": {
         "entryPointId": "<uuid>"
       },
@@ -643,6 +645,7 @@ A flow with input, state, and output variables:
       "id": "end1",
       "type": "core.control.end",
       "typeVersion": "1.0.0",
+      "display": { "label": "End" },
       "inputs": {},
       "outputs": {
         "result": {


### PR DESCRIPTION
## Summary

Adds explicit emphasis that `display: { "label": "..." }` is required on **every** node — including control-flow nodes (`core.control.end`, `core.logic.terminate`) where it may "feel" optional.

## Why

In coder_eval e2e run `2026-05-04_04-05-27`, the agent for `skill-flow-hitl-smoke-multi-outcome-routing` emitted two `core.control.end` nodes without a `display` field. The validator returned the vague `[(root)] Schema validation failed: Invalid input: expected object, received undefined` — which does NOT pinpoint the missing node or field. The agent then burned 57 turns running 4 controlled experiments to isolate the offending field, mis-attributing the cause to `inputs:{}` rather than missing `display`.

The schema in `@uipath/flow-schema` (`nodeSchema.display` is required, not `.optional()`) is correct. The doc just didn't surface the rule clearly enough.

Empirical re-test confirming the actual rule:

| Configuration | Result |
|---|---|
| end with `display` + `inputs: {}` | **SUCCESS** |
| end with `display` + no `inputs` | **SUCCESS** |
| end with no `display` + `inputs: {}` | **FAILURE** |
| end with no `display` + no `inputs` | **FAILURE** |

## Changes

- `skills/uipath-maestro-flow/references/shared/file-format.md` (`Node instance` section):
  - Update `Required fields` list from `id, type, typeVersion` to include `display`.
  - Add a "Gotcha — vague schema-validation error on missing `display`" callout that shows the literal error string and the audit step.
  - Cross-link to [MST-9368](https://uipath.atlassian.net/browse/MST-9368) (validator-error-clarity follow-up: pinpoint the missing field rather than collapsing to `(root)`).
- `skills/uipath-maestro-flow/references/author/references/editing-operations-json.md` (`Add a node` section):
  - Mirror the `display` callout before the existing "Node outputs are required" reminder.
  - Cross-link to file-format.md and MST-9368.

## Verification

Ran the originally-failing task with 5 replicates against this worktree:

```bash
coder-eval run tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml --repeats 5
```

| rep | status | score | turns |
|---|---|---|---|
| 00 | SUCCESS | 1.0 | 60 |
| 01 | SUCCESS | 1.0 | 31 |
| 02 | SUCCESS | 1.0 | 77 |
| 03 | SUCCESS | 1.0 | 69 |
| 04 | SUCCESS | 1.0 | 76 |

**5/5 SUCCESS** at scores 1.0; all replicates emitted `display: { "label": "End ..." }` on `core.control.end` nodes correctly. Wall time 425s (vs the original failing run's 600s `turn_timeout` per replicate), well under the 80 max_turns budget.

## Cross-references

- Fixes: [MST-9346](https://uipath.atlassian.net/browse/MST-9346) (this ticket)
- Related upstream validator fix: [MST-9368](https://uipath.atlassian.net/browse/MST-9368) — `parseWorkflowJson` includes Zod issue path (PR: UiPath/flow-workbench#1378). Once that lands, the agent will get `nodes[N].display: ...` directly and the doc emphasis becomes a backstop rather than the primary diagnostic surface.
- Sibling: [MST-9345](https://uipath.atlassian.net/browse/MST-9345) — HITL `.output`/`.result` v1.0 alignment (separate PR on `tmatup/fix-mst-9345-hitl-result-access-pattern`).

## Out of scope (deferred)

- `turn_timeout` budget bump (Layer D in the original deep-dive). Per the methodology gate, do NOT bump until Layer A (MST-9368) ships and we re-measure. With the doc fix here, the agent now writes correct `display` fields without reverse-engineering, so the original 600s timeout should be sufficient — Layer D can be re-evaluated after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-9368]: https://uipath.atlassian.net/browse/MST-9368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ