### PR TITLE
fix(maestro-flow): align pattern-node docs with current canvas .flow shape

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
@@ -90,7 +90,7 @@ Notes:
 - **No instance-level `model` block.** BPMN type and `serviceType: "ECS.BatchTransform"` live only in the corresponding `definitions[]` entry — copy that verbatim from `uip maestro flow registry get uipath.pattern.batch-transform --output json`. Per [author/CAPABILITY.md rule 16](../../CAPABILITY.md), node instances normally have no `model` block.
 - **`typeVersion` must match `definitions[<batch-transform>].version` exactly** — the registry currently emits `"1.0"` (one dot). Do not guess `"1.0.0"`.
 - `inputs.outputColumns` is an **array of objects** with exactly the keys `name` and `description`. Do not flatten to a map (`{ Category: "...", Summary: "..." }`) — the canvas editor and the BPMN serializer expect the array shape.
-- `outputs.output.source` is the literal **`=response`** (the convention every BPMN ServiceTask follows; the engine wraps its result under that key). Do not rewrite to `=batchTransformResult`, `=result.output`, or similar — that's a stale pre-#1380 shape.
+- `outputs.output.source` is the literal **`=response`** (the convention every BPMN ServiceTask follows; the engine wraps its result under that key). Do not rewrite to `=batchTransformResult`, `=result.output`, or similar.
 - `outputs.output.type` is **`"file"`**; the result is a file handle (not a row array).
 
 ## End-node output mapping
