### PR TITLE
fix(hitl-skill): align field formats, outputs block, and definition with workbench ground truth

### DIFF
--- a/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
@@ -282,31 +282,62 @@ Merge rules:
 {
   "id": "invoiceReview1",
   "type": "uipath.human-in-the-loop",
-  "typeVersion": "1.0.0",
+  "typeVersion": "1.0",
   "display": { "label": "Invoice Review" },
-  "ui": { "position": { "x": 474, "y": 144 } },
   "inputs": {
     "type": "custom",
-    "channels": [],
     "recipient": {
-      "channels": ["Email"],
-      "assignee": { "type": "user", "value": "reviewer@company.com" }
+      "channels": ["ActionCenter"],
+      "connections": {},
+      "assignee": { "type": "group" }
     },
     "app": {
+      "displayName": "Invoice Approval",
       "name": "Invoice Approval",
       "key": "c0ba97df-8a30-4fe0-b4b4-4611a631d77b",
       "folderPath": "Shared",
-      "inputSchema": [],
-      "inOutSchema": [],
-      "appSystemName": "invoice-approval",
-      "appVersionRef": { "key": "<APP_VERSION_REF.key>", "name": "Invoice Approval" }
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "AI Agent Decision": { "type": "string" },
+          "Invoice Amount":    { "type": "integer" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "Human Agent Decision": { "type": "string" }
+        }
+      }
+    },
+    "appInputBindings": {
+      "AI Agent Decision": "=vars.<nodeId>.output.<field>",
+      "Invoice Amount":    "=metadata.InstanceId"
     },
     "schema": {
       "fields": [],
       "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }]
     }
   },
-  "model": { "type": "bpmn:UserTask", "serviceType": "Actions.HITL" }
+  "outputs": {
+    "output": {
+      "type": "object",
+      "description": "Task result data",
+      "source": "=result",
+      "var": "output",
+      "properties": {
+        "Action": { "type": "string", "enum": ["Submit"], "default": "Submit" }
+      }
+    },
+    "status": {
+      "type": "string",
+      "description": "Task completion status",
+      "source": "=result.Action",
+      "var": "status",
+      "enum": ["Submit"],
+      "default": "Submit"
+    }
+  }
 }
 ```
 
@@ -314,13 +345,25 @@ Merge rules:
 
 | Field | Source | Example |
 |---|---|---|
+| `displayName` | `selectedApp.name` from search | `"Invoice Approval"` |
 | `name` | `selectedApp.name` from search | `"Invoice Approval"` |
 | `key` | `selectedApp.key` from search | `"c0ba97df-8a30-4fe0-b4b4-4611a631d77b"` |
 | `folderPath` | `selectedApp.folder.fullyQualifiedName` from search | `"Shared"` |
-| `inputSchema` | `config.inputSchema` from retrieve-configuration | `[]` |
-| `inOutSchema` | `config.inOutSchema` from retrieve-configuration | `[]` |
-| `appSystemName` | `config.appSystemName` from retrieve-configuration | `"invoice-approval"` |
-| `appVersionRef` | `config.appVersionRef` from retrieve-configuration | `{ "key": "...", "name": "Invoice Approval" }` |
+| `inputSchema` | JSON Schema object built from `config.actionSchema.inputs` — `{ "type": "object", "properties": { "<param>": { "type": "string" }, ... } }` | See note |
+| `outputSchema` | JSON Schema object built from `config.actionSchema.outputs` — `{ "type": "object", "properties": { "<param>": { "type": "string" }, ... } }` | See note |
+
+> `inputSchema` and `outputSchema` are JSON Schema objects (`{ "type": "object", "properties": { ... } }`), **not arrays**. Parse `spec.actionSchema` (a JSON string) from the retrieve-configuration response and extract `inputs`/`outputs` to build the property maps.
+
+### `inputs.appInputBindings` format
+
+Maps app parameter names to binding expressions. Format: `"=vars.<path>"` (with `=` prefix, no `js:`):
+
+```json
+"appInputBindings": {
+  "AI Agent Decision": "=vars.<nodeId>.output.<field>",
+  "Invoice Amount":    "=metadata.InstanceId"
+}
+```
 
 ### `inputs.recipient` options
 

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -58,14 +58,14 @@ Also read `workflow.variables.globals`. Each entry has an `id` that maps directl
 { "id": "customerName", "direction": "in", "type": "string" }
 ```
 
-→ binding: `"=js:$vars.customerName"`
+→ HITL binding: `"vars.customerName"` (no `=js:$` prefix — HITL binding is a raw path)
 
