### PR TITLE
docs(uipath-rpa): clarify coded entry-point args and add out/ref runtime error

### DIFF
--- a/skills/uipath-rpa/references/coded/coding-guidelines.md
+++ b/skills/uipath-rpa/references/coded/coding-guidelines.md
@@ -114,7 +114,7 @@ if (system.PathExists(@"C:\Reports\report.pdf", PathType.File, out ILocalResourc
 
 ### Code Quality
 - **Start simple, iterate** — Create minimal working version first, then refine
-- **NEVER use C# `out` or `ref` keywords in `[Workflow]` methods** — The auto-generated `*+Activity.cs` wrapper does not handle them correctly, causing compile error CS1620. Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead
+- **NEVER use C# `out` or `ref` keywords in `[Workflow]` methods** — The auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead
 - **Only include using statements for packages in project.json** — Adding unused usings causes compile errors
 - **Match input parameter names exactly** — Execute method signature must match `--input` arguments (case-sensitive)
 - **Escape backslashes in paths** — Use `C:\\path\\file.txt` not `C:\path\file.txt` in input arguments

--- a/skills/uipath-rpa/references/coded/operations-guide.md
+++ b/skills/uipath-rpa/references/coded/operations-guide.md
@@ -54,18 +54,19 @@ These contain valid defaults (correct schema version, runtime options, dependenc
    - Use the project name as namespace
    - Class name = file name (without .cs)
    - Inherit from `CodedWorkflow`
-   - Add `[Workflow]` attribute on `Execute` method
+   - Add `[Workflow]` attribute on the entry-point method. Method name does not have to be `Execute` — any name works. `Execute` is convention; keep it unless the user asks otherwise
    - Add appropriate `using` statements based on which activities are needed
-3. Argument direction is determined by the `Execute` method signature:
+3. Argument direction is determined by the entry-point method signature. Single-return OutArgument is named **`"Output"`**. Tuple returns produce one OutArgument per element, named after the element. A tuple element name matching an input parameter name — or, for single returns, an input parameter literally named `"Output"` — collapses into one **`InOutArgument`**:
 
    | Signature | Example | Argument directions |
    |-----------|---------|---------------------|
-   | Single return | `public string Execute(int a, int b)` | `a` = In, `b` = In, return = Out (named `"Output"`) |
-   | Tuple return | `public (string a, string b) Execute()` | `a` = Out, `b` = Out |
-   | Mixed with InOut | `public (string a, string b) Execute(string b, int c)` | `a` = Out, `b` = InOut (same name in input and tuple), `c` = In |
+   | Single return | `public string Execute(int a, int b)` | `a` = In, `b` = In, return = Out named `"Output"` |
+   | Tuple return | `public (string Test, int A) Execute()` | `Test` = Out, `A` = Out |
+   | Tuple + name collision | `public (string a, string b) Execute(string b, int c)` | `a` = Out, `b` = InOut (same name in input and tuple), `c` = In |
+   | Single return + `Output` input | `public string Execute(string Output, int c)` | `Output` = InOut (input named `"Output"` collides with implicit return name), `c` = In |
    | No return | `public void Execute(string input)` | `input` = In |
 
-   > **NEVER use C# `out` or `ref` keywords** on `Execute` parameters — the auto-generated `*+Activity.cs` wrapper does not handle them correctly, causing compile error CS1620. Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead.
+   > **NEVER use C# `out` or `ref` keywords** on `Execute` parameters — the auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead.
 4. Update `project.json` (**Process projects only** — skip `entryPoints` for Tests and Library projects):
    - Add new entry to `entryPoints` array with `filePath`, unique `uniqueId`, `input`, and `output` definitions
    - If the workflow has parameters, define them in `input`/`output` with `name`, `type`, and `required`
@@ -80,7 +81,7 @@ Coded test cases automate and validate application behavior using a structured *
 **Steps:**
 1. Read existing `project.json` to get project name, `outputType`, and current entry points
 2. Create the `.cs` file following the same rules as workflows, but with:
-   - `[TestCase]` attribute instead of `[Workflow]` on the `Execute` method
+   - `[TestCase]` attribute instead of `[Workflow]` on the entry-point method (method name does not have to be `Execute` — any name works; keep `Execute` unless the user asks otherwise)
    - Structured code in three phases: **Arrange**, **Act**, **Assert**
 3. Update `project.json`:
    - Add entry to `entryPoints` array (**Process projects only** — skip `entryPoints` for Tests and Library projects)


### PR DESCRIPTION
## Summary
- Clarify that `[Workflow]` and `[TestCase]` entry-point methods do **not** require the name `Execute` — any method name works; `Execute` is convention only.
- Document the argument-direction rules for the entry-point signature:
  - Single return → OutArgument named `"Output"`
  - Tuple return → one OutArgument per element, named after the tuple element
  - Tuple element name colliding with an input parameter name → collapses to `InOutArgument`
  - Single return + input parameter literally named `Output` → also `InOutArgument`
- Add the runtime error string `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` alongside the existing `CS1620` compile-error symptom in both `out`/`ref` rules so agents recognize either failure mode.

## Test plan
- [ ] Confirm rendered tables in `operations-guide.md` are correct
- [ ] Confirm `out`/`ref` rule wording in `coding-guidelines.md` and `operations-guide.md` is consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)