### PR TITLE
MST-9400: grade DevCon HITL flow semantically

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -85,6 +85,15 @@ def main() -> None:
     if not (has_boolean_decision or has_approval_outcomes):
         fail("HITL must capture the manager decision as a boolean output or approve/reject outcomes")
 
+    reason_keywords = ("reason", "comment", "explanation", "justification", "note")
+    if not any(
+        f.get("direction") in {"output", "inOut"}
+        and f.get("type") in {"text", "string", "textarea"}
+        and any(kw in field_text(f, "id") or kw in field_text(f, "label") for kw in reason_keywords)
+        for f in fields
+    ):
+        fail("HITL must expose a text output field for the rejection reason (e.g., reason, comment)")
+
     input_bindings = [
         f.get("binding", "")
         for f in fields
@@ -107,7 +116,7 @@ def main() -> None:
     if not any(expected_output_path in script for script in scripts):
         fail(f"Downstream script must read HITL output via {expected_output_path}")
 
-    print(f"OK: HITL node {hitl_id} uses v1.0 schema, captures approval, wires completed, and uses .output paths")
+    print(f"OK: HITL node {hitl_id} uses v1.0 schema, captures approval + reason, wires completed, and uses .output paths")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Validate the DevCon expense approval flow's HITL semantics.
+
+The task is intentionally about the workflow behavior, not the exact editing
+mechanism. Inline HITL can be authored directly in the .flow file, and approval
+can be represented either as a boolean output field or as approve/reject
+outcomes.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import sys
+from pathlib import Path
+
+
+FLOW_GLOB = "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+
+
+def fail(message: str) -> None:
+    sys.exit(f"FAIL: {message}")
+
+
+def load_flow() -> dict:
+    matches = glob.glob(FLOW_GLOB)
+    if not matches:
+        fail(f"No flow file matching {FLOW_GLOB}")
+    path = Path(matches[0])
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"{path} is not valid JSON: {exc}")
+
+
+def field_text(field: dict, key: str) -> str:
+    value = field.get(key)
+    return value.lower() if isinstance(value, str) else ""
+
+
+def main() -> None:
+    flow = load_flow()
+    nodes = flow.get("nodes")
+    edges = flow.get("edges")
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        fail("Flow must contain nodes[] and edges[]")
+
+    hitl_nodes = [n for n in nodes if n.get("type") == "uipath.human-in-the-loop"]
+    if len(hitl_nodes) != 1:
+        fail(f"Expected exactly one uipath.human-in-the-loop node, found {len(hitl_nodes)}")
+    hitl = hitl_nodes[0]
+    hitl_id = hitl.get("id")
+    if not hitl_id:
+        fail("HITL node is missing id")
+
+    version = str(hitl.get("typeVersion", ""))
+    if not version.startswith("1.0"):
+        fail(f"HITL node typeVersion should be a v1.0 schema, found {version!r}")
+
+    schema = hitl.get("inputs", {}).get("schema", {})
+    fields = schema.get("fields")
+    outcomes = schema.get("outcomes")
+    if not isinstance(fields, list) or not fields:
+        fail("HITL schema must define fields")
+    if not isinstance(outcomes, list) or len(outcomes) < 2:
+        fail("HITL schema must define at least two outcomes")
+
+    if not any(
+        (field_text(f, "id") == "amount" or "amount" in field_text(f, "label")) and f.get("type") == "number"
+        for f in fields
+    ):
+        fail("Amount field must use type number")
+
+    decision_fields = [
+        f
+        for f in fields
+        if f.get("direction") in {"output", "inOut"}
+        and ("approval" in field_text(f, "id") or "approved" in field_text(f, "id") or "decision" in field_text(f, "id"))
+    ]
+    has_boolean_decision = any(f.get("type") == "boolean" for f in decision_fields)
+    outcome_names = {str(o.get("name") or o.get("id") or "").lower() for o in outcomes}
+    has_approval_outcomes = any("approve" in name for name in outcome_names) and any(
+        "reject" in name for name in outcome_names
+    )
+    if not (has_boolean_decision or has_approval_outcomes):
+        fail("HITL must capture the manager decision as a boolean output or approve/reject outcomes")
+
+    input_bindings = [
+        f.get("binding", "")
+        for f in fields
+        if f.get("direction") in {"input", "inOut"} and isinstance(f.get("binding"), str)
+    ]
+    if not input_bindings:
+        fail("HITL input fields must be bound to upstream script output")
+    if not any(binding.startswith("=js:$vars.") and ".output." in binding for binding in input_bindings):
+        fail("HITL input bindings must use =js:$vars.<node>.output.<field>")
+
+    if not any(e.get("sourceNodeId") == hitl_id and e.get("sourcePort") == "completed" for e in edges):
+        fail("HITL completed handle must be wired")
+
+    scripts = [
+        str(n.get("inputs", {}).get("script", ""))
+        for n in nodes
+        if n.get("type") == "core.action.script"
+    ]
+    expected_output_path = f"$vars.{hitl_id}.output"
+    if not any(expected_output_path in script for script in scripts):
+        fail(f"Downstream script must read HITL output via {expected_output_path}")
+
+    print(f"OK: HITL node {hitl_id} uses v1.0 schema, captures approval, wires completed, and uses .output paths")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -52,14 +52,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used uip maestro flow hitl add to add the HITL node"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+hitl\s+add'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Flow file exists at correct double-nested path"
     command: "test -f ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
@@ -68,62 +60,12 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
-    description: "HITL node is present with correct type"
-    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
-    includes:
-      - '"uipath.human-in-the-loop"'
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "HITL node uses v1.0 schema (typeVersion 1.0)"
-    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
-    includes:
-      - '"typeVersion": "1.0"'
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Amount field uses number type (not text)"
-    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
-    includes:
-      - '"number"'
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Decision/approval field uses boolean type"
-    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
-    includes:
-      - '"boolean"'
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Completed handle is wired"
-    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
-    includes:
-      - '"completed"'
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Input fields are bound to upstream script output using correct v1.0 .output path"
-    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
-    includes:
-      - '"binding": "=js:$vars.'
-      - '.output.'
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Downstream script accesses HITL output via $vars.<nodeId>.output path"
-    path: "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
-    includes:
-      - "$vars."
-      - ".output."
-    weight: 2.0
+  - type: run_command
+    description: "Flow has semantically correct inline HITL schema, decision capture, completed wiring, and .output access paths"
+    command: "python3 $TASK_DIR/check_devcon_expense_approval.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 16.5
     pass_threshold: 1.0
 
   - type: command_executed


### PR DESCRIPTION
## Summary

This PR replaces the brittle DevCon expense-approval HITL checks with a semantic checker. The task now accepts the current inline HITL v1.0.0 schema, validates the amount field, accepts either approve/reject outcomes or a boolean decision field, and verifies completed-edge wiring plus downstream .output access paths.

The change fixes the false negative from run 2026-05-05_04-05-27, where the generated flow validated successfully but failed criteria that required exact command and string fragments.

## Validation

- YAML task validation passed for `tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml`.
- Semantic checker passed against the failed run artifact from `2026-05-05_04-05-27`.
- `uv run python -m py_compile tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py`
- `git diff --check`

Jira: https://uipath.atlassian.net/browse/MST-9400
