### PR TITLE
test(uipath-agents): fill remaining coded-agent test gaps

### DIFF
--- a/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/antipattern_openai_agents_hitl.yaml
+++ b/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/antipattern_openai_agents_hitl.yaml
@@ -1,0 +1,112 @@
+task_id: skill-agent-coded-antipattern-openai-agents-hitl
+description: >
+  Negative test for the OpenAI Agents framework capability boundary:
+  OpenAI Agents has NO first-class HITL support
+  (`references/coded/capabilities/human-in-the-loop.md` and
+  `frameworks/openai-agents-integration.md`). The seed wires up
+  `interrupt(...)` — a LangGraph primitive — inside an OpenAI Agents
+  project. The skill must recognise the framework/feature mismatch
+  and remove the broken `interrupt(...)` invocation (and its
+  langgraph import) without breaking the OpenAI Agents shape. Closes
+  the explicit gap that no negative test enforces this constraint.
+tags: [uipath-agents, smoke, mode:build, coded, lifecycle:edit, feature:antipattern, feature:framework-openai-agents]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Recreate the UiPath coded agent project under `triage-broken/`
+  exactly as below, then review and fix anything that won't
+  actually work — in place. Keep the agent's existing behavior
+  (triaging customer messages between billing and technical
+  handlers); just make it correct.
+
+  **triage-broken/pyproject.toml**:
+  ```toml
+  [project]
+  name = "triage-broken"
+  version = "0.0.1"
+  description = "Triage bot (in-flight edit)"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath", "uipath-openai-agents"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **triage-broken/main.py**:
+  ```python
+  from agents import Agent, RunContextWrapper
+  from pydantic import BaseModel
+  from langgraph.types import interrupt
+
+
+  class CustomerCtx(BaseModel):
+      customer_id: str
+
+
+  def _maybe_pause(ctx: RunContextWrapper[CustomerCtx]) -> str:
+      decision = interrupt({"prompt": "Approve handoff?", "customer": ctx.context.customer_id})
+      return decision.get("status", "pending")
+
+
+  billing = Agent[CustomerCtx](
+      name="billing",
+      instructions="Handle billing questions.",
+  )
+
+  technical = Agent[CustomerCtx](
+      name="technical",
+      instructions="Handle technical questions.",
+  )
+
+
+  def main() -> Agent[CustomerCtx]:
+      return Agent[CustomerCtx](
+          name="triage",
+          instructions="Route to billing or technical, but call _maybe_pause first.",
+          handoffs=[billing, technical],
+      )
+  ```
+
+  **triage-broken/openai_agents.json**:
+  ```json
+  {"agents": {"agent": "./main.py:main"}}
+  ```
+
+  The graph must still expose a top-level `main` factory that
+  returns an `Agent`, and `openai_agents.json` must keep pointing
+  at it.
+
+  Do NOT publish, upload, or deploy. Do NOT pause between planning
+  and implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "main.py still exists under triage-broken/"
+    path: "triage-broken/main.py"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "openai_agents.json framework marker preserved"
+    path: "triage-broken/openai_agents.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "main.py no longer uses `interrupt(...)` or langgraph imports; OpenAI Agents `Agent` factory still exported"
+    command: "python3 $TASK_DIR/check_antipattern_openai_agents_hitl.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/check_antipattern_openai_agents_hitl.py
+++ b/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/check_antipattern_openai_agents_hitl.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Anti-pattern check — OpenAI Agents framework has no HITL.
+
+The skill documents that OpenAI Agents has no first-class HITL support;
+`interrupt(...)` is a LangGraph primitive. After the fix, asserts:
+
+  1. `main.py` no longer calls `interrupt(...)`.
+  2. `main.py` no longer imports from `langgraph.types` (that pulls in
+     the wrong framework's HITL primitive).
+  3. `main.py` still exports a `main` factory that returns an `Agent`
+     (OpenAI Agents shape preserved).
+  4. `openai_agents.json` still points at `./main.py:main`.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("triage-broken")
+MAIN = ROOT / "main.py"
+FRAMEWORK_JSON = ROOT / "openai_agents.json"
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _has_interrupt_call(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "interrupt":
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == "interrupt":
+                return True
+    return False
+
+
+def main() -> None:
+    if not MAIN.is_file():
+        fail(f"missing {MAIN}")
+    text = MAIN.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=str(MAIN))
+    except SyntaxError as exc:
+        fail(f"{MAIN} has a syntax error: {exc}")
+
+    if _has_interrupt_call(tree):
+        fail(
+            "main.py still calls `interrupt(...)`. "
+            "OpenAI Agents has no first-class HITL — `interrupt` is a LangGraph "
+            "primitive and does not work here. Remove the interrupt call (or, if "
+            "HITL is essential, migrate the project to LangGraph)."
+        )
+    print("OK: main.py no longer contains an `interrupt(...)` call")
+
+    if re.search(r"from\s+langgraph\.types\s+import", text):
+        fail(
+            "main.py still imports from `langgraph.types`. "
+            "That pulls in LangGraph primitives into an OpenAI Agents project. "
+            "Drop the import."
+        )
+    if re.search(r"^\s*import\s+langgraph\b", text, re.M):
+        fail("main.py still imports `langgraph`. Drop it — wrong framework.")
+    print("OK: main.py no longer imports from langgraph")
+
+    if not re.search(r"^\s*def\s+main\s*\(", text, re.M):
+        fail(
+            "main.py no longer defines a top-level `main` factory. "
+            "OpenAI Agents requires `def main() -> Agent` so `uip codedagent init` "
+            "can discover the entrypoint via `openai_agents.json`."
+        )
+    print("OK: top-level `main` factory function preserved")
+
+    if "Agent[" not in text and re.search(r"\bAgent\s*\(", text) is None:
+        fail(
+            "main.py no longer constructs an `Agent(...)` — the OpenAI Agents "
+            "primitive must remain. Replacing it with something else would break "
+            "the framework shape."
+        )
+    print("OK: `Agent` construction preserved")
+
+    if not FRAMEWORK_JSON.is_file():
+        fail(f"missing {FRAMEWORK_JSON} — framework marker must be preserved")
+    try:
+        payload = json.loads(FRAMEWORK_JSON.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"openai_agents.json is not valid JSON: {exc}")
+    target = (payload.get("agents") or {}).get("agent")
+    # Accept either "./main.py:main" or "main.py:main" — both forms are
+    # equivalent at runtime.
+    if target not in ("./main.py:main", "main.py:main"):
+        fail(
+            f"openai_agents.json `agents.agent` is {target!r}; "
+            "must point at `main.py:main` (the entrypoint that returns the Agent factory)"
+        )
+    print(f"OK: openai_agents.json still points at {target!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/auth_one_shot_login/auth_one_shot_login.yaml
+++ b/tests/tasks/uipath-agents/auth_one_shot_login/auth_one_shot_login.yaml
@@ -1,0 +1,84 @@
+task_id: skill-agent-coded-auth-one-shot-login
+description: >
+  Auth-shape integration test. Sandbox starts unauthenticated. The
+  skill must (1) check `uip login status --output json` once and
+  parse its output, (2) issue `uip login` in the one-shot form with
+  BOTH `--organization` and `--tenant` flags — never the interactive
+  picker, never without `--tenant` (Critical Rule 2 in
+  `authentication.md`). **Sandbox must start unauthenticated** for
+  this to be meaningful. The actual `uip login` call is allowed to
+  fail (no browser in the sandbox) — the test asserts COMMAND SHAPE,
+  not auth success.
+tags: [uipath-agents, integration, mode:build, coded, lifecycle:activate, feature:auth]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Connect to UiPath with these details:
+
+    - environment: cloud
+    - organization: acme
+    - tenant: DefaultTenant
+
+  Before doing anything else, capture the current login status
+  output (whatever it says — logged in or not) and save it to
+  `hello/auth-status.txt` so the result is on record.
+
+  Then scaffold a minimal coded agent named `hello` that echoes
+  back a `message` string. Do NOT run, publish, or deploy. Do NOT
+  pause between planning and implementation. Complete in a single
+  pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent checked login state up front (status --output json)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran `uip login` with both --organization AND --tenant (one-shot form)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+(?!status|tenant|logout)(?=.*--organization\b)(?=.*--tenant\b)'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent scaffolded the hello echo agent"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Scaffolded coded agent has the expected pyproject.toml"
+    path: "hello/pyproject.toml"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Login status output captured to auth-status.txt (proves the agent consumed the JSON, not just ran the command)"
+    path: "hello/auth-status.txt"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "auth-status.txt carries the Status field from `uip login status --output json`"
+    path: "hello/auth-status.txt"
+    includes:
+      - "Status"
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/coded_in_flow_published/check_coded_in_flow_published.py
+++ b/tests/tasks/uipath-agents/coded_in_flow_published/check_coded_in_flow_published.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Flow Integration Pattern 2 (Published coded agent) shape check.
+
+Asserts:
+  1. A `.flow` file exists somewhere under a `triage-flow` project that
+     is NOT colocated with the coded agent (no
+     `resources/solution_folder/process/agent/<name>.json` sibling — that
+     would indicate Pattern 1, not Pattern 2).
+  2. The flow file contains at least one node of type
+     `uipath.core.agent.<resourceKey>`.
+  3. That agent node's `model.section` is `"Published"` (the Pattern 2
+     marker per `flow-integration.md`'s Pattern Comparison table).
+  4. The flow file does NOT contain `"In this solution"` for that node
+     (would indicate Pattern 1).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+CWD = Path(os.getcwd())
+FLOW_PROJECT_HINT = "triage-flow"
+AGENT_PROJECT_HINT = "tone-classifier"
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def discover_flow_file() -> Path:
+    candidates = list(CWD.rglob("*.flow"))
+    if not candidates:
+        fail("no .flow file found anywhere under the working tree")
+    triage = [p for p in candidates if FLOW_PROJECT_HINT in str(p)]
+    if triage:
+        return triage[0]
+    return candidates[0]
+
+
+def assert_pattern_2_not_pattern_1(flow_path: Path) -> dict:
+    text = flow_path.read_text(encoding="utf-8")
+    try:
+        doc = json.loads(text)
+    except json.JSONDecodeError as exc:
+        fail(f"{flow_path} is not valid JSON: {exc}")
+
+    agent_nodes = re.findall(r'"uipath\.core\.agent\.[0-9a-fA-F-]{8,}"', text)
+    if not agent_nodes:
+        fail(
+            f"{flow_path} contains no `uipath.core.agent.<resourceKey>` node — "
+            "the flow must reference the published agent"
+        )
+    print(f"OK: flow references a uipath.core.agent.<key> node ({len(agent_nodes)} occurrence(s))")
+
+    if '"In this solution"' in text:
+        fail(
+            f"{flow_path} references the agent with `section: \"In this solution\"` — "
+            "that is Pattern 1 (in-solution). This test verifies Pattern 2 (Published). "
+            "The agent must be referenced as a Published resource."
+        )
+
+    if '"Published"' not in text:
+        fail(
+            f"{flow_path} does not contain `section: \"Published\"` for the agent node. "
+            "Pattern 2 requires the agent node's model.section to be 'Published'."
+        )
+    print("OK: agent node carries `section: \"Published\"` (Pattern 2)")
+
+    return doc
+
+
+def assert_not_in_solution_sibling() -> None:
+    # Pattern 1 places the resource manifest at
+    # `<Solution>/resources/solution_folder/process/agent/<name>.json`.
+    # Pattern 2 should NOT have one — the agent is a tenant-level resource,
+    # not a solution-local one.
+    matches = list(CWD.rglob("resources/solution_folder/process/agent/*.json"))
+    if matches:
+        fail(
+            "found in-solution resource manifest(s) at "
+            + ", ".join(str(p.relative_to(CWD)) for p in matches)
+            + " — these indicate Pattern 1 (in-solution), not Pattern 2 (published). "
+            "The coded agent must NOT be registered as a sibling of the flow."
+        )
+    print("OK: no in-solution resource manifest exists (correctly publishes as Pattern 2)")
+
+
+def main() -> None:
+    flow_path = discover_flow_file()
+    print(f"OK: discovered flow file {flow_path.relative_to(CWD)}")
+    assert_pattern_2_not_pattern_1(flow_path)
+    assert_not_in_solution_sibling()
+
+    agent_marker = next(CWD.rglob(f"{AGENT_PROJECT_HINT}/langgraph.json"), None)
+    if agent_marker is None:
+        fail(
+            f"coded agent project `{AGENT_PROJECT_HINT}` is missing its langgraph.json "
+            "— the agent must be a LangGraph project before it can be deployed and referenced"
+        )
+    print(f"OK: coded agent LangGraph marker present at {agent_marker.relative_to(CWD)}")
+
+    print("OK: Pattern 2 (Published coded agent) wiring verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded_in_flow_published/coded_in_flow_published.yaml
+++ b/tests/tasks/uipath-agents/coded_in_flow_published/coded_in_flow_published.yaml
@@ -1,0 +1,110 @@
+task_id: skill-agent-coded-in-flow-published
+description: >
+  End-to-end test for Flow Integration Pattern 2 — a Published coded
+  agent referenced from a Maestro Flow project. Verifies the agent is deployed to the personal workspace,
+  the registry is refreshed to surface the new published resource,
+  and a separate flow project references it as a
+  `uipath.core.agent.<resourceKey>` node with `section: "Published"`.
+  **Cross-cutting:** exercises both `uipath-agents` (coded scaffold +
+  deploy) and `uipath-maestro-flow` (flow validate + agent-node
+  wiring); skill ownership tagged to `uipath-agents` since this is a
+  coded-agent capability gap. **Cloud auth required** — the test runner
+  must have UiPath auth pre-configured and the deploy will create a
+  real published resource in the tenant's personal workspace.
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, shape:single-node, resource, feature:framework-langgraph]
+max_iterations: 1
+task_timeout: 1800
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1500
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a small UiPath coded agent named `tone-classifier` that
+  reads a short message and labels it as `friendly`, `neutral`,
+  or `frustrated`. Publish it into the personal workspace so it's
+  available as a regular UiPath resource.
+
+  Then, in a separate Maestro Flow project called `triage-flow`,
+  use that published `tone-classifier` agent as one of the steps.
+  The flow takes a `message` from the caller, hands it to the
+  classifier, and surfaces the resulting `label`.
+
+  The flow project must be its OWN project, NOT a sibling of the
+  coded agent under the same solution — the agent is consumed as
+  a published resource, not an in-solution component.
+
+  The test harness has UiPath auth pre-configured. Take everything
+  end-to-end: build the agent, publish it, set up the flow, wire
+  the agent in as a node, and make sure the flow validates. Do
+  NOT pause between planning and implementation. Complete in a
+  single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the coded agent"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent generated entry-points.json from the code"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deployed to the personal workspace (deploy or publish, --my-workspace)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+(deploy|publish)\s+.*--my-workspace'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the flow registry so the new published resource surfaces"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(pull|search)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created and validated the flow"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Coded agent project has the LangGraph marker"
+    path: "tone-classifier/langgraph.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow file references the agent as a `uipath.core.agent.<key>` node with section=\"Published\" (Pattern 2, NOT in-solution)"
+    command: "python3 $TASK_DIR/check_coded_in_flow_published.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/deploy_folder_and_rebump/check_deploy_folder_and_rebump.py
+++ b/tests/tasks/uipath-agents/deploy_folder_and_rebump/check_deploy_folder_and_rebump.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Deploy-to-folder + patch-bump-on-redeploy check.
+
+The agent must deploy twice to the same Orchestrator folder. The
+second deploy fails with `Version already exists` unless the agent
+bumps the patch version in `pyproject.toml` between the deploys
+(documented in the skill's Troubleshooting table).
+
+Asserts:
+  1. `acme-echo/pyproject.toml` is valid TOML with a `[project]` table.
+  2. The `version` follows semver `MAJOR.MINOR.PATCH`.
+  3. The `version` is strictly greater than `0.0.1` (the scaffold default
+     `uip codedagent new` writes). Any of `0.0.2`, `0.1.0`, `1.0.0`, etc.
+     proves a bump happened.
+  4. The edit landed: `main.py` mentions the `acme: ` prefix the user
+     asked for (otherwise the second deploy would be a no-op rebump).
+  5. No `[build-system]` section (Critical Rule C1).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+ROOT = Path(os.getcwd()) / "acme-echo"
+PYPROJECT = ROOT / "pyproject.toml"
+MAIN = ROOT / "main.py"
+
+SCAFFOLD_VERSION = (0, 0, 1)
+
+
+def parse_version(text: str) -> tuple[int, int, int]:
+    """Return (major, minor, patch) for the version inside [project]."""
+    in_project = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("["):
+            in_project = stripped == "[project]"
+            continue
+        if not in_project:
+            continue
+        m = re.match(r'^\s*version\s*=\s*"([^"]+)"\s*$', line)
+        if m:
+            parts = m.group(1).split(".")
+            if len(parts) != 3:
+                fail(f"version {m.group(1)!r} is not semver MAJOR.MINOR.PATCH")
+            try:
+                return (int(parts[0]), int(parts[1]), int(parts[2]))
+            except ValueError:
+                fail(f"version {m.group(1)!r} has non-integer components")
+    fail("`version =` not found inside [project] in pyproject.toml")
+    raise SystemExit(1)  # for type checkers
+
+
+def main() -> None:
+    if not PYPROJECT.is_file():
+        fail(f"missing {PYPROJECT}")
+    text = PYPROJECT.read_text(encoding="utf-8")
+
+    if re.search(r"^\s*\[build-system\]", text, re.M):
+        fail(
+            "pyproject.toml has a [build-system] section — Critical Rule C1: "
+            "UiPath coded agents do not use a build backend."
+        )
+    print("OK: pyproject.toml has no [build-system] section")
+
+    version = parse_version(text)
+    print(f"OK: pyproject.toml [project].version parses as {version}")
+    if version <= SCAFFOLD_VERSION:
+        fail(
+            f"version {version} is not greater than the scaffold default 0.0.1. "
+            "The second deploy fails with `Version already exists` unless the "
+            "patch was bumped — bump the version in pyproject.toml between the "
+            "two deploys."
+        )
+    print(f"OK: version {version} is greater than the scaffold default 0.0.1 — re-deploy bump happened")
+
+    if not MAIN.is_file():
+        fail(f"missing {MAIN}")
+    main_text = MAIN.read_text(encoding="utf-8")
+    if "acme: " not in main_text:
+        fail(
+            "main.py does not contain the `acme: ` prefix the user asked for in "
+            "the second iteration — the edit was not applied before the second deploy"
+        )
+    print("OK: main.py contains the `acme: ` prefix (edit applied)")
+
+    print("OK: deploy-to-folder + patch-bump roundtrip verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/deploy_folder_and_rebump/deploy_folder_and_rebump.yaml
+++ b/tests/tasks/uipath-agents/deploy_folder_and_rebump/deploy_folder_and_rebump.yaml
@@ -1,0 +1,81 @@
+task_id: skill-agent-coded-deploy-folder-and-rebump
+description: >
+  Deploy to a named Orchestrator folder (NOT `--my-workspace` — that
+  branch is already covered by `deploy_my_workspace`) and re-deploy
+  after a tiny code change. Exercises two deploy paths: (1) `uip codedagent deploy --folder
+  "<Name>"`, and (2) the troubleshooting row "Version already exists
+  on deploy → bump patch version in pyproject.toml". A second deploy
+  without the patch bump fails with `Version already exists`, so the
+  agent must update `pyproject.toml` between the two deploys.
+  **Cloud auth + a writable folder named `Shared` required** — the
+  test harness must provision or alias that folder for the tenant
+  identity before the agent turn starts.
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:deploy, feature:deploy]
+max_iterations: 1
+task_timeout: 1800
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1500
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a minimal echo agent named `acme-echo` that takes a
+  `message` (string) and returns `{"echoed": message}`. No LLM
+  needed.
+
+  Once it's working locally, ship it to the `Shared` folder in
+  Orchestrator. After that first ship, apply one small change so
+  the output prepends `"acme: "` — i.e. `main(message="hi")` now
+  returns `echoed="acme: hi"` — and ship to the same `Shared`
+  folder a second time.
+
+  The test harness has UiPath auth pre-configured and the
+  `Shared` folder already exists. Do NOT pause between planning
+  and implementation. Do NOT ask for approval, confirmation, or
+  feedback between the two ships. Complete end-to-end in a single
+  pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deployed to the `Shared` folder TWICE (initial + after edit)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+(deploy|publish)\s+.*--folder\s+["'']?Shared'
+    min_count: 2
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Coded agent project exists"
+    path: "acme-echo/pyproject.toml"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "pyproject.toml version was bumped past the scaffold default (0.0.1), proving the re-deploy bumped the patch"
+    command: "python3 $TASK_DIR/check_deploy_folder_and_rebump.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/existing_project_resume/check_existing_project_resume.py
+++ b/tests/tasks/uipath-agents/existing_project_resume/check_existing_project_resume.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Existing-coded project resume check.
+
+The seed left a half-finished LangGraph project on disk:
+  - has_venv == false, has_entry_points == false, scaffolding done.
+
+A correct resume:
+  - prepares the missing `.venv/`
+  - regenerates `entry-points.json` from the (edited) code
+  - preserves the original `mood` field in `main.py`
+  - adds the new `confidence` field to the output
+
+Asserts:
+  1. `mood-meter/.venv/` exists (the missing venv was prepped).
+  2. `mood-meter/entry-points.json` exists and advertises BOTH `mood`
+     and `confidence` as output fields.
+  3. `main.py` still defines a `mood` field (original logic kept).
+  4. `main.py` now defines a `confidence` field (new feature landed).
+  5. `main.py` still exports a top-level `graph =` variable
+     (LangGraph entrypoint preserved).
+  6. `pyproject.toml` still has no `[build-system]` section
+     (Critical Rule C1 — the resume must not introduce one).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "mood-meter"
+MAIN = ROOT / "main.py"
+ENTRY_POINTS = ROOT / "entry-points.json"
+PYPROJECT = ROOT / "pyproject.toml"
+VENV = ROOT / ".venv"
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        fail(f"missing project directory {ROOT}")
+
+    if not VENV.is_dir():
+        fail(
+            f"{VENV} does not exist. The seed had no `.venv/` (has_venv == false); "
+            "the skill must prep the missing venv on resume."
+        )
+    print("OK: .venv was prepped (has_venv flipped to true)")
+
+    if not ENTRY_POINTS.is_file():
+        fail(
+            f"{ENTRY_POINTS} missing. The seed had no `entry-points.json` "
+            "(has_entry_points == false); the skill must regenerate the schema "
+            "via `uip codedagent init` on resume."
+        )
+    try:
+        ep_payload = json.loads(ENTRY_POINTS.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"entry-points.json is not valid JSON: {exc}")
+    serialized = json.dumps(ep_payload)
+    if "mood" not in serialized:
+        fail("entry-points.json does not advertise the original `mood` field — schema may have been clobbered")
+    if "confidence" not in serialized:
+        fail(
+            "entry-points.json does not advertise the new `confidence` field. "
+            "Either the edit was missing, or `uip codedagent init` was not re-run "
+            "after the edit to pick up the new output."
+        )
+    print("OK: entry-points.json advertises both `mood` and `confidence`")
+
+    if not MAIN.is_file():
+        fail(f"missing {MAIN}")
+    main_text = MAIN.read_text(encoding="utf-8")
+    if "mood" not in main_text:
+        fail(
+            "main.py no longer mentions `mood`. The resume must edit IN PLACE; "
+            "the original feature must survive."
+        )
+    print("OK: main.py preserves the original `mood` field")
+
+    if "confidence" not in main_text:
+        fail("main.py does not contain the new `confidence` field — the feature was not added")
+    print("OK: main.py adds the new `confidence` field")
+
+    if not re.search(r"^\s*graph\s*=\s*", main_text, re.M):
+        fail("main.py no longer exports a top-level `graph =` variable — LangGraph entrypoint broken")
+    print("OK: top-level `graph` variable still exported")
+
+    if not PYPROJECT.is_file():
+        fail(f"missing {PYPROJECT}")
+    if re.search(r"^\s*\[build-system\]", PYPROJECT.read_text(encoding="utf-8"), re.M):
+        fail("pyproject.toml gained a [build-system] section — Critical Rule C1 violation")
+    print("OK: pyproject.toml still has no [build-system] section")
+
+    print("OK: existing-coded resume completed without clobbering")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/existing_project_resume/existing_project_resume.yaml
+++ b/tests/tasks/uipath-agents/existing_project_resume/existing_project_resume.yaml
@@ -1,0 +1,130 @@
+task_id: skill-agent-coded-existing-project-resume
+description: >
+  Coded-agent resume scenario for `project_state == existing-coded`
+  with `has_venv == false` AND `has_entry_points == false`. The
+  prompt seeds a LangGraph project on disk; the skill must detect
+  that scaffolding is already done, prep the missing venv,
+  regenerate the schema from the existing code, and edit `main.py`
+  in place — without ever running `uip codedagent new` (which
+  would clobber the existing project).
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:edit, feature:framework-langgraph, feature:schema-sync]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Recreate the half-finished coded agent project under
+  `mood-meter/` exactly as below, then pick it up from this
+  state and add one small feature.
+
+  **mood-meter/pyproject.toml**:
+  ```toml
+  [project]
+  name = "mood-meter"
+  version = "0.0.1"
+  description = "Half-finished mood detector"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath", "uipath-langchain"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **mood-meter/main.py**:
+  ```python
+  from typing_extensions import TypedDict
+  from langgraph.graph import StateGraph, START, END
+  from pydantic import BaseModel
+
+
+  class GraphInput(BaseModel):
+      text: str
+
+
+  class GraphOutput(BaseModel):
+      mood: str
+
+
+  class GraphState(TypedDict):
+      text: str
+      mood: str
+
+
+  async def classify_mood(state: GraphState):
+      lower = state["text"].lower()
+      if "great" in lower or "love" in lower:
+          mood = "happy"
+      elif "bad" in lower or "hate" in lower:
+          mood = "sad"
+      else:
+          mood = "neutral"
+      return {"mood": mood}
+
+
+  builder = StateGraph(GraphState, input_schema=GraphInput, output_schema=GraphOutput)
+  builder.add_node("classify_mood", classify_mood)
+  builder.add_edge(START, "classify_mood")
+  builder.add_edge("classify_mood", END)
+  graph = builder.compile()
+  ```
+
+  **mood-meter/langgraph.json**:
+  ```json
+  {"graphs": {"agent": "./main.py:graph"}}
+  ```
+
+  Do NOT create any other files in the seed. Specifically, there
+  is NO `.venv/` and NO `entry-points.json` — that is part of the
+  starting state.
+
+  The feature to add: alongside the existing `mood`, the output
+  must also include a `confidence` field — a float between `0.0`
+  and `1.0` indicating how sure the agent is about the mood label.
+  A simple heuristic (e.g. number of matching keywords / something
+  bounded) is fine. After the change, run the agent locally with
+  `{"text": "I really love how great this is"}` and write the
+  result to `mood-meter/run_result.json`.
+
+  Do NOT publish, upload, or deploy. Do NOT call `uip login`. Do
+  NOT pause between planning and implementation. Complete
+  end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent regenerated entry-points.json from the (now-edited) code"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran the agent locally to verify the new feature"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run\s+agent'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Run result captured for sanity-check"
+    path: "mood-meter/run_result.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Existing project preserved + feature added + venv prepped + schema regenerated"
+    command: "python3 $TASK_DIR/check_existing_project_resume.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/hitl_create_task_with_app/check_hitl_create_task_with_app.py
+++ b/tests/tasks/uipath-agents/hitl_create_task_with_app/check_hitl_create_task_with_app.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""HITL `interrupt(CreateTask)` shape check — regular Action Center task (NOT escalation).
+
+Asserts:
+  1. `main.py` imports `interrupt` from `langgraph.types`.
+  2. `main.py` imports `CreateTask` from `uipath.platform.common`.
+  3. At least one `interrupt(CreateTask(...))` call site exists.
+  4. The `CreateTask` call targets `app_name="RefundReview"`,
+     `app_folder_path="Compliance"`.
+  5. `main.py` does NOT use `CreateEscalation` (that's a different pattern
+     covered by hitl_create_task — keep them disjoint).
+  6. `bindings.json` declares the `app` resource for `RefundReview` /
+     `Compliance`.
+  7. A top-level `graph =` variable is exported.
+  8. No module-level UiPath* construction (Critical Rule C4).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import (  # noqa: E402
+    load_bindings,
+    find_resource,
+    assert_value_field,
+    assert_metadata_field,
+)
+
+ROOT = find_project_root("refund-gate")
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def find_graph_module() -> Path:
+    for candidate in ("main.py", "graph.py"):
+        path = ROOT / candidate
+        if path.is_file():
+            return path
+    fail(f"neither main.py nor graph.py found under {ROOT}")
+    raise SystemExit(1)
+
+
+def module_constants(tree: ast.Module) -> dict[str, object]:
+    consts: dict[str, object] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    consts[tgt.id] = node.value.value
+    return consts
+
+
+def resolve_kwarg(value: ast.expr, consts: dict[str, object]) -> object | None:
+    if isinstance(value, ast.Constant):
+        return value.value
+    if isinstance(value, ast.Name) and value.id in consts:
+        return consts[value.id]
+    return None
+
+
+def find_create_task_call(tree: ast.Module) -> ast.Call | None:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "interrupt"):
+            continue
+        if not node.args:
+            continue
+        inner = node.args[0]
+        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id == "CreateTask":
+            return inner
+    return None
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        fail(f"project directory {ROOT} does not exist")
+
+    module = find_graph_module()
+    text = module.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=str(module))
+    except SyntaxError as exc:
+        fail(f"{module} has a syntax error: {exc}")
+
+    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+        fail("missing `from langgraph.types import interrupt`")
+    print("OK: imports `interrupt` from langgraph.types")
+
+    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateTask\b", text):
+        fail(
+            "missing `from uipath.platform.common import CreateTask`. "
+            "The scenario opens a new Action Center task — use `CreateTask`."
+        )
+    print("OK: imports CreateTask from uipath.platform.common")
+
+    if re.search(r"\bCreateEscalation\s*\(", text):
+        fail(
+            "main.py invokes `CreateEscalation(...)`. The scenario is a regular "
+            "compliance review, not an escalation. Use `CreateTask` only."
+        )
+    print("OK: no CreateEscalation usage (scenario is the regular task pattern)")
+
+    call = find_create_task_call(tree)
+    if call is None:
+        fail("no `interrupt(CreateTask(...))` call site found")
+
+    consts = module_constants(tree)
+    kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
+    expected = {"app_name": "RefundReview", "app_folder_path": "Compliance"}
+    for kw, want in expected.items():
+        if kw not in kwargs:
+            fail(f"`CreateTask(...)` is missing `{kw}=`")
+        got = resolve_kwarg(kwargs[kw], consts)
+        if got != want:
+            fail(f"`CreateTask({kw}=...)` resolves to {got!r}, expected {want!r}")
+    print('OK: CreateTask targets app_name="RefundReview" / app_folder_path="Compliance"')
+
+    if not re.search(r"^\s*graph\s*=\s*", text, re.M):
+        fail("main.py does not export a top-level `graph =` variable")
+    print("OK: top-level `graph` variable exported")
+
+    violations = find_module_level_llm_clients(module)
+    if violations:
+        fail("module-level UiPath* construction (C4): " + " | ".join(violations))
+    print("OK: no module-level UiPath* construction")
+
+    doc = load_bindings(ROOT / "bindings.json")
+    entry = find_resource(doc, resource="app", key="RefundReview.Compliance")
+    assert_value_field(entry, field="name", expected="RefundReview")
+    assert_value_field(entry, field="folderPath", expected="Compliance")
+    assert_metadata_field(entry, field="ActivityName", expected="create_async")
+    assert_metadata_field(entry, field="DisplayLabel", expected="RefundReview")
+    print("OK: bindings.json declares the RefundReview/Compliance `app` resource")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -1,0 +1,80 @@
+task_id: skill-agent-coded-hitl-create-task-with-app
+description: >
+  Coded-agent HITL via `interrupt(CreateTask(...))` — the regular
+  Action Center task pattern (NOT escalation). Distinct from
+  `hitl_create_task` (which targets `CreateEscalation`) and from
+  `hitl_wait_task` (which monitors an existing task). Verifies the
+  agent imports `CreateTask` from `uipath.platform.common`, wires
+  `interrupt(CreateTask(app_name=..., app_folder_path=..., title=...,
+  data={...}, assignee=...))` into a graph node, and emits the
+  matching `app` resource binding. 
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-langgraph, feature:hitl-coded]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath agent named `refund-gate`. When asked to issue a
+  refund over $500, the agent must pause and file a structured
+  request for a reviewer on the Compliance team in their
+  `RefundReview` Action Center app (folder `Compliance`); the
+  reviewer needs the customer, amount, and stated reason. Once
+  the reviewer replies, the agent continues and produces a final
+  outcome stating whether to issue the refund and the reviewer's
+  note. Refunds at or below $500 go through without review.
+
+  Make sure the Compliance app is wired up as a resource for this
+  agent — without that the request can't be filed.
+
+  Inputs:
+    - `customer` (string)
+    - `amount` (number)
+    - `reason` (string)
+
+  Outputs:
+    - `issue_refund` (bool)
+    - `reviewer_note` (string|null)
+
+  Take the agent through scaffold → schema sync. Do NOT run,
+  publish, upload, or deploy. Do NOT call `uip login`. Do NOT pause
+  between planning and implementation. Complete end-to-end in a
+  single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent regenerated schemas from the code"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "LangGraph project config present"
+    path: "langgraph.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "interrupt(CreateTask) shape (not CreateEscalation), correct app targeting, RefundReview/Compliance app binding"
+    command: "python3 $TASK_DIR/check_hitl_create_task_with_app.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/hitl_wait_task/check_hitl_wait_task.py
+++ b/tests/tasks/uipath-agents/hitl_wait_task/check_hitl_wait_task.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""HITL `interrupt(WaitTask)` shape check.
+
+This is the "wait on a task that already exists" pattern, distinct from
+`CreateTask` / `CreateEscalation` (which open a new task). Asserts:
+
+  1. `main.py` imports `interrupt` from `langgraph.types`.
+  2. `main.py` imports `WaitTask` from `uipath.platform.common`.
+  3. At least one `interrupt(WaitTask(...))` call exists.
+  4. `main.py` does NOT use `CreateTask` / `CreateEscalation` — the
+     scenario is monitoring an existing task, not creating one.
+  5. A top-level `graph =` variable is exported (LangGraph entrypoint).
+  6. No module-level UiPath* client construction (Critical Rule C4).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+
+ROOT = find_project_root("purchase-gate")
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def find_graph_module() -> Path:
+    for candidate in ("main.py", "graph.py"):
+        path = ROOT / candidate
+        if path.is_file():
+            return path
+    fail(f"neither main.py nor graph.py found under {ROOT}")
+    raise SystemExit(1)  # unreachable, for type checkers
+
+
+def has_interrupt_wait_task(tree: ast.Module) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not (isinstance(func, ast.Name) and func.id == "interrupt"):
+            continue
+        if not node.args:
+            continue
+        inner = node.args[0]
+        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id == "WaitTask":
+            return True
+    return False
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        fail(f"project directory {ROOT} does not exist")
+
+    module = find_graph_module()
+    text = module.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=str(module))
+    except SyntaxError as exc:
+        fail(f"{module} has a syntax error: {exc}")
+
+    if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
+        fail("missing `from langgraph.types import interrupt`")
+    print("OK: imports `interrupt` from langgraph.types")
+
+    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bWaitTask\b", text):
+        fail(
+            "missing `from uipath.platform.common import WaitTask`. "
+            "The scenario is `WaitTask` (wait on an existing Action Center task), "
+            "not `CreateTask` (which opens a new one)."
+        )
+    print("OK: imports WaitTask from uipath.platform.common")
+
+    if not has_interrupt_wait_task(tree):
+        fail(
+            "no `interrupt(WaitTask(...))` call site found. "
+            "The agent must pause on the existing task via `interrupt(WaitTask(action=...))`."
+        )
+    print("OK: graph node calls interrupt(WaitTask(...))")
+
+    if re.search(r"\bCreateTask\s*\(", text) or re.search(r"\bCreateEscalation\s*\(", text):
+        fail(
+            "main.py invokes `CreateTask(...)` or `CreateEscalation(...)`. "
+            "Those open a NEW Action Center task — the scenario is monitoring an "
+            "ALREADY-CREATED task via `WaitTask`. Use `WaitTask` only."
+        )
+    print("OK: no CreateTask / CreateEscalation usage (scenario is monitor-existing-task)")
+
+    if not re.search(r"^\s*graph\s*=\s*", text, re.M):
+        fail("main.py does not export a top-level `graph =` variable")
+    print("OK: top-level `graph` variable exported")
+
+    violations = find_module_level_llm_clients(module)
+    if violations:
+        fail("module-level UiPath* construction (C4): " + " | ".join(violations))
+    print("OK: no module-level UiPath* construction")
+
+    print("OK: WaitTask HITL shape verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/hitl_wait_task/hitl_wait_task.yaml
+++ b/tests/tasks/uipath-agents/hitl_wait_task/hitl_wait_task.yaml
@@ -1,0 +1,78 @@
+task_id: skill-agent-coded-hitl-wait-task
+description: >
+  Coded-agent HITL via `interrupt(WaitTask(...))` — the "wait for an
+  already-created Action Center task" pattern. Verifies the agent
+  imports `interrupt` from `langgraph.types` and `WaitTask` from
+  `uipath.platform.common`, wires a graph node that pauses on a task
+  the caller passes in, and keeps the resume payload available for a
+  downstream node. Distinct from `CreateTask` / `CreateEscalation`
+  (those make a new task).
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-langgraph, feature:hitl-coded]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath agent named `purchase-gate` that closes the loop
+  on purchase requests already opened for human review elsewhere.
+  An Action Center task has already been filed by someone else and
+  is handed to the agent as input. The agent must pause until the
+  reviewer completes that existing task, then read the decision
+  and produce a short, structured outcome.
+
+  Inputs:
+    - `task` — the Action Center task object that's already open
+      and waiting for a human (treat it as the action the agent
+      should monitor).
+    - `request_summary` — a one-line description of the purchase,
+      useful for context.
+
+  Outputs:
+    - `approved` (bool) — true if the reviewer marked the task
+      approved, false otherwise.
+    - `reviewer_note` (string) — whatever free-form note the
+      reviewer left.
+
+  Take the agent through scaffold → schema sync. Do NOT run,
+  publish, upload, or deploy. Do NOT call `uip login`. Do NOT pause
+  between planning and implementation. Complete end-to-end in a
+  single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent regenerated schemas from the code"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "LangGraph project config present"
+    path: "langgraph.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "interrupt(WaitTask) shape, correct imports, no CreateTask/CreateEscalation, graph exported"
+    command: "python3 $TASK_DIR/check_hitl_wait_task.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/llamaindex_rag/check_llamaindex_rag.py
+++ b/tests/tasks/uipath-agents/llamaindex_rag/check_llamaindex_rag.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""LlamaIndex Workflow + UiPath Context Grounding RAG check.
+
+Asserts:
+  1. `hr-helper/llama_index.json` exists and points at a workflow inside
+     `main.py` (LlamaIndex framework was correctly selected).
+  2. `main.py` imports `Workflow` and `step` from `llama_index.core.workflow`
+     and decorates at least one method with `@step`.
+  3. `main.py` imports `ContextGroundingQueryEngine` from
+     `uipath_llamaindex.query_engines` — the UiPath RAG primitive.
+  4. The query engine is instantiated with `index_name="hr-policy"`
+     (the index the user named in the prompt).
+  5. `pyproject.toml` includes `uipath-llamaindex` as a dependency.
+  6. No module-level UiPath* client construction (Critical Rule C4 —
+     LLM clients must be lazy inside a `@step` body, never class- or
+     module-level).
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("hr-helper")
+MAIN = ROOT / "main.py"
+LLAMA_JSON = ROOT / "llama_index.json"
+PYPROJECT = ROOT / "pyproject.toml"
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def find_call(tree: ast.Module, func_name: str) -> ast.Call | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == func_name:
+            return node
+    return None
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        fail(f"project directory {ROOT} does not exist")
+
+    if not LLAMA_JSON.is_file():
+        fail(f"missing {LLAMA_JSON} — LlamaIndex was not selected as the framework")
+    try:
+        cfg = json.loads(LLAMA_JSON.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"llama_index.json is not valid JSON: {exc}")
+    workflows = cfg.get("workflows") or cfg.get("graphs") or {}
+    if not workflows:
+        fail("llama_index.json has no `workflows` entries")
+    if not any("./main.py" in str(v) for v in workflows.values()):
+        fail(f"llama_index.json workflows do not point at ./main.py: {workflows}")
+    print("OK: llama_index.json points at a workflow in main.py")
+
+    if not MAIN.is_file():
+        fail(f"missing {MAIN}")
+    text = MAIN.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=str(MAIN))
+    except SyntaxError as exc:
+        fail(f"main.py has a syntax error: {exc}")
+
+    if not re.search(r"from\s+llama_index\.core\.workflow\s+import\s+[^\n]*\bWorkflow\b", text):
+        fail("main.py does not import `Workflow` from `llama_index.core.workflow`")
+    if not re.search(r"from\s+llama_index\.core\.workflow\s+import\s+[^\n]*\bstep\b", text):
+        fail("main.py does not import `step` from `llama_index.core.workflow`")
+    if not re.search(r"@step\b", text):
+        fail("main.py has no `@step` decorator — the workflow nodes must be marked with @step")
+    print("OK: LlamaIndex Workflow shape (Workflow import + @step decorator) present")
+
+    if not re.search(r"from\s+uipath_llamaindex\.query_engines\s+import\s+[^\n]*\bContextGroundingQueryEngine\b", text):
+        fail(
+            "main.py does not import `ContextGroundingQueryEngine` from "
+            "`uipath_llamaindex.query_engines`. That is the UiPath RAG primitive "
+            "for LlamaIndex — use it to ground answers in the index."
+        )
+    print("OK: imports ContextGroundingQueryEngine from uipath_llamaindex.query_engines")
+
+    call = find_call(tree, "ContextGroundingQueryEngine")
+    if call is None:
+        fail("no `ContextGroundingQueryEngine(...)` call site found")
+    kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
+    name_node = kwargs.get("index_name")
+    if name_node is None or not (isinstance(name_node, ast.Constant) and name_node.value == "hr-policy"):
+        got = getattr(name_node, "value", name_node)
+        fail(
+            f"`ContextGroundingQueryEngine(index_name=...)` resolves to {got!r}, "
+            "expected 'hr-policy' (the index the user named in the prompt)"
+        )
+    print('OK: ContextGroundingQueryEngine bound to index_name="hr-policy"')
+
+    if not PYPROJECT.is_file():
+        fail(f"missing {PYPROJECT}")
+    pyp = PYPROJECT.read_text(encoding="utf-8")
+    if "uipath-llamaindex" not in pyp:
+        fail(
+            "pyproject.toml does not declare `uipath-llamaindex` — required for "
+            "LlamaIndex coded agents (it registers the LlamaIndex runtime factory)"
+        )
+    print("OK: pyproject.toml includes `uipath-llamaindex`")
+
+    violations = find_module_level_llm_clients(MAIN)
+    if violations:
+        fail("module-level UiPath* construction (C4): " + " | ".join(violations))
+    print("OK: no module-level UiPath* construction")
+
+    print("OK: LlamaIndex + Context Grounding RAG wiring verified")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/llamaindex_rag/llamaindex_rag.yaml
+++ b/tests/tasks/uipath-agents/llamaindex_rag/llamaindex_rag.yaml
@@ -1,0 +1,73 @@
+task_id: skill-agent-coded-llamaindex-rag
+description: >
+  LlamaIndex Workflow + UiPath Context Grounding RAG. Verifies the
+  skill picks LlamaIndex for a RAG scenario, scaffolds the project,
+  wires `ContextGroundingQueryEngine` from
+  `uipath_llamaindex.query_engines`, and binds it to the named
+  index in the prompt. The framework choice is a deliberate test of
+  the skill's framework-selection logic — the prompt names neither
+  the framework nor the RAG primitive.
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-llamaindex, feature:rag-coded]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a UiPath coded agent named `hr-helper` that answers
+  employee questions about HR policy. The agent reads the
+  question, looks up the relevant passages in the company
+  knowledge base, and returns an answer grounded in what it
+  found.
+
+  The knowledge base is already set up as an index named
+  `hr-policy` inside the `Shared` folder.
+
+  Inputs:
+    - `question` (string)
+
+  Outputs:
+    - `answer` (string)
+
+  Take the agent through scaffold → schema sync. Do NOT run,
+  publish, upload, or deploy. Do NOT call `uip login`. Do NOT
+  pause between planning and implementation. Complete end-to-end
+  in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent regenerated schemas from the code"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "LlamaIndex framework marker present (proves framework selection)"
+    path: "llama_index.json"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "LlamaIndex Workflow shape + UiPath ContextGroundingQueryEngine wired to the `hr-policy` index"
+    command: "python3 $TASK_DIR/check_llamaindex_rag.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/local_workspace_iterate/check_local_workspace_iterate.py
+++ b/tests/tasks/uipath-agents/local_workspace_iterate/check_local_workspace_iterate.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Local Workspace iteration check — preserve SW-owned files, edit the graph, run both branches.
+
+Asserts:
+  1. `.sw-path-marker` and `.local/folder.lock` are still present (untouched).
+  2. `project.uiproj` still exists (Local Workspace anti-pattern: do not delete it).
+  3. `.env` still contains the original `UIPATH_PROJECT_ID=ws-baseline-...` sentinel.
+  4. `main.py` declares a `category` field on the LangGraph output schema.
+  5. `entry-points.json` advertises a `category` output (init regenerated the schema).
+  6. `outputs.json` captured a `tiny` run for value=2 and a `huge` run for value=150.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "GateSol"
+AGENT_DIR = ROOT / "gate-agent"
+MAIN = AGENT_DIR / "main.py"
+ENTRY_POINTS = AGENT_DIR / "entry-points.json"
+ENV_FILE = AGENT_DIR / ".env"
+PROJECT_UIPROJ = AGENT_DIR / "project.uiproj"
+SW_MARKER = ROOT / ".sw-path-marker"
+FOLDER_LOCK = ROOT / ".local" / "folder.lock"
+OUTPUTS = AGENT_DIR / "outputs.json"
+
+SENTINEL_PROJECT_ID = "ws-baseline-00000000-0000-0000-0000-000000000000"
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def main() -> None:
+    # --- Studio Web ownership preserved ---
+    if not SW_MARKER.is_file():
+        fail(f"missing Studio Web detection marker {SW_MARKER} — Local Workspace identity lost")
+    if not FOLDER_LOCK.is_file():
+        fail(f"missing Studio Web folder lock {FOLDER_LOCK} — Local Workspace identity lost")
+    if not PROJECT_UIPROJ.is_file():
+        fail(f"{PROJECT_UIPROJ} missing — Local Workspace anti-pattern: do not delete project.uiproj")
+    print("OK: Studio Web markers and project.uiproj are intact")
+
+    # --- UIPATH_PROJECT_ID sentinel untouched ---
+    if not ENV_FILE.is_file():
+        fail(f"{ENV_FILE} missing — Local Workspace anti-pattern: do not delete .env")
+    env_text = ENV_FILE.read_text(encoding="utf-8")
+    if SENTINEL_PROJECT_ID not in env_text:
+        fail(
+            f"UIPATH_PROJECT_ID changed in {ENV_FILE} — must remain {SENTINEL_PROJECT_ID} "
+            "(changing it breaks auto-sync identity)"
+        )
+    print("OK: UIPATH_PROJECT_ID sentinel preserved")
+
+    # --- main.py has the edit ---
+    if not MAIN.is_file():
+        fail(f"missing {MAIN}")
+    main_text = MAIN.read_text(encoding="utf-8")
+    if "category" not in main_text:
+        fail("main.py does not mention a `category` field — the requested behavior is missing")
+    print("OK: main.py declares the `category` field")
+
+    # --- entry-points.json regenerated to advertise the new output ---
+    if not ENTRY_POINTS.is_file():
+        fail(f"missing {ENTRY_POINTS}")
+    try:
+        ep_payload = json.loads(ENTRY_POINTS.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"entry-points.json is not valid JSON: {exc}")
+    serialized = json.dumps(ep_payload)
+    if "category" not in serialized:
+        fail(
+            "entry-points.json does not advertise `category` — schema was not regenerated "
+            "after the edit (run `uip codedagent init` to refresh it)"
+        )
+    print("OK: entry-points.json advertises the new `category` output")
+
+    # --- outputs.json captured both edge-case runs ---
+    if not OUTPUTS.is_file():
+        fail(f"missing {OUTPUTS} — agent did not save the verification runs")
+    try:
+        outs = json.loads(OUTPUTS.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"outputs.json is not valid JSON: {exc}")
+    flat = json.dumps(outs).lower()
+    if "tiny" not in flat:
+        fail("outputs.json does not mention a `tiny` result — value=2 run not captured or wrong branch")
+    if "huge" not in flat:
+        fail("outputs.json does not mention a `huge` result — value=150 run not captured or wrong branch")
+    print("OK: outputs.json captured both `tiny` and `huge` branches")
+
+    print("OK: Local Workspace iteration completed without violating ownership invariants")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/local_workspace_iterate/local_workspace_iterate.yaml
+++ b/tests/tasks/uipath-agents/local_workspace_iterate/local_workspace_iterate.yaml
@@ -1,0 +1,177 @@
+task_id: skill-agent-coded-local-workspace-iterate
+description: >
+  Coded-agent iteration inside a Studio Web Local Workspace. The
+  prompt seeds an existing Local Workspace layout (`.sw-path-marker`,
+  `.local/folder.lock`, `project.uiproj`, `.env` with a sentinel
+  `UIPATH_PROJECT_ID`, and a pre-scaffolded LangGraph agent with no
+  `.venv/`). The user asks for a behavior change; the skill must
+  detect `project_state == local-workspace`, prep the venv,
+  regenerate the schema, run the agent locally — and MUST NOT scaffold
+  a new project, manually push, delete `project.uiproj`, or change
+  `UIPATH_PROJECT_ID`. Closes the entire `local-workspace` branch of
+  the One-Prompt Flow (steps 2, 3, 8) plus Local-Workspace anti-patterns.
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:edit, feature:framework-langgraph, feature:local-workspace]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Recreate the working tree below exactly — Studio Web has already
+  set this Local Workspace solution up; nothing here should be
+  scaffolded from scratch.
+
+  **GateSol/.sw-path-marker** — empty file
+  **GateSol/.local/folder.lock** — empty file
+  **GateSol/GateSol.uipx** — empty file
+
+  **GateSol/gate-agent/project.uiproj** — empty file (managed by
+  Studio Web; leave it alone)
+
+  **GateSol/gate-agent/.env**:
+  ```
+  UIPATH_PROJECT_ID=ws-baseline-00000000-0000-0000-0000-000000000000
+  ```
+
+  **GateSol/gate-agent/pyproject.toml**:
+  ```toml
+  [project]
+  name = "gate-agent"
+  version = "0.0.1"
+  description = "Threshold classifier (Studio Web Local Workspace baseline)"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath", "uipath-langchain"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **GateSol/gate-agent/main.py**:
+  ```python
+  from typing_extensions import TypedDict
+  from langgraph.graph import StateGraph, START, END
+  from pydantic import BaseModel
+
+
+  class GraphInput(BaseModel):
+      value: int
+
+
+  class GraphOutput(BaseModel):
+      size: str
+
+
+  class GraphState(TypedDict):
+      value: int
+      size: str
+
+
+  async def classify(state: GraphState):
+      size = "small" if state["value"] < 50 else "large"
+      return {"size": size}
+
+
+  builder = StateGraph(GraphState, input_schema=GraphInput, output_schema=GraphOutput)
+  builder.add_node("classify", classify)
+  builder.add_edge(START, "classify")
+  builder.add_edge("classify", END)
+  graph = builder.compile()
+  ```
+
+  **GateSol/gate-agent/langgraph.json**:
+  ```json
+  {"graphs": {"agent": "./main.py:graph"}}
+  ```
+
+  **GateSol/gate-agent/entry-points.json**:
+  ```json
+  {
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+      {
+        "filePath": "agent",
+        "uniqueId": "ws-baseline-entrypoint",
+        "type": "agent",
+        "input": {"type": "object", "properties": {"value": {"type": "integer"}}, "required": ["value"]},
+        "output": {"type": "object", "properties": {"size": {"type": "string"}}, "required": ["size"]}
+      }
+    ]
+  }
+  ```
+
+  **GateSol/gate-agent/bindings.json**:
+  ```json
+  {"version": "2.0", "resources": []}
+  ```
+
+  The classifier currently only returns a `size` ("small" or
+  "large"). Extend it to also return a `category` field — "tiny"
+  if `value < 5`, "huge" if `value > 100`, otherwise repeat the
+  existing `size` label. After the change, run the agent twice
+  locally — once with `value=2` (expect category `tiny`) and once
+  with `value=150` (expect category `huge`) — and save both
+  outputs side-by-side to `GateSol/gate-agent/outputs.json`.
+
+  Do NOT publish, upload, or deploy. Complete end-to-end in a
+  single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent regenerated the schema after editing main.py"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent executed the modified agent locally"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run\s+agent'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "GateSol/gate-agent/outputs.json captured both edge-case runs"
+    path: "GateSol/gate-agent/outputs.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Must NOT scaffold a new project — Studio Web already set up the Local Workspace"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new\b'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Must NOT manually push — Studio Web auto-syncs Local Workspace"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+push\b'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Must NOT publish or deploy — local iteration only"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+(publish|deploy)\b'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Local Workspace invariants preserved + edit shape + both branch outputs"
+    command: "python3 $TASK_DIR/check_local_workspace_iterate.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/push_pull_roundtrip/check_push_pull_roundtrip.py
+++ b/tests/tasks/uipath-agents/push_pull_roundtrip/check_push_pull_roundtrip.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Push/pull roundtrip check.
+
+Asserts:
+  1. The local edit landed in `roundtrip-agent/main.py` (output prefix `echo: `).
+  2. `.env` still has a `UIPATH_PROJECT_ID=` line (auto-sync identity preserved).
+  3. The pulled sibling directory exists and contains the same source files.
+  4. The pulled `main.py` carries the same edit (proves push went up before pull came down).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+CWD = Path(os.getcwd())
+LOCAL = CWD / "roundtrip-agent"
+PULLED = CWD / "roundtrip-agent-pulled"
+LOCAL_MAIN = LOCAL / "main.py"
+PULLED_MAIN = PULLED / "main.py"
+LOCAL_ENV = LOCAL / ".env"
+
+EDIT_MARKER = "echo: "
+EXPECTED_PROJECT_ID = "a54c3bf0-985c-45a7-a1c4-92e6d8888faa"
+
+
+def fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def main() -> None:
+    if not LOCAL_MAIN.is_file():
+        fail(f"missing {LOCAL_MAIN}")
+    local_text = LOCAL_MAIN.read_text(encoding="utf-8")
+    if EDIT_MARKER not in local_text:
+        fail(
+            f"local main.py does not contain the requested edit marker '{EDIT_MARKER}'. "
+            "The agent never applied the local change before pushing."
+        )
+    print("OK: local main.py carries the requested edit")
+
+    if not LOCAL_ENV.is_file():
+        fail(f"missing {LOCAL_ENV} — push/pull anti-pattern: do not delete .env")
+    env_text = LOCAL_ENV.read_text(encoding="utf-8")
+    if not re.search(
+        rf"^UIPATH_PROJECT_ID={re.escape(EXPECTED_PROJECT_ID)}\s*$",
+        env_text,
+        re.M,
+    ):
+        fail(
+            f".env no longer carries `UIPATH_PROJECT_ID={EXPECTED_PROJECT_ID}` — "
+            "sync identity must be preserved (changing this id breaks the link "
+            "between the local folder and its Studio Web project)."
+        )
+    print(f"OK: .env still pins UIPATH_PROJECT_ID={EXPECTED_PROJECT_ID}")
+
+    if not PULLED.is_dir():
+        fail(f"missing pulled sibling directory {PULLED} — agent did not pull a fresh copy")
+    if not PULLED_MAIN.is_file():
+        fail(f"missing {PULLED_MAIN} — pulled copy is incomplete")
+    pulled_text = PULLED_MAIN.read_text(encoding="utf-8")
+    if EDIT_MARKER not in pulled_text:
+        fail(
+            f"pulled main.py does not contain '{EDIT_MARKER}' — either the push did not land "
+            "on the remote before the pull, or push/pull operated on different projects"
+        )
+    print("OK: pulled main.py reflects the pushed edit (round-trip closed)")
+
+    print("OK: push/pull roundtrip completed and .env identity preserved")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/push_pull_roundtrip/push_pull_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/push_pull_roundtrip/push_pull_roundtrip.yaml
@@ -1,0 +1,146 @@
+task_id: skill-agent-coded-push-pull-roundtrip
+description: >
+  Coded-agent push/pull file-sync roundtrip against an existing Studio
+  Web project. The seed wires a minimal Simple Function agent with
+  `.env` already containing `UIPATH_PROJECT_ID`, so the skill must
+  short-circuit the delivery fork and use sync directly. Verifies the
+  agent uploads local edits, then pulls a fresh copy, without
+  scaffolding a new project or mutating `.env`. Closes the file-sync
+  coverage gap. **Cloud auth required** — the test harness must be
+  authenticated against the cloud environment with org `agenthubdri`
+  (the org that owns the Studio Web project referenced in `.env`).
+tags: [uipath-agents, e2e, mode:operate, coded, lifecycle:execute, feature:file-sync]
+max_iterations: 1
+task_timeout: 1800
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1800
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Recreate the working tree below exactly — this is an existing
+  UiPath coded agent whose Studio Web project is already set up
+  on the cloud side. The goal is keeping local and remote in sync.
+
+  **roundtrip-agent/pyproject.toml**:
+  ```toml
+  [project]
+  name = "roundtrip-agent"
+  version = "0.0.1"
+  description = "Roundtrip sync fixture"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **roundtrip-agent/main.py**:
+  ```python
+  from pydantic import BaseModel
+
+
+  class Input(BaseModel):
+      message: str
+
+
+  class Output(BaseModel):
+      echoed: str
+
+
+  async def main(payload: Input) -> Output:
+      return Output(echoed=payload.message)
+  ```
+
+  **roundtrip-agent/uipath.json**:
+  ```json
+  {
+    "$schema": "https://cloud.uipath.com/draft/2024-12/uipath",
+    "runtimeOptions": {"isConversational": false},
+    "packOptions": {
+      "fileExtensionsIncluded": [],
+      "filesIncluded": [],
+      "filesExcluded": [],
+      "directoriesExcluded": [],
+      "includeUvLock": true
+    },
+    "functions": {"main": "./main.py:main"}
+  }
+  ```
+
+  **roundtrip-agent/entry-points.json**:
+  ```json
+  {
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+      {
+        "filePath": "main",
+        "uniqueId": "roundtrip-main",
+        "type": "agent",
+        "input": {"type": "object", "properties": {"message": {"type": "string"}}, "required": ["message"]},
+        "output": {"type": "object", "properties": {"echoed": {"type": "string"}}, "required": ["echoed"]}
+      }
+    ]
+  }
+  ```
+
+  **roundtrip-agent/bindings.json**:
+  ```json
+  {"version": "2.0", "resources": []}
+  ```
+
+  **roundtrip-agent/.env** — leave this file exactly as written
+  (it points the local folder at the Studio Web project on the
+  cloud side):
+  ```
+  UIPATH_PROJECT_ID=a54c3bf0-985c-45a7-a1c4-92e6d8888faa
+  ```
+
+  Then:
+
+  1. Edit `main.py` so the echo prepends `"echo: "` — i.e.
+     `main(message="hi")` should now return `echoed="echo: hi"`.
+  2. Upload the latest local state of this project to the Studio
+     Web project that `.env` is pointing at.
+  3. Bring down a fresh copy from that same Studio Web project
+     into a sibling directory called `roundtrip-agent-pulled/`
+     so we can compare what came back.
+
+  The test harness has UiPath auth pre-configured and the Studio
+  Web project already exists. Do NOT publish to a feed, deploy, or
+  invoke. Do NOT scaffold a fresh local project — the one above is
+  the source of truth. Do NOT pause between planning and
+  implementation. Complete end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent pushed local edits to Studio Web"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+push'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent pulled a fresh copy from Studio Web"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+pull'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Local edit applied, .env UIPATH_PROJECT_ID preserved, pulled directory has the same source"
+    command: "python3 $TASK_DIR/check_push_pull_roundtrip.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Adds 10 coded-agent tests covering high-priority gaps in the uipath-agents test suite. Brings the Coded Agents coverage to ~85%.

## Tests added

| Task | Tier | What it covers |
|---|---|---|
| `skill-agent-coded-antipattern-openai-agents-hitl` | smoke | Negative: OpenAI Agents has no first-class HITL — agent must remove a stray `interrupt(...)` + `langgraph.types` import without breaking the OpenAI Agents shape. |
| `skill-agent-coded-auth-one-shot-login` | integration | C2 — when unauthenticated, agent must issue `uip login` in one-shot form (`--organization` + `--tenant`), never the interactive picker. Asserts command shape, not auth success. |
| `skill-agent-coded-in-flow-published` | e2e | Flow Integration Pattern 2 — coded agent deployed to personal workspace, registry refreshed, separate Maestro Flow references it as `uipath.core.agent.<key>` with `section: "Published"`. |
| `skill-agent-coded-deploy-folder-and-rebump` | e2e | `uip codedagent deploy --folder <Name>` (non `--my-workspace`) + the "Version already exists" recovery path: agent must bump the patch version in `pyproject.toml` between two deploys to the same folder. |
| `skill-agent-coded-existing-project-resume` | e2e | Resume scenario — seed is an existing coded project with no `.venv/` and no `entry-points.json`. Agent must detect existing state, prep the venv, regenerate the schema, and edit in place; must NOT run `uip codedagent new`. |
| `skill-agent-coded-hitl-create-task-with-app` | e2e | HITL via `interrupt(CreateTask(...))` — regular Action Center task pattern (not escalation), with `app_name` / `app_folder_path` and matching `app` resource binding. |
| `skill-agent-coded-hitl-wait-task` | e2e | HITL via `interrupt(WaitTask(...))` — wait on an existing Action Center task and pass the resume payload to the next node. |
| `skill-agent-coded-llamaindex-rag` | e2e | Framework-selection inference — prompt names RAG semantics but not the framework; skill must pick LlamaIndex and wire `ContextGroundingQueryEngine` to the named index. |
| `skill-agent-coded-local-workspace-iterate` | e2e | Studio Web Local Workspace iteration — agent must detect `project_state == local-workspace`, prep venv, regenerate schema, run locally. MUST NOT scaffold, push, publish, deploy, or mutate `project.uiproj` / `UIPATH_PROJECT_ID`. |
| `skill-agent-coded-push-pull-roundtrip` | e2e | File-sync roundtrip against an existing Studio Web project — agent uploads local edits then pulls a fresh copy, without scaffolding or mutating `.env`. |

## Test plan

- [x] Each `check_*.py` dry-runs green against synthetic well-formed projects.
- [x] All YAMLs parse, tag lists conform to the namespaced taxonomy in `tests/README.md`.