### PR TITLE
fix(maestro-flow): grade CEQL where test against artifacts the prompt asks for

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -1,8 +1,12 @@
 task_id: skill-flow-ipe-ceql-where
 description: >
-  Tests the CEQL where query IS feature — configures a Microsoft Entra (Azure
-  AD) "List groups" connector node with a CEQL filter on displayName = "active",
-  persisted as a structured filter tree (Studio Web contract).
+  Tests the CEQL where query IS feature — agent plans a structured filter
+  tree for the Microsoft Entra (Azure AD) connector's "List groups"
+  operation with a `displayName = "active"` filter, following the canonical
+  shape documented in the Filter Trees (CEQL) section of the
+  uipath-platform skill. The flow must reference the registered connector
+  key (`uipath-microsoft-azureactivedirectory`), use Decision + Terminate
+  for routing, and pass `uip maestro flow validate`.
 tags: [uipath-maestro-flow, smoke, connector, ceql, filter]
 
 task_timeout: 1500
@@ -21,30 +25,49 @@ sandbox:
       - "@uipath/cli"
 initial_prompt: |
   Use the `uipath-maestro-flow` skill. Do NOT run `uip flow node configure`
-  or any command that requires a live connection — this sandbox has no UiPath
-  tenant. Instead, plan the exact `--detail` JSON you would pass to
-  `uip flow node configure` for the where.
-  Write the planned filter `--detail` JSON to `where_detail.json`. It must
-  contain, at minimum:
-    - connectionId, folderKey, eventMode (placeholder values are fine)
-    - a `filter` object (the structured filter tree)
+  or any command that requires a live connection — this sandbox has no
+  UiPath tenant. Instead, plan the exact `--detail` JSON you would pass to
+  `uip flow node configure` and emit it to `where_detail.json`.
 
-  Also save a short summary to report.json 
+  Read the canonical filter-tree shape before writing:
+  `skills/uipath-platform/references/integration-service/activities.md`,
+  section "Filter Trees (CEQL)". The Maestro Flow connector plugin's
+  Step 6a (`skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md`)
+  cross-references that section.
+
+  `where_detail.json` must contain, at minimum:
+    - `connectionId`, `folderKey`, `eventMode` (placeholder values are fine)
+    - a top-level `filter` object using the CANONICAL shape from the doc:
+        `{"groupOperator": <0|1>, "index": 0, "filters": [...], "groups": []}`
+      Each leaf filter must use:
+        - `id`: the field name (e.g. `"displayName"`)
+        - `operator`: PascalCase (`"Equals"`, `"Contains"`, ...)
+        - `value`: a `WorkflowValue` object
+            `{"value": <typed>, "rawString": <verbatim>, "isLiteral": true}`
+
+  Save a short summary to `report.json`:
     {
       "scenario": "ceql-where-filter-tree",
       "uses_filter_tree": true,
       "used_filter_expression_string": false,
       "notes": "<one sentence explaining why the tree is the correct input>"
     }
+
   Create a flow called "CeqlWhereTest" with a manual trigger that uses the
-  Microsoft Entra (Azure AD) connector to list all groups whose `displayName`
-  equals "active". The CEQL where filter must be persisted as a structured
-  filter tree (the same shape Studio Web reads to render the filter builder),
-  not just as a raw expression string.
+  Microsoft Entra (Azure AD) connector's "List groups" operation, filtering
+  on `displayName = "active"`.
+
+  Connector key: use `uipath-microsoft-azureactivedirectory` exactly. That
+  is the registered key for the Microsoft Entra ID connector in this
+  tenant — display names like "Microsoft Entra" or "Microsoft Entra ID"
+  are NOT registry keys. Confirm the key with
+  `uip maestro flow registry search "azureactivedirectory"` before adding
+  the node.
+
   Add a Decision node to check whether the call succeeded.
   Route failure to a Terminate node with error message "CeqlWhere test failed".
   Route success to a final action that logs "CeqlWhere test passed".
-  Validate the final flow file.
+  Validate the final flow file with `uip maestro flow validate`.
 
 success_criteria:
   - type: file_exists
@@ -54,10 +77,10 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow targets uipath-microsoft-azureactivedirectory List Groups with displayName=active filter tree, plus Decision + Terminate nodes"
+    description: "where_detail.json has a canonical CEQL filter tree on displayName='active'; flow references the registered Azure AD / Entra connector key with List Groups + Decision + Terminate nodes"
     command: "python3 $TASK_DIR/check_ceql_where_flow.py"
     timeout: 60
