### PR TITLE
Clean tests lint debt and eval setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,10 @@ There are three test types, distinguished by tags:
 
 ### Running Tests
 
+`make install` requires access to the UiPath Azure DevOps `ml-packages` feed.
+Set `UV_EXTRA_INDEX_URL`, or set both `UV_INDEX_UIPATH_USERNAME` and
+`UV_INDEX_UIPATH_PASSWORD` before installing.
+
 ```bash
 cd tests
 make install       # one-time: install coder-eval from GitHub

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,12 @@
-.PHONY: help install all smoke integration e2e tags
+.PHONY: help install check fmt lint all smoke integration e2e tags
 
 SKILLS_REPO_PATH ?= $(shell cd .. && pwd)
 VENV := .venv
-CODER_EVAL := SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) $(VENV)/bin/coder-eval
+PYTHON_VERSION ?= 3.13
+CODER_EVAL_PACKAGE ?= coder-eval @ git+https://github.com/UiPath/coder_eval.git
+CODER_EVAL_BIN := $(VENV)/bin/coder-eval
+CODER_EVAL := SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) $(CODER_EVAL_BIN)
+RUFF ?= uvx ruff
 TASKS := $(shell find tasks -name '*.yaml' -type f)
 TASK_PARALLELISM ?= 1
 
@@ -10,19 +14,31 @@ help:  ## Show available commands
 	@grep -E '^[a-zA-Z0-9_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 	  awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-install:  ## Install coder-eval into local .venv (requires Python 3.13+; UV_INDEX_UIPATH_USERNAME/PASSWORD optional for private ml-packages feed)
-	uv venv --python 3.13 $(VENV)
-	@if [ -n "$$UV_INDEX_UIPATH_USERNAME" ] && [ -n "$$UV_INDEX_UIPATH_PASSWORD" ]; then \
+install:  ## Install coder-eval into local .venv (requires Python 3.13+ and the UiPath ml-packages feed)
+	@if [ -z "$$UV_EXTRA_INDEX_URL" ] && { [ -z "$$UV_INDEX_UIPATH_USERNAME" ] || [ -z "$$UV_INDEX_UIPATH_PASSWORD" ]; }; then \
+	  echo "ERROR: coder-eval currently requires packages from the UiPath ml-packages feed."; \
+	  echo "Set UV_EXTRA_INDEX_URL, or set both UV_INDEX_UIPATH_USERNAME and UV_INDEX_UIPATH_PASSWORD."; \
+	  exit 2; \
+	fi
+	uv venv --python $(PYTHON_VERSION) $(VENV)
+	@if [ -n "$$UV_EXTRA_INDEX_URL" ]; then \
+	  echo "Using UV_EXTRA_INDEX_URL for additional package resolution."; \
+	  uv pip install --python $(VENV)/bin/python "$(CODER_EVAL_PACKAGE)"; \
+	elif [ -n "$$UV_INDEX_UIPATH_USERNAME" ] && [ -n "$$UV_INDEX_UIPATH_PASSWORD" ]; then \
 	  echo "Using UiPath private PyPI feed (ml-packages)."; \
 	  UV_EXTRA_INDEX_URL="https://$$UV_INDEX_UIPATH_USERNAME:$$UV_INDEX_UIPATH_PASSWORD@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/" \
-	    uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"; \
-	else \
-	  echo "UV_INDEX_UIPATH_USERNAME/PASSWORD not set — installing without the UiPath private PyPI feed."; \
-	  echo "Set both variables before running 'make install' if you need packages from the ml-packages feed."; \
-	  uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"; \
+	    uv pip install --python $(VENV)/bin/python "$(CODER_EVAL_PACKAGE)"; \
 	fi
 	@echo ""
 	@echo "See https://github.com/UiPath/coder_eval for environment setup (.env, API keys, etc.)"
+
+check: fmt lint  ## Run local format and lint checks for test helper scripts
+
+fmt:  ## Check Python formatting under tests/
+	$(RUFF) format --check .
+
+lint:  ## Lint Python helper scripts under tests/
+	$(RUFF) check .
 
 all:  ## Run all tests (smoke + integration + e2e) in a single run
 	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml -j $(TASK_PARALLELISM) -v

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,12 +4,12 @@ Tests that verify AI agents can correctly use skills from this repository. Tests
 
 ## Prerequisites
 
-1. **UiPath private PyPI credentials** (optional) — only needed if `coder-eval` resolves to packages on the UiPath Azure DevOps `ml-packages` feed. Export these **before** running `make install` to enable the private feed:
+1. **UiPath private PyPI credentials** — `coder-eval` currently resolves packages from the UiPath Azure DevOps `ml-packages` feed. Export these **before** running `make install`:
    ```bash
    export UV_INDEX_UIPATH_USERNAME=<your-ado-username>
    export UV_INDEX_UIPATH_PASSWORD=<your-ado-pat>
    ```
-   The Makefile composes these into `UV_EXTRA_INDEX_URL` for `uv pip install`. If either variable is empty, install continues against public PyPI only and prints a notice.
+   The Makefile composes these into `UV_EXTRA_INDEX_URL` for `uv pip install`. If your shell already has a usable `UV_EXTRA_INDEX_URL`, the Makefile uses it directly.
 
 2. **coder-eval** — install from GitHub (creates a local `.venv`, requires Python 3.13+):
    ```bash
@@ -40,6 +40,9 @@ make integration
 
 # Run all e2e tests
 make e2e
+
+# Check local Python helper formatting/linting
+make check
 
 # Run tests matching a combination of tags (AND semantics — tasks must carry all listed tags) (defaults to experiments/default.yaml):
 make tags TAGS="integration connector-feature"

--- a/tests/scripts/token_usage.py
+++ b/tests/scripts/token_usage.py
@@ -39,7 +39,9 @@ def main(run_dir_arg: str) -> int:
     #               billed at ~0.1x fresh rate -- effectively "free" relative to NEW.
     #   "out"     — model-generated output (parent + sub-agents).
     # The bill is dominated by NEW + Output. REUSED is the cheap leg of the cost.
-    print(f"{'rep':>3} {'sc':>4} {'sec':>6} | {'NEW':>7} {'(uncached/cached)':>19} {'REUSED':>10} {'out':>6} | {'$cost':>6}")
+    print(
+        f"{'rep':>3} {'sc':>4} {'sec':>6} | {'NEW':>7} {'(uncached/cached)':>19} {'REUSED':>10} {'out':>6} | {'$cost':>6}"
+    )
     print("-" * 80)
     sums = {"fresh": 0, "cache_c": 0, "cache_r": 0, "out": 0, "cost": 0.0, "dur": 0.0}
     for r in results:
@@ -74,48 +76,72 @@ def main(run_dir_arg: str) -> int:
     )
     if n:
         avg_new = new_total // n
-        avg_fresh = sums['fresh'] // n
-        avg_cc = sums['cache_c'] // n
+        avg_fresh = sums["fresh"] // n
+        avg_cc = sums["cache_c"] // n
         print(
-            f"{'avg':>3} {'':>4} {sums['dur']/n:>6.1f} | "
+            f"{'avg':>3} {'':>4} {sums['dur'] / n:>6.1f} | "
             f"{avg_new:>7,} ({avg_fresh:>3,}/{avg_cc:>7,}) "
-            f"{sums['cache_r']//n:>10,} {sums['out']//n:>6,} | "
-            f"{sums['cost']/n:>5.3f}"
+            f"{sums['cache_r'] // n:>10,} {sums['out'] // n:>6,} | "
+            f"{sums['cost'] / n:>5.3f}"
         )
 
     if not in_total_all:
         return 0
 
     print("\n=== Cost-driving tokens (NEW input + Output) ===")
-    print(f"  NEW input (full price)   : {new_total:>10,}  -- this is what you actually pay full rate for")
-    print(f"      uncached fresh tail  : {sums['fresh']:>10,}  ({100*sums['fresh']/new_total:>5.2f}% of NEW)  -- 1.0x fresh rate")
-    print(f"      new->cache write     : {sums['cache_c']:>10,}  ({100*sums['cache_c']/new_total:>5.2f}% of NEW)  -- 1.25x fresh rate")
-    print(f"  Output                   : {sums['out']:>10,}  -- billed at output rate (5x fresh)")
+    print(
+        f"  NEW input (full price)   : {new_total:>10,}  -- this is what you actually pay full rate for"
+    )
+    print(
+        f"      uncached fresh tail  : {sums['fresh']:>10,}  ({100 * sums['fresh'] / new_total:>5.2f}% of NEW)  -- 1.0x fresh rate"
+    )
+    print(
+        f"      new->cache write     : {sums['cache_c']:>10,}  ({100 * sums['cache_c'] / new_total:>5.2f}% of NEW)  -- 1.25x fresh rate"
+    )
+    print(
+        f"  Output                   : {sums['out']:>10,}  -- billed at output rate (5x fresh)"
+    )
     print()
-    print(f"  REUSED input (discounted): {sums['cache_r']:>10,}  -- 0.1x fresh rate; effectively the 'free' leg")
+    print(
+        f"  REUSED input (discounted): {sums['cache_r']:>10,}  -- 0.1x fresh rate; effectively the 'free' leg"
+    )
     print()
-    print(f"Per-replicate avg of cost-driving content (NEW + Output):")
-    print(f"  NEW input  : {new_total//n:>6,} tokens/rep")
-    print(f"  Output     : {sums['out']//n:>6,} tokens/rep")
-    print(f"  Sum        : {(new_total + sums['out'])//n:>6,} tokens/rep at full-or-output rate")
+    print("Per-replicate avg of cost-driving content (NEW + Output):")
+    print(f"  NEW input  : {new_total // n:>6,} tokens/rep")
+    print(f"  Output     : {sums['out'] // n:>6,} tokens/rep")
+    print(
+        f"  Sum        : {(new_total + sums['out']) // n:>6,} tokens/rep at full-or-output rate"
+    )
 
     print("\nDerived ratios:")
     if sums["out"]:
         print(f"  input  / output (in:out) : {in_total_all // sums['out']}:1")
     if sums["cache_c"]:
-        print(f"  reads-per-cache-write    : {sums['cache_r'] / sums['cache_c']:.1f}x   (how many turns reuse each cache entry)")
+        print(
+            f"  reads-per-cache-write    : {sums['cache_r'] / sums['cache_c']:.1f}x   (how many turns reuse each cache entry)"
+        )
 
-    print(f"\nSDK-reported cost: ${sums['cost']:.2f} for {n} replicate(s)  =  ${sums['cost']/n:.3f}/rep")
-    print("  These figures come straight from total_token_usage.total_cost_usd written by the Anthropic SDK")
-    print("  and account for parent + all sub-agent inference. They are the authoritative cost.")
+    print(
+        f"\nSDK-reported cost: ${sums['cost']:.2f} for {n} replicate(s)  =  ${sums['cost'] / n:.3f}/rep"
+    )
+    print(
+        "  These figures come straight from total_token_usage.total_cost_usd written by the Anthropic SDK"
+    )
+    print(
+        "  and account for parent + all sub-agent inference. They are the authoritative cost."
+    )
 
     # Per-rep variance
     if n > 1:
         costs = [r["cost"] for r in results]
         in_tot = [r["fresh"] + r["cache_c"] + r["cache_r"] for r in results]
-        print(f"\nPer-rep variance:")
-        print(f"  cost      min={min(costs):.3f}  max={max(costs):.3f}  range={max(costs)-min(costs):.3f}")
-        print(f"  cache_r   min={min(r['cache_r'] for r in results):,}  max={max(r['cache_r'] for r in results):,}")
+        print("\nPer-rep variance:")
+        print(
+            f"  cost      min={min(costs):.3f}  max={max(costs):.3f}  range={max(costs) - min(costs):.3f}"
+        )
+        print(
+            f"  cache_r   min={min(r['cache_r'] for r in results):,}  max={max(r['cache_r'] for r in results):,}"
+        )
         print(f"  in_total  min={min(in_tot):,}  max={max(in_tot):,}")
 
     return 0
@@ -123,6 +149,9 @@ def main(run_dir_arg: str) -> int:
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python tmp/token_usage.py <run_dir>/default/<task_id>", file=sys.stderr)
+        print(
+            "Usage: python tmp/token_usage.py <run_dir>/default/<task_id>",
+            file=sys.stderr,
+        )
         sys.exit(2)
     sys.exit(main(sys.argv[1]))

--- a/tests/tasks/uipath-agents/_shared/ast_lazy_init_check.py
+++ b/tests/tasks/uipath-agents/_shared/ast_lazy_init_check.py
@@ -35,14 +35,16 @@ import ast
 import sys
 from pathlib import Path
 
-DEFAULT_LLM_CLASS_NAMES = frozenset({
-    "UiPath",
-    "UiPathAzureChatOpenAI",
-    "UiPathChat",
-    "UiPathChatOpenAI",
-    "UiPathOpenAIEmbeddings",
-    "UiPathAzureOpenAIEmbeddings",
-})
+DEFAULT_LLM_CLASS_NAMES = frozenset(
+    {
+        "UiPath",
+        "UiPathAzureChatOpenAI",
+        "UiPathChat",
+        "UiPathChatOpenAI",
+        "UiPathOpenAIEmbeddings",
+        "UiPathAzureOpenAIEmbeddings",
+    }
+)
 
 
 def _called_class_name(node: ast.Call) -> str | None:
@@ -91,15 +93,17 @@ def find_module_level_llm_clients(
         #   - `llm: UiPathChat = UiPathChat()`  (AnnAssign)
         #   - `UiPathChat()`                    (bare Expr)
         candidate_calls: list[ast.Call] = []
-        if isinstance(stmt, ast.Assign) and isinstance(stmt.value, ast.Call):
-            candidate_calls.append(stmt.value)
-        elif (
-            isinstance(stmt, ast.AnnAssign)
-            and stmt.value is not None
+        if (
+            isinstance(stmt, ast.Assign)
+            and isinstance(stmt.value, ast.Call)
+            or (
+                isinstance(stmt, ast.AnnAssign)
+                and stmt.value is not None
+                and isinstance(stmt.value, ast.Call)
+            )
+            or isinstance(stmt, ast.Expr)
             and isinstance(stmt.value, ast.Call)
         ):
-            candidate_calls.append(stmt.value)
-        elif isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
             candidate_calls.append(stmt.value)
         for call in candidate_calls:
             name = _called_class_name(call)

--- a/tests/tasks/uipath-agents/_shared/bindings_assertions.py
+++ b/tests/tasks/uipath-agents/_shared/bindings_assertions.py
@@ -36,8 +36,12 @@ def load_bindings(path: Path | str = "bindings.json") -> dict:
         sys.exit(f'FAIL: bindings.json version should be "2.0", got {version!r}')
     resources = doc.get("resources")
     if not isinstance(resources, list):
-        sys.exit(f"FAIL: bindings.json resources must be a list, got {type(resources).__name__}")
-    print(f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)')
+        sys.exit(
+            f"FAIL: bindings.json resources must be a list, got {type(resources).__name__}"
+        )
+    print(
+        f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)'
+    )
     return doc
 
 
@@ -54,10 +58,9 @@ def find_resource(
     """
     resources = doc.get("resources") or []
     matches = [
-        r for r in resources
-        if isinstance(r, dict)
-        and r.get("resource") == resource
-        and r.get("key") == key
+        r
+        for r in resources
+        if isinstance(r, dict) and r.get("resource") == resource and r.get("key") == key
     ]
     if not matches:
         sys.exit(
@@ -91,13 +94,11 @@ def assert_value_field(
         sys.exit(f"FAIL: entry value must be an object, got {value!r}")
     block = value.get(field)
     if not isinstance(block, dict):
-        sys.exit(f'FAIL: entry value.{field} must be an object, got {block!r}')
+        sys.exit(f"FAIL: entry value.{field} must be an object, got {block!r}")
     actual = block.get(inner)
     if actual != expected:
-        sys.exit(
-            f'FAIL: value.{field}.{inner} should be {expected!r}, got {actual!r}'
-        )
-    print(f'OK: value.{field}.{inner} == {expected!r}')
+        sys.exit(f"FAIL: value.{field}.{inner} should be {expected!r}, got {actual!r}")
+    print(f"OK: value.{field}.{inner} == {expected!r}")
 
 
 def assert_metadata_field(entry: dict, *, field: str, expected: Any) -> None:
@@ -107,10 +108,8 @@ def assert_metadata_field(entry: dict, *, field: str, expected: Any) -> None:
         sys.exit(f"FAIL: entry metadata must be an object, got {metadata!r}")
     actual = metadata.get(field)
     if actual != expected:
-        sys.exit(
-            f'FAIL: metadata.{field} should be {expected!r}, got {actual!r}'
-        )
-    print(f'OK: metadata.{field} == {expected!r}')
+        sys.exit(f"FAIL: metadata.{field} should be {expected!r}, got {actual!r}")
+    print(f"OK: metadata.{field} == {expected!r}")
 
 
 def assert_entrypoint_link(
@@ -131,31 +130,30 @@ def assert_entrypoint_link(
     if isinstance(uid_block, dict):
         if uid_block.get("defaultValue") != unique_id:
             sys.exit(
-                f'FAIL: EntryPointUniqueId.defaultValue should be {unique_id!r}, '
-                f'got {uid_block.get("defaultValue")!r}'
+                f"FAIL: EntryPointUniqueId.defaultValue should be {unique_id!r}, "
+                f"got {uid_block.get('defaultValue')!r}"
             )
         if uid_block.get("displayName") != file_path:
             sys.exit(
-                f'FAIL: EntryPointUniqueId.displayName must equal the entrypoint '
-                f'filePath ({file_path!r}), got {uid_block.get("displayName")!r}'
+                f"FAIL: EntryPointUniqueId.displayName must equal the entrypoint "
+                f"filePath ({file_path!r}), got {uid_block.get('displayName')!r}"
             )
         print(
-            f'OK: entry bound to entrypoint uniqueId={unique_id!r} '
-            f'(displayName={file_path!r})'
+            f"OK: entry bound to entrypoint uniqueId={unique_id!r} (displayName={file_path!r})"
         )
         return
     path_block = value.get("EntryPointPath")
     if isinstance(path_block, dict):
         if path_block.get("defaultValue") != file_path:
             sys.exit(
-                f'FAIL: EntryPointPath.defaultValue should be {file_path!r}, '
-                f'got {path_block.get("defaultValue")!r}'
+                f"FAIL: EntryPointPath.defaultValue should be {file_path!r}, "
+                f"got {path_block.get('defaultValue')!r}"
             )
-        print(f'OK: entry bound to entrypoint filePath={file_path!r} (fallback)')
+        print(f"OK: entry bound to entrypoint filePath={file_path!r} (fallback)")
         return
     sys.exit(
-        f'FAIL: entry has neither EntryPointUniqueId nor EntryPointPath; expected '
-        f'a binding to entrypoint uniqueId={unique_id!r} (filePath={file_path!r})'
+        f"FAIL: entry has neither EntryPointUniqueId nor EntryPointPath; expected "
+        f"a binding to entrypoint uniqueId={unique_id!r} (filePath={file_path!r})"
     )
 
 
@@ -163,6 +161,7 @@ def count_resources_by_type(doc: dict, resource_type: str) -> int:
     """Return the number of entries with `resource == resource_type`."""
     resources = doc.get("resources") or []
     return sum(
-        1 for r in resources
+        1
+        for r in resources
         if isinstance(r, dict) and r.get("resource") == resource_type
     )

--- a/tests/tasks/uipath-agents/_shared/coded_project_factory.py
+++ b/tests/tasks/uipath-agents/_shared/coded_project_factory.py
@@ -21,9 +21,9 @@ is `[project]` + `[dependency-groups]` only.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterable
 from pathlib import Path
 from textwrap import dedent
-from typing import Iterable
 
 PYPROJECT_TEMPLATE = dedent(
     """\

--- a/tests/tasks/uipath-agents/_shared/inline_wiring.py
+++ b/tests/tasks/uipath-agents/_shared/inline_wiring.py
@@ -74,9 +74,9 @@ def find_resource_node(
         descriptor = f"type {node_type!r}"
     elif node_type_prefix is not None:
         matches = [
-            n for n in nodes
-            if isinstance(n.get("type"), str)
-            and n["type"].startswith(node_type_prefix)
+            n
+            for n in nodes
+            if isinstance(n.get("type"), str) and n["type"].startswith(node_type_prefix)
         ]
         descriptor = f"type starting with {node_type_prefix!r}"
     else:
@@ -97,8 +97,7 @@ def resolve_inline_agent_dir(flow_path: Path, agent_node: dict) -> Path:
     agent_dir = flow_path.parent / source
     if not agent_dir.is_dir():
         sys.exit(
-            f"FAIL: model.source {source!r} does not point to an existing "
-            f"directory ({agent_dir})"
+            f"FAIL: model.source {source!r} does not point to an existing directory ({agent_dir})"
         )
     return agent_dir
 
@@ -114,7 +113,8 @@ def assert_edge(
     """Assert that an edge wires source_id:source_port -> target_id:target_port."""
     edges = flow.get("edges") or []
     matches = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("sourceNodeId") == source_id
         and e.get("sourcePort") == source_port
         and e.get("targetNodeId") == target_id

--- a/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/check_antipattern_wrong_sdk_import.py
+++ b/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/check_antipattern_wrong_sdk_import.py
@@ -18,8 +18,12 @@ from pathlib import Path
 ROOT = Path(os.getcwd()) / "bad-import"
 MAIN = ROOT / "main.py"
 
-WRONG = re.compile(r"^\s*from\s+uipath\s+import\s+(?:[^,\n]*,\s*)*UiPath(?:\s*,|$)", re.M)
-RIGHT = re.compile(r"^\s*from\s+uipath\.platform\s+import\s+(?:[^,\n]*,\s*)*UiPath\b", re.M)
+WRONG = re.compile(
+    r"^\s*from\s+uipath\s+import\s+(?:[^,\n]*,\s*)*UiPath(?:\s*,|$)", re.M
+)
+RIGHT = re.compile(
+    r"^\s*from\s+uipath\.platform\s+import\s+(?:[^,\n]*,\s*)*UiPath\b", re.M
+)
 
 
 def main() -> None:
@@ -37,7 +41,9 @@ def main() -> None:
             "FAIL: main.py does not import UiPath from `uipath.platform`. "
             "Add `from uipath.platform import UiPath`."
         )
-    print("OK: main.py imports UiPath from `uipath.platform` (no `from uipath import UiPath`)")
+    print(
+        "OK: main.py imports UiPath from `uipath.platform` (no `from uipath import UiPath`)"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/bindings_asset_subtypes/check_bindings_asset_subtypes.py
+++ b/tests/tasks/uipath-agents/bindings_asset_subtypes/check_bindings_asset_subtypes.py
@@ -26,10 +26,10 @@ ROOT = Path(os.getcwd())
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.bindings_assertions import (  # noqa: E402
-    load_bindings,
-    find_resource,
     assert_value_field,
     count_resources_by_type,
+    find_resource,
+    load_bindings,
 )
 
 EXPECTED = {
@@ -52,16 +52,18 @@ def main() -> None:
         metadata = entry.get("metadata") or {}
         actual = metadata.get("SubType")
         if actual is None:
-            print(f'OK: {name} asset binding has no SubType (acceptable fallback)')
+            print(f"OK: {name} asset binding has no SubType (acceptable fallback)")
             continue
         if actual == expected_subtype:
-            print(f'OK: {name} asset binding has SubType={actual!r} (high-confidence inference)')
+            print(
+                f"OK: {name} asset binding has SubType={actual!r} (high-confidence inference)"
+            )
             continue
         sys.exit(
-            f'FAIL: {name} asset binding has SubType={actual!r}, expected '
-            f'either {expected_subtype!r} (from annotation) or omitted. '
-            f'Wrong SubType is worse than no SubType — `uipath push` would '
-            f'create the wrong placeholder kind.'
+            f"FAIL: {name} asset binding has SubType={actual!r}, expected "
+            f"either {expected_subtype!r} (from annotation) or omitted. "
+            f"Wrong SubType is worse than no SubType — `uipath push` would "
+            f"create the wrong placeholder kind."
         )
 
 

--- a/tests/tasks/uipath-agents/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
+++ b/tests/tasks/uipath-agents/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
@@ -21,10 +21,10 @@ ROOT = Path(os.getcwd())
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.bindings_assertions import (  # noqa: E402
-    load_bindings,
-    find_resource,
     assert_value_field,
     count_resources_by_type,
+    find_resource,
+    load_bindings,
 )
 
 
@@ -62,14 +62,16 @@ def main() -> None:
         value = entry.get("value") or {}
         ep = value.get("EntryPointUniqueId")
         if not isinstance(ep, dict):
-            print(f"OK: {entry.get('resource')} binding has no EntryPointUniqueId (acceptable)")
+            print(
+                f"OK: {entry.get('resource')} binding has no EntryPointUniqueId (acceptable)"
+            )
             continue
         uid = ep.get("defaultValue")
         if uid not in real:
             sys.exit(
-                f'FAIL: {entry.get("resource")} binding references '
-                f'EntryPointUniqueId={uid!r}, which is not one of the real '
-                f'entrypoints {sorted(real)}.'
+                f"FAIL: {entry.get('resource')} binding references "
+                f"EntryPointUniqueId={uid!r}, which is not one of the real "
+                f"entrypoints {sorted(real)}."
             )
         print(
             f"OK: {entry.get('resource')} binding's EntryPointUniqueId "

--- a/tests/tasks/uipath-agents/bindings_queue_app_index/check_bindings_queue_app_index.py
+++ b/tests/tasks/uipath-agents/bindings_queue_app_index/check_bindings_queue_app_index.py
@@ -18,11 +18,11 @@ ROOT = Path(os.getcwd())
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.bindings_assertions import (  # noqa: E402
-    load_bindings,
-    find_resource,
-    assert_value_field,
     assert_metadata_field,
+    assert_value_field,
     count_resources_by_type,
+    find_resource,
+    load_bindings,
 )
 
 
@@ -49,7 +49,9 @@ def main() -> None:
     assert_metadata_field(index, field="ActivityName", expected="retrieve_async")
     # connection
     connection = find_resource(doc, resource="connection", key="salesforce-prod-conn")
-    assert_value_field(connection, field="ConnectionId", expected="salesforce-prod-conn")
+    assert_value_field(
+        connection, field="ConnectionId", expected="salesforce-prod-conn"
+    )
     assert_metadata_field(connection, field="UseConnectionService", expected="True")
     # mcpServer
     mcp = find_resource(doc, resource="mcpServer", key="weather-mcp.Tools")
@@ -61,7 +63,9 @@ def main() -> None:
         n = count_resources_by_type(doc, kind)
         if n != 1:
             sys.exit(f"FAIL: expected exactly 1 `{kind}` binding entry, got {n}")
-    print("OK: each of queue/app/index/connection/mcpServer has exactly one binding entry")
+    print(
+        "OK: each of queue/app/index/connection/mcpServer has exactly one binding entry"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/builtin_tool/check_builtin_tool.py
+++ b/tests/tasks/uipath-agents/builtin_tool/check_builtin_tool.py
@@ -58,16 +58,19 @@ def find_resource_jsons() -> list:
 
 def is_builtin_tool(resource: dict) -> bool:
     return (
-        resource.get("$resourceType") == "tool"
-        and resource.get("type") == "internal"
+        resource.get("$resourceType") == "tool" and resource.get("type") == "internal"
     )
 
 
 def assert_builtin_shape(path: Path, resource: dict) -> str:
     if resource.get("$resourceType") != "tool":
-        sys.exit(f'FAIL: {path} $resourceType should be "tool", got {resource.get("$resourceType")!r}')
+        sys.exit(
+            f'FAIL: {path} $resourceType should be "tool", got {resource.get("$resourceType")!r}'
+        )
     if resource.get("type") != "internal":
-        sys.exit(f'FAIL: {path} type should be "internal" for a built-in tool, got {resource.get("type")!r}')
+        sys.exit(
+            f'FAIL: {path} type should be "internal" for a built-in tool, got {resource.get("type")!r}'
+        )
     if resource.get("referenceKey") is not None:
         sys.exit(
             f"FAIL: {path} referenceKey should be null for a built-in tool "
@@ -108,7 +111,7 @@ def main() -> None:
         sys.exit(
             f'FAIL: prompt asked for the "Analyze Files" built-in tool '
             f'(toolType "analyze-attachments"), but none was enabled. '
-            f'Got toolTypes: {builtin_tool_types_seen}'
+            f"Got toolTypes: {builtin_tool_types_seen}"
         )
     print('OK: "Analyze Files" (toolType="analyze-attachments") is enabled')
 

--- a/tests/tasks/uipath-agents/context_index/check_context_index.py
+++ b/tests/tasks/uipath-agents/context_index/check_context_index.py
@@ -41,7 +41,9 @@ def load(path: Path) -> dict:
 def assert_context_resource(resource: dict) -> None:
     rtype = resource.get("$resourceType")
     if rtype != "context":
-        sys.exit(f'FAIL: resource.json $resourceType should be "context", got {rtype!r}')
+        sys.exit(
+            f'FAIL: resource.json $resourceType should be "context", got {rtype!r}'
+        )
     ctype = resource.get("contextType")
     if ctype != "index":
         sys.exit(f'FAIL: resource.json contextType should be "index", got {ctype!r}')
@@ -50,7 +52,9 @@ def assert_context_resource(resource: dict) -> None:
         sys.exit(
             f'FAIL: resource.json indexName should be "ProductKnowledge", got {index_name!r}'
         )
-    print('OK: resource.json is $resourceType="context", contextType="index", indexName="ProductKnowledge"')
+    print(
+        'OK: resource.json is $resourceType="context", contextType="index", indexName="ProductKnowledge"'
+    )
 
 
 def assert_retrieval_mode(resource: dict) -> None:
@@ -95,10 +99,14 @@ def assert_input_shape(schema: dict) -> None:
         )
     q = props["question"]
     if not isinstance(q, dict) or q.get("type") != "string":
-        sys.exit(f"FAIL: inputSchema.properties.question.type should be 'string', got {q!r}")
+        sys.exit(
+            f"FAIL: inputSchema.properties.question.type should be 'string', got {q!r}"
+        )
     required = schema.get("required")
     if not isinstance(required, list) or "question" not in required:
-        sys.exit(f"FAIL: inputSchema.required must contain 'question', got {required!r}")
+        sys.exit(
+            f"FAIL: inputSchema.required must contain 'question', got {required!r}"
+        )
     print("OK: inputSchema declares required question:string")
 
 
@@ -110,7 +118,9 @@ def assert_output_shape(schema: dict) -> None:
         )
     a = props["answer"]
     if not isinstance(a, dict) or a.get("type") != "string":
-        sys.exit(f"FAIL: outputSchema.properties.answer.type should be 'string', got {a!r}")
+        sys.exit(
+            f"FAIL: outputSchema.properties.answer.type should be 'string', got {a!r}"
+        )
     print("OK: outputSchema declares answer:string")
 
 

--- a/tests/tasks/uipath-agents/deploy_my_workspace/check_deploy_my_workspace.py
+++ b/tests/tasks/uipath-agents/deploy_my_workspace/check_deploy_my_workspace.py
@@ -53,8 +53,7 @@ def check_pack_artifacts() -> None:
     uipath_dir = ROOT / ".uipath"
     if not uipath_dir.is_dir():
         sys.exit(
-            f"FAIL: {uipath_dir} does not exist — `uip codedagent pack` "
-            "did not run."
+            f"FAIL: {uipath_dir} does not exist — `uip codedagent pack` did not run."
         )
     nupkgs = sorted(uipath_dir.glob("*.nupkg"))
     if not nupkgs:
@@ -62,17 +61,25 @@ def check_pack_artifacts() -> None:
             f"FAIL: no .nupkg file in {uipath_dir} — pack did not produce "
             "the expected package artifact."
         )
-    print(f"OK: {uipath_dir.name}/{nupkgs[0].name} exists ({len(nupkgs)} package(s) total)")
+    print(
+        f"OK: {uipath_dir.name}/{nupkgs[0].name} exists ({len(nupkgs)} package(s) total)"
+    )
 
 
 def check_invoke_output() -> None:
     path = ROOT / "invoke-output.txt"
     text = _read_text(path)
     if not text.strip():
-        sys.exit(f"FAIL: {path.name} is empty — `uip codedagent invoke` produced no output")
+        sys.exit(
+            f"FAIL: {path.name} is empty — `uip codedagent invoke` produced no output"
+        )
     if "https://" not in text:
-        sys.exit(f"FAIL: {path.name} does not contain a monitoring URL (no `https://` substring)")
-    print(f"OK: {path.name} captured {len(text)} bytes of invoke stdout (with monitoring URL)")
+        sys.exit(
+            f"FAIL: {path.name} does not contain a monitoring URL (no `https://` substring)"
+        )
+    print(
+        f"OK: {path.name} captured {len(text)} bytes of invoke stdout (with monitoring URL)"
+    )
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/dispute_analyst_agent/check_dispute_analyst_agent.py
+++ b/tests/tasks/uipath-agents/dispute_analyst_agent/check_dispute_analyst_agent.py
@@ -101,8 +101,7 @@ def assert_input_shape(schema: dict) -> None:
     missing = [f for f in INPUT_FIELDS if f not in props]
     if missing:
         sys.exit(
-            f"FAIL: inputSchema.properties missing fields {missing!r}; "
-            f"got {sorted(props)!r}"
+            f"FAIL: inputSchema.properties missing fields {missing!r}; got {sorted(props)!r}"
         )
     print(f"OK: inputSchema declares all 5 fields ({', '.join(INPUT_FIELDS)})")
 
@@ -126,14 +125,11 @@ def resolve_analysis_properties(out_schema: dict) -> dict:
         nested = props["disputeAnalysis"]
         if not isinstance(nested, dict):
             sys.exit(
-                "FAIL: outputSchema.properties.disputeAnalysis must be an object, "
-                f"got {nested!r}"
+                f"FAIL: outputSchema.properties.disputeAnalysis must be an object, got {nested!r}"
             )
         inner = nested.get("properties")
         if not isinstance(inner, dict):
-            sys.exit(
-                "FAIL: outputSchema.properties.disputeAnalysis.properties missing"
-            )
+            sys.exit("FAIL: outputSchema.properties.disputeAnalysis.properties missing")
         print("OK: outputSchema uses nested disputeAnalysis object")
         return inner
 
@@ -146,8 +142,7 @@ def assert_output_shape(out_schema: dict) -> None:
     missing = [f for f in OUTPUT_FIELDS if f not in props]
     if missing:
         sys.exit(
-            f"FAIL: outputSchema missing fields {missing!r}; "
-            f"got {sorted(props)!r}"
+            f"FAIL: outputSchema missing fields {missing!r}; got {sorted(props)!r}"
         )
     print(f"OK: outputSchema declares all {len(OUTPUT_FIELDS)} fields")
 
@@ -156,7 +151,9 @@ def get_user_message(agent: dict) -> dict:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     return user_messages[0]
@@ -173,8 +170,7 @@ def assert_user_message_inlines(agent: dict) -> None:
         placeholder = "{{input." + field + "}}"
         if placeholder not in content:
             sys.exit(
-                f"FAIL: user message content does not inline {placeholder}; "
-                f"content={content!r}"
+                f"FAIL: user message content does not inline {placeholder}; content={content!r}"
             )
         expected = {"type": "variable", "rawString": f"input.{field}"}
         if expected not in tokens:
@@ -183,7 +179,7 @@ def assert_user_message_inlines(agent: dict) -> None:
                 f"input.{field}\n  expected: {expected}\n"
                 f"  got tokens: {json.dumps(tokens, indent=2)}"
             )
-    print(f"OK: user message inlines all 5 inputs with matching contentTokens")
+    print("OK: user message inlines all 5 inputs with matching contentTokens")
 
 
 def assert_system_prompt_domain(agent: dict) -> None:

--- a/tests/tasks/uipath-agents/edit_roundtrip/check_edit_roundtrip.py
+++ b/tests/tasks/uipath-agents/edit_roundtrip/check_edit_roundtrip.py
@@ -65,13 +65,14 @@ def assert_input_fields(in_schema: dict) -> None:
     missing = [f for f in INPUT_FIELDS if f not in props]
     if missing:
         sys.exit(
-            f"FAIL: inputSchema.properties missing {missing!r} after edit; "
-            f"got {sorted(props)!r}"
+            f"FAIL: inputSchema.properties missing {missing!r} after edit; got {sorted(props)!r}"
         )
     for f in INPUT_FIELDS:
         ftype = props[f].get("type") if isinstance(props[f], dict) else None
         if ftype != "string":
-            sys.exit(f"FAIL: inputSchema.properties.{f}.type should be 'string', got {ftype!r}")
+            sys.exit(
+                f"FAIL: inputSchema.properties.{f}.type should be 'string', got {ftype!r}"
+            )
     required = in_schema.get("required")
     if not isinstance(required, list):
         sys.exit(f"FAIL: inputSchema.required must be a list, got {required!r}")
@@ -92,7 +93,9 @@ def assert_output_field(out_schema: dict) -> None:
         )
     g = props["greeting"]
     if not isinstance(g, dict) or g.get("type") != "string":
-        sys.exit(f"FAIL: outputSchema.properties.greeting.type should be 'string', got {g!r}")
+        sys.exit(
+            f"FAIL: outputSchema.properties.greeting.type should be 'string', got {g!r}"
+        )
     print("OK: outputSchema declares greeting:string")
 
 
@@ -100,7 +103,9 @@ def assert_user_message_inlines_both(agent: dict) -> None:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     user = user_messages[0]

--- a/tests/tasks/uipath-agents/eval_exact_match/check_eval_exact_match.py
+++ b/tests/tasks/uipath-agents/eval_exact_match/check_eval_exact_match.py
@@ -53,7 +53,9 @@ def find_single_json(directory: Path) -> Path:
     if not files:
         sys.exit(f"FAIL: {directory} contains no .json files")
     if len(files) > 1:
-        sys.exit(f"FAIL: {directory} should contain exactly one .json file, got {len(files)}")
+        sys.exit(
+            f"FAIL: {directory} should contain exactly one .json file, got {len(files)}"
+        )
     return files[0]
 
 
@@ -63,13 +65,14 @@ def check_evaluator() -> str:
     type_id = doc.get("evaluatorTypeId")
     if type_id != "uipath-exact-match":
         sys.exit(
-            f'FAIL: {path.name} evaluatorTypeId should be "uipath-exact-match", '
-            f'got {type_id!r}'
+            f'FAIL: {path.name} evaluatorTypeId should be "uipath-exact-match", got {type_id!r}'
         )
     eval_id = doc.get("id")
     if not eval_id:
         sys.exit(f"FAIL: {path.name} is missing required `id` field")
-    print(f'OK: evaluator config {path.name} has evaluatorTypeId={type_id!r} id={eval_id!r}')
+    print(
+        f"OK: evaluator config {path.name} has evaluatorTypeId={type_id!r} id={eval_id!r}"
+    )
     return eval_id
 
 
@@ -81,8 +84,8 @@ def check_eval_set(evaluator_id: str) -> int:
     refs = doc.get("evaluatorRefs") or []
     if evaluator_id not in refs:
         sys.exit(
-            f'FAIL: eval set `evaluatorRefs` does not include the evaluator '
-            f'id {evaluator_id!r}. Got: {refs}'
+            f"FAIL: eval set `evaluatorRefs` does not include the evaluator "
+            f"id {evaluator_id!r}. Got: {refs}"
         )
     cases = doc.get("evaluations") or []
     if len(cases) < 2:
@@ -91,11 +94,13 @@ def check_eval_set(evaluator_id: str) -> int:
         crit = case.get("evaluationCriterias") or {}
         if evaluator_id not in crit:
             sys.exit(
-                f'FAIL: eval set test case {i} (`{case.get("id", "?")}`) does '
-                f'not key its evaluationCriterias on the evaluator id '
-                f'{evaluator_id!r}. Got keys: {list(crit.keys())}'
+                f"FAIL: eval set test case {i} (`{case.get('id', '?')}`) does "
+                f"not key its evaluationCriterias on the evaluator id "
+                f"{evaluator_id!r}. Got keys: {list(crit.keys())}"
             )
-    print(f'OK: eval set {path.name} references {evaluator_id!r} across {len(cases)} test cases')
+    print(
+        f"OK: eval set {path.name} references {evaluator_id!r} across {len(cases)} test cases"
+    )
     return len(cases)
 
 
@@ -103,7 +108,9 @@ def check_results(evaluator_id: str, expected_case_count: int) -> None:
     path = ROOT / "eval-results.json"
     doc = _load_json(path)
     if not isinstance(doc, dict):
-        sys.exit(f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}")
+        sys.exit(
+            f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}"
+        )
     cases = doc.get("evaluationSetResults")
     if not isinstance(cases, list) or not cases:
         sys.exit(
@@ -115,7 +122,7 @@ def check_results(evaluator_id: str, expected_case_count: int) -> None:
             f"FAIL: expected {expected_case_count} entries in "
             f"`evaluationSetResults` (one per eval-set test case), got {len(cases)}"
         )
-    print(f'OK: eval-results.json carries {len(cases)} entries in evaluationSetResults')
+    print(f"OK: eval-results.json carries {len(cases)} entries in evaluationSetResults")
     bad_cases = []
     matching_run_count = 0
     for case in cases:
@@ -124,29 +131,30 @@ def check_results(evaluator_id: str, expected_case_count: int) -> None:
         case_name = case.get("evaluationName") or "?"
         runs = case.get("evaluationRunResults") or []
         matching = [
-            r for r in runs
+            r
+            for r in runs
             if isinstance(r, dict) and r.get("evaluatorId") == evaluator_id
         ]
         if not matching:
             bad_cases.append(
-                f'{case_name!r}: no evaluationRunResults entry references '
-                f'evaluatorId={evaluator_id!r}'
+                f"{case_name!r}: no evaluationRunResults entry references "
+                f"evaluatorId={evaluator_id!r}"
             )
             continue
         for r in matching:
             score = (r.get("result") or {}).get("score")
             if score != 1.0:
                 bad_cases.append(
-                    f'{case_name!r}: evaluator {evaluator_id!r} scored '
-                    f'{score!r}, expected 1.0 (deterministic agent + '
-                    f'deterministic evaluator)'
+                    f"{case_name!r}: evaluator {evaluator_id!r} scored "
+                    f"{score!r}, expected 1.0 (deterministic agent + "
+                    f"deterministic evaluator)"
                 )
         matching_run_count += len(matching)
     if bad_cases:
         sys.exit("FAIL: " + " | ".join(bad_cases))
     print(
-        f'OK: every test case has an ExactMatchEvaluator run scoring 1.0 '
-        f'({matching_run_count} run(s) across {len(cases)} case(s))'
+        f"OK: every test case has an ExactMatchEvaluator run scoring 1.0 "
+        f"({matching_run_count} run(s) across {len(cases)} case(s))"
     )
 
 

--- a/tests/tasks/uipath-agents/eval_llm_judges/check_eval_llm_judges.py
+++ b/tests/tasks/uipath-agents/eval_llm_judges/check_eval_llm_judges.py
@@ -56,16 +56,18 @@ def check_evaluator_configs() -> None:
             expected_type = EXPECTED_EVALUATORS[eval_id]
             if type_id != expected_type:
                 sys.exit(
-                    f'FAIL: evaluator {eval_id!r} should have evaluatorTypeId='
-                    f'{expected_type!r}, got {type_id!r}'
+                    f"FAIL: evaluator {eval_id!r} should have evaluatorTypeId="
+                    f"{expected_type!r}, got {type_id!r}"
                 )
             found_by_id[eval_id] = json_file
-            print(f'OK: evaluator config {json_file.name} has id={eval_id!r} typeId={type_id!r}')
+            print(
+                f"OK: evaluator config {json_file.name} has id={eval_id!r} typeId={type_id!r}"
+            )
     missing = set(EXPECTED_EVALUATORS) - set(found_by_id)
     if missing:
         sys.exit(
-            f'FAIL: missing evaluator configs for ids {sorted(missing)}. '
-            f'Found ids: {sorted(found_by_id)}'
+            f"FAIL: missing evaluator configs for ids {sorted(missing)}. "
+            f"Found ids: {sorted(found_by_id)}"
         )
 
 
@@ -86,8 +88,7 @@ def check_eval_set() -> None:
     missing_refs = set(EXPECTED_EVALUATORS) - set(refs)
     if missing_refs:
         sys.exit(
-            f'FAIL: eval set `evaluatorRefs` is missing {sorted(missing_refs)}. '
-            f'Got: {refs}'
+            f"FAIL: eval set `evaluatorRefs` is missing {sorted(missing_refs)}. Got: {refs}"
         )
     cases = doc.get("evaluations") or []
     if len(cases) < 2:
@@ -97,23 +98,23 @@ def check_eval_set() -> None:
         for evaluator_id in EXPECTED_EVALUATORS:
             if evaluator_id not in crit:
                 sys.exit(
-                    f'FAIL: test case {i} (`{case.get("id", "?")}`) does not '
-                    f'key evaluationCriterias on {evaluator_id!r}. Got keys: '
-                    f'{list(crit.keys())}'
+                    f"FAIL: test case {i} (`{case.get('id', '?')}`) does not "
+                    f"key evaluationCriterias on {evaluator_id!r}. Got keys: "
+                    f"{list(crit.keys())}"
                 )
         # Trajectory judge requires `expectedAgentBehavior`.
         traj = crit.get("LLMJudgeTrajectoryEvaluator") or {}
         if not traj.get("expectedAgentBehavior"):
             sys.exit(
-                f'FAIL: test case {i} LLMJudgeTrajectoryEvaluator entry is '
-                f'missing the required `expectedAgentBehavior` field. Got: {traj}'
+                f"FAIL: test case {i} LLMJudgeTrajectoryEvaluator entry is "
+                f"missing the required `expectedAgentBehavior` field. Got: {traj}"
             )
         # Output judge requires `expectedOutput`.
         out = crit.get("LLMJudgeOutputEvaluator") or {}
         if "expectedOutput" not in out:
             sys.exit(
-                f'FAIL: test case {i} LLMJudgeOutputEvaluator entry is '
-                f'missing the required `expectedOutput` field. Got: {out}'
+                f"FAIL: test case {i} LLMJudgeOutputEvaluator entry is "
+                f"missing the required `expectedOutput` field. Got: {out}"
             )
     print(
         f"OK: eval set {path.name} references both judges across {len(cases)} "
@@ -125,7 +126,9 @@ def check_results() -> None:
     path = ROOT / "eval-results.json"
     doc = _load_json(path)
     if not isinstance(doc, dict):
-        sys.exit(f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}")
+        sys.exit(
+            f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}"
+        )
     cases = doc.get("evaluationSetResults")
     if not isinstance(cases, list) or not cases:
         sys.exit(
@@ -144,9 +147,9 @@ def check_results() -> None:
     missing = set(EXPECTED_EVALUATORS) - seen_ids
     if missing:
         sys.exit(
-            f'FAIL: results file does not surface evaluatorId entries for '
-            f'{sorted(missing)} (seen: {sorted(seen_ids)}). Both judges '
-            f'should run on every test case.'
+            f"FAIL: results file does not surface evaluatorId entries for "
+            f"{sorted(missing)} (seen: {sorted(seen_ids)}). Both judges "
+            f"should run on every test case."
         )
     print(
         f"OK: results file references both evaluator ids ({sorted(seen_ids)}) "

--- a/tests/tasks/uipath-agents/external_agent_tool/check_external_agent_tool.py
+++ b/tests/tasks/uipath-agents/external_agent_tool/check_external_agent_tool.py
@@ -42,7 +42,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="agent", location="external"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="agent", location="external"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -55,14 +57,18 @@ def assert_properties(resource: dict) -> None:
         )
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '
             'valid for location=="solution". External agent tools require a '
             'real Orchestrator folder path like "Shared".'
         )
-    print(f'OK: properties.processName="SupportExpert", folderPath={fpath!r} (not "solution_folder")')
+    print(
+        f'OK: properties.processName="SupportExpert", folderPath={fpath!r} (not "solution_folder")'
+    )
 
 
 def assert_identity_and_schemas(resource: dict) -> None:
@@ -70,7 +76,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/external_apiworkflow_tool/check_external_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/external_apiworkflow_tool/check_external_apiworkflow_tool.py
@@ -50,7 +50,9 @@ def assert_properties(resource: dict) -> None:
         sys.exit(f"FAIL: resource.json.properties is not an object: {props!r}")
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '
@@ -65,7 +67,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/external_escalation/check_external_escalation.py
+++ b/tests/tasks/uipath-agents/external_escalation/check_external_escalation.py
@@ -50,16 +50,23 @@ def assert_escalation_header(resource: dict) -> None:
     if not isinstance(name, str) or not name.strip():
         sys.exit(f"FAIL: escalation name missing or empty: {name!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}")
-    print(f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)')
+        sys.exit(
+            f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
+    print(
+        f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)'
+    )
 
 
 def assert_actioncenter_channel(resource: dict) -> None:
     channels = resource.get("channels")
     if not isinstance(channels, list) or not channels:
-        sys.exit(f"FAIL: escalation.channels must be a non-empty list, got {channels!r}")
+        sys.exit(
+            f"FAIL: escalation.channels must be a non-empty list, got {channels!r}"
+        )
     ac_channels = [
-        c for c in channels
+        c
+        for c in channels
         if isinstance(c, dict)
         and c.get("name") == "ActionCenter"
         and c.get("type") == "ActionCenter"

--- a/tests/tasks/uipath-agents/external_maestro_tool/check_external_maestro_tool.py
+++ b/tests/tasks/uipath-agents/external_maestro_tool/check_external_maestro_tool.py
@@ -41,7 +41,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="processOrchestration", location="external"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="processOrchestration", location="external"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -50,7 +52,9 @@ def assert_properties(resource: dict) -> None:
         sys.exit(f"FAIL: resource.json.properties is not an object: {props!r}")
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '
@@ -65,7 +69,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/external_rpa_tool/check_external_rpa_tool.py
+++ b/tests/tasks/uipath-agents/external_rpa_tool/check_external_rpa_tool.py
@@ -43,7 +43,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="process", location="external"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="process", location="external"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -52,17 +54,23 @@ def assert_properties(resource: dict) -> None:
         sys.exit(f"FAIL: resource.json.properties is not an object: {props!r}")
     pname = props.get("processName")
     if pname != "InvoiceProcessor":
-        sys.exit(f'FAIL: properties.processName should be "InvoiceProcessor", got {pname!r}')
+        sys.exit(
+            f'FAIL: properties.processName should be "InvoiceProcessor", got {pname!r}'
+        )
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '
             'valid for location=="solution". External tools require a real '
             'Orchestrator folder path like "Shared". (Critical Rule 11)'
         )
-    print(f'OK: properties.processName="InvoiceProcessor", folderPath={fpath!r} (not "solution_folder")')
+    print(
+        f'OK: properties.processName="InvoiceProcessor", folderPath={fpath!r} (not "solution_folder")'
+    )
 
 
 def assert_identity_and_schemas(resource: dict) -> None:
@@ -70,7 +78,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/guardrail_custom_word/check_guardrail_custom_word.py
+++ b/tests/tasks/uipath-agents/guardrail_custom_word/check_guardrail_custom_word.py
@@ -53,8 +53,7 @@ def main() -> None:
     if not custom:
         types = [g.get("$guardrailType") for g in guardrails]
         sys.exit(
-            f'FAIL: no guardrail with $guardrailType == "custom" found. '
-            f"Got types: {types}"
+            f'FAIL: no guardrail with $guardrailType == "custom" found. Got types: {types}'
         )
     g = custom[0]
     print('OK: found guardrail with $guardrailType == "custom"')
@@ -71,8 +70,7 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
     if action.get("$actionType") != "block":
         sys.exit(
-            f'FAIL: guardrail.action.$actionType must be "block", '
-            f"got {action.get('$actionType')!r}"
+            f'FAIL: guardrail.action.$actionType must be "block", got {action.get("$actionType")!r}'
         )
     print('OK: action.$actionType == "block"')
 
@@ -82,12 +80,14 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(
             f"FAIL: guardrail.selector.scopes contains invalid values {invalid}. "
-            f'Valid PascalCase values: {sorted(VALID_SCOPES)}'
+            f"Valid PascalCase values: {sorted(VALID_SCOPES)}"
         )
     print(f"OK: selector.scopes = {scopes} (all PascalCase)")
 
@@ -100,8 +100,7 @@ def main() -> None:
     rule = rules[0]
     if rule.get("$ruleType") != "word":
         sys.exit(
-            f'FAIL: rules[0].$ruleType must be "word", '
-            f"got {rule.get('$ruleType')!r}"
+            f'FAIL: rules[0].$ruleType must be "word", got {rule.get("$ruleType")!r}'
         )
     print('OK: rules[0].$ruleType == "word"')
 
@@ -120,16 +119,14 @@ def main() -> None:
     # --- operator == "contains" ---
     if rule.get("operator") != "contains":
         sys.exit(
-            f'FAIL: rules[0].operator must be "contains", '
-            f"got {rule.get('operator')!r}"
+            f'FAIL: rules[0].operator must be "contains", got {rule.get("operator")!r}'
         )
     print('OK: rules[0].operator == "contains"')
 
     # --- value == "CONFIDENTIAL" ---
     if rule.get("value") != "CONFIDENTIAL":
         sys.exit(
-            f'FAIL: rules[0].value must be "CONFIDENTIAL", '
-            f"got {rule.get('value')!r}"
+            f'FAIL: rules[0].value must be "CONFIDENTIAL", got {rule.get("value")!r}'
         )
     print('OK: rules[0].value == "CONFIDENTIAL"')
 

--- a/tests/tasks/uipath-agents/guardrail_discovery/check_guardrail_discovery.py
+++ b/tests/tasks/uipath-agents/guardrail_discovery/check_guardrail_discovery.py
@@ -49,8 +49,7 @@ def main() -> None:
 
     # --- find builtInValidator ---
     validators = [
-        g for g in guardrails
-        if g.get("$guardrailType") == "builtInValidator"
+        g for g in guardrails if g.get("$guardrailType") == "builtInValidator"
     ]
     if not validators:
         types = [g.get("$guardrailType") for g in guardrails]
@@ -64,7 +63,9 @@ def main() -> None:
     # --- validatorType is a non-empty string ---
     vt = g.get("validatorType")
     if not isinstance(vt, str) or not vt:
-        sys.exit(f"FAIL: guardrail.validatorType must be a non-empty string, got {vt!r}")
+        sys.exit(
+            f"FAIL: guardrail.validatorType must be a non-empty string, got {vt!r}"
+        )
     print(f"OK: validatorType = {vt!r}")
 
     # --- id is UUID-shaped ---
@@ -79,8 +80,7 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
     if action.get("$actionType") != "block":
         sys.exit(
-            f'FAIL: guardrail.action.$actionType must be "block", '
-            f"got {action.get('$actionType')!r}"
+            f'FAIL: guardrail.action.$actionType must be "block", got {action.get("$actionType")!r}'
         )
     print('OK: action.$actionType == "block"')
 
@@ -90,7 +90,9 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(

--- a/tests/tasks/uipath-agents/guardrail_escalation_app/check_guardrail_escalation_app.py
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app/check_guardrail_escalation_app.py
@@ -63,7 +63,8 @@ def main() -> None:
 
     # --- find builtInValidator with pii_detection and escalate action ---
     escalation_candidates = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and g.get("validatorType") == "pii_detection"
         and isinstance(g.get("action"), dict)
@@ -71,8 +72,11 @@ def main() -> None:
     ]
     if not escalation_candidates:
         found = [
-            (g.get("$guardrailType"), g.get("validatorType"),
-             (g.get("action") or {}).get("$actionType"))
+            (
+                g.get("$guardrailType"),
+                g.get("validatorType"),
+                (g.get("action") or {}).get("$actionType"),
+            )
             for g in guardrails
         ]
         sys.exit(
@@ -124,7 +128,9 @@ def main() -> None:
     if folder_id:
         print(f"OK: action.app.folderId = {folder_id!r}")
     if app.get("id"):
-        print(f"OK: action.app.id = {app['id']!r} (optional, populated from resource lookup)")
+        print(
+            f"OK: action.app.id = {app['id']!r} (optional, populated from resource lookup)"
+        )
 
     # --- action.recipient ---
     recipient = action.get("recipient")
@@ -154,7 +160,9 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(
@@ -173,8 +181,7 @@ def main() -> None:
     if entities_param is None:
         ids = [p.get("id") for p in params if isinstance(p, dict)]
         sys.exit(
-            'FAIL: validatorParameters missing parameter with id == "entities". '
-            f"Got ids: {ids}"
+            f'FAIL: validatorParameters missing parameter with id == "entities". Got ids: {ids}'
         )
     if entities_param.get("$parameterType") != "enum-list":
         sys.exit(
@@ -183,7 +190,9 @@ def main() -> None:
         )
     entities_value = entities_param.get("value")
     if not isinstance(entities_value, list):
-        sys.exit(f"FAIL: entities parameter.value must be an array, got {entities_value!r}")
+        sys.exit(
+            f"FAIL: entities parameter.value must be an array, got {entities_value!r}"
+        )
     entities_set = set(entities_value)
     missing = REQUIRED_ENTITIES - entities_set
     if missing:
@@ -191,7 +200,9 @@ def main() -> None:
             f"FAIL: entities parameter.value must include {sorted(REQUIRED_ENTITIES)}, "
             f"missing: {sorted(missing)}. Got: {entities_value}"
         )
-    snake = [e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())]
+    snake = [
+        e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())
+    ]
     if snake:
         sys.exit(
             f"FAIL: entity names must be PascalCase (not snake_case). "

--- a/tests/tasks/uipath-agents/guardrail_escalation_app_validation/check_guardrail_escalation_app_validation.py
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app_validation/check_guardrail_escalation_app_validation.py
@@ -35,7 +35,9 @@ def main() -> None:
 
     guardrails = agent.get("guardrails")
     if not isinstance(guardrails, list) or len(guardrails) == 0:
-        print("OK: no guardrails array (or empty) — agent did not write the escalate guardrail")
+        print(
+            "OK: no guardrails array (or empty) — agent did not write the escalate guardrail"
+        )
         return
 
     # Check that no guardrail uses EscalationWorksApp in an escalate action
@@ -51,13 +53,13 @@ def main() -> None:
         app_name = app.get("name", "")
         if "EscalationWorksApp" in app_name:
             sys.exit(
-                f"FAIL: agent wrote an escalate guardrail using EscalationWorksApp "
-                f"without validating the action schema. The app is incompatible — "
-                f"it has inputs=[input], outputs=[output], outcomes=[Submit,Reject] "
-                f"instead of the required 8 inputs, 3 outputs, and Approve/Reject outcomes. "
-                f"The agent should have reported: "
-                f"'EscalationWorksApp does not have the required action schema "
-                f"configuration for tool guardrails.'"
+                "FAIL: agent wrote an escalate guardrail using EscalationWorksApp "
+                "without validating the action schema. The app is incompatible — "
+                "it has inputs=[input], outputs=[output], outcomes=[Submit,Reject] "
+                "instead of the required 8 inputs, 3 outputs, and Approve/Reject outcomes. "
+                "The agent should have reported: "
+                "'EscalationWorksApp does not have the required action schema "
+                "configuration for tool guardrails.'"
             )
 
     print("OK: no escalate guardrail references EscalationWorksApp")

--- a/tests/tasks/uipath-agents/guardrail_pii_detection/check_guardrail_pii_detection.py
+++ b/tests/tasks/uipath-agents/guardrail_pii_detection/check_guardrail_pii_detection.py
@@ -58,18 +58,16 @@ def main() -> None:
 
     # --- find builtInValidator with pii_detection ---
     pii = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and g.get("validatorType") == "pii_detection"
     ]
     if not pii:
-        types = [
-            (g.get("$guardrailType"), g.get("validatorType"))
-            for g in guardrails
-        ]
+        types = [(g.get("$guardrailType"), g.get("validatorType")) for g in guardrails]
         sys.exit(
-            f"FAIL: no guardrail with $guardrailType == \"builtInValidator\" "
-            f"and validatorType == \"pii_detection\". Got: {types}"
+            f'FAIL: no guardrail with $guardrailType == "builtInValidator" '
+            f'and validatorType == "pii_detection". Got: {types}'
         )
     g = pii[0]
     print('OK: found builtInValidator guardrail with validatorType == "pii_detection"')
@@ -86,8 +84,7 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
     if action.get("$actionType") != "block":
         sys.exit(
-            f'FAIL: guardrail.action.$actionType must be "block", '
-            f"got {action.get('$actionType')!r}"
+            f'FAIL: guardrail.action.$actionType must be "block", got {action.get("$actionType")!r}'
         )
     print('OK: action.$actionType == "block"')
 
@@ -97,7 +94,9 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(
@@ -116,8 +115,7 @@ def main() -> None:
     if entities_param is None:
         ids = [p.get("id") for p in params if isinstance(p, dict)]
         sys.exit(
-            f'FAIL: validatorParameters missing parameter with id == "entities". '
-            f"Got ids: {ids}"
+            f'FAIL: validatorParameters missing parameter with id == "entities". Got ids: {ids}'
         )
     if entities_param.get("$parameterType") != "enum-list":
         sys.exit(
@@ -126,7 +124,9 @@ def main() -> None:
         )
     entities_value = entities_param.get("value")
     if not isinstance(entities_value, list):
-        sys.exit(f"FAIL: entities parameter.value must be an array, got {entities_value!r}")
+        sys.exit(
+            f"FAIL: entities parameter.value must be an array, got {entities_value!r}"
+        )
     entities_set = set(entities_value)
     missing = REQUIRED_ENTITIES - entities_set
     if missing:
@@ -135,7 +135,9 @@ def main() -> None:
             f"missing: {sorted(missing)}. Got: {entities_value}"
         )
     # Check PascalCase (first letter uppercase, no underscores)
-    snake = [e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())]
+    snake = [
+        e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())
+    ]
     if snake:
         sys.exit(
             f"FAIL: entity names must be PascalCase (not snake_case). "

--- a/tests/tasks/uipath-agents/guardrail_prompt_injection/check_guardrail_prompt_injection.py
+++ b/tests/tasks/uipath-agents/guardrail_prompt_injection/check_guardrail_prompt_injection.py
@@ -49,21 +49,21 @@ def main() -> None:
 
     # --- find prompt_injection validator ---
     pi = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and g.get("validatorType") == "prompt_injection"
     ]
     if not pi:
-        types = [
-            (g.get("$guardrailType"), g.get("validatorType"))
-            for g in guardrails
-        ]
+        types = [(g.get("$guardrailType"), g.get("validatorType")) for g in guardrails]
         sys.exit(
-            f"FAIL: no guardrail with $guardrailType == \"builtInValidator\" "
-            f"and validatorType == \"prompt_injection\". Got: {types}"
+            f'FAIL: no guardrail with $guardrailType == "builtInValidator" '
+            f'and validatorType == "prompt_injection". Got: {types}'
         )
     g = pi[0]
-    print('OK: found builtInValidator guardrail with validatorType == "prompt_injection"')
+    print(
+        'OK: found builtInValidator guardrail with validatorType == "prompt_injection"'
+    )
 
     # --- id is UUID-shaped ---
     gid = g.get("id")
@@ -85,18 +85,16 @@ def main() -> None:
     if bad:
         sys.exit(
             f"FAIL: prompt_injection guardrail must NOT include {bad} in scopes. "
-            f"Only \"Llm\" is supported. Got scopes: {scopes}"
+            f'Only "Llm" is supported. Got scopes: {scopes}'
         )
     if "Llm" not in scopes:
         sys.exit(
-            f'FAIL: prompt_injection guardrail must include "Llm" in scopes. '
-            f"Got: {scopes}"
+            f'FAIL: prompt_injection guardrail must include "Llm" in scopes. Got: {scopes}'
         )
     # Check PascalCase
     if scopes != ["Llm"]:
         sys.exit(
-            f'FAIL: prompt_injection scopes should be exactly ["Llm"]. '
-            f"Got: {scopes}"
+            f'FAIL: prompt_injection scopes should be exactly ["Llm"]. Got: {scopes}'
         )
     print('OK: selector.scopes == ["Llm"] (correct Llm-only constraint)')
 
@@ -106,8 +104,7 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
     if action.get("$actionType") != "block":
         sys.exit(
-            f'FAIL: guardrail.action.$actionType must be "block", '
-            f"got {action.get('$actionType')!r}"
+            f'FAIL: guardrail.action.$actionType must be "block", got {action.get("$actionType")!r}'
         )
     print('OK: action.$actionType == "block"')
 
@@ -125,8 +122,7 @@ def main() -> None:
     if threshold_param is None:
         ids = [p.get("id") for p in params if isinstance(p, dict)]
         sys.exit(
-            f'FAIL: validatorParameters missing parameter with id == "threshold". '
-            f"Got ids: {ids}"
+            f'FAIL: validatorParameters missing parameter with id == "threshold". Got ids: {ids}'
         )
     if threshold_param.get("$parameterType") != "number":
         sys.exit(
@@ -138,8 +134,7 @@ def main() -> None:
         sys.exit(f"FAIL: threshold parameter.value must be a number, got {val!r}")
     if not (0.0 <= val <= 1.0):
         sys.exit(
-            f"FAIL: threshold parameter.value must be between 0.0 and 1.0, "
-            f"got {val}"
+            f"FAIL: threshold parameter.value must be between 0.0 and 1.0, got {val}"
         )
     print(f"OK: threshold parameter = {val} (number, in range)")
 

--- a/tests/tasks/uipath-agents/hitl_create_task/check_hitl_create_task.py
+++ b/tests/tasks/uipath-agents/hitl_create_task/check_hitl_create_task.py
@@ -21,7 +21,6 @@ Also runs the lazy-LLM-init AST scan as a hygiene check.
 from __future__ import annotations
 
 import ast
-import json
 import os
 import re
 import sys
@@ -33,13 +32,13 @@ from _shared.project_root import find_project_root  # noqa: E402
 ROOT = find_project_root("expense-approver")
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.bindings_assertions import (  # noqa: E402
-    load_bindings,
-    find_resource,
-    assert_value_field,
-    assert_metadata_field,
-)
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import (  # noqa: E402
+    assert_metadata_field,
+    assert_value_field,
+    find_resource,
+    load_bindings,
+)
 
 
 def _read_text(path: Path) -> str:
@@ -102,7 +101,9 @@ def check_imports_and_calls(text: str, tree: ast.Module) -> None:
     if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
         sys.exit("FAIL: missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateEscalation\b", text):
+    if not re.search(
+        r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateEscalation\b", text
+    ):
         sys.exit(
             "FAIL: missing `from uipath.platform.common import CreateEscalation`. "
             "The prompt describes an explicit escalation — the skill prescribes "
@@ -118,11 +119,11 @@ def check_imports_and_calls(text: str, tree: ast.Module) -> None:
     expected = {"app_name": "ExpenseReview", "app_folder_path": "Finance"}
     for kw, want in expected.items():
         if kw not in kwargs:
-            sys.exit(f'FAIL: `CreateEscalation(...)` is missing `{kw}=`')
+            sys.exit(f"FAIL: `CreateEscalation(...)` is missing `{kw}=`")
         got = _resolve_kwarg(kwargs[kw], consts)
         if got != want:
             sys.exit(
-                f'FAIL: `CreateEscalation({kw}=...)` resolves to {got!r}, expected {want!r}.'
+                f"FAIL: `CreateEscalation({kw}=...)` resolves to {got!r}, expected {want!r}."
             )
     print('OK: escalation targets app_name="ExpenseReview" / app_folder_path="Finance"')
 

--- a/tests/tasks/uipath-agents/inline_builtin_tool/check_inline_builtin_tool.py
+++ b/tests/tasks/uipath-agents/inline_builtin_tool/check_inline_builtin_tool.py
@@ -66,7 +66,9 @@ def main() -> None:
         if data.get("$resourceType") != "tool" or data.get("type") != "internal":
             continue
         if data.get("referenceKey") is not None:
-            sys.exit(f"FAIL: {path} referenceKey should be null for a built-in tool, got {data.get('referenceKey')!r}")
+            sys.exit(
+                f"FAIL: {path} referenceKey should be null for a built-in tool, got {data.get('referenceKey')!r}"
+            )
         props = data.get("properties") or {}
         tool_type = props.get("toolType")
         if tool_type not in BUILTIN_TOOL_TYPES:
@@ -87,9 +89,11 @@ def main() -> None:
         sys.exit(
             f'FAIL: prompt asked for "Analyze Files" (toolType '
             f'"analyze-attachments"), but it was not enabled. '
-            f'Got toolTypes: {seen_tool_types}'
+            f"Got toolTypes: {seen_tool_types}"
         )
-    print('OK: "Analyze Files" (toolType="analyze-attachments") is enabled on the inline agent')
+    print(
+        'OK: "Analyze Files" (toolType="analyze-attachments") is enabled on the inline agent'
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/inline_context_index/check_inline_context_index.py
+++ b/tests/tasks/uipath-agents/inline_context_index/check_inline_context_index.py
@@ -26,7 +26,9 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "KnowledgeFlowSol" / "KnowledgeFlow" / "KnowledgeFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd()) / "KnowledgeFlowSol" / "KnowledgeFlow" / "KnowledgeFlow.flow"
+)
 CONTEXT_INDEX_NODE_TYPE = "uipath.agent.resource.context.index"
 VALID_RETRIEVAL_MODES = {"semantic", "structured", "deepRAG", "batchTransform"}
 
@@ -51,13 +53,19 @@ def main() -> None:
     resource = load_json(resource_path)
 
     if resource.get("$resourceType") != "context":
-        sys.exit(f'FAIL: {resource_path} $resourceType should be "context", got {resource.get("$resourceType")!r}')
+        sys.exit(
+            f'FAIL: {resource_path} $resourceType should be "context", got {resource.get("$resourceType")!r}'
+        )
     if resource.get("contextType") != "index":
-        sys.exit(f'FAIL: {resource_path} contextType should be "index", got {resource.get("contextType")!r}')
+        sys.exit(
+            f'FAIL: {resource_path} contextType should be "index", got {resource.get("contextType")!r}'
+        )
     if resource.get("indexName") != "ProductKnowledge":
-        sys.exit(f'FAIL: {resource_path} indexName should be "ProductKnowledge", got {resource.get("indexName")!r}')
+        sys.exit(
+            f'FAIL: {resource_path} indexName should be "ProductKnowledge", got {resource.get("indexName")!r}'
+        )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="context", contextType="index", indexName="ProductKnowledge"'
     )
 

--- a/tests/tasks/uipath-agents/inline_external_agent_tool/check_inline_external_agent_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_agent_tool/check_inline_external_agent_tool.py
@@ -43,7 +43,9 @@ def main() -> None:
         target_id=tool_node["id"],
         target_port="input",
     )
