### PR TITLE
test(uipath-test): tighten real-env tests for stable CI [TMHUB-31750]

### DIFF
--- a/tests/tasks/uipath-test/auth_project_discovery.yaml
+++ b/tests/tasks/uipath-test/auth_project_discovery.yaml
@@ -1,11 +1,12 @@
 task_id: skill-test-auth-project-discovery
 description: >
   Smoke test: agent uses the uipath-test skill to verify authentication and
-  list Test Manager projects. Validates Critical Rule #1 ("always check login
-  first"), the core `uip tm project list` workflow, and Critical Rule #2 (use
-  `--output json`). The skill — not the prompt — must teach the auth-first
-  ordering and the `--output json` flag.
-tags: [uipath-test, smoke, auth, project]
+  list Test Manager projects. Asserts that the agent (a) runs
+  `uip login status --output json` (Critical Rule #1 + Critical Rule #2) and
+  (b) runs `uip tm project list --output json` (Critical Rule #2 applied to
+  the core project-discovery command). The skill — not the prompt — must
+  teach the auth-first ordering and the `--output json` flag.
+tags: [uipath-test, smoke, mode:operate, lifecycle:discover]
 
 sandbox:
   driver: tempdir
@@ -23,25 +24,17 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (Critical Rule #1)"
+    description: "Agent checked login status with `--output json` (Critical Rule #1 + #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent listed Test Manager projects with `uip tm project list`"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+project\s+list'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used `--output json` on uip tm commands (Critical Rule #2)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status.*--output\s+json'
     min_count: 1
     weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed Test Manager projects with `--output json` (Critical Rule #2)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+project\s+list.*--output\s+json'
+    min_count: 1
+    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -1,21 +1,21 @@
 task_id: skill-test-report-generation-qa
 description: >
   Integration test: agent uses the uipath-test skill to generate a QA Engineer
-  test report from Test Manager data. Asserts that the agent (a) runs
-  `uip login status` at least once, (b) lists executions for a test set with
-  `--test-set-id`, (c) uses `--output json` on at least two `uip tm` commands
-  per Critical Rule #2, (d) writes the report to
-  `test-report-<persona>-<YYYY-MM-DD>.md` per the skill's filename convention,
-  and (e) the report body contains the QA-persona structural sections taught
-  by references/test-result-report-guide.md (regression analysis + a
-  pass/fail/none breakdown) and references the target test set. The skill —
-  not the prompt — must teach the filename convention, the persona-specific
-  sections, and the `--output json` flag. The prompt does not name a specific
-  test set so the test runs against any tenant; when the chosen test set has
-  no executions, the skill correctly stops early (Critical Rule #4), so the
-  downstream `list-testcaselogs` step is not asserted by this task; the
-  report is expected to render the empty-data sections honestly.
-tags: [uipath-test, integration, report, qa]
+  test report from Test Manager data against a live tenant. Asserts that the
+  agent (a) runs `uip login status` at least once, (b) lists executions for
+  a test set with `--test-set-id` and `--output json`, (c) writes the
+  report to `test-report-qa-<TODAY>.md` (the skill's default filename for
+  today's date), and (d) the report body contains the QA-persona structural
+  sections taught by references/test-result-report-guide.md (regression
+  analysis + the full pass/fail/none breakdown) and references the target
+  test set. The prompt does not name a specific test set so the test runs
+  against any tenant; the agent picks one with data. The skill — not the
+  prompt — must teach the filename convention, the persona-specific
+  sections, and the `--output json` flag. Note: when the chosen test set
+  has no executions, the skill correctly stops before running
+  `list-testcaselogs` (Critical Rule #4), so that command is not asserted
+  here; the report is expected to render the empty-data sections honestly.
+tags: [uipath-test, integration, mode:operate, lifecycle:generate, feature:test-case]
 
 agent:
   type: claude-code
@@ -32,46 +32,38 @@ sandbox:
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 
-  Generate a **QA Engineer** test report for one of my UiPath Test Manager
-  test sets — pick any test set you can find. Save the report file in the
-  current working directory using the default filename convention from the
-  skill.
+  Generate a **QA Engineer** test report from one of my UiPath Test Manager
+  test sets. Pick a test set that actually has data so the report is
+  meaningful, and save the report file in the current working directory
+  using the default filename convention from the skill.
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (Critical Rule #1)"
+    description: "Agent checked login status with `--output json` (Critical Rule #1 + #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status'
+    command_pattern: 'uip\s+login\s+status.*--output\s+json'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed executions for the test set (`uip tm execution list --test-set-id`)"
+    description: "Agent listed executions for a test set (`--test-set-id` + `--output json`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+execution\s+list\s+.*--test-set-id'
+    command_pattern: 'uip\s+tm\s+execution\s+list\s+.*--test-set-id.*--output\s+json|uip\s+tm\s+execution\s+list\s+.*--output\s+json.*--test-set-id'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used `--output json` on uip tm commands (Critical Rule #2)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
-    description: "Report file written using QA persona filename convention (test-report-qa-YYYY-MM-DD.md)"
-    command: "ls test-report-qa-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9].md >/dev/null 2>&1"
+    description: "Report file written using the QA persona filename convention with today's date (test-report-qa-<TODAY>.md)"
+    command: "ls \"test-report-qa-$(date -u +%Y-%m-%d).md\" >/dev/null 2>&1"
     timeout: 5
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
-    description: "QA persona report contains skill-taught structural sections (regression + pass/fail breakdown) and the target test-set key"
+    description: "QA persona report contains skill-taught structural sections (regression + full pass/fail/none breakdown) and references the test set"
     command: |
       python3 -c "
       import glob, re, sys
@@ -83,7 +75,7 @@ success_criteria:
       checks = {
           'markdown header anchor': re.search(r'(?m)^#{1,3}\s+\S', body) is not None,
           'regression section taught by skill': re.search(r'(?im)^#{1,4}.*regression', body) is not None,
-          'pass/fail terms (per the skill\'s common metrics)': all(t in lower for t in ['passed', 'failed']),
+          'full pass/fail/none breakdown taught by skill': all(t in lower for t in ['passed', 'failed', 'none']),
           'test set referenced in body': re.search(r'(?i)test\s*set', body) is not None,
       }
       missing = [k for k, ok in checks.items() if not ok]

--- a/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
@@ -1,11 +1,14 @@
 task_id: skill-test-testset-hierarchy-discovery
 description: >
   Smoke test: agent uses the uipath-test skill to traverse the Test Manager
-  discovery chain — project → testset → testcases. Validates Critical Rule #7
-  ("discover before assuming"), the correct `uip tm` list commands for project,
-  testset, and testset list-testcases, and Critical Rule #2 (use `--output
-  json`). The skill — not the prompt — must teach the chain and the flags.
-tags: [uipath-test, smoke, testset, discovery]
+  discovery chain — project → testset → testcases. Asserts the correct
+  `uip tm` list commands for project (with `--output json`), testset list
+  (with `--project-key` + `--output json`), and testset list-testcases
+  (with `--test-set-key` + `--output json`). The prompt steers the agent
+  toward a project that has test sets, so the chain runs against
+  non-empty data without prescribing how to search. The skill — not the
+  prompt — must teach the chain commands and the `--output json` flag.
+tags: [uipath-test, smoke, mode:operate, lifecycle:discover, feature:test-case]
 
 agent:
   type: claude-code
@@ -22,39 +25,31 @@ sandbox:
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 
-  I want to explore my UiPath Test Manager: list my projects, then for one of
-  them show the test sets, then for the first test set show the test cases
-  inside.
+  Walk me through the structure of one of my UiPath Test Manager projects.
+  Find a project that actually has test sets, list its test sets, and for
+  the first test set show me the test cases inside.
 
 success_criteria:
   - type: command_executed
-    description: "Agent looked up the project with `uip tm project list`"
+    description: "Agent looked up Test Manager projects with `--output json` (Critical Rule #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+project\s+list'
+    command_pattern: 'uip\s+tm\s+project\s+list.*--output\s+json'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed test sets scoped to a project (`uip tm testset list --project-key`)"
+    description: "Agent listed test sets scoped to a project (`--project-key` + `--output json`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testset\s+list\s+.*--project-key'
+    command_pattern: 'uip\s+tm\s+testset\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+testset\s+list\s+.*--output\s+json.*--project-key'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed test cases in a test set (`uip tm testset list-testcases --test-set-key`)"
+    description: "Agent listed test cases in a test set (`--test-set-key` + `--output json`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testset\s+list-testcases\s+.*--test-set-key'
+    command_pattern: 'uip\s+tm\s+testset\s+list-testcases\s+.*--test-set-key.*--output\s+json|uip\s+tm\s+testset\s+list-testcases\s+.*--output\s+json.*--test-set-key'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used `--output json` on uip tm commands (Critical Rule #2)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- **Prompts** nudge the agent toward non-empty data so the chain runs end-to-end against any tenant (smoke/integration tests no longer abort mid-chain when the first project happens to have no test sets).
- **Criteria** now require `--output json` co-occurring with the relevant command flag in each smoke check, dynamically match today's UTC date in the report filename, and require the full `pass/fail/none` breakdown per the skill's common metrics — addressing the outstanding Codex P2 comments from #370.
- **Descriptions** now honestly state what is asserted: no claims of "validates auth-first ordering" (coder-eval has no ordering primitive once the self-report file was removed) and no claim of validating `list-testcaselogs` (the chosen test set may have zero executions, where Rule #4 correctly stops the agent).

## Test plan

All three pass locally against the live alpha tenant:

```
cd /Users/ganeshborle/Projects/coder_eval && source .venv/bin/activate
SKILLS_REPO_PATH=/Users/ganeshborle/Projects/skills coder-eval run \
  ../skills/tests/tasks/uipath-test/auth_project_discovery.yaml \
  ../skills/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml \
  --experiment ../skills/tests/experiments/default.yaml --tags smoke
# → 2/2 succeeded (1.000 each)

SKILLS_REPO_PATH=/Users/ganeshborle/Projects/skills coder-eval run \
  ../skills/tests/tasks/uipath-test/report_generation.yaml \
  --experiment ../skills/tests/experiments/integration.yaml --tags integration
# → 1/1 succeeded (1.000)
```

CI will exercise the smoke pair (`auth_project_discovery`, `testset_hierarchy_discovery`) on the alpha tenant via the smoke-skills workflow's pre-auth (`OR.* + TM.*` scopes added in PR #370). The integration test uses the same auth path locally; CI for the integration tier is out of scope of this PR.

https://uipath.atlassian.net/browse/TMHUB-31750

🤖 Generated with [Claude Code](https://claude.com/claude-code)