@@ -171,4 +171,4 @@ The validator checks that required inputs (`attachment`, `prompt`, `outputColumn
 - **Do not reference downstream rows inside the prompt** — each row is processed independently; there is no way to see sibling rows. Pre-aggregate or use [Summarize](../summarize/impl.md) on a synthesized document instead.
 - **Do not chain a Batch Transform's `$vars.{nodeId}.output` directly into a Script expecting rows** — it is a file handle, not a row array.
 - **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. The canonical wiring is a flow `in` variable of `type: "file"` bound to the trigger via `triggerNodeId`, referenced as `=js:$vars.<triggerId>.output.<fileVarId>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.
-- **Do not write `outputs.output.source: "=batchTransformResult"`.** That string is a stale pre-#1380 shape; the canonical value is `"=response"` (the convention every BPMN ServiceTask follows).
+- **Do not write `outputs.output.source: "=batchTransformResult"`.** The canonical value is `"=response"` (the convention every BPMN ServiceTask follows).

--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/impl.md
@@ -14,8 +14,8 @@ Confirm:
 - Output ports: `output`, `error`
 - `model.type` — `bpmn:ServiceTask`
 - `model.serviceType` — `ECS.BatchTransform`
-- `inputDefinition.properties` — `attachment` (object — full Flow Attachment, **not** a bare id), `prompt` (string), `enableWebSearchGrounding` (boolean), `outputColumns` (array of `{ name, description }`). The schema declares `string` because Studio Web's file picker serializes the whole Attachment object into that slot at save time; the runtime parses it back as an object — pass the **whole** `{ FullName, Id, Metadata, MimeType }` object, not a GUID, URL, or path.
-- `outputDefinition.output.schema.properties` — `id`, `fileName`, `mimeType`
+- `inputDefinition.properties` — `attachment` (declared `string`; runtime wants the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }` — Studio Web's file-picker form serializes the whole object into that slot, the engine deserializes it back), `prompt` (string), `enableWebSearchGrounding` (boolean), `outputColumns` (array of `{ name, description }`)
+- `outputDefinition.output.type` — `"file"`; `outputDefinition.output.source` — `"=response"` (the BPMN engine wraps the result under that key — same convention as every other ServiceTask)
 - `outputDefinition.error.schema.required` — `code`, `message`, `detail`, `category`, `status`
 
 If the command errors with **"Node type not found: uipath.pattern.batch-transform"**, the CLI build predates Batch Transform support or the tenant's `canvas.nodes.batch-transform` server flag is off. Run `uip cli update` and `uip maestro flow registry pull --force`; if it still errors, confirm with your UiPath admin that the `canvas.nodes.batch-transform` flag is enabled on the tenant.
@@ -23,6 +23,34 @@ If the command errors with **"Node type not found: uipath.pattern.batch-transfor
 ## Adding / Editing
 
 Pattern nodes are OOTB BPMN service tasks — author them by editing the `.flow` JSON directly (Edit/Write). This is the canonical authoring path per [author/CAPABILITY.md rule 2](../../CAPABILITY.md): the `uip maestro flow node add` / `edge add` carve-out is reserved for connectors, connector-triggers, and managed HTTP, where the CLI populates product-managed state. For OOTB structural edits — adding the BT node, wiring its edges, adding the `attachment` flow input — use Edit/Write against the `.flow` file. See [editing-operations.md](../../editing-operations.md) for the JSON authoring mechanics; the snippets below cover what is **specific** to Batch Transform.
+
+## Wiring `attachment` — file variable bound to the trigger
+
+The canonical canvas-produced shape is a flow `in` variable of `type: "file"` bound to the trigger via `triggerNodeId`, with the BT node's `attachment` referencing it through the trigger's output:
+
+```json
+"variables": {
+  "globals": [
+    {
+      "id": "csvFile",
+      "direction": "in",
+      "type": "file",
+      "triggerNodeId": "start"
+    }
+  ]
+}
+```
+
+Then on the BT node:
+
+```json
+"inputs": {
+  "attachment": "=js:$vars.start.output.csvFile",
+  ...
+}
+```
+
+`uip maestro flow debug --file csvFile=./path/to/data.csv` populates that variable as a `{ FullName, Id, Metadata, MimeType }` Attachment object at runtime. Do not declare the variable as `type: "object"`, do not reference it as `=js:$vars.csvFile` directly without the trigger output path, and do not pass a bare GUID/URL/path/`.Id`/`.FullName`.
 
 ## JSON Structure
 
@@ -33,7 +61,7 @@ Pattern nodes are OOTB BPMN service tasks — author them by editing the `.flow`
   "typeVersion": "1.0",
   "display": { "label": "Categorize Invoices" },
   "inputs": {
-    "attachment": "=js:$vars.invoiceCsv",
+    "attachment": "=js:$vars.start.output.csvFile",
     "prompt": "Classify each invoice by category and write a one-line summary.",
     "enableWebSearchGrounding": false,
     "outputColumns": [
@@ -44,13 +72,12 @@ Pattern nodes are OOTB BPMN service tasks — author them by editing the `.flow`
   "outputs": {
     "output": {
       "type": "file",
-      "description": "Result file handle",
-      "source": "=batchTransformResult",
+      "source": "=response",
       "var": "output"
     },
     "error": {
       "type": "object",
-      "description": "Error information if the batch job fails",
+      "description": "Error information if the node fails",
       "source": "=Error",
       "var": "error"
     }
@@ -63,7 +90,8 @@ Notes:
 - **No instance-level `model` block.** BPMN type and `serviceType: "ECS.BatchTransform"` live only in the corresponding `definitions[]` entry — copy that verbatim from `uip maestro flow registry get uipath.pattern.batch-transform --output json`. Per [author/CAPABILITY.md rule 16](../../CAPABILITY.md), node instances normally have no `model` block.
 - **`typeVersion` must match `definitions[<batch-transform>].version` exactly** — the registry currently emits `"1.0"` (one dot). Do not guess `"1.0.0"`.
 - `inputs.outputColumns` is an **array of objects** with exactly the keys `name` and `description`. Do not flatten to a map (`{ Category: "...", Summary: "..." }`) — the canvas editor and the BPMN serializer expect the array shape.
-- `outputs.output.source` is the literal `=batchTransformResult` — do not rewrite to `=result.output` or similar.
+- `outputs.output.source` is the literal **`=response`** (the convention every BPMN ServiceTask follows; the engine wraps its result under that key). Do not rewrite to `=batchTransformResult`, `=result.output`, or similar — that's a stale pre-#1380 shape.
+- `outputs.output.type` is **`"file"`**; the result is a file handle (not a row array).
 
 ## End-node output mapping
 
@@ -90,7 +118,7 @@ The `uip maestro flow node add` / `edge add` CLI is **not** the canonical author
 uip maestro flow node add <FlowName>.flow uipath.pattern.batch-transform \
   --label "<LABEL>" \
   --input '{
-    "attachment": "=js:$vars.<inputAttachmentVar>",
+    "attachment": "=js:$vars.<triggerId>.output.<fileVarId>",
     "prompt": "<INSTRUCTION describing every output column>",
     "outputColumns": [
       { "name": "<COLUMN_NAME>", "description": "<WHAT TO PUT IN THIS COLUMN>" }
@@ -100,16 +128,18 @@ uip maestro flow node add <FlowName>.flow uipath.pattern.batch-transform \
   --output json
 ```
 
-`attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object.
+`attachment` must resolve to a **full Flow Attachment object** (`{ FullName, Id, Metadata, MimeType }`). Reference it through the trigger's output (`$vars.<triggerId>.output.<fileVarId>`) — that's how the canvas wires file-typed flow `in` variables. Do **not** pass a bare GUID, URL, byte stream, or path; even though the OOTB `inputDefinition` declares `type: "string"`, the engine wants the object.
 
 ## Accessing Output
 
-The result is a file handle, not the transformed rows themselves. To use the new columns downstream, feed the handle to another node that consumes files (another Batch Transform, a connector that uploads, a Script that parses):
+The result is a file handle, not the transformed rows themselves. Pass `$vars.{nodeId}.output` to a downstream node that consumes files (another Batch Transform, a connector that uploads, a Script that fetches and parses):
 
 ```javascript
 // Downstream Script node
-const resultFile = $vars.categorizeRows.output; // { id, fileName, mimeType }
-return { resultFileId: resultFile.id };
+const resultFile = $vars.categorizeRows.output; // file handle
+// Use the handle as the `attachment` input on a downstream Pattern node, or
+// pass it to an HTTP/connector step that uploads or downloads the file.
+return { resultFile };
 ```
 
 If you need the rows as JSON inside the flow, add a downstream step that fetches and parses the file — Batch Transform itself never materializes rows into `$vars`.
@@ -140,4 +170,5 @@ The validator checks that required inputs (`attachment`, `prompt`, `outputColumn
 - **Do not reshape `outputColumns` to a map** — the array-of-`{name, description}` shape is contractual with the canvas property panel and the BPMN `ECS.BatchTransform` serializer.
 - **Do not reference downstream rows inside the prompt** — each row is processed independently; there is no way to see sibling rows. Pre-aggregate or use [Summarize](../summarize/impl.md) on a synthesized document instead.
 - **Do not chain a Batch Transform's `$vars.{nodeId}.output` directly into a Script expecting rows** — it is a file handle, not a row array.
-- **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. Always pass the whole object via `=js:$vars.<name>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.
+- **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. The canonical wiring is a flow `in` variable of `type: "file"` bound to the trigger via `triggerNodeId`, referenced as `=js:$vars.<triggerId>.output.<fileVarId>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.
+- **Do not write `outputs.output.source: "=batchTransformResult"`.** That string is a stale pre-#1380 shape; the canonical value is `"=response"` (the convention every BPMN ServiceTask follows).

--- a/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/batch-transform/planning.md
@@ -41,14 +41,14 @@ No artifact ports. Pattern-style nodes do not wire to resource files — the pro
 
 ## Output Variables
 
-- `$vars.{nodeId}.output` — file handle of the result CSV: `{ id, fileName, mimeType }`. Pass this to downstream nodes that consume files (e.g., another Batch Transform, a connector that uploads the result).
+- `$vars.{nodeId}.output` — the result file handle. The OOTB definition declares `outputDefinition.output.type: "file"` (no nested schema today), and `source: "=response"` — i.e. the BPMN engine returns its result wrapped under the `response` key. Pass `$vars.{nodeId}.output` to downstream nodes that consume files (e.g., another Batch Transform, a connector that uploads the result, a Script that fetches and parses).
 - `$vars.{nodeId}.error` — populated on failure: `{ code, message, detail, category, status }`.
 
 ## Key Inputs
 
 | Input | Required | Type | Description |
 | --- | --- | --- | --- |
-| `attachment` | Yes | object (full Flow Attachment) | The full Flow Attachment object for the source CSV — shape `{ FullName, Id, Metadata, MimeType }`. Source it as a flow-level `in` variable of `type: "object"` populated by `uip maestro flow debug --file <name>=<path>`, or from an upstream node that emits a Flow Attachment. Reference the **whole object** with `=js:$vars.<name>` — never `.Id`, a GUID literal, URL, or path. The OOTB schema says `string` and Studio Web shows a file picker, but at runtime the engine deserializes the slot back to the object. |
+| `attachment` | Yes | full Flow Attachment | The runtime engine wants the **full Flow Attachment object** (`{ FullName, Id, Metadata, MimeType }`). Source it as a flow-level `in` variable of `type: "file"` bound to the trigger via `triggerNodeId: "<triggerId>"`. The variable's payload is populated by `uip maestro flow debug --file <fileVarId>=<path>`. Reference it on the BT node as `=js:$vars.<triggerId>.output.<fileVarId>` — that path resolves to the whole Attachment object at runtime. The OOTB `inputDefinition.attachment` declares `type: "string"` because Studio Web's file-picker form serializes the object into that string slot at save time; the engine deserializes it back. **Never** wire a bare GUID, URL, byte stream, file path, or `.Id`/`.FullName` subfield. |
 | `prompt` | Yes | string | The instruction describing what each output column should contain. Can reference column names from the source via natural language ("summarize the `Description` field"). |
 | `outputColumns` | Yes | array of `{ name, description }` | The columns to produce. Max 10. `name` is the column header; `description` tells the LLM what to put in it. |
 | `enableWebSearchGrounding` | No | boolean | When `true`, the LLM can issue web searches per row to ground its answer. Slower and costlier — use only when rows need external facts. Default `false`. |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
@@ -14,8 +14,11 @@ Confirm:
 - Output ports: `output`, `error`
 - `model.type` — `bpmn:ServiceTask`
 - `model.serviceType` — `ECS.DeepRag`
-- `inputDefinition.properties` — `attachment` (object — full Flow Attachment, **not** a bare id), `prompt` (string), `returnCitations` (boolean). The schema declares `string` because Studio Web's file picker serializes the whole Attachment object into that slot at save time; the runtime parses it back as an object — pass the **whole** `{ FullName, Id, Metadata, MimeType }` object, not a GUID, URL, or path.
-- `outputDefinition.output.schema.properties.content` contains `text` (and `citations` when enabled)
+- `inputDefinition.properties` — `attachment` (declared `string`; runtime wants the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }` — Studio Web's file-picker form serializes the whole object into that slot, the engine deserializes it back), `prompt` (string), `returnCitations` (boolean)
+- `outputDefinition.output.type` — `"object"`; `outputDefinition.output.source` — `"=response"` (the BPMN engine wraps the result under that key — same convention as every other ServiceTask)
+- `outputDefinition.output.schema` — top-level fields `id` (string) and `content` (object|null) with PascalCase nested fields:
+  - `content.Text` — string
+  - `content.Citations` — array|null of `{ Ordinal: integer, PageNumber: integer, Source: string, Reference: string }`
 - `outputDefinition.error.schema.required` — `code`, `message`, `detail`, `category`, `status`
 
 If the command errors with **"Node type not found: uipath.pattern.deep-rag"**, the CLI build predates Summarize support or the tenant's `canvas.nodes.summarize` server flag is off. Run `uip cli update` and `uip maestro flow registry pull --force`; if it still errors, confirm with your UiPath admin that `canvas.nodes.summarize` is enabled on the tenant.
@@ -23,6 +26,34 @@ If the command errors with **"Node type not found: uipath.pattern.deep-rag"**, t
 ## Adding / Editing
 
 Pattern nodes are OOTB BPMN service tasks — author them by editing the `.flow` JSON directly (Edit/Write). This is the canonical authoring path per [author/CAPABILITY.md rule 2](../../CAPABILITY.md): the `uip maestro flow node add` / `edge add` carve-out is reserved for connectors, connector-triggers, and managed HTTP, where the CLI populates product-managed state. For OOTB structural edits — adding the Summarize node, wiring its edges, adding the `attachment` flow input — use Edit/Write against the `.flow` file. See [editing-operations.md](../../editing-operations.md) for the JSON authoring mechanics; the snippets below cover what is **specific** to Summarize.
+
+## Wiring `attachment` — file variable bound to the trigger
+
+The canonical canvas-produced shape is a flow `in` variable of `type: "file"` bound to the trigger via `triggerNodeId`, with the Summarize node's `attachment` referencing it through the trigger's output:
+
+```json
+"variables": {
+  "globals": [
+    {
+      "id": "documentFile",
+      "direction": "in",
+      "type": "file",
+      "triggerNodeId": "start"
+    }
+  ]
+}
+```
+
+Then on the Summarize node:
+
+```json
+"inputs": {
+  "attachment": "=js:$vars.start.output.documentFile",
+  ...
+}
+```
+
+`uip maestro flow debug --file documentFile=./path/to/doc.pdf` populates that variable as a `{ FullName, Id, Metadata, MimeType }` Attachment object at runtime. Do not declare the variable as `type: "object"`, do not reference it as `=js:$vars.documentFile` directly without the trigger output path, and do not pass a bare GUID/URL/path/`.Id`/`.FullName`.
 
 ## JSON Structure
 
@@ -33,20 +64,44 @@ Pattern nodes are OOTB BPMN service tasks — author them by editing the `.flow`
   "typeVersion": "1.0",
   "display": { "label": "Summarize Contract" },
   "inputs": {
-    "attachment": "=js:$vars.contractDoc",
+    "attachment": "=js:$vars.start.output.documentFile",
     "prompt": "Write a 5-bullet executive summary covering scope, term, SLAs, penalties, and termination.",
     "returnCitations": true
   },
   "outputs": {
     "output": {
       "type": "object",
-      "description": "Synthesis result",
-      "source": "=deepRagResult",
-      "var": "output"
+      "source": "=response",
+      "var": "output",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "content": {
+            "type": ["object", "null"],
+            "properties": {
+              "Text": { "type": "string" },
+              "Citations": {
+                "type": ["array", "null"],
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "Ordinal":    { "type": "integer" },
+                    "PageNumber": { "type": "integer" },
+                    "Source":     { "type": "string" },
+                    "Reference":  { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "error": {
       "type": "object",
-      "description": "Error information if the synthesis fails",
+      "description": "Error information if the node fails",
       "source": "=Error",
       "var": "error"
     }
@@ -58,12 +113,13 @@ Notes:
 
 - **No instance-level `model` block.** BPMN type and `serviceType: "ECS.DeepRag"` live only in the corresponding `definitions[]` entry — copy that verbatim from `uip maestro flow registry get uipath.pattern.deep-rag --output json`. Per [author/CAPABILITY.md rule 16](../../CAPABILITY.md), node instances normally have no `model` block.
 - **`typeVersion` must match `definitions[<deep-rag>].version` exactly** — the registry currently emits `"1.0"` (one dot). Do not guess `"1.0.0"`.
-- `outputs.output.source` is the literal `=deepRagResult` — do not rewrite.
-- Setting `returnCitations: true` populates `content.citations`; setting `false` omits the array entirely (the downstream consumer should tolerate either).
+- `outputs.output.source` is the literal **`=response`** (the convention every BPMN ServiceTask follows). Do not rewrite to `=deepRagResult` or similar — that's a stale pre-#1380 shape.
+- `outputs.output.type` is **`"object"`**, with the nested PascalCase schema above.
+- Setting `returnCitations: true` populates `content.Citations`; setting `false` omits the array entirely (the downstream consumer should tolerate either).
 
 ## End-node output mapping
 
-If the flow surfaces the synthesized text or citations as flow `out` variables, the End node must map them. Per [author/CAPABILITY.md rule 12](../../CAPABILITY.md), value-field expressions need the `=js:` prefix:
+If the flow surfaces the synthesized text or citations as flow `out` variables, the End node must map them. Per [author/CAPABILITY.md rule 12](../../CAPABILITY.md), value-field expressions need the `=js:` prefix. Note the **PascalCase** field names:
 
 ```json
 {
@@ -71,13 +127,13 @@ If the flow surfaces the synthesized text or citations as flow `out` variables, 
   "type": "core.control.end",
   "typeVersion": "1.0",
   "outputs": {
-    "summary":   { "source": "=js:$vars.summarizeContract.output.content.text" },
-    "citations": { "source": "=js:$vars.summarizeContract.output.content.citations" }
+    "summary":   { "source": "=js:$vars.summarizeContract.output.content.Text" },
+    "citations": { "source": "=js:$vars.summarizeContract.output.content.Citations" }
   }
 }
 ```
 
-Without `=js:`, the runtime stores the literal string (e.g. `"$vars.summarizeContract.output.content.text"`) into the flow output instead of the real value. When `returnCitations: false`, drop the `citations` mapping rather than mapping a missing field.
+Without `=js:`, the runtime stores the literal string (e.g. `"$vars.summarizeContract.output.content.Text"`) into the flow output instead of the real value. When `returnCitations: false`, drop the `citations` mapping rather than mapping a missing field. Lowercase variants (`.text`, `.citations`) do not exist in the response shape — they would resolve to `undefined`.
 
 ## Add via CLI (opt-in, not preferred)
 
@@ -87,29 +143,29 @@ The `uip maestro flow node add` / `edge add` CLI is **not** the canonical author
 uip maestro flow node add <FlowName>.flow uipath.pattern.deep-rag \
   --label "<LABEL>" \
   --input '{
-    "attachment": "=js:$vars.<inputAttachmentVar>",
+    "attachment": "=js:$vars.<triggerId>.output.<fileVarId>",
     "prompt": "<INSTRUCTION for the synthesis>",
     "returnCitations": true
   }' \
   --output json
 ```
 
-`attachment` must resolve to a **full Flow Attachment object** with shape `{ FullName, Id, Metadata, MimeType }` — point it at an upstream variable holding the whole object (typically a flow `in` variable populated by `uip maestro flow debug --file <name>=<path>`, or an upstream node that emits a Flow Attachment). **Not** a bare id, URL, byte stream, or path; even though Studio Web's form metadata calls this a `file` field and the OOTB schema says `type: "string"`, the engine wants the object. Set `returnCitations: false` (or omit) when downstream consumers do not need page-level provenance.
+`attachment` must resolve to a **full Flow Attachment object** (`{ FullName, Id, Metadata, MimeType }`). Reference it through the trigger's output (`$vars.<triggerId>.output.<fileVarId>`) — that's how the canvas wires file-typed flow `in` variables. Do **not** pass a bare GUID, URL, byte stream, or path; even though the OOTB `inputDefinition` declares `type: "string"`, the engine wants the object. Set `returnCitations: false` (or omit) when downstream consumers do not need page-level provenance.
 
 ## Accessing Output
 
 ```javascript
 // Downstream Script node
 const result = $vars.summarizeContract.output;
-const text = result.content.text;                   // the synthesized prose
-const citations = result.content.citations ?? [];    // [{ ordinal, page, source }, ...]
+const text = result.content.Text;                   // the synthesized prose
+const citations = result.content.Citations ?? [];   // [{ Ordinal, PageNumber, Source, Reference }, ...]
 return {
   summary: text,
   citationCount: citations.length,
 };
 ```
 
-If `returnCitations: false`, the `citations` array is not present. Guard with `?? []` or check `result.content.citations != null` before iterating.
+Field names are **PascalCase** (`Text`, `Citations`, `Ordinal`, `PageNumber`, `Source`, `Reference`). If `returnCitations: false`, the `Citations` array is not present. Guard with `?? []` or check `result.content.Citations != null` before iterating.
 
 ## Validate
 
@@ -124,10 +180,11 @@ The validator checks that required inputs (`attachment`, `prompt`) are present a
 | Error | Cause | Fix |
 | --- | --- | --- |
 | `Node type not found: uipath.pattern.deep-rag` | CLI predates Summarize support, or tenant flag `canvas.nodes.summarize` is off | `uip cli update`, `uip maestro flow registry pull --force`; check with admin that `canvas.nodes.summarize` is enabled if still missing |
-| Runtime: synthesis returns empty `content.text` | Prompt too vague, or attachment unreadable (image-only PDF with no OCR, corrupted file) | Tighten the prompt; confirm the attachment type is supported and has selectable text |
-| `content.citations` missing even though set `returnCitations: true` | Downstream consumer read the node's `inputDefaults` before the runtime produced the output | Reference `$vars.{nodeId}.output.content.citations` only in nodes downstream of Summarize; do not precompute |
+| Runtime: synthesis returns empty `content.Text` | Prompt too vague, or attachment unreadable (image-only PDF with no OCR, corrupted file) | Tighten the prompt; confirm the attachment type is supported and has selectable text |
+| `content.Citations` missing even though set `returnCitations: true` | Downstream consumer read the node's `inputDefaults` before the runtime produced the output | Reference `$vars.{nodeId}.output.content.Citations` only in nodes downstream of Summarize; do not precompute |
+| Downstream `result.content.text` / `result.content.citations` is `undefined` | Used lowercase field names — the response shape is PascalCase | Switch to `result.content.Text` / `result.content.Citations` |
 | Large documents time out | Synthesis cost scales with doc size; single call is bounded | Split the document upstream (per-section Summarize calls + a final merge step) or move to a published [Agent](../agent/impl.md) with a context-grounding resource |
-| Wrong citations (pages off by one, wrong source) | The attached document's page numbering doesn't match the displayed page ordinal | Treat `ordinal` and `page` as advisory — present the source identifier alongside and let the reader verify |
+| Wrong citations (pages off by one, wrong source) | The attached document's page numbering doesn't match the displayed page ordinal | Treat `Ordinal` and `PageNumber` as advisory — present `Source`/`Reference` alongside and let the reader verify |
 
 ## What NOT to Do
 
@@ -135,5 +192,7 @@ The validator checks that required inputs (`attachment`, `prompt`) are present a
 - **Do not pass `--source` on `uip maestro flow node add`** — `--source` is only for inline agent nodes. Summarize has no agent project behind it.
 - **Do not chain Summarize for multi-turn chat.** It is single-turn; each call is independent. Use a published [Agent](../agent/impl.md) for conversational flows.
 - **Do not stuff `prompt` with entire document text.** The attachment is already ingested — the prompt should describe **the task**, not the input.
-- **Do not assume `content.citations` is always present.** When `returnCitations: false`, the field is omitted; downstream code must guard.
-- **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. Always pass the whole object via `=js:$vars.<name>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.
+- **Do not assume `content.Citations` is always present.** When `returnCitations: false`, the field is omitted; downstream code must guard.
+- **Do not use lowercase field names** (`content.text`, `content.citations`, `.ordinal`, `.page`). The runtime emits PascalCase: `content.Text`, `content.Citations`, `Ordinal`, `PageNumber`, `Source`, `Reference`.
+- **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. The canonical wiring is a flow `in` variable of `type: "file"` bound to the trigger via `triggerNodeId`, referenced as `=js:$vars.<triggerId>.output.<fileVarId>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.
+- **Do not write `outputs.output.source: "=deepRagResult"`.** That string is a stale pre-#1380 shape; the canonical value is `"=response"` (the convention every BPMN ServiceTask follows).

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/impl.md
@@ -113,7 +113,7 @@ Notes:
 
 - **No instance-level `model` block.** BPMN type and `serviceType: "ECS.DeepRag"` live only in the corresponding `definitions[]` entry — copy that verbatim from `uip maestro flow registry get uipath.pattern.deep-rag --output json`. Per [author/CAPABILITY.md rule 16](../../CAPABILITY.md), node instances normally have no `model` block.
 - **`typeVersion` must match `definitions[<deep-rag>].version` exactly** — the registry currently emits `"1.0"` (one dot). Do not guess `"1.0.0"`.
-- `outputs.output.source` is the literal **`=response`** (the convention every BPMN ServiceTask follows). Do not rewrite to `=deepRagResult` or similar — that's a stale pre-#1380 shape.
+- `outputs.output.source` is the literal **`=response`** (the convention every BPMN ServiceTask follows). Do not rewrite to `=deepRagResult` or similar.
 - `outputs.output.type` is **`"object"`**, with the nested PascalCase schema above.
 - Setting `returnCitations: true` populates `content.Citations`; setting `false` omits the array entirely (the downstream consumer should tolerate either).
 
@@ -195,4 +195,4 @@ The validator checks that required inputs (`attachment`, `prompt`) are present a
 - **Do not assume `content.Citations` is always present.** When `returnCitations: false`, the field is omitted; downstream code must guard.
 - **Do not use lowercase field names** (`content.text`, `content.citations`, `.ordinal`, `.page`). The runtime emits PascalCase: `content.Text`, `content.Citations`, `Ordinal`, `PageNumber`, `Source`, `Reference`.
 - **Do not pass `attachment` as a bare string id, GUID, URL, or path.** The OOTB schema and Studio Web's file-picker UI suggest a string, but the runtime needs the **full Flow Attachment object** `{ FullName, Id, Metadata, MimeType }`. The canonical wiring is a flow `in` variable of `type: "file"` bound to the trigger via `triggerNodeId`, referenced as `=js:$vars.<triggerId>.output.<fileVarId>` (see Key Inputs in `planning.md`). Bare-id mistakes pass `flow validate` cleanly and fault at runtime.
-- **Do not write `outputs.output.source: "=deepRagResult"`.** That string is a stale pre-#1380 shape; the canonical value is `"=response"` (the convention every BPMN ServiceTask follows).
+- **Do not write `outputs.output.source: "=deepRagResult"`.** The canonical value is `"=response"` (the convention every BPMN ServiceTask follows).

--- a/skills/uipath-maestro-flow/references/author/references/plugins/summarize/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/summarize/planning.md
@@ -44,23 +44,28 @@ No artifact ports. Pattern-style nodes do not wire to resource files — the pro
 
 ## Output Variables
 
-- `$vars.{nodeId}.output` — an object with:
-  - `id` — the result identifier
-  - `content.text` — the synthesized prose
-  - `content.citations` — optional array (present only when `returnCitations: true`) of `{ ordinal, page, source }` pointing back to the attachment
-- `$vars.{nodeId}.error` — populated on failure: `{ code, message, detail, category, status }`.
+`$vars.{nodeId}.output` is an object whose schema is published on the OOTB definition (also mirrored on the node instance's `outputs.output.schema`):
+
+- `id` — string, the result identifier
+- `content` — `object | null`
+  - `content.Text` — string, the synthesized prose
+  - `content.Citations` — `array | null`, present only when `returnCitations: true`. Each entry: `{ Ordinal: integer, PageNumber: integer, Source: string, Reference: string }`
+
+Note the **PascalCase** field names (`Text`, `Citations`, `Ordinal`, `PageNumber`, `Source`, `Reference`) — the runtime emits them this way to match the engine response shape; lowercase variants (`text`, `citations`, `page`) are wrong.
+
+`$vars.{nodeId}.error` — populated on failure: `{ code, message, detail, category, status }`.
 
 ## Key Inputs
 
 | Input | Required | Type | Description |
 | --- | --- | --- | --- |
-| `attachment` | Yes | object (full Flow Attachment) | The full Flow Attachment object for the document — shape `{ FullName, Id, Metadata, MimeType }`. Source it as a flow-level `in` variable of `type: "object"` populated by `uip maestro flow debug --file <name>=<path>`, or from an upstream node that emits a Flow Attachment. Reference the **whole object** with `=js:$vars.<name>` — never `.Id`, a GUID literal, URL, or path. The OOTB schema says `string` and Studio Web shows a file picker, but at runtime the engine deserializes the slot back to the object. |
+| `attachment` | Yes | full Flow Attachment | The runtime engine wants the **full Flow Attachment object** (`{ FullName, Id, Metadata, MimeType }`). Source it as a flow-level `in` variable of `type: "file"` bound to the trigger via `triggerNodeId: "<triggerId>"`. The variable's payload is populated by `uip maestro flow debug --file <fileVarId>=<path>`. Reference it on the Summarize node as `=js:$vars.<triggerId>.output.<fileVarId>` — that path resolves to the whole Attachment object at runtime. The OOTB `inputDefinition.attachment` declares `type: "string"` because Studio Web's file-picker form serializes the object into that string slot at save time; the engine deserializes it back. **Never** wire a bare GUID, URL, byte stream, file path, or `.Id`/`.FullName` subfield. |
 | `prompt` | Yes | string | The task instruction — e.g., "Write a 3-paragraph executive summary", "List every SLA penalty clause", "Answer: what is the termination notice period?". |
-| `returnCitations` | No | boolean | When `true`, the `content.citations` array is populated with per-claim page references. Default `false`. |
+| `returnCitations` | No | boolean | When `true`, the `content.Citations` array is populated with per-claim page references. Default `false`. |
 
 ## Planning Annotation
 
 In the architectural plan:
 
-- `pattern: summarize — <one-line purpose>` with a placeholder for the attachment source (usually a `$vars.<upstream>.output.*` file handle) and a short summary of the prompt.
+- `pattern: summarize — <one-line purpose>` with a placeholder for the attachment source (a `=js:$vars.<triggerId>.output.<fileVarId>` reference to a trigger-bound `in` variable of `type: "file"`) and a short summary of the prompt.
 - If the downstream step needs to display or audit sources, call out `returnCitations: true` explicitly in the node table; otherwise leave it `false`.

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
@@ -23,20 +23,30 @@ sandbox:
 initial_prompt: |
   Create a UiPath Flow project named "BatchTransformDemo" that uses a Batch
   Transform pattern node to enrich rows of a CSV. The flow takes one `in`
-  variable of `type: "object"` named `csvAttachment` — the full Flow Attachment
-  object for the source CSV (shape `{ FullName, Id, Metadata, MimeType }`).
-  The Batch Transform node must:
+  variable of `type: "file"` named `csvFile`, bound to the trigger via
+  `triggerNodeId: "<triggerId>"`. The variable's runtime payload is a full
+  Flow Attachment object (`{ FullName, Id, Metadata, MimeType }`). The Batch
+  Transform node must:
 
-    - have its `attachment` input wired to the flow input variable as the
-      WHOLE object (`=js:$vars.csvAttachment`, not `.Id` or any subfield)
+    - have its `attachment` input wired to the trigger output, NOT the bare
+      variable: `=js:$vars.<triggerId>.output.csvFile`. Do not use
+      `=js:$vars.csvFile`, `.Id`, `.FullName`, or any other subfield — the
+      runtime engine wants the WHOLE Attachment object resolved through the
+      trigger output binding.
     - use this prompt: `Classify each row by category and write a one-line summary.`
     - declare two output columns:
         - `Category`     — One of: Utility, Software, Travel, Other
         - `Summary`      — Plain-English one-line summary of the row
     - leave `enableWebSearchGrounding` at its default
 
+  The node's instance JSON must NOT contain a `model` block (BPMN type /
+  serviceType belongs only in `definitions[]`), and `typeVersion` must be
+  exactly `"1.0"` matching `definitions[<bt>].version`. The instance
+  `outputs.output` must use `source: "=response"` (NOT `=batchTransformResult`).
+
   Wire the Batch Transform's `output` port through to an End node and surface
-  the result file handle as a flow output variable named `result`.
+  the result file handle as a flow output variable named `result` mapped via
+  `outputs.result.source: "=js:$vars.<bt-node-id>.output"`.
 
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
@@ -4,28 +4,43 @@
 Generation-only — does not run `uip maestro flow debug`. Verifies:
 
   1. Exactly one `uipath.pattern.batch-transform` node is present.
-  2. `inputs.prompt` is non-empty.
-  3. `inputs.outputColumns` is an array of objects with `name` + `description`
+  2. The instance has no `model` block (BPMN type/serviceType lives in
+     `definitions[].model` only — rule 16).
+  3. `typeVersion` is exactly `"1.0"` (matches `definitions[<bt>].version`).
+  4. `inputs.prompt` is non-empty.
+  5. `inputs.outputColumns` is an array of objects with `name` + `description`
      keys (not flattened to a `{name: description}` map and not a string array).
-  4. `inputs.attachment` is wired to the WHOLE flow input object via
-     `=js:$vars.<name>` — not `.Id`, `.FullName`, or any subfield. The runtime
-     wants the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`.
-  5. The referenced flow input variable is declared `type: "object"`.
-  6. The flow declares an `out` variable named `result`, and at least one End
+  6. `inputs.attachment` matches the canonical canvas-produced wiring:
+     `=js:$vars.<triggerId>.output.<fileVarId>` — referencing a flow `in`
+     variable of `type: "file"` bound to the trigger via `triggerNodeId`.
+     Bare `=js:$vars.<name>` (no trigger output) is rejected.
+  7. The instance `outputs.output.source` is the literal `=response`.
+  8. The flow declares an `out` variable named `result`, and at least one End
      node maps it via `outputs.result.source` using a `=js:$vars.<bt>.output`
-     reference (not a bare `$vars.…` literal — rule 12 requires the `=js:`
-     prefix).
+     reference.
 """
 
 import glob
 import json
 import re
 import sys
+from typing import NoReturn
 
 NODE_TYPE = "uipath.pattern.batch-transform"
+EXPECTED_TYPE_VERSION = "1.0"
+EXPECTED_OUTPUT_SOURCE = "=response"
+
+# Canonical canvas wiring: =js:$vars.<triggerId>.output.<fileVarId>
+# (a trigger-bound `in` file variable surfaces under the trigger's output)
+_ATTACHMENT_REF = re.compile(
+    r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\.([A-Za-z_][A-Za-z0-9_]*)\s*$"
+)
+
+# Output mapping: =js:$vars.<bt>.output  (or any deeper subfield path)
+_OUTPUT_MAPPING_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\b")
 
 
-def _fail(msg: str):
+def _fail(msg: str) -> NoReturn:
     sys.exit(f"FAIL: {msg}")
 
 
@@ -69,43 +84,89 @@ def _check_outputColumns(value) -> None:
                 )
 
 
-_ATTACHMENT_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\s*$")
-
-
-def _check_attachment_is_whole_object(flow: dict, attachment) -> None:
+def _check_attachment_canonical(flow: dict, attachment) -> None:
     if not isinstance(attachment, str) or not attachment.strip():
-        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
+        _fail("inputs.attachment missing or empty — wire it to the trigger output binding")
     m = _ATTACHMENT_REF.match(attachment.strip())
     if not m:
         _fail(
-            f"inputs.attachment={attachment!r} must be `=js:$vars.<name>` referencing the WHOLE "
-            "Flow Attachment object — not a bare id, GUID, URL, path, or subfield like `.Id`."
+            f"inputs.attachment={attachment!r} is not the canonical canvas-produced shape. "
+            "Expected `=js:$vars.<triggerId>.output.<fileVarId>` — the canvas wires file-typed "
+            "flow `in` variables through the trigger's output. Do NOT use the bare "
+            "`=js:$vars.<name>` shape, a `.Id`/`.FullName` subfield, or a literal id/URL/path."
         )
-    var_name = m.group(1)
+    trigger_id, file_var_id = m.group(1), m.group(2)
+
+    # Trigger node must exist and be a trigger
+    trigger_node = next(
+        (n for n in flow.get("nodes", []) if n.get("id") == trigger_id),
+        None,
+    )
+    if trigger_node is None:
+        _fail(
+            f"inputs.attachment references `$vars.{trigger_id}.output...` but no node with "
+            f"id={trigger_id!r} exists in the flow."
+        )
+    if not isinstance(trigger_node.get("type"), str) or "trigger" not in trigger_node["type"]:
+        _fail(
+            f"node id={trigger_id!r} has type={trigger_node.get('type')!r}; expected a trigger "
+            "(file-typed input variables must be trigger-bound)."
+        )
+
+    # File variable must exist as a flow `in` of type "file" with triggerNodeId binding
     globals_ = (flow.get("variables") or {}).get("globals") or []
-    var = next((v for v in globals_ if v.get("id") == var_name), None)
+    var = next((v for v in globals_ if v.get("id") == file_var_id), None)
     if var is None:
         _fail(
-            f"inputs.attachment references `$vars.{var_name}` but no flow `globals` variable "
-            f"with id={var_name!r} exists. Declare it as an `in` variable of type `object`."
+            f"inputs.attachment references `$vars.{trigger_id}.output.{file_var_id}` but no "
+            f"flow `globals` variable with id={file_var_id!r} exists. Declare it as an `in` "
+            "variable of type `file` with `triggerNodeId` set to the trigger id."
         )
-    if var.get("type") != "object":
+    if var.get("direction") != "in":
         _fail(
-            f"flow input variable `{var_name}` has type={var.get('type')!r}; must be `object` "
-            "to hold the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`."
+            f"flow input variable `{file_var_id}` has direction={var.get('direction')!r}; "
+            "must be `in` to receive the attachment from outside the flow."
+        )
+    if var.get("type") != "file":
+        _fail(
+            f"flow input variable `{file_var_id}` has type={var.get('type')!r}; must be `file` "
+            "to hold the full Flow Attachment `{ FullName, Id, Metadata, MimeType }` payload at runtime."
+        )
+    if var.get("triggerNodeId") != trigger_id:
+        _fail(
+            f"flow input variable `{file_var_id}` has triggerNodeId={var.get('triggerNodeId')!r}; "
+            f"must be {trigger_id!r} to surface under that trigger's output."
         )
 
 
