### PR TITLE
chore(tests): general improvements to test harness

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"89772662-5edf-489c-8fff-1f71d20f6404","pid":10328,"acquiredAt":1776708244900}

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -247,12 +247,13 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_REGION }}
           BEDROCK_MODEL: ${{ secrets.BEDROCK_MODEL }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TASK_PARALLELISM: ${{ vars.TASK_PARALLELISM || '1' }}
         working-directory: tests
         id: smoke
         run: |
-          echo "Running: coder-eval run ${{ needs.detect.outputs.task_globs }} --tags smoke"
+          echo "Running: coder-eval run ${{ needs.detect.outputs.task_globs }} --tags smoke -j $TASK_PARALLELISM"
           coder-eval run ${{ needs.detect.outputs.task_globs }} \
-            -e experiments/default.yaml --tags smoke -j 1 -v
+            -e experiments/default.yaml --tags smoke -j "$TASK_PARALLELISM" -v
         continue-on-error: true
 
       - name: Summarize results

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,9 @@ site
 # Hook scripts that may contain personal paths
 **/.claude/hooks/*.local.*
 
+# Transient session lockfiles
+**/.claude/*.lock
+
 # coder_eval test run artifacts
 tests/reports/
 tests/runs/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -4,6 +4,7 @@ SKILLS_REPO_PATH ?= $(shell cd .. && pwd)
 VENV := .venv
 CODER_EVAL := SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) $(VENV)/bin/coder-eval
 TASKS := $(shell find tasks -name '*.yaml' -type f)
+TASK_PARALLELISM ?= 1
 
 help:  ## Show available commands
 	@grep -E '^[a-zA-Z0-9_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
@@ -24,16 +25,16 @@ install:  ## Install coder-eval into local .venv (requires Python 3.13+; UV_INDE
 	@echo "See https://github.com/UiPath/coder_eval for environment setup (.env, API keys, etc.)"
 
 all:  ## Run all tests (smoke + integration + e2e) in a single run
-	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml -j 1 -v
+	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml -j $(TASK_PARALLELISM) -v
 
 smoke:  ## Run all smoke tests
-	$(CODER_EVAL) run $(TASKS) -e experiments/default.yaml --tags smoke -j 1 -v
+	$(CODER_EVAL) run $(TASKS) -e experiments/default.yaml --tags smoke -j $(TASK_PARALLELISM) -v
 
 integration:  ## Run all integration tests
-	$(CODER_EVAL) run $(TASKS) -e experiments/integration.yaml --tags integration -j 1 -v
+	$(CODER_EVAL) run $(TASKS) -e experiments/integration.yaml --tags integration -j $(TASK_PARALLELISM) -v
 
 e2e:  ## Run all end-to-end tests
-	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml --tags e2e -j 1 -v
+	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml --tags e2e -j $(TASK_PARALLELISM) -v
 
 tags:  ## Run tests matching one or more tags: make tags TAGS="integration connector-feature" [EXPERIMENT=experiments/integration.yaml]
 	@if [ -z "$(TAGS)" ]; then echo "Usage: make tags TAGS=\"tag1 tag2\" [EXPERIMENT=experiments/<file>.yaml]"; exit 2; fi
@@ -45,10 +46,10 @@ matches=[]; \
 print(f"Matched {len(matches)} task(s) for tags: {sorted(wanted)}"); \
 [print(f"  - {m}") for m in matches]; \
 sys.exit(0 if matches else 3)'
-	$(CODER_EVAL) run $(TASKS) -e $(or $(EXPERIMENT),experiments/default.yaml) $(foreach t,$(TAGS),--tags $(t)) -j 1 -v
+	$(CODER_EVAL) run $(TASKS) -e $(or $(EXPERIMENT),experiments/default.yaml) $(foreach t,$(TAGS),--tags $(t)) -j $(TASK_PARALLELISM) -v
 
 # Run all tests for a specific skill: make test-uipath-maestro-flow
 test-%:  ## Run all tests for a specific skill
-	$(CODER_EVAL) run $(shell find tasks/$* -name '*.yaml' -type f) -e experiments/default.yaml -j 1 -v
+	$(CODER_EVAL) run $(shell find tasks/$* -name '*.yaml' -type f) -e experiments/default.yaml -j $(TASK_PARALLELISM) -v
 
 .DEFAULT_GOAL := help

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,6 +57,19 @@ SKILLS_REPO_PATH=$(cd .. && pwd) \
 
 The `SKILLS_REPO_PATH` environment variable defaults to the parent directory (repo root) when using `make`.
 
+### Parallelism
+
+All `make` targets run tasks serially by default (`-j 1`). Override with `TASK_PARALLELISM`:
+
+```bash
+# Run smoke tests with 4 tasks in parallel
+TASK_PARALLELISM=4 make smoke
+
+# Or export once for the shell session
+export TASK_PARALLELISM=4
+make all
+```
+
 ## Evaluation Framework
 
 Tests are organized into three types, distinguished by **tags** (not directories). All tests for a skill live together in `tests/tasks/<skill-name>/`.

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -18,6 +18,8 @@ defaults:
     # cutting before/after-hooks and coded-test-case off mid-task.
     max_turns: 40
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+    system_prompt: |
+      You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
     plugins:
       - type: "local"
         path: "$SKILLS_REPO_PATH"

--- a/tests/experiments/e2e.yaml
+++ b/tests/experiments/e2e.yaml
@@ -12,6 +12,8 @@ defaults:
     model: claude-sonnet-4-6
     max_turns: 200
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+    system_prompt: |
+      You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
     plugins:
       - type: "local"
         path: "$SKILLS_REPO_PATH"

--- a/tests/experiments/integration.yaml
+++ b/tests/experiments/integration.yaml
@@ -12,6 +12,8 @@ defaults:
     model: claude-sonnet-4-6
     max_turns: 30
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+    system_prompt: |
+      You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
     plugins:
       - type: "local"
         path: "$SKILLS_REPO_PATH"


### PR DESCRIPTION
- Add TASK_PARALLELISM Make var (default 1) to control coder-eval -j
- Wire vars.TASK_PARALLELISM into smoke-skills workflow
- Document parallelism override in tests/README.md
- Add system_prompt to experiment configs restricting agent file access to its working directory (no sibling runs/* access)
- Remove accidentally committed .claude/scheduled_tasks.lock
- Gitignore **/.claude/*.lock to prevent recurrence

All smoke tests are tested on this change. Total runtime down from ~1 hour 45 mins to ~30 minutes.