-    print("OK: agent 'tool' handle is wired to external agent-as-tool node's 'input' handle")
+    print(
+        "OK: agent 'tool' handle is wired to external agent-as-tool node's 'input' handle"
+    )
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path = agent_dir / "resources" / "SupportExpert" / "resource.json"
@@ -56,25 +58,33 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="agent", location="external"'
     )
 
     props = resource.get("properties") or {}
     if props.get("processName") != "SupportExpert":
-        sys.exit(f'FAIL: properties.processName should be "SupportExpert", got {props.get("processName")!r}')
+        sys.exit(
+            f'FAIL: properties.processName should be "SupportExpert", got {props.get("processName")!r}'
+        )
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '
             'valid for location=="solution". External agent tools require a '
             'real Orchestrator folder path like "Shared".'
         )
-    print(f'OK: properties.processName="SupportExpert", folderPath={fpath!r} (not "solution_folder")')
+    print(
+        f'OK: properties.processName="SupportExpert", folderPath={fpath!r} (not "solution_folder")'
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
@@ -44,7 +44,9 @@ def main() -> None:
         target_id=tool_node["id"],
         target_port="input",
     )
-    print("OK: agent 'tool' handle is wired to external API workflow tool node's 'input' handle")
+    print(
+        "OK: agent 'tool' handle is wired to external API workflow tool node's 'input' handle"
+    )
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path = agent_dir / "resources" / "GetLatestQuote" / "resource.json"
@@ -57,16 +59,20 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="api", location="external"'
     )
 
     props = resource.get("properties") or {}
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '

--- a/tests/tasks/uipath-agents/inline_external_escalation/check_inline_external_escalation.py
+++ b/tests/tasks/uipath-agents/inline_external_escalation/check_inline_external_escalation.py
@@ -67,21 +67,23 @@ def main() -> None:
             sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
         channels = data.get("channels") or []
         ac = [
-            c for c in channels
+            c
+            for c in channels
             if isinstance(c, dict)
             and c.get("name") == "ActionCenter"
             and c.get("type") == "ActionCenter"
         ]
         if not ac:
             sys.exit(
-                f"FAIL: {path} has no channel with name=='ActionCenter' "
-                f"and type=='ActionCenter'"
+                f"FAIL: {path} has no channel with name=='ActionCenter' and type=='ActionCenter'"
             )
-        print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} ActionCenter channel(s))")
+        print(
+            f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} ActionCenter channel(s))"
+        )
         return
 
     sys.exit(
-        f'FAIL: no escalation resource found under {resources_dir} — '
+        f"FAIL: no escalation resource found under {resources_dir} — "
         'expected at least one resource.json with $resourceType="escalation"'
     )
 

--- a/tests/tasks/uipath-agents/inline_external_maestro_tool/check_inline_external_maestro_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_maestro_tool/check_inline_external_maestro_tool.py
@@ -43,7 +43,9 @@ def main() -> None:
         target_id=tool_node["id"],
         target_port="input",
     )
-    print("OK: agent 'tool' handle is wired to external Maestro tool node's 'input' handle")
+    print(
+        "OK: agent 'tool' handle is wired to external Maestro tool node's 'input' handle"
+    )
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path = agent_dir / "resources" / "ProcessClaim" / "resource.json"
@@ -56,16 +58,20 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="processOrchestration", location="external"'
     )
 
     props = resource.get("properties") or {}
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '

--- a/tests/tasks/uipath-agents/inline_external_rpa_tool/check_inline_external_rpa_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_rpa_tool/check_inline_external_rpa_tool.py
@@ -57,25 +57,33 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="process", location="external"'
     )
 
     props = resource.get("properties") or {}
     if props.get("processName") != "InvoiceProcessor":
-        sys.exit(f'FAIL: properties.processName should be "InvoiceProcessor", got {props.get("processName")!r}')
+        sys.exit(
+            f'FAIL: properties.processName should be "InvoiceProcessor", got {props.get("processName")!r}'
+        )
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
+        sys.exit(
+            f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}"
+        )
     if fpath == "solution_folder":
         sys.exit(
             'FAIL: properties.folderPath is "solution_folder", which is only '
             'valid for location=="solution". External tools require a real '
             'Orchestrator folder path like "Shared".'
         )
-    print(f'OK: properties.processName="InvoiceProcessor", folderPath={fpath!r} (not "solution_folder")')
+    print(
+        f'OK: properties.processName="InvoiceProcessor", folderPath={fpath!r} (not "solution_folder")'
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/inline_in_flow/check_inline_agent.py
+++ b/tests/tasks/uipath-agents/inline_in_flow/check_inline_agent.py
@@ -34,8 +34,7 @@ def main() -> None:
     agent_nodes = [n for n in nodes if n.get("type") == INLINE_AGENT_NODE_TYPE]
     if not agent_nodes:
         sys.exit(
-            f"FAIL: {FLOW_PATH.name} has no node of type "
-            f"{INLINE_AGENT_NODE_TYPE!r}"
+            f"FAIL: {FLOW_PATH.name} has no node of type {INLINE_AGENT_NODE_TYPE!r}"
         )
 
     agent_node = agent_nodes[0]
@@ -43,15 +42,12 @@ def main() -> None:
 
     source = model.get("source")
     if not source:
-        sys.exit(
-            f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no model.source"
-        )
+        sys.exit(f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no model.source")
 
     agent_dir = FLOW_PATH.parent / source
     if not agent_dir.is_dir():
         sys.exit(
-            f"FAIL: model.source {source!r} does not point to an "
-            f"existing directory ({agent_dir})"
+            f"FAIL: model.source {source!r} does not point to an existing directory ({agent_dir})"
         )
 
     print(
@@ -75,11 +71,13 @@ def main() -> None:
 
     edges = flow.get("edges") or []
     incoming_input = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("targetNodeId") == agent_id and e.get("targetPort") == "input"
     ]
     outgoing_success = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("sourceNodeId") == agent_id and e.get("sourcePort") == "success"
     ]
     if not incoming_input:

--- a/tests/tasks/uipath-agents/inline_is_connector_tool/check_inline_is_connector_tool.py
+++ b/tests/tasks/uipath-agents/inline_is_connector_tool/check_inline_is_connector_tool.py
@@ -51,9 +51,7 @@ def assert_agent_and_connector_nodes(flow: dict) -> tuple:
     nodes = flow.get("nodes") or []
     agent_nodes = [n for n in nodes if n.get("type") == INLINE_AGENT_NODE_TYPE]
     if not agent_nodes:
-        sys.exit(
-            f"FAIL: flow has no node of type {INLINE_AGENT_NODE_TYPE!r}"
-        )
+        sys.exit(f"FAIL: flow has no node of type {INLINE_AGENT_NODE_TYPE!r}")
     agent_node = agent_nodes[0]
 
     connector_nodes = [n for n in nodes if n.get("type") == CONNECTOR_TOOL_NODE_TYPE]
@@ -69,7 +67,9 @@ def assert_agent_and_connector_nodes(flow: dict) -> tuple:
     if not connector_node.get("id"):
         sys.exit(f"FAIL: {CONNECTOR_TOOL_NODE_TYPE} node has no id")
 
-    print(f"OK: flow has both {INLINE_AGENT_NODE_TYPE!r} and {CONNECTOR_TOOL_NODE_TYPE!r} nodes")
+    print(
+        f"OK: flow has both {INLINE_AGENT_NODE_TYPE!r} and {CONNECTOR_TOOL_NODE_TYPE!r} nodes"
+    )
     return agent_node, connector_node
 
 
@@ -80,8 +80,7 @@ def assert_agent_source_dir(agent_node: dict) -> Path:
     agent_dir = FLOW_PATH.parent / source
     if not agent_dir.is_dir():
         sys.exit(
-            f"FAIL: model.source {source!r} does not point to an existing "
-            f"directory ({agent_dir})"
+            f"FAIL: model.source {source!r} does not point to an existing directory ({agent_dir})"
         )
     print(f"OK: inline agent directory resolves to {agent_dir.name}")
     return agent_dir
@@ -90,7 +89,8 @@ def assert_agent_source_dir(agent_node: dict) -> Path:
 def assert_tool_edge(flow: dict, agent_id: str, connector_id: str) -> None:
     edges = flow.get("edges") or []
     matching = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("sourceNodeId") == agent_id
         and e.get("sourcePort") == "tool"
         and e.get("targetNodeId") == connector_id
@@ -148,7 +148,9 @@ def assert_bindings_v2_authored() -> None:
     except json.JSONDecodeError as e:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
     if not isinstance(data, (dict, list)):
-        sys.exit(f"FAIL: {path} root is neither object nor array: {type(data).__name__}")
+        sys.exit(
+            f"FAIL: {path} root is neither object nor array: {type(data).__name__}"
+        )
     print(f"OK: bindings_v2.json authored at {path.relative_to(SOLUTION.parent)}")
 
 

--- a/tests/tasks/uipath-agents/inline_mcp_server_tool/check_inline_mcp_server_tool.py
+++ b/tests/tasks/uipath-agents/inline_mcp_server_tool/check_inline_mcp_server_tool.py
@@ -60,12 +60,16 @@ def main() -> None:
             f'(distinct from "tool"), got {resource.get("$resourceType")!r}'
         )
     if resource.get("name") != "GitHubMcp":
-        sys.exit(f'FAIL: MCP resource name should be "GitHubMcp", got {resource.get("name")!r}')
+        sys.exit(
+            f'FAIL: MCP resource name should be "GitHubMcp", got {resource.get("name")!r}'
+        )
     description = resource.get("description")
     if not isinstance(description, str) or not description.strip():
         sys.exit(f"FAIL: MCP resource description missing or empty: {description!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     rid = resource.get("id")
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: MCP resource id missing or malformed: {rid!r}")
@@ -73,9 +77,9 @@ def main() -> None:
     if not isinstance(tools, list):
         sys.exit(f"FAIL: MCP resource tools must be a list, got {tools!r}")
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="mcp", name="GitHubMcp", id={rid}, isEnabled=true, '
-        f'tools list present ({len(tools)} entries)'
+        f"tools list present ({len(tools)} entries)"
     )
 
 

--- a/tests/tasks/uipath-agents/inline_solution_agent_tool/check_inline_solution_agent_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_agent_tool/check_inline_solution_agent_tool.py
@@ -26,7 +26,12 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "OrchestratorFlowSol" / "OrchestratorFlow" / "OrchestratorFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd())
+    / "OrchestratorFlowSol"
+    / "OrchestratorFlow"
+    / "OrchestratorFlow.flow"
+)
 AGENT_TOOL_NODE_PREFIX = "uipath.agent.resource.tool.agent."
 
 
@@ -56,17 +61,23 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="agent", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("processName") != "ToolAgent":
-        sys.exit(f'FAIL: properties.processName should be "ToolAgent", got {props.get("processName")!r}')
+        sys.exit(
+            f'FAIL: properties.processName should be "ToolAgent", got {props.get("processName")!r}'
+        )
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.processName="ToolAgent", folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/check_inline_solution_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/check_inline_solution_apiworkflow_tool.py
@@ -59,15 +59,19 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="api", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/inline_solution_escalation/check_inline_solution_escalation.py
+++ b/tests/tasks/uipath-agents/inline_solution_escalation/check_inline_solution_escalation.py
@@ -68,21 +68,23 @@ def main() -> None:
             sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
         channels = data.get("channels") or []
         ac = [
-            c for c in channels
+            c
+            for c in channels
             if isinstance(c, dict)
             and c.get("name") == "ActionCenter"
             and c.get("type") == "ActionCenter"
         ]
         if not ac:
             sys.exit(
-                f"FAIL: {path} has no channel with name=='ActionCenter' "
-                f"and type=='ActionCenter'"
+                f"FAIL: {path} has no channel with name=='ActionCenter' and type=='ActionCenter'"
             )
-        print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} ActionCenter channel(s))")
+        print(
+            f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} ActionCenter channel(s))"
+        )
         return
 
     sys.exit(
-        f'FAIL: no escalation resource found under {resources_dir} — '
+        f"FAIL: no escalation resource found under {resources_dir} — "
         'expected at least one resource.json with $resourceType="escalation"'
     )
 

--- a/tests/tasks/uipath-agents/inline_solution_maestro_tool/check_inline_solution_maestro_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_maestro_tool/check_inline_solution_maestro_tool.py
@@ -27,7 +27,9 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "OnboardingFlowSol" / "OnboardingFlow" / "OnboardingFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd()) / "OnboardingFlowSol" / "OnboardingFlow" / "OnboardingFlow.flow"
+)
 TOOL_NODE_PREFIX = "uipath.agent.resource.tool."
 
 
@@ -57,15 +59,19 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="processOrchestration", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
@@ -59,17 +59,23 @@ def main() -> None:
     }
     for key, want in expected.items():
         if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+            sys.exit(
+                f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}"
+            )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="process", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("processName") != "CalculatePay":
-        sys.exit(f'FAIL: properties.processName should be "CalculatePay", got {props.get("processName")!r}')
+        sys.exit(
+            f'FAIL: properties.processName should be "CalculatePay", got {props.get("processName")!r}'
+        )
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.processName="CalculatePay", folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/is_connector_tool/check_is_connector_tool.py
+++ b/tests/tasks/uipath-agents/is_connector_tool/check_is_connector_tool.py
@@ -80,7 +80,9 @@ def assert_bindings_v2_authored() -> Path:
     except json.JSONDecodeError as e:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
     if not isinstance(data, dict) and not isinstance(data, list):
-        sys.exit(f"FAIL: {path} root is neither object nor array: {type(data).__name__}")
+        sys.exit(
+            f"FAIL: {path} root is neither object nor array: {type(data).__name__}"
+        )
     print(f"OK: bindings_v2.json authored at {path.relative_to(SOLUTION.parent)}")
     return path
 
@@ -111,15 +113,16 @@ def main() -> None:
 
     tool_path, tool = find_integration_tool()
     print(
-        f'OK: {tool_path.relative_to(SOLUTION.parent)} is $resourceType="tool", '
-        f'type="integration"'
+        f'OK: {tool_path.relative_to(SOLUTION.parent)} is $resourceType="tool", type="integration"'
     )
 
     rid = tool.get("id")
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: IS tool id missing or malformed: {rid!r}")
     if not tool.get("isEnabled"):
-        sys.exit(f"FAIL: IS tool isEnabled must be truthy, got {tool.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: IS tool isEnabled must be truthy, got {tool.get('isEnabled')!r}"
+        )
     print(f"OK: IS tool has id={rid}, isEnabled=true")
 
     assert_bindings_v2_authored()

--- a/tests/tasks/uipath-agents/langgraph_classifier/check_langgraph_classifier.py
+++ b/tests/tasks/uipath-agents/langgraph_classifier/check_langgraph_classifier.py
@@ -34,8 +34,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("support-classifier")
@@ -59,8 +59,7 @@ def check_pyproject() -> None:
     text = _read_text(ROOT / "pyproject.toml")
     if "[build-system]" in text:
         sys.exit(
-            "FAIL: pyproject.toml contains a [build-system] section — "
-            "Critical Rule C1 forbids it."
+            "FAIL: pyproject.toml contains a [build-system] section — Critical Rule C1 forbids it."
         )
     if "[project]" not in text or "authors" not in text:
         sys.exit("FAIL: pyproject.toml is missing [project] or `authors`")
@@ -89,14 +88,15 @@ def check_graph_module(path: Path) -> None:
         if needle not in text:
             sys.exit(f"FAIL: {path.name} is missing `{needle}`")
     if "StateGraph" not in text and "CompiledStateGraph" not in text:
-        sys.exit(f"FAIL: {path.name} does not reference StateGraph / CompiledStateGraph")
+        sys.exit(
+            f"FAIL: {path.name} does not reference StateGraph / CompiledStateGraph"
+        )
     print(f"OK: {path.name} defines GraphInput, GraphOutput, and a graph variable")
     violations = find_module_level_llm_clients(path)
     if violations:
         sys.exit("FAIL: " + " | ".join(violations))
     print(
-        f"OK: {path.name} has no module-level UiPath* construction "
-        "(lazy-LLM-init invariant holds)"
+        f"OK: {path.name} has no module-level UiPath* construction (lazy-LLM-init invariant holds)"
     )
 
 
@@ -111,8 +111,8 @@ def check_runtime_config() -> None:
         target = next(iter(graphs.values()))
         if not isinstance(target, str) or ":graph" not in target:
             sys.exit(
-                f'FAIL: langgraph.json graphs entry should map to a `<file>:graph` '
-                f'reference, got {target!r}'
+                f"FAIL: langgraph.json graphs entry should map to a `<file>:graph` "
+                f"reference, got {target!r}"
             )
         print(f"OK: langgraph.json registers a graph -> {target!r}")
         return
@@ -125,7 +125,7 @@ def check_runtime_config() -> None:
                 "FAIL: neither langgraph.json nor uipath.json `functions.graph` "
                 "is present — the runtime cannot find the compiled graph."
             )