-    expected_exit_code: 0 
+    expected_exit_code: 0
     weight: 8.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
@@ -1,79 +1,34 @@
 #!/usr/bin/env python3
-"""CEQL where: verify the flow targets the Microsoft Entra (Azure AD)
-connector's "List Groups" operation, has Decision + Terminate nodes for
-the success/failure routing, and has the connector node configured with a
-``where`` CEQL filter on ``displayName = "active"`` — persisted both as a
-``queryParameters.where`` expression and as a structured
-``savedFilterTrees.where`` tree inside the connector ``configuration`` blob
-(same Studio Web contract used for connector-trigger filter trees)."""
+"""CEQL where: verify the agent's planned `--detail` JSON in
+``where_detail.json`` carries a canonical CEQL filter tree per
+``skills/uipath-platform/references/integration-service/activities.md``
+— section "Filter Trees (CEQL)" — and that the .flow file references
+the registered Microsoft Entra (Azure AD) connector with the List
+Groups operation, plus Decision and Terminate nodes for routing.
+
+Why we grade ``where_detail.json`` and not the .flow file's
+``inputs.detail``:
+  The task prompt forbids ``uip flow node configure`` (no live tenant),
+  which is the command that populates ``inputs.detail``. The CLI's own
+  ``uip maestro flow validate`` accepts a connector node with empty
+  ``inputs: {}``, so requiring a fully-expanded ``inputs.detail`` here
+  would test something the prompt forbids and the CLI doesn't enforce.
+  ``where_detail.json`` is the artifact the prompt asks the agent to
+  plan, so that is the artifact we grade.
+"""
 
 import glob
 import json
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
 from _shared.flow_check import assert_flow_has_node_type  # noqa: E402
 
-CONNECTOR_KEYS = (
-    "uipath-microsoft-azureactivedirectory",
-)
+CONNECTOR_KEY = "uipath-microsoft-azureactivedirectory"
 FLOW_GLOB = "**/CeqlWhereTest*.flow"
 EXPECTED_FIELD = "displayname"
 EXPECTED_VALUE = "active"
-
-
-def _find_flow() -> str:
-    flows = glob.glob(FLOW_GLOB, recursive=True)
-    if not flows:
-        sys.exit(f"FAIL: No flow file matching {FLOW_GLOB}")
-    return flows[0]
-
-
-def _find_connector_node(flow: dict) -> dict:
-    for node in flow.get("nodes") or []:
-        node_type = node.get("type", "")
-        if not node_type.startswith("uipath.connector."):
-            continue
-        if any(key in node_type for key in CONNECTOR_KEYS):
-            return node
-    sys.exit(
-        f"FAIL: No connector node with type containing one of {CONNECTOR_KEYS} found"
-    )
-
-
-def _assert_list_groups_operation(node: dict) -> None:
-    """The operation key/path must reference groups (List Groups)."""
-    node_type = node.get("type", "")
-    detail = (node.get("inputs") or {}).get("detail") or {}
-    haystack_parts = [node_type]
-    if isinstance(detail, dict):
-        for key in ("operationId", "operation", "method", "path", "resource"):
-            v = detail.get(key)
-            if isinstance(v, str):
-                haystack_parts.append(v)
-    elif isinstance(detail, str):
-        haystack_parts.append(detail)
-    haystack = " ".join(haystack_parts).lower()
-    if "group" not in haystack:
-        sys.exit(
-            "FAIL: connector node does not appear to target the List Groups "
-            f"operation (no 'group' token found in type/operation: {haystack!r})"
-        )
-
-
-def _parse_configuration(detail: dict) -> dict:
-    """``inputs.detail.configuration`` is stored as ``=jsonString:{...}``.
-    Strip the prefix and parse the JSON payload."""
-    raw = detail.get("configuration")
-    if not isinstance(raw, str) or not raw.strip():
-        sys.exit("FAIL: connector node inputs.detail.configuration is missing or empty")
-    payload = re.sub(r"^\s*=jsonString:\s*", "", raw)
-    try:
-        return json.loads(payload)
-    except json.JSONDecodeError as e:
-        sys.exit(f"FAIL: inputs.detail.configuration is not valid JSON: {e}")
 
 
 def _walk(node):
