### PR TITLE
fix(maestro-case): remove task-output exemption that caused silent variable skips

### DIFF
--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -255,8 +255,6 @@ Title format: `Declare <category> "<name>"` where category is `In argument`, `Ou
 
 One T-entry per variable or argument from the sdd.md "Case Variables" table. Place these after the case file (T01) and **all** trigger T-entries (T02+) — i.e., after the last trigger row, before stages. In multi-trigger cases the variables block starts at `T0<last-trigger>+1`, not at `T03`. Consult [`plugins/variables/global-vars/planning.md`](plugins/variables/global-vars/planning.md) for the SDD-to-category mapping rules and entry format.
 
-Task-output variables (produced by tasks during execution) do NOT get T-entries here — they are wired automatically during task creation (§4.6).
-
 ### 4.3 Configure trigger(s) (T02+)
 
 Title format: `Configure <trigger-type> trigger "<name>"`

--- a/skills/uipath-maestro-case/references/plugins/variables/global-vars/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/global-vars/planning.md
@@ -49,8 +49,6 @@ One T-entry per variable/argument. Place after the case file (T01) and **all** t
 - verify: Confirm entry exists in the variables block (per schema)
 ```
 
-Task-output variables are wired automatically during task creation (§4.6) — no T-entry needed here.
-
 ## Types
 
 `"string"` | `"number"` | `"boolean"` | `"date"` | `"object"` | `"array"` | `"jsonSchema"`


### PR DESCRIPTION
## Summary

- Drops two parallel sentences from `planning.md` and `plugins/variables/global-vars/planning.md` that told agents task-output variables should NOT get §4.2.1 T-entries (\"wired automatically during task creation\").
- That exemption clashed with Rule 6 / §4.0 \"every Case Variables row gets a T-entry\" and produced silent variable skips: agents read the exemption, omitted task-output rows from `tasks.md`, and the resulting `caseplan.json` was missing global var declarations the SDD called out.
- After the change the two docs agree: every row in the SDD Case Variables table emits exactly one T-entry, regardless of producer.

## Test plan

- [x] Re-ran the skill end-to-end on a 47-variable SDD (`sdd_5_5.md`, CommercialLoanOrigination, v20 schema, alpha tenant). Phase 1 emitted all 48 variable/argument T-entries (10 In args + 38 inputOutputs) — no silent skips.
- [x] Phase 2 caseplan.json upload accepted by alpha tenant API; CLI `validate --skeleton` returns `Status: Valid` (after CLI rebuild for v20).
- [ ] Reviewer to confirm no other reference doc still implies task-output rows skip §4.2.1.