### PR TITLE
docs: solution resource list --kind is required

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/process/process.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/process.md
@@ -31,13 +31,13 @@ Two supported invocations — pick one based on where you're looking:
 **Local (in-solution):**
 
 ```bash
-uip solution resource list --source local --output json
+uip solution resource list --kind Process --source local --output json
 ```
 
 **Remote (Orchestrator / RCS):**
 
 ```bash
-uip solution resource list --source remote --kind Process --search "<NAME>" --output json
+uip solution resource list --kind Process --source remote --search "<NAME>" --output json
 ```
 
 > **`--kind` and `--search` only work with `--source remote`.** With `--source local` or `--source all` (default), both flags must be omitted — list everything and filter `.Data[]` client-side by `Kind` and `Name`.
@@ -172,11 +172,9 @@ For in-solution agents already registered with the parent solution — auto-regi
 ```bash
 # 1. Scaffold solution + agent per [project-lifecycle.md § End-to-End Example](../../project-lifecycle.md#end-to-end-example--new-standalone-agent).
 
-# 2. Discover the process
-# Remote: --kind / --search supported server-side.
-uip solution resource list --source remote --kind Process --search "<NAME>" --output json
-# Local: --kind and --search NOT supported — list, then filter .Data[] client-side.
-uip solution resource list --source local --output json
+# 2. Discover the process — --kind is required, pick one kind per call.
+uip solution resource list --kind Process --source remote --search "<NAME>" --output json
+uip solution resource list --kind Process --source local --output json
 # Parse .Data[]. Each entry: Source, Key, Name, Kind, Type (lowercase), Folder, FolderKey.
 # Source: "Local" → location: "solution". "Remote" → location: "external".
 # Use Key as referenceKey, Name as processName, Type for the agent-level type,
@@ -226,9 +224,8 @@ uip agent init "ToolAgent" --output json
 # resources/solution_folder/process/agent/ToolAgent.json automatically.
 
 # 3. From ParentAgent, add ToolAgent as a tool — discovery via the unified flow.
-# `--source local` accepts neither --kind nor --search; list then filter client-side.
-uip solution resource list --source local --output json
-# Pick the row with Kind="Process" and Name="ToolAgent", then:
+uip solution resource list --kind Process --source local --output json
+# Pick the row with Name="ToolAgent", then:
 uip solution resource get <KEY> --output json
 # Then create ParentAgent/resources/ToolAgent/resource.json with location: "solution".
 

--- a/skills/uipath-agents/references/lowcode/project-lifecycle.md
+++ b/skills/uipath-agents/references/lowcode/project-lifecycle.md
@@ -176,24 +176,18 @@ uip solution bundle . -d ./dist --output json
 
 ## Resource Discovery
 
-`uip solution resource list` queries the Resource Catalog Service for all resources visible to the tenant and returns a compact JSON list. Use it as the first step of any tool-authoring flow — it replaces `uip or folders list` and `uip or processes list`, and covers Action Center apps and Context Grounding indexes too.
-
-Two supported invocations:
+`uip solution resource list` queries the Resource Catalog Service for resources of one kind visible to the tenant and returns a compact JSON list. Use it as the first step of any tool-authoring flow — it replaces `uip or folders list` and `uip or processes list`, and covers Action Center apps and Context Grounding indexes too.
 
 ```bash
-# Local (in-solution): --kind and --search not allowed.
-uip solution resource list [solutionPath] --source local --output json
-
-# Remote (Orchestrator / RCS): --kind and --search supported.
-uip solution resource list [solutionPath] --source remote [--kind <kind>] [--search <term>] --output json
+# Pick one kind per call; --kind is required.
+uip solution resource list --kind <kind> --solution-folder <path> --source <all|local|remote> [--search <term>] --output json
 ```
 
 **Flags:**
-- `--source <all|local|remote>` — default `all`. `local` lists resources already in the solution; `remote` queries Orchestrator / RCS.
-- `--kind <kind>` — filter by resource kind. Supported: `Queue`, `Asset`, `Bucket`, `Process`, `Connection`, `App`, `Index`. **Only valid with `--source remote`.**
-- `--search <term>` — substring match on the resource name (case-insensitive). **Only valid with `--source remote`.**
-
-> **`--kind` and `--search` only work with `--source remote`.** With `--source local` or `--source all` (default), both flags must be omitted — list everything and filter `.Data[]` client-side by `Kind` and `Name`.
+- `--kind <kind>` (required) — one resource kind per invocation. Supported: `Queue`, `Asset`, `Bucket`, `Process`, `Connection`, `App`, `Index`, `Trigger` (any kind RCS indexes).
+- `--source <all|local|remote>` — default `all`. `local` returns resources already in the solution; `remote` queries Orchestrator / RCS only; `all` returns both (with locals winning on `(Kind, Name)` collisions).
+- `--search <term>` — substring match on the resource name (case-insensitive).
+- `--solution-folder <path>` — solution root (default: current directory).
 
 **Output row:**
 

--- a/skills/uipath-platform/references/solution/develop-solution.md
+++ b/skills/uipath-platform/references/solution/develop-solution.md
@@ -90,22 +90,22 @@ uip solution project list --solution-folder ./InvoiceAutomation --output json
 
 ## Step 6: List Resources
 
-Show resources declared in the solution, available in Orchestrator, or both. Run from inside the solution directory (default), or pass `--solution-folder <path>` to target another location.
+Show resources of a given kind declared in the solution, available in Orchestrator, or both. `--kind` is required — pick one kind at a time. Run from inside the solution directory (default), or pass `--solution-folder <path>` to target another location.
 
 ```bash
 # from inside the solution dir
