### PR TITLE
test(hitl): migrate HITL smoke tasks to canonical pattern vocabulary

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
@@ -13,16 +13,31 @@ initial_prompt: |
   I have a UiPath Flow. Add a Human-in-the-Loop node before the final data
   write step so a manager can review and approve the data before it is posted.
 
-  Write a recommendation.json file with:
+  Recommend whether HITL is needed and identify which canonical HITL
+  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
+  `references/hitl-patterns.md` enumerates six canonical patterns; pick
+  exactly one and emit its machine name verbatim.
+
+  Write a `recommendation.json` file with this exact shape:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<which business pattern applies>",
+    "pattern": "<one of the canonical pattern names listed below>",
     "proposed_schema": {
       "inputs": ["<field names the human will see>"],
       "outputs": ["<field names the human fills in>"],
       "outcomes": ["<action button names>"]
     }
   }
+
+  Use EXACTLY one of these machine names for `pattern` (lowercase,
+  hyphenated, no extra adjectives or prefixes — names mirror the
+  section titles in `references/hitl-patterns.md`):
+    - approval-gate
+    - exception-escalation
+    - data-enrichment
+    - compliance-checkpoint
+    - write-back-validation
+    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -40,20 +55,19 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Agent named an approval or write-back pattern (case-tolerant)"
+    description: >
+      Agent picked a canonical HITL pattern that fits an "approve before
+      writing" scenario. Either approval-gate (manager approves the
+      artifact) or write-back-validation (HITL gates a write to a
+      system of record) is documented in `references/hitl-patterns.md`
+      as applicable here; both are accepted.
     path: "recommendation.json"
     assertions:
       - expression: "pattern"
-        operator: contains
-        expected: "pprov"
-      - expression: "pattern"
-        operator: contains
-        expected: "rite"
-      - expression: "pattern"
-        operator: contains
-        expected: "alid"
+        operator: regex
+        expected: "^(approval-gate|write-back-validation)$"
     weight: 1.5
-    pass_threshold: 0.33
+    pass_threshold: 1.0
 
   - type: file_contains
     description: "Agent proposed a schema with outcomes"

--- a/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
@@ -14,16 +14,31 @@ initial_prompt: |
   finance — but a manager must approve each expense report before the email
   is sent.
 
-  Write a recommendation.json file with:
+  Recommend whether HITL is needed and identify which canonical HITL
+  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
+  `references/hitl-patterns.md` enumerates six canonical patterns; pick
+  exactly one and emit its machine name verbatim.
+
+  Write a `recommendation.json` file with this exact shape:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<which business pattern applies>",
+    "pattern": "<one of the canonical pattern names listed below>",
     "proposed_schema": {
       "inputs": ["<field names>"],
       "outputs": ["<field names>"],
       "outcomes": ["<button names>"]
     }
   }
+
+  Use EXACTLY one of these machine names for `pattern` (lowercase,
+  hyphenated, no extra adjectives or prefixes — names mirror the
+  section titles in `references/hitl-patterns.md`):
+    - approval-gate
+    - exception-escalation
+    - data-enrichment
+    - compliance-checkpoint
+    - write-back-validation
+    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -41,11 +56,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Agent identified an approval gate pattern (case-tolerant)"
+    description: "Agent identified the canonical approval-gate pattern"
     path: "recommendation.json"
     assertions:
       - expression: "pattern"
-        operator: contains
-        expected: "pprov"
+        operator: equals
+        expected: "approval-gate"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
@@ -10,20 +10,37 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  My UiPath Flow has an AI agent that classifies customer complaints. When
-  the agent confidence is below 70%, a human needs to step in and make the
-  final call before the complaint is routed.
+  My UiPath Flow has an AI agent that classifies customer complaints.
+  Most classifications are confident and route automatically, but a
+  fraction land below the 70% confidence threshold. Those are edge
+  cases the agent cannot resolve autonomously — they need to escalate
+  to a human supervisor who makes the final routing call.
 
-  Write a recommendation.json file with:
+  Recommend whether HITL is needed and identify which canonical HITL
+  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
+  `references/hitl-patterns.md` enumerates six canonical patterns; pick
+  exactly one and emit its machine name verbatim.
+
+  Write a `recommendation.json` file with this exact shape:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<which business pattern applies>",
-    "insertion_point": "<where in the flow the HITL node should go>",
+    "pattern": "<one of the canonical pattern names listed below>",
+    "insertion_point": "<short phrase describing where in the flow>",
     "proposed_schema": {
       "inputs": ["<field names>"],
       "outcomes": ["<button names>"]
     }
   }
