### PR TITLE
MST-9509: relax connector fallback criteria

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py
@@ -44,7 +44,7 @@ def _check_generate_schema(flow: dict[str, Any]) -> None:
     http_text = _http_fallback_text(flow)
     _require_all(
         http_text,
-        ["api.applicationinsights.io", "/query", "method", "post", "query", "timespan"],
+        ["api.applicationinsights.io", "/query", "method", "post", "query"],
         "Application Insights HTTP fallback",
     )
     _require_all(
@@ -62,8 +62,6 @@ def _check_path_params(flow: dict[str, Any]) -> None:
             "/tasks/",
             "method",
             "delete",
-            "tasklistid",
-            "taskid",
         ],
         "Google Tasks path-params HTTP fallback",
     )
@@ -84,11 +82,27 @@ def _check_query_params(flow: dict[str, Any]) -> None:
     )
 
 
+def _check_method_override(flow: dict[str, Any]) -> None:
+    _require_all(
+        _http_fallback_text(flow),
+        [
+            "management.azure.com",
+            "desktopvirtualization",
+            "hostpools",
+            "retrieveregistrationtoken",
+            "method",
+            "post",
+            "api-version",
+        ],
+        "Azure method-override HTTP fallback",
+    )
+
+
 def main() -> None:
     if len(sys.argv) != 4:
         _fail(
             "usage: check_managed_http_fallback.py <flow_glob> <connector_key> "
-            "<generate_schema|path_params|query_params>"
+            "<generate_schema|method_override|path_params|query_params>"
         )
 
     flow = _load_flow(sys.argv[1])
@@ -102,6 +116,7 @@ def main() -> None:
 
     checks = {
         "generate_schema": _check_generate_schema,
+        "method_override": _check_method_override,
         "path_params": _check_path_params,
         "query_params": _check_query_params,
     }

--- a/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/method_override.yaml
@@ -29,6 +29,10 @@ initial_prompt: |
   Route failure to a Terminate node with error message "MethodOverride test failed".
   Route success to a final action that logs "MethodOverride test passed".
   Validate the final flow file.
+  If the Azure connector operation is not present in the registry, use a
+  managed HTTP fallback for the same Azure AVD retrieveRegistrationToken REST
+  call and finish after validation. Do not keep searching for a connector node
+  that the registry does not expose.
 
 success_criteria:
   - type: run_command
@@ -40,8 +44,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Flow has a connector node referencing uipath-microsoft-azure"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/MethodOverrideTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-azure' in content, 'Connector key not found'; print('OK: connector key present')\""
+    description: "Flow uses Azure connector or task-specific managed HTTP fallback"
+    command: "python3 $TASK_DIR/check_managed_http_fallback.py '**/MethodOverrideTest*.flow' uipath-microsoft-azure method_override"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## Summary

Connector-feature tasks now accept the managed HTTP fallback shape that the prompt tells agents to use when a connector operation is absent from the registry.

This relaxes non-load-bearing fallback evidence for `generate_schema` and `path_params`, adds `method_override` fallback coverage for Azure AVD `retrieveRegistrationToken`, and updates `method_override.yaml` to use the shared fallback checker instead of a connector-key-only assertion.

## Validation

- Ran the updated fallback checker against captured run artifacts for `skill-flow-ipe-generate-schema`.
- Ran the updated fallback checker against captured run artifacts for `skill-flow-ipe-path-params`.
- Ran the updated fallback checker against captured run artifacts for `skill-flow-ipe-method-override`.
- Validated changed connector-feature YAMLs against `TaskDefinition`.
- `git diff --check`

Jira: https://uipath.atlassian.net/browse/MST-9509
