### PR TITLE
fix(smoke-rpa): de-flake coded-test-case and uia-google-search smoke tasks

### DIFF
--- a/skills/uipath-rpa/assets/before-after-hooks-template.md
+++ b/skills/uipath-rpa/assets/before-after-hooks-template.md
@@ -58,9 +58,8 @@ namespace {{PROJECT_NAME}}
         {
             Log($"[BEFORE] Execution started for {context.RelativeFilePath}");
 
-            // Stub is acceptable when no Object Repository targets are configured.
-            // Real call (requires OR targets):
-            //     var app = uiAutomation.Open("myApp");
+            // Example: Open application
+            // var app = uiAutomation.Open("myApp");
 
             // Example: Log in
             // Login("testuser", "password");
@@ -70,9 +69,8 @@ namespace {{PROJECT_NAME}}
         {
             Log($"[AFTER] Execution finished for {context.RelativeFilePath}");
 
-            // Stub is acceptable when no Object Repository targets are configured.
-            // Real call (requires OR targets):
-            //     uiAutomation.Close(app);
+            // Example: Close application
+            // uiAutomation.Close(app);
 
             // Example: Clean up test data
             // DeleteTestData();

--- a/skills/uipath-rpa/assets/before-after-hooks-template.md
+++ b/skills/uipath-rpa/assets/before-after-hooks-template.md
@@ -58,8 +58,9 @@ namespace {{PROJECT_NAME}}
         {
             Log($"[BEFORE] Execution started for {context.RelativeFilePath}");
 
-            // Example: Open application
-            // var app = uiAutomation.Open("myApp");
+            // Stub is acceptable when no Object Repository targets are configured.
+            // Real call (requires OR targets):
+            //     var app = uiAutomation.Open("myApp");
 
             // Example: Log in
             // Login("testuser", "password");
@@ -69,8 +70,9 @@ namespace {{PROJECT_NAME}}
         {
             Log($"[AFTER] Execution finished for {context.RelativeFilePath}");
 
-            // Example: Close application
-            // uiAutomation.Close(app);
+            // Stub is acceptable when no Object Repository targets are configured.
+            // Real call (requires OR targets):
+            //     uiAutomation.Close(app);
 
             // Example: Clean up test data
             // DeleteTestData();

--- a/tests/tasks/uipath-rpa/coded_test_case.yaml
+++ b/tests/tasks/uipath-rpa/coded_test_case.yaml
@@ -32,7 +32,13 @@ initial_prompt: |
         (the partial-class pattern from the skill — NOT a base class, NOT
         a separate `CodedWorkflowHooks` class). The file extends the
         existing `CodedWorkflow` partial declared by the project.
-      * Browser open in `Before(...)`, browser close in `After(...)`.
+      * `Before(...)` and `After(...)` may contain stub bodies — a
+        `Log(...)` call or a comment describing the intended browser
+        open/close is fine. Do NOT install
+        `UiPath.UIAutomation.Activities` or chase the `uiAutomation`
+        service in coded mode for this task; the test scaffold has no
+        Object Repository targets configured, and the rubric validates
+        the partial-class hook *shape*, not real browser automation.
   - Create one coded test case `LoginTests/TestLoginSuccess.cs`:
       * Class `TestLoginSuccess : CodedWorkflow` with the `[TestCase]`
         attribute on the `Execute` method.

--- a/tests/tasks/uipath-rpa/uia_google_search.yaml
+++ b/tests/tasks/uipath-rpa/uia_google_search.yaml
@@ -43,11 +43,11 @@ llm_reviewer:
     - GoogleSearch/Main.xaml opens chrome.exe at google.com, types
       "UiPath automation" into the search box, and clicks the search
       button, using the three known selectors (chrome.exe URL,
-      textarea name='q', input name='btnK'). Either modern
-      (NApplicationCard + NTypeInto + NClick) or classic
-      (OpenBrowser + TypeInto + Click) is acceptable in CI — the
-      modern Object Repository / configure-target pipeline can't run
-      without an interactive Studio session.
+      textarea name='q', input name='btnK'). Use the modern Nx
+      activities (NApplicationCard + NTypeInto + NClick); the classic
+      OpenBrowser + TypeInto + Click triple is not a clean fit.
+      The Object Repository / configure-target
+      pipeline can't run without an interactive Studio session.
     - The harness runs `uip rpa build` programmatically; the build's
       exit code is the compile gate.
 
@@ -70,14 +70,19 @@ initial_prompt: |
     Input:  webctrl tag='textarea' name='q'
     Button: webctrl tag='input' name='btnK' type='submit'
 
-  Use whichever `UiPath.UIAutomation.Activities` activities you need
-  to open the browser, type the query, and click search — both modern
-  (`NApplicationCard` + `NTypeInto` + `NClick`) and classic
-  (`OpenBrowser` + `TypeInto` + `Click`) shapes are acceptable as long
-  as the project compiles. Author the XAML directly with the selectors
-  above; do NOT engage the multi-phase `uia-configure-target` /
-  Object Repository pipeline — Studio is not running interactively in
-  CI, so its OR registration steps can't complete and will time out.
+  Use the modern `UiPath.UIAutomation.Activities` Nx activities
+  (`NApplicationCard` + `NTypeInto` + `NClick`) to open the browser,
+  type the query, and click search. The classic
+  `OpenBrowser` / inline-selector `TypeInto` / `Click` triple is
+  not a clean fit — do NOT pivot to it if the
+  modern Nx activities look unavailable in the installed package
+  version; instead, update `UiPath.UIAutomation.Activities` to a
+  version that surfaces the Nx classes (`find-activities` reports
+  the version they ship in). Author the XAML directly with the
+  selectors above; do NOT engage the multi-phase
+  `uia-configure-target` / Object Repository pipeline — Studio is
+  not running interactively in CI, so its OR registration steps
+  can't complete and will time out.
 
   Follow the uipath-rpa skill's normal flow for everything else
   (project scaffolding, validation). The `uip` CLI is authenticated

--- a/tests/tasks/uipath-rpa/uia_google_search.yaml
+++ b/tests/tasks/uipath-rpa/uia_google_search.yaml
@@ -72,17 +72,12 @@ initial_prompt: |
 
   Use the modern `UiPath.UIAutomation.Activities` Nx activities
   (`NApplicationCard` + `NTypeInto` + `NClick`) to open the browser,
-  type the query, and click search. The classic
-  `OpenBrowser` / inline-selector `TypeInto` / `Click` triple is
-  not a clean fit — do NOT pivot to it if the
-  modern Nx activities look unavailable in the installed package
-  version; instead, update `UiPath.UIAutomation.Activities` to a
-  version that surfaces the Nx classes (`find-activities` reports
-  the version they ship in). Author the XAML directly with the
-  selectors above; do NOT engage the multi-phase
-  `uia-configure-target` / Object Repository pipeline — Studio is
-  not running interactively in CI, so its OR registration steps
-  can't complete and will time out.
+  type the query, and click search. Do NOT pivot to classic
+  activities; update the package if the Nx classes are missing.
+  Author the XAML directly with the selectors above; do NOT engage
+  the multi-phase `uia-configure-target` / Object Repository
+  pipeline — Studio is not running interactively in CI, so its OR
+  registration steps can't complete and will time out.
 
   Follow the uipath-rpa skill's normal flow for everything else
   (project scaffolding, validation). The `uip` CLI is authenticated
@@ -114,7 +109,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Main.xaml contains TypeInto + Click UIA activities (modern or classic)"
+    description: "Main.xaml contains NTypeInto + NClick Nx UIA activities"
     path: "GoogleSearch/Main.xaml"
     includes:
       - "TypeInto"


### PR DESCRIPTION
- Force modern Nx UIA activities (`NApplicationCard` + `NTypeInto` + `NClick`) in
  `uia_google_search.yaml`; drop the "or classic" fallback that caused 30+-turn
  version-mismatch oscillation when the scaffolded package didn't expose Nx.
  - Permit stub `Before`/`After` bodies in `coded_test_case.yaml`; tell the agent
  **not** to install `UiPath.UIAutomation.Activities` or chase the `uiAutomation`
  service in coded mode for this task — the CI sandbox has no Object Repository
  targets and the rubric only validates the hook *shape*.
  - Both target the same failure class on `smoke-rpa-skills.yml`: same task, same
  model, same package versions, but `MAX_TURNS_EXHAUSTED` vs `SUCCESS` depending on
  whether sampling lands the right pivot. Encode the pivot in the task prompt
  instead of leaving it to the model.
