### PR TITLE
fix(maestro-case): action recipient — Type fallback for unresolved sdd.md labels

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -35,7 +35,7 @@
 |---|---|
 | `data.taskTitle` | Required, even on skeletons. Validator rejects empty. |
 | `data.priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
-| `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. See fallback below for unresolved-UUID handling. |
+| `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. See fallback below when sdd.md `Value` is not a resolved UUID. |
 | `data.actionCatalogName` | `deploymentTitle` from tasks.md |
 | `data.labels` | Label set from tasks.md |
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -35,11 +35,11 @@
 |---|---|
 | `data.taskTitle` | Required, even on skeletons. Validator rejects empty. |
 | `data.priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
-| `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. Omit for group/role assignment. |
+| `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. See fallback below for unresolved-UUID handling. |
 | `data.actionCatalogName` | `deploymentTitle` from tasks.md |
 | `data.labels` | Label set from tasks.md |
 
-`recipient.Type` values: `0` = user ID, `1` = group ID, `2` = email address, `3` = `"=vars.<varId>"` for runtime resolution. Email recipients always use Type `2`. **Fallback when sdd.md value is not a resolved UUID** (e.g., `UserGroup: closing-officer-group`, `User: maya@accrual.com`, `Role: Underwriter`): pick the closest `Type` from the rationale of the sdd.md label (`User:` → 0, `UserGroup:` / `Role:` → 1, plain email → 2, `=vars.X` → 3) and write `{ "Type": <picked>, "Value": "<sdd-name-or-string>" }` — schema-conformant skeleton, user resolves the Value to a real UUID later. Drop `data.recipient` only when no reasonable Type maps. **Never invent a non-conforming shape** (`{ kind, id }`, `{ scope, target, value }`, etc.) — Studio Web canvas crashes on unknown shapes and CLI validate misses it.
+`recipient.Type` values: `0` = user ID (sdd `User:`), `1` = group ID (sdd `UserGroup:` / `Role:`), `2` = email address, `3` = `"=vars.<varId>"`. **Fallback when sdd.md value is not a resolved UUID:** write `{ "Type": <picked>, "Value": "<sdd-string-as-is>" }` — schema-conformant skeleton, user resolves Value later. Drop `data.recipient` only when no Type maps. **Never invent a non-conforming shape** (`{ kind, id }`, `{ scope, target, value }`, etc.) — Studio Web canvas crashes silently; CLI validate misses it.
 
 ## Procedure
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -35,7 +35,7 @@
 |---|---|
 | `data.taskTitle` | Required, even on skeletons. Validator rejects empty. |
 | `data.priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
-| `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. See fallback below when sdd.md `Value` is not a resolved UUID. |
+| `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. See fallback below for unresolved-UUID handling. |
 | `data.actionCatalogName` | `deploymentTitle` from tasks.md |
 | `data.labels` | Label set from tasks.md |
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -39,7 +39,7 @@
 | `data.actionCatalogName` | `deploymentTitle` from tasks.md |
 | `data.labels` | Label set from tasks.md |
 
-`recipient.Type` values: `0` = user ID, `1` = group ID, `2` = email address, `3` = `"=vars.<varId>"` for runtime resolution. Email recipients always use Type `2`.
+`recipient.Type` values: `0` = user ID, `1` = group ID, `2` = email address, `3` = `"=vars.<varId>"` for runtime resolution. Email recipients always use Type `2`. **Fallback when sdd.md value is not a resolved UUID** (e.g., `UserGroup: closing-officer-group`, `User: maya@accrual.com`, `Role: Underwriter`): pick the closest `Type` from the rationale of the sdd.md label (`User:` → 0, `UserGroup:` / `Role:` → 1, plain email → 2, `=vars.X` → 3) and write `{ "Type": <picked>, "Value": "<sdd-name-or-string>" }` — schema-conformant skeleton, user resolves the Value to a real UUID later. Drop `data.recipient` only when no reasonable Type maps. **Never invent a non-conforming shape** (`{ kind, id }`, `{ scope, target, value }`, etc.) — Studio Web canvas crashes on unknown shapes and CLI validate misses it.
 
 ## Procedure
 


### PR DESCRIPTION
## Summary

- Without a fallback, agents authoring action skeletons from sdd.md (where recipients are bare strings like `UserGroup: closing-officer-group`) had no guidance on how to populate `data.recipient` and would either omit it (losing intent) or improvise a non-conforming shape like `{ kind, id }` — which the Studio Web canvas crashes on silently and CLI validate does not catch.
- This PR amends the `recipient.Type` line in `plugins/tasks/action/impl-json.md` to give agents an explicit fallback: map the sdd.md label prefix (`User:` → 0, `UserGroup:`/`Role:` → 1, plain email → 2, `=vars.X` → 3) and write `{ "Type": <picked>, "Value": "<sdd-name-or-string>" }`. The shape stays schema-conformant; the user swaps the Value to a real UUID after the resource is registered.
- Drop `data.recipient` only when no Type maps. Explicit anti-pattern callout against `{ kind, id }` and other invented shapes.

## Test plan

- [x] Spawned a fresh agent (no prior context) with only this recipe + the SDD task entry `Recipient: UserGroup: closing-officer-group`. Output before the change: omitted `data.recipient` entirely. Output after the change: `{ "Type": 1, "Value": "closing-officer-group" }` — schema-conformant skeleton with the right rationale cited.
- [ ] Reviewer to confirm the line wording is clear without inflating the file.