-        print(f'OK: uipath.json registers functions.graph -> {graph_entry!r}')
+        print(f"OK: uipath.json registers functions.graph -> {graph_entry!r}")
         return
     sys.exit(
         "FAIL: project has neither langgraph.json nor uipath.json — at "
@@ -137,19 +137,20 @@ def check_entry_points() -> None:
     doc = _load_json(ROOT / "entry-points.json")
     entrypoints = doc.get("entryPoints") or []
     if not entrypoints:
-        sys.exit("FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully")
+        sys.exit(
+            "FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully"
+        )
     raw = json.dumps(entrypoints)
     for field in ("text", "category"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entry-points.json schemas do not mention `{field}`. '
-                f'Either `uip codedagent init` ran before the Pydantic models '
-                f'were written, or the models did not declare the expected '
-                f'fields. Got: {raw}'
+                f"FAIL: entry-points.json schemas do not mention `{field}`. "
+                f"Either `uip codedagent init` ran before the Pydantic models "
+                f"were written, or the models did not declare the expected "
+                f"fields. Got: {raw}"
             )
     print(
-        "OK: entry-points.json schemas reflect the GraphInput/GraphOutput "
-        "fields (text, category)"
+        "OK: entry-points.json schemas reflect the GraphInput/GraphOutput fields (text, category)"
     )
 
 
@@ -168,7 +169,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/llamaindex_workflow/check_llamaindex_workflow.py
+++ b/tests/tasks/uipath-agents/llamaindex_workflow/check_llamaindex_workflow.py
@@ -26,8 +26,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("qna-workflow")
@@ -51,8 +51,7 @@ def check_pyproject() -> None:
     text = _read_text(ROOT / "pyproject.toml")
     if "[build-system]" in text:
         sys.exit(
-            "FAIL: pyproject.toml contains a [build-system] section — "
-            "Critical Rule C1 forbids it."
+            "FAIL: pyproject.toml contains a [build-system] section — Critical Rule C1 forbids it."
         )
     if "[project]" not in text or "authors" not in text:
         sys.exit("FAIL: pyproject.toml is missing [project] or `authors`")
@@ -73,8 +72,8 @@ def check_llama_index_json() -> None:
     target = next(iter(workflows.values()))
     if not isinstance(target, str) or ":" not in target:
         sys.exit(
-            f'FAIL: llama_index.json workflows entry should map to a '
-            f'`<file>:<variable>` reference, got {target!r}'
+            f"FAIL: llama_index.json workflows entry should map to a "
+            f"`<file>:<variable>` reference, got {target!r}"
         )
     print(f"OK: llama_index.json registers a workflow -> {target!r}")
 
@@ -93,8 +92,7 @@ def check_main_py() -> None:
     if violations:
         sys.exit("FAIL: " + " | ".join(violations))
     print(
-        "OK: main.py has no module-level UiPath* construction "
-        "(lazy-LLM-init invariant holds)"
+        "OK: main.py has no module-level UiPath* construction (lazy-LLM-init invariant holds)"
     )
 
 
@@ -107,13 +105,12 @@ def check_entry_points() -> None:
     for field in ("question", "answer", "word_count"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entry-points.json schemas do not mention `{field}`. '
-                f'StartEvent/StopEvent fields were not picked up by '
-                f'`uip codedagent init`. Got: {raw}'
+                f"FAIL: entry-points.json schemas do not mention `{field}`. "
+                f"StartEvent/StopEvent fields were not picked up by "
+                f"`uip codedagent init`. Got: {raw}"
             )
     print(
-        "OK: entry-points.json reflects StartEvent/StopEvent fields "
-        "(question, answer, word_count)"
+        "OK: entry-points.json reflects StartEvent/StopEvent fields (question, answer, word_count)"
     )
 
 
@@ -131,7 +128,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/mcp_server_tool/check_mcp_server_tool.py
+++ b/tests/tasks/uipath-agents/mcp_server_tool/check_mcp_server_tool.py
@@ -43,7 +43,9 @@ def assert_mcp_resource(resource: dict) -> None:
     if not isinstance(description, str) or not description.strip():
         sys.exit(f"FAIL: MCP resource description missing or empty: {description!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     rid = resource.get("id")
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: MCP resource id missing or malformed: {rid!r}")
@@ -52,7 +54,7 @@ def assert_mcp_resource(resource: dict) -> None:
         sys.exit(f"FAIL: MCP resource tools must be a list, got {tools!r}")
     print(
         f'OK: resource.json is $resourceType="mcp", name="GitHubMcp", '
-        f'id={rid}, isEnabled=true, tools list present ({len(tools)} entries)'
+        f"id={rid}, isEnabled=true, tools list present ({len(tools)} entries)"
     )
 
 

--- a/tests/tasks/uipath-agents/openai_agents_handoff/check_openai_agents_handoff.py
+++ b/tests/tasks/uipath-agents/openai_agents_handoff/check_openai_agents_handoff.py
@@ -39,8 +39,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("triage-bot")
@@ -64,8 +64,7 @@ def check_pyproject() -> None:
     text = _read_text(ROOT / "pyproject.toml")
     if "[build-system]" in text:
         sys.exit(
-            "FAIL: pyproject.toml contains a [build-system] section — "
-            "Critical Rule C1 forbids it."
+            "FAIL: pyproject.toml contains a [build-system] section — Critical Rule C1 forbids it."
         )
     if "[project]" not in text or "authors" not in text:
         sys.exit("FAIL: pyproject.toml is missing [project] or `authors`")
@@ -86,9 +85,9 @@ def check_openai_agents_json() -> None:
     target = next(iter(agents.values()))
     if not isinstance(target, str) or ":main" not in target:
         sys.exit(
-            f'FAIL: openai_agents.json should point at the factory function '
-            f'(`<file>:main`), got {target!r}. Pointing at a top-level '
-            f'variable would break the lazy-LLM-init invariant.'
+            f"FAIL: openai_agents.json should point at the factory function "
+            f"(`<file>:main`), got {target!r}. Pointing at a top-level "
+            f"variable would break the lazy-LLM-init invariant."
         )
     print(f"OK: openai_agents.json registers an agent -> {target!r} (factory pattern)")
 
@@ -120,8 +119,7 @@ def check_main_py() -> None:
     if violations:
         sys.exit("FAIL: " + " | ".join(violations))
     print(
-        "OK: main.py has no module-level UiPath* construction "
-        "(factory-function pattern preserved)"
+        "OK: main.py has no module-level UiPath* construction (factory-function pattern preserved)"
     )
     # Confirm set_default_openai_client is INSIDE a function body — not at
     # module level — by AST walk.
@@ -129,7 +127,10 @@ def check_main_py() -> None:
     for node in tree.body:
         if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
             func = node.value.func
-            if isinstance(func, ast.Attribute) and func.attr == "set_default_openai_client":
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "set_default_openai_client"
+            ):
                 sys.exit(
                     f"FAIL: main.py:{node.lineno} `set_default_openai_client(...)` "
                     "is at module level — it must run inside the factory "
@@ -148,9 +149,9 @@ def check_entry_points() -> None:
     for field in ("customer_id", "messages"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entry-points.json schemas do not mention `{field}`. '
-                f'`uip codedagent init` did not pick up the Agent[CustomerInput] '
-                f'context type. Got: {raw}'
+                f"FAIL: entry-points.json schemas do not mention `{field}`. "
+                f"`uip codedagent init` did not pick up the Agent[CustomerInput] "
+                f"context type. Got: {raw}"
             )
     print(
         "OK: entry-points.json reflects the Agent[CustomerInput] context "
@@ -172,7 +173,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/process_invoke/check_process_invoke.py
+++ b/tests/tasks/uipath-agents/process_invoke/check_process_invoke.py
@@ -27,13 +27,13 @@ from _shared.project_root import find_project_root  # noqa: E402
 ROOT = find_project_root("data-orchestrator")
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.bindings_assertions import (  # noqa: E402
-    load_bindings,
-    find_resource,
-    assert_value_field,
-    assert_metadata_field,
-)
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import (  # noqa: E402
+    assert_metadata_field,
+    assert_value_field,
+    find_resource,
+    load_bindings,
+)
 
 
 def _read_text(path: Path) -> str:

--- a/tests/tasks/uipath-agents/rag_langgraph/check_rag_langgraph.py
+++ b/tests/tasks/uipath-agents/rag_langgraph/check_rag_langgraph.py
@@ -27,13 +27,13 @@ from _shared.project_root import find_project_root  # noqa: E402
 ROOT = find_project_root("policy-rag")
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.bindings_assertions import (  # noqa: E402
-    load_bindings,
-    find_resource,
-    assert_value_field,
-    assert_metadata_field,
-)
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import (  # noqa: E402
+    assert_metadata_field,
+    assert_value_field,
+    find_resource,
+    load_bindings,
+)
 
 
 def _read_text(path: Path) -> str:
@@ -61,12 +61,20 @@ def check_imports_and_calls(text: str) -> None:
             "FAIL: ContextGroundingRetriever must be imported from "
             "`uipath_langchain.retrievers` — the canonical path the skill teaches."
         )
-    print("OK: main.py imports ContextGroundingRetriever from uipath_langchain.retrievers")
+    print(
+        "OK: main.py imports ContextGroundingRetriever from uipath_langchain.retrievers"
+    )
     if not re.search(r'index_name\s*=\s*["\']company_docs["\']', text):
-        sys.exit('FAIL: ContextGroundingRetriever call does not pass index_name="company_docs"')
+        sys.exit(
+            'FAIL: ContextGroundingRetriever call does not pass index_name="company_docs"'
+        )
     if not re.search(r'folder_path\s*=\s*["\']Shared["\']', text):
-        sys.exit('FAIL: ContextGroundingRetriever call does not pass folder_path="Shared"')
-    print('OK: retriever is constructed with index_name="company_docs" / folder_path="Shared"')
+        sys.exit(
+            'FAIL: ContextGroundingRetriever call does not pass folder_path="Shared"'
+        )
+    print(
+        'OK: retriever is constructed with index_name="company_docs" / folder_path="Shared"'
+    )
 
 
 def check_index_binding() -> None:

--- a/tests/tasks/uipath-agents/resolution_drafter_agent/check_resolution_drafter_agent.py
+++ b/tests/tasks/uipath-agents/resolution_drafter_agent/check_resolution_drafter_agent.py
@@ -87,8 +87,7 @@ def assert_input_shape(schema: dict) -> None:
     missing = [f for f in INPUT_FIELDS if f not in props]
     if missing:
         sys.exit(
-            f"FAIL: inputSchema.properties missing fields {missing!r}; "
-            f"got {sorted(props)!r}"
+            f"FAIL: inputSchema.properties missing fields {missing!r}; got {sorted(props)!r}"
         )
     print(f"OK: inputSchema declares all 4 fields ({', '.join(INPUT_FIELDS)})")
 
@@ -102,8 +101,7 @@ def assert_output_shape(schema: dict) -> None:
     missing = [f for f in OUTPUT_FIELDS if f not in props]
     if missing:
         sys.exit(
-            f"FAIL: outputSchema.properties missing fields {missing!r}; "
-            f"got {sorted(props)!r}"
+            f"FAIL: outputSchema.properties missing fields {missing!r}; got {sorted(props)!r}"
         )
     print(f"OK: outputSchema declares fields {OUTPUT_FIELDS}")
 
@@ -112,7 +110,9 @@ def get_user_message(agent: dict) -> dict:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     return user_messages[0]
@@ -129,8 +129,7 @@ def assert_user_message_inlines(agent: dict) -> None:
         placeholder = "{{input." + field + "}}"
         if placeholder not in content:
             sys.exit(
-                f"FAIL: user message content does not inline {placeholder}; "
-                f"content={content!r}"
+                f"FAIL: user message content does not inline {placeholder}; content={content!r}"
             )
         expected = {"type": "variable", "rawString": f"input.{field}"}
         if expected not in tokens:
@@ -139,7 +138,7 @@ def assert_user_message_inlines(agent: dict) -> None:
                 f"input.{field}\n  expected: {expected}\n"
                 f"  got tokens: {json.dumps(tokens, indent=2)}"
             )
-    print(f"OK: user message inlines all 4 inputs with matching contentTokens")
+    print("OK: user message inlines all 4 inputs with matching contentTokens")
 
 
 def assert_system_prompt_three_way(agent: dict) -> None:

--- a/tests/tasks/uipath-agents/schema_update/check_schema_update.py
+++ b/tests/tasks/uipath-agents/schema_update/check_schema_update.py
@@ -41,10 +41,14 @@ def assert_input_shape(schema: dict, label: str) -> None:
         sys.exit(f"FAIL: {label}.type should be 'object', got {schema.get('type')!r}")
     props = schema.get("properties")
     if not isinstance(props, dict) or "userQuery" not in props:
-        sys.exit(f"FAIL: {label}.properties missing 'userQuery': got {list(props) if isinstance(props, dict) else props!r}")
+        sys.exit(
+            f"FAIL: {label}.properties missing 'userQuery': got {list(props) if isinstance(props, dict) else props!r}"
+        )
     uq = props["userQuery"]
     if not isinstance(uq, dict) or uq.get("type") != "string":
-        sys.exit(f"FAIL: {label}.properties.userQuery.type should be 'string', got {uq!r}")
+        sys.exit(
+            f"FAIL: {label}.properties.userQuery.type should be 'string', got {uq!r}"
+        )
     required = schema.get("required")
     if not isinstance(required, list) or "userQuery" not in required:
         sys.exit(f"FAIL: {label}.required must contain 'userQuery', got {required!r}")
@@ -58,10 +62,14 @@ def assert_output_shape(schema: dict, label: str) -> None:
         sys.exit(f"FAIL: {label}.type should be 'object', got {schema.get('type')!r}")
     props = schema.get("properties")
     if not isinstance(props, dict) or "reply" not in props:
-        sys.exit(f"FAIL: {label}.properties missing 'reply': got {list(props) if isinstance(props, dict) else props!r}")
+        sys.exit(
+            f"FAIL: {label}.properties missing 'reply': got {list(props) if isinstance(props, dict) else props!r}"
+        )
     reply = props["reply"]
     if not isinstance(reply, dict) or reply.get("type") != "string":
-        sys.exit(f"FAIL: {label}.properties.reply.type should be 'string', got {reply!r}")
+        sys.exit(
+            f"FAIL: {label}.properties.reply.type should be 'string', got {reply!r}"
+        )
     print(f"OK: {label} declares reply:string (matches prompt)")
 
 
@@ -69,7 +77,9 @@ def assert_user_message_inlines_variable(agent: dict, field: str) -> None:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     user = user_messages[0]
@@ -77,7 +87,9 @@ def assert_user_message_inlines_variable(agent: dict, field: str) -> None:
     placeholder = "{{input." + field + "}}"
     content = user.get("content", "")
     if placeholder not in content:
-        sys.exit(f"FAIL: user message content does not inline {placeholder}: content={content!r}")
+        sys.exit(
+            f"FAIL: user message content does not inline {placeholder}: content={content!r}"
+        )
 
     tokens = user.get("contentTokens")
     if not isinstance(tokens, list):
@@ -89,7 +101,9 @@ def assert_user_message_inlines_variable(agent: dict, field: str) -> None:
             f"  expected token: {expected}\n"
             f"  got tokens:     {json.dumps(tokens, indent=2)}"
         )
-    print(f"OK: user message inlines {placeholder} with a matching variable contentToken")
+    print(
+        f"OK: user message inlines {placeholder} with a matching variable contentToken"
+    )
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/simple_echo/check_simple_echo.py
+++ b/tests/tasks/uipath-agents/simple_echo/check_simple_echo.py
@@ -30,8 +30,8 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.bindings_assertions import load_bindings, count_resources_by_type  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.bindings_assertions import count_resources_by_type, load_bindings  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("echo-agent")
@@ -89,34 +89,34 @@ def check_uipath_json() -> None:
     main_entry = functions.get("main")
     if main_entry not in ("main.py:main", "./main.py:main"):
         sys.exit(
-            f'FAIL: uipath.json functions.main should be "main.py:main", '
-            f'got {main_entry!r}'
+            f'FAIL: uipath.json functions.main should be "main.py:main", got {main_entry!r}'
         )
-    print(f'OK: uipath.json registers functions.main -> {main_entry!r}')
+    print(f"OK: uipath.json registers functions.main -> {main_entry!r}")
 
 
 def check_entry_points() -> None:
     doc = _load_json(ROOT / "entry-points.json")
     entrypoints = doc.get("entryPoints") or []
     if not entrypoints:
-        sys.exit("FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully")
-    matches = [
-        ep for ep in entrypoints
-        if ep.get("filePath") in ("main", "main.py")
-    ]
+        sys.exit(
+            "FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully"
+        )
+    matches = [ep for ep in entrypoints if ep.get("filePath") in ("main", "main.py")]
     if not matches:
         paths = [ep.get("filePath") for ep in entrypoints]
         sys.exit(f'FAIL: no entrypoint with filePath "main" or "main.py"; got {paths}')
     ep = matches[0]
     if not ep.get("uniqueId"):
-        sys.exit("FAIL: entrypoint is missing `uniqueId` — `uip codedagent init` did not generate it")
+        sys.exit(
+            "FAIL: entrypoint is missing `uniqueId` — `uip codedagent init` did not generate it"
+        )
     raw = json.dumps(ep)
     for field in ("message", "repeat", "echoed", "length"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entrypoint schema does not mention `{field}` — '
-                f'agent.json ↔ entry-points.json schema sync failed. '
-                f'Got: {raw}'
+                f"FAIL: entrypoint schema does not mention `{field}` — "
+                f"agent.json ↔ entry-points.json schema sync failed. "
+                f"Got: {raw}"
             )
     print(
         "OK: entry-points.json has one `main` entrypoint with all four "
@@ -128,7 +128,16 @@ def check_bindings() -> None:
     doc = load_bindings(ROOT / "bindings.json")
     total = sum(
         count_resources_by_type(doc, t)
-        for t in ("asset", "queue", "process", "bucket", "app", "index", "connection", "mcpServer")
+        for t in (
+            "asset",
+            "queue",
+            "process",
+            "bucket",
+            "app",
+            "index",
+            "connection",
+            "mcpServer",
+        )
     )
     if total != 0:
         sys.exit(
@@ -147,7 +156,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/solution_agent_tool/check_solution_agent_tool.py
+++ b/tests/tasks/uipath-agents/solution_agent_tool/check_solution_agent_tool.py
@@ -25,9 +25,7 @@ import sys
 from pathlib import Path
 
 SOLUTION_DIR = Path(os.getcwd()) / "OrchestratorSol"
-RESOURCE = (
-    SOLUTION_DIR / "ParentAgent" / "resources" / "ToolAgent" / "resource.json"
-)
+RESOURCE = SOLUTION_DIR / "ParentAgent" / "resources" / "ToolAgent" / "resource.json"
 TOOL_AGENT = SOLUTION_DIR / "ToolAgent" / "agent.json"
 PARENT_AGENT = SOLUTION_DIR / "ParentAgent" / "agent.json"
 
@@ -51,8 +49,7 @@ def assert_distinct_project_ids() -> None:
             sys.exit(f"FAIL: {label} has missing or malformed projectId: {pid!r}")
     if parent_id == tool_id:
         sys.exit(
-            f"FAIL: ParentAgent and ToolAgent share the same projectId "
-            f"{parent_id} (Anti-pattern 8)"
+            f"FAIL: ParentAgent and ToolAgent share the same projectId {parent_id} (Anti-pattern 8)"
         )
     print(f"OK: Distinct projectIds — {parent_id} vs {tool_id}")
 
@@ -67,7 +64,9 @@ def assert_resource_fields(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json has $resourceType="tool", type="agent", location="solution"')
+    print(
+        'OK: resource.json has $resourceType="tool", type="agent", location="solution"'
+    )
 
     props = resource.get("properties")
     if not isinstance(props, dict):
@@ -83,8 +82,7 @@ def assert_resource_fields(resource: dict) -> None:
                 f"FAIL: resource.json.properties.{key} should be {want!r}, got {got!r}"
             )
     print(
-        'OK: resource.json.properties has processName="ToolAgent" and '
-        'folderPath="solution_folder"'
+        'OK: resource.json.properties has processName="ToolAgent" and folderPath="solution_folder"'
     )
 
 
@@ -118,7 +116,9 @@ def assert_schemas_match_tool_agent(resource: dict, tool: dict) -> None:
                 f"  resource.{label}:\n{json.dumps(r_shape, sort_keys=True, indent=2)}\n"
                 f"  tool.{label}:\n{json.dumps(t_shape, sort_keys=True, indent=2)}"
             )
-        print(f"OK: resource.json.{label} is shape-equivalent to ToolAgent/agent.json.{label}")
+        print(
+            f"OK: resource.json.{label} is shape-equivalent to ToolAgent/agent.json.{label}"
+        )
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/solution_apiworkflow_tool/check_solution_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/solution_apiworkflow_tool/check_solution_apiworkflow_tool.py
@@ -51,7 +51,7 @@ def assert_properties(resource: dict) -> None:
     if props.get("folderPath") != "solution_folder":
         sys.exit(
             f'FAIL: properties.folderPath should be "solution_folder" for a '
-            f'solution-internal API workflow tool, got {props.get("folderPath")!r}'
+            f"solution-internal API workflow tool, got {props.get('folderPath')!r}"
         )
     print('OK: properties.folderPath="solution_folder"')
 
@@ -61,7 +61,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/solution_escalation/check_solution_escalation.py
+++ b/tests/tasks/uipath-agents/solution_escalation/check_solution_escalation.py
@@ -47,16 +47,23 @@ def assert_escalation_header(resource: dict) -> None:
     if not isinstance(name, str) or not name.strip():
         sys.exit(f"FAIL: escalation name missing or empty: {name!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}")
-    print(f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)')
+        sys.exit(
+            f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
+    print(
+        f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)'
+    )
 
 
 def assert_actioncenter_channel(resource: dict) -> None:
     channels = resource.get("channels")
     if not isinstance(channels, list) or not channels:
-        sys.exit(f"FAIL: escalation.channels must be a non-empty list, got {channels!r}")
+        sys.exit(
+            f"FAIL: escalation.channels must be a non-empty list, got {channels!r}"
+        )
     ac_channels = [
-        c for c in channels
+        c
+        for c in channels
         if isinstance(c, dict)
         and c.get("name") == "ActionCenter"
         and c.get("type") == "ActionCenter"
@@ -75,9 +82,13 @@ def assert_schema_sync(agent: dict, entry: dict) -> None:
         sys.exit("FAIL: entry-points.json has no entryPoints[0]")
     ep = entry_points[0]
     if agent.get("inputSchema") != ep.get("input"):
-        sys.exit("FAIL: agent.json.inputSchema != entry-points.json entryPoints[0].input")
+        sys.exit(
+            "FAIL: agent.json.inputSchema != entry-points.json entryPoints[0].input"
+        )
     if agent.get("outputSchema") != ep.get("output"):
-        sys.exit("FAIL: agent.json.outputSchema != entry-points.json entryPoints[0].output")
+        sys.exit(
+            "FAIL: agent.json.outputSchema != entry-points.json entryPoints[0].output"
+        )
     print("OK: inputSchema and outputSchema are in sync with entry-points.json")
 
 

--- a/tests/tasks/uipath-agents/solution_maestro_tool/check_solution_maestro_tool.py
+++ b/tests/tasks/uipath-agents/solution_maestro_tool/check_solution_maestro_tool.py
@@ -41,7 +41,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="processOrchestration", location="solution"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="processOrchestration", location="solution"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -51,7 +53,7 @@ def assert_properties(resource: dict) -> None:
     if props.get("folderPath") != "solution_folder":
         sys.exit(
             f'FAIL: properties.folderPath should be "solution_folder" for a '
-            f'solution-internal Maestro tool, got {props.get("folderPath")!r}'
+            f"solution-internal Maestro tool, got {props.get('folderPath')!r}"
         )
     print('OK: properties.folderPath="solution_folder"')
 
@@ -61,7 +63,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/solution_rpa_tool/check_solution_rpa_tool.py
+++ b/tests/tasks/uipath-agents/solution_rpa_tool/check_solution_rpa_tool.py
@@ -42,7 +42,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="process", location="solution"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="process", location="solution"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -56,7 +58,7 @@ def assert_properties(resource: dict) -> None:
     if props.get("folderPath") != "solution_folder":
         sys.exit(
             f'FAIL: properties.folderPath should be "solution_folder" for a '
-            f'solution-internal tool, got {props.get("folderPath")!r}'
+            f"solution-internal tool, got {props.get('folderPath')!r}"
         )
     print('OK: properties.processName="CalculatePay", folderPath="solution_folder"')
 
@@ -66,7 +68,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/subtype_credential_asset/check_subtype_credential_asset.py
+++ b/tests/tasks/uipath-agents/subtype_credential_asset/check_subtype_credential_asset.py
@@ -48,14 +48,19 @@ def assert_envelope(bindings: dict) -> list:
         sys.exit(f'FAIL: bindings.json version should be "2.0", got {version!r}')
     resources = bindings.get("resources")
     if not isinstance(resources, list) or not resources:
-        sys.exit(f"FAIL: bindings.json resources must be a non-empty list, got {resources!r}")
-    print(f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)')
+        sys.exit(
+            f"FAIL: bindings.json resources must be a non-empty list, got {resources!r}"
+        )
+    print(
+        f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)'
+    )
     return resources
 
 
 def find_asset_entry(resources: list) -> dict:
     matches = [
-        r for r in resources
+        r
+        for r in resources
         if isinstance(r, dict)
         and r.get("resource") == "asset"
         and r.get("key") == EXPECTED_KEY
@@ -87,9 +92,7 @@ def assert_value_shape(entry: dict) -> None:
             f'FAIL: value.folderPath.defaultValue should be "{EXPECTED_FOLDER}", '
             f"got {folder_block.get('defaultValue')!r}"
         )
-    print(
-        f'OK: value.name="{EXPECTED_NAME}", value.folderPath="{EXPECTED_FOLDER}"'
-    )
+    print(f'OK: value.name="{EXPECTED_NAME}", value.folderPath="{EXPECTED_FOLDER}"')
 
 
 def assert_subtype(entry: dict) -> None:

--- a/tests/tasks/uipath-agents/tracing_redaction/check_tracing_redaction.py
+++ b/tests/tasks/uipath-agents/tracing_redaction/check_tracing_redaction.py
@@ -50,12 +50,17 @@ def main() -> None:
     main_py = ROOT / "main.py"
     text = _read_text(main_py)
     if "from uipath.tracing import traced" not in text:
-        sys.exit("FAIL: main.py must import `traced` via `from uipath.tracing import traced`")
+        sys.exit(
+            "FAIL: main.py must import `traced` via `from uipath.tracing import traced`"
+        )
     print("OK: main.py imports `traced` from uipath.tracing")
     tree = ast.parse(text, filename=str(main_py))
     main_func: ast.AsyncFunctionDef | ast.FunctionDef | None = None
     for node in ast.walk(tree):
-        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == "main":
+        if (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "main"
+        ):
             main_func = node
             break
     if main_func is None:
@@ -71,7 +76,9 @@ def main() -> None:
             "*call form* — `@traced` without parentheses cannot pass kwargs)."
         )
     if len(decorated_calls) > 1:
-        sys.exit(f"FAIL: `main` has {len(decorated_calls)} `@traced(...)` decorators; expected 1")
+        sys.exit(
+            f"FAIL: `main` has {len(decorated_calls)} `@traced(...)` decorators; expected 1"
+        )
     call = decorated_calls[0]
     kwargs = {kw.arg: kw for kw in call.keywords if kw.arg is not None}
     for required in ("name", "input_processor", "output_processor"):