-_OUTPUT_MAPPING_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\b")
+def _check_no_instance_model(node: dict) -> None:
+    if "model" in node:
+        _fail(
+            "Batch Transform node instance has a `model` block. Per rule 16, BPMN type / "
+            "serviceType belong only in `definitions[].model`. Drop the instance `model` field."
+        )
+
+
+def _check_type_version(node: dict) -> None:
+    tv = node.get("typeVersion")
+    if tv != EXPECTED_TYPE_VERSION:
+        _fail(
+            f"typeVersion={tv!r}; must be {EXPECTED_TYPE_VERSION!r} (matches "
+            "`definitions[<batch-transform>].version`). `1.0.0` is wrong."
+        )
+
+
+def _check_output_source(node: dict) -> None:
+    src = ((node.get("outputs") or {}).get("output") or {}).get("source")
+    if src != EXPECTED_OUTPUT_SOURCE:
+        _fail(
+            f"outputs.output.source={src!r}; must be {EXPECTED_OUTPUT_SOURCE!r} (the BPMN "
+            "engine wraps its result under that key — convention every ServiceTask follows). "
+            "`=batchTransformResult` is a stale pre-#1380 shape."
+        )
 
 
 def _check_result_output_mapping(flow: dict, bt_node_id: str) -> None:
