### PR TITLE
fix(maestro-flow): anchor scaffold self-check on $(pwd) so persistent cd doesn't fake a layout bug [MST-9582]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/greenfield.md
+++ b/skills/uipath-maestro-flow/references/author/references/greenfield.md
@@ -98,6 +98,8 @@ cd <directory>/<SolutionName> && uip maestro flow init <ProjectName> --output js
 
 The `cd` is required. Running `uip maestro flow init` from outside the solution directory (or from the parent of `<SolutionName>/`) is wrong — it produces a single-nested layout and breaks every later step.
 
+> **Bash session state persists across tool calls.** This `cd` is **not scoped to one Bash invocation** — your cwd remains inside `<SolutionName>/` for every subsequent `Bash` call until you `cd` somewhere else. Plan the rest of Step 2 (and Steps 3–6) accordingly: either keep using paths relative to the solution dir, or anchor with `$(pwd)` / the absolute `Data.Path` returned by `flow init`. Do NOT prefix later commands with the original `<directory>/<SolutionName>/...` — that would resolve as `<SolutionName>/<directory>/<SolutionName>/...` and look like a layout bug when it isn't.
+
 `--output json` is required so Step 2c can inspect `Data.SolutionRegistration.Status` to confirm the project was auto-registered with the parent solution.
 
 ### 2c. Verify the project is registered in the solution
@@ -150,11 +152,17 @@ If the registration was skipped because of single-nesting, **delete the partial 
 
 **Self-check — run this before Step 3:**
 
+After Step 2b your cwd is inside `<SolutionName>/` (the `cd` persists). Verify the flow file using a `$(pwd)`-anchored absolute path so the check is robust to that cwd drift:
+
 ```bash
-ls "<directory>/<SolutionName>/<ProjectName>/<ProjectName>.flow"
+ls "$(pwd)/<ProjectName>/<ProjectName>.flow"
 ```
 
-If the file does not exist at that exact path (double-nested), Step 2 is wrong. Delete the partial scaffold and restart from Step 2a — do not try to patch the layout by hand.
+Equivalent: use the absolute project dir reported by `flow init` in `Data.Path` and append `/<ProjectName>.flow`. Either form gives an absolute path that doesn't depend on the current cwd.
+
+> **Don't write `<SolutionName>/<ProjectName>/<ProjectName>.flow` here.** From inside `<SolutionName>/` that resolves to `<SolutionName>/<SolutionName>/<ProjectName>/<ProjectName>.flow` (triple-nested) and the `ls` will fail even though the layout is correct. That false negative wastes turns chasing a non-bug.
+
+If the file does not exist at the absolute double-nested path, Step 2 is wrong. Delete the partial scaffold and restart from Step 2a — do not try to patch the layout by hand.
 
 See [shared/file-format.md](../../shared/file-format.md) for the full project structure.
 

--- a/skills/uipath-maestro-flow/references/diagnose/references/failure-modes.md
+++ b/skills/uipath-maestro-flow/references/diagnose/references/failure-modes.md
@@ -158,13 +158,15 @@ uip maestro flow init <ProjectName> --output json
 #   uip solution project add <SolutionName>/<ProjectName> <SolutionName>/<SolutionName>.uipx
 ```
 
-After running, verify the file exists at the double-nested path:
+After running, verify the file exists at the double-nested path. The `cd <SolutionName>` above persists across Bash calls, so anchor the check with `$(pwd)` instead of repeating `<SolutionName>/`:
 
 ```bash
-ls "<SolutionName>/<ProjectName>/<ProjectName>.flow"
+ls "$(pwd)/<ProjectName>/<ProjectName>.flow"
 ```
 
-If not, the `init` step was wrong — do not try to patch the layout by hand.
+A relative `ls "<SolutionName>/<ProjectName>/<ProjectName>.flow"` here resolves to `<SolutionName>/<SolutionName>/<ProjectName>/<ProjectName>.flow` (triple-nested) and reports "no such file" even on a correctly-scaffolded solution — a false negative that turns a healthy layout into a fake bug.
+
+If the absolute path doesn't exist, the `init` step was wrong — do not try to patch the layout by hand.
 
 ### Reference
 


### PR DESCRIPTION
## Summary

- Step 2 self-check in `greenfield.md` and the matching recovery snippet in `diagnose/failure-modes.md` used a placeholder-style relative path. After Step 2b's `cd <SolutionName>` — which **persists across Claude Code Bash calls** — that relative path resolves to a *triple-nested* location and reports "no such file" on a correctly-built project, sending the agent to chase a non-bug.
- Anchor the check on `$(pwd)` (or the absolute `Data.Path` returned by `flow init`) so it's robust to the persisted cwd, and add an explicit note that `cd` state carries over.

## Tracking

- Jira: [MST-9582](https://uipath.atlassian.net/browse/MST-9582) (under epic MST-8796 — coder_eval e2e triage)

## Why now

`skill-flow-hitl-smoke-completed-port` timed out on the 2026-05-08 daily eval run with `final_status=ERROR` after burning ~520s in long thinking-blocks reacting to a fake layout bug. Both sister HITL smoke tasks (`multi-outcome-routing`, `node-placed`) hit the same symptom but recovered just under the 600s `turn_timeout`. Trace evidence in `runs/2026-05-08_04-46-07/`:

- Agent ran `cd PurchaseApproval && uip maestro flow init PurchaseApproval` (the `cd` persisted).
- Agent then ran the literal self-check `ls "PurchaseApproval/PurchaseApproval/PurchaseApproval.flow"` from inside `PurchaseApproval/`, which resolved to a triple-nested path that doesn't exist.
- Layout was actually correct (`<artifacts>/.../PurchaseApproval/PurchaseApproval/PurchaseApproval.flow` was on disk). The agent re-Wrote the file at the same path it already lived, then ran out of time on the next `validate`.

## What changed

- `skills/uipath-maestro-flow/references/author/references/greenfield.md` — Step 2c self-check now uses `$(pwd)/<ProjectName>/<ProjectName>.flow`, with a "don't write the relative form" warning and an explicit note about persistent Bash state under Step 2b.
- `skills/uipath-maestro-flow/references/diagnose/references/failure-modes.md` — single-nested-layout recovery snippet's verify step uses `$(pwd)`-anchored path with a one-line explanation of why the relative form silently triple-nests.

No code, no behavior in CLI / runtime — pure doc fix to remove a known false-negative trap from the agent's recipe.

## Test plan

- [ ] Trigger the next coder_eval daily run (or run the three HITL smoke tasks individually) and confirm `skill-flow-hitl-smoke-completed-port` passes (`weighted_score=1.0`) and `multi-outcome-routing` / `node-placed` finish faster than before.
- [ ] Spot-check that no other doc examples in `uipath-maestro-flow/references/` rely on the old `<directory>/<SolutionName>/...` placeholder shape.
- [ ] Manual repro: in a fresh dir run `uip solution new "X" --output json` then `cd X && uip maestro flow init X --output json` then `ls "$(pwd)/X/X.flow"` — should succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-9582]: https://uipath.atlassian.net/browse/MST-9582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