### PR TITLE
fix(codeowners): use * for repo-wide default rule

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for the entire repo
-- @gabrielavaduva @AlvinStanescu @marius-bughiu @RaduAna-Maria @uipreliga @dmetzgar @rockymadden @gozhang2
+* @gabrielavaduva @AlvinStanescu @marius-bughiu @RaduAna-Maria @uipreliga @dmetzgar @rockymadden @gozhang2
 
 # CI workflows and review config
 /.github/ @uipreliga


### PR DESCRIPTION
## Summary

The default-owner line in `CODEOWNERS` starts with `-` instead of `*`, so GitHub parses it as a literal pattern matching a file named `-` rather than the catch-all glob. Paths without a more specific rule end up with **no codeowner**, defeating the intent of the default rule.

Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

```
# These owners will be the default owners for everything in
# the repo. Unless a later match takes precedence,
# @global-owner1 and @global-owner2 will be requested for
# review when someone opens a pull request.
*       @global-owner1 @global-owner2
```