### PR TITLE
feat(uipath-rpa): require uip rpa analyze error-free for project-level done

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -123,10 +123,10 @@ Skip this path when the task has no UI surface (data transforms, IS connector ca
      1. `uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json` until 0 errors. Catches: structural XAML, missing references, analyzer rules, schema violations.
      2. Then `uip rpa build "<PROJECT_DIR>" --output json` until clean. Catches what `get-errors` misses: **unknown member names** (`NGetText.Value` when the property is `Text`), **invalid enum values** (`Operator="StartsWith"` when the enum has no such member), **member resolution / CacheMetadata failures**, attribute-form C# expression JIT failures. `get-errors` returns "no diagnostics found" for these; `build` reports them at compile time.
      3. Cap the combined loop at 5 fix attempts. Fix one thing per iteration; re-run both validators.
-   - **Project-level end-goal** (before reporting done): the per-file step's project-level `build` already establishes compilability. A successful `uip rpa run-file` smoke test covers this too. Skip the standalone end-goal `build` only if the per-file `build` already passed clean on the project's current state.
+   - **Project-level end-goal** (before reporting done): the per-file step's project-level `build` establishes compilability — successful `uip rpa run-file` smoke test covers this too. Then `uip rpa analyze "<PROJECT_DIR>" --output json` must report zero `severity: error` items (warnings and info do not block). `analyze` catches what `build` and `get-errors` miss: empty argument values, project-wide analyzer rules, governance violations. **Never skip `analyze` before declaring done** — Studio's "Analyze Project" runs the same checks and will surface what was skipped. If an `error` rule looks bogus or domain-incorrect, escalate to the user with rule ID + recommendation rather than silencing it.
 
    See [references/validation-guide.md](references/validation-guide.md).
-4. **ALWAYS validate files as you go AND verify the project builds before declaring done.** After every create or edit: per-file `get-errors` to clean **and** project-level `build` to clean — both, in that order. `get-errors` clean alone is not "validated"; it cannot see member or enum errors. See [references/validation-guide.md](references/validation-guide.md).
+4. **ALWAYS validate files as you go AND verify the project builds and analyzes clean before declaring done.** After every create or edit: per-file `get-errors` to clean, then project-level `uip rpa build` to clean. Before declaring a project-level task done: `uip rpa analyze "<PROJECT_DIR>" --output json` must be error-free (zero `severity: error` items; warnings and info do not block). All three gates, in that order. `get-errors` clean alone is not "validated" — it cannot see member, enum, or project-wide analyzer errors. Bogus-looking error rules go to the user, not to silent suppression. See [references/validation-guide.md](references/validation-guide.md).
 5. **Prefer UiPath built-in activities** for Orchestrator integration, UI automation, and document handling. Prefer plain .NET / third-party packages for pure data transforms, HTTP calls, parsing.
 6. **ALWAYS ensure required package dependencies are in `project.json`** before using their activities or services.
 6a. **Pre-edit verification gate.** Two authoring actions are hard to roll back once `build` fails — verify before serialization, not after.
@@ -275,6 +275,7 @@ Check `expressionLanguage` in `project.json`. VB.NET uses `[brackets]` for expre
 | `get-analyzer-rules --project-dir "<dir>"` | List enabled Workflow Analyzer rules — run before generating |
 | `get-errors --file-path "<file>"` | Per-file static validation (structure, references, analyzer rules) |
 | `build "<PROJECT_DIR>"` | Compile-time validation (member names, enum values, JIT expressions) — run after `get-errors` is clean |
+| `analyze "<PROJECT_DIR>"` | Project-level analyzer (empty arg values, project-wide rules, governance) — required error-free before declaring done |
 
 ### Common Activities
 
@@ -351,7 +352,7 @@ Additional UIA procedures and guides:
 
 When you finish a task, report to the user:
 1. **What was done** — files created, edited, or deleted (list file paths)
-2. **Validation status** — per-file `get-errors` result (all files passed, or remaining errors) **and** project-level `uip rpa build` result. Both must be clean to claim verification — `get-errors` clean alone is insufficient (it does not detect unknown member names or invalid enum values). If `build` has not run since the last edit, say so explicitly rather than claiming success.
+2. **Validation status** — per-file `get-errors` result (all files passed, or remaining errors), project-level `uip rpa build` result, **and** project-level `uip rpa analyze` result (zero `severity: error` items). All three must be clean to claim verification — `get-errors` clean alone is insufficient (no member/enum errors), and `build` clean alone misses what only `analyze` catches (empty argument values, project-wide analyzer rules). If any of the three has not run since the last edit, say so explicitly rather than claiming success. If `analyze` reports an `error` rule that looks bogus, surface the rule ID + recommendation to the user instead of declaring done.
 3. **Plan completion** — which task checkboxes in `docs/plans/*.md` are now `[x]`; list any still `[ ]` and, for each, the Stop-condition item that interrupted it (or "not reached" if execution was cut short another way)
 4. **How to run** — the `uip rpa run-file` command (if applicable)
 5. **Next steps** — follow-up actions (configure connections, add OR elements, fill placeholders)

--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -233,6 +233,34 @@ uip rpa build "<PROJECT_DIR>" --log-level Warn --output json```
 
 **Relationship to `run-file`:** `run-file` compiles internally, so a successful smoke test implies `build` would pass. When no smoke test is run (side effects, interactive workflow, no test input), `build` is the required end-goal check for compilability — including attribute-form expression failures (`JIT compilation is disabled for non-Legacy projects`) in XAML projects with `expressionLanguage: CSharp` that don't surface during static `get-errors`.
 
+`build` does NOT run the workflow analyzer end-to-end; project-wide rules (empty argument values, naming conventions, governance policies) require `uip rpa analyze` separately. See [validation-guide.md § Project-Level Done Gate](validation-guide.md#project-level-done-gate-required-before-returning-a-project).
+
+---
+
+### analyze
+
+Run the UiPath Workflow Analyzer against the project. Catches what `build` and `get-errors` miss: empty argument values, project-wide analyzer rules, governance/policy violations. CLI equivalent of Studio's "Analyze Project". Required error-free before declaring a project-level task done.
+
+```bash
+uip rpa analyze "<PROJECT_DIR>" --output json
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `<projectDir>` | Yes | Path to the project directory (positional — not `--project-dir`) |
+| `--log-level` | No | `Debug` / `Info` / `Warn` / `Error`. Default `Warn`. |
+| `--exclude-configured-sources` | No | Exclude user/machine-configured NuGet sources |
+| `--nuget-sources-config-path` | No | Path to a custom NuGet sources config file |
+| `--default-severity` | No | Default severity when a rule has none configured |
+| `--governance-file-path` | No | Path to a governance/policy rules file |
+| `--governance-file-type` | No | Type of the governance file |
+| `--detailed-log-path` | No | Path to write a detailed log file |
+| `--skip-analyze` | No | No-op for this subcommand; present for parity with `build` |
+
+**Done-gate semantics.** Only items with `severity: error` block. `warning` and `info` do not require fixing. If an `error` rule appears bogus or domain-incorrect, escalate to the user with rule ID + recommendation rather than silencing it. See [validation-guide.md § Bogus-rule escalation](validation-guide.md#bogus-rule-escalation).
+
+**Relationship to `pack`.** `uip rpa pack` runs `analyze` implicitly unless `--skip-analyze` is passed. Running `analyze` standalone gives a clean pass/fail signal independent of pack output — see [publishing-guide.md](publishing-guide.md).
+
 ---
 
 ### get-analyzer-rules

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -32,22 +32,37 @@ When an error occurs, identify the root cause, fix **only** that one thing, and 
 
 ## Validation Iteration Loop
 
-After every file create or edit, validate with **both** `get-errors` and `build`. They catch disjoint error classes — neither alone is sufficient. Run them in sequence on every iteration; do not stop at "`get-errors` is clean".
+After every file create or edit, validate with `get-errors`, `build`, and `analyze`. They catch disjoint error classes — none alone is sufficient. The first two run on every iteration; `analyze` is the project-level done gate that runs once after the inner loop converges.
 
 ```
-REPEAT:
+REPEAT (per-file inner loop):
   1. uip rpa get-errors --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json
   2. IF get-errors has errors -> fix one thing, GOTO 1
   3. uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
   4. IF build has errors -> fix one thing, GOTO 1
-  5. EXIT to Smoke Test
+  5. EXIT inner loop
+
+PROJECT-LEVEL DONE GATE (before declaring done):
+  6. uip rpa analyze "<PROJECT_DIR>" --output json
+  7. IF any item has severity: error -> fix one thing, GOTO 1
+     - If a severity:error rule appears bogus or domain-incorrect, escalate to the user
+       with rule ID + recommendation; do NOT silence the rule unilaterally
+  8. EXIT to Smoke Test
 ```
 
-**Why both.** `get-errors` is static analysis: it catches structural XAML, missing references, analyzer rules, and schema violations. `build` is the compiler: it catches **unknown member names** (e.g. `NGetText.Value` when the property is `Text`), **invalid enum values** (e.g. `Operator="StartsWith"` when the enum has no such member), **member resolution / CacheMetadata failures**, and attribute-form C# expression JIT failures. `get-errors` returns "no diagnostics found" for these classes; `build` flags them at compile time. Trusting only `get-errors` ships broken workflows.
+**Why all three.** Each catches a disjoint error class:
 
-**Target the specific file:** Use `--file-path` on `get-errors` to validate only the file you changed -- faster than validating the whole project. `build` is project-scoped (no `--file-path`); when it errors, identify the offending file from the build output and re-run `get-errors --file-path` on that file as part of the fix loop.
+- `get-errors` — static per-file analysis: structural XAML, missing references, analyzer rules, schema violations.
+- `build` — compiler: **unknown member names** (e.g. `NGetText.Value` when the property is `Text`), **invalid enum values** (e.g. `Operator="StartsWith"` when the enum has no such member), **member resolution / CacheMetadata failures**, attribute-form C# expression JIT failures. `get-errors` returns "no diagnostics found" for these.
+- `analyze` — project-level analyzer: **empty argument values** (e.g. `<InArgument></InArgument>` — passes per-file `get-errors`, fails project-level `analyze`), project-wide analyzer rules with no per-file pointer, governance/policy violations when `--governance-file-path` is set. `build` doesn't run these checks.
 
-**Cap at 5 fix attempts** across the combined `get-errors` + `build` loop. After 5 failed iterations, present the remaining errors to the user. They may require domain knowledge or environment-specific fixes.
+Trusting only `get-errors` + `build` ships projects that fail Studio's "Analyze Project" the moment the user opens them.
+
+**Severity threshold for `analyze`.** Only `severity: error` items block the done gate. `warning` and `info` items are advisory and do not require fixing. If an `error` rule looks bogus (false positive on a project-specific pattern, conflicts with a documented exception), escalate to the user with the rule ID, file path, and recommendation — never silently suppress.
+
+**Target the specific file:** Use `--file-path` on `get-errors` to validate only the file you changed — faster than validating the whole project. `build` and `analyze` are project-scoped (no `--file-path`); when either errors, identify the offending file from the output and re-run `get-errors --file-path` on that file as part of the fix loop.
+
+**Cap at 5 fix attempts** across the combined `get-errors` + `build` + `analyze` loop. After 5 failed iterations, present the remaining errors to the user. They may require domain knowledge or environment-specific fixes.
 
 ### Rules
 
@@ -59,26 +74,40 @@ REPEAT:
 
 See [cli-reference.md](cli-reference.md) for full `get-errors` and `run-file` command documentation.
 
-## Project Build Verification (Required Before Returning a Project)
+## Project-Level Done Gate (Required Before Returning a Project)
 
-Every project returned to the user must compile. The per-file iteration loop above already includes `build` after `get-errors` is clean — if that loop completed cleanly on the project's current state, this gate is already satisfied. Otherwise, run:
+Every project returned to the user must compile **and** pass project-level analysis. The per-file iteration loop above includes `build` after `get-errors` is clean. The done gate adds `analyze` on top:
 
 ```bash
 uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
+uip rpa analyze "<PROJECT_DIR>" --output json
 ```
 
-`get-errors` is static analysis and misses compile-time failures: unknown member names, invalid enum values, member resolution / CacheMetadata failures, and JIT failures like `JIT compilation is disabled for non-Legacy projects` — see [xaml/csharp-expression-pitfalls.md](xaml/csharp-expression-pitfalls.md). If `build` fails, apply the same fix loop as above (fix one thing, re-run, cap at 5). A successful `run-file` smoke test substitutes for `build` — `run-file` compiles internally.
+A successful `run-file` smoke test substitutes for `build` (run-file compiles internally) but does NOT substitute for `analyze` — they cover different error classes.
 
-### Errors `build` catches that `get-errors` misses
+### Disjoint error classes — what each command catches
 
-| Error class | Example | Why `get-errors` misses it |
-|-------------|---------|----------------------------|
-| Unknown member name | `<uix:NGetText Value="[x]" />` (correct: `Text`) | `get-errors` does not resolve property names against activity assemblies |
-| Invalid enum value | `Operator="StartsWith"` on `VerifyExpressionWithOperator` (enum has no such member) | Enum membership is checked at CacheMetadata / compile time, not static parse |
-| CacheMetadata / member resolution | Required-extension misses, type-mismatch on `InArgument<T>` | Surfaces only when the runtime instantiates the activity |
-| Attribute-form C# expressions | `Value="x + y"` in `expressionLanguage: CSharp` projects | JIT compiler needs the expression in element form — see [xaml/csharp-expression-pitfalls.md](xaml/csharp-expression-pitfalls.md) |
+| Error class | Caught by | Example | Why others miss it |
+|-------------|-----------|---------|--------------------|
+| Structural XAML, missing references, schema | `get-errors` | malformed XML, undeclared namespace | `build` and `analyze` assume parseable input |
+| Unknown member name | `build` | `<uix:NGetText Value="[x]" />` (correct: `Text`) | `get-errors` does not resolve property names against activity assemblies |
+| Invalid enum value | `build` | `Operator="StartsWith"` on `VerifyExpressionWithOperator` | Enum membership is checked at CacheMetadata / compile time, not static parse |
+| CacheMetadata / member resolution | `build` | Required-extension misses, type-mismatch on `InArgument<T>` | Surfaces only when the runtime instantiates the activity |
+| Attribute-form C# expressions | `build` | `Value="x + y"` in `expressionLanguage: CSharp` projects | JIT compiler needs the expression in element form — see [xaml/csharp-expression-pitfalls.md](xaml/csharp-expression-pitfalls.md) |
+| Empty argument values | `analyze` | `<InArgument x:TypeArguments="x:String"></InArgument>` | Passes per-file `get-errors`; `build` accepts the empty form. See [xaml/common-pitfalls.md § Empty Argument Values](xaml/common-pitfalls.md#empty-argument-values) |
+| Project-wide analyzer rules with no per-file pointer | `analyze` | naming conventions, package usage rules, missing required arguments at project scope | `get-errors` reports per-file scope only |
+| Governance / policy violations | `analyze` (with `--governance-file-path`) | required logging activities, restricted package usage | Outside `build`'s compile pass |
 
-When you see "no diagnostics found" from `get-errors`, you have not validated the file. Run `build` next.
+When `get-errors` reports "no diagnostics found", you have not validated the file. Run `build`. When `build` is clean, you have not validated the project. Run `analyze`.
+
+### Bogus-rule escalation
+
+If `analyze` reports a `severity: error` item that appears to be a false positive (rule contradicts a documented exception, fails on a project-specific intentional pattern, or recommends a change that breaks a working integration):
+
+1. Do NOT silence the rule by editing analyzer config.
+2. Surface to the user: rule ID (e.g. `ST-DBP-010`), severity, file path / activity, recommendation, and why it appears bogus.
+3. Offer choices: (a) accept the recommendation and apply the fix, (b) suppress the rule for this instance with a code comment / project-level exclusion, (c) keep as-is and document the deviation. Let the user decide.
+4. Only proceed past the done gate after the user confirms.
 
 ## Smoke Test
 

--- a/skills/uipath-rpa/references/xaml/workflow-guide.md
+++ b/skills/uipath-rpa/references/xaml/workflow-guide.md
@@ -8,7 +8,7 @@ Discovery-first approach with iterative error-driven refinement for generating a
 2. **Know Before You Write** — **NEVER** generate XAML blind. Understand the project structure, packages, expression language, and existing patterns.
 3. **Use What You Know, Skip What You Don't Need** — If you already know the package ID and activity class name, go directly to its doc file. Be efficient: the discovery steps are a priority ladder, not a mandatory checklist.
 4. **Start Minimal, Iterate to Correct** — Start one workflow at a time and break out logic into multiple files if needed. Build one activity at a time within each workflow. Write the smallest working XAML, validate with `uip rpa get-errors`, fix what breaks, repeat.
-5. **Validate After Every Change** — **MUST** validate with **both** `get-errors` and `uip rpa build` after every change. **NEVER** assume an edit succeeded. `get-errors` clean alone is not validated — it does not catch unknown member names or invalid enum values; `build` does.
+5. **Validate After Every Change** — **MUST** validate with `get-errors` then `uip rpa build` after every change. **NEVER** assume an edit succeeded. Before declaring the project-level task done, also run `uip rpa analyze` and require zero `severity: error` items — `build` does not catch empty argument values, project-wide analyzer rules, or governance violations. `get-errors` clean alone is not validated.
 6. **Fix Errors by Category** — Triage in order: Package → Structure → Type → Activity Properties → Logic.
 
 ---
@@ -195,18 +195,22 @@ Edit: file_path=... old_string=<exact text> new_string=<modified text>
 
 ## Phase 3: Validate & Fix Loop
 
-**MUST** repeat until 0-error state from **both** `get-errors` and `build`, or max 5 fix attempts. After 5 attempts, stop and present remaining errors to the user.
+**MUST** repeat the per-file inner loop until 0-error state from `get-errors` and `build`, or max 5 fix attempts. After the inner loop converges, run `uip rpa analyze` as the project-level done gate — must be error-free. After 5 combined fix attempts, stop and present remaining errors to the user.
 
 ### Step 3.1: Check for Errors
 
-Run both validators per iteration. `get-errors` catches structural / reference / analyzer issues; `build` catches member-name and enum-value mistakes that `get-errors` misses (e.g. `NGetText.Value` when the property is `Text`, `Operator="StartsWith"` when the enum has no such member). See [../validation-guide.md § Validation Iteration Loop](../validation-guide.md#validation-iteration-loop) for the canonical loop.
+Run validators in three layers. `get-errors` catches structural / reference / per-file analyzer issues; `build` catches member-name and enum-value mistakes (e.g. `NGetText.Value` when the property is `Text`, `Operator="StartsWith"` when the enum has no such member); `analyze` catches project-wide issues `build` doesn't run — empty argument values, naming-convention rules, governance violations. See [../validation-guide.md § Validation Iteration Loop](../validation-guide.md#validation-iteration-loop) for the canonical loop.
 
 ```bash
+# Per-file inner loop:
 uip rpa get-errors --file-path "Workflows/MyWorkflow.xaml" --output json
 uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
+
+# Project-level done gate (before declaring done):
+uip rpa analyze "<PROJECT_DIR>" --output json
 ```
 
-`--file-path` must be **relative to the project directory**. Use `--skip-validation` only for quick cached-error checks. Treat `get-errors` clean as half-done — `build` clean is the signal to exit the loop.
+`--file-path` must be **relative to the project directory**. Use `--skip-validation` only for quick cached-error checks. Treat `get-errors` clean as one-third done — only zero `severity: error` items from `analyze` after `build` is clean is the signal to exit. If an `analyze` `error` rule looks bogus, escalate to the user with rule ID + recommendation; do not silence it.
 
 ### Step 3.2: Categorize and Fix
 
@@ -240,8 +244,9 @@ For detailed procedures, see [../validation-guide.md](../validation-guide.md).
 
 - **NEVER** generate large, complex workflows in one go
 - **NEVER** manually craft UI selectors outside of `uia-configure-target` skill flow
-- **NEVER** assume a create/edit succeeded without validating with **both** `get-errors` and `build`
-- **NEVER** treat "no diagnostics found" from `get-errors` as final — run `build` next; member-name and enum-value errors hide behind a clean `get-errors`
+- **NEVER** assume a create/edit succeeded without validating with `get-errors` then `build`, and **NEVER** declare project-level done without `analyze` error-free
+- **NEVER** treat "no diagnostics found" from `get-errors` as final — run `build` next; member-name and enum-value errors hide behind a clean `get-errors`. And `build` clean is not "done" — empty argument values and project-wide analyzer rules surface only in `analyze`
+- **NEVER** silently silence an `analyze` `severity: error` rule that looks bogus — escalate to the user with rule ID and recommendation
 - **NEVER** stop the iteration loop before correctly rendering all activities
 - **NEVER** guess properties, types, or configurations without checking docs
 - **NEVER** use incorrect keys with `uip rpa get-workflow-example` (always from list results)


### PR DESCRIPTION
## Summary

- Add `uip rpa analyze` as the project-level done gate alongside `uip rpa build`. `analyze` catches empty argument values, project-wide analyzer rules, and governance violations that `get-errors` + `build` miss — the same checks Studio runs when a user clicks "Analyze Project".
- Only `severity: error` items block; `warning` and `info` are advisory.
- Bogus-looking `error` rules escalate to the user with rule ID + recommendation rather than being silenced unilaterally.

### Why

Real customer session (Reporter end-to-end): user had to manually run "Analyze Project" in Studio and feed errors back through 2-3 iterations because the agent treated `get-errors` + `build` clean as "done". This change closes that gap.

### Files

- `skills/uipath-rpa/SKILL.md` — Critical Rules 3 + 4, CLI commands table, Completion Output checklist.
- `skills/uipath-rpa/references/validation-guide.md` — extended iteration loop, three-way catches/misses matrix, bogus-rule escalation procedure.
- `skills/uipath-rpa/references/cli-reference.md` — new `analyze` command reference.
- `skills/uipath-rpa/references/xaml/workflow-guide.md` — Phase 3 loop and anti-patterns updated.

## Test plan

- [ ] `bash hooks/validate-skill-descriptions.sh` exits 0 (verified locally)
- [ ] Anchor links resolve (`#project-level-done-gate-required-before-returning-a-project`, `#bogus-rule-escalation`, `#empty-argument-values`, `#validation-iteration-loop`)
- [ ] Spot-check that next agent run on a clean XAML project includes `uip rpa analyze` in the validation sequence before claiming done
- [ ] Confirm bogus-rule escalation behavior on a project with a known analyzer false positive (e.g. naming-convention rule against intentional pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)