### PR TITLE
fix(maestro-flow): force-pull before falling back to HTTP when registry only has triggers [MST-9584]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
@@ -52,6 +52,21 @@ uip is connectors list --output json
 
 Keys are often prefixed — e.g., `uipath-salesforce-slack` not `slack`.
 
+### Sanity-check before deciding "no connector activity exists"
+
+A `registry search <service>` that returns **only `uipath.connector.trigger.*`** entries — zero activity entries — is **suspicious, not authoritative**. Connector activities and triggers are independent fetches against different typecache endpoints; the registry cache can transiently miss the activity branch when one of those endpoints flakes (TTL: 30 min). Falling through to managed HTTP at this point produces a flow that *validates* but skips the real connector node — a silent topology mistake.
+
+When `registry search` returns triggers but **no activities** for a service whose connector you've already confirmed exists (`uip is connectors list`), or returns nothing at all for a well-known connector, **force a fresh pull before falling back**:
+
+```bash
+uip maestro flow registry pull --force                                  # bypass the 30-min cache
+uip maestro flow registry search <service> --output json                # re-check after the fresh pull
+```
+
+If the second search still returns no activities for that connector, the fallback to managed HTTP (Tier 2 below) is legitimate. If the second search now lists activities, the cache was stale — proceed with the connector activity node as Tier 1.
+
+> **Why this matters**: a partial registry pull is an indirect failure — `registry pull` reports `Success` even when one node-source branch silently dropped its contribution. The shape (`triggers > 0 && activities == 0`) is the only local signal you have. Treat it like a stale-cache symptom, not a topology fact.
+
 ### Disambiguation — when search returns multiple connectors for the same intent
 
 `uip maestro flow registry search <keyword>` routinely returns multiple connectors for the same user intent (e.g. searching `databricks` returns both the native AI-serving connector and the JDBC gateway). **Never silently pick the first match.**


### PR DESCRIPTION
> **Tracking ticket: [MST-9584](https://uipath.atlassian.net/browse/MST-9584)** — root-cause layer of the May 2026 partial-cache incident. Companion to [MST-9564](https://uipath.atlassian.net/browse/MST-9564) (checker-side fix). Closed twin: [MST-8935](https://uipath.atlassian.net/browse/MST-8935).

## Summary
- Add a defensive instruction to `skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md`: when `registry search <connector>` returns triggers but **no activities**, force a fresh pull and re-check before deciding to fall back to managed HTTP (Tier 2).
- This is the in-skill backstop for a partial registry cache. The CLI-side fixes ([UiPath/cli#1913](https://github.com/UiPath/cli/pull/1913) ratio guard + [UiPath/cli#1915](https://github.com/UiPath/cli/pull/1915) structural guard) prevent the cache from being poisoned in the first place; the flow-core fix ([UiPath/flow-workbench#1512](https://github.com/UiPath/flow-workbench/pull/1512)) surfaces fetcher failures so the CLI guards have a deterministic signal. This skill update ensures the agent doesn't silently mis-diagnose a stale cache as "no connector activity exists" even if the cache somehow gets through.

## Context — why we need this
On 2026-05-08 the daily `coder-eval` run failed `skill-flow-slack-weather-pipeline`. Trace:

1. The CLI's registry cache was poisoned with a 488-node partial pull (vs 4157 healthy) — connectors branch silently dropped at the typecache layer.
2. The agent ran `uip maestro flow registry search "slack" --output json` and saw only `uipath.connector.trigger.uipath-salesforce-slack.*` entries. No activities.
3. Per the existing Tier-1 → Tier-2 fallback ladder in `connector/planning.md`, the agent reasonably fell through to `core.action.http.v2` in connector mode and built a Slack-by-managed-HTTP flow.
4. `flow validate` accepted it (managed HTTP nodes are legitimate), but the e2e check requires a real `uipath.connector` node and failed.

The agent did the locally-correct thing given what `registry search` told it. The mis-step was treating the registry response as authoritative when it was actually stale. The new section adds:

> When `registry search` returns triggers but **no activities** for a service whose connector you've already confirmed exists (`uip is connectors list`), or returns nothing at all for a well-known connector, **force a fresh pull before falling back**.

This gives the agent one cheap retry with `--force` (bypasses the 30-min cache) before locking in the Tier-2 fallback decision.

## Test plan
- [x] Read-through: the Tier 1 → 2 → 3 → 4 ladder is unchanged; the new subsection only governs *when* you've decided to leave Tier 1.
- [x] Cross-references intact: `core.action.http.v2`, `uip is connectors list`, `uip maestro flow registry pull --force`, etc. all match existing CLI surface.
- [ ] Followup: the eval re-run after CLI #1915 lands should show this task passing without invoking the doc-level retry, since the cache won't be polluted in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-9584]: https://uipath.atlassian.net/browse/MST-9584?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MST-9564]: https://uipath.atlassian.net/browse/MST-9564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MST-8935]: https://uipath.atlassian.net/browse/MST-8935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