### PR TITLE
MST-9459: accept connector feature fallbacks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Validate native connector use or task-specific managed HTTP fallback."""
+
+from __future__ import annotations
+
+import glob
+import json
+import sys
+from typing import Any
+
+
+def _fail(message: str) -> None:
+    sys.exit(f"FAIL: {message}")
+
+
+def _load_flow(pattern: str) -> dict[str, Any]:
+    matches = sorted(glob.glob(pattern, recursive=True))
+    if not matches:
+        _fail(f"No flow found for {pattern!r}")
+    if len(matches) > 1:
+        _fail(f"Multiple flows found for {pattern!r}: {matches}")
+    with open(matches[0], encoding="utf-8") as flow_file:
+        return json.load(flow_file)
+
+
+def _require_all(haystack: str, needles: list[str], label: str) -> None:
+    missing = [needle for needle in needles if needle.lower() not in haystack]
+    if missing:
+        _fail(f"{label} missing expected evidence: {missing}")
+
+
+def _http_fallback_text(flow: dict[str, Any]) -> str:
+    http_nodes = [
+        node
+        for node in flow.get("nodes", [])
+        if "core.action.http.v2" in str(node.get("type", "")).lower()
+    ]
+    if not http_nodes:
+        _fail("Neither native connector nor managed HTTP fallback found")
+    return json.dumps(http_nodes, sort_keys=True).lower()
+
+
+def _check_generate_schema(flow: dict[str, Any]) -> None:
+    http_text = _http_fallback_text(flow)
+    _require_all(
+        http_text,
+        ["api.applicationinsights.io", "/query", "method", "post", "query", "timespan"],
+        "Application Insights HTTP fallback",
+    )
+    _require_all(
+        json.dumps(flow, sort_keys=True).lower(),
+        ["schema", "columns"],
+        "Generate-schema post-processing",
+    )
+
+
+def _check_path_params(flow: dict[str, Any]) -> None:
+    _require_all(
+        _http_fallback_text(flow),
+        [
+            "tasks.googleapis.com/tasks/v1/lists",
+            "/tasks/",
+            "method",
+            "delete",
+            "tasklistid",
+            "taskid",
+        ],
+        "Google Tasks path-params HTTP fallback",
+    )
+
+
+def _check_query_params(flow: dict[str, Any]) -> None:
+    _require_all(
+        _http_fallback_text(flow),
+        [
+            "tasks.googleapis.com/tasks/v1/lists",
+            "/tasks",
+            "method",
+            "get",
+            "showhidden",
+            "true",
+        ],
+        "Google Tasks query-params HTTP fallback",
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        _fail(
+            "usage: check_managed_http_fallback.py <flow_glob> <connector_key> "
+            "<generate_schema|path_params|query_params>"
+        )
+
+    flow = _load_flow(sys.argv[1])
+    connector_key = sys.argv[2]
+    check_name = sys.argv[3]
+    full_text = json.dumps(flow, sort_keys=True).lower()
+
+    if connector_key.lower() in full_text:
+        print(f"OK: native connector present ({connector_key})")
+        return
+
+    checks = {
+        "generate_schema": _check_generate_schema,
+        "path_params": _check_path_params,
+        "query_params": _check_query_params,
+    }
+    check = checks.get(check_name)
+    if check is None:
+        _fail(f"Unknown check {check_name!r}")
+    check(flow)
+    print(f"OK: managed HTTP fallback has {check_name} evidence")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -29,6 +29,11 @@ initial_prompt: |
   Route failure to a Terminate node with error message "EnhancedEnum test failed".
   Route success to a final action that logs "EnhancedEnum test passed".
   Validate the final flow file.
+  If the WooCommerce operation exists in the registry but the tenant has no
+  live connection, use planned connector-node mode: keep the real connector
+  node type, leave its inputs empty, validate that shape, and stop. Do not
+  keep hand-authoring connection detail after the empty-input connector node
+  validates.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -44,8 +44,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow uses Application Insights connector or managed HTTP fallback"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/GenerateSchemaTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert ('uipath-microsoft-azureapplicationinsights' in content or 'core.action.http.v2' in content), 'Neither Application Insights connector nor HTTP fallback found'; print('OK: connector or HTTP fallback present')\""
+    description: "Flow uses Application Insights connector or task-specific managed HTTP fallback"
+    command: "python3 $TASK_DIR/check_managed_http_fallback.py '**/GenerateSchemaTest*.flow' uipath-microsoft-azureapplicationinsights generate_schema"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -29,6 +29,10 @@ initial_prompt: |
   Route failure to a Terminate node with error message "GenerateSchema test failed".
   Route success to a final action that logs "GenerateSchema test passed".
   Validate the final flow file.
+  If the Application Insights connector operation is not present in the
+  registry, use a managed HTTP fallback for the same request and finish after
+  validation. Do not keep searching for a connector node that the registry does
+  not expose.
 
 success_criteria:
   - type: run_command
@@ -40,8 +44,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow has a connector node referencing uipath-microsoft-azureapplicationinsights"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/GenerateSchemaTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-azureapplicationinsights' in content, 'Connector key not found'; print('OK: connector key present')\""
+    description: "Flow uses Application Insights connector or managed HTTP fallback"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/GenerateSchemaTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert ('uipath-microsoft-azureapplicationinsights' in content or 'core.action.http.v2' in content), 'Neither Application Insights connector nor HTTP fallback found'; print('OK: connector or HTTP fallback present')\""
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -42,8 +42,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow uses Google Tasks connector or managed HTTP fallback"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/PathParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert ('uipath-google-tasks' in content or 'core.action.http.v2' in content), 'Neither Google Tasks connector nor HTTP fallback found'; print('OK: connector or HTTP fallback present')\""
+    description: "Flow uses Google Tasks connector or task-specific managed HTTP fallback"
+    command: "python3 $TASK_DIR/check_managed_http_fallback.py '**/PathParamsTest*.flow' uipath-google-tasks path_params"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -28,6 +28,9 @@ initial_prompt: |
   Route failure to a Terminate node with error message "PathParams test failed".
   Route success to a final action that logs "PathParams test passed".
   Validate the final flow file.
+  If the Google Tasks connector operation is not present in the registry, use
+  a managed HTTP fallback for the same REST call and finish after validation.
+  Do not keep searching for a connector node that the registry does not expose.
 
 success_criteria:
   - type: run_command
@@ -39,8 +42,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow has a connector node referencing uipath-google-tasks"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/PathParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-google-tasks' in content, 'Connector key not found'; print('OK: connector key present')\""
+    description: "Flow uses Google Tasks connector or managed HTTP fallback"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/PathParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert ('uipath-google-tasks' in content or 'core.action.http.v2' in content), 'Neither Google Tasks connector nor HTTP fallback found'; print('OK: connector or HTTP fallback present')\""
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -28,6 +28,9 @@ initial_prompt: |
   Route failure to a Terminate node with error message "QueryParams test failed".
   Route success to a final action that logs "QueryParams test passed".
   Validate the final flow file.
+  If the Google Tasks connector operation is not present in the registry, use
+  a managed HTTP fallback for the same REST call and finish after validation.
+  Do not keep searching for a connector node that the registry does not expose.
 
 success_criteria:
   - type: run_command
@@ -39,8 +42,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow has a connector node referencing uipath-google-tasks"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/QueryParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-google-tasks' in content, 'Connector key not found'; print('OK: connector key present')\""
+    description: "Flow uses Google Tasks connector or managed HTTP fallback"
+    command: "python3 -c \"import json,glob; flows=glob.glob('**/QueryParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert ('uipath-google-tasks' in content or 'core.action.http.v2' in content), 'Neither Google Tasks connector nor HTTP fallback found'; print('OK: connector or HTTP fallback present')\""
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -42,8 +42,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow uses Google Tasks connector or managed HTTP fallback"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/QueryParamsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert ('uipath-google-tasks' in content or 'core.action.http.v2' in content), 'Neither Google Tasks connector nor HTTP fallback found'; print('OK: connector or HTTP fallback present')\""
+    description: "Flow uses Google Tasks connector or task-specific managed HTTP fallback"
+    command: "python3 $TASK_DIR/check_managed_http_fallback.py '**/QueryParamsTest*.flow' uipath-google-tasks query_params"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## Summary
- Add no-live guidance for the WooCommerce enhanced-enum connector task so agents stop after a valid empty-input planned connector node.
- Allow Application Insights and Google Tasks connector-feature tasks to use a managed HTTP fallback when the requested connector operation is absent from the registry.
- Require task-specific evidence on HTTP fallback flows, so a generic `core.action.http.v2` node is not enough to pass the GenerateSchema, PathParams, or QueryParams criteria.

## Root Cause
Run 2026-05-06_04-04-31 still exposed residual connector-feature eval drift after MST-9399: some tasks assumed connector operations or live connections were available in staging even when the registry did not expose them, or when validation accepted an empty-input planned connector node.

## Validation
- YAML schema validation for enhanced_enum, generate_schema, path_params, and query_params passed.
- `check_managed_http_fallback.py` compiled successfully.
- Revised GenerateSchemaTest criterion passed against the captured failed artifact.
- Revised PathParamsTest criterion passed against the captured failed artifact.
- Revised QueryParamsTest criterion passed against the captured failed artifact.
- `git diff --check` passed.

## Notes
- skill-flow-ipe-filter-builder and skill-flow-ipe-list-curated were already removed on main by 52d19f98, so this PR covers the remaining connector-feature residuals from the latest run.