-    """The flow surfaces the BT result as an `out` variable `result`. Verify
-    the variable exists and at least one End node maps it correctly.
-
-    Each End node may carry an `outputs.<varId>.source` for every `out`
-    variable; the source MUST use `=js:$vars.<bt>.output` (rule 12).
-    """
     globals_ = (flow.get("variables") or {}).get("globals") or []
     result_var = next(
         (v for v in globals_ if v.get("id") == "result" and v.get("direction") == "out"),
@@ -121,20 +182,19 @@ def _check_result_output_mapping(flow: dict, bt_node_id: str) -> None:
     if not end_nodes:
         _fail("flow has no End node — required to terminate the path and map outputs")
 
-    mapped_on = []
     for end in end_nodes:
         src = ((end.get("outputs") or {}).get("result") or {}).get("source")
         if not isinstance(src, str) or not src.strip():
             continue
         m = _OUTPUT_MAPPING_REF.match(src.strip())
         if m and m.group(1) == bt_node_id:
-            mapped_on.append(end.get("id"))
-    if not mapped_on:
-        _fail(
-            "no End node maps `outputs.result.source` to `=js:$vars."
-            f"{bt_node_id}.output` (or similar). Without an `=js:` mapping per rule 12, "
-            "the flow output is the literal string instead of the real BT result handle."
-        )
+            return
+
+    _fail(
+        f"no End node maps `outputs.result.source` to `=js:$vars.{bt_node_id}.output` "
+        "(or similar). Without an `=js:` mapping per rule 12, the flow output is the literal "
+        "string instead of the real BT result handle."
+    )
 
 
 def main():
@@ -142,18 +202,23 @@ def main():
     node = _find_node(flow)
     inputs = node.get("inputs") or {}
 
+    _check_no_instance_model(node)
+    _check_type_version(node)
+
     prompt = inputs.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         _fail("inputs.prompt missing or empty")
 
-    _check_attachment_is_whole_object(flow, inputs.get("attachment"))
+    _check_attachment_canonical(flow, inputs.get("attachment"))
     _check_outputColumns(inputs.get("outputColumns"))
+    _check_output_source(node)
     _check_result_output_mapping(flow, node["id"])
 
     print(
-        f"OK: {NODE_TYPE} node present; prompt set; attachment is whole-object ref to a "
-        f"`type: object` flow input; outputColumns has {len(inputs['outputColumns'])} "
-        "{name,description} entries; End node maps `result` via `=js:` reference"
+        f"OK: {NODE_TYPE} node present; no instance model; typeVersion=1.0; prompt set; "
+        f"attachment wired via trigger output to a `type: file` `in` variable; "
+        f"outputColumns has {len(inputs['outputColumns'])} {{name,description}} entries; "
+        f"output source=`=response`; End node maps `result` via `=js:` reference"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
@@ -5,28 +5,40 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
 
   1. Exactly one `uipath.pattern.deep-rag` node is present (the wire type
      stays `deep-rag` even though the canvas display name is "Summarize").
-  2. `inputs.prompt` is non-empty.
-  3. `inputs.attachment` is wired to the WHOLE flow input object via
-     `=js:$vars.<name>` — not `.Id`, `.FullName`, or any subfield. The runtime
-     wants the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`.
-  4. The referenced flow input variable is declared `type: "object"`.
-  5. `inputs.returnCitations` is the boolean `true` (per the prompt's request).
-  6. The flow declares `out` variables `summary` and `citations`, and at least
-     one End node maps each via `outputs.<var>.source` using a
-     `=js:$vars.<dr>.output.content.<field>` reference (rule 12 — value-field
-     expressions need the `=js:` prefix).
+  2. The instance has no `model` block (BPMN type/serviceType lives in
+     `definitions[].model` only — rule 16).
+  3. `typeVersion` is exactly `"1.0"` (matches `definitions[<dr>].version`).
+  4. `inputs.prompt` is non-empty.
+  5. `inputs.attachment` matches the canonical canvas-produced wiring:
+     `=js:$vars.<triggerId>.output.<fileVarId>` — referencing a flow `in`
+     variable of `type: "file"` bound to the trigger via `triggerNodeId`.
+  6. `inputs.returnCitations` is the boolean `true` (per the prompt's request).
+  7. The instance `outputs.output.source` is the literal `=response`.
+  8. The flow declares `out` variables `summary` and `citations`, and at least
+     one End node maps each via PascalCase paths:
+       summary    -> =js:$vars.<dr>.output.content.Text
+       citations  -> =js:$vars.<dr>.output.content.Citations
+     Lowercase `.text` / `.citations` is rejected (the response shape is
+     PascalCase; lowercase resolves to undefined at runtime).
 """
 
 import glob
 import json
 import re
 import sys
+from typing import NoReturn
 
 NODE_TYPE = "uipath.pattern.deep-rag"
-_ATTACHMENT_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\s*$")
+EXPECTED_TYPE_VERSION = "1.0"
+EXPECTED_OUTPUT_SOURCE = "=response"
+
+_ATTACHMENT_REF = re.compile(
+    r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\.([A-Za-z_][A-Za-z0-9_]*)\s*$"
+)
+_OUTPUT_MAPPING_BASE = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\.content\.")
 
 
-def _fail(msg: str):
+def _fail(msg: str) -> NoReturn:
     sys.exit(f"FAIL: {msg}")
 
 
@@ -51,39 +63,87 @@ def _find_node(flow: dict) -> dict:
     return matches[0]
 
 
-def _check_attachment_is_whole_object(flow: dict, attachment) -> None:
+def _check_attachment_canonical(flow: dict, attachment) -> None:
     if not isinstance(attachment, str) or not attachment.strip():
-        _fail("inputs.attachment missing or empty — wire it to the flow input variable")
+        _fail("inputs.attachment missing or empty — wire it to the trigger output binding")
     m = _ATTACHMENT_REF.match(attachment.strip())
     if not m:
         _fail(
-            f"inputs.attachment={attachment!r} must be `=js:$vars.<name>` referencing the WHOLE "
-            "Flow Attachment object — not a bare id, GUID, URL, path, or subfield like `.Id`."
+            f"inputs.attachment={attachment!r} is not the canonical canvas-produced shape. "
+            "Expected `=js:$vars.<triggerId>.output.<fileVarId>` — the canvas wires file-typed "
+            "flow `in` variables through the trigger's output. Do NOT use the bare "
+            "`=js:$vars.<name>` shape, a `.Id`/`.FullName` subfield, or a literal id/URL/path."
         )
-    var_name = m.group(1)
+    trigger_id, file_var_id = m.group(1), m.group(2)
+
+    trigger_node = next(
+        (n for n in flow.get("nodes", []) if n.get("id") == trigger_id),
+        None,
+    )
+    if trigger_node is None:
+        _fail(
+            f"inputs.attachment references `$vars.{trigger_id}.output...` but no node with "
+            f"id={trigger_id!r} exists in the flow."
+        )
+    if not isinstance(trigger_node.get("type"), str) or "trigger" not in trigger_node["type"]:
+        _fail(
+            f"node id={trigger_id!r} has type={trigger_node.get('type')!r}; expected a trigger."
+        )
+
     globals_ = (flow.get("variables") or {}).get("globals") or []
-    var = next((v for v in globals_ if v.get("id") == var_name), None)
+    var = next((v for v in globals_ if v.get("id") == file_var_id), None)
     if var is None:
         _fail(
-            f"inputs.attachment references `$vars.{var_name}` but no flow `globals` variable "
-            f"with id={var_name!r} exists. Declare it as an `in` variable of type `object`."
+            f"inputs.attachment references `$vars.{trigger_id}.output.{file_var_id}` but no "
+            f"flow `globals` variable with id={file_var_id!r} exists."
         )
-    if var.get("type") != "object":
+    if var.get("direction") != "in":
         _fail(
-            f"flow input variable `{var_name}` has type={var.get('type')!r}; must be `object` "
-            "to hold the full Flow Attachment `{ FullName, Id, Metadata, MimeType }`."
+            f"flow input variable `{file_var_id}` has direction={var.get('direction')!r}; "
+            "must be `in`."
+        )
+    if var.get("type") != "file":
+        _fail(
+            f"flow input variable `{file_var_id}` has type={var.get('type')!r}; must be `file`."
+        )
+    if var.get("triggerNodeId") != trigger_id:
+        _fail(
+            f"flow input variable `{file_var_id}` has triggerNodeId={var.get('triggerNodeId')!r}; "
+            f"must be {trigger_id!r}."
         )
 
 
-_OUTPUT_MAPPING_REF = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\b")
+def _check_no_instance_model(node: dict) -> None:
+    if "model" in node:
+        _fail(
+            "Summarize node instance has a `model` block. Per rule 16, BPMN type / serviceType "
+            "belong only in `definitions[].model`. Drop the instance `model` field."
+        )
 
 
-def _check_output_mappings(flow: dict, dr_node_id: str) -> None:
+def _check_type_version(node: dict) -> None:
+    tv = node.get("typeVersion")
+    if tv != EXPECTED_TYPE_VERSION:
+        _fail(
+            f"typeVersion={tv!r}; must be {EXPECTED_TYPE_VERSION!r} (matches "
+            "`definitions[<deep-rag>].version`). `1.0.0` is wrong."
+        )
+
+
+def _check_output_source(node: dict) -> None:
+    src = ((node.get("outputs") or {}).get("output") or {}).get("source")
+    if src != EXPECTED_OUTPUT_SOURCE:
+        _fail(
+            f"outputs.output.source={src!r}; must be {EXPECTED_OUTPUT_SOURCE!r} (the BPMN "
+            "engine wraps its result under that key). `=deepRagResult` is a stale "
+            "pre-#1380 shape."
+        )
+
+
+def _check_pascal_output_mappings(flow: dict, dr_node_id: str) -> None:
     """The flow surfaces synthesis text + citations as `out` variables. Verify
-    both variables exist and at least one End node maps each correctly.
-
-    Each End node may carry an `outputs.<varId>.source` for every `out`
-    variable; the source MUST use `=js:$vars.<dr>.output.content.<field>`.
+    both variables exist and at least one End node maps each correctly with
+    PascalCase nested paths.
     """
     globals_ = (flow.get("variables") or {}).get("globals") or []
     for var_id in ("summary", "citations"):
@@ -97,22 +157,38 @@ def _check_output_mappings(flow: dict, dr_node_id: str) -> None:
     if not end_nodes:
         _fail("flow has no End node — required to terminate the path and map outputs")
 
-    for var_id in ("summary", "citations"):
+    expected = {
+        "summary": "Text",
+        "citations": "Citations",
+    }
+    for var_id, pascal_field in expected.items():
         mapped = False
         for end in end_nodes:
             src = ((end.get("outputs") or {}).get(var_id) or {}).get("source")
             if not isinstance(src, str) or not src.strip():
                 continue
-            m = _OUTPUT_MAPPING_REF.match(src.strip())
-            if m and m.group(1) == dr_node_id:
+            src_stripped = src.strip()
+            base_m = _OUTPUT_MAPPING_BASE.match(src_stripped)
+            if not base_m or base_m.group(1) != dr_node_id:
+                continue
+            # Ensure the Pascal field is in the path
+            if f".content.{pascal_field}" in src_stripped:
                 mapped = True
                 break
+            # Detect lowercase mistake explicitly
+            lowercase_field = pascal_field[0].lower() + pascal_field[1:]
+            if f".content.{lowercase_field}" in src_stripped:
+                _fail(
+                    f"End node maps `outputs.{var_id}.source={src!r}` using lowercase "
+                    f"`.content.{lowercase_field}` — the response shape is PascalCase "
+                    f"`.content.{pascal_field}`. Lowercase fields resolve to undefined at runtime."
+                )
         if not mapped:
             _fail(
                 f"no End node maps `outputs.{var_id}.source` to "
-                f"`=js:$vars.{dr_node_id}.output.content.<field>` (or similar). Without an "
-                "`=js:` mapping per rule 12, the flow output is the literal string instead "
-                "of the real synthesis result."
+                f"`=js:$vars.{dr_node_id}.output.content.{pascal_field}` (or a deeper path). "
+                "Without the PascalCase mapping, the flow output is the literal string or "
+                "undefined at runtime."
             )
 
 
@@ -121,11 +197,14 @@ def main():
     node = _find_node(flow)
     inputs = node.get("inputs") or {}
 
+    _check_no_instance_model(node)
+    _check_type_version(node)
+
     prompt = inputs.get("prompt")
     if not isinstance(prompt, str) or not prompt.strip():
         _fail("inputs.prompt missing or empty")
 
-    _check_attachment_is_whole_object(flow, inputs.get("attachment"))
+    _check_attachment_canonical(flow, inputs.get("attachment"))
 
     return_citations = inputs.get("returnCitations")
     if return_citations is not True:
@@ -134,12 +213,14 @@ def main():
             f"got {return_citations!r}"
         )
 
-    _check_output_mappings(flow, node["id"])
+    _check_output_source(node)
+    _check_pascal_output_mappings(flow, node["id"])
 
     print(
-        f"OK: {NODE_TYPE} node present; prompt set; attachment is whole-object ref to a "
-        "`type: object` flow input; returnCitations=true; End node maps "
-        "`summary` and `citations` via `=js:` references"
+        f"OK: {NODE_TYPE} node present; no instance model; typeVersion=1.0; prompt set; "
+        f"attachment wired via trigger output to a `type: file` `in` variable; "
+        f"returnCitations=true; output source=`=response`; End node maps `summary` to "
+        f"`content.Text` and `citations` to `content.Citations` (PascalCase) via `=js:`"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
@@ -23,18 +23,32 @@ sandbox:
 initial_prompt: |
   Create a UiPath Flow project named "SummarizeDemo" that uses a Summarize
   pattern node to synthesize a response over an attached document. The flow
-  takes one `in` variable of `type: "object"` named `documentAttachment` —
-  the full Flow Attachment object for the document (shape
-  `{ FullName, Id, Metadata, MimeType }`). The Summarize node must:
+  takes one `in` variable of `type: "file"` named `documentFile`, bound to
+  the trigger via `triggerNodeId: "<triggerId>"`. The variable's runtime
+  payload is a full Flow Attachment object (`{ FullName, Id, Metadata, MimeType }`).
+  The Summarize node must:
 
-    - have its `attachment` input wired to the flow input variable as the
-      WHOLE object (`=js:$vars.documentAttachment`, not `.Id` or any subfield)
+    - have its `attachment` input wired to the trigger output, NOT the bare
+      variable: `=js:$vars.<triggerId>.output.documentFile`. Do not use
+      `=js:$vars.documentFile`, `.Id`, `.FullName`, or any other subfield —
+      the runtime engine wants the WHOLE Attachment object resolved through
+      the trigger output binding.
     - use this prompt: `Write a 5-bullet executive summary covering scope, term, SLAs, penalties, and termination.`
     - set `returnCitations` to `true`
 
+  The node's instance JSON must NOT contain a `model` block, and `typeVersion`
+  must be exactly `"1.0"`. The instance `outputs.output` must use
+  `source: "=response"` (NOT `=deepRagResult`). The output schema's nested
+  fields are PascalCase: `content.Text` and `content.Citations[]` (each with
+  `Ordinal`, `PageNumber`, `Source`, `Reference`).
+
   Wire the Summarize node's `output` port through to an End node and surface
   the synthesized text + citations as flow output variables `summary` and
-  `citations`.
+  `citations`, mapped via:
+    - `outputs.summary.source:   "=js:$vars.<dr-node-id>.output.content.Text"`
+    - `outputs.citations.source: "=js:$vars.<dr-node-id>.output.content.Citations"`
+  Note the PascalCase nested field names — lowercase `text`/`citations` would
+  resolve to `undefined` at runtime.
 
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between


### PR DESCRIPTION
## Summary

Follow-up to UiPath/skills#299 (which merged) — catches up the `batch-transform` and `summarize` pattern-node docs with three flow-workbench changes that landed since #299 was first written:

| Source | Change in canvas/runtime | Doc impact |
| --- | --- | --- |
| flow-workbench [#1380](https://github.com/UiPath/flow-workbench/pull/1380) / [#1516](https://github.com/UiPath/flow-workbench/pull/1516) | Pattern-node `outputs.output.source` is now the literal **`=response`** (BPMN engine wraps results under that key — convention every ServiceTask follows) | `=batchTransformResult` / `=deepRagResult` removed from JSON examples and "What NOT to Do" entries |
| flow-workbench [#1477](https://github.com/UiPath/flow-workbench/pull/1477) | File-typed flow `in` variables are now bound to the trigger via `triggerNodeId`. Pattern node `attachment` is referenced through the trigger output as `=js:$vars.<triggerId>.output.<fileVarId>`. Variable's declared `type` is **`"file"`** (not `"object"` — runtime still hands the BPMN engine a full `{ FullName, Id, Metadata, MimeType }` Attachment from that slot) | New "Wiring `attachment` — file variable bound to the trigger" section in both impl.md files |
| flow-workbench [#1516](https://github.com/UiPath/flow-workbench/pull/1516) | Summarize output schema fields renamed PascalCase: `Text`, `Citations[]` of `{ Ordinal, PageNumber, Source, Reference }` (top-level still `id` + `content`). Lowercase variants do not exist in the response shape | "End-node output mapping", "Accessing Output", Debug table, "What NOT to Do" all updated to PascalCase paths |

Verified against the Studio Web canonical `.flow` example shipped with the canvas:

```
"variables": {
  "globals": [
    { "id": "documentFile", "direction": "in", "type": "file", "triggerNodeId": "start" }
  ]
},
"nodes": [
  ...,
  {
    "id": "summarize1",
    "type": "uipath.pattern.deep-rag",
    "typeVersion": "1.0",
    "inputs": {
      "attachment": "=js:$vars.start.output.documentFile",
      "prompt": "...",
      "returnCitations": false
    },
    "outputs": {
      "output": { "type": "object", "source": "=response", ... }
    }
  }
]
```

## Changes

**Plugin docs** (`skills/uipath-maestro-flow/references/author/references/plugins/`):

- `batch-transform/{planning,impl}.md` — Output Variables describes `type: "file"` handle; Key Inputs `attachment` describes the trigger-bound file variable shape; new "Wiring `attachment`" section in impl.md with the canonical `globals` declaration; JSON Structure example uses `=js:$vars.start.output.csvFile` and `outputs.output.source: "=response"`; "What NOT to Do" gains a `=batchTransformResult` warning.
- `summarize/{planning,impl}.md` — same shape updates; output schema in JSON example carries the full PascalCase JSON schema (`id` + `content.{Text, Citations[]}` with `Ordinal`/`PageNumber`/`Source`/`Reference`); End-node mapping example uses `.content.Text` and `.content.Citations`; Debug table and "Accessing Output" JS example switch to PascalCase; "What NOT to Do" gains a "do not use lowercase field names" entry.

**Tests** (`tests/tasks/uipath-maestro-flow/single_node/`):

- `batch_transform.yaml` and `summarize.yaml` initial_prompt rewritten — agent is told to declare the attachment as a `type: "file"` `in` variable bound via `triggerNodeId`, reference it through the trigger output, and explicitly avoid the old bare-variable / lowercase-PascalCase shapes. End-node mappings spelled out with the canonical PascalCase paths.
- `check_batch_transform_flow.py` and `check_summarize_flow.py` are significantly stricter:
  - Reject any instance-level `model` block (rule 16).
  - Require `typeVersion === "1.0"` and `outputs.output.source === "=response"` exactly.
  - Attachment regex now requires the canonical `=js:$vars.<triggerId>.output.<fileVarId>` shape; the trigger node must exist and be a trigger; the referenced flow `globals` variable must have `direction: "in"` + `type: "file"` + `triggerNodeId: "<triggerId>"`.
  - Summarize End-node mapping check requires PascalCase paths (`content.Text`, `content.Citations`); the lowercase variants emit a targeted "this is the lowercase mistake — fix to PascalCase" failure message.

Both stricter check scripts confirmed to reject the prior good-but-now-stale runs from #299 with the right corrective error message — proving the assertions do real work.

## Test evidence

Ran both tasks locally against alpha (`https://alpha.uipath.com`, ECS / dev_test, where `canvas.nodes.batch-transform` and `canvas.nodes.summarize` are both ON), driving Claude Code via `coder-eval` and the UiPath LLM Gateway proxy.

**Batch Transform** (`runs/2026-05-08_15-07-52/default/skill-flow-batch-transform/`):

```
nodes: [('start', 'core.trigger.manual'),
        ('batchTransform', 'uipath.pattern.batch-transform'),
        ('end', 'core.control.end')]
vars:  [('csvFile', 'file', 'in', triggerNodeId='start'),
        ('result',  'object', 'out')]
batchTransform instance keys: ['display', 'id', 'inputs', 'outputs', 'type', 'typeVersion']
typeVersion: 1.0           ← matches definitions[<bt>].version
model on instance: None
attachment: =js:$vars.start.output.csvFile   ← canonical trigger-bound file-variable wiring
output source: =response
End outputs.result.source: =js:$vars.batchTransform.output
```

`check_batch_transform_flow.py` →

> OK: uipath.pattern.batch-transform node present; no instance model; typeVersion=1.0; prompt set; attachment wired via trigger output to a `type: file` `in` variable; outputColumns has 2 {name,description} entries; output source=`=response`; End node maps `result` via `=js:` reference

**Summarize** (`runs/2026-05-08_15-07-52/default/skill-flow-summarize/`):

```
nodes: [('start', 'core.trigger.manual'),
        ('summarizeContract', 'uipath.pattern.deep-rag'),
        ('end', 'core.control.end')]
vars:  [('documentFile', 'file', 'in', triggerNodeId='start'),
        ('summary', 'out'),
        ('citations', 'out')]
summarizeContract instance keys: ['display', 'id', 'inputs', 'outputs', 'type', 'typeVersion']
typeVersion: 1.0
model on instance: None
attachment: =js:$vars.start.output.documentFile   ← canonical trigger-bound file-variable wiring
output source: =response
returnCitations: true
End outputs.summary.source:   =js:$vars.summarizeContract.output.content.Text       (PascalCase)
End outputs.citations.source: =js:$vars.summarizeContract.output.content.Citations  (PascalCase)
```

`check_summarize_flow.py` →

> OK: uipath.pattern.deep-rag node present; no instance model; typeVersion=1.0; prompt set; attachment wired via trigger output to a `type: file` `in` variable; returnCitations=true; output source=`=response`; End node maps `summary` to `content.Text` and `citations` to `content.Citations` (PascalCase) via `=js:`

In both cases `uip maestro flow validate` passed cleanly.

### Headline scoring caveats

`coder-eval` reports each task with `score=0.375` because the `run_command` criterion that invokes `python3 $TASK_DIR/check_*_flow.py` doesn't expand `$TASK_DIR` on Windows (every peer test that uses the same convention — `decision`, `rpa`, `api_workflow`, `outlook_trigger_inbox`, `subflow`, etc. — has the same Windows-only behavior). On Linux/CI the substitution works and the same checks pass. Substantive verdicts above were obtained by running the check scripts directly with the cwd set to each task's sandbox dir. Summarize additionally hit `MAX_TURNS_EXHAUSTED` (the agent iterated through registry/validate/tidy several times on the way to the right answer); its produced flow is nonetheless correct end-to-end per the manual strict check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
