### PR TITLE
docs(maestro-flow): strip restating inline comments in connector sanity-check section

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
@@ -59,8 +59,8 @@ A `registry search <service>` that returns **only `uipath.connector.trigger.*`**
 When `registry search` returns triggers but **no activities** for a service whose connector you've already confirmed exists (`uip is connectors list`), or returns nothing at all for a well-known connector, **force a fresh pull before falling back**:
 
 ```bash
-uip maestro flow registry pull --force                                  # bypass the 30-min cache
-uip maestro flow registry search <service> --output json                # re-check after the fresh pull
+uip maestro flow registry pull --force
+uip maestro flow registry search <service> --output json
 ```
 
 If the second search still returns no activities for that connector, the fallback to managed HTTP (Tier 2 below) is legitimate. If the second search now lists activities, the cache was stale — proceed with the connector activity node as Tier 1.


### PR DESCRIPTION
## Summary
- Follow-up to [#669](https://github.com/UiPath/skills/pull/669) (merged). Addresses the `github-actions[bot]` review item 1a from that PR.
- Strips two inline bash comments in the new "Sanity-check before deciding 'no connector activity exists'" section of `skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md`. Per `.claude/rules/token-optimization.md` §2 ("Comment restates section heading or surrounding bullet point"), the inline comments restate the immediately-preceding paragraph and are duplicate tokens.

## Why a follow-up
[#669](https://github.com/UiPath/skills/pull/669) merged cleanly with the human reviewer's approval before the bot's nit could be incorporated. Surfacing as a tiny separate PR rather than letting the nit slip.

The bot's other Low item (drop the "Why this matters" blockquote) is **not** addressed here — bot self-rated it as a judgment call, and the blockquote contributes a unique signal (`registry pull` reports `Success` even on partial fetches) that the surrounding prose doesn't carry.

## Diff

```diff
-uip maestro flow registry pull --force                                  # bypass the 30-min cache
-uip maestro flow registry search <service> --output json                # re-check after the fresh pull
+uip maestro flow registry pull --force
+uip maestro flow registry search <service> --output json
```

## Test plan
- [x] Read-through: the surrounding prose ("force a fresh pull before falling back") covers what the comments said.
- [x] No CLI surface change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)