-**When to use globals instead of node outputs:** When data was declared as a flow-level input variable (e.g. the trigger passes it as a named parameter via `triggerNodeId`), it lives in `globals` with `direction: "in"`. Bind directly to `=js:$vars.<globalId>` — do not add `.output` or a node prefix.
+**When to use globals instead of node outputs:** When data was declared as a flow-level input variable (e.g. the trigger passes it as a named parameter via `triggerNodeId`), it lives in `globals` with `direction: "in"`. Bind directly to `vars.<globalId>` — do not add `.output` or a node prefix.
 
-| Source | Access pattern |
-|---|---|
-| Node output | `=js:$vars.<nodeId>.output.<field>` |
-| Flow global (`direction: "in"`) | `=js:$vars.<globalId>` |
+| Source | HITL `binding` format | Expression format (other nodes) |
+|---|---|---|
+| Node output | `vars.<nodeId>.output.<field>` | `=js:$vars.<nodeId>.output.<field>` |
+| Flow global (`direction: "in"`) | `vars.<globalId>` | `=js:$vars.<globalId>` |
 
 For the full variable system, see → [uipath-maestro-flow — variables-and-expressions.md](../../../../uipath-maestro-flow/references/shared/variables-and-expressions.md)
 
@@ -111,30 +111,28 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
     },
     "priority": "Low",
     "schema": {
-      "id": "a3f7c2d1-8b4e-4f9a-b2c5-6d8e1f3a7b9c",
+      "schemaId": "a3f7c2d1-8b4e-4f9a-b2c5-6d8e1f3a7b9c",
       "fields": [
         {
           "id": "invoiceid",
           "label": "Invoice ID",
           "type": "text",
           "direction": "input",
-          "binding": "=js:$vars.fetchInvoice.output.invoiceId",
-          "variable": "=js:$vars.fetchInvoice.output.invoiceId"
+          "binding": "vars.fetchInvoice.output.invoiceId"
         },
         {
           "id": "amount",
           "label": "Amount",
           "type": "number",
           "direction": "input",
-          "binding": "=js:$vars.fetchInvoice.output.amount",
-          "variable": "=js:$vars.fetchInvoice.output.amount"
+          "binding": "vars.fetchInvoice.output.amount"
         },
         {
           "id": "notes",
           "label": "Notes",
           "type": "text",
           "direction": "output",
-          "variable": "notes",
+          "variable": "vars.notes",
           "required": false
         },
         {
@@ -142,21 +140,36 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
           "label": "Decision",
           "type": "text",
           "direction": "output",
-          "variable": "decision",
+          "variable": "vars.decision",
           "required": true
         }
       ],
       "outcomes": [
-        { "id": "approve", "name": "Approve", "isPrimary": true,  "outcomeType": "Positive" },
-        { "id": "reject",  "name": "Reject",  "isPrimary": false, "outcomeType": "Negative" }
+        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "action": "Continue" },
+        { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "action": "End" }
       ]
     }
   },
   "outputs": {
-    "output":   { "type": "object", "source": "=result",        "var": "output" },
-    "status":   { "type": "string", "source": "=result.Action", "var": "status" },
-    "notes":    { "type": "string", "source": "=result.notes",    "var": "notes",    "custom": true },
-    "decision": { "type": "string", "source": "=result.decision", "var": "decision", "custom": true }
+    "output": {
+      "type": "object",
+      "description": "Task result data",
+      "source": "=result",
+      "var": "output",
+      "properties": {
+        "notes":    { "type": "string" },
+        "decision": { "type": "string" },
+        "Action":   { "type": "string", "enum": ["Approve", "Reject"], "default": "Approve" }
+      }
+    },
+    "status": {
+      "type": "string",
+      "description": "Task completion status",
+      "source": "=result.Action",
+      "var": "status",
+      "enum": ["Approve", "Reject"],
+      "default": "Approve"
+    }
   }
 }
 ```
@@ -203,20 +216,18 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop`
       "visible": true
     }
   ],
