### PR TITLE
MST-9460: avoid live debug in RPA flow eval

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
@@ -39,7 +39,10 @@ def main():
 
     end_nodes = [node for node in nodes if node.get("type") == "core.control.end"]
     output_sources = json.dumps([node.get("outputs") or {} for node in end_nodes])
-    expected_source = f"$vars.{rpa_node['id']}.output.title"
+    rpa_node_id = rpa_node.get("id")
+    if not rpa_node_id:
+        _fail("RPA node is missing id")
+    expected_source = f"$vars.{rpa_node_id}.output.title"
     if expected_source not in output_sources:
         _fail(f"End node output must map from {expected_source}")
 

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
@@ -1,24 +1,49 @@
 #!/usr/bin/env python3
-"""ProjectEulerTitle: an RPA-workflow node executes; output holds the title."""
+"""ProjectEulerTitle: an RPA-workflow node is wired to return the title."""
 
-import os
+import glob
+import json
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
-    assert_outputs_contain,
-    run_debug,
-)
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _load_single_flow() -> dict:
+    flows = sorted(glob.glob("**/ProjectEulerTitle.flow", recursive=True))
+    if not flows:
+        _fail("No ProjectEulerTitle.flow found")
+    if len(flows) > 1:
+        _fail(f"Multiple ProjectEulerTitle.flow files found: {flows}")
+    with open(flows[0]) as f:
+        return json.load(f)
 
 
 def main():
-    assert_flow_has_node_type(["uipath.core.rpa-workflow"])
-    # RPA workflows are slow: spin up robot, launch Chrome, scrape. 4 min
-    # is routinely not enough on this tenant.
-    payload = run_debug(timeout=540)
-    assert_outputs_contain(payload, "prime square remainders")
-    print("OK: RPA node present; output contains 'prime square remainders'")
+    flow = _load_single_flow()
+    nodes = flow.get("nodes") or []
+    rpa_nodes = [
+        node for node in nodes if "uipath.core.rpa-workflow" in node.get("type", "")
+    ]
+    if len(rpa_nodes) != 1:
+        _fail(f"Expected exactly one RPA node, found {len(rpa_nodes)}")
+
+    rpa_node = rpa_nodes[0]
+    if (rpa_node.get("inputs") or {}).get("problemId") != 123:
+        _fail("RPA node must pass problemId=123")
+
+    bindings_text = json.dumps(flow.get("bindings") or [])
+    if "ProjectEuler RPA" not in bindings_text or "RPA Workflow" not in bindings_text:
+        _fail("RPA process bindings must reference ProjectEuler RPA.RPA Workflow")
+
+    end_nodes = [node for node in nodes if node.get("type") == "core.control.end"]
+    output_sources = json.dumps([node.get("outputs") or {} for node in end_nodes])
+    expected_source = f"$vars.{rpa_node['id']}.output.title"
+    if expected_source not in output_sources:
+        _fail(f"End node output must map from {expected_source}")
+
+    print("OK: RPA node present; problemId and title output are wired")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -37,7 +37,7 @@ success_criteria:
 
   # ── Execution checks ──────────────────────────────────────────────────
   - type: run_command
-    description: "Flow has an RPA node and debug returns the problem title"
+    description: "Flow has an RPA node wired to return the problem title"
     command: "python3 $TASK_DIR/check_rpa_flow.py"
     timeout: 600
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -2,7 +2,8 @@ task_id: skill-flow-rpa
 description: >
   Create a UiPath Flow that uses the ProjectEuler RPA workflow to retrieve the
   title for problem 123. Exercises RPA resource node discovery, registry get,
-  and node wiring.
+  and node wiring. Validate-only: RPA runtime requires attended browser
+  (SW-28504).
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 max_iterations: 1
 
@@ -39,7 +40,7 @@ success_criteria:
   - type: run_command
     description: "Flow has an RPA node wired to return the problem title"
     command: "python3 $TASK_DIR/check_rpa_flow.py"
-    timeout: 600
+    timeout: 60
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- Replace the ProjectEuler RPA checker's live flow-debug assertion with source-file structural validation.
- Require the generated flow to contain exactly one RPA workflow node, pass problemId 123, reference the ProjectEuler RPA workflow binding, and map the End output from the RPA title output.
- Align the YAML success criterion description with the task prompt, which already says to validate the flow and not run debug.

## Root Cause
Run 2026-05-06_04-04-31 failed skill-flow-rpa because the checker invoked live browser-backed debug even though the task contract said not to run debug. The runtime failure matches existing browser unattended execution blocker SW-28504, so this eval should grade the authored RPA wiring instead of depending on that product-side runtime path.

## Validation
- Updated checker passed against the captured failed skill-flow-rpa artifact.
- rpa.yaml schema validation passed.
- check_rpa_flow.py compiled successfully.
- git diff --check passed.

## Notes
- Cross-linked Jira ticket: MST-9460.
- Related product issue: SW-28504.
