### PR TITLE
MST-9401: require registry pull in discovery prompt

### DIFF
--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -20,6 +20,7 @@ initial_prompt: |
 
   Important:
   - The `uip` CLI is already available in the environment.
+  - Start by refreshing the registry cache with `uip maestro flow registry pull --output json`.
   - Use `--output json` on all uip commands.
   - Do not build the flow — just explore.
 


### PR DESCRIPTION
## Summary

This PR aligns the registry-discovery prompt with the existing success criteria by explicitly instructing agents to start with `uip maestro flow registry pull --output json` before list, search, and get operations.

The change fixes the run 2026-05-05_04-05-27 failure where the agent completed registry list/get discovery but never ran the pull command that the checker required.

## Validation

- YAML task validation passed for `tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml`.
- `git diff --check`

Jira: https://uipath.atlassian.net/browse/MST-9401
