### PR TITLE
feat(uipath-maestro-flow): add IXP node plugin

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/planning-impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/planning-impl.md
@@ -58,6 +58,7 @@ uip maestro flow registry get <nodeType> --output json
 | `uipath.core.hitl.*`            | [hitl/impl.md](plugins/hitl/impl.md)                           |
 | `uipath.connector.*`            | [connector/impl.md](plugins/connector/impl.md)                 |
 | `uipath.connector.trigger.*`    | [connector-trigger/impl.md](plugins/connector-trigger/impl.md) |
+| `uipath.ixp.*`                  | [ixp/impl.md](plugins/ixp/impl.md)                             |
 
 For each node type, record:
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
@@ -1,0 +1,36 @@
+# IXP / Document Extraction Node — Implementation
+
+## Node Type
+
+`uipath.ixp.<modelName>.shared-<modelName>` — tenant-specific. One node type per published IXP extraction model. Find via `uip maestro flow registry search ixp`.
+
+## Registry Validation
+
+```bash
+uip maestro flow registry get "<nodeType>" --output json
+```
+
+Confirm: input port `input`, output ports `success` + `error`, required input `fileRef`.
+
+## Adding the Node
+
+```bash
+uip maestro flow node add <flow.flow> "<nodeType>" \
+    --input '{"fileRef":"=js:$vars.<upstream-node-id>.output"}'
+```
+
+You only need to provide:
+
+- **`fileRef`** (required) — JS expression pointing at an upstream node's file output, e.g. `"=js:$vars.downloadFile1.output"`. The upstream node id is the `id` field (not display label, not nodeType).
+- **`pageRange`** (optional) — e.g. `"1-5"`.
+
+Everything else (model name, folder, project, etc.) is auto-filled from the registry. Don't pass them via `--input`.
+
+`node add` does NOT auto-wire edges — connect with `uip maestro flow edge add` (use `--source-port success`).
+
+## Output
+
+Output schema is defined in the manifest's `outputDefinition` — read it via `registry get` to see the exact shape (varies by model taxonomy).
+
+- `$vars.{nodeId}.output` — extraction result.
+- `$vars.{nodeId}.error` — populated on failure.


### PR DESCRIPTION
[MST-8797](https://uipath.atlassian.net/browse/MST-8797)


## Summary

- Adds `plugins/ixp/impl.md` to the maestro-flow skill — describes how to add document-extraction nodes (`uipath.ixp.*`).
- Key insight: only `fileRef` (required) and `pageRange` (optional) are user-supplied; everything else (modelName, projectName, folderKey, folderName, etc.) auto-fills from the registry's `inputDefaults` at `node add` time.
- Adds `uipath.ixp.*` to the `planning-impl.md` routing index so the plugin is discoverable in Phase 2.

## Verification

End-to-end against an IXP solution: deleted the IXP node, re-added with only \`--input '{"fileRef":"=js:\$vars.downloadFile1.output"}'\`, wired edges, ran \`maestro flow debug\` — finalStatus: Completed, all four element executions succeeded.

## Test plan

- [ ] Open the new \`plugins/ixp/impl.md\` and confirm it follows the skill's plugin-doc conventions
- [ ] Confirm \`planning-impl.md\` table row for \`uipath.ixp.*\` renders correctly

[MST-8797]: https://uipath.atlassian.net/browse/MST-8797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