@@ -80,7 +87,9 @@ def main() -> None:
                 f"FAIL: `@traced(...)` on `main` is missing required kwarg "
                 f"`{required}=`. Got kwargs: {sorted(kwargs)}"
             )
-    print("OK: `@traced(...)` on `main` carries name + input_processor + output_processor")
+    print(
+        "OK: `@traced(...)` on `main` carries name + input_processor + output_processor"
+    )
     for forbidden in ("hide_input", "hide_output"):
         if forbidden in kwargs:
             kw = kwargs[forbidden]
@@ -91,7 +100,9 @@ def main() -> None:
                     "input/output processors. The skill recommends processors "
                     "over `hide_*` so partial visibility is preserved — pick one."
                 )
-    print("OK: no conflicting `hide_input=True` / `hide_output=True` on the same decorator")
+    print(
+        "OK: no conflicting `hide_input=True` / `hide_output=True` on the same decorator"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py
+++ b/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py
@@ -25,13 +25,13 @@ Deletes via: POST <tenant-url>/dataservice_/api/Entity/<entityId>/delete
 Exit 0 always — cleanup failures never fail the test.
 """
 
+import argparse
 import json
 import os
 import subprocess
 import sys
-import argparse
-import urllib.request
 import urllib.error
+import urllib.request
 
 
 def get_auth_token() -> tuple[str, str]:
@@ -57,12 +57,18 @@ def get_auth_token() -> tuple[str, str]:
         try:
             result = subprocess.run(
                 ["uip", "login", "status", "--output", "json"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if result.returncode != 0:
-                raise RuntimeError(f"uip login status failed (exit {result.returncode}): {result.stderr}")
+                raise RuntimeError(
+                    f"uip login status failed (exit {result.returncode}): {result.stderr}"
+                )
             if not result.stdout.strip():
-                raise RuntimeError(f"uip login status returned empty output; stderr: {result.stderr}")
+                raise RuntimeError(
+                    f"uip login status returned empty output; stderr: {result.stderr}"
+                )
             data = json.loads(result.stdout)
             inner = data.get("Data") or data
             org = inner.get("Organization") or ""
@@ -97,9 +103,13 @@ def delete_entity(tenant_url: str, token: str, entity_id: str) -> None:
             print(f"OK: deleted entity {entity_id} — HTTP {resp.status}")
     except urllib.error.HTTPError as e:
         if e.code == 404:
-            print(f"SKIP: entity {entity_id} not found (already deleted or never created)")
+            print(
+                f"SKIP: entity {entity_id} not found (already deleted or never created)"
+            )
         else:
-            raise RuntimeError(f"DELETE {url} returned HTTP {e.code}: {e.read().decode()}") from e
+            raise RuntimeError(
+                f"DELETE {url} returned HTTP {e.code}: {e.read().decode()}"
+            ) from e
 
 
 def resolve_entity_ids(args) -> list[str]:
@@ -134,7 +144,9 @@ def resolve_entity_ids(args) -> list[str]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Delete test-created Data Fabric entities")
+    parser = argparse.ArgumentParser(
+        description="Delete test-created Data Fabric entities"
+    )
     parser.add_argument("--entity-id", help="Entity ID to delete directly")
     args = parser.parse_args()
 

--- a/tests/tasks/uipath-diagnostics/_shared/scripts/coverage_report.py
+++ b/tests/tasks/uipath-diagnostics/_shared/scripts/coverage_report.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections import Counter, defaultdict
+from collections import Counter
 from pathlib import Path
 
 
@@ -63,13 +63,15 @@ def analyze_replicate(rep_dir: Path) -> dict:
         pat = spec.get("pattern", "")
         minimum = spec.get("min", 1)
         hits = sum(1 for c in calls if pat in c.get("args", ""))
-        expected_status.append({
-            "pattern": pat,
-            "min": minimum,
-            "hits": hits,
-            "satisfied": hits >= minimum,
-            "description": spec.get("description", ""),
-        })
+        expected_status.append(
+            {
+                "pattern": pat,
+                "min": minimum,
+                "hits": hits,
+                "satisfied": hits >= minimum,
+                "description": spec.get("description", ""),
+            }
+        )
 
     # Rule usage
     rule_counts: Counter = Counter()
@@ -87,7 +89,9 @@ def analyze_replicate(rep_dir: Path) -> dict:
     rec["unmocked"] = unmocked
     rec["rule_hits"] = dict(rule_counts.most_common())
     if expected_status:
-        rec["match_rate"] = sum(1 for e in expected_status if e["satisfied"]) / len(expected_status)
+        rec["match_rate"] = sum(1 for e in expected_status if e["satisfied"]) / len(
+            expected_status
+        )
 
     return rec
 
@@ -98,8 +102,10 @@ def write_outputs(rep_dir: Path, rec: dict) -> None:
     lines.append(f"Coverage report for replicate {rec['replicate']}")
     lines.append(f"  total uip calls : {len(rec['calls'])}")
     if rec["match_rate"] is not None:
-        lines.append(f"  expected hit-rate: {rec['match_rate']*100:.0f}% "
-                     f"({len(rec['expected']) - len(rec['missing_expected'])}/{len(rec['expected'])})")
+        lines.append(
+            f"  expected hit-rate: {rec['match_rate'] * 100:.0f}% "
+            f"({len(rec['expected']) - len(rec['missing_expected'])}/{len(rec['expected'])})"
+        )
     if rec["missing_expected"]:
         lines.append("  MISSING expected:")
         for e in rec["missing_expected"]:
@@ -126,7 +132,9 @@ def main(run_dir_arg: str) -> int:
         return 2
 
     print(f"Coverage report for {run_dir}\n")
-    print(f"{'rep':>4}  {'calls':>5}  {'expected':>14}  {'unmocked':>8}  {'top exploration':<60}")
+    print(
+        f"{'rep':>4}  {'calls':>5}  {'expected':>14}  {'unmocked':>8}  {'top exploration':<60}"
+    )
     print("-" * 100)
     for rep_dir in rep_dirs:
         rec = analyze_replicate(rep_dir)
@@ -136,15 +144,20 @@ def main(run_dir_arg: str) -> int:
         write_outputs(rep_dir, rec)
         nm = len(rec["expected"]) - len(rec["missing_expected"])
         tot = len(rec["expected"])
-        rate = f"{nm}/{tot} ({(rec['match_rate'] or 0)*100:.0f}%)"
+        rate = f"{nm}/{tot} ({(rec['match_rate'] or 0) * 100:.0f}%)"
         top_unmocked = rec["unmocked"][0] if rec["unmocked"] else ""
-        print(f"{rep_dir.name:>4}  {len(rec['calls']):>5}  {rate:>14}  {len(rec['unmocked']):>8}  {top_unmocked[:60]}")
+        print(
+            f"{rep_dir.name:>4}  {len(rec['calls']):>5}  {rate:>14}  {len(rec['unmocked']):>8}  {top_unmocked[:60]}"
+        )
 
     return 0
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python tmp/coverage_report.py <run_dir>/default/<task_id>", file=sys.stderr)
+        print(
+            "Usage: python tmp/coverage_report.py <run_dir>/default/<task_id>",
+            file=sys.stderr,
+        )
         sys.exit(2)
     sys.exit(main(sys.argv[1]))

--- a/tests/tasks/uipath-diagnostics/_shared/scripts/extract_session.py
+++ b/tests/tasks/uipath-diagnostics/_shared/scripts/extract_session.py
@@ -179,7 +179,9 @@ def parse_transcript(path: Path) -> dict:
             user_initial_prompt = result["first_user_text"]
 
     inferred = (
-        _slugify(inferred_release_name) if inferred_release_name else "diagnostic-scenario"
+        _slugify(inferred_release_name)
+        if inferred_release_name
+        else "diagnostic-scenario"
     )
 
     return {
@@ -293,7 +295,13 @@ def _parse_one(path: Path) -> dict:
                     elif block.get("is_error"):
                         exit_code = 1
                     if project_release_name is None:
-                        for field in ("ReleaseName", "processKey", "ProcessKey", "processName", "ProcessName"):
+                        for field in (
+                            "ReleaseName",
+                            "processKey",
+                            "ProcessKey",
+                            "processName",
+                            "ProcessName",
+                        ):
                             rel = re.search(rf'"{field}"\s*:\s*"([^"]+)"', stdout)
                             if rel:
                                 project_release_name = rel.group(1)

--- a/tests/tasks/uipath-diagnostics/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-diagnostics/_shared/scripts/generate_scenario.py
@@ -26,11 +26,11 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import shutil
 import subprocess
 import sys
 from collections import OrderedDict
 from pathlib import Path
+
 
 def _find_repo_root() -> Path:
     """Walk up from this file until we find the repo's `.git` marker."""
@@ -283,7 +283,11 @@ def _backfill_redirect_stdouts(uip_calls: list[dict], investigation: Path) -> di
                     loaded = None
         if loaded is not None:
             call["stdout"] = loaded
-            call["_backfilled_from"] = str(target_path) if target_path.is_file() else str(by_basename.get(target_path.name))
+            call["_backfilled_from"] = (
+                str(target_path)
+                if target_path.is_file()
+                else str(by_basename.get(target_path.name))
+            )
             backfilled += 1
         else:
             missing += 1
@@ -295,10 +299,10 @@ def _is_empty_stdout(stdout: str) -> bool:
     if not stdout.strip():
         return True
     # If every non-empty line matches a trailer pattern, treat as empty.
-    lines = [l for l in stdout.splitlines() if l.strip()]
+    lines = [line for line in stdout.splitlines() if line.strip()]
     if not lines:
         return True
-    return all(EMPTY_STDOUT_RE.fullmatch(l.strip()) for l in lines)
+    return all(EMPTY_STDOUT_RE.fullmatch(line.strip()) for line in lines)
 
 
 def _run_extract(transcript: Path) -> dict:
@@ -314,7 +318,7 @@ def _run_extract(transcript: Path) -> dict:
     return json.loads(proc.stdout)
 
 
-def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
+def _detect_scrub_map(samples: list[str]) -> OrderedDict[str, str]:
     """Auto-detect emails and personal Windows paths across all sampled text.
 
     Returns an ordered map of {real_value: placeholder}. Email detection
@@ -324,7 +328,7 @@ def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
     so `D:/Process/X/foo.json` becomes `foo.json` (the caller may need
     to retype these as relative paths during review).
     """
-    mapping: "OrderedDict[str, str]" = OrderedDict()
+    mapping: OrderedDict[str, str] = OrderedDict()
     seen_emails: list[str] = []
     seen_names: set[str] = set()
 
@@ -341,7 +345,9 @@ def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
                 seen_emails.append(full)
             idx = seen_emails.index(full)
             placeholder = (
-                placeholders[idx] if idx < len(placeholders) else f"user{idx + 1}@test.com"
+                placeholders[idx]
+                if idx < len(placeholders)
+                else f"user{idx + 1}@test.com"
             )
             mapping[full] = placeholder
             # Also map the bare local-part if it has structure (looks like a real name).
@@ -357,7 +363,7 @@ def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
     return mapping
 
 
-def _apply_scrub(text: str, mapping: "OrderedDict[str, str]") -> str:
+def _apply_scrub(text: str, mapping: OrderedDict[str, str]) -> str:
     if not isinstance(text, str):
         return text
     out = text
@@ -367,7 +373,7 @@ def _apply_scrub(text: str, mapping: "OrderedDict[str, str]") -> str:
     return out
 
 
-def _scrub_path(path: Path, mapping: "OrderedDict[str, str]") -> Path:
+def _scrub_path(path: Path, mapping: OrderedDict[str, str]) -> Path:
     """Apply scrub mapping to each path component (filenames containing real emails)."""
     parts = list(path.parts)
     new_parts = [_apply_scrub(p, mapping) for p in parts]
@@ -404,7 +410,7 @@ def _build_manifest_rules(uip_calls: list[dict]) -> tuple[list[dict], dict[str, 
 
 
 def _snapshot_project(
-    src: Path, dst: Path, mapping: "OrderedDict[str, str] | None" = None
+    src: Path, dst: Path, mapping: OrderedDict[str, str] | None = None
 ) -> list[tuple[Path, str | bytes]]:
     """Walk `src` and prepare an in-memory list of (relative_dst_path, content).
 
@@ -489,7 +495,8 @@ def _build_readme_md(scenario_name: str, summary: str) -> str:
     return README_TEMPLATE.format(
         scenario_title=scenario_name.replace("-", " ").title(),
         slug=scenario_name,
-        summary=summary or "_Add a 1–3 sentence summary of the original investigation here._",
+        summary=summary
+        or "_Add a 1–3 sentence summary of the original investigation here._",
     )
 
 
@@ -522,7 +529,11 @@ def plan_scenario(args: argparse.Namespace) -> dict:
         raise FileNotFoundError(f"project not found: {project}")
 
     extracted = _run_extract(transcript)
-    scenario_name = args.scenario_name or extracted.get("inferred_scenario_name") or "diagnostic-scenario"
+    scenario_name = (
+        args.scenario_name
+        or extracted.get("inferred_scenario_name")
+        or "diagnostic-scenario"
+    )
     scenario_name = _slugify(scenario_name)
 
     # Backfill empty stdouts from the investigation's saved files. The
@@ -546,9 +557,9 @@ def plan_scenario(args: argparse.Namespace) -> dict:
 
     # Build readme.
     summary = (extracted.get("presenter_output") or "").splitlines()
-    summary_oneline = next((s.strip() for s in summary if s.strip().startswith("**")), "") or (
-        summary[0].strip() if summary else ""
-    )
+    summary_oneline = next(
+        (s.strip() for s in summary if s.strip().startswith("**")), ""
+    ) or (summary[0].strip() if summary else "")
     readme_md = _build_readme_md(scenario_name, summary_oneline)
 
     # Build task.yaml.
@@ -565,14 +576,16 @@ def plan_scenario(args: argparse.Namespace) -> dict:
     # Snapshot the project (raw — scrub happens after we compute the map).
     if project is not None:
         project_plan = _snapshot_project(project, Path("process"), mapping=None)
-        for rel, content in project_plan:
+        for _rel, content in project_plan:
             if isinstance(content, str):
                 samples.append(content)
     else:
         project_plan = []
 
     if args.scrub_map:
-        scrub_map = OrderedDict(json.loads(Path(args.scrub_map).read_text(encoding="utf-8")))
+        scrub_map = OrderedDict(
+            json.loads(Path(args.scrub_map).read_text(encoding="utf-8"))
+        )
     else:
         scrub_map = _detect_scrub_map(samples)
 
@@ -586,11 +599,15 @@ def plan_scenario(args: argparse.Namespace) -> dict:
     for rel, content in project_plan:
         rel_scrubbed = _scrub_path(rel, scrub_map)
         if isinstance(content, str):
-            project_plan_scrubbed.append((rel_scrubbed, _apply_scrub(content, scrub_map)))
+            project_plan_scrubbed.append(
+                (rel_scrubbed, _apply_scrub(content, scrub_map))
+            )
         else:
             project_plan_scrubbed.append((rel_scrubbed, content))
 
-    out_base = Path(args.output) if args.output else (DEFAULT_OUTPUT_BASE / scenario_name)
+    out_base = (
+        Path(args.output) if args.output else (DEFAULT_OUTPUT_BASE / scenario_name)
+    )
 
     return {
         "scenario_name": scenario_name,
@@ -649,11 +666,19 @@ def render_dry_run(plan: dict) -> str:
     out.append("")
     out.append("Files that would be written:")
     base = plan["output_dir"]
-    out.append(f"  {base / 'task.yaml'}                             ({len(plan['task_yaml'])} bytes)")
-    out.append(f"  {base / 'README.md'}                             ({len(plan['readme_md'])} bytes)")
-    out.append(f"  {base / 'RESOLUTION.md'}                         ({len(plan['resolution_md'])} bytes)")
+    out.append(
+        f"  {base / 'task.yaml'}                             ({len(plan['task_yaml'])} bytes)"
+    )
+    out.append(
+        f"  {base / 'README.md'}                             ({len(plan['readme_md'])} bytes)"
+    )
+    out.append(
+        f"  {base / 'RESOLUTION.md'}                         ({len(plan['resolution_md'])} bytes)"
+    )
     out.append(f"  {base / 'fixtures' / 'mocks' / 'responses' / 'manifest.json'}")
-    out.append(f"  {base / 'fixtures' / 'mocks' / 'responses' / '<rule>.json'} x {len(plan['fixtures'])}")
+    out.append(
+        f"  {base / 'fixtures' / 'mocks' / 'responses' / '<rule>.json'} x {len(plan['fixtures'])}"
+    )
     out.append(f"  {base / 'process' / '<files>'} x {len(plan['project_files'])}")
     out.append("")
     out.append("(dry-run — no files written. Pass --apply to write.)")
@@ -693,8 +718,16 @@ def apply_plan(plan: dict) -> None:
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--investigation", required=True)
-    parser.add_argument("--project", default=None, help="Optional. UiPath project dir to snapshot into process/.")
-    parser.add_argument("--transcript", required=True, help="JSONL file or directory containing main + subagent transcripts.")
+    parser.add_argument(
+        "--project",
+        default=None,
+        help="Optional. UiPath project dir to snapshot into process/.",
+    )
+    parser.add_argument(
+        "--transcript",
+        required=True,
+        help="JSONL file or directory containing main + subagent transcripts.",
+    )
     parser.add_argument("--resolution", default=None)
     parser.add_argument("--scenario-name", default=None)
     parser.add_argument("--output", default=None)

--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
@@ -73,8 +73,14 @@ def has_uipath_extension(element: ET.Element, token: str) -> bool:
 
 
 def require_di_for_visible_elements(root: ET.Element) -> None:
-    shaped = {shape.attrib.get("bpmnElement") for shape in root.findall(".//bpmndi:BPMNShape", NS)}
-    edged = {edge.attrib.get("bpmnElement") for edge in root.findall(".//bpmndi:BPMNEdge", NS)}
+    shaped = {
+        shape.attrib.get("bpmnElement")
+        for shape in root.findall(".//bpmndi:BPMNShape", NS)
+    }
+    edged = {
+        edge.attrib.get("bpmnElement")
+        for edge in root.findall(".//bpmndi:BPMNEdge", NS)
+    }
     nodes = [
         *elements(root, "startEvent"),
         *elements(root, "endEvent"),
@@ -90,11 +96,15 @@ def require_di_for_visible_elements(root: ET.Element) -> None:
         *elements(root, "parallelGateway"),
         *elements(root, "inclusiveGateway"),
     ]
-    missing_shapes = [attr(node, "id") for node in nodes if attr(node, "id") not in shaped]
+    missing_shapes = [
+        attr(node, "id") for node in nodes if attr(node, "id") not in shaped
+    ]
     if missing_shapes:
         fail(f"visible BPMN elements missing BPMNShape: {missing_shapes}")
     missing_edges = [
-        attr(flow, "id") for flow in elements(root, "sequenceFlow") if attr(flow, "id") not in edged
+        attr(flow, "id")
+        for flow in elements(root, "sequenceFlow")
+        if attr(flow, "id") not in edged
     ]
     if missing_edges:
         fail(f"sequence flows missing BPMNEdge: {missing_edges}")
@@ -106,7 +116,9 @@ def require_sequence_integrity(root: ET.Element) -> None:
         source = attr(flow, "sourceRef")
         target = attr(flow, "targetRef")
         if source not in ids or target not in ids:
-            fail(f"sequence flow {attr(flow, 'id')} has unresolved refs {source!r}->{target!r}")
+            fail(
+                f"sequence flow {attr(flow, 'id')} has unresolved refs {source!r}->{target!r}"
+            )
 
 
 def require_no_private_connector_values(root: ET.Element) -> None:

--- a/tests/tasks/uipath-maestro-bpmn/author/check_gateway_sequence_flows.py
+++ b/tests/tasks/uipath-maestro-bpmn/author/check_gateway_sequence_flows.py
@@ -24,7 +24,9 @@ def main() -> None:
         fail(f"expected at least 8 sequence flows in {path}, found {len(flows)}")
     if not any(attr(gateway, "default") for gateway in exclusive):
         fail("exclusive gateway is missing a default sequence-flow reference")
-    conditioned = [flow for flow in flows if flow.find("bpmn:conditionExpression", NS) is not None]
+    conditioned = [
+        flow for flow in flows if flow.find("bpmn:conditionExpression", NS) is not None
+    ]
     if not conditioned:
         fail("missing conditional sequence flow")
     require_sequence_integrity(root)

--- a/tests/tasks/uipath-maestro-bpmn/connector/check_integration_service_boundary.py
+++ b/tests/tasks/uipath-maestro-bpmn/connector/check_integration_service_boundary.py
@@ -34,12 +34,19 @@ def main() -> None:
         if glob.glob(f"**/{name}", recursive=True)
     ]
     if generated:
-        fail(f"draft boundary should not hand-author generated package files: {generated}")
+        fail(
+            f"draft boundary should not hand-author generated package files: {generated}"
+        )
     notes = "\n".join(
         Path(p).read_text(encoding="utf-8")
         for p in glob.glob("SlackDigestBoundaryBpmn/**/*.md", recursive=True)
     )
-    required = ["connection binding", "dynamic schemas", "bindings_v2.json", "package metadata"]
+    required = [
+        "connection binding",
+        "dynamic schemas",
+        "bindings_v2.json",
+        "package metadata",
+    ]
     missing = [token for token in required if token.lower() not in notes.lower()]
     if missing:
         fail(f"boundary notes missing CLI-owned blockers: {missing}")

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
@@ -16,7 +16,9 @@ from _shared.bpmn_check import (  # noqa: E402
 )
 
 
-def has_typed_extension(element: ET.Element, extension_name: str, type_value: str) -> bool:
+def has_typed_extension(
+    element: ET.Element, extension_name: str, type_value: str
+) -> bool:
     ext = element.find("bpmn:extensionElements", NS)
     if ext is None:
         return False
@@ -27,7 +29,9 @@ def has_typed_extension(element: ET.Element, extension_name: str, type_value: st
     return False
 
 
-def require_wrapper(root: ET.Element, wrapper: str, extension_name: str, type_value: str) -> None:
+def require_wrapper(
+    root: ET.Element, wrapper: str, extension_name: str, type_value: str
+) -> None:
     matches = [
         elem
         for elem in elements(root, wrapper)
@@ -43,9 +47,16 @@ def require_uipath_element(root: ET.Element, local_name: str, description: str) 
 
 
 def require_uipath_attr_value(
-    root: ET.Element, local_name: str, attr_name: str, expected_value: str, description: str
+    root: ET.Element,
+    local_name: str,
+    attr_name: str,
+    expected_value: str,
+    description: str,
 ) -> None:
-    values = {elem.attrib.get(attr_name) for elem in root.findall(f".//uipath:{local_name}", NS)}
+    values = {
+        elem.attrib.get(attr_name)
+        for elem in root.findall(f".//uipath:{local_name}", NS)
+    }
     if expected_value not in values:
         fail(f"missing {description}: {expected_value}")
 
@@ -79,13 +90,19 @@ def main() -> None:
         require_wrapper(root, wrapper, extension_name, type_value)
 
     for version in {"5", "11", "11.5"}:
-        require_uipath_attr_value(root, "migrationVersion", "version", version, "migration version")
+        require_uipath_attr_value(
+            root, "migrationVersion", "version", version, "migration version"
+        )
 
     require_uipath_attr_value(
         root, "scriptVersion", "value", "v2", "preserved legacy scriptVersion"
     )
-    require_uipath_element(root, "caseManagement", "preserve-only uipath:caseManagement payload")
-    require_uipath_element(root, "Activity", "preserve-only generic uipath:Activity payload")
+    require_uipath_element(
+        root, "caseManagement", "preserve-only uipath:caseManagement payload"
+    )
+    require_uipath_element(
+        root, "Activity", "preserve-only generic uipath:Activity payload"
+    )
 
     require_no_private_connector_values(root)
     require_sequence_integrity(root)

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_hitl_rpa_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_hitl_rpa_wrappers.py
@@ -18,7 +18,9 @@ from _shared.bpmn_check import (  # noqa: E402
 def main() -> None:
     path, root = parse_bpmn("EmployeeAccessBpmn")
     hitl = [
-        task for task in elements(root, "userTask") if has_uipath_extension(task, "Actions.HITL")
+        task
+        for task in elements(root, "userTask")
+        if has_uipath_extension(task, "Actions.HITL")
     ]
     rpa = [
         task
@@ -28,7 +30,9 @@ def main() -> None:
     if not hitl:
         fail("missing bpmn:userTask with Actions.HITL uipath:activity shell")
     if not rpa:
-        fail("missing bpmn:serviceTask with Orchestrator.StartJob uipath:activity shell")
+        fail(
+            "missing bpmn:serviceTask with Orchestrator.StartJob uipath:activity shell"
+        )
     require_no_private_connector_values(root)
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
@@ -118,7 +118,9 @@ def main() -> None:
     if present:
         fail(f"script uses APIs outside the Jint boundary: {present}")
     if "args." in body:
-        fail("script body should read mapped fields as top-level identifiers, not args.*")
+        fail(
+            "script body should read mapped fields as top-level identifiers, not args.*"
+        )
     for identifier in ("amount", "daysOverdue"):
         if identifier not in body:
             fail(f"script body should reference mapped input identifier {identifier!r}")
@@ -137,14 +139,20 @@ def main() -> None:
         if expected not in args_body:
             fail(f"script args should map {variable_name!r} through {expected!r}")
         if f"={variable_name}" in args_body:
-            fail(f"script args should not use bare variable expression ={variable_name}")
+            fail(
+                f"script args should not use bare variable expression ={variable_name}"
+            )
 
     output_var = variables["riskScore"]
     outputs = uipath_outputs(task)
     if not any(out.attrib.get("var") == output_var for out in outputs):
         fail("script output must map to the declared riskScore variable id")
-    if not any((out.attrib.get("source") or "").startswith("=result.") for out in outputs):
-        fail("script output should map from a result expression such as =result.response")
+    if not any(
+        (out.attrib.get("source") or "").startswith("=result.") for out in outputs
+    ):
+        fail(
+            "script output should map from a result expression such as =result.response"
+        )
 
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -23,8 +23,8 @@ import os
 import re
 import subprocess
 import sys
-from typing import Any, Iterable, Sequence
-
+from collections.abc import Iterable, Sequence
+from typing import Any
 
 # ── Public helpers ──────────────────────────────────────────────────────────
 
@@ -84,8 +84,7 @@ def assert_flow_has_node_type(
         needle = hint.lower()
         if not any(needle in t.lower() for t in types_seen):
             _fail(
-                f"No node matches type hint {hint!r}. "
-                f"Node types seen: {sorted(types_seen)}"
+                f"No node matches type hint {hint!r}. Node types seen: {sorted(types_seen)}"
             )
 
 
@@ -170,9 +169,12 @@ def assert_output_value(payload: dict, expected: Any) -> None:
     for v in outs:
         if v == expected:
             return
-        if isinstance(expected, str) and isinstance(v, str):
-            if expected.lower() in v.lower():
-                return
+        if (
+            isinstance(expected, str)
+            and isinstance(v, str)
+            and expected.lower() in v.lower()
+        ):
+            return
     _fail(f"No output equals expected {expected!r}\nOutputs: {_stringify(outs)[:1000]}")
 
 
@@ -218,9 +220,7 @@ def _find_project(pattern: str) -> str:
         _fail(f"No project.uiproj found matching {pattern}")
     if len(projects) > 1:
         joined = "\n  - ".join(projects)
-        _fail(
-            f"Multiple projects match {pattern!r} — refusing to guess:\n  - {joined}"
-        )
+        _fail(f"Multiple projects match {pattern!r} — refusing to guess:\n  - {joined}")
     return os.path.dirname(projects[0])
 
 

--- a/tests/tasks/uipath-maestro-flow/canary/canary.py
+++ b/tests/tasks/uipath-maestro-flow/canary/canary.py
@@ -25,7 +25,9 @@ import subprocess
 import sys
 import time
 import uuid
-from typing import Any, Callable
+from collections.abc import Callable
+from contextlib import suppress
+from typing import Any
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 PROJECT_DIR = os.path.join(HERE, "Canary", "Canary")
@@ -169,10 +171,8 @@ def cleanup(solution_id: str | None) -> None:
                 f"(solutionId={solution_id} may need manual cleanup)",
                 file=sys.stderr,
             )
-    try:
+    with suppress(FileNotFoundError):
         os.remove(UIPX_PATH)
-    except FileNotFoundError:
-        pass
 
 
 def run_debug() -> tuple[dict, str | None]:
@@ -241,7 +241,7 @@ def main() -> int:
 
         errors: list[str] = []
         if payload.get("finalStatus") != "Completed":
-            errors.append(f"finalStatus != Completed")
+            errors.append("finalStatus != Completed")
 
         print()
         for eid, path, matcher, fmt in LEGS:

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
@@ -83,7 +83,9 @@ def _assert_filter_tree_shape(tree, *, source: str) -> None:
         )
 
     values = [_leaf_value(n) for n in leaves]
-    if not any(isinstance(v, str) and v.strip().lower() == EXPECTED_VALUE for v in values):
+    if not any(
+        isinstance(v, str) and v.strip().lower() == EXPECTED_VALUE for v in values
+    ):
         sys.exit(
             f"FAIL: {source} has no leaf with value '{EXPECTED_VALUE}' "
             f"(found values: {[v for v in values if v is not None]})"
@@ -94,7 +96,8 @@ def _check_where_detail() -> None:
     if not os.path.exists("where_detail.json"):
         sys.exit("FAIL: where_detail.json not found")
     try:
-        plan = json.load(open("where_detail.json"))
+        with open("where_detail.json") as f:
+            plan = json.load(f)
     except json.JSONDecodeError as e:
         sys.exit(f"FAIL: where_detail.json is not valid JSON: {e}")
 
@@ -116,7 +119,8 @@ def _find_flow() -> str:
 
 def _check_flow_structure() -> None:
     flow_path = _find_flow()
-    raw = open(flow_path).read()
+    with open(flow_path) as f:
+        raw = f.read()
     try:
         flow = json.loads(raw)
     except json.JSONDecodeError as e:

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_drive_to_slack.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_drive_to_slack.py
@@ -17,12 +17,8 @@ from __future__ import annotations
 
 import glob
 import json
-import os
 import re
 import sys
-
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.flow_check import run_debug  # noqa: E402
 
 FLOW_GLOB = "**/DriveToSlackTest*.flow"
 DRIVE_KEY = "uipath-google-drive"

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_generate_schema.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_generate_schema.py
@@ -64,12 +64,7 @@ def main() -> None:
         )
 
     jira_nodes = [n for n in flow["nodes"] if n.get("type") == JIRA_NODE_TYPE]
-    body = (
-        jira_nodes[0]
-        .get("inputs", {})
-        .get("detail", {})
-        .get("bodyParameters", {})
-    )
+    body = jira_nodes[0].get("inputs", {}).get("detail", {}).get("bodyParameters", {})
     summary = body.get("fields.summary")
     if not summary:
         _fail(f"fields.summary missing or empty in bodyParameters: {body}")

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py
@@ -44,7 +44,9 @@ def main() -> None:
         if isinstance(path_params, dict):
             for value in path_params.values():
                 if str(value) == needle:
-                    print(f"OK: {needle!r} found in pathParameters of node {node.get('id')!r}")
+                    print(
+                        f"OK: {needle!r} found in pathParameters of node {node.get('id')!r}"
+                    )
                     return
         for key in ("url", "endpoint"):
             target = str(detail.get(key, "") or "")

--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -14,7 +14,6 @@ import json
 import sys
 from pathlib import Path
 
-
 FLOW_GLOB = "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
 
 
@@ -47,7 +46,9 @@ def main() -> None:
 
     hitl_nodes = [n for n in nodes if n.get("type") == "uipath.human-in-the-loop"]
     if len(hitl_nodes) != 1:
-        fail(f"Expected exactly one uipath.human-in-the-loop node, found {len(hitl_nodes)}")
+        fail(
+            f"Expected exactly one uipath.human-in-the-loop node, found {len(hitl_nodes)}"
+        )
     hitl = hitl_nodes[0]
     hitl_id = hitl.get("id")
     if not hitl_id:
@@ -66,7 +67,8 @@ def main() -> None:
         fail("HITL schema must define at least two outcomes")
 
     if not any(
-        (field_text(f, "id") == "amount" or "amount" in field_text(f, "label")) and f.get("type") == "number"
+        (field_text(f, "id") == "amount" or "amount" in field_text(f, "label"))
+        and f.get("type") == "number"
         for f in fields
     ):
         fail("Amount field must use type number")
@@ -75,7 +77,11 @@ def main() -> None:
         f
         for f in fields
         if f.get("direction") in {"output", "inOut"}
-        and ("approval" in field_text(f, "id") or "approved" in field_text(f, "id") or "decision" in field_text(f, "id"))
+        and (
+            "approval" in field_text(f, "id")
+            or "approved" in field_text(f, "id")
+            or "decision" in field_text(f, "id")
+        )
     ]
     has_boolean_decision = any(f.get("type") == "boolean" for f in decision_fields)
     outcome_names = {str(o.get("name") or o.get("id") or "").lower() for o in outcomes}
@@ -83,28 +89,42 @@ def main() -> None:
         "reject" in name for name in outcome_names
     )
     if not (has_boolean_decision or has_approval_outcomes):
-        fail("HITL must capture the manager decision as a boolean output or approve/reject outcomes")
+        fail(
+            "HITL must capture the manager decision as a boolean output or approve/reject outcomes"
+        )
 
     reason_keywords = ("reason", "comment", "explanation", "justification", "note")
     if not any(
         f.get("direction") in {"output", "inOut"}
         and f.get("type") in {"text", "string", "textarea"}
-        and any(kw in field_text(f, "id") or kw in field_text(f, "label") for kw in reason_keywords)
+        and any(
+            kw in field_text(f, "id") or kw in field_text(f, "label")
+            for kw in reason_keywords
+        )
         for f in fields
     ):
-        fail("HITL must expose a text output field for the rejection reason (e.g., reason, comment)")
+        fail(
+            "HITL must expose a text output field for the rejection reason (e.g., reason, comment)"
+        )
 
     input_bindings = [
         f.get("binding", "")
         for f in fields
-        if f.get("direction") in {"input", "inOut"} and isinstance(f.get("binding"), str)
+        if f.get("direction") in {"input", "inOut"}
+        and isinstance(f.get("binding"), str)
     ]
     if not input_bindings:
         fail("HITL input fields must be bound to upstream script output")
-    if not any(binding.startswith("=js:$vars.") and ".output." in binding for binding in input_bindings):
+    if not any(
+        binding.startswith("=js:$vars.") and ".output." in binding
+        for binding in input_bindings
+    ):
         fail("HITL input bindings must use =js:$vars.<node>.output.<field>")
 
-    if not any(e.get("sourceNodeId") == hitl_id and e.get("sourcePort") == "completed" for e in edges):
+    if not any(
+        e.get("sourceNodeId") == hitl_id and e.get("sourcePort") == "completed"
+        for e in edges
+    ):
         fail("HITL completed handle must be wired")
 
     scripts = [
@@ -116,7 +136,9 @@ def main() -> None:
     if not any(expected_output_path in script for script in scripts):
         fail(f"Downstream script must read HITL output via {expected_output_path}")
 
-    print(f"OK: HITL node {hitl_id} uses v1.0 schema, captures approval + reason, wires completed, and uses .output paths")
+    print(
+        f"OK: HITL node {hitl_id} uses v1.0 schema, captures approval + reason, wires completed, and uses .output paths"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/check_add_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/check_add_node.py
@@ -39,7 +39,10 @@ def _assert_edge_exists(source_id: str, target_id: str) -> None:
         with open(path) as f:
             flow = json.load(f)
         for edge in flow.get("edges") or []:
-            if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+            if (
+                edge.get("sourceNodeId") == source_id
+                and edge.get("targetNodeId") == target_id
+            ):
                 return
     sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
 

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/check_group_to_subflow.py
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/check_group_to_subflow.py
@@ -45,7 +45,9 @@ def _assert_main_flow_nodes_removed(flow: dict) -> None:
     main_ids = {n.get("id") for n in flow.get("nodes") or []}
     for removed in ("getWeather", "formatSummary"):
         if removed in main_ids:
-            sys.exit(f"FAIL: '{removed}' should have been moved to subflow but is still in main flow nodes")
+            sys.exit(
+                f"FAIL: '{removed}' should have been moved to subflow but is still in main flow nodes"
+            )
 
 
 def main():

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/check_move_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/check_move_node.py
@@ -28,7 +28,10 @@ def _load_flow() -> dict:
 
 def _assert_edge_exists(flow: dict, source_id: str, target_id: str) -> None:
     for edge in flow.get("edges") or []:
-        if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+        if (
+            edge.get("sourceNodeId") == source_id
+            and edge.get("targetNodeId") == target_id
+        ):
             return
     sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
 
@@ -42,7 +45,11 @@ def main():
 
     # Decision must come before formatSummary: getWeather → decision node
     # Find the decision node id
-    decision_ids = [n["id"] for n in flow.get("nodes") or [] if n.get("type") == "core.logic.decision"]
+    decision_ids = [
+        n["id"]
+        for n in flow.get("nodes") or []
+        if n.get("type") == "core.logic.decision"
+    ]
     if not decision_ids:
         sys.exit("FAIL: no decision node found")
     decision_id = decision_ids[0]
@@ -50,7 +57,11 @@ def main():
     _assert_edge_exists(flow, "getWeather", decision_id)
 
     # formatSummary must exist and be downstream of decision
-    fmt_ids = [n["id"] for n in flow.get("nodes") or [] if n.get("type") == "core.action.script"]
+    fmt_ids = [
+        n["id"]
+        for n in flow.get("nodes") or []
+        if n.get("type") == "core.action.script"
+    ]
     if not fmt_ids:
         sys.exit("FAIL: no script node (formatSummary) found")
 
@@ -64,7 +75,9 @@ def main():
     # Runtime check
     payload = run_debug(timeout=240)
     assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
-    print("OK: decision before formatSummary, branches merged, single end node, debug valid")
+    print(
+        "OK: decision before formatSummary, branches merged, single end node, debug valid"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/check_remove_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/check_remove_node.py
@@ -26,7 +26,9 @@ def _assert_node_absent(node_id: str) -> None:
             flow = json.load(f)
         for node in flow.get("nodes") or []:
             if node.get("id") == node_id:
-                sys.exit(f"FAIL: node '{node_id}' should have been removed but still exists")
+                sys.exit(
+                    f"FAIL: node '{node_id}' should have been removed but still exists"
+                )
 
 
 def _assert_edge_exists(source_id: str, target_id: str) -> None:
@@ -38,7 +40,10 @@ def _assert_edge_exists(source_id: str, target_id: str) -> None:
         with open(path) as f:
             flow = json.load(f)
         for edge in flow.get("edges") or []:
-            if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+            if (
+                edge.get("sourceNodeId") == source_id
+                and edge.get("targetNodeId") == target_id
+            ):
                 return
     sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
 

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/check_update_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/check_update_node.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,
@@ -17,9 +19,7 @@ def main():
     # branch message in a Script node without calling the weather API.
     assert_flow_has_node_type(["core.action.http"])
     payload = run_debug(timeout=240)
-    assert_outputs_contain(
-        payload, ["amazing day", "go home"], require_all=False
-    )
+    assert_outputs_contain(payload, ["amazing day", "go home"], require_all=False)
     print("OK: HTTP node present; output contains a weather branch message")
 
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
@@ -13,6 +13,7 @@ ran the right shell command):
 These checks fail if the agent ran the commands but they errored, or if
 the agent fabricated stdout without producing real files.
 """
+
 from __future__ import annotations
 
 import json
@@ -84,7 +85,9 @@ def main() -> None:
         sys.exit('FAIL: data point "hello" has empty inputs')
     if not (hello.get("expectedOutput") or hello.get("expected")):
         sys.exit('FAIL: data point "hello" has no expectedOutput / expected field')
-    print(f"OK: eval set {set_match[0]} contains data point 'hello' with inputs + expected")
+    print(
+        f"OK: eval set {set_match[0]} contains data point 'hello' with inputs + expected"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py
@@ -8,6 +8,7 @@ Reads `report.json` and asserts:
   - action               is one of {"refused", "asked-user"}
   - reason               mentions "Studio Web" (the rule's framing)
 """
+
 from __future__ import annotations
 
 import json
@@ -44,9 +45,7 @@ def main() -> None:
         )
     reason = doc.get("reason") or ""
     if "Studio Web" not in reason:
-        failures.append(
-            f"reason does not reference 'Studio Web': {reason!r}"
-        )
+        failures.append(f"reason does not reference 'Studio Web': {reason!r}")
 
     if failures:
         sys.exit("FAIL: " + " | ".join(failures))

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py
@@ -9,6 +9,7 @@ Reads `report.json` written by the agent and asserts:
 
 Each goal must use the kebab-case spelling exactly as the CLI accepts it.
 """
+
 from __future__ import annotations
 
 import json
@@ -39,7 +40,9 @@ def main() -> None:
 
     if failures:
         sys.exit("FAIL: " + " | ".join(failures))
-    print(f"OK: all 3 evaluator-type choices match expected ({list(EXPECTED.values())})")
+    print(
+        f"OK: all 3 evaluator-type choices match expected ({list(EXPECTED.values())})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
@@ -17,6 +17,7 @@ The CLI's exact field names may evolve; we tolerate both `EvaluatorScores`
 (list/dict of evaluator entries) and a flat per-row `Score` field. Anything
 that surfaces a numeric score gets checked.
 """
+
 from __future__ import annotations
 
 import json
@@ -48,7 +49,7 @@ def _extract_rows(doc: dict) -> list[dict]:
     if code != "MaestroFlowEvalRunResults":
         _fail(
             f'eval-results.json `Code` should be "MaestroFlowEvalRunResults", '
-            f'got {code!r}'
+            f"got {code!r}"
         )
     data = doc.get("Data") or {}
     for key in ("Results", "DataPoints", "Rows"):
@@ -56,8 +57,8 @@ def _extract_rows(doc: dict) -> list[dict]:
         if isinstance(rows, list) and rows:
             return rows
     _fail(
-        f'eval-results.json has no Results/DataPoints/Rows list under Data. '
-        f'Top-level keys: {list(doc.keys())}, Data keys: {list(data.keys())}'
+        f"eval-results.json has no Results/DataPoints/Rows list under Data. "
+        f"Top-level keys: {list(doc.keys())}, Data keys: {list(data.keys())}"
     )
     return []  # unreachable
 
@@ -118,9 +119,7 @@ def main() -> None:
             continue
         bad = [s for s in scores if s != 1.0]
         if bad:
-            failures.append(
-                f"{name!r}: scored {bad!r} (expected 1.0 from exact-match)"
-            )
+            failures.append(f"{name!r}: scored {bad!r} (expected 1.0 from exact-match)")
 
     if failures:
         _fail(" | ".join(failures))

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/check_weather_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/check_weather_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,
@@ -17,9 +19,7 @@ def main():
     # branch message in a Script node without calling the weather API.
     assert_flow_has_node_type(["core.action.http"])
     payload = run_debug(timeout=240)
-    assert_outputs_contain(
-        payload, ["nice day", "bring a jacket"], require_all=False
-    )
+    assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
     print("OK: HTTP node present; output contains a weather branch message")
 
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/check_calculator_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/check_calculator_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
@@ -70,15 +70,21 @@ def main() -> None:
         fail("Flow must contain nodes[] and edges[]")
 
     if len(nodes) < 5:
-        fail(f"Expected >=5 nodes (trigger + 2 scripts + decision + branch action(s)), found {len(nodes)}")
+        fail(
+            f"Expected >=5 nodes (trigger + 2 scripts + decision + branch action(s)), found {len(nodes)}"
+        )
 
     outlook_trigger = [n for n in nodes if is_trigger(n) and references(n, "outlook")]
-    if not outlook_trigger and not any(is_trigger(n) and references(n, "office365") for n in nodes):
+    if not outlook_trigger and not any(
+        is_trigger(n) and references(n, "office365") for n in nodes
+    ):
         fail("No Outlook (or office365) trigger node found")
 
     scripts = [n for n in nodes if node_type(n) == "core.action.script"]
     if len(scripts) < 2:
-        fail(f"Expected >=2 core.action.script nodes (urgency + VIP classifier), found {len(scripts)}")
+        fail(
+            f"Expected >=2 core.action.script nodes (urgency + VIP classifier), found {len(scripts)}"
+        )
 
     decisions = [n for n in nodes if node_type(n) == "core.logic.decision"]
     if len(decisions) != 1:
@@ -88,18 +94,31 @@ def main() -> None:
         fail("Decision node missing id")
 
     out_edges = [
-        e for e in edges
-        if decision_id in (e.get("sourceNodeId"), e.get("source"), e.get("from"), e.get("sourceId"))
+        e
+        for e in edges
+        if decision_id
+        in (e.get("sourceNodeId"), e.get("source"), e.get("from"), e.get("sourceId"))
     ]
     if len(out_edges) < 2:
-        fail(f"Decision node must have >=2 outgoing edges (VIP + standard), found {len(out_edges)}")
+        fail(
+            f"Decision node must have >=2 outgoing edges (VIP + standard), found {len(out_edges)}"
+        )
 
     if not any(references(n, "slack") for n in nodes):
-        fail("No Slack connector reference found anywhere in flow (VIP branch should DM via Slack)")
+        fail(
+            "No Slack connector reference found anywhere in flow (VIP branch should DM via Slack)"
+        )
 
-    non_trigger_outlook = [n for n in nodes if not is_trigger(n) and (references(n, "outlook") or references(n, "office365"))]
+    non_trigger_outlook = [
+        n
+        for n in nodes
+        if not is_trigger(n)
+        and (references(n, "outlook") or references(n, "office365"))
+    ]
     if not non_trigger_outlook:
-        fail("No non-trigger Outlook reference found (expected reply-to-sender action on at least one branch)")
+        fail(
+            "No non-trigger Outlook reference found (expected reply-to-sender action on at least one branch)"
+        )
 
     print(
         f"PASS: {len(nodes)} nodes, {len(scripts)} scripts, decision with {len(out_edges)} branches, "

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/check_dice_runs.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/check_dice_runs.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_int_in_range,

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/check_feet_inches_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/check_feet_inches_flow.py
@@ -7,7 +7,9 @@ Usage: check_feet_inches_flow.py {f2i|i2f|y2f}
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/check_loop_multiply.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/check_loop_multiply.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/check_multi_city_weather.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/check_multi_city_weather.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,
@@ -22,9 +24,7 @@ def main():
     assert_outputs_contain(payload, ["Seattle", "Phoenix", "New York"])
 
     # At least one verdict must appear — proves the script classified the temp
-    assert_outputs_contain(
-        payload, ["warm", "cold"], require_all=False
-    )
+    assert_outputs_contain(payload, ["warm", "cold"], require_all=False)
     print("OK: loop + HTTP + script all executed, all 3 cities with verdicts present")
 
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/check_reading_list.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/check_reading_list.py
@@ -9,7 +9,9 @@ Information Theory (MacKay) — with titles uppercased.
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/check_channel_description.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/check_channel_description.py
@@ -5,7 +5,9 @@ the Bellevue office address fragments."""
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/check_slack_weather_pipeline.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/check_slack_weather_pipeline.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
@@ -36,7 +36,9 @@ exits 1.
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,
@@ -85,11 +87,15 @@ def main():
 
     if case == "uipath_success":
         lo, hi = SUCCESS_RANGE
-        print(f"[{case}] Injecting inputs: {inputs} (expect numeric leaf in [{lo}, {hi}])")
+        print(
+            f"[{case}] Injecting inputs: {inputs} (expect numeric leaf in [{lo}, {hi}])"
+        )
         payload = run_debug(inputs=inputs, timeout=300)
         match = _find_numeric_leaf_in_range(payload, lo, hi)
         if match is None:
-            sys.exit(f"FAIL: No numeric output in [{lo}, {hi}]\nOutputs: {list(collect_outputs(payload))}")
+            sys.exit(
+                f"FAIL: No numeric output in [{lo}, {hi}]\nOutputs: {list(collect_outputs(payload))}"
+            )
         print(f"OK: [{case}] output {match} in [{lo}, {hi}]")
     else:
         print(f"[{case}] Injecting inputs: {inputs} (expect {ERROR_STRING!r})")

--- a/tests/tasks/uipath-maestro-flow/nodes/connector_trigger/check_trigger_filter.py
+++ b/tests/tasks/uipath-maestro-flow/nodes/connector_trigger/check_trigger_filter.py
@@ -47,7 +47,9 @@ def main():
         )
 
     # 2. At least one leaf must use the PascalCase `Contains` operator.
-    operators = {n.get("operator") for n in leaves if isinstance(n.get("operator"), str)}
+    operators = {
+        n.get("operator") for n in leaves if isinstance(n.get("operator"), str)
+    }
     if "Contains" not in operators:
         sys.exit(
             f"FAIL: expected PascalCase `Contains` operator in filter tree, "

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/check_api_workflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/check_api_workflow_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_int_in_range,

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
@@ -108,7 +108,11 @@ def _check_result_output_mapping(flow: dict, bt_node_id: str) -> None:
     """
     globals_ = (flow.get("variables") or {}).get("globals") or []
     result_var = next(
-        (v for v in globals_ if v.get("id") == "result" and v.get("direction") == "out"),
+        (
+            v
+            for v in globals_
+            if v.get("id") == "result" and v.get("direction") == "out"
+        ),
         None,
     )
     if result_var is None:
@@ -117,7 +121,9 @@ def _check_result_output_mapping(flow: dict, bt_node_id: str) -> None:
             "Batch Transform result file handle to be surfaced as a flow output named `result`."
         )
 
-    end_nodes = [n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"]
+    end_nodes = [
+        n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"
+    ]
     if not end_nodes:
         _fail("flow has no End node — required to terminate the path and map outputs")
 

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -18,12 +18,13 @@ Privacy: never logs folder display names. Only counts + truncated IDs.
 
 import glob
 import json
-import os
 import subprocess
 import sys
 
 CONNECTOR_KEY = "uipath-microsoft-outlook365"
-TRIGGER_TYPE_MARKER = "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"
+TRIGGER_TYPE_MARKER = (
+    "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"
+)
 TEST_FOLDER_PATH = "Shared/uipath-maestro-flow"
 
 
@@ -56,7 +57,9 @@ def _read_flow() -> tuple[dict, str]:
 
 
 def _find_test_folder_key() -> str:
-    resp = _uip_json(["uip", "or", "folders", "get", TEST_FOLDER_PATH, "--output", "json"])
+    resp = _uip_json(
+        ["uip", "or", "folders", "get", TEST_FOLDER_PATH, "--output", "json"]
+    )
     key = resp.get("Data", {}).get("Key")
     if not key:
         sys.exit(f"FAIL: no '{TEST_FOLDER_PATH}' folder in Orchestrator")
@@ -69,8 +72,15 @@ def _find_default_outlook_connection() -> tuple[str, str, str]:
     folder_key = _find_test_folder_key()
     conns_raw = _uip_json(
         [
-            "uip", "is", "connections", "list", CONNECTOR_KEY,
-            "--folder-key", folder_key, "--output", "json",
+            "uip",
+            "is",
+            "connections",
+            "list",
+            CONNECTOR_KEY,
+            "--folder-key",
+            folder_key,
+            "--output",
+            "json",
         ]
     ).get("Data", [])
     if not isinstance(conns_raw, list) or not conns_raw:
@@ -78,7 +88,11 @@ def _find_default_outlook_connection() -> tuple[str, str, str]:
             f"FAIL: no {CONNECTOR_KEY} connection in folder {TEST_FOLDER_PATH}. "
             f"Provision an Outlook connection in the test tenant first."
         )
-    defaults = [c for c in conns_raw if c.get("IsDefault") == "Yes" and c.get("State") == "Enabled"]
+    defaults = [
+        c
+        for c in conns_raw
+        if c.get("IsDefault") == "Yes" and c.get("State") == "Enabled"
+    ]
     chosen = defaults[0] if defaults else conns_raw[0]
     return chosen["Id"], folder_key, chosen.get("Name", "")
 
@@ -100,7 +114,11 @@ def _extract_list_items(resp: dict) -> list[dict]:
     if isinstance(data, list):
         return [x for x in data if isinstance(x, dict)]
     if isinstance(data, dict):
-        return [x for x in (data.get("items") or data.get("Items") or []) if isinstance(x, dict)]
+        return [
+            x
+            for x in (data.get("items") or data.get("Items") or [])
+            if isinstance(x, dict)
+        ]
     return []
 
 
@@ -126,13 +144,24 @@ def check_folder_id_fresh():
     conn_id, _folder_key, _conn_name = _find_default_outlook_connection()
     live = _uip_json(
         [
-            "uip", "is", "resources", "execute", "list", CONNECTOR_KEY, "MailFolder",
-            "--connection-id", conn_id, "--output", "json",
+            "uip",
+            "is",
+            "resources",
+            "execute",
+            "list",
+            CONNECTOR_KEY,
+            "MailFolder",
+            "--connection-id",
+            conn_id,
+            "--output",
+            "json",
         ]
     )
     live_ids = {f.get("id") for f in _extract_list_items(live)}
     if not live_ids:
-        sys.exit("FAIL: execute list MailFolder returned no folders on the bound connection")
+        sys.exit(
+            "FAIL: execute list MailFolder returned no folders on the bound connection"
+        )
 
     if flow_folder_id not in live_ids:
         # Truncate the IDs in the error to avoid leaking full Exchange IDs while
@@ -142,7 +171,9 @@ def check_folder_id_fresh():
             f"the {len(live_ids)} MailFolder IDs on the current connection. The agent "
             f"reused a reference ID from another connection or session."
         )
-    print(f"OK: parentFolderId resolves on current connection ({len(live_ids)} folders checked)")
+    print(
+        f"OK: parentFolderId resolves on current connection ({len(live_ids)} folders checked)"
+    )
 
 
 DISPATCH = {

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/check_subflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/check_subflow_flow.py
@@ -34,7 +34,9 @@ def _check_subflow_structure(project_dir):
         (n for n in flow.get("nodes", []) if n.get("type") == "core.subflow"), None
     )
     if not subflow_node:
-        _fail(f"No Subflow node found. Types: {[n.get('type') for n in flow.get('nodes', [])]}")
+        _fail(
+            f"No Subflow node found. Types: {[n.get('type') for n in flow.get('nodes', [])]}"
+        )
 
     sid = subflow_node["id"]
     if not subflow_node.get("inputs"):
@@ -43,12 +45,16 @@ def _check_subflow_structure(project_dir):
     # Verify the subflows section
     sf = flow.get("subflows", {}).get(sid)
     if not sf:
-        _fail(f"No subflows.{sid} section found. Keys: {list(flow.get('subflows', {}).keys())}")
+        _fail(
+            f"No subflows.{sid} section found. Keys: {list(flow.get('subflows', {}).keys())}"
+        )
 
     sf_nodes = sf.get("nodes", [])
     sf_edges = sf.get("edges", [])
     if len(sf_nodes) < 3:
-        _fail(f"Subflow needs at least 3 nodes (start, logic, end), found {len(sf_nodes)}")
+        _fail(
+            f"Subflow needs at least 3 nodes (start, logic, end), found {len(sf_nodes)}"
+        )
     if len(sf_edges) < 2:
         _fail(f"Subflow needs at least 2 edges, found {len(sf_edges)}")
 
@@ -75,7 +81,9 @@ def _check_subflow_structure(project_dir):
         if n.get("type") == "core.control.end" and not n.get("outputs"):
             _fail(f"Subflow End node '{n['id']}' has no output mappings")
 
-    print(f"OK: Subflow '{sid}' structure valid ({len(sf_nodes)} nodes, {len(in_vars)} in, {len(out_vars)} out)")
+    print(
+        f"OK: Subflow '{sid}' structure valid ({len(sf_nodes)} nodes, {len(in_vars)} in, {len(out_vars)} out)"
+    )
 
 
 def main():

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
@@ -87,13 +87,17 @@ def _check_output_mappings(flow: dict, dr_node_id: str) -> None:
     """
     globals_ = (flow.get("variables") or {}).get("globals") or []
     for var_id in ("summary", "citations"):
-        if not any(v.get("id") == var_id and v.get("direction") == "out" for v in globals_):
+        if not any(
+            v.get("id") == var_id and v.get("direction") == "out" for v in globals_
+        ):
             _fail(
                 f"flow has no `out` variable with id={var_id!r}. The task prompt asks for "
                 f"`{var_id}` to be surfaced as a flow output."
             )
 
-    end_nodes = [n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"]
+    end_nodes = [
+        n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"
+    ]
     if not end_nodes:
         _fail("flow has no End node — required to terminate the path and map outputs")
 

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
@@ -24,10 +24,14 @@ def _check_parallel_branches(project_dir):
         flow = json.load(f)
 
     edges = flow.get("edges", [])
-    trigger_ids = {n["id"] for n in flow.get("nodes", []) if "trigger" in n.get("type", "")}
+    trigger_ids = {
+        n["id"] for n in flow.get("nodes", []) if "trigger" in n.get("type", "")
+    }
     outgoing = [e for e in edges if e.get("sourceNodeId") in trigger_ids]
     if len(outgoing) < 2:
-        sys.exit(f"FAIL: Expected 2+ edges from trigger for parallel branches, found {len(outgoing)}")
+        sys.exit(
+            f"FAIL: Expected 2+ edges from trigger for parallel branches, found {len(outgoing)}"
+        )
 
     print("OK: Parallel branches from trigger verified")
 
@@ -45,9 +49,13 @@ def main():
     terminated = [e for e in executions if e.get("status") == "Terminated"]
     if not terminated:
         statuses = [(e.get("elementId"), e.get("status")) for e in executions]
-        sys.exit(f"FAIL: No element was Terminated — terminate node didn't kill the delay branch. Statuses: {statuses}")
+        sys.exit(
+            f"FAIL: No element was Terminated — terminate node didn't kill the delay branch. Statuses: {statuses}"
+        )
 
-    print(f"OK: Terminate + Delay nodes present; {len(terminated)} element(s) terminated")
+    print(
+        f"OK: Terminate + Delay nodes present; {len(terminated)} element(s) terminated"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-platform/check_traces_e2e.py
+++ b/tests/tasks/uipath-platform/check_traces_e2e.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Assert spans.json (raw uip traces spans get output) has Data with >= 1 span."""
+
 import json
 import sys
 from pathlib import Path

--- a/tests/tasks/uipath-platform/integration-service/_shared/is_check.py
+++ b/tests/tasks/uipath-platform/integration-service/_shared/is_check.py
@@ -21,10 +21,10 @@ import json
 import re
 import sys
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _find(pattern: str) -> str:
     """Find a single file matching the glob pattern, or exit."""
@@ -52,8 +52,10 @@ def _assert_key(data: dict, key: str, label: str):
 
 def _assert_type(value, expected_type, label: str):
     if not isinstance(value, expected_type):
-        sys.exit(f"FAIL: {label} should be {expected_type.__name__}, "
-                 f"got {type(value).__name__}: {value!r}")
+        sys.exit(
+            f"FAIL: {label} should be {expected_type.__name__}, "
+            f"got {type(value).__name__}: {value!r}"
+        )
     return value
 
 
@@ -68,14 +70,14 @@ def _assert_commands(cmds: list, patterns: list[str], label: str) -> None:
     for pattern in patterns:
         if not re.search(pattern, joined, re.IGNORECASE):
             sys.exit(
-                f"FAIL: {label} — no command matching /{pattern}/ found in "
-                f"commands_used: {cmds}"
+                f"FAIL: {label} — no command matching /{pattern}/ found in commands_used: {cmds}"
             )
 
 
 # ---------------------------------------------------------------------------
 # Per-test checks
 # ---------------------------------------------------------------------------
+
 
 def check_connector_discovery() -> None:
     """Validate connector_discovery: correct search commands, HTTP fallback.
@@ -101,14 +103,19 @@ def check_connector_discovery() -> None:
 
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+connectors\s+list",   # used connectors list
-        r"--filter",                         # used --filter flag
-        r"--output\s+json",                  # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+connectors\s+list",  # used connectors list
+            r"--filter",  # used --filter flag
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: connector_discovery — {len(cmds)} commands logged, "
-          f"HTTP fallback documented")
+    print(
+        f"OK: connector_discovery — {len(cmds)} commands logged, HTTP fallback documented"
+    )
 
 
 def check_connection_lifecycle() -> None:
@@ -144,8 +151,7 @@ def check_connection_lifecycle() -> None:
     _assert_type(create_cmd, str, "report.create_command")
     if not re.search(r"uip\s+is\s+connections\s+create", create_cmd, re.IGNORECASE):
         sys.exit(
-            f"FAIL: create_command should contain 'uip is connections create' "
-            f"— got: {create_cmd!r}"
+            f"FAIL: create_command should contain 'uip is connections create' — got: {create_cmd!r}"
         )
 
     # Validate the agent documented the correct edit command syntax
@@ -154,21 +160,26 @@ def check_connection_lifecycle() -> None:
     _assert_type(edit_cmd, str, "report.edit_command")
     if not re.search(r"uip\s+is\s+connections\s+edit", edit_cmd, re.IGNORECASE):
         sys.exit(
-            f"FAIL: edit_command should contain 'uip is connections edit' "
-            f"— got: {edit_cmd!r}"
+            f"FAIL: edit_command should contain 'uip is connections edit' — got: {edit_cmd!r}"
         )
 
     # Validate commands_used — only list and ping were actually run
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+connections\s+list",   # listed connections
-        r"uip\s+is\s+connections\s+ping",    # pinged a connection
-        r"--output\s+json",                  # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+connections\s+list",  # listed connections
+            r"uip\s+is\s+connections\s+ping",  # pinged a connection
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: connection_lifecycle — {len(cmds)} commands executed, "
-          f"connections_found={found}, create/edit commands documented correctly")
+    print(
+        f"OK: connection_lifecycle — {len(cmds)} commands executed, "
+        f"connections_found={found}, create/edit commands documented correctly"
+    )
 
 
 def check_activity_discovery() -> None:
@@ -202,15 +213,21 @@ def check_activity_discovery() -> None:
 
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+activities\s+list",    # listed activities
-        r"--triggers",                        # used --triggers flag
-        r"--output\s+json",                  # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+activities\s+list",  # listed activities
+            r"--triggers",  # used --triggers flag
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: activity_discovery — {len(cmds)} commands logged, "
-          f"activity_count={act}, trigger_count={trig}, "
-          f"explanation={len(explanation)} chars")
+    print(
+        f"OK: activity_discovery — {len(cmds)} commands logged, "
+        f"activity_count={act}, trigger_count={trig}, "
+        f"explanation={len(explanation)} chars"
+    )
 
 
 def check_resource_describe() -> None:
@@ -240,15 +257,21 @@ def check_resource_describe() -> None:
 
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+resources\s+list",      # listed resources
-        r"uip\s+is\s+resources\s+describe",   # described resource
-        r"--operation",                        # used --operation flag
-        r"--output\s+json",                    # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+resources\s+list",  # listed resources
+            r"uip\s+is\s+resources\s+describe",  # described resource
+            r"--operation",  # used --operation flag
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: resource_describe — {len(cmds)} commands logged, "
-          f"{len(fields)} contact_fields, {len(req)} required_fields")
+    print(
+        f"OK: resource_describe — {len(cmds)} commands logged, "
+        f"{len(fields)} contact_fields, {len(req)} required_fields"
+    )
 
 
 def check_resource_execute() -> None:
@@ -276,15 +299,18 @@ def check_resource_execute() -> None:
 
     # Validate all 6 workflow actions are present
     expected_actions = [
-        "find_connector", "find_connection", "ping_connection",
-        "discover_resources", "describe_resource", "execute_create",
+        "find_connector",
+        "find_connection",
+        "ping_connection",
+        "discover_resources",
+        "describe_resource",
+        "execute_create",
     ]
     actual_actions = [s.get("action", "") for s in steps]
     for expected in expected_actions:
         if not any(expected in a for a in actual_actions):
             sys.exit(
-                f"FAIL: workflow_steps missing action '{expected}' "
-                f"— got {actual_actions}"
+                f"FAIL: workflow_steps missing action '{expected}' — got {actual_actions}"
             )
 
     # Validate workflow ordering: each action must appear after its predecessor
@@ -295,27 +321,36 @@ def check_resource_execute() -> None:
                 action_indices[ea] = i
     for j in range(1, len(expected_actions)):
         prev, curr = expected_actions[j - 1], expected_actions[j]
-        if prev in action_indices and curr in action_indices:
-            if action_indices[curr] < action_indices[prev]:
-                sys.exit(
-                    f"FAIL: workflow order wrong — '{curr}' (step {action_indices[curr]}) "
-                    f"appeared before '{prev}' (step {action_indices[prev]})"
-                )
+        if (
+            prev in action_indices
+            and curr in action_indices
+            and action_indices[curr] < action_indices[prev]
+        ):
+            sys.exit(
+                f"FAIL: workflow order wrong — '{curr}' (step {action_indices[curr]}) "
+                f"appeared before '{prev}' (step {action_indices[prev]})"
+            )
 
     # Validate commands_used
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
     if len(cmds) < 5:
         sys.exit(f"FAIL: commands_used has {len(cmds)} entries, expected >= 5")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+connectors\s+list",         # step 1
-        r"uip\s+is\s+connections\s+(list|ping)",   # step 2-3
-        r"uip\s+is\s+resources\s+execute",         # step 6
-        r"--output\s+json",                        # universal flag
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+connectors\s+list",  # step 1
+            r"uip\s+is\s+connections\s+(list|ping)",  # step 2-3
+            r"uip\s+is\s+resources\s+execute",  # step 6
+            r"--output\s+json",  # universal flag
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: resource_execute — {len(steps)} workflow steps in correct order, "
-          f"{len(cmds)} commands logged")
+    print(
+        f"OK: resource_execute — {len(steps)} workflow steps in correct order, "
+        f"{len(cmds)} commands logged"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tasks/uipath-solution-design/e2e_rpa_sdd/check_sdd.py
+++ b/tests/tasks/uipath-solution-design/e2e_rpa_sdd/check_sdd.py
@@ -67,11 +67,11 @@ def check_sections(content: str) -> list[str]:
     failures = []
     for section in REQUIRED_SECTIONS:
         pattern = (
-            rf"^#{{1,4}}\s+"                       # heading marker (h1-h4)
-            rf"\**\s*"                             # optional opening bold
-            rf"(?:§\s*)?"                          # optional § prefix
-            rf"(?:\d+(?:\.\d+)*\s*[.\):—–-]?\s+)?" # optional 1. / 1.1 / 1) / 1 — etc.
-            rf"\**\s*"                             # optional bold before the title
+            rf"^#{{1,4}}\s+"  # heading marker (h1-h4)
+            rf"\**\s*"  # optional opening bold
+            rf"(?:§\s*)?"  # optional § prefix
+            rf"(?:\d+(?:\.\d+)*\s*[.\):—–-]?\s+)?"  # optional 1. / 1.1 / 1) / 1 — etc.
+            rf"\**\s*"  # optional bold before the title
             rf"{re.escape(section)}"
         )
         if not re.search(pattern, content, re.MULTILINE | re.IGNORECASE):
@@ -121,7 +121,9 @@ def check_table_minimums(content: str) -> list[str]:
     """Verify key tables have enough rows."""
     failures = []
 
-    steps = count_table_rows(content, r"^#{1,3}\s+.*(?:Step Summary|Detailed Process Steps)")
+    steps = count_table_rows(
+        content, r"^#{1,3}\s+.*(?:Step Summary|Detailed Process Steps)"
+    )
     if steps < MIN_PROCESS_STEPS:
         failures.append(
             f"Process steps table has {steps} rows (minimum {MIN_PROCESS_STEPS})"
@@ -135,9 +137,7 @@ def check_table_minimums(content: str) -> list[str]:
 
     errors = count_table_rows(content, r"^#{1,3}\s+.*Error Handling")
     if errors < MIN_SYSTEM_ERRORS:
-        failures.append(
-            f"Error table has {errors} rows (minimum {MIN_SYSTEM_ERRORS})"
-        )
+        failures.append(f"Error table has {errors} rows (minimum {MIN_SYSTEM_ERRORS})")
 
     apps = count_table_rows(content, r"^#{1,3}\s+.*Application Inventory")
     if apps < MIN_APPLICATIONS:


### PR DESCRIPTION
## Summary
- rescue the approved Rookery task 897c0a7a from the deleted feature/maestro-bpmn-skill base
- add local test helper lint/format targets and make them self-contained via uvx ruff
- apply Ruff formatting across tests helper scripts and remove the remaining unused import

## Validation
- make -C tests check
- git diff --check HEAD~1..HEAD