+
+  Use EXACTLY one of these machine names for `pattern` (lowercase,
+  hyphenated, no extra adjectives or prefixes — names mirror the
+  section titles in `references/hitl-patterns.md`):
+    - approval-gate
+    - exception-escalation
+    - data-enrichment
+    - compliance-checkpoint
+    - write-back-validation
+    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -41,21 +58,25 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Agent identified an escalation pattern"
+    description: >
+      Agent picked a canonical HITL pattern that fits a low-confidence-AI
+      scenario. Either Exception escalation (conditional escalate-when-stuck)
+      or Agentic output review (always-verify-AI) is documented in
+      `references/hitl-patterns.md` as applicable here; both are accepted.
     path: "recommendation.json"
     assertions:
       - expression: "pattern"
-        operator: contains
-        expected: "scalat"
+        operator: regex
+        expected: "^(exception-escalation|agentic-output-review)$"
     weight: 1.5
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Agent proposed an insertion point after the AI classifier (case-tolerant)"
+    description: "Agent proposed an insertion point that references the AI classifier, the confidence threshold, or the routing branch"
     path: "recommendation.json"
     assertions:
       - expression: "insertion_point"
-        operator: contains
-        expected: "lassif"
+        operator: regex
+        expected: "(?i)(classif|confidence|routing|low.{0,10}confidence|after.{0,30}\\bAI\\b)"
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
@@ -14,14 +14,28 @@ initial_prompt: |
   enriches the missing vendor and cost-center fields using company data, and
   writes the corrected records back to SAP.
 
-  Analyze whether this flow needs any human checkpoints. Write a
-  recommendation.json file with:
+  Analyze whether this flow needs any human checkpoints. If yes, identify
+  which canonical HITL pattern from the `uipath-human-in-the-loop` skill
+  applies. The skill's `references/hitl-patterns.md` enumerates six
+  canonical patterns; pick exactly one and emit its machine name verbatim.
+
+  Write a `recommendation.json` file with this exact shape:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<pattern name if applicable>",
+    "pattern": "<one of the canonical pattern names listed below>",
     "reason": "<why HITL is or is not needed>",
     "proposed_insertion_point": "<where in the flow>"
   }
+
+  Use EXACTLY one of these machine names for `pattern` (lowercase,
+  hyphenated, no extra adjectives or prefixes — names mirror the
+  section titles in `references/hitl-patterns.md`):
+    - approval-gate
+    - exception-escalation
+    - data-enrichment
+    - compliance-checkpoint
+    - write-back-validation
+    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -39,17 +53,17 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Agent named a write-back / validation / enrichment pattern (any one, case-tolerant)"
+    description: >
+      Agent picked a canonical HITL pattern that fits an "AI enriches data,
+      writes it back to a system of record" scenario. Write-back-validation
+      (HITL before write to system of record), data-enrichment (HITL fills
+      / validates incomplete data), and agentic-output-review (human
+      verifies AI output before downstream use) are all documented in
+      `references/hitl-patterns.md` as applicable here.
     path: "recommendation.json"
     assertions:
       - expression: "pattern"
-        operator: contains
-        expected: "rite"
-      - expression: "pattern"
-        operator: contains
-        expected: "alid"
-      - expression: "pattern"
-        operator: contains
-        expected: "nrich"
+        operator: regex
+        expected: "^(write-back-validation|data-enrichment|agentic-output-review)$"
     weight: 1.5
-    pass_threshold: 0.33
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
@@ -9,20 +9,37 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Automate GDPR data deletion requests. Each request requires documented
-  sign-off from our data privacy officer before the deletion actually runs —
-  we need an audit trail for every decision.
+  Automate GDPR data deletion requests. These are subject to regulatory
+  compliance requirements: each request needs documented regulatory
+  sign-off from our data privacy officer before the deletion runs, plus
+  an audit trail for every decision (required for compliance with GDPR
+  Article 17 — Right to Erasure).
 
-  Write a recommendation.json file with:
+  Recommend whether HITL is needed and identify which canonical HITL
+  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
+  `references/hitl-patterns.md` enumerates six canonical patterns; pick
+  exactly one and emit its machine name verbatim.
+
+  Write a `recommendation.json` file with this exact shape:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<which business pattern applies>",
+    "pattern": "<one of the canonical pattern names listed below>",
     "proposed_schema": {
       "inputs": ["<what the privacy officer will see>"],
       "outputs": ["<what they fill in>"],
       "outcomes": ["<their decision options>"]
     }
   }
+
+  Use EXACTLY one of these machine names for `pattern` (lowercase,
+  hyphenated, no extra adjectives or prefixes — names mirror the
+  section titles in `references/hitl-patterns.md`):
+    - approval-gate
+    - exception-escalation
+    - data-enrichment
+    - compliance-checkpoint
+    - write-back-validation
+    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -40,20 +57,16 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Agent identified a compliance / audit / sign-off / approval pattern (any one, case-tolerant)"
+    description: >
+      Agent picked a canonical HITL pattern that fits a regulatory-sign-off
+      scenario. Compliance-checkpoint is the textbook fit (the doc lists
+      "regulatory sign-off" and "GDPR consent flows" as its examples), but
+      approval-gate is also defensible since "sign off" is a shared signal
+      phrase. Both are accepted.
     path: "recommendation.json"
     assertions:
       - expression: "pattern"
-        operator: contains
-        expected: "udit"
-      - expression: "pattern"
-        operator: contains
-        expected: "omplianc"
-      - expression: "pattern"
-        operator: contains
-        expected: "ign"
-      - expression: "pattern"
-        operator: contains
-        expected: "pprov"
+        operator: regex
+        expected: "^(compliance-checkpoint|approval-gate)$"
     weight: 1.5
-    pass_threshold: 0.25
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Replaces 12 brittle `json_check.contains` substring assertions across the five HITL smoke tasks with strict canonical-name checks aligned with `references/hitl-patterns.md`.

| Task | Before | After |
|---|---|---|
| `smoke_01_explicit` | `pattern contains pprov \| rite \| alid` (3 fragments, OR @ 0.33) | `pattern regex ^(approval-gate\|write-back-validation)$` |
| `smoke_02_approval_gate` | `pattern contains pprov` | `pattern equals approval-gate` |
| `smoke_03_escalation` | `pattern contains scalat`, `insertion_point contains lassif` | `pattern regex ^(exception-escalation\|agentic-output-review)$`, `insertion_point regex (?i)(classif\|confidence\|routing\|...)` |
| `smoke_04_writeback` | `pattern contains rite \| alid \| nrich` (3 fragments, OR @ 0.33) | `pattern regex ^(write-back-validation\|data-enrichment\|agentic-output-review)$` |
| `smoke_05_compliance` | `pattern contains udit \| omplianc \| ign \| pprov` (4 fragments, OR @ 0.25) | `pattern regex ^(compliance-checkpoint\|approval-gate)$` (+ prompt strengthened with explicit "regulatory compliance" framing and GDPR Article 17 reference) |

Each task's prompt now lists the **same** 6 canonical pattern machine names mirroring the section titles in `references/hitl-patterns.md`:
- `approval-gate`, `exception-escalation`, `data-enrichment`, `compliance-checkpoint`, `write-back-validation`, `agentic-output-review`

The agent is required to emit exactly one of those names verbatim. Where the scenario maps to multiple defensible canonical answers per the skill doc, the criterion uses `regex` and accepts each documented option.

## Why

The original assertions used 4–6-character substrings of the canonical pattern names (e.g. `expected: "scalat"` for "escalation", `expected: "udit"` for "audit", `expected: "ign"` for "sign-off"). When the agent's free-form English answer didn't happen to contain that exact substring fragment, the smoke task failed — even when the answer was semantically correct. Local triage of run `2026-05-04_04-05-27` (and a 9-rep cross-grid across PR #517 / #545 / #546 worktrees) traced one such failure to `expected: "scalat"`: smoke_03_escalation passed 8/9 locally but the failing rep emitted `pattern: "confidence-gated human review"` — a perfectly correct semantic answer that just didn't contain the literal substring.

Replacing the substring trap with a controlled vocabulary:
- Decouples the test from agent-paraphrase variance.
- Forces the agent to consult `references/hitl-patterns.md` (the prompt names the file) and pick a documented pattern.
- Surfaces test/skill drift loudly: if the skill ever renames a pattern, the test fails immediately rather than slowly drifting into uselessness.

## Commits

1. `fix(hitl): rewrite smoke_03_escalation around canonical pattern vocabulary` — the originally failing test that triggered the investigation.
2. `test(hitl): migrate 4 HITL smoke tasks to canonical pattern vocabulary` — the proactive cleanup of the same anti-pattern in the four sibling smoke tasks.

## Test plan

- [x] Local: `coder-eval run --repeats 3` against this branch — **3/3 SUCCESS** at score 1.0 for smoke_03 (commit 1) and **12/12 SUCCESS** at score 1.0 across smoke_01/02/04/05 (commit 2). 15/15 total.
- [x] Authoritative validator-driven scan of `origin/main` (post-sync) confirms all 6 failing criteria across these 5 files are covered. After this PR lands: 0 violators repo-wide.
- [ ] CI smoke-skills run (will fire on PR push).

## Companion PR

- UiPath/coder_eval#212 — adds the matching Pydantic validator that hard-fails any task YAML using `json_check.contains` with a `< 8`-char literal at task-load time. **Merge this PR first**, otherwise smoke-skills CI will go red the moment coder_eval ships the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)