### PR TITLE
fix(uipath-rpa): prefix bare uia subcommands and fix wrong window-listing command

### DIFF
--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -31,7 +31,7 @@ Do not re-inspect or keep polling after the initial check — subsequent capture
 
 | Sense | Used in | What it is | Boundary / identity |
 |-------|---------|------------|---------------------|
-| **Capture screen** | XAML Multi-Screen Authoring (below), [uia-configure-target-workflows.md § Multi-Step UI Flows](uia-configure-target-workflows.md#multi-step-ui-flows) | A distinct UI state that requires its own `uia-configure-target` pass because the app has to be advanced (via the `uia interact` CLI) between captures. | Bounded by app advancement — everything captured before the next advance is one capture screen. |
+| **Capture screen** | XAML Multi-Screen Authoring (below), [uia-configure-target-workflows.md § Multi-Step UI Flows](uia-configure-target-workflows.md#multi-step-ui-flows) | A distinct UI state that requires its own `uia-configure-target` pass because the app has to be advanced (via the `uip rpa uia interact` CLI) between captures. | Bounded by app advancement — everything captured before the next advance is one capture screen. |
 | **OR screen** | Object Repository CLI, `.objects/` layout, `Descriptors.<App>.<Screen>.<Element>`, [uia-configure-target-workflows.md](uia-configure-target-workflows.md) | A data-model entity in the Object Repository, registered via `create-screen` / matched via `get-screens`. | Identified by its window selector. |
 | **Screen handle** (coded only) | "Screen Handle Affinity" under § For Coded Workflows | A runtime `UiTargetApp` returned by `uiAutomation.Open` / `Attach`, bound to one OR screen. | Element descriptors are valid only on the handle for their own OR screen. |
 
@@ -180,7 +180,7 @@ For XAML-specific activity details: `.local/docs/packages/UiPath.UIAutomation.Ac
 
 ### Multi-Screen Authoring
 
-> "Screen" in this section means the **capture-screen** sense (see § Terminology) — a distinct UI state that requires its own `uia-configure-target` pass because the app has to be advanced between captures. It is NOT the OR-screen sense. A workflow that ends up with one OR screen entry can still be multi-screen here — what matters is the number of capture passes separated by `uia interact` CLI advances, not the number of `.objects/` screen entries that get created.
+> "Screen" in this section means the **capture-screen** sense (see § Terminology) — a distinct UI state that requires its own `uia-configure-target` pass because the app has to be advanced between captures. It is NOT the OR-screen sense. A workflow that ends up with one OR screen entry can still be multi-screen here — what matters is the number of capture passes separated by `uip rpa uia interact` CLI advances, not the number of `.objects/` screen entries that get created.
 
 For workflows spanning multiple capture screens, add each screen's activities to the workflow as its targets are registered in the OR. All UI activities belong inside the `NApplicationCard` scope. Validate with `get-errors` after each batch. See [uia-configure-target-workflows.md § Multi-Step UI Flows](uia-configure-target-workflows.md#multi-step-ui-flows) for the capture loop and the Complete-then-advance rule.
 

--- a/skills/uipath-rpa/references/uia-configure-target-workflows.md
+++ b/skills/uipath-rpa/references/uia-configure-target-workflows.md
@@ -30,11 +30,11 @@ Some UI elements only become visible after interacting with earlier elements (e.
 
 > **CRITICAL: Complete-then-advance.** Finish ALL `uia-configure-target` calls for elements visible in the current screen state — including OR registration (the full skill flow) — before advancing to the next state. Interactions change the app state irreversibly. If you advance before registering, elements from the previous state may no longer be visible, causing OR registration to fail.
 >
-> **Do NOT use the `uia interact` CLI to "test" element interactions** (e.g., verifying autocomplete behavior, checking what happens when you click a button) during the capture phase. Testing happens later, when running the completed workflow. During capture, these commands are ONLY for advancing the app to the next screen so you can capture the newly revealed elements.
+> **Do NOT use the `uip rpa uia interact` CLI to "test" element interactions** (e.g., verifying autocomplete behavior, checking what happens when you click a button) during the capture phase. Testing happens later, when running the completed workflow. During capture, these commands are ONLY for advancing the app to the next screen so you can capture the newly revealed elements.
 
 ### Advancing UI State
 
-After registering an element in the Object Repository, interact with it (or a sibling element) to reveal the next screen via the `uia interact` CLI. See the skill at `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`.
+After registering an element in the Object Repository, interact with it (or a sibling element) to reveal the next screen via the `uip rpa uia interact` CLI. See the skill at `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`.
 
 **Reuse refs from the current `uia-configure-target` capture — do not re-inspect.** The `uip rpa uia interact` CLI resolves element refs against the most recent snapshot in memory regardless of which CLI wrote it (the two write to different folders, but the snapshot is shared). Pass the same e-refs (`e28`, `e35`, etc.) directly to `uip rpa uia interact click`/`type`/`select`. Running `uip rpa uia snapshot inspect` just to re-mint refs for an unchanged UI is wasted work — the refs you have are still live.
 
@@ -43,11 +43,11 @@ Re-inspect (or re-run `uip rpa uia snapshot capture`) only when the UI has actua
 ### Capture Loop
 
 1. **Capture current state completely:** Run `uia-configure-target` for ALL elements visible on the current screen. Let the skill run through to OR registration for each element. Do not stop after getting a raw selector.
-2. **Advance the UI** to the next state via the `uia interact` CLI.
+2. **Advance the UI** to the next state via the `uip rpa uia interact` CLI.
 3. **Capture the new state:** Run `uia-configure-target` again for elements now visible on the new screen (full skill flow).
 4. **Repeat** until all workflow targets are registered in the OR.
 
-**Do NOT use `uip rpa run-file` with partial workflows to advance UI state** — the workflow lifecycle may close the target application when execution ends. The `uia interact` CLI is stateless: it performs one action and leaves the app in the resulting state.
+**Do NOT use `uip rpa run-file` with partial workflows to advance UI state** — the workflow lifecycle may close the target application when execution ends. The `uip rpa uia interact` CLI is stateless: it performs one action and leaves the app in the resulting state.
 
 ## Indication Fallback
 
@@ -61,4 +61,4 @@ Once targets are registered in the OR (via `uia-configure-target` or indication 
 
 ### Multi-Screen Workflows
 
-For XAML workflows spanning multiple capture screens, add each screen's activities to the workflow as its OR references become available. Each batch aligns with the Complete-then-advance rule in § Multi-Step UI Flows — everything configured before the next `uia interact` advance belongs to one batch. Validate with `get-errors` after each batch. Attach each target per `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/uia-target-attachment-guide.md`.
+For XAML workflows spanning multiple capture screens, add each screen's activities to the workflow as its OR references become available. Each batch aligns with the Complete-then-advance rule in § Multi-Step UI Flows — everything configured before the next `uip rpa uia interact` advance belongs to one batch. Validate with `get-errors` after each batch. Attach each target per `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/uia-target-attachment-guide.md`.

--- a/skills/uipath-rpa/references/uia-debug-workflow.md
+++ b/skills/uipath-rpa/references/uia-debug-workflow.md
@@ -4,7 +4,7 @@
 
 **Every debug run** must follow this procedure to prevent stale windows from accumulating or being reused in a dirty state:
 
-1. **Record the window baseline** — list top-level windows via the `uia interact` CLI and note which w-refs and titles are already present. See the skill (`{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-interact/SKILL.md`) for the exact command.
+1. **Record the window baseline** — list top-level windows via `uip rpa uia snapshot inspect` and note which w-refs and titles are already present. Full flag reference: `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/cli-reference.md`.
 2. **Run the workflow:**
    ```bash
    uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command StartDebugging --output json   ```
@@ -12,7 +12,7 @@
 3. **When done** (success or failure) — **stop the debug session:**
    ```bash
    uip rpa run-file --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --command Stop --output json   ```
-4. **List windows again** via the `uia interact` CLI.
-5. **Diff before vs after.** Any window present now that was NOT in the baseline was opened by the workflow. Close each such window via the `uia interact` CLI's window command (see the skill).
+4. **List windows again** via `uip rpa uia snapshot inspect`.
+5. **Diff before vs after.** Any window present now that was NOT in the baseline was opened by the workflow. Close each such window via `uip rpa uia interact window` (see `{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/references/cli-reference.md` for the exact close-action flags).
 
 Skipping steps 4-5 causes the next run's open-if-not-open behavior to reuse a stale window in whatever state it was left in, or -- if the selector doesn't match -- to spawn a duplicate instance.


### PR DESCRIPTION
## Summary

Two changes to `skills/uipath-rpa/references/` after exhaustively exploring `uip rpa uia <subcommand> --help` from a real project directory:

- Prefix all 9 bare `uia interact` mentions across `ui-automation-guide.md`, `uia-configure-target-workflows.md`, and `uia-debug-workflow.md` with `uip rpa uia interact` so they are copy-paste runnable.
- Fix `uia-debug-workflow.md`, which was calling the **wrong command** for window listing: it said `uia interact`, but `uip rpa uia interact` only performs window *actions* (close, foreground, maximize). The canonical command for listing top-level windows + browser tabs is `uip rpa uia snapshot inspect`. Window close in step 5 stays with `uip rpa uia interact window`.

This is a follow-up to #579, which addressed the original hallucinated CLI references; this PR cleans up adjacent stale formatting and one wrong-command bug uncovered while reviewing the same area.

## Test plan

- [ ] Verify `uip rpa uia snapshot inspect` lists top-level windows from a UiPath project directory.
- [ ] Verify `uip rpa uia interact window <action>` performs window actions (close, etc.).
- [ ] Sanity-check that no bare ``uia interact`` remains in `skills/uipath-rpa/references/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)