### PR TITLE
MST-9508: accept flow init auto-registration

### DIFF
--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -62,17 +62,8 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent linked flow project to solution"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+solution\s+project\s+add'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Flow file was created inside the solution"
     path: "WeatherAlert/WeatherAlert/WeatherAlert.flow"
     weight: 1.5
     pass_threshold: 1.0
-


### PR DESCRIPTION
## Summary

`skill-flow-init-validate` now grades the observable solution-first result instead of requiring one command spelling.

Current CLI behavior can register a flow project automatically when `uip maestro flow init` runs inside a solution. The captured run showed `SolutionRegistration.Status=Registered` and `uip maestro flow validate WeatherAlert/WeatherAlert/WeatherAlert.flow` returned `Status=Valid`, but the task failed because it required an explicit `uip solution project add` command.

## Validation

- Confirmed the remaining command criteria match the captured successful trace from run `2026-05-07_06-02-52`.
- Validated `tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml` against `TaskDefinition`.
- `git diff --check`

Jira: https://uipath.atlassian.net/browse/MST-9508