-  "model": { "type": "bpmn:UserTask" },
-  "inputDefinition": {
+  "model": { "type": "bpmn:UserTask", "serviceType": "Actions.HITL" },
+  "inputDefaults": {
     "type": "quick",
     "schema": {
       "fields": [],
-      "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "outcomeType": "Positive" }]
+      "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }]
     },
     "recipient": {
       "channels": ["Email", "ActionCenter"],
       "connections": {},
       "assignee": { "type": "group" }
-    },
-    "timeout": "PT24H",
-    "priority": "Normal"
+    }
   },
   "outputDefinition": {
     "output": { "type": "object", "description": "Task result data", "source": "=result", "var": "output" },
@@ -249,30 +260,22 @@ The HITL node exposes two outputs (`output`, `status`). After adding it, **compl
     {
       "id": "invoiceReview1.output",
       "type": "object",
+      "description": "Task result data",
       "binding": { "nodeId": "invoiceReview1", "outputId": "output" }
     },
     {
       "id": "invoiceReview1.status",
       "type": "string",
+      "description": "Task completion status",
       "binding": { "nodeId": "invoiceReview1", "outputId": "status" }
-    },
-    {
-      "id": "invoiceReview1.notes",
-      "type": "string",
-      "binding": { "nodeId": "invoiceReview1", "outputId": "notes" }
-    },
-    {
-      "id": "invoiceReview1.decision",
-      "type": "string",
-      "binding": { "nodeId": "invoiceReview1", "outputId": "decision" }
     }
   ]
 }
 ```
 
-Include entries for **all** nodes in the flow, not just the HITL node. Replace the entire array — do not append.
+Include entries for **all** nodes in the flow, not just the HITL node. Replace the entire array — do not append. Add one `output` entry and one `status` entry per HITL node — no per-field entries. Output and inOut field values from the task are accessible via `$vars.<nodeId>.output.<fieldId>` at runtime (fields are embedded in the output object, not exposed as separate node variables).
 
-**Per-field outputs:** When the schema has `output` or `inOut` direction fields, add one entry per field using the output key name from `node.outputs` (the `variable` property value, or the camelCase-derived name when `variable` is omitted). These are also materialized as flow-level globals in `variables.globals` with `direction: "out"`.
+Output-direction and inOut-direction fields are also materialized as workflow-level globals in `variables.globals` with `direction: "inout"` — these are accessible directly as `$vars.<globalId>` without a node prefix.
 
 ---
 
@@ -287,13 +290,12 @@ The agent translates the user's business description into the `fields[]` and `ou
 | field `id` | lowercase label, spaces→`-`, strip non-alphanumeric. `"Invoice ID"` → `"invoiceid"`, `"Due Date"` → `"due-date"` |
 | `direction` | `inputs[]` items → `"input"`, `outputs[]` → `"output"`, `inOuts[]` → `"inOut"` |
 | field `type` | `"string"` → `"text"`, `"number"` → `"number"`, `"boolean"` → `"boolean"`, `"date"` → `"date"` |
-| `binding` | Read `variables.nodes` for node outputs → `"=js:$vars.<nodeId>.<outputId>.<field>"`. Read `variables.globals` for flow-level inputs → `"=js:$vars.<globalId>"`. Always read both before constructing bindings — never assume source |
-| `variable` (input/inOut direction) | Set to the **same expression as `binding`**. The BPMN engine reads `variable` to build `HitlTaskArguments` and pre-populate the form at task-creation time. `binding` alone is only stored for workbench display — the runtime does not read it. Without `variable`, input fields appear blank in Action Center and inline debug. |
-| `variable` (output direction) | Short camelCase name for the output variable — defaults to `id` if not specified |
+| `binding` | **Input / inOut fields only.** Format: `"vars.<nodeId>.output.<field>"` for node outputs; `"vars.<globalId>"` for flow globals. **No `=js:$` prefix** — HITL binding is a raw path, not an expression. |
+| `variable` | **Output / inOut fields only** — absent on input fields. Format: `"vars.<name>"` (with `vars.` prefix). Defaults to `"vars.<camelCaseId>"` if not specified. |
 | `required` | omit if false; set `true` for mandatory outputs |
-| `outcomes[0]` | `isPrimary: true`, `outcomeType: "Positive"` |
-| `outcomes[1+]` | `isPrimary: false`, `outcomeType: "Negative"` (use `"Neutral"` for middle outcomes like Skip/Defer) |
-| `schema.id` | Generate a fresh UUID (e.g. `crypto.randomUUID()` or any UUID v4) |
+| `outcomes[0]` | `isPrimary: true`, `action: "Continue"` |
+| `outcomes[1+]` | `isPrimary: false`, `action: "End"` |
+| `schema.schemaId` | Generate a fresh UUID (e.g. `crypto.randomUUID()` or any UUID v4) |
 
 ### Example 1 — Simple approval (inputs only + outcomes)
 