@@ -88,7 +43,7 @@ def _walk(node):
 
 
 def _leaf_field(n: dict):
-    return n.get("fieldName") or n.get("field") or n.get("id") or n.get("name")
+    return n.get("id") or n.get("fieldName") or n.get("field") or n.get("name")
 
 
 def _leaf_value(n: dict):
@@ -98,116 +53,107 @@ def _leaf_value(n: dict):
     return v
 
 
-def _assert_filter_tree_shape(where_tree) -> None:
-    """Same shape contract trigger_with_filter.yaml enforces: a structured
-    tree with a numeric groupOperator, a non-empty filters array, at least
-    one leaf referencing the displayName field, and the value 'active'."""
-    if not isinstance(where_tree, dict):
+def _assert_filter_tree_shape(tree, *, source: str) -> None:
+    """Per Filter Trees (CEQL) doc: structured tree with numeric
+    groupOperator (0 = And, 1 = Or), at least one leaf with PascalCase
+    operator referencing displayName='active'. Leaves use ``id`` (canonical)
+    or fall back to ``fieldName``/``field``/``name`` for older shapes."""
+    if not isinstance(tree, dict):
+        sys.exit(f"FAIL: {source} must be a filter-tree object")
+
+    if not isinstance(tree.get("groupOperator"), (int, float)):
         sys.exit(
-            "FAIL: savedFilterTrees.where is missing — the CEQL filter must be "
-            "persisted in the structured filter builder tree, not only as a "
-            "raw expression string"
+            f"FAIL: {source}.groupOperator must be a number "
+            "(0 = And, 1 = Or) — see Filter Trees (CEQL) doc"
         )
 
-    if not isinstance(where_tree.get("groupOperator"), (int, float)):
-        sys.exit(
-            "FAIL: savedFilterTrees.where.groupOperator must be a number "
-            "(0 = And, 1 = Or) — Studio Web's persisted shape"
-        )
-
-    filters = where_tree.get("filters")
+    filters = tree.get("filters")
     if not isinstance(filters, list) or not filters:
-        sys.exit(
-            "FAIL: savedFilterTrees.where.filters is empty — "
-            "add at least one filter entry on displayName"
-        )
+        sys.exit(f"FAIL: {source}.filters must be a non-empty list")
 
-    leaves = [n for n in _walk(where_tree) if isinstance(n.get("operator"), str)]
+    leaves = [n for n in _walk(tree) if isinstance(n.get("operator"), str)]
     if not leaves:
-        sys.exit("FAIL: savedFilterTrees.where contains no leaf filter with an `operator`")
+        sys.exit(f"FAIL: {source} has no leaf filter with `operator`")
 
     fields = [_leaf_field(n) for n in leaves]
     if not any(isinstance(f, str) and EXPECTED_FIELD in f.lower() for f in fields):
         sys.exit(
-            f"FAIL: filter tree does not reference the `displayName` field "
+            f"FAIL: {source} leaves do not reference the displayName field "
             f"(found fields: {[f for f in fields if f]})"
         )
 
     values = [_leaf_value(n) for n in leaves]
     if not any(isinstance(v, str) and v.strip().lower() == EXPECTED_VALUE for v in values):
         sys.exit(
-            f"FAIL: no leaf has value '{EXPECTED_VALUE}' "
+            f"FAIL: {source} has no leaf with value '{EXPECTED_VALUE}' "
             f"(found values: {[v for v in values if v is not None]})"
         )
 
 
-def assert_where_configured(node: dict) -> None:
-    detail = (node.get("inputs") or {}).get("detail") or {}
-    if not detail:
-        sys.exit("FAIL: connector node is missing inputs.detail")
+def _check_where_detail() -> None:
+    if not os.path.exists("where_detail.json"):
+        sys.exit("FAIL: where_detail.json not found")
+    try:
+        plan = json.load(open("where_detail.json"))
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: where_detail.json is not valid JSON: {e}")
 
