### PR TITLE
docs(uipath-platform): consolidate connector disambiguation + JDBC gateway in platform

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -73,6 +73,7 @@ These rules apply across all three capabilities. Each capability index adds capa
 
 - **Never use `--format json` on any `uip` command** — the flag is `--output json` (rule #1). `--format` produces `error: unknown option '--format'` and exit code 3 on every `uip` subcommand, not a helpful message pointing you at `--output`.
 - **Never run `flow debug` as a validation step** — debug executes the flow with real side effects (rule #2). Use `flow validate` for checking correctness.
+- **Never silently pick the first match from `uip maestro flow registry search`.** When a search returns multiple connectors for the same intent, apply the canonical Connector Disambiguation ladder via [connector/planning.md — Disambiguation](references/author/references/plugins/connector/planning.md#disambiguation--when-search-returns-multiple-connectors-for-the-same-intent), which defers to the Integration Service rules.
 - **Never write `customFieldsRequestDetails.parameterValues` as a JSON object map** — Studio Web's TS port emits `Map<string,string|null>` via `Array.from(entries())`, so the on-wire shape is `[[key, value], ...]` tuples. Object-form `{key: value}` is rejected by the CLI at validate time. Inner keys are camelCase (`objectActionName`, `parameterValues`), not PascalCase. See [connector/impl.md Step 6c](references/author/references/plugins/connector/impl.md).
 
 > **Trouble?** If something didn't work as expected, use `/uipath-feedback` to send a report.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
@@ -52,6 +52,17 @@ uip is connectors list --output json
 
 Keys are often prefixed — e.g., `uipath-salesforce-slack` not `slack`.
 
+### Disambiguation — when search returns multiple connectors for the same intent
+
+`uip maestro flow registry search <keyword>` routinely returns multiple connectors for the same user intent (e.g. searching `databricks` returns both the native AI-serving connector and the JDBC gateway). **Never silently pick the first match.**
+
+Apply the canonical disambiguation ladder owned by Integration Service:
+
+- [/uipath:uipath-platform — Integration Service — connectors.md — Connector Disambiguation](../../../../../../uipath-platform/references/integration-service/connectors.md#connector-disambiguation) — classify catalog/custom/mock, intent-match by `Description`, count remaining candidates (1 → silent, >1 → AskUser, 0 catalog → STOP).
+- [/uipath:uipath-platform — Integration Service — connectors.md — JDBC Gateway — Database SQL Intent](../../../../../../uipath-platform/references/integration-service/connectors.md#jdbc-gateway--database-sql-intent) — special handling when the user's intent is a database SQL operation (native connector vs JDBC gateway, connection-name keyword matching, decision matrix, lifecycle disclosure).
+
+Lock the chosen connector key in the planning notes — never re-derive per node within the same flow.
+
 ### Check Connector Connections
 
 For each connector found in registry search, verify a healthy connection exists. Extract the connector key from the node type name (e.g., `uipath.connector.uipath-microsoft-outlook365.get-newest-email` -> key is `uipath-microsoft-outlook365`).

--- a/skills/uipath-platform/references/integration-service/connections.md
+++ b/skills/uipath-platform/references/integration-service/connections.md
@@ -87,6 +87,29 @@ For webhook URL retrieval after the trigger is configured, see [triggers.md — 
 
 ---
 
+## Identifying a JDBC Connection's Target DB
+
+For the JDBC gateway connector (`uipath-uipath-jdbc`, "Database Hub"), `connections list` does **not** expose `jdbcUrl` or `driverClass` — config is intentionally hidden. The only signal for "what DB does this JDBC connection point to?" is the connection **`name`**.
+
+Match case-insensitively (weak signal — surface as "likely &lt;DB&gt;", never "is &lt;DB&gt;"):
+
+| DB | Substrings in `connection.name` |
+|---|---|
+| Snowflake | `snowflake`, `sf` |
+| Databricks | `databricks`, `dbx` |
+| Postgres | `postgres`, `postgresql`, `pg` |
+| MySQL | `mysql` |
+| SQL Server | `sqlserver`, `mssql` |
+| Oracle | `oracle` |
+| Redshift | `redshift` |
+| BigQuery | `bigquery`, `bq` |
+
+If the user explicitly named a connection in their prompt (e.g. "use the `pat_databricks` connection"), that overrides name-matching — bind it directly.
+
+Used by the [connectors.md — JDBC Gateway](connectors.md#jdbc-gateway--database-sql-intent) decision matrix.
+
+---
+
 ## Scope-Related Errors
 
 A connection can be `Enabled` but lack optional OAuth scopes needed for specific activities. This typically surfaces as a **403 Forbidden** error during execute.

--- a/skills/uipath-platform/references/integration-service/connectors.md
+++ b/skills/uipath-platform/references/integration-service/connectors.md
@@ -59,3 +59,76 @@ Body fields:
 | `headers` | Optional request headers (object) |
 | `query` | Optional query parameters (object) |
 | `body` | Optional request body (for POST/PUT/PATCH) |
+
+---
+
+## Connector Disambiguation
+
+When a connector/registry search returns multiple results for the same user intent, **never silently pick the first match**. Apply this short ladder before binding:
+
+1. **Classify each result by connector key prefix.**
+   - `uipath-<vendor>-<service>` = **catalog** — UiPath-shipped IS catalog connector. Default choice.
+   - `custom-entity-*` = **custom** — tenant-built via Connector Builder. Use only when no catalog match exists, or the user explicitly names one.
+   - `uipath-mock-*` = **mock** — internal dev artifact. Filter from results, treat as if absent.
+
+   Connector keys typically appear inside richer activity / node-type strings such as `uipath.connector.<key>.<op>`, `uipath.connector.trigger.<key>.<op>`, or `uipath.agent.resource.tool.connector.<key>.<op>` — extract the `<key>` segment for classification.
+
+2. **Intent-match by reading each result's `Description`.** Drop catalog candidates whose described operation does not match the user's intent. Example: a "pull user data from Databricks" prompt drops `uipath-databricks-databricks.query-a-serving-endpoint` (AI inference) and keeps `uipath-uipath-jdbc.execute-query-synchronously` (SQL).
+
+3. **Count what's left after steps 1–2.**
+   - 1 catalog candidate → take it silently.
+   - >1 catalog candidates with different keys → AskUser. Use option label `<DisplayName> · <connector-key>` and put each candidate's `Description` in the option description — that text is the user's primary signal.
+   - 0 catalog, only custom → STOP. Surface in the consumer skill's Open Questions. Never silently bind to a custom-entity connector.
+
+4. **Lock the choice** in the consumer skill's planning notes. Never re-derive per node within the same flow / agent / run.
+
+For the database-SQL special case (a single intent satisfied by either a per-vendor catalog connector or the JDBC gateway), see [JDBC Gateway — Database SQL Intent](#jdbc-gateway--database-sql-intent) below.
+
+---
+
+## JDBC Gateway — Database SQL Intent
+
+When the user names a database (Snowflake, Databricks, Postgres, Oracle, SQL Server, Redshift, MySQL, BigQuery, etc.) for a SQL operation, two paths can satisfy the same intent:
+
+1. **Native database connector** — e.g. `uipath-snowflake-snowflake`. Vendor-specific. May not expose SQL at all (e.g. `uipath-databricks-databricks` only exposes AI serving endpoints — its SQL search hit is the JDBC gateway, not the native key).
+2. **JDBC gateway** — `uipath-uipath-jdbc` (Database Hub) with `Execute Query Synchronously` plus `*-record` CRUD activities, fronting any JDBC-compatible DB via tenant-registered connections.
+
+> **Lifecycle**: read each candidate's lifecycle from the consumer skill's registry / discovery response (`Tags` / status field) and surface it to the user when binding. The JDBC gateway has historically been PREVIEW — do not assume GA. Hard-coded lifecycle labels in this doc would rot; always defer to the registry.
+
+### Discovery
+
+A keyword search by DB name (run via the consumer skill's discovery API) returns BOTH paths because the gateway's `Description` text names every supported DB. **Do not dismiss `uipath-uipath-jdbc.*` results** because the key looks unrelated — the cross-reference is registry-surfaced.
+
+For the JDBC connection-side probe (platform-native, same regardless of consumer):
+
+```bash
+uip is connections list "uipath-uipath-jdbc" --output json
+```
+
+### Connection identity
+
+`connections list` does not expose `jdbcUrl` or `driverClass`. The only signal for "what DB does this JDBC connection point to?" is the connection **`name`**. Match case-insensitively (weak signal — surface as "likely &lt;DB&gt;", never "is &lt;DB&gt;"):
+
+| DB | Substrings in `connection.name` |
+|---|---|
+| Snowflake | `snowflake`, `sf` |
+| Databricks | `databricks`, `dbx` |
+| Postgres | `postgres`, `postgresql`, `pg` |
+| MySQL | `mysql` |
+| SQL Server | `sqlserver`, `mssql` |
+| Oracle | `oracle` |
+| Redshift | `redshift` |
+| BigQuery | `bigquery`, `bq` |
+
+If the user explicitly named a connection in their prompt (e.g. "use the `pat_databricks` connection"), that overrides name-matching — bind it directly.
+
+### Decision
+
+After dropping intent-mismatched candidates per [Connector Disambiguation](#connector-disambiguation) above:
+
+| Confident paths remaining | Action |
+|---|---|
+| Exactly one (native SQL connector, OR a single name-matched JDBC connection) | Take it silently. Disclose lifecycle from the discovery response. |
+| Native SQL connector AND a name-matched JDBC connection | **AskUser**. Option labels: `Native <DB> · <key>` / `JDBC gateway · <name> — likely <DB>`. Append the registry lifecycle (e.g. ` · PREVIEW`) per option. |
+| No native, only ambiguously-named JDBC connections (e.g. `DH-Conn-001`) | **AskUser**, flag each option as "purpose unknown, please confirm". |
+| No native and no JDBC connection | Fall back via the consumer skill's HTTP-fallback or placeholder patterns, or instruct the user to create a JDBC connection (`uip is connections create "uipath-uipath-jdbc"`). Do not silently STOP. |

--- a/skills/uipath-platform/references/integration-service/connectors.md
+++ b/skills/uipath-platform/references/integration-service/connectors.md
@@ -107,20 +107,7 @@ uip is connections list "uipath-uipath-jdbc" --output json
 
 ### Connection identity
 
-`connections list` does not expose `jdbcUrl` or `driverClass`. The only signal for "what DB does this JDBC connection point to?" is the connection **`name`**. Match case-insensitively (weak signal — surface as "likely &lt;DB&gt;", never "is &lt;DB&gt;"):
-
-| DB | Substrings in `connection.name` |
-|---|---|
-| Snowflake | `snowflake`, `sf` |
-| Databricks | `databricks`, `dbx` |
-| Postgres | `postgres`, `postgresql`, `pg` |
-| MySQL | `mysql` |
-| SQL Server | `sqlserver`, `mssql` |
-| Oracle | `oracle` |
-| Redshift | `redshift` |
-| BigQuery | `bigquery`, `bq` |
-
-If the user explicitly named a connection in their prompt (e.g. "use the `pat_databricks` connection"), that overrides name-matching — bind it directly.
+For the rules on inferring a JDBC connection's target DB from its `name` (since `jdbcUrl` / `driverClass` are not exposed by `connections list`), and the explicit-user-named-connection override, see [connections.md — Identifying a JDBC Connection's Target DB](connections.md#identifying-a-jdbc-connections-target-db). The Decision matrix below assumes each JDBC connection has been classified as "name-matched" or "ambiguously named" using that guide.
 
 ### Decision
 


### PR DESCRIPTION
## Summary

- Move the canonical **Connector Disambiguation** ladder and **JDBC Gateway — Database SQL Intent** rules into `uipath-platform/integration-service/connectors.md`. Reduce the maestro-flow copies to references.
- Enforce direction discipline: `uipath-maestro-flow` MAY reference `uipath-platform`; `uipath-platform` MUST NOT reference `uipath-maestro-flow`. Removed the back-reference I had introduced earlier.
- Anti-pattern fix: no `uip maestro flow ...` commands inside `uipath-platform/references/integration-service`. The platform doc now uses only platform-native commands (`uip is connections list` / `uip is connections create`) and abstract phrasing for the consumer skill's discovery API.

## Behavior changes

- **Intent-match BEFORE counting candidates.** Reading each result's `Description` to drop wrong-operation candidates is now Step 2 of the ladder. This silently routes "pull data from Databricks" to the JDBC gateway (the native `uipath-databricks-databricks` key only exposes AI serving endpoints), instead of asking the user to choose between obviously different operations.
- **Lifecycle is dynamic, not hard-coded.** Read each candidate's lifecycle from the discovery response (`Tags` / status) and surface it to the user. Removed the hard-coded "PREVIEW at time of writing" lines that would rot when the gateway moves to GA.
- **"No native and no JDBC connection" has a concrete fallback ladder** (consumer skill's HTTP fallback / placeholder pattern / `uip is connections create`) instead of a bare STOP.
- **Explicit user-named connection overrides name-keyword matching.**

## Files

- `skills/uipath-platform/references/integration-service/connectors.md` — canonical home (+73 lines).
- `skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md` — reference only (+11 lines).
- `skills/uipath-maestro-flow/SKILL.md` — one-line universal rule, links into planning.md (+1 line).

## Out of scope

Pre-existing platform → maestro-flow back-references in:

- `skills/uipath-platform/references/integration-service/activities.md:202`
- `skills/uipath-platform/references/integration-service/triggers.md:134`

These exist on `main` and predate this branch. Flagging for a separate cleanup PR — both should restate the relevant rule inline so platform stands alone.

## Test plan

- [ ] Verify the cross-doc anchors resolve in the rendered docs (`#connector-disambiguation`, `#jdbc-gateway--database-sql-intent`).
- [ ] Verify a maestro-flow planning run on a "pull user data from Databricks" prompt picks `uipath-uipath-jdbc.execute-query-synchronously` silently (no AskUser) when only the AI-serving native and the JDBC gateway are returned by registry search.
- [ ] Verify a planning run on a "use Snowflake to query X" prompt with both a `uipath-snowflake-snowflake` native connector and a `snowflake_prod` JDBC connection prompts AskUser per the decision matrix.
- [ ] Verify lifecycle (e.g. `PREVIEW`) appears in the AskUser option labels when the registry response carries it.