@@ -301,12 +303,12 @@ Business description: *"Reviewer sees invoice ID and amount, clicks Approve or R
 
 ```json
 "fields": [
-  { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "=js:$vars.fetchData1.output.invoiceId", "variable": "=js:$vars.fetchData1.output.invoiceId" },
-  { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "=js:$vars.fetchData1.output.amount",    "variable": "=js:$vars.fetchData1.output.amount" }
+  { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "vars.fetchData1.output.invoiceId" },
+  { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "vars.fetchData1.output.amount" }
 ],
 "outcomes": [
-  { "id": "approve", "name": "Approve", "isPrimary": true,  "outcomeType": "Positive" },
-  { "id": "reject",  "name": "Reject",  "isPrimary": false, "outcomeType": "Negative" }
+  { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "action": "Continue" },
+  { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "action": "End" }
 ]
 ```
 
@@ -316,12 +318,12 @@ Business description: *"Human sees the AI-drafted email, can edit it, then click
 
 ```json
 "fields": [
-  { "id": "recipient",  "label": "Recipient",  "type": "text", "direction": "input", "binding": "=js:$vars.draft1.output.recipient", "variable": "=js:$vars.draft1.output.recipient" },
-  { "id": "emailbody",  "label": "Email Body", "type": "text", "direction": "inOut", "binding": "=js:$vars.draft1.output.body", "variable": "emailBody" }
+  { "id": "recipient",  "label": "Recipient",  "type": "text", "direction": "input", "binding": "vars.draft1.output.recipient" },
+  { "id": "emailbody",  "label": "Email Body", "type": "text", "direction": "inOut", "binding": "vars.draft1.output.body", "variable": "vars.emailBody" }
 ],
 "outcomes": [
-  { "id": "send",    "name": "Send",    "isPrimary": true,  "outcomeType": "Positive" },
-  { "id": "discard", "name": "Discard", "isPrimary": false, "outcomeType": "Negative" }
+  { "id": "send",    "name": "Send",    "type": "string", "isPrimary": true,  "action": "Continue" },
+  { "id": "discard", "name": "Discard", "type": "string", "isPrimary": false, "action": "End" }
 ]
 ```
 
@@ -331,12 +333,12 @@ Business description: *"Agent couldn't extract vendor name or cost center. Human
 
 ```json
 "fields": [
-  { "id": "rawextract",  "label": "Raw Extract",  "type": "text", "direction": "input",  "binding": "=js:$vars.extract1.output.rawText", "variable": "=js:$vars.extract1.output.rawText" },
-  { "id": "vendorname",  "label": "Vendor Name",  "type": "text", "direction": "output", "variable": "vendorName",  "required": true },
-  { "id": "costcenter",  "label": "Cost Center",  "type": "text", "direction": "output", "variable": "costCenter", "required": true }
+  { "id": "rawextract",  "label": "Raw Extract",  "type": "text", "direction": "input",  "binding": "vars.extract1.output.rawText" },
+  { "id": "vendorname",  "label": "Vendor Name",  "type": "text", "direction": "output", "variable": "vars.vendorName",  "required": true },
+  { "id": "costcenter",  "label": "Cost Center",  "type": "text", "direction": "output", "variable": "vars.costCenter", "required": true }
 ],
 "outcomes": [
-  { "id": "submit", "name": "Submit", "isPrimary": true, "outcomeType": "Positive" }
+  { "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }
 ]
 ```
 
@@ -346,14 +348,14 @@ Business description: *"If agent confidence is low, escalate. Human sees reasoni
 
 ```json
 "fields": [
-  { "id": "reasoning",       "label": "Agent Reasoning",  "type": "text",   "direction": "input",  "binding": "=js:$vars.classify1.output.reasoning", "variable": "=js:$vars.classify1.output.reasoning" },
-  { "id": "confidencescore", "label": "Confidence Score", "type": "number", "direction": "input",  "binding": "=js:$vars.classify1.output.score",     "variable": "=js:$vars.classify1.output.score" },
-  { "id": "notes",           "label": "Notes",            "type": "text",   "direction": "output", "variable": "notes" }
+  { "id": "reasoning",       "label": "Agent Reasoning",  "type": "text",   "direction": "input",  "binding": "vars.classify1.output.reasoning" },
+  { "id": "confidencescore", "label": "Confidence Score", "type": "number", "direction": "input",  "binding": "vars.classify1.output.score" },
+  { "id": "notes",           "label": "Notes",            "type": "text",   "direction": "output", "variable": "vars.notes" }
 ],
 "outcomes": [
-  { "id": "retry",    "name": "Retry",    "isPrimary": true,  "outcomeType": "Positive" },
-  { "id": "skip",     "name": "Skip",     "isPrimary": false, "outcomeType": "Neutral"  },
-  { "id": "escalate", "name": "Escalate", "isPrimary": false, "outcomeType": "Negative" }
+  { "id": "retry",    "name": "Retry",    "type": "string", "isPrimary": true,  "action": "Continue" },
+  { "id": "skip",     "name": "Skip",     "type": "string", "isPrimary": false, "action": "End" },
+  { "id": "escalate", "name": "Escalate", "type": "string", "isPrimary": false, "action": "End" }
 ]
 ```
 
