### PR TITLE
docs: clarify permissions allowlist wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you've already installed manually, uninstall and re-install via `uip skills i
 
 #### Reduce permission prompts
 
-By default, Claude Code prompts for approval on every `uip` command, and a realistic Flow or RPA build runs 25+ distinct subcommands. Claude Code plugins cannot ship permission allowlists declaratively, so run this once to install a curated allowlist of safe read-only commands (registry lookups, validation, local scaffolding) while keeping prompts for side-effectful operations (login, debug, publish):
+By default, Claude Code prompts for approval on every `uip` command, and a realistic Flow or RPA build runs 25+ distinct subcommands. Claude Code plugins cannot ship permission allowlists declaratively, so run this once to install a curated allowlist of read-only and local-only commands (registry lookups, validation, local scaffolding) while keeping prompts for side-effectful operations (login, debug, publish):
 
 ```text
 /uipath:install-permissions

--- a/commands/install-permissions.md
+++ b/commands/install-permissions.md
@@ -1,10 +1,10 @@
 ---
-description: Install a curated Claude Code allowlist for safe `uip` subcommands so the agent is not prompted on every command.
+description: Install a curated Claude Code allowlist for read-only and local-only `uip` subcommands so the agent is not prompted on every command.
 ---
 
 # Install UiPath permission allowlist
 
-Help the user add a curated allowlist of safe `uip` subcommands to their Claude Code settings so the agent is not prompted on every command.
+Help the user add a curated allowlist of read-only and local-only `uip` subcommands to their Claude Code settings so the agent is not prompted on every command.
 
 **Why this command exists.** Claude Code plugins cannot ship permission rules declaratively — per the [plugins docs](https://code.claude.com/docs/en/plugins.md#ship-default-settings-with-your-plugin), only the `agent` and `subagentStatusLine` keys are honored in a plugin-shipped `settings.json`; any `permissions` block is silently ignored. Without a user-configured allowlist, every `Bash(...)` invocation prompts for approval, and a realistic Flow or RPA build runs 25+ distinct `uip` subcommands.
 


### PR DESCRIPTION
## Summary
Clarifies that the recommended Claude Code permissions allowlist covers both read-only commands and local-only scaffolding commands.

## Why
The current README wording says "safe read-only commands", but the documented allowlist intentionally includes local-only mutating commands such as flow/solution/agent scaffolding. This PR tightens the wording without changing behavior.

## Changes
- update the README wording under `/uipath:install-permissions`
- align the command description in `commands/install-permissions.md`
