### PR TITLE
docs(uipath-platform): revert --all-fields PascalCase note

### DIFF
--- a/skills/uipath-platform/references/orchestrator/orchestrator.md
+++ b/skills/uipath-platform/references/orchestrator/orchestrator.md
@@ -17,7 +17,7 @@ All `uip or` commands share a set of cross-cutting options:
 | `--limit <n>` | List commands | Number of items to return (default 50). |
 | `--offset <n>` | List commands | Number of items to skip for pagination. |
 | `--order-by <field>` | List commands | OData-style sort (e.g., `'Name asc'`, `'Id desc'`). |
-| `--all-fields` | Most get/list commands | Return the full API DTO (PascalCase keys) instead of the curated summary. Output casing matches the curated default — no casing flip when toggling the flag. Use when you need a field not in the default output. |
+| `--all-fields` | Most get/list commands | Return the full API DTO instead of the curated summary. Use when you need a field not in the default output. |
 | `--output-filter <expr>` | All commands | JMESPath expression to filter/reshape JSON output (e.g., `--output-filter "Data[].Key"`). |
 
 **Pagination pattern.** List responses include a `Pagination` block with `Returned`, `Limit`, `Offset`, and `HasMore`. When `HasMore` is `true`, increment `--offset` by `--limit` and fetch again. Continue until `HasMore` is `false` or `Returned < Limit`.


### PR DESCRIPTION
## Summary

PR #612 added a note to \`orchestrator.md\`'s common-flags table claiming \`--all-fields\` returns PascalCase keys end-to-end. The corresponding CLI change ([cli/PR#1884](https://github.com/UiPath/cli/pull/1884)) was reverted — the \`toPascalCaseKeys\` helper lived under \`@uipath/common\` which is default-owned by \`@UiPath/core-cli\` per CODEOWNERS, and the cross-team approval requirement wasn't worth the casing-consistency win.

\`--all-fields\` is back to its prior behavior (raw camelCase API DTO). Drop the inaccurate note.

## Test plan

- [x] Single-line revert in \`orchestrator.md\` only.
- [x] No other docs reference the PascalCase claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)