@@ -367,13 +369,12 @@ After the HITL node, downstream nodes can reference:
 
 | Variable | Type | What it contains |
 |---|---|---|
-| `$vars.<nodeId>.output` | object | All `output` and `inOut` fields the human filled in, keyed by **field `id`** |
-| `$vars.<nodeId>.output.<fieldId>` | varies | Individual field value using the field's `id` property (e.g. `$vars.invoiceReview1.output.decision`) |
-| `$vars.<nodeId>.status` | string | Selected outcome id (e.g. `"approve"`, `"reject"`) |
-| `$vars.<nodeId>.<variable>` | varies | Per-field output also exposed as a named node variable (key matches `field.variable` or the derived camelCase name) |
-| `$vars.<variable>` | varies | Workflow-global variable (`custom: true` in `outputs`). Accessible without the node prefix in downstream expressions |
+| `$vars.<nodeId>.output` | object | All `output` and `inOut` field values keyed by **field `id`** |
+| `$vars.<nodeId>.output.<fieldId>` | varies | Individual field value using the field's `id` (e.g. `$vars.invoiceReview1.output.decision`) |
+| `$vars.<nodeId>.status` | string | Selected outcome name (e.g. `"Approve"`, `"Reject"`) |
+| `$vars.<globalId>` | varies | Workflow-global variable for output/inOut fields — accessible without node prefix. The `globalId` is derived from `field.variable` (strip `vars.` prefix) |
 
-> **`fieldId` not `variable`**: The output object properties are keyed by the field's `id` (e.g. `"decision"`), not by the `variable` property. The `variable` property creates a separate workflow-global variable (`$vars.{variable}`) — it does not change the key used in the output object. If a field has `"id": "dec1"` and `"variable": "approvalResult"`, access it as `$vars.nodeId.output.dec1`, not `.approvalResult`.
+> **`fieldId` not `variable`**: The output object properties are keyed by the field's `id` (e.g. `"decision"`), not by the `variable` property. The `variable` property (`"vars.approvalResult"`) creates a separate workflow-global variable (`$vars.approvalResult`) — it does not change the key used in the output object. If a field has `"id": "dec1"` and `"variable": "vars.approvalResult"`, access it via the object as `$vars.nodeId.output.dec1`, or directly as `$vars.approvalResult`.
 
 **In a downstream script node:**
 ```javascript


### PR DESCRIPTION
## Summary

Ground truth source: workbench-generated `.flow` file (`new (15).flow`) — verified against `applyHitlExtension` in `@uipath/flow-converter`.

**`hitl-node-quickform.md`:**
- `typeVersion`: `"1.0"` (not `"1.0.0"`)
- `schemaId` key (not `id`) at schema level
- Input fields: `binding: "vars.<path>"` only — no `variable` property (workbench does not set variable on input-direction fields)
- Output/inOut fields: `variable: "vars.<name>"` (with `vars.` prefix, not plain name)
- `outputs` block: no `custom:true` per-field entries; `output.properties` contains fieldId→type entries + `Action` outcome; `status` has `enum`+`default` from outcomes
- `variables.nodes`: only `output`+`status` entries — no per-field entries
- `variables.globals` direction: `"inout"` (not `"out"`)
- Definition: `inputDefaults` (not `inputDefinition`), `serviceType` in model, outcomes use `action:Continue/End` (not `outcomeType`)
- Step 1b binding table: HITL `binding` format vs expression format clarified

**`hitl-node-apptask.md`:**
- `inputSchema`/`outputSchema`: JSON Schema objects `{type:object, properties:{…}}` — not arrays
- `appInputBindings` format: `"=vars.<path>"` (= prefix, no `js:`)
- `displayName` added to `inputs.app` object
- `outputs` block added with `output`+`status` (properties/enum/default)
- `typeVersion: "1.0"`, no `model` on node instance

## Test plan
- [ ] Run `uip maestro flow hitl add` on a flow and confirm output matches the reference JSON in this doc
- [ ] Confirm Action Center renders pre-populated fields correctly using `vars.*` binding format
- [ ] Confirm output variables are created with `direction: "inout"` in the flow globals

🤖 Generated with [Claude Code](https://claude.com/claude-code)