### PR TITLE
ci: drop paths filter from smoke workflows so required checks don't deadlock

### DIFF
--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -5,14 +5,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # No `paths:` filter on purpose. This workflow is a required status
+  # check; if `paths:` excluded a PR the workflow wouldn't run, no
+  # check would be reported, and merge would block forever. Instead we
+  # always trigger and let the `detect` job short-circuit via
+  # `skip=true` — the gated job is then reported as skipped, which
+  # GitHub counts as a pass for required checks.
   pull_request:
-    paths:
-      - 'skills/uipath-rpa/**'
-      - 'skills/uipath-rpa-legacy/**'
-      - 'tests/tasks/uipath-rpa/**'
-      - 'tests/tasks/uipath-rpa-legacy/**'
-      - 'tests/experiments/**'
-      - '.github/workflows/smoke-rpa-skills.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -5,11 +5,13 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # No `paths:` filter on purpose. This workflow is a required status
+  # check; if `paths:` excluded a PR the workflow wouldn't run, no
+  # check would be reported, and merge would block forever. Instead we
+  # always trigger and let the `detect` job short-circuit via
+  # `skip=true` — the gated job is then reported as skipped, which
+  # GitHub counts as a pass for required checks.
   pull_request:
-    paths:
-      - 'skills/*/SKILL.md'
-      - 'skills/*/references/**'
-      - 'tests/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Both smoke workflows are about to be required status checks. With `on.pull_request.paths`, a PR that doesn't touch the listed paths never triggers the workflow, the check is never reported, and merge blocks forever.

The detect job already short-circuits via `skip=true` when nothing relevant changed; the heavy job is gated on that output. Dropping `paths:` makes detect run on every PR and report the heavy job as skipped — which GitHub counts as a pass for required checks. Cost is ~30s of detect runtime per PR.