### PR TITLE
fix(test): accept Slack HTTP connector proxy flows [MST-9564]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -71,15 +71,11 @@ def assert_flow_has_node_type(
     """
     if not hints:
         return
-    project_dir = _find_project(project_glob)
     types_seen: set[str] = set()
-    for path in glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
-        with open(path) as f:
-            flow = json.load(f)
-        for node in flow.get("nodes") or []:
-            t = node.get("type")
-            if t:
-                types_seen.add(t)
+    for node in _iter_flow_nodes(project_glob):
+        t = node.get("type")
+        if t:
+            types_seen.add(t)
     for hint in hints:
         needle = hint.lower()
         if not any(needle in t.lower() for t in types_seen):
@@ -87,6 +83,54 @@ def assert_flow_has_node_type(
                 f"No node matches type hint {hint!r}. "
                 f"Node types seen: {sorted(types_seen)}"
             )
+
+
+def assert_flow_uses_connector_target(
+    connector_key: str, *, project_glob: str = "**/project.uiproj"
+) -> None:
+    """Require a native connector node or HTTP proxy node targeting connector_key.
+
+    Some connector-backed flows are authored as ``core.action.http.v2`` nodes
+    with ``bodyParameters.authentication = "connector"`` and a
+    ``targetConnector`` rather than as ``uipath.connector.*`` node types.
+    Treat that as connector usage only when a real connection id and folder key
+    are also present, so a manual HTTP request cannot satisfy connector tests.
+    """
+    expected = connector_key.lower()
+    seen: list[str] = []
+
+    for node in _iter_flow_nodes(project_glob):
+        node_type = str(node.get("type") or "")
+        node_type_lower = node_type.lower()
+        seen.append(node_type)
+
+        if "uipath.connector" in node_type_lower and expected in node_type_lower:
+            return
+
+        detail = (node.get("inputs") or {}).get("detail") or {}
+        if not isinstance(detail, dict):
+            continue
+        body = detail.get("bodyParameters") or {}
+        if not isinstance(body, dict):
+            continue
+
+        target = str(body.get("targetConnector") or body.get("connectorKey") or "")
+        authentication = str(body.get("authentication") or "")
+        connection_id = detail.get("connectionId")
+        folder_key = detail.get("connectionFolderKey")
+        if (
+            node_type_lower.startswith("core.action.http")
+            and target.lower() == expected
+            and authentication.lower() == "connector"
+            and _non_empty_binding_value(connection_id)
+            and _non_empty_binding_value(folder_key)
+        ):
+            return
+
+    _fail(
+        f"No node uses connector target {connector_key!r}. "
+        f"Node types seen: {sorted(set(seen))}"
+    )
 
 
 def collect_outputs(payload: dict) -> list[Any]:
@@ -210,6 +254,18 @@ def _parse_json(stdout: str) -> dict | None:
                 except json.JSONDecodeError:
                     continue
     return None
+
+
+def _iter_flow_nodes(project_glob: str):
+    project_dir = _find_project(project_glob)
+    for path in glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+        with open(path) as f:
+            flow = json.load(f)
+        yield from flow.get("nodes") or []
+
+
+def _non_empty_binding_value(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip()) and value != "ImplicitConnection"
 
 
 def _find_project(pattern: str) -> str:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from flow_check import (  # noqa: E402
     assert_flow_has_node_type,
+    assert_flow_uses_connector_target,
     assert_output_int_in_range,
     assert_output_value,
     assert_outputs_contain,
@@ -37,7 +38,12 @@ def _write_flow(tmp_path, node_types):
     proj = tmp_path / "MyFlow"
     proj.mkdir()
     (proj / "project.uiproj").write_text("{}")
-    flow = {"nodes": [{"id": f"n{i}", "type": t} for i, t in enumerate(node_types)]}
+    flow = {
+        "nodes": [
+            node if isinstance(node, dict) else {"id": f"n{i}", "type": node}
+            for i, node in enumerate(node_types)
+        ]
+    }
     (proj / "MyFlow.flow").write_text(json.dumps(flow))
     return tmp_path
 
@@ -114,6 +120,70 @@ def test_assert_flow_has_node_type_fails_when_absent(tmp_path, monkeypatch):
 def test_assert_flow_has_node_type_empty_hints_is_noop(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)  # no project needed when hints are empty
     assert_flow_has_node_type([])
+
+
+# ── assert_flow_uses_connector_target ──────────────────────────────────────
+
+
+def test_assert_flow_uses_connector_target_accepts_native_connector_node(
+    tmp_path, monkeypatch
+):
+    root = _write_flow(
+        tmp_path, ["uipath.connector.uipath-salesforce-slack.ConversationsInfo"]
+    )
+    monkeypatch.chdir(root)
+    assert_flow_uses_connector_target("uipath-salesforce-slack")
+
+
+def test_assert_flow_uses_connector_target_accepts_http_proxy_binding(
+    tmp_path, monkeypatch
+):
+    root = _write_flow(
+        tmp_path,
+        [
+            {
+                "id": "getChannelInfo",
+                "type": "core.action.http.v2",
+                "inputs": {
+                    "detail": {
+                        "connectionId": "7aa668d3-12eb-45a6-96d0-59617fd834d7",
+                        "connectionFolderKey": "5da18ec0-7de1-4e57-aaf1-ddc8a369c199",
+                        "bodyParameters": {
+                            "authentication": "connector",
+                            "targetConnector": "uipath-salesforce-slack",
+                        },
+                    }
+                },
+            }
+        ],
+    )
+    monkeypatch.chdir(root)
+    assert_flow_uses_connector_target("uipath-salesforce-slack")
+
+
+def test_assert_flow_uses_connector_target_rejects_manual_http(tmp_path, monkeypatch):
+    root = _write_flow(
+        tmp_path,
+        [
+            {
+                "id": "manualRequest",
+                "type": "core.action.http.v2",
+                "inputs": {
+                    "detail": {
+                        "connectionId": "ImplicitConnection",
+                        "connectionFolderKey": "ImplicitConnection",
+                        "bodyParameters": {
+                            "authentication": "anonymous",
+                            "targetConnector": "uipath-salesforce-slack",
+                        },
+                    }
+                },
+            }
+        ],
+    )
+    monkeypatch.chdir(root)
+    with pytest.raises(SystemExit, match="uipath-salesforce-slack"):
+        assert_flow_uses_connector_target("uipath-salesforce-slack")
 
 
 # ── assert_output_value ─────────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/check_channel_description.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/check_channel_description.py
@@ -7,7 +7,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
+    assert_flow_uses_connector_target,
     assert_outputs_contain,
     run_debug,
 )
@@ -21,12 +21,13 @@ ADDRESS_FRAGMENTS = [
 
 
 def main():
-    # Require a Slack connector node in the flow — prevents the agent passing
-    # by hardcoding the address in a Script node.
-    assert_flow_has_node_type(["uipath.connector"])
+    # Require a real Slack-backed connector call. Current flows may represent
+    # this either as a native uipath.connector node or as HTTP v2 with
+    # bodyParameters.targetConnector = uipath-salesforce-slack.
+    assert_flow_uses_connector_target("uipath-salesforce-slack")
     payload = run_debug(timeout=240)
     assert_outputs_contain(payload, ADDRESS_FRAGMENTS, require_all=True)
-    print("OK: Connector node present; output contains Bellevue office address")
+    print("OK: Slack connector target present; output contains Bellevue office address")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/check_slack_weather_pipeline.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/check_slack_weather_pipeline.py
@@ -7,15 +7,18 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
+    assert_flow_uses_connector_target,
     assert_outputs_contain,
     run_debug,
 )
 
 
 def main():
-    # Must have both a Slack connector and an HTTP node — proves the pipeline
-    # isn't shortcutting by hardcoding the city or skipping the Slack read
-    assert_flow_has_node_type(["uipath.connector", "core.action.http"])
+    # Must have a real Slack-backed connector call and an HTTP node — proves
+    # the pipeline isn't shortcutting by hardcoding the city or skipping the
+    # Slack read. The Slack call may be represented as an HTTP v2 proxy node.
+    assert_flow_uses_connector_target("uipath-salesforce-slack")
+    assert_flow_has_node_type(["core.action.http"])
 
     payload = run_debug(timeout=240)
 
@@ -23,7 +26,7 @@ def main():
     assert_outputs_contain(
         payload, ["warm office today", "cold office today"], require_all=False
     )
-    print("OK: Slack connector + HTTP + decision all executed, verdict present")
+    print("OK: Slack connector target + HTTP + decision all executed, verdict present")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Teach the shared flow checker to accept connector-backed HTTP v2 proxy nodes when they target the expected connector and carry real connection/folder bindings.
- Keep manual HTTP requests from satisfying connector-required eval checks.
- Update the Slack channel description and Slack weather pipeline checks to use the connector-target assertion.
- Add focused tests for native connector nodes, HTTP proxy connector bindings, and manual HTTP rejection.

## Validation

- `uv run python -m py_compile tests/tasks/uipath-maestro-flow/_shared/flow_check.py tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/check_channel_description.py tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/check_slack_weather_pipeline.py`
- `uv run --with pytest pytest tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py` — 22 passed (post-rebase)
- Captured-run structural probe against run `2026-05-08_04-46-07` accepted the Slack connector target in both Slack `.flow` artifacts.
- **Re-confirmed against run `2026-05-13_03-38-18`** during the cross-ticket triage on 2026-05-13: `skill-flow-slack-channel-description/00` and `skill-flow-slack-weather-pipeline/00` both still fail on the legacy `assert_flow_has_node_type(["uipath.connector"])` shape because the agent correctly produces a `core.action.http.v2` proxy node; this PR's assertion accepts that shape and resolves both failures.
- `git diff --check`

## Rebase note

Rebased onto current `origin/main` on 2026-05-13 to clear unrelated `extra_forbidden` Pydantic errors in `Run skill smoke tests`. Those errors came from origin/main's `run_limits` migration to `tests/experiments/default.yaml` (PR #721, merged after this PR was opened) and were unrelated to this PR's changes. New head: `950e5ee0`. All 22 unit tests still pass.

## Related

Surfaced and triaged alongside five sibling PRs from run `2026-05-13_03-38-18`, all addressing checker/skill drift against the same e2e suite:

- #708 (merged) — `uip is resources execute` → `run` docs migration
- #741 — MST-9752: require `registry get` for OOTB action nodes during discovery
- #742 — MST-9751: customer escalation checker accepts manual+graph fallback
- #743 — MST-9734: central `_find_project` fix for multi-project solutions (alternative to #732)
- #744 — MST-9611: replace PIMS-coupled debug with structural API workflow check
- #745 — MST-9674: verb-tolerant outlook trigger checker
- [coder_eval#250](https://github.com/UiPath/coder_eval/pull/250) — MST-9674 sandbox-layer companion (NODE_PATH / NPM_CONFIG_PREFIX isolation)

## Issue

MST-9564