### PR TITLE
fix(skill): document inline-agent prompt-to-flow-variable wiring (MST-9318)

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
@@ -71,7 +71,7 @@ Generate a unique UUID (e.g., `5029c8a8-799b-426a-803f-c4ec75255439`). Create a 
 
 Same schema as a standalone agent (see [../../agent-definition.md](../../agent-definition.md)), with these conventions:
 - `projectId` matches the folder name UUID
-- `inputSchema.properties` is empty (flow wires data via node connections)
+- `inputSchema.properties` starts empty, but **must declare one slot per `{{input.<id>}}` token used in `messages[].content`**. Each slot's `<id>` and `type` must match the corresponding `agentInputVariables[]` entry on the flow node. See the `uipath-maestro-flow` skill's [inline-agent prompt-wiring guide](../../../../../uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md#wiring-flow-variables-into-agent-prompts) for the full four-place contract.
 - `messages` have empty `content` and `contentTokens` initially (edit agent.json to set prompts with `type: "simpleText"` and `rawString`)
 - `guardrails: []` at root level — can be populated with guardrail objects. See [../guardrails/guardrails.md](../guardrails/guardrails.md)
 - No `metadata.targetRuntime` field

--- a/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
@@ -67,7 +67,7 @@ Flow node (excerpt):
   "type": "uipath.agent.autonomous",
   "inputs": {
     "systemPrompt": "Triage the inbound email.",
-    "userPrompt": "From {{input.emailFrom}}\nSubject: {{input.emailSubject}}\n\n{{input.emailBody}}",
+    "userPrompt": "Process the inbound email payload.",
     "source": "<projectId-uuid>",
     "agentInputVariables": [
       { "id": "emailSubject", "type": "string", "binding": "=js:$vars.emailReceived1.output.subject" },
@@ -113,7 +113,7 @@ Matching `agent.json` (excerpt):
 }
 ```
 
-The flow-node `inputs.systemPrompt` / `inputs.userPrompt` remain validator placeholders; the canonical prompts live in `agent.json.messages[]`. Keep the placeholder text in sync with the agent prompt only when convenient — what matters is that every `{{input.<id>}}` token in `agent.json` has a matching `inputSchema.properties.<id>` slot and a matching `agentInputVariables[]` binding on the flow node.
+The flow-node `inputs.systemPrompt` / `inputs.userPrompt` stay as short, generic validator placeholders — **do not copy the templated agent.json prompt with `{{input.<id>}}` tokens here**. Those runtime tokens only resolve inside `agent.json messages[].content`; in the flow-node they are inert text that just duplicates content and obscures which prompt is canonical. The contract that matters is: every `{{input.<id>}}` token in `agent.json` has a matching `inputSchema.properties.<id>` slot and a matching `agentInputVariables[]` binding on the flow node.
 
 ### When the source field name is unknown at authoring time
 
@@ -128,6 +128,7 @@ Some upstream nodes (notably connector triggers like email-received) only expose
 
 - **Never write `{{plainName}}` (no `input.` prefix) in `agent.json` prompts.** It is treated as literal text by the agent runtime.
 - **Never write `{{$vars.X}}` or `{{ $vars.X }}` directly in `agent.json` prompts.** That mustache form is canvas-input syntax, not the runtime token; without the workbench rewrite step, it ships verbatim and resolves to nothing. The runtime form is `{{input.<id>}}`, paired with an `agentInputVariables[]` binding.
+- **Never copy `{{input.<id>}}` tokens into the flow-node `inputs.systemPrompt` / `inputs.userPrompt`.** Those fields are validator placeholders — keep them as short, generic strings. Runtime tokens belong in `agent.json messages[].content` only.
 - **Never leave `agentInputVariables: []` while the prompt references flow data.** Empty bindings means no values reach the agent.
 - **Never declare an `inputSchema.properties.<id>` slot without a matching `agentInputVariables[]` binding** (the slot stays empty at runtime), and never the reverse (the binding has nowhere to land).
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
@@ -42,6 +42,95 @@ Use `type: "simpleText"` with `rawString` for `contentTokens`:
 
 For detailed agent configuration (contentTokens format, model settings, resource files, tool bindings), use the `uipath-agents` skill.
 
+## Wiring Flow Variables into Agent Prompts
+
+The agent runtime cannot read `$vars.*` directly. Every flow value the prompt needs (trigger output, upstream node output, flow variable) must travel through the **agent input bridge**, and every prompt token must use the runtime form `{{input.<id>}}`. Bare `{{emailSubject}}` (no `input.` prefix) and raw `{{$vars.X}}` inside `agent.json` resolve to literal text — the prompt looks plausible but the agent receives no data.
+
+The bridge is one binding plus three matching declarations. Author all four whenever the prompt references a flow value:
+
+| Where | What | Example |
+| --- | --- | --- |
+| Flow node `inputs.agentInputVariables[]` | Binding from `$vars` source to a flat slot id | `{ "id": "emailSubject", "type": "string", "binding": "=js:$vars.emailReceived1.output.subject" }` |
+| `agent.json` `inputSchema.properties.<id>` | Slot declaration matching the binding `id` and `type` | `"emailSubject": { "type": "string" }` |
+| `agent.json` `messages[].content` | Runtime token referencing the slot | `"Email subject: {{input.emailSubject}}"` |
+| `agent.json` `messages[].contentTokens[]` | Mirror of `content` with one `{ "type": "variable", "rawString": "input.<id>" }` per `{{input.X}}` token | `{ "type": "variable", "rawString": "input.emailSubject" }` |
+
+The `id` is a flat identifier you choose (alphanumeric + `_`, no dots). Use it consistently in all four places. The binding `=js:$vars.<sourceNodeId>.output.<field>` follows the standard `=js:` rule — see [../../../../shared/node-output-wiring.md](../../../../shared/node-output-wiring.md) for the full expression contract.
+
+### Worked example — wire an email-trigger payload into the agent prompt
+
+Flow node (excerpt):
+
+```json
+{
+  "id": "autonomousAgent1",
+  "type": "uipath.agent.autonomous",
+  "inputs": {
+    "systemPrompt": "Triage the inbound email.",
+    "userPrompt": "From {{input.emailFrom}}\nSubject: {{input.emailSubject}}\n\n{{input.emailBody}}",
+    "source": "<projectId-uuid>",
+    "agentInputVariables": [
+      { "id": "emailSubject", "type": "string", "binding": "=js:$vars.emailReceived1.output.subject" },
+      { "id": "emailFrom",    "type": "string", "binding": "=js:$vars.emailReceived1.output.from" },
+      { "id": "emailBody",    "type": "string", "binding": "=js:$vars.emailReceived1.output.body" }
+    ],
+    "agentOutputVariables": [{ "id": "content", "type": "string" }]
+  }
+}
+```
+
+Matching `agent.json` (excerpt):
+
+```json
+{
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "emailSubject": { "type": "string" },
+      "emailFrom":    { "type": "string" },
+      "emailBody":    { "type": "string" }
+    }
+  },
+  "messages": [
+    {
+      "role": "system",
+      "content": "Triage the inbound email.",
+      "contentTokens": [{ "type": "simpleText", "rawString": "Triage the inbound email." }]
+    },
+    {
+      "role": "user",
+      "content": "From {{input.emailFrom}}\nSubject: {{input.emailSubject}}\n\n{{input.emailBody}}",
+      "contentTokens": [
+        { "type": "simpleText", "rawString": "From " },
+        { "type": "variable",   "rawString": "input.emailFrom" },
+        { "type": "simpleText", "rawString": "\nSubject: " },
+        { "type": "variable",   "rawString": "input.emailSubject" },
+        { "type": "simpleText", "rawString": "\n\n" },
+        { "type": "variable",   "rawString": "input.emailBody" }
+      ]
+    }
+  ]
+}
+```
+
+The flow-node `inputs.systemPrompt` / `inputs.userPrompt` remain validator placeholders; the canonical prompts live in `agent.json.messages[]`. Keep the placeholder text in sync with the agent prompt only when convenient — what matters is that every `{{input.<id>}}` token in `agent.json` has a matching `inputSchema.properties.<id>` slot and a matching `agentInputVariables[]` binding on the flow node.
+
+### When the source field name is unknown at authoring time
+
+Some upstream nodes (notably connector triggers like email-received) only expose their full output shape after a real run — `subject`, `from`, `body` are not knowable from the registry definition alone. In that case:
+
+1. Pick descriptive slot ids (`emailSubject`, `emailFrom`, `emailBody`) and write the prompt + `inputSchema` against them.
+2. Record the `binding` strings as your **best guess** based on the connector's documented output schema (e.g., `=js:$vars.emailReceived1.output.subject`).
+3. Surface the assumption to the user with `AskUserQuestion` — list the bindings and ask the user to correct any source paths before they run or upload the flow. Do not invent field names silently.
+4. After the first real run, the author can verify the actual output paths and update the bindings; the prompt and `inputSchema` do not need to change because the slot ids are stable.
+
+### Anti-patterns
+
+- **Never write `{{plainName}}` (no `input.` prefix) in `agent.json` prompts.** It is treated as literal text by the agent runtime.
+- **Never write `{{$vars.X}}` or `{{ $vars.X }}` directly in `agent.json` prompts.** That mustache form is canvas-input syntax, not the runtime token; without the workbench rewrite step, it ships verbatim and resolves to nothing. The runtime form is `{{input.<id>}}`, paired with an `agentInputVariables[]` binding.
+- **Never leave `agentInputVariables: []` while the prompt references flow data.** Empty bindings means no values reach the agent.
+- **Never declare an `inputSchema.properties.<id>` slot without a matching `agentInputVariables[]` binding** (the slot stays empty at runtime), and never the reverse (the binding has nowhere to land).
+
 ## Registry Validation
 
 Even though `uipath.agent.autonomous` is OOTB, validate it against the registry during Phase 2 to confirm the current product state:
@@ -241,6 +330,7 @@ Notes:
 
 - `inputs.source` — the inline agent's `projectId`; must match the subdirectory name and `agent.json.projectId`. The definition still declares `model.source: true`, but flow-core hoists that identity field onto `inputs.source` for the node instance.
 - `inputs.systemPrompt` / `inputs.userPrompt` must be non-empty for current `flow validate`. Treat them as validator placeholders; the canonical inline-agent prompts live in `agent.json`.
+- `inputs.agentInputVariables` is `[]` only for agents whose prompts reference no flow data. Whenever the prompt needs a trigger output, upstream-node output, or flow variable, populate this array per § Wiring Flow Variables into Agent Prompts above — and add matching `inputSchema.properties.<id>` slots in `agent.json`.
 - **No `model` block on the inline-agent node instance.** The node inherits serviceType/version/context from `definitions[]`; `source` lives at `inputs.source`. Stale instance fields such as `model.serviceType`, `model.version`, or `model.context` override the inherited definition and can cause runtime mismatch.
 
 ## Accessing Output
@@ -288,6 +378,7 @@ uip maestro flow validate <FlowName>.flow --output json
 | Inline agent rejected by `uip agent validate` | `entry-points.json` or `project.uiproj` present inside the inline agent dir | Delete those files — they belong only to standalone agent projects |
 | Folder name is human-readable instead of UUID | Folder renamed after scaffolding | Rename to the original `projectId` UUID — the folder name must match `inputs.source` and the `projectId` field inside `agent.json` |
 | Agent runs but returns empty `output.content` | Missing or malformed `contentTokens` in `agent.json` | Rebuild `messages[].contentTokens` using `{ "type": "simpleText", "rawString": "..." }` entries; see `uipath-agents` for detail |
+| Agent prompt receives literal `{{X}}` text instead of flow data, or one prompt slot resolves to nothing while others work | Bare `{{X}}` placeholders without the `input.` prefix; or `{{input.<id>}}` token written without a matching `inputSchema.properties.<id>` slot in `agent.json` and `agentInputVariables[]` binding on the flow node | Adopt the four-place contract from § Wiring Flow Variables into Agent Prompts: pick a flat slot id, add an `agentInputVariables[]` entry with `{ id, type, binding: "=js:$vars.<sourceNode>.output.<field>" }`, declare `inputSchema.properties.<id>`, write the prompt token as `{{input.<id>}}`, and add a matching `{ "type": "variable", "rawString": "input.<id>" }` to `messages[].contentTokens` |
 
 ## Repair Recipes
 

--- a/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
+++ b/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
@@ -71,7 +71,8 @@ Three failure modes observed in agent-generated `.flow` files:
 | **Loop nodes** (`core.logic.loop`) | `inputs.collection` | **YES** |
 | **Subflow nodes** (`core.subflow`) | `inputs.<inputId>.source` | **YES** |
 | **Script nodes** (`core.action.script`) | `inputs.script` body — `$vars.*` is read inside JS, no `=js:` wrapping | **NO** — the body is already JS |
-| **Native flow text fields** (agent prompt, sticky note) | Any string with `{$vars.X}` template interpolation | **NO** — uses `{ }` template, not `=js:` |
+| **Inline-agent prompt** (`uipath.agent.autonomous` `agent.json` `messages[].content`) | Tokens reference an `agentInputVariables[]` binding via `{{input.<id>}}` — never raw `{{ $vars.X }}` and never bare `{{name}}` | **NO** — runtime tokens, not `=js:`. See [author/references/plugins/inline-agent/impl.md § Wiring Flow Variables into Agent Prompts](../author/references/plugins/inline-agent/impl.md#wiring-flow-variables-into-agent-prompts) for the four-place contract |
+| **Sticky-note text** | Any string with `{{ $vars.X }}` mustache interpolation | **NO** — uses `{{ }}` template, not `=js:` |
 
 **Rule of thumb:** If the field is *value-typed* (anything other than a hardcoded condition), `=js:` is required for `$vars`/`$metadata`/`$self` references. The two condition fields (Decision, Switch) and the script body are the only exceptions — they are always parsed as JS regardless.
 

--- a/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
+++ b/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
@@ -72,7 +72,6 @@ Three failure modes observed in agent-generated `.flow` files:
 | **Subflow nodes** (`core.subflow`) | `inputs.<inputId>.source` | **YES** |
 | **Script nodes** (`core.action.script`) | `inputs.script` body — `$vars.*` is read inside JS, no `=js:` wrapping | **NO** — the body is already JS |
 | **Inline-agent prompt** (`uipath.agent.autonomous` `agent.json` `messages[].content`) | Tokens reference an `agentInputVariables[]` binding via `{{input.<id>}}` — never raw `{{ $vars.X }}` and never bare `{{name}}` | **NO** — runtime tokens, not `=js:`. See [author/references/plugins/inline-agent/impl.md § Wiring Flow Variables into Agent Prompts](../author/references/plugins/inline-agent/impl.md#wiring-flow-variables-into-agent-prompts) for the four-place contract |
-| **Sticky-note text** | Any string with `{{ $vars.X }}` mustache interpolation | **NO** — uses `{{ }}` template, not `=js:` |
 
 **Rule of thumb:** If the field is *value-typed* (anything other than a hardcoded condition), `=js:` is required for `$vars`/`$metadata`/`$self` references. The two condition fields (Decision, Switch) and the script body are the only exceptions — they are always parsed as JS regardless.
 


### PR DESCRIPTION
## Summary

Closes the documentation gap that was causing coding agents to insert bare `{{emailSubject}}`-style placeholders into inline-agent prompts — the placeholders resolve to literal text at runtime because the skill never documented how flow data reaches an inline agent.

- **Add** *Wiring Flow Variables into Agent Prompts* section to `skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md`: the four-place contract (`agentInputVariables[]` binding ↔ `inputSchema.properties.<id>` slot ↔ `{{input.<id>}}` token ↔ `contentTokens` variable entry), a worked email-trigger example, anti-patterns, and a Debug-table row.
- **Fix** the misleading line in `skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md` that said `inputSchema.properties` "is empty (flow wires data via node connections)" — that was actively wrong; each binding requires a matching declared slot.
- **Split** the *Native flow text fields* row in `skills/uipath-maestro-flow/references/shared/node-output-wiring.md` into separate inline-agent-prompt and sticky-note rows, with a cross-reference to the new section.
- **Address** Gunter's secondary point in [thread](https://uipath-product.slack.com/archives/C0A2T23NJ59/p1777667693138899): when connector trigger output fields are not knowable at authoring time, the new section instructs the agent to surface bindings via `AskUserQuestion` rather than invent field names silently.

## Root cause (first principles)

The runtime contract is correct (verified in `flow-workbench/packages/services/src/serialization/agent-cluster-rewrite.ts` and `agent-storage/agent-fields.ts`):

- Canvas form `{{ \$vars.<sourceNode>.output.<field> }}` → workbench scans → derives `agentInputVariables[]` → rewrites prompt to runtime form `{{input.<flatName>}}` in `agent.json`.
- Hand-authored canonical form lives in `agent.json messages[].content` as `{{input.<id>}}`, with `inputSchema.properties.<id>` declaring the slot and the flow-node `agentInputVariables[]` providing the source binding.

Coding agents bypass the canvas, so they hand-author `agent.json` directly — but the inline-agent skill's worked examples all showed `agentInputVariables: []` with no commentary on populating it, the companion `inline-in-flow.md` actively misled with "schema is empty (flow wires data via node connections)", and the shared expression-rules table had a vague "Native flow text fields (agent prompt, sticky note)" row that conflated two unrelated cases. With no documented contract and no discovery API, the model invented `{{plainName}}` placeholders.

No CLI or workbench code change is required.

## Test plan

- [ ] Existing `tests/tasks/uipath-agents/inline_in_flow/` eval still passes (the WeatherFlow prompt does not pass flow data into the agent, so empty `agentInputVariables: []` remains valid)
- [ ] Markdown link checks pass — all new cross-references (`#wiring-flow-variables-into-agent-prompts` anchor and relative paths between the two skills) resolve
- [ ] Spot-check via fresh inline-agent build with a flow-variable reference (e.g., email trigger → agent prompt) — agent now writes a populated `agentInputVariables[]` plus matching `inputSchema.properties` and `{{input.X}}` tokens, instead of bare `{{X}}` placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)