### PR TITLE
fix(hitl): align flow plugin hitl/impl.md with CLI contract

### DIFF
--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -99,7 +99,7 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
 {
   "id": "invoiceReview1",
   "type": "uipath.human-in-the-loop",
-  "typeVersion": "1.0.0",
+  "typeVersion": "1.0",
   "display": { "label": "Invoice Review" },
   "inputs": {
     "type": "quick",
@@ -118,14 +118,16 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
           "label": "Invoice ID",
           "type": "text",
           "direction": "input",
-          "binding": "=js:$vars.fetchInvoice.output.invoiceId"
+          "binding": "=js:$vars.fetchInvoice.output.invoiceId",
+          "variable": "=js:$vars.fetchInvoice.output.invoiceId"
         },
         {
           "id": "amount",
           "label": "Amount",
           "type": "number",
           "direction": "input",
-          "binding": "=js:$vars.fetchInvoice.output.amount"
+          "binding": "=js:$vars.fetchInvoice.output.amount",
+          "variable": "=js:$vars.fetchInvoice.output.amount"
         },
         {
           "id": "notes",
@@ -155,8 +157,7 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
     "status":   { "type": "string", "source": "=result.Action", "var": "status" },
     "notes":    { "type": "string", "source": "=result.notes",    "var": "notes",    "custom": true },
     "decision": { "type": "string", "source": "=result.decision", "var": "decision", "custom": true }
-  },
-  "model": { "type": "bpmn:UserTask", "serviceType": "Actions.HITL" }
+  }
 }
 ```
 
@@ -287,7 +288,8 @@ The agent translates the user's business description into the `fields[]` and `ou
 | `direction` | `inputs[]` items → `"input"`, `outputs[]` → `"output"`, `inOuts[]` → `"inOut"` |
 | field `type` | `"string"` → `"text"`, `"number"` → `"number"`, `"boolean"` → `"boolean"`, `"date"` → `"date"` |
 | `binding` | Read `variables.nodes` for node outputs → `"=js:$vars.<nodeId>.<outputId>.<field>"`. Read `variables.globals` for flow-level inputs → `"=js:$vars.<globalId>"`. Always read both before constructing bindings — never assume source |
-| `variable` | output/inOut variable name — defaults to `id` if not specified |
+| `variable` (input/inOut direction) | Set to the **same expression as `binding`**. The BPMN engine reads `variable` to build `HitlTaskArguments` and pre-populate the form at task-creation time. `binding` alone is only stored for workbench display — the runtime does not read it. Without `variable`, input fields appear blank in Action Center and inline debug. |
+| `variable` (output direction) | Short camelCase name for the output variable — defaults to `id` if not specified |
 | `required` | omit if false; set `true` for mandatory outputs |
 | `outcomes[0]` | `isPrimary: true`, `outcomeType: "Positive"` |
 | `outcomes[1+]` | `isPrimary: false`, `outcomeType: "Negative"` (use `"Neutral"` for middle outcomes like Skip/Defer) |