-uip solution resource list --output json
-uip solution resource list --source local --output json
+uip solution resource list --kind Queue --output json
+uip solution resource list --kind Process --source local --output json
 uip solution resource list --kind Queue --search "Invoice" --output json
 
 # explicit folder
-uip solution resource list --solution-folder ./InvoiceAutomation --output json
+uip solution resource list --kind App --solution-folder ./InvoiceAutomation --output json
 ```
 
 | Option | Values | Default |
 |--------|--------|---------|
 | `--solution-folder <path>` | Path to solution root | Current working directory |
-| `--kind <kind>` | `Queue`, `Asset`, `Bucket`, `Process`, `Connection`, `App`, `Index`, `Trigger` (any RCS kind) | All kinds |
+| `--kind <kind>` (required) | `Queue`, `Asset`, `Bucket`, `Process`, `Connection`, `App`, `Index`, `Trigger` (any RCS kind) | — |
 | `--search <term>` | Name substring match | No filter |
 | `--source <source>` | `all`, `local`, `remote` | `all` |
 | `--login-validity <minutes>` | Minimum minutes left on token before refresh | `10` |
@@ -244,8 +244,9 @@ cd ./InvoiceAutomation
 # 4. Sync resource declarations from project bindings
 uip solution resource refresh --output json
 
-# 5. Verify resources are tracked
-uip solution resource list --source local --output json
+# 5. Verify resources are tracked (per kind)
+uip solution resource list --kind Process --source local --output json
+uip solution resource list --kind Queue --source local --output json
 
 # 6. Inspect one resource's full configuration (local + RCS fallback)
 uip solution resource get <resource-key> --output json
@@ -346,11 +347,11 @@ When `[solutionFile]` is omitted, the CLI walks up from the project path looking
 
 ### `--solution-folder` defaults to cwd
 
-`resource list / refresh / get` default `--solution-folder` to the current working directory. Run them from inside the solution dir for the shortest invocation (`uip solution resource list`) or pass `--solution-folder <path>` explicitly.
+`resource list / refresh / get` default `--solution-folder` to the current working directory. Run them from inside the solution dir for the shortest invocation (`uip solution resource list --kind <kind>`) or pass `--solution-folder <path>` explicitly.
 
 ### `resource get` for cross-folder inspection
 
-Because `get` falls back to RCS + FPS export when the key isn't local, it works as a quick way to fetch the full server spec for any resource your tenant exposes — even ones that aren't yet bound to this solution. Pair with `solution resource list --source remote` to discover keys.
+Because `get` falls back to RCS + FPS export when the key isn't local, it works as a quick way to fetch the full server spec for any resource your tenant exposes — even ones that aren't yet bound to this solution. Pair with `solution resource list --kind <kind> --source remote` to discover keys.
 
 ---
 
@@ -363,7 +364,7 @@ Because `get` falls back to RCS + FPS export when the key isn't local, it works 
 | Pull in an external project | `uip solution project import --source <path>` | Rename source folder first to avoid 3-name divergence |
 | Sync resource bindings | `uip solution resource refresh --solution-folder <solution-dir>` | **Check stderr for ERROR**; `Result: Success` with 0/0/0 counts is suspicious if `bindings_v2.json` exists |
 | Remove a project | `uip solution project remove ./<dir>` | Manually delete `resources/.../package/<name>.json` afterwards |
-| List resources | `uip solution resource list --solution-folder <solution-dir> --source local` | Good sanity check after any mutation |
+| List resources | `uip solution resource list --kind <kind> --solution-folder <solution-dir> --source local` | Good sanity check after any mutation; pick one kind per call |
 | Pack | `uip solution pack <solution-dir> <output-dir>` | See [pack-and-deploy.md](pack-and-deploy.md) for full pack/publish/deploy flow |
 
 ---

--- a/skills/uipath-platform/references/solution/scenarios/intra-solution-references.md
+++ b/skills/uipath-platform/references/solution/scenarios/intra-solution-references.md
@@ -20,7 +20,7 @@ MySolution/
     └── process/agent/Worker.json         (auto on add)
 ```
 
