### PR TITLE
docs(maestro-flow): document generic-activity workflow + path-by-id pattern

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -13,6 +13,7 @@ For generic node/edge add, delete, and wiring procedures, see [editing-operation
    - `connectionFolderKey` — the Orchestrator folder key in the authored `.flow` file. `node configure --detail` accepts `folderKey` as input and writes it back as `connectionFolderKey`.
    - `method` — HTTP method from `registry get` → `connectorMethodInfo.method` (e.g., `POST`)
    - `endpoint` — API path. Read `connectorMethodInfo.path` (from `registry get`) or `availableOperations[].path` (from `is resources describe`).
+   - `objectName` — required for generic activities (see below). The API object name (e.g. `"Opportunity"`); ignored for concrete nodes.
    - `bodyParameters` — field-value pairs for the request body. Read field names from `inputDefinition.fields[].name` (`registry get`) or `requestFields[].name` (`is resources describe`).
    - `queryParameters` — field-value pairs for query string parameters. Read from `connectorMethodInfo.parameters[]` where `type: query` (`registry get`) or `parameters[]` (`is resources describe`).
    - `pathParameters` — field-value pairs for path placeholders in `endpoint` (e.g. `{conversationsInfoId}`). Read from `connectorMethodInfo.parameters[]` where `type: path` (`registry get`) or `parameters[]` (`is resources describe`).
@@ -20,6 +21,15 @@ For generic node/edge add, delete, and wiring procedures, see [editing-operation
    - `customFieldsRequestDetails` — design-time cache for connectors with an api-type ObjectAction at top-level `objectActions[]` OR `connectorMethodInfo.design.actions[]` (e.g. Jira `GenerateSchema`, Dataservice V3 `FetchObjectMetadataTenant`). camelCase keys; `parameterValues` as `[key, value]` tuples. See Step 6c.
 
 ---
+
+## Generic vs Concrete Activities
+
+Connector nodes come in two flavors:
+
+- **Concrete** — the node type encodes a specific object + operation (e.g. `uipath.connector.uipath-atlassian-jira.curated_create_issue`). `inputDefinition.fields[]` is populated; `method` and `endpoint` are fixed.
+- **Generic** — the node type encodes only the operation (e.g. `uipath.connector.uipath-salesforce-sfdc.list-records`, `…insert-record`, `…update-record`). `inputDefinition` is `{}`; the node needs an extra `objectName` in `--detail`, and `method` / `endpoint` come from `is resources describe`.
+
+To classify a node, read `Node.form.sections[0].fields[0].componentProps.connectorDetail.configuration` from the `registry get` response, parse it as JSON, and check `activityType`. `"Generic"` → run Step 2a to discover `objectName` (and capture `operation` from the same marker for the `--operation` flag in Step 3). Anything else → skip Step 2a.
 
 ## Critical: Connector Definition Must Include `form`
 
@@ -71,6 +81,21 @@ uip maestro flow registry get <nodeType> --connection-id <connection-id> --outpu
 This returns enriched `inputDefinition.fields` and `outputDefinition.fields` with accurate type, required, description, enum, and `reference` info. Without `--connection-id`, only standard/base fields are returned.
 
 The response also includes `connectorMethodInfo` with the real HTTP `method` (e.g. `GET`, `POST`) and `path` template (e.g. `/ConversationsInfo/{conversationsInfoId}`). **Save `connectorMethodInfo.method` and `connectorMethodInfo.path`** — you must pass them to `node configure` later as `method` and `endpoint`.
+
+> **For generic activities, `connectorMethodInfo` is empty.** Method and endpoint are object-specific and only resolve once Step 2a picks an `objectName`; Step 3 then surfaces them via `availableOperations[]`. Don't try to derive them from the manifest alone.
+
+### Step 2a — Discover the object name (generic activities only)
+
+Skip this step for concrete activities — they encode the object in the node type. For generic activities (`activityType: "Generic"`), list the connection's catalog and pick the object the user wants to act on.
+
+```bash
+uip is resources list "<connector-key>" --connection-id "<connection-id>" --output json \
+  --output-filter "[?contains(DisplayName,'<search>')].{Name:Name,Path:Path,Custom:Custom}"
+```
+
+- `Name` — what `--detail.objectName` accepts. Case-sensitive (e.g. `"Opportunity"`, not `"opportunity"`). Don't substitute `DisplayName`.
+- `Path` — API endpoint suffix (e.g. `/Opportunity`). Pair with the operation's HTTP method (Step 3) for `endpoint`.
+- `Custom` — `true` for tenant-defined objects.
 
 ### Step 3 — Describe the resource and read full metadata
 
@@ -192,7 +217,9 @@ Workaround:
 
 #### Step 6b — Run configure
 
-After adding the node with `uip maestro flow node add`, configure it with the resolved connection and field values:
+After adding the node with `uip maestro flow node add`, configure it with the resolved connection and field values.
+
+**Concrete activity** (Jira `curated_create_issue` — object encoded in node type):
 
 ```bash
 uip maestro flow node configure <file> <nodeId> \
@@ -200,12 +227,36 @@ uip maestro flow node configure <file> <nodeId> \
   --output json
 ```
 
+**Generic activity, list** (Salesforce `list-records` against Opportunity — object selected at configure time, no per-record input):
+
+```bash
+uip maestro flow node configure <file> <nodeId> \
+  --detail '{"connectionId": "<id>", "folderKey": "<key>", "method": "GET", "endpoint": "/Opportunity", "objectName": "Opportunity"}' \
+  --output json
+```
+
+**Generic activity, retrieve-by-id** (Salesforce `get-record` against Account — object plus a path parameter for the record ID):
+
+```bash
+uip maestro flow node configure <file> <nodeId> \
+  --detail '{"connectionId": "<id>", "folderKey": "<key>", "method": "GETBYID", "endpoint": "/Account/{accountId}", "objectName": "Account", "pathParameters": {"accountId": "001KY000007uI02YAE"}}' \
+  --output json
+```
+
+Path-parameterized GETs are a distinct shape from list/query: `endpoint` carries `{<placeholder>}` tokens and `pathParameters` supplies the values. Resolve the ID via `is resources execute list <connector-key> <objectName>` (Step 4) — never paste IDs across connections (see [reference-resolution.md](../../../../../../uipath-platform/references/integration-service/reference-resolution.md#reference-ids-are-connection-scoped-critical)).
+
+The `objectName` field is required for generic nodes (see "Generic vs Concrete Activities" above). The CLI fails fast with a runnable hint when it's missing on a generic node. For concrete nodes the field is ignored if supplied.
+
 **Source of truth for `method` and `endpoint`** — pick either (both read the same upstream IS metadata):
 
-- `registry get` (Step 2) → `connectorMethodInfo.method` and `connectorMethodInfo.path`
-- `is resources describe ... --operation <Op>` (Step 3) → `availableOperations[].method` and `availableOperations[].path`
+- `registry get` (Step 2) → `connectorMethodInfo.method` and `connectorMethodInfo.path` — populated for **concrete** activities only.
+- `is resources describe <connector-key> <objectName> --operation <Op>` (Step 3) → `availableOperations[].method` and `availableOperations[].path` — works for both, and is the only source for **generic** activities.
 
-Body field names in `bodyParameters` come from `inputDefinition.fields[].name` (`registry get`) or `requestFields[].name` (`is resources describe`).
+> **Method label — pass the IS describe value verbatim.** `is resources describe` sometimes returns synthesized IS-side labels (notably `"GETBYID"` for path-parameterized retrieve operations). The CLI accepts both standard HTTP verbs (`GET`, `POST`, …) and IS-side labels (`GETBYID`) — copy `operation.method` from `is resources describe` as-is and the CLI normalizes to the underlying HTTP verb internally. Don't translate by hand.
+
+> **`flow validate` cross-checks `method` against the activity's `operation`.** If the value you pass disagrees with the operation baked into the node by `node add` (e.g. `method: "POST"` on a Retrieve activity), validate fails with `HTTP method "<X>" does not match operation "<Y>". Expected "<Z>"`. This catches stale copy-paste — fix by re-reading `operation.method` from `is resources describe` against the right `--operation`.
+
+Body field names in `bodyParameters` come from `inputDefinition.fields[].name` (`registry get`, concrete only) or `requestFields[].name` (`is resources describe`, both).
 
 The command populates `inputs.detail` and creates workflow-level `bindings` entries. Use **resolved IDs** from Step 4, not display names. For FilterBuilder params, see Step 6a.
 


### PR DESCRIPTION
## Summary

Updates the connector plugin's `impl.md` to document the generic-vs-concrete connector activity distinction and the path-by-id retrieve pattern. Verified end-to-end against a Salesforce flow (`list-records` on Opportunity, `get-record` on Account).

### What's added

- **Generic vs Concrete Activities** section (after "How Connector Nodes Differ from OOTB") — explains node-type encoding, `inputDefinition` shape, and how to classify via the marker JSON at `Node.form.sections[0].fields[0].componentProps.connectorDetail.configuration`.
- **`objectName` field** in the `inputs.detail` reference list — required for generic activities, ignored for concrete.
- **Step 2a — Discover the object name (generic activities only)** — `uip is resources list` recipe with `Name`/`Path`/`Custom` semantics.
- **Step 2 callout**: `connectorMethodInfo` is empty for generic activities; method/endpoint resolve only via `is resources describe` after `objectName` is picked.
- **Step 6b** split into three examples:
  - Concrete activity (Jira `curated_create_issue`) — body parameters
  - Generic activity, list (Salesforce `list-records` against Opportunity)
  - Generic activity, retrieve-by-id (Salesforce `get-record` against Account) — `pathParameters` with `{placeholder}` endpoint
- **Two new safety callouts** in Step 6b's source-of-truth section:
  - The CLI accepts both standard HTTP verbs and IS-side labels (`GETBYID`) verbatim — copy `operation.method` from `is resources describe` as-is, no manual translation.
  - `flow validate` cross-checks `method` against the activity's `operation` and rejects mismatches with a precise error message.

### Companion CLI work

Pairs with UiPath/cli#1898 (`fix(intsvc-sdk): normalize GETBYID method label and cross-validate against operation`), which is what makes the verbatim `GETBYID` claim accurate and enables the validate-time cross-check this doc references.

## Test plan

- [x] Manual: agent walks Step 1 → Step 6b for Salesforce `list-records` on Opportunity (concrete-style usage of generic node) — succeeds
- [x] Manual: agent walks Step 1 → Step 6b → Step 4 for Salesforce `get-record` on Account (path-by-id pattern) — succeeds, returns the real record
- [x] Manual: deliberate `method: "POST"` on Retrieve — `flow validate` rejects with the documented error message