@@ -299,8 +301,8 @@ Business description: *"Reviewer sees invoice ID and amount, clicks Approve or R
 
 ```json
 "fields": [
-  { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "=js:$vars.fetchData1.output.invoiceId" },
-  { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "=js:$vars.fetchData1.output.amount" }
+  { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "=js:$vars.fetchData1.output.invoiceId", "variable": "=js:$vars.fetchData1.output.invoiceId" },
+  { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "=js:$vars.fetchData1.output.amount",    "variable": "=js:$vars.fetchData1.output.amount" }
 ],
 "outcomes": [
   { "id": "approve", "name": "Approve", "isPrimary": true,  "outcomeType": "Positive" },
@@ -314,7 +316,7 @@ Business description: *"Human sees the AI-drafted email, can edit it, then click
 
 ```json
 "fields": [
-  { "id": "recipient",  "label": "Recipient",  "type": "text", "direction": "input", "binding": "=js:$vars.draft1.output.recipient" },
+  { "id": "recipient",  "label": "Recipient",  "type": "text", "direction": "input", "binding": "=js:$vars.draft1.output.recipient", "variable": "=js:$vars.draft1.output.recipient" },
   { "id": "emailbody",  "label": "Email Body", "type": "text", "direction": "inOut", "binding": "=js:$vars.draft1.output.body", "variable": "emailBody" }
 ],
 "outcomes": [
@@ -329,7 +331,7 @@ Business description: *"Agent couldn't extract vendor name or cost center. Human
 
 ```json
 "fields": [
-  { "id": "rawextract",  "label": "Raw Extract",  "type": "text", "direction": "input",  "binding": "=js:$vars.extract1.output.rawText" },
+  { "id": "rawextract",  "label": "Raw Extract",  "type": "text", "direction": "input",  "binding": "=js:$vars.extract1.output.rawText", "variable": "=js:$vars.extract1.output.rawText" },
   { "id": "vendorname",  "label": "Vendor Name",  "type": "text", "direction": "output", "variable": "vendorName",  "required": true },
   { "id": "costcenter",  "label": "Cost Center",  "type": "text", "direction": "output", "variable": "costCenter", "required": true }
 ],
@@ -344,8 +346,8 @@ Business description: *"If agent confidence is low, escalate. Human sees reasoni
 
 ```json
 "fields": [
-  { "id": "reasoning",       "label": "Agent Reasoning",  "type": "text",   "direction": "input",  "binding": "=js:$vars.classify1.output.reasoning" },
-  { "id": "confidencescore", "label": "Confidence Score", "type": "number", "direction": "input",  "binding": "=js:$vars.classify1.output.score" },
+  { "id": "reasoning",       "label": "Agent Reasoning",  "type": "text",   "direction": "input",  "binding": "=js:$vars.classify1.output.reasoning", "variable": "=js:$vars.classify1.output.reasoning" },
+  { "id": "confidencescore", "label": "Confidence Score", "type": "number", "direction": "input",  "binding": "=js:$vars.classify1.output.score",     "variable": "=js:$vars.classify1.output.score" },
   { "id": "notes",           "label": "Notes",            "type": "text",   "direction": "output", "variable": "notes" }
 ],
 "outcomes": [

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -31,8 +31,8 @@ For add, delete, and wiring procedures, see [editing-operations.md](../../editin
     "type": "quick",
     "schema": {
       "fields": [
-        { "id": "invoiceId", "label": "Invoice ID", "type": "text",   "direction": "input" },
-        { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input" }
+        { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "=js:$vars.fetchInvoice.output.invoiceId", "variable": "=js:$vars.fetchInvoice.output.invoiceId" },
+        { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "=js:$vars.fetchInvoice.output.amount",    "variable": "=js:$vars.fetchInvoice.output.amount" }
       ],
       "outcomes": [
         { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "outcomeType": "Positive" },
@@ -51,6 +51,8 @@ For add, delete, and wiring procedures, see [editing-operations.md](../../editin
 ```
 
 `custom: true` on per-field outputs marks them as workflow-global variables (accessible as `$vars.<variable>`, not prefixed by nodeId). Add one entry per `output` / `inOut` direction field. Omit the `<variable>` entry when the schema has no `output` or `inOut` fields.
+
+**Input fields require both `binding` and `variable`** — `binding` stores the expression for the workbench display; `variable` is what the BPMN engine evaluates to pre-populate the form at task-creation time (`HitlTaskArguments`). Without `variable`, input fields appear blank in Action Center and inline debug. Both must point to the same `=js:$vars.…` expression.
 
 BPMN type (`bpmn:UserTask`) and serviceType (`Actions.HITL`) come from the `uipath.human-in-the-loop` entry in `definitions[]` — the instance carries no `model` block.
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -35,19 +35,22 @@ For add, delete, and wiring procedures, see [editing-operations.md](../../editin
         { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input" }
       ],
       "outcomes": [
-        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "outcomeType": "Positive", "action": "Continue" },
-        { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "outcomeType": "Negative", "action": "End" }
+        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "outcomeType": "Positive" },
+        { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "outcomeType": "Negative" }
       ]
     },
     "recipient": { "channels": ["Email", "ActionCenter"], "connections": {}, "assignee": { "type": "group" } },
     "priority": "Low"
   },
   "outputs": {
-    "output": { "type": "object", "description": "Task result data", "source": "=result", "var": "output" },
-    "status": { "type": "string", "description": "Task completion status", "source": "=result.Action", "var": "status" }
+    "output": { "type": "object", "source": "=result",        "var": "output" },
+    "status": { "type": "string", "source": "=result.Action", "var": "status" },
+    "<variable>": { "type": "string", "source": "=result.<fieldId>", "var": "<variable>", "custom": true }
   }
 }
 ```
+
+`custom: true` on per-field outputs marks them as workflow-global variables (accessible as `$vars.<variable>`, not prefixed by nodeId). Add one entry per `output` / `inOut` direction field. Omit the `<variable>` entry when the schema has no `output` or `inOut` fields.
 
 BPMN type (`bpmn:UserTask`) and serviceType (`Actions.HITL`) come from the `uipath.human-in-the-loop` entry in `definitions[]` — the instance carries no `model` block.
 
@@ -56,7 +59,8 @@ BPMN type (`bpmn:UserTask`) and serviceType (`Actions.HITL`) come from the `uipa
 **Output variables:**
 - `$vars.{nodeId}.output` — object with all `output` / `inOut` fields the human filled in
 - `$vars.{nodeId}.output.{fieldName}` — individual field value
-- `$vars.{nodeId}.status` — selected outcome's action value (`"Continue"` or `"End"`)
+- `$vars.{nodeId}.status` — selected outcome id (e.g. `"approve"`, `"reject"`)
+- `$vars.{variable}` — per-field workflow-global variable (`custom: true`); one per `output` / `inOut` field
 
 ---
 
@@ -120,13 +124,11 @@ The instance carries only per-instance data (`inputs`, `outputs`, `display`). BP
   "outputs": {
     "output": {
       "type": "object",
-      "description": "Form data submitted by the user",
       "source": "=result.response",
       "var": "output"
     },
     "error": {
       "type": "object",
-      "description": "Error information if the human task fails",
       "source": "=result.Error",
       "var": "error"
     }

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -9,7 +9,7 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   max_turns: 80
-  turn_timeout: 600
+  turn_timeout: 900
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
## Summary

Alignment fixes in `skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md`:

- Remove spurious `action: "Continue"/"End"` from QuickForm outcomes example (was removed from `hitl-node-quickform.md` in #627 but missed here)
- Strip `description` fields from node instance `outputs` (not generated by CLI; lives in definition's `outputDefinition`, not the instance)
- Add per-field `custom: true` entry to the Quick Reference outputs JSON and document `$vars.<variable>` as a workflow-global variable path
- Fix `$vars.{nodeId}.status` description from "action value" to "outcome id" (returns e.g. `"approve"`, not `"Continue"`)

## Background

Corresponds to uipcli PR #1894 (HITL `node.outputs` fix). The Quick Reference node JSON was showing stale fields that the CLI does not write, causing divergence between what the skill documents and what the actual `.flow` file contains.

## Test plan

- [ ] QuickForm outcomes in `impl.md` no longer have `action` field
- [ ] `outputs` block matches CLI output format
- [ ] `status` variable description correctly says "outcome id"