-The right `referenceKey` for the Worker tool is the **solution-resource key** of `Worker.json` (read from `uip solution resource list --source local --output json`), **not** the `projectId` from `.uipx`.
+The right `referenceKey` for the Worker tool is the **solution-resource key** of `Worker.json` (read from `uip solution resource list --kind Process --source local --output json`), **not** the `projectId` from `.uipx`.
 
 ```jsonc
 // Coordinator/resources/WorkerTool/resource.json
@@ -29,7 +29,7 @@ The right `referenceKey` for the Worker tool is the **solution-resource key** of
   "name": "WorkerTool",
   "type": "agent",
   "location": "solution",                              // ← intra-solution, not "external"
-  "referenceKey": "<solution-resource-key-of-Worker>", // from `resource list --source local`
+  "referenceKey": "<solution-resource-key-of-Worker>", // from `resource list --kind Process --source local`
   "properties": {
     "processName": "Worker",
     "folderPath": "solution_folder"
@@ -46,14 +46,14 @@ The right `referenceKey` for the Worker tool is the **solution-resource key** of
 ## Gotchas
 
 - **Don't put the cloud key of a different (already-published) Worker** if you intend to ship Worker as part of this solution. `referenceKey` to a cloud key skips the intra-solution link and points the runtime at the cloud copy — which may or may not exist in the target tenant at deploy time.
-- **The solution-resource key is stable across refreshes within an instance** but **regenerates if you delete and re-create the solution** (`solution new` → mint fresh UUIDs). Hard-coding the key in `resource.json` survives normal refresh cycles but breaks if anyone wipes-and-recreates. If that's a risk, rebuild the file from `resource list --source local` output as part of CI.
+- **The solution-resource key is stable across refreshes within an instance** but **regenerates if you delete and re-create the solution** (`solution new` → mint fresh UUIDs). Hard-coding the key in `resource.json` survives normal refresh cycles but breaks if anyone wipes-and-recreates. If that's a risk, rebuild the file from `resource list --kind Process --source local` output as part of CI.
 - **`location` must be `"solution"`, not `"external"`** for intra-solution tools. SW UI shows external-tool dialogs differently and won't render the link state correctly.
 - **Worker → Coordinator cycles**: nothing prevents you from declaring a tool in Worker that points back at Coordinator. The runtime supports it; if the agent prompts loop, that's an authoring issue, not a deploy one.
 
 ## Verify
 
 ```bash
-uip solution resource list --source local --output json | jq '.Data[] | select(.Kind == "process")'
+uip solution resource list --kind Process --source local --output json
 ```
 
 The keys you see here are what `referenceKey` should be in any `location: "solution"` tool resource file.

--- a/skills/uipath-platform/references/solution/scenarios/manual-edits.md
+++ b/skills/uipath-platform/references/solution/scenarios/manual-edits.md
@@ -82,7 +82,7 @@ Open the file. The shape is roughly:
 After any solution-level edit, run a sanity check:
 
 ```bash
-uip solution resource list --solution-folder . --source local --output json
+uip solution resource list --kind <kind> --solution-folder . --source local --output json
 ```
 
 The list should show your resource with the new spec. If `resource refresh` reverts the change on the next run, you edited a field the bindings re-derive — back out and use the deploy-config path or SW UI instead.

--- a/skills/uipath-platform/references/solution/scenarios/same-name-across-folders.md
+++ b/skills/uipath-platform/references/solution/scenarios/same-name-across-folders.md
@@ -49,7 +49,7 @@ The `_1` suffix is **expected and stable** — re-running refresh does not bump 
 ## Verify
 
 ```bash
-uip solution resource list --solution-folder ./MySolution --source local --output json
+uip solution resource list --kind Process --solution-folder ./MySolution --source local --output json
 ```
 
 You should see two `process`/`api` entries with **different keys** but matching the cloud GUIDs you wanted (compare against `uip maestro flow registry search "API Workflow"`).

--- a/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
@@ -36,9 +36,10 @@ initial_prompt: |
   - Escalation app name: "Tool.Guardrail.Escalation.Action.App"
   - Recipient email: reviewer@example.com (type 3)
 
-  Use `uip solution resource list` to attempt to discover the app and
-  populate app fields. If the app is not found remotely, write the
-  minimum required fields (app.name, app.version, app.folderName).
+  Use `uip solution resource list --kind App --source remote` to attempt
+  to discover the app and populate app fields. If the app is not found
+  remotely, write the minimum required fields (app.name, app.version,
+  app.folderName).
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and


### PR DESCRIPTION
## Summary

Companion to UiPath/cli#1910 — `uip solution resource list` now requires `--kind`. Update docs and scenario examples to match.

- `develop-solution.md` — Step 6 + cheatsheet + cross-references
- `project-lifecycle.md` — rewrite the resource-list explainer (the old "--kind only valid with --source remote" claim was already incorrect; collapsed to the single canonical syntax)
- `process.md` — 3 example invocations
- 3 scenario docs (`manual-edits`, `intra-solution-references`, `same-name-across-folders`)
- `guardrail_escalation_app.yaml` — task prompt now uses `--kind App --source remote`

## Test plan

- [x] `grep -r 'solution resource list' skills/ tests/` — every command invocation now carries `--kind`; remaining hits are conceptual references to the output's `Folder` field, intentionally untouched
- [ ] Wait for cli#1910 merge before merging this so docs don't lead users to invocations that fail on the latest published CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)