### PR TITLE
[codex] Pilot Maestro BPMN skill scenarios

### DIFF
--- a/skills/uipath-maestro-bpmn/.maintenance/check-validation-fixtures.py
+++ b/skills/uipath-maestro-bpmn/.maintenance/check-validation-fixtures.py
@@ -173,6 +173,8 @@ class Validator:
         self.validate_entry_points(path, process)
         self.validate_gateway_conditions(path, root)
         self.validate_error_events(path, root, elements_by_id)
+        self.validate_message_events(path, root, elements_by_id)
+        self.validate_multi_instance(path, root, variables)
         self.validate_uipath_extensions(path, root, bindings, variables)
 
     def collect_root_bindings(self, process: ET.Element) -> dict[str, ET.Element]:
@@ -321,6 +323,68 @@ class Validator:
                     f"boundaryEvent {boundary.attrib.get('id')} references missing activity {attached}",
                 )
 
+    def validate_message_events(
+        self, path: Path, root: ET.Element, elements_by_id: dict[str, ET.Element]
+    ) -> None:
+        for event_def in root.findall(f".//{{{BPMN_NS}}}messageEventDefinition"):
+            ref = event_def.attrib.get("messageRef")
+            if ref and ref not in elements_by_id:
+                self.error(path, f"messageEventDefinition references missing message {ref}")
+
+    def validate_multi_instance(
+        self, path: Path, root: ET.Element, variables: dict[str, set[str]]
+    ) -> None:
+        for loop in root.findall(f".//{{{BPMN_NS}}}multiInstanceLoopCharacteristics"):
+            marker = loop.attrib.get("isSequential")
+            if marker not in {"true", "false"}:
+                self.error(
+                    path,
+                    f"multiInstanceLoopCharacteristics {loop.attrib.get('id')} "
+                    "must set isSequential to true or false",
+                )
+
+            metadata = loop.find(
+                f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}loopCharacteristics"
+            )
+            if metadata is None:
+                self.error(
+                    path,
+                    f"multiInstanceLoopCharacteristics {loop.attrib.get('id')} "
+                    "missing uipath:loopCharacteristics",
+                )
+                continue
+
+            input_collection = metadata.attrib.get("inputCollection", "")
+            collection_var = self.expression_variable(input_collection)
+            if not collection_var or collection_var not in variables["all"]:
+                self.error(
+                    path,
+                    f"multi-instance inputCollection references undeclared variable "
+                    f"{input_collection}",
+                )
+
+            input_element = metadata.attrib.get("inputElement")
+            if not input_element or input_element not in variables["all"]:
+                self.error(
+                    path,
+                    f"multi-instance inputElement references undeclared variable {input_element}",
+                )
+
+            completion = loop.find(f"{{{BPMN_NS}}}completionCondition")
+            if completion is not None and self.contains_assignment(completion.text or ""):
+                self.error(
+                    path,
+                    f"multiInstanceLoopCharacteristics {loop.attrib.get('id')} "
+                    "completionCondition may contain assignment",
+                )
+
+    def expression_variable(self, value: str) -> str | None:
+        match = re.fullmatch(r"=([A-Za-z_][A-Za-z0-9_]*)", value.strip())
+        return match.group(1) if match else None
+
+    def contains_assignment(self, value: str) -> bool:
+        return "=" in value and re.search(r"(?<![=!<>])=(?!=)", value[1:]) is not None
+
     def validate_uipath_extensions(
         self,
         path: Path,
@@ -343,7 +407,7 @@ class Validator:
                     self.error(
                         path, f"binding expression references undeclared binding {binding_ref}"
                     )
-            if "=" in value and re.search(r"(?<![=!<>])=(?!=)", value[1:]):
+            if self.contains_assignment(value):
                 self.error(path, f"expression may contain assignment: {value}")
 
     def validate_activity_or_event(

--- a/skills/uipath-maestro-bpmn/fixtures/validation/README.md
+++ b/skills/uipath-maestro-bpmn/fixtures/validation/README.md
@@ -11,6 +11,30 @@ Public-safe fixture corpus for the `uipath-maestro-bpmn` skill maintenance check
 | `integration-service-enriched/` | Integration Service trigger and activity extensions, root connection/property bindings, generated `bindings_v2.json` resources, entry point schema, and package metadata. |
 | `subprocess-multi-instance/` | Subprocess scoped variables, multi-instance loop metadata, script task metadata, mappings, message event, and diagram/waypoint coverage. |
 
+## Pilot Scenarios
+
+The corpus was piloted against these public-safe authoring and debugging requests:
+
+| Request | Fixtures used | Result |
+| --- | --- | --- |
+| Create a service-desk intake process with a connector trigger, ticket creation, and generated package metadata. | `integration-service-enriched/` | Kept the model/CLI boundary explicit: connector metadata, connection bindings, and generated resources must come from enrichment before Operate. |
+| Debug an approval workflow where the run takes the wrong branch and then faults on error handling. | `gateway-boundary-error/` | Tightened checks around gateway conditions/defaults, boundary error references, and package metadata drift. |
+| Author a batch item processor with a scoped subprocess, sequential multi-instance loop, script normalization, and a message wait. | `subprocess-multi-instance/` | Added checks for message references and multi-instance collection/item metadata so stuck-loop and stuck-wait issues are caught locally. |
+
+## Validation Output
+
+Latest local fixture validation from this pilot:
+
+```text
+validation_fixture_projects=4 bpmn_files=4 errors=0
+```
+
+## Open Questions for Maestro Owners
+
+- Should `uipath:loopCharacteristics` remain the stable public contract for multi-instance collection and item binding, or should fixture validation prefer registry/CLI-generated loop metadata when available?
+- Which `Intsvc.*` context fields are mandatory across all connector families versus connector-specific fields that should stay outside this static checker?
+- Should `entry-points.json` validation compare full input schemas against root variables, or only verify entry point IDs and file paths until the CLI generator owns schema normalization?
+
 ## Maintenance Commands
 
 Contributor check from the repository root:

--- a/skills/uipath-maestro-bpmn/references/author/references/validation.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/validation.md
@@ -18,10 +18,12 @@ Validate these before Operate:
 - Required context/input fields are present for documented service types.
 - Sequence flows connect legal source and target types.
 - Message flows do not connect elements inside the same pool.
+- Message event definitions reference declared `bpmn:message` elements.
 - Gateway splits have valid conditions/defaults.
 - Each scope has at most one blank start event.
 - Event subprocesses have exactly one start event.
 - Boundary error events and error event subprocesses reference valid error definitions.
+- Multi-instance collection and item bindings reference declared variables and use explicit sequential/parallel metadata.
 - Expressions avoid assignment operators where frontend validation forbids assignment.
 - Output mappings target declared variables.
 - CLI-owned Integration Service fields have been enriched or are clearly marked as blockers.

--- a/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
@@ -70,6 +70,30 @@ Diagnose with variables at the gateway, element executions, and cursors before c
 A boundary error event references a missing or duplicate error definition, or is attached to an invalid activity.
 Reconcile the error definition within the correct scope.
 
+## Multi-instance variable mismatch
+
+A multi-instance activity references an input collection or item variable that is not declared in the expected scope.
+The process may parse, then fail or stall when the loop starts because the runtime cannot bind per-item state.
+
+Signs:
+
+- `uipath:loopCharacteristics` uses an `inputCollection` expression that does not match a declared variable.
+- `inputElement` points at an undeclared item variable or a variable that is reused for unrelated state.
+- A completion condition mutates state instead of evaluating state.
+- Per-item output mappings target variables that are not declared in the subprocess or root scope.
+
+Fix ownership: declare collection and item variables in `.bpmn`, keep item and aggregate outputs distinct,
+and model retry/error behavior as visible BPMN paths rather than hidden loop metadata.
+
+## Message reference mismatch
+
+A catch, throw, or receive event references a message ID that is missing, renamed, or no longer matches the runtime
+message contract.
+
+Runtime symptom: the instance waits indefinitely at a message event or faults during event subscription.
+Diagnose with cursors and element executions, then reconcile the `bpmn:message`, `messageRef`, and any
+`uipath:event` message context in BPMN source.
+
 ## Expression treated as literal
 
 An expression field is authored as a plain literal string.


### PR DESCRIPTION
## Summary

Pilots the `uipath-maestro-bpmn` skill against three public-safe authoring/debugging requests and folds the findings back into the synthetic validation corpus:

- service-desk connector intake with generated package metadata
- gateway and boundary-error debugging for approval-style branching
- subprocess multi-instance batch processing with script normalization and message wait

## Changes

- Documents the pilot scenarios, latest fixture validation output, and open questions for Maestro owners in `fixtures/validation/README.md`.
- Extends the public-safe fixture checker to validate message event references and multi-instance loop metadata.
- Adds author validation bullets and diagnose failure modes for multi-instance variable drift and message reference mismatch.

## Validation

- `bash skills/uipath-maestro-bpmn/.maintenance/check-validation-fixtures.sh` -> `validation_fixture_projects=4 bpmn_files=4 errors=0`
- `bash skills/uipath-maestro-bpmn/.maintenance/check-all.sh` -> All checks passed.
- `uv run ruff check skills/uipath-maestro-bpmn/.maintenance/check-validation-fixtures.py` -> All checks passed.
- `run_workspace_checks(kinds='auto')` -> changed-file fmt passed, pytest passed, typecheck skipped; repo-wide tests lint still has 49 pre-existing errors.
- `run_workspace_checks(check_kinds=["fmt","lint","typecheck","test","test_web"])` -> full gate failed on pre-existing repo-wide `tests/` formatting/lint issues; pytest passed, typecheck/test_web skipped.

## Open Questions

- Should `uipath:loopCharacteristics` remain the stable public contract for multi-instance collection and item binding, or should fixture validation prefer registry/CLI-generated loop metadata when available?
- Which `Intsvc.*` context fields are mandatory across all connector families versus connector-specific fields that should stay outside this static checker?
- Should `entry-points.json` validation compare full input schemas against root variables, or only verify entry point IDs and file paths until the CLI generator owns schema normalization?