### PR TITLE
docs: tighten installation guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ winget install OpenJS.NodeJS.LTS
 ```
 
 **Linux**
-```bash
-curl -fsSL https://fnm.vercel.app/install | bash
-fnm install --lts
-```
-See [Installing Node.js via package manager](https://nodejs.org/en/download/package-manager) for other methods.
+Use your distribution's package manager or another method from [Installing Node.js via package manager](https://nodejs.org/en/download/package-manager).
 
 After installing, verify with `node -v` and then run the quick start command above.
 

--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -37,7 +37,7 @@ $UIP --version
 
 Use `$UIP` in place of `uip` for all subsequent commands if the plain `uip` command isn't found.
 
-If `npm install -g` fails with a permission error, prompt the user to re-run it with the appropriate privileges (e.g., `sudo npm install -g @uipath/cli@latest`) — do not retry automatically.
+If `npm install -g` fails with a permission error, prompt the user to switch to a user-local installation method (for example, a Node version manager or a user-scoped npm prefix) rather than retrying with `sudo` — do not retry automatically.
 
 ## Step 1 — Check login and pull registry
 


### PR DESCRIPTION
## Summary
Removes two avoidable high-friction installation suggestions from the docs and points users toward safer user-local installation paths.

## Changes
- remove the Linux `curl | bash` Node.js example from `README.md`
- update `uipath-maestro-case` planning guidance to prefer user-local npm installation methods instead of suggesting `sudo npm install -g`

## Why
These changes keep the docs aligned with safer default installation guidance without changing product behavior.
