### PR TITLE
fix(contract): define one authoritative SKILL.md contract (#583)

### DIFF
--- a/.claude/rules/skill-structure.md
+++ b/.claude/rules/skill-structure.md
@@ -17,26 +17,30 @@ skills/uipath-<name>/
 
 ## SKILL.md Frontmatter
 
-Every SKILL.md MUST begin with valid YAML frontmatter containing at minimum:
+Every SKILL.md MUST begin with valid YAML frontmatter. All fields MUST be at the top level — NOT nested under a `metadata:` key (Claude Code only reads top-level keys).
 
-```yaml
----
-name: uipath-<name>
-description: "<identity> (<unique signal>). <core actions>. For <confusing-case>→<correct-skill>."
----
-```
+This section is the **single source of truth** for the SKILL.md frontmatter contract. CLAUDE.md and CONTRIBUTING.md defer to this file.
 
-### Validation Rules
+### Required fields (enforced by `hooks/validate-skill-descriptions.sh`)
 
-- `name` MUST exactly match the parent folder name
-- `description` MUST be under 1024 characters. Claude Code truncates `description` + `when_to_use` at 1,536 chars in the skill listing ([source](https://code.claude.com/docs/en/skills.md)); 1024 is the repo cap to keep descriptions focused and leave headroom
-- `description` MUST front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`) within the first ~100 characters — the first ~100 chars carry the most matching signal
-- `description` MUST start with the brand or domain identity (e.g., `UiPath`, `UiPath RPA`, `UiPath Maestro Flow`). Do NOT prefix with metadata tags like `[PREVIEW]`, `[BETA]`, etc. — those displace high-value matching tokens and semantically de-prioritize the skill
-- Preview / beta status MUST be indicated in the SKILL.md body (e.g., a `> **Preview**` callout under the H1), NOT in the frontmatter description
-- `description` MUST include compact redirects for commonly confused sibling skills using `→` notation (e.g., `For XAML→uipath-rpa`)
-- `description` MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — these waste characters and get truncated. Use `→` redirects for sibling disambiguation instead
-- All frontmatter fields (`allowed-tools`, `user-invocable`, etc.) MUST be at the top level — NOT nested under a `metadata:` key (Claude Code only reads top-level fields)
-- Frontmatter MUST be valid YAML (no tabs, proper quoting of strings with colons)
+| Field | Rule |
+|-------|------|
+| `name` | MUST exactly match the parent folder name (kebab-case, `uipath-<domain>`). |
+| `description` | ≤ 1024 characters. Front-load identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`, `BYO LLM`) within the first ~100 characters — that prefix carries the most matching signal. Use `→` redirects for sibling disambiguation (`For XAML→uipath-rpa`). MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — replaced by `→` redirects. |
+
+### Optional fields (recognized; used in real skills today)
+
+| Field | Use |
+|-------|-----|
+| `when_to_use` | Standalone trigger sentence (e.g., "User says 'X', 'Y'…"). Useful when the `description` is identity/capability-focused and you want a separate, scannable trigger phrasing. Claude Code truncates the combined `description` + `when_to_use` at 1,536 characters in the skill listing ([source](https://code.claude.com/docs/en/skills.md)); 1024 chars on `description` leaves ~500 chars of headroom for `when_to_use`. |
+| `allowed-tools` | Comma-separated tool list (e.g., `Bash, Read, Write, Glob, Grep, AskUserQuestion`). Restricts which tools the skill is allowed to call. Bash invocations may be scoped (e.g., `Bash(uip:*)`). |
+| `user-invocable` | Defaults to `true`. Set `false` to make the skill agent-only (not directly invocable as `/uipath:<name>` by users). |
+
+### Style guidance (SHOULD, not enforced)
+
+- **Front-load the brand/domain identity** ("UiPath …") when natural. Most skills do, and it places the strongest matching signal first. Action verbs ("Manage", "Send", "Always invoke") are acceptable when they make the skill's purpose clearer in the first ~100 chars.
+- **Avoid metadata prefixes** like `[PREVIEW]` / `[BETA]` at the start of `description` — they displace high-value matching tokens. Indicate preview status in the SKILL.md body instead, with a `> **Preview**` or `> **Experimental**` callout under the H1.
+- **Frontmatter MUST be valid YAML** — no tabs, proper quoting of strings containing colons.
 
 ## SKILL.md Body Structure
 
@@ -59,9 +63,20 @@ The markdown body SHOULD follow this order:
 | Template files | `<name>-template.<ext>` | `codedworkflow-template.md` |
 | Subdirectories | `kebab-case/` | `integration-service/` |
 
+## Cross-Skill Boundaries
+
+Skills are **runtime-independent**: a skill MUST NOT import, link to, or rely on content from another skill's `references/` or `assets/`. Each `skills/uipath-*/` folder is fully self-contained at runtime.
+
+However, **disambiguation pointers in the `description` are required, not violations.** Every skill SHOULD include `→` redirects for sibling skills it commonly gets confused with. These tell the matcher which skill is correct:
+
+- `For Python agents→uipath-agents`
+- `For .flow files→uipath-maestro-flow`
+- `For Test Manager→uipath-test`
+
+Routing skills (e.g., `uipath-planner`) explicitly delegate to specialist skills by name — that is the routing skill's purpose, not a cross-dependency.
+
 ## Content Rules
 
-- Skills MUST be self-contained — no references to other skills
 - CLI commands MUST include `--output json` when output is parsed programmatically
 - All file links MUST use relative paths from the SKILL.md location
 - All file links MUST point to files that actually exist in the repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,19 +4,31 @@ This repository contains self-contained AI agent skills for UiPath automation de
 
 ## Architecture
 
-- **Skills are fully independent.** Each skill under `skills/` is self-contained. Skills cannot reference, import, or depend on other skills.
+- **Skills are runtime-independent.** Each skill under `skills/` is self-contained — no imports from another skill's `references/` or `assets/`. Disambiguation pointers in the `description` field (`For X→uipath-other-skill`) are required for sibling clarity, not violations.
 - **SKILL.md is the contract.** Every skill folder must have a `SKILL.md` with valid YAML frontmatter. This is the only file the plugin system reads to discover and activate skills.
 - **No build system.** This repo contains only markdown documentation and shell scripts. There is no compilation or packaging step.
+
+## Canonical SKILL.md Contract
+
+The authoritative SKILL.md frontmatter contract lives in **[.claude/rules/skill-structure.md](.claude/rules/skill-structure.md)**. CONTRIBUTING.md ([Canonical SKILL.md Contract](CONTRIBUTING.md#canonical-skillmd-contract)) mirrors it for human contributors. Both are kept in sync; this CLAUDE.md is a brief overview only.
+
+**Required frontmatter:**
+- `name` — exactly matches folder name
+- `description` — ≤ 1024 chars, front-loads identity, uses `→` redirects for sibling disambiguation
+
+**Optional frontmatter** (all currently used in real skills): `when_to_use`, `allowed-tools`, `user-invocable`.
+
+Do **not** use `TRIGGER when:` / `DO NOT TRIGGER when:` clauses in `description` — they waste characters and have been replaced by `→` redirects.
 
 ## Contribution Rules
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Key rules:
 
 1. **Skill folder naming:** `uipath-<kebab-case>` under `skills/`
-2. **SKILL.md frontmatter is required:** must include `name` (matching folder name) and `description` (with TRIGGER/DO NOT TRIGGER conditions)
+2. **SKILL.md frontmatter is required:** `name` (matching folder name) and `description`. See the [Canonical SKILL.md Contract](CONTRIBUTING.md#canonical-skillmd-contract) for the full schema, including supported optional fields.
 3. **References use kebab-case filenames** with `-guide.md` and `-template.md` suffixes
 4. **Update CODEOWNERS** when adding or modifying skill ownership
-5. **No cross-skill references** — each skill must work in isolation
+5. **No runtime cross-skill imports** — each skill must work in isolation. `→` redirects in `description` are required for disambiguation, not violations.
 6. **No secrets or personal paths** in committed files
 7. **CLI commands must use `--output json`** when output is parsed programmatically
 
@@ -34,4 +46,4 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Key rules:
 - Read the existing SKILL.md before making changes
 - Preserve the Critical Rules section — these prevent expensive agent mistakes
 - Validate YAML frontmatter — broken frontmatter breaks skill discovery
-- Ensure `description` field has both TRIGGER and DO NOT TRIGGER conditions
+- Run `bash hooks/validate-skill-descriptions.sh skills/<your-skill>/SKILL.md` to check `name` matches the folder, required fields are present, and length caps hold

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for your interest in contributing! Whether you're adding a new skill, 
 ## Table of Contents
 
 - [Repository Structure](#repository-structure)
+- [Canonical SKILL.md Contract](#canonical-skillmd-contract)
 - [Adding a New Skill](#adding-a-new-skill)
 - [Modifying an Existing Skill](#modifying-an-existing-skill)
 - [Developing Experimental Skills](#developing-experimental-skills)
@@ -56,7 +57,7 @@ Thank you for your interest in contributing! Whether you're adding a new skill, 
 
 ### Key Principles
 
-- **Skills are self-contained.** Each skill is an independent folder under `skills/`. Skills cannot reference or depend on other skills.
+- **Skills are runtime-independent.** Each skill is an independent folder under `skills/`. A skill MUST NOT import or link to another skill's `references/` or `assets/`. Sibling-disambiguation pointers in the `description` field (`For X→uipath-other-skill`) are required for the matcher, not violations — see [Cross-skill boundaries](#cross-skill-boundaries).
 - **SKILL.md is the entry point.** The AI agent reads `SKILL.md` first. Everything the agent needs to know must be reachable from there.
 - **References are supplementary.** Large reference material goes in `references/` subdirectories, linked from SKILL.md.
 - **No build system.** This is a documentation and skill-definitions repository. There is no compilation, bundling, or package publishing from this repo.
@@ -76,6 +77,56 @@ Tool wiring lives outside `skills/`:
 | GitHub Copilot coding agent | `AGENTS.md` (symlink → `CLAUDE.md`) | Copilot reads `AGENTS.md` natively (since Aug 2025) |
 
 When adding a skill, only touch files under `skills/uipath-<name>/` — the root integration files already wire every tool up automatically.
+
+## Canonical SKILL.md Contract
+
+This section is the single source of truth for the SKILL.md frontmatter contract in this repo. Both `CLAUDE.md` and `.claude/rules/skill-structure.md` defer to this section. Validators enforce the **Required** rules; **Optional** fields are recognized and used in real skills today; **Style guidance** is a SHOULD.
+
+### Required fields (enforced)
+
+| Field | Rule |
+|-------|------|
+| `name` | MUST match the parent folder name exactly (kebab-case, `uipath-<domain>`). |
+| `description` | ≤ 1024 characters. Front-load identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`, `interact`, `BYO LLM`) within the first ~100 chars. Use `→` redirects for sibling disambiguation (`For XAML→uipath-rpa`). MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — those have been replaced by `→` redirects. |
+
+### Optional fields (recognized; in use across real skills)
+
+| Field | Use |
+|-------|-----|
+| `when_to_use` | Standalone trigger sentence ("User says 'X'…"). Useful when the `description` is identity/capability-focused and you want a separate trigger phrasing. Combined `description + when_to_use` is truncated by Claude Code at 1,536 chars in the skill listing — the 1024 cap on `description` leaves ~500 chars of headroom for `when_to_use`. |
+| `allowed-tools` | Comma-separated tool list (e.g., `Bash, Read, Write, Glob, Grep, AskUserQuestion`). Restricts which tools the skill is allowed to call. Bash invocations may be scoped (e.g., `Bash(uip:*)`). |
+| `user-invocable` | Defaults to `true`. Set `false` to make the skill agent-only — not directly invocable as `/uipath:<name>` by users. |
+
+### Style guidance (SHOULD, not enforced)
+
+- **Front-load the brand/domain identity** ("UiPath …") when natural. Most skills do, and it places the strongest matching signal first. Action verbs ("Manage", "Send", "Always invoke for `.flow` files") are acceptable when they make the skill's purpose clearer in the first ~100 chars.
+- **Avoid metadata prefixes** like `[PREVIEW]` / `[BETA]` at the start of `description` — they displace high-value matching tokens. Indicate preview / experimental status in the SKILL.md body instead, with a `> **Preview**` or `> **Experimental**` callout under the H1.
+- **All frontmatter fields MUST be at the top level** — never nested under a `metadata:` key. Claude Code only reads top-level keys.
+- **Frontmatter MUST be valid YAML** — no tabs, proper quoting of strings containing colons.
+
+### Cross-skill boundaries
+
+Skills are **runtime-independent**. A skill MUST NOT import, link to, or rely on content from another skill's `references/` or `assets/`. Each `skills/uipath-*/` folder is fully self-contained when an agent loads it.
+
+However, **disambiguation pointers in `description` are required, not violations.** Every skill SHOULD include `→` redirects for sibling skills it commonly gets confused with — these tell the matcher which skill is correct:
+
+- `For Python agents→uipath-agents`
+- `For .flow files→uipath-maestro-flow`
+- `For Test Manager→uipath-test`
+
+Routing skills (e.g., `uipath-planner`) explicitly delegate to specialist skills by name — that is the routing skill's purpose, not a cross-dependency.
+
+### What the validator enforces today
+
+`hooks/validate-skill-descriptions.sh` (run by the pre-commit hook and the [Validate Skills](.github/workflows/validate-skills.yml) CI job) enforces:
+
+- `name` field is present
+- `name` matches the parent folder name
+- `description` field is present
+- `description` ≤ 1024 chars
+- Combined `description + when_to_use` ≤ 1,500 chars (warning when exceeded)
+
+Style guidance (brand identity, `→` redirects, metadata prefixes) is reviewer-enforced, not validator-enforced. New validators should be proposed via a PR that updates this section, the rules, and the script together.
 
 ## Adding a New Skill
 
@@ -113,7 +164,7 @@ skills/uipath-<your-skill>/
 
 ### 3. Write SKILL.md
 
-SKILL.md is the most important file. It uses YAML frontmatter followed by markdown content.
+SKILL.md is the most important file. It uses YAML frontmatter followed by markdown content. The full schema is documented in the [Canonical SKILL.md Contract](#canonical-skillmd-contract) section below — this section gives the quick view.
 
 #### Frontmatter Format
 
@@ -130,15 +181,18 @@ description: "<identity> (<unique signal>). <core actions>. For <confusing-case>
 
 | Field | Description |
 |-------|-------------|
-| `name` | Exact skill identifier, must match the folder name |
-| `description` | Under 1024 chars. Front-load identity and unique signals, then core actions, then compact `→` redirects for commonly confused sibling skills. Do NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — they waste characters. |
+| `name` | Exact skill identifier, MUST match the folder name. Enforced by `hooks/validate-skill-descriptions.sh`. |
+| `description` | ≤ 1024 chars (enforced). Front-load identity and unique signals, then core actions, then compact `→` redirects for commonly confused sibling skills. Do NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — they waste characters. |
 
-**Optional frontmatter fields:**
+**Optional frontmatter fields** (all in current use across real skills):
 
 | Field | Description |
 |-------|-------------|
-| `allowed-tools` | Restricts which tools the skill can use (e.g., `Bash, Read, Write, Glob, Grep`) |
-| `user-invocable` | Defaults to `true`. Set to `false` if the skill should only be discoverable by the agent, not directly invocable by users |
+| `when_to_use` | Standalone trigger phrasing ("User says 'X', 'Y'…"). Useful when `description` is identity/capability-focused and you want a separate, scannable trigger sentence. The combined `description + when_to_use` is truncated by Claude Code at 1,536 chars in the skill listing. |
+| `allowed-tools` | Restricts which tools the skill can use (e.g., `Bash, Read, Write, Glob, Grep`). Bash invocations may be scoped (e.g., `Bash(uip:*)`). |
+| `user-invocable` | Defaults to `true`. Set to `false` if the skill should only be discoverable by the agent, not directly invocable by users via `/uipath:<name>`. |
+
+> **No nested `metadata:` key.** All fields above MUST be at the top level of the frontmatter. Claude Code only reads top-level keys; anything nested under `metadata:` is invisible to the matcher.
 
 #### Content Structure
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Thank you for your interest in contributing! Whether you're adding a new skill, 
 - [Repository Structure](#repository-structure)
 - [Adding a New Skill](#adding-a-new-skill)
 - [Modifying an Existing Skill](#modifying-an-existing-skill)
+- [Developing Experimental Skills](#developing-experimental-skills)
 - [Hooks](#hooks)
 - [Quality Checklist](#quality-checklist)
 - [Pull Request Process](#pull-request-process)
@@ -202,6 +203,47 @@ Static files like code templates go in `assets/`:
 4. **Test your changes.** After editing, verify the skill still activates correctly for its intended scenarios.
 5. **Coordinate with CODEOWNERS.** Check who owns the skill and tag them in your PR.
 
+## Developing Experimental Skills
+
+Some skills take weeks to reach a usable state — for example, large new product surfaces or skills that need an unreleased CLI feature to land first. This section covers how to develop those in this repository without disrupting users who install the published plugin.
+
+> **This repository is public.** Branches, commits, PR titles, and review comments are visible to everyone, including customers and competitors. Treat every push as a public statement.
+
+### Default: build in the open
+
+Develop directly in this repository on a feature branch off `main`. Skills are largely self-contained, so a long-lived `develop` integration branch is not useful here — each experimental skill gets its own branch and merges into `main` independently when ready.
+
+Only develop in a private fork when the feature must stay confidential before release (e.g., tied to an unannounced product). In that case, fork this repository, develop privately, and open the PR back here once the feature can be public.
+
+### Branch naming
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| New experimental skill | `feat/experimental/<skill-name>` | `feat/experimental/uipath-maestro-bpmn` |
+| Experimental change to existing skill | `feat/experimental/<skill-name>-<topic>` | `feat/experimental/uipath-rpa-coded-codegen` |
+
+### Workflow
+
+1. **Branch from `main`.** `git checkout -b feat/experimental/<skill-name>`.
+2. **Push the branch early and iterate on it.** Push intermediate commits to your branch, not to `main`. The branch is publicly visible — that is expected and fine.
+3. **Stay current with `main`.** Merge or rebase `main` into your branch regularly so the eventual integration PR stays small. Rebase if your branch has not been shared for review yet; merge once others are reviewing or building on it.
+4. **Mark the skill as experimental in `SKILL.md`.** Preview / experimental status goes in the SKILL.md body, not in frontmatter (per [.claude/rules/skill-structure.md](.claude/rules/skill-structure.md)). Example callout under the H1:
+
+   ```markdown
+   # UiPath My New Skill
+
+   > **Experimental.** This skill is under active development. Behavior, CLI flags, and reference structure may change without notice. Not recommended for production use.
+   ```
+
+5. **Merge to `main` only when the skill is usable end-to-end.** Do not merge work-in-progress commits straight to `main` just to keep the branch short — `main` is what users install. Open the integration PR when the skill triggers correctly, has at least the smoke + e2e tests required by the [Quality Checklist](#quality-checklist), and follows the rest of the contribution guidelines.
+
+### Public-repo discipline
+
+- **Never commit secrets, tokens, internal hostnames, customer data, or unreleased product/feature names that have not been publicly announced.** Use placeholders (`<TOKEN>`, `<TENANT_URL>`) in examples.
+- **Write commit messages and PR titles as if a customer is reading them** — because they are.
+- **If you accidentally commit a secret or confidential reference**, rotate the secret immediately, then contact a maintainer to coordinate history rewrite. Do not force-push over it yourself; the leaked value still needs to be rotated regardless.
+- **Avoid screenshots of internal tools** in PR descriptions or skill assets.
+
 ## Hooks
 
 Hooks are defined in `hooks/hooks.json` and run during plugin lifecycle events (e.g., `SessionStart`).
@@ -327,6 +369,7 @@ Before submitting your PR, verify:
 |------|---------|---------|
 | New skill | `feat/add-<skill-name>` | `feat/add-uipath-data-service` |
 | Skill improvement | `feat/<skill-name>-<description>` | `feat/uia-add-drag-support` |
+| Experimental / long-running work | `feat/experimental/<skill-name>` | `feat/experimental/uipath-maestro-bpmn` |
 | Bug fix | `fix/<skill-name>-<description>` | `fix/flow-validate-edge-ports` |
 | Documentation | `docs/<description>` | `docs/update-platform-cli-reference` |
 

--- a/hooks/validate-skill-descriptions.sh
+++ b/hooks/validate-skill-descriptions.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
-# Validate skill description lengths
-# Enforces a 1024-character limit on all SKILL.md descriptions.
-# Claude Code truncates the combined `description` + `when_to_use` at 1,536 chars
-# in the skill listing (https://code.claude.com/docs/en/skills.md). 1024 keeps
-# us comfortably under that cap while leaving headroom for `when_to_use`.
+# Validate SKILL.md frontmatter against the canonical SKILL contract.
+# See CONTRIBUTING.md#canonical-skillmd-contract and .claude/rules/skill-structure.md.
+#
+# Enforced rules (non-zero exit on failure):
+#   1. `name` field is present
+#   2. `name` matches the parent folder name exactly
+#   3. `description` field is present
+#   4. `description` ≤ 1024 characters
+#
+# Warning (non-fatal):
+#   - Combined `description` + `when_to_use` > 1500 chars (Claude Code truncates
+#     the skill listing at 1,536 chars: https://code.claude.com/docs/en/skills.md)
+#
+# The script keeps its historical filename so the pre-commit hook and CI workflow
+# do not need to change. Despite the name, it now validates the full canonical
+# contract, not only description length.
 #
 # Usage:
 #   validate-skill-descriptions.sh [file1 file2 ...]
-# If no files specified, checks staged files (for pre-commit hook)
+# If no files are specified, checks staged SKILL.md files (pre-commit mode).
 
 set -e
 
 LIMIT=1024
+COMBINED_WARN=1500
 FAILED=0
 
 # Determine which files to check
@@ -23,35 +35,89 @@ else
   FILES="$@"
 fi
 
+# Extract a top-level frontmatter scalar field. Handles both quoted ("...")
+# and unquoted forms; returns the value without surrounding double quotes.
+extract_field() {
+  local file="$1"
+  local field="$2"
+  awk -v f="$field" '
+    /^---$/ { c++; if (c == 2) exit; next }
+    c == 1 && $0 ~ "^"f": " {
+      sub("^"f": *", "")
+      # Strip a single pair of surrounding double quotes if present
+      if (substr($0, 1, 1) == "\"" && substr($0, length($0), 1) == "\"") {
+        $0 = substr($0, 2, length($0) - 2)
+      }
+      print
+      exit
+    }
+  ' "$file"
+}
+
 for file in $FILES; do
   if [ ! -f "$file" ]; then
     continue
   fi
 
-  # Extract description from frontmatter
-  desc=$(sed -n 's/^description: "\(.*\)"$/\1/p' "$file" | head -1)
+  # Defensive: only validate files that look like skill SKILL.md
+  case "$file" in
+    *skills/*/SKILL.md) ;;
+    *)
+      echo "↷ $file: not a skill SKILL.md, skipping"
+      continue
+      ;;
+  esac
 
-  # Also handle descriptions without surrounding quotes
-  if [ -z "$desc" ]; then
-    desc=$(sed -n 's/^description: \(.*\)$/\1/p' "$file" | head -1)
+  folder_name=$(basename "$(dirname "$file")")
+  name=$(extract_field "$file" "name")
+  desc=$(extract_field "$file" "description")
+  wtu=$(extract_field "$file" "when_to_use")
+
+  file_failed=0
+
+  # Required: name present
+  if [ -z "$name" ]; then
+    echo "❌ $file: missing 'name' field in frontmatter"
+    file_failed=1
+  elif [ "$name" != "$folder_name" ]; then
+    # Required: name matches folder
+    echo "❌ $file: name '$name' does not match parent folder '$folder_name'"
+    file_failed=1
   fi
 
-  len=${#desc}
-
-  if [ "$len" -gt "$LIMIT" ]; then
-    echo "❌ $file: description exceeds $LIMIT characters ($len chars)"
-    FAILED=1
+  # Required: description present
+  if [ -z "$desc" ]; then
+    echo "❌ $file: missing 'description' field in frontmatter"
+    file_failed=1
   else
-    echo "✓ $file: $len chars"
+    desc_len=${#desc}
+    if [ "$desc_len" -gt "$LIMIT" ]; then
+      echo "❌ $file: description exceeds $LIMIT characters ($desc_len chars)"
+      file_failed=1
+    fi
+
+    # Warning: combined description + when_to_use length
+    if [ -n "$wtu" ]; then
+      combined_len=$((desc_len + ${#wtu}))
+      if [ "$combined_len" -gt "$COMBINED_WARN" ]; then
+        echo "⚠ $file: description + when_to_use is $combined_len chars (Claude Code truncates at 1,536)"
+      fi
+    fi
+  fi
+
+  if [ "$file_failed" -eq 0 ]; then
+    echo "✓ $file: name='$name', description=${#desc} chars$( [ -n "$wtu" ] && echo ", when_to_use=${#wtu} chars" )"
+  else
+    FAILED=1
   fi
 done
 
 if [ "$FAILED" -eq 1 ]; then
   echo ""
-  echo "Skill description validation failed. Descriptions must be ≤ $LIMIT characters."
-  echo "Claude Code truncates description + when_to_use at 1,536 chars in the skill listing;"
-  echo "this repo caps at $LIMIT to leave headroom and keep descriptions focused."
-  echo "Edit the 'description' field in SKILL.md frontmatter and try again."
+  echo "Skill frontmatter validation failed. See:"
+  echo "  - CONTRIBUTING.md#canonical-skillmd-contract"
+  echo "  - .claude/rules/skill-structure.md"
+  echo "Edit the offending SKILL.md frontmatter and try again."
   exit 1
 fi
 


### PR DESCRIPTION
Closes #583.

## Problem

Issue #583 documented contract drift between root guidance, actual skills, and validators:

- `CLAUDE.md` required `description` to include `TRIGGER/DO NOT TRIGGER` clauses, while `.claude/rules/skill-structure.md` and `CONTRIBUTING.md` explicitly forbid them. Reality: **0 of 20 skills** use that form.
- `when_to_use` is used in 5 real skills (uipath-rpa, uipath-interact, uipath-planner, uipath-feedback, uipath-tasks) but is undocumented in `CONTRIBUTING.md`.
- `CLAUDE.md` and `.claude/rules/skill-structure.md` both said "no cross-skill references", yet **every** description contains `→` redirects to sibling skills (and `uipath-planner` exists specifically to route between them).
- `validate-skill-descriptions.sh` only checked description length — no `name`-folder match, no required-field check.
- Strict rules like "MUST start with brand identity" and "no `[PREVIEW]` prefix" don't match reality (e.g., `uipath-review` uses `[PREVIEW]`; 7 skills lead with action verbs instead of "UiPath…").

## Approach

**Ground truth = current skill structure.** No skills were modified. All four changed files now agree with what skills actually look like.

### Audit (20 skills)
| Field | Coverage |
|---|---|
| `name` | 20/20 (required) |
| `description` | 20/20 (required) |
| `allowed-tools` | 14/20 (optional) |
| `when_to_use` | 5/20 (optional) |
| `user-invocable` | 5/20 (optional, always `true`) |
| Nested `metadata:` | 0/20 ✓ |
| `TRIGGER:` / `DO NOT TRIGGER:` clauses | 0/20 |
| `→` redirects in description | ~20/20 |

### Changes
- **`.claude/rules/skill-structure.md`** — rewrite as the single source of truth. Required/Optional/Style tables. New `## Cross-Skill Boundaries` section: runtime independence required; `→` redirects are required, not violations.
- **`CLAUDE.md`** — drop the `TRIGGER/DO NOT TRIGGER` requirement. Point at the canonical files. Restate the cross-skill rule correctly.
- **`CONTRIBUTING.md`** — new top-level **Canonical SKILL.md Contract** section enumerating Required, Optional, Style, Cross-skill boundaries, and What the validator enforces. `when_to_use` added to the optional fields table.
- **`hooks/validate-skill-descriptions.sh`** — extend with `name` present, `name` matches folder, `description` present, plus a non-fatal warning when combined `description + when_to_use` > 1,500 chars (Claude Code truncates at 1,536). Filename kept for compatibility with the pre-commit hook and `.github/workflows/validate-skills.yml`.

## Validation

- `bash hooks/validate-skill-descriptions.sh skills/uipath-*/SKILL.md` → all 20 skills pass
- Failure paths exercised against synthetic fixtures:
  - Name/folder mismatch → fails
  - Missing `description` → fails
  - 1025-char `description` → fails (existing behavior preserved)
  - 1600-char combined → warns + exits 0

## Test plan
- [ ] CI: `Validate Skills` workflow passes against this branch
- [ ] CI: pre-commit hook (if installed locally via `scripts/setup-hooks.sh`) passes
- [ ] Manual: render `CONTRIBUTING.md` on GitHub, verify the new **Canonical SKILL.md Contract** anchor and table-of-contents entry
- [ ] Manual: confirm `CLAUDE.md` links to `.claude/rules/skill-structure.md` and `CONTRIBUTING.md#canonical-skillmd-contract` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)