### PR TITLE
[ENGCE-57552] skills(uipath-maestro-flow, uipath-platform): array filter + mandatory-filter contract

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
@@ -131,7 +131,7 @@ Check every field in `eventParameters.fields` where `required: true`. All requir
 
 1. Collect all required event parameter fields
 2. For each, check if the user's prompt provides a value
-3. If any required field is missing, **ask the user** — list the missing fields with their `displayName`. Free-form input is appropriate when the value space is open-ended; when a finite set of sensible values exists, present them via `AskUserQuestion` per the dropdown rule in [SKILL.md](../../../../../SKILL.md).
+3. If any required field is missing, **ask the user** — list the missing fields with their `displayName`
 4. Only proceed after all required event parameters are resolved
 
 ### Step 4b — Map trigger output fields for downstream nodes
@@ -297,13 +297,9 @@ A no-op filter — used when the user wants all events to fire the trigger — i
 
 ### How to build a filter tree from `filterFields`
 
-1. Run `registry get` with `--connection-id` (Step 2) and read the `filterFields.fields` array.
-2. For each user-intent condition, pick a matching field `name` from that array — using an unknown field name will be rejected by the CLI at configure time.
-3. Choose an operator based on the user's intent and the field type (see operator table).
-4. Build one leaf per condition; place multiple conditions under the same `groupOperator` (0 for AND, 1 for OR).
-5. If you need mixed AND/OR logic, use nested `groups`.
-6. **Wrap string values in a `value` object** with `value`, `rawString`, `isLiteral: true` — passing a bare string will fail validation.
-7. If `filterFields` is empty or absent, the trigger does not support filtering — omit `filter` entirely.
+1. Run `flow registry get` with `--connection-id` (Step 2) and read the `filterFields.fields` array. Each entry has a `name` (use as the leaf `id`), a `type` (drives operator selection), and an optional `description`.
+
+Then follow [/uipath:uipath-platform — triggers.md > Building Filter Trees from filterFields](../../../../../../uipath-platform/references/integration-service/triggers.md#building-filter-trees-from-filterfields) for the rest of the procedure (operator selection, leaf composition, value wrapping), the mandatory-filter contract (connector-mandated values like Gmail folder go on `eventParameters`, never the freeform `filter` tree), and array-shaped field handling.
 
 ### What NOT to generate
 
@@ -315,7 +311,7 @@ A no-op filter — used when the user wants all events to fire the trigger — i
 | `{ "id": "subject", "operator": "contains", ... }` | Operator is case-sensitive — use PascalCase. | `"operator": "Contains"` |
 | `{ "value": "urgent" }` on a leaf | Bare string — must be wrapped in the `WorkflowValue` object. | `{ "value": { "value": "urgent", "rawString": "\"urgent\"", "isLiteral": true } }` |
 | `{ "isLiteral": false, "value": "${var}" }` | Expression values are not yet supported by the CLI port. | Resolve the value first, then pass it as a literal. |
-| `{ "id": "tags[*].name", ... }` | Array-field filters are not yet supported. | File a follow-up; use a scheduled poll + in-flow filter for now. |
+| Adding a freeform leaf for a connector-mandated field (e.g. Gmail folder, Slack channelId) | Mandatory filters derived from connector event metadata are emitted automatically by the CLI from `eventParameters` — duplicating them in the freeform tree double-applies the clause. | Set the value through `eventParameters` only; the CLI persists the mandatory JMES clause on `essentialConfiguration.mandatoryFilterExpression`. |
 
 ---
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
@@ -311,7 +311,7 @@ Then follow [/uipath:uipath-platform — triggers.md > Building Filter Trees fro
 | `{ "id": "subject", "operator": "contains", ... }` | Operator is case-sensitive — use PascalCase. | `"operator": "Contains"` |
 | `{ "value": "urgent" }` on a leaf | Bare string — must be wrapped in the `WorkflowValue` object. | `{ "value": { "value": "urgent", "rawString": "\"urgent\"", "isLiteral": true } }` |
 | `{ "isLiteral": false, "value": "${var}" }` | Expression values are not yet supported by the CLI port. | Resolve the value first, then pass it as a literal. |
-| Adding a freeform leaf for a connector-mandated field (e.g. Gmail folder, Slack channelId) | Mandatory filters derived from connector event metadata are emitted automatically by the CLI from `eventParameters` — duplicating them in the freeform tree double-applies the clause. | Set the value through `eventParameters` only; the CLI persists the mandatory JMES clause on `essentialConfiguration.mandatoryFilterExpression`. |
+| Adding a freeform leaf for a connector-mandated field (e.g. Gmail folder, Slack channelId) | Mandatory filters derived from connector event metadata are emitted automatically by the CLI from `eventParameters` — duplicating them in the freeform tree double-applies the clause. | Set the value through `eventParameters` only; the CLI AND-joins the mandatory JMES clause into the top-level `inputs.detail.filterExpression` (matching SW's `combinedFilterExpression`). It is *not* persisted on `essentialConfiguration` — SW classifies it optional and rebuilds it from input field values on restore. |
 
 ---
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
@@ -182,7 +182,27 @@ uip maestro flow node configure <PROJECT>.flow <triggerId> --output json --detai
 
 The CLI derives the runtime JMESPath `filterExpression` from `filter` automatically and persists both into the workflow so Studio Web can re-open the trigger without losing the filter configuration (MST-8802). **Do not pass `filterExpression` directly — the validator rejects it.**
 
-The command populates `inputs.detail` (including the internal `configuration` blob with the `filter` tree and derived `filterExpression`) and creates workflow-level connection bindings.
+**Mandatory filters (ENGCE-57498):** When `eventParameters` includes values for **required** event parameters (identified by `events.<operation>.required: true` in the trigger metadata), the CLI automatically generates a mandatory filter expression. This is combined with any user-defined `filter` using AND logic:
+
+- **Both mandatory and user filter exist:** `detail.filterExpression = "<mandatory> && <user>"`
+- **Only mandatory filter:** `detail.filterExpression = "<mandatory>"` (e.g., Gmail Email Received with folder selection but no additional filters)
+- **Only user filter:** `detail.filterExpression = "<user>"`
+- **Neither:** `detail.filterExpression = ""`
+
+Example (Gmail Email Received):
+```json
+{
+  "eventParameters": {
+    "ParentFolders": "INBOX"  // Required parameter
+  }
+  // No additional filter tree
+}
+```
+Result: `detail.filterExpression = "(ParentFolders[?ID=='INBOX'])"`
+
+The mandatory filter expression is also persisted in `essentialConfiguration.mandatoryFilterExpression` so the StudioWeb translator can reconstruct the combined expression without rehydrating the view model.
+
+The command populates `inputs.detail` (including the internal `configuration` blob with the `filter` tree, `mandatoryFilterExpression`, and combined `filterExpression`) and creates workflow-level connection bindings.
 
 > **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)" --output json`
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
@@ -2,6 +2,7 @@
 
 How to configure connector trigger nodes: connection binding, enriched metadata, event parameter resolution, and trigger-specific `node configure` fields. This replaces the IS activity workflow (Steps 1-6 in [connector/impl.md](../connector/impl.md)) — trigger nodes have different metadata and configuration.
 
+
 ## Configuration Workflow
 
 Follow these steps for every IS trigger node.
@@ -131,7 +132,7 @@ Check every field in `eventParameters.fields` where `required: true`. All requir
 
 1. Collect all required event parameter fields
 2. For each, check if the user's prompt provides a value
-3. If any required field is missing, **ask the user** — list the missing fields with their `displayName`
+3. If any required field is missing, **ask the user** — list the missing fields with their `displayName`. Free-form input is appropriate when the value space is open-ended; when a finite set of sensible values exists, present them via `AskUserQuestion` per the dropdown rule in [SKILL.md](../../../../../SKILL.md).
 4. Only proceed after all required event parameters are resolved
 
 ### Step 4b — Map trigger output fields for downstream nodes
@@ -180,29 +181,8 @@ uip maestro flow node configure <PROJECT>.flow <triggerId> --output json --detai
 | `eventParameters` | No | JSON object of resolved event parameter values from Steps 3-4 |
 | `filter` | No | Structured filter tree — see [Filter Trees](#filter-trees) below. Omit to trigger on all events |
 
-The CLI derives the runtime JMESPath `filterExpression` from `filter` automatically and persists both into the workflow so Studio Web can re-open the trigger without losing the filter configuration (MST-8802). **Do not pass `filterExpression` directly — the validator rejects it.**
-
-**Mandatory filters (ENGCE-57498):** When `eventParameters` includes values for **required** event parameters (identified by `events.<operation>.required: true` in the trigger metadata), the CLI automatically generates a mandatory filter expression. This is combined with any user-defined `filter` using AND logic:
-
-- **Both mandatory and user filter exist:** `detail.filterExpression = "<mandatory> && <user>"`
-- **Only mandatory filter:** `detail.filterExpression = "<mandatory>"` (e.g., Gmail Email Received with folder selection but no additional filters)
-- **Only user filter:** `detail.filterExpression = "<user>"`
-- **Neither:** `detail.filterExpression = ""`
-
-Example (Gmail Email Received):
-```json
-{
-  "eventParameters": {
-    "ParentFolders": "INBOX"  // Required parameter
-  }
-  // No additional filter tree
-}
-```
-Result: `detail.filterExpression = "(ParentFolders[?ID=='INBOX'])"`
-
-The mandatory filter expression is also persisted in `essentialConfiguration.mandatoryFilterExpression` so the StudioWeb translator can reconstruct the combined expression without rehydrating the view model.
-
-The command populates `inputs.detail` (including the internal `configuration` blob with the `filter` tree, `mandatoryFilterExpression`, and combined `filterExpression`) and creates workflow-level connection bindings.
+The CLI computes the runtime JMESPath `filterExpression` from `filter` automatically and persists both into the workflow so Studio Web can re-open the trigger without losing the filter configuration. **Do not pass `filterExpression` directly — the validator rejects it.**
+The command populates `inputs.detail` (including the internal `configuration` blob with the `filter` tree and combined `filterExpression`) and creates workflow-level connection bindings.
 
 > **Shell quoting tip:** For complex `--detail` JSON, write it to a temp file: `uip maestro flow node configure <file> <nodeId> --detail "$(cat /tmp/detail.json)" --output json`
 

--- a/skills/uipath-platform/references/integration-service/triggers.md
+++ b/skills/uipath-platform/references/integration-service/triggers.md
@@ -139,9 +139,11 @@ These steps assume the consuming skill has already loaded the trigger's `filterF
 
 ### Mandatory filter parameters
 
-Some triggers carry **mandatory event-parameter filters** the connector requires for subscription (e.g. Gmail Email Received always filters by folder; Slack message triggers filter by channel). These are **not** authored as freeform `filter` leaves. Set the value through `eventParameters` instead — the CLI runs it through the same mandatory-filter pipeline Studio Web uses (`buildMandatoryFilterExpression`) and persists the result on `essentialConfiguration.mandatoryFilterExpression`. The runtime `filterExpression` is the AND-join of the user's freeform tree and the mandatory clause; SW's translator reads it through `combinedFilterExpression`.
+Some triggers carry **mandatory event-parameter filters** the connector requires for subscription (e.g. Gmail Email Received always filters by folder; Slack message triggers filter by channel). These are **not** authored as freeform `filter` leaves. Set the value through `eventParameters` — the CLI runs it through the same mandatory-filter pipeline Studio Web uses (`buildMandatoryFilterExpression`) and AND-joins the result into the runtime `filterExpression` written at the **top level of the node's `inputs.detail`**. This matches what SW persists via `combinedFilterExpression`.
 
-Duplicating a mandatory clause in the freeform tree double-applies the constraint at runtime. Always set connector-mandated values via `eventParameters`, not `filter`.
+The mandatory clause is **not** persisted on `essentialConfiguration` — SW classifies it as optional (rebuilt from input field values on restore; only `filter`, the user-authored FilterTree, is essential per `TRIGGER_ACTIVITY_ESSENTIAL_PROPERTIES`). Persisting it there would diverge from SW's shape and double on the next save in SW.
+
+Duplicating a mandatory clause in the freeform `filter` tree double-applies the constraint at runtime. Always set connector-mandated values via `eventParameters`, not `filter`.
 
 ### Array-shaped fields
 

--- a/skills/uipath-platform/references/integration-service/triggers.md
+++ b/skills/uipath-platform/references/integration-service/triggers.md
@@ -13,6 +13,7 @@ Triggers are event-based activities that fire when something happens in an exter
 - [Trigger Metadata (Describe)](#trigger-metadata-describe)
 - [CRUD vs Non-CRUD Triggers](#crud-vs-non-crud-triggers)
 - [Response Fields](#response-fields)
+- [Building Filter Trees from filterFields](#building-filter-trees-from-filterfields)
 - [Webhook URL Retrieval](#webhook-url-retrieval)
 - [Happy-Path Example](#happy-path-example)
 
@@ -118,6 +119,33 @@ Additional fields:
 | `eventMode` | `"webhooks"` or `"polling"` |
 | `byoaConnection` | `true` if this trigger requires a BYOA connection |
 | `isWebhookUrlVisible` | `true` if the webhook URL should be shown |
+
+---
+
+## Building Filter Trees from filterFields
+
+Trigger filters narrow which events fire the trigger (e.g. only emails from a specific sender). They are authored as a **structured tree**, not a JMESPath string — the CLI compiles the tree into the runtime `filterExpression` using the same logic Studio Web does, and writes both forms into the workflow so the trigger round-trips cleanly when re-opened in SW. **Do not pass `filterExpression` directly** — the validator rejects it.
+
+### Steps
+
+These steps assume the consuming skill has already loaded the trigger's `filterFields.fields` array (the source command varies by surface — e.g. maestro-flow uses `flow registry get`).
+
+1. For each user-intent condition, pick a matching `name` from `filterFields.fields` — using an unknown field name will be rejected by the CLI at configure time.
+2. Choose an operator based on the user's intent and the field type (see the operator table in the consuming skill — e.g. [uipath-maestro-flow > connector-trigger](../../../uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md#supported-operators)).
+3. Build one leaf per condition; place multiple conditions under the same `groupOperator` (`0` for AND, `1` for OR).
+4. If you need mixed AND/OR logic, use nested `groups` (same shape as the root tree).
+5. **Wrap string values in a `value` object** with `value`, `rawString` (verbatim user-entered text including quotes for strings), and `isLiteral: true` — passing a bare string fails validation. Expression values (`isLiteral: false`) are not yet supported by the CLI port.
+6. If `filterFields` is empty or absent, the trigger does not support filtering — omit `filter` entirely. Do not invent an "empty" expression.
+
+### Mandatory filter parameters
+
+Some triggers carry **mandatory event-parameter filters** the connector requires for subscription (e.g. Gmail Email Received always filters by folder; Slack message triggers filter by channel). These are **not** authored as freeform `filter` leaves. Set the value through `eventParameters` instead — the CLI runs it through the same mandatory-filter pipeline Studio Web uses (`buildMandatoryFilterExpression`) and persists the result on `essentialConfiguration.mandatoryFilterExpression`. The runtime `filterExpression` is the AND-join of the user's freeform tree and the mandatory clause; SW's translator reads it through `combinedFilterExpression`.
+
+Duplicating a mandatory clause in the freeform tree double-applies the constraint at runtime. Always set connector-mandated values via `eventParameters`, not `filter`.
+
+### Array-shaped fields
+
+When `filterFields[].name` contains a `[*]` segment (e.g. `tags[*]`, `ParentFolders[*].ID`), the CLI emits filter-projection JMESPath instead of scalar comparison: `(tags[?@=='urgent'])`, `(ParentFolders[?ID=='INBOX'])`. Reference the field by its full schema name in the leaf `id` — the projection syntax is generated, not authored.
 
 ---
 

--- a/skills/uipath-platform/references/integration-service/triggers.md
+++ b/skills/uipath-platform/references/integration-service/triggers.md
@@ -139,11 +139,7 @@ These steps assume the consuming skill has already loaded the trigger's `filterF
 
 ### Mandatory filter parameters
 
-Some triggers carry **mandatory event-parameter filters** the connector requires for subscription (e.g. Gmail Email Received always filters by folder; Slack message triggers filter by channel). These are **not** authored as freeform `filter` leaves. Set the value through `eventParameters` — the CLI runs it through the same mandatory-filter pipeline Studio Web uses (`buildMandatoryFilterExpression`) and AND-joins the result into the runtime `filterExpression` written at the **top level of the node's `inputs.detail`**. This matches what SW persists via `combinedFilterExpression`.
-
-The mandatory clause is **not** persisted on `essentialConfiguration` — SW classifies it as optional (rebuilt from input field values on restore; only `filter`, the user-authored FilterTree, is essential per `TRIGGER_ACTIVITY_ESSENTIAL_PROPERTIES`). Persisting it there would diverge from SW's shape and double on the next save in SW.
-
-Duplicating a mandatory clause in the freeform `filter` tree double-applies the constraint at runtime. Always set connector-mandated values via `eventParameters`, not `filter`.
+Some triggers carry **mandatory event-parameter filters** the connector requires for subscription (e.g. Gmail Email Received always filters by folder; Slack message triggers filter by channel). These are **not** authored as freeform `filter` leaves. Set the value through `eventParameters` — the CLI runs it and AND-joins the result into the runtime `filterExpression` written at the **top level of the node's `inputs.detail`**. 
 
 ### Array-shaped fields
 


### PR DESCRIPTION
**Jira:** [ENGCE-57552](https://uipath.atlassian.net/browse/ENGCE-57552) — `[Skills][CLI] Add support for array filter in trigger`
**RCA:** [ENGCE-57498](https://uipath.atlassian.net/browse/ENGCE-57498) — Gmail Email Received trigger returns 400 on Debug ([Confluence](https://uipath.atlassian.net/wiki/spaces/INSCE/pages/90646937757/))
**Companion PR:** [skills #N — array filter smoke test](#) (the matching `trigger_with_array_filter.yaml` eval ships separately so reviewers can land docs and tests independently).


Expected 

**No user configured filters**
filterExpression: "(ParentFolders[?ID=='INBOX'])"


**Actual agent generated**
<img width="1819" height="927" alt="image" src="https://github.com/user-attachments/assets/e0d335b5-4d22-4f9b-8e5e-16bc12de8a95" />

Both work as expected

[ENGCE-57552]: https://uipath.atlassian.net/browse/ENGCE-57552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ENGCE-57498]: https://uipath.atlassian.net/browse/ENGCE-57498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