-    if isinstance(detail, str):
-        # `=js:` expression form — the whole detail object is computed at
-        # runtime, so structural fields (queryParameters, savedFilterTrees)
-        # live inside the expression string. Accept iff the where filter
-        # is referenced lexically and mentions displayName + active.
-        for token, label in (
-            ("queryParameters", "'queryParameters'"),
-            (r"\bwhere\b", "a 'where' filter"),
-            ("displayName", "the displayName field"),
-            ("active", "the value 'active'"),
-        ):
-            if not re.search(token, detail, flags=re.IGNORECASE):
-                sys.exit(
-                    f"FAIL: connector node inputs.detail is a JS expression "
-                    f"but does not reference {label}"
-                )
-        return
-
-    query_params = detail.get("queryParameters") or {}
-    where_value = query_params.get("where")
-    if not isinstance(where_value, str) or not where_value.strip():
+    filter_tree = plan.get("filter")
+    if not isinstance(filter_tree, dict):
         sys.exit(
-            "FAIL: connector node inputs.detail.queryParameters.where "
-            "must be a non-empty string"
+            "FAIL: where_detail.json missing top-level `filter` object — "
+            "the prompt requires a structured filter tree under that key"
         )
-    if "displayname" not in where_value.lower() or EXPECTED_VALUE not in where_value.lower():
-        sys.exit(
-            "FAIL: queryParameters.where must reference displayName and 'active' "
-            f"(got: {where_value!r})"
-        )
-
-    config = _parse_configuration(detail)
-    essential = config.get("essentialConfiguration") or {}
-    saved_trees = essential.get("savedFilterTrees") or {}
-    _assert_filter_tree_shape(saved_trees.get("where"))
+    _assert_filter_tree_shape(filter_tree, source="where_detail.json.filter")
 
 
-def main():
+def _find_flow() -> str:
+    flows = glob.glob(FLOW_GLOB, recursive=True)
+    if not flows:
+        sys.exit(f"FAIL: No flow file matching {FLOW_GLOB}")
+    return flows[0]
+
+
+def _check_flow_structure() -> None:
     flow_path = _find_flow()
-    with open(flow_path) as f:
-        raw = f.read()
-    flow = json.loads(raw)
+    raw = open(flow_path).read()
+    try:
+        flow = json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {flow_path} is not valid JSON: {e}")
     if "nodes" not in flow or "edges" not in flow:
         sys.exit("FAIL: Flow missing 'nodes' or 'edges'")
 
-    if not any(key in raw for key in CONNECTOR_KEYS):
+    if CONNECTOR_KEY not in raw:
         sys.exit(
-            f"FAIL: None of the expected Azure AD / Entra connector keys "
-            f"{CONNECTOR_KEYS} found in {flow_path}"
+            f"FAIL: Flow does not reference the registered Azure AD / Entra "
+            f"connector key {CONNECTOR_KEY!r}. Display names like 'Microsoft "
+            "Entra' or 'Microsoft Entra ID' are NOT registry keys — confirm "
+            "the registered key with `uip maestro flow registry search`."
         )
 
-    connector_node = _find_connector_node(flow)
-    _assert_list_groups_operation(connector_node)
-    assert_where_configured(connector_node)
+    found_groups = False
+    for node in flow.get("nodes", []):
+        node_type = node.get("type", "")
+        if CONNECTOR_KEY in node_type and "group" in node_type.lower():
+            found_groups = True
+            break
+    if not found_groups:
+        sys.exit(
+            f"FAIL: No connector node of type "
+            f"`uipath.connector.{CONNECTOR_KEY}.list-groups` (or similar) found"
+        )
 
     assert_flow_has_node_type(["decision", "terminate"])
 
+
+def main() -> None:
+    _check_where_detail()
+    _check_flow_structure()
     print(
-        f"OK: {len(flow['nodes'])} nodes, {len(flow['edges'])} edges; "
-        f"Azure AD / Entra List Groups referenced; Decision and Terminate nodes "
-        f"present; where filter tree on displayName='active' configured in "
-        f"queryParameters and savedFilterTrees"
+        f"OK: where_detail.json carries canonical CEQL filter tree on "
+        f"displayName='{EXPECTED_VALUE}'; flow targets {CONNECTOR_KEY} "
+        "List Groups; Decision and Terminate nodes present"
     )
 
 


### PR DESCRIPTION
## Summary

- Replaces brittle .flow-file-internals checks with structural+canonical-shape grading.
- Agent now gets the registered connector key (`uipath-microsoft-azureactivedirectory`) and a pointer to the Filter Trees (CEQL) doc in the prompt.
- Drops the requirement that `inputs.detail` be hand-populated — `uip maestro flow validate` accepts a connector node with `inputs: {}`, so we shouldn't be stricter than the CLI.
- Local verification: **3/3 SUCCESS at score 1.0** vs 0/3 baseline.

## Background

Local 3-rep baseline on current `origin/main` for `skill-flow-ipe-ceql-where`: **0/3 PASS**, all three FAILURE at score 0.273. Three reps split across two checker-driven failure modes that aren't really agent failures:

| Failure mode | Reps | Why |
|---|---|---|
| **Connector-key invention** | 00 + 02 | Agent wrote `uipath-microsoft-entra` / `uipath-microsoft-entra-id`, derived from the current product name "Microsoft Entra ID". The registered key is the legacy `uipath-microsoft-azureactivedirectory`, and nothing in the prompt or `SKILL.md` surfaced that. |
| **Empty `inputs.detail`** | 01 | Agent built a structurally-valid flow with `inputs: {}` and ran `uip maestro flow validate` → "Status: Valid". The CLI itself does not require `inputs.detail` populated; only this test's checker did. The prompt forbids `uip flow node configure` (no live tenant) — the command that populates `inputs.detail`. Asking the agent to reverse-engineer that population is asking for something the prompt forbids and the CLI doesn't enforce. |

The pattern is identical to UiPath/skills#555 (smoke_03_escalation): the checker grades artifacts/shapes that the prompt doesn't ask for and the agent has no reliable signal to know about.

## Approach

Mirror the HITL fix's playbook: **give the agent the canonical vocabulary, grade what the prompt asks for**.

### Prompt
- Name the registered connector key verbatim (`uipath-microsoft-azureactivedirectory`) and explicitly warn that "Microsoft Entra" / "Microsoft Entra ID" are display names, not registry keys.
- Point the agent at the canonical filter-tree shape: the **"Filter Trees (CEQL)"** section in `skills/uipath-platform/references/integration-service/activities.md` (added by #492) and the cross-reference in Step 6a of the Maestro Flow connector plugin's `impl.md`.
- Enumerate the required `where_detail.json` shape inline: `groupOperator` + `filters[].id` + PascalCase `operator` + `WorkflowValue`-wrapped `value`.

### Checker
- **Validates `where_detail.json`'s `filter`** against the canonical shape (the artifact the prompt asks the agent to plan).
- **Validates the `.flow` file at structural level only**: registered connector key present + List Groups operation referenced + Decision + Terminate nodes. No more `inputs.detail` / `queryParameters.where` / `configuration: '=jsonString:...'` reverse-engineering — those are what `uip flow node configure` produces, and that command is forbidden by the prompt.
- Drops the `=js:` expression-form fallback path (only meaningful for the persisted shape we're no longer grading).

## Test plan

Baseline (current `origin/main`):
- rep 00: FAILURE 0.273 — `uipath-microsoft-entra` (invented key)
- rep 01: FAILURE 0.273 — empty `inputs.detail`
- rep 02: FAILURE 0.273 — `uipath-microsoft-entra-id` (invented key)

After fix (this branch):
- rep 00: **SUCCESS 1.0** in 298s
- rep 01: **SUCCESS 1.0** in 602s
- rep 02: **SUCCESS 1.0** in 346s

Average duration: 415s (vs 774s baseline — the canonical-key directive shaves ~45% off the agent's trial-and-error on connector picking and validator schema reverse-engineering). All three reps converged on the canonical filter-tree shape verbatim:

```json
{
  "groupOperator": 0, "index": 0,
  "filters": [
    { "id": "displayName", "operator": "Equals",
      "value": { "value": "active", "rawString": "\"active\"", "isLiteral": true } }
  ],
  "groups": []
}
```

## Companion PRs in flight

- UiPath/skills#555 — same-spirit fix for `skill-hitl-smoke-escalation` + four sibling HITL smoke tasks.
- UiPath/coder_eval#212 — Pydantic validator that rejects brittle `json_check.contains` short-literal assertions at task-load time. Independent of this PR (CEQL fix doesn't touch `json_check.contains`).

## Follow-ups (out of scope)

- **Tier-1 connector cheat sheet in the maestro-flow skill.** All three baseline reps independently invented connector keys from product names. Adding a "display name → registry key" table for Tier-1 connectors (Microsoft Entra ID → `uipath-microsoft-azureactivedirectory`, OneDrive/SharePoint/M365 → `uipath-microsoft-onedrive`, etc.) would close that gap for future tasks. Documented but not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)