### PR TITLE
fix(maestro-flow/hitl): align Quick Reference JSON with workbench ground truth

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -30,146 +30,155 @@ For add, delete, and wiring procedures, see [editing-operations.md](../../editin
   "inputs": {
     "type": "quick",
     "schema": {
+      "schemaId": "<uuid>",
       "fields": [
-        { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "=js:$vars.fetchInvoice.output.invoiceId", "variable": "=js:$vars.fetchInvoice.output.invoiceId" },
-        { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "=js:$vars.fetchInvoice.output.amount",    "variable": "=js:$vars.fetchInvoice.output.amount" }
+        { "id": "invoiceid", "label": "Invoice ID", "type": "text",   "direction": "input", "binding": "vars.fetchInvoice.output.invoiceId" },
+        { "id": "amount",    "label": "Amount",     "type": "number", "direction": "input", "binding": "vars.fetchInvoice.output.amount" },
+        { "id": "decision",  "label": "Decision",   "type": "text",   "direction": "output", "variable": "vars.decision" }
       ],
       "outcomes": [
-        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "outcomeType": "Positive" },
-        { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "outcomeType": "Negative" }
+        { "id": "approve", "name": "Approve", "type": "string", "isPrimary": true,  "action": "Continue" },
+        { "id": "reject",  "name": "Reject",  "type": "string", "isPrimary": false, "action": "End" }
       ]
     },
     "recipient": { "channels": ["Email", "ActionCenter"], "connections": {}, "assignee": { "type": "group" } },
     "priority": "Low"
   },
   "outputs": {
-    "output": { "type": "object", "source": "=result",        "var": "output" },
-    "status": { "type": "string", "source": "=result.Action", "var": "status" },
-    "<variable>": { "type": "string", "source": "=result.<fieldId>", "var": "<variable>", "custom": true }
-  }
-}
-```
-
-`custom: true` on per-field outputs marks them as workflow-global variables (accessible as `$vars.<variable>`, not prefixed by nodeId). Add one entry per `output` / `inOut` direction field. Omit the `<variable>` entry when the schema has no `output` or `inOut` fields.
-
-**Input fields require both `binding` and `variable`** — `binding` stores the expression for the workbench display; `variable` is what the BPMN engine evaluates to pre-populate the form at task-creation time (`HitlTaskArguments`). Without `variable`, input fields appear blank in Action Center and inline debug. Both must point to the same `=js:$vars.…` expression.
-
-BPMN type (`bpmn:UserTask`) and serviceType (`Actions.HITL`) come from the `uipath.human-in-the-loop` entry in `definitions[]` — the instance carries no `model` block.
-
-**Ports:** `input` (target) → `completed` (source)
-
-**Output variables:**
-- `$vars.{nodeId}.output` — object with all `output` / `inOut` fields the human filled in
-- `$vars.{nodeId}.output.{fieldName}` — individual field value
-- `$vars.{nodeId}.status` — selected outcome id (e.g. `"approve"`, `"reject"`)
-- `$vars.{variable}` — per-field workflow-global variable (`custom: true`); one per `output` / `inOut` field
-
----
-
-## Option 2 — `uipath.core.human-task.{key}` (App-Based)
-
-Use when there is an existing deployed Action Center app that should serve as the task form.
-
-### Discovery
-
-**Published (tenant registry):**
-
-```bash
-uip maestro flow registry pull --force
-uip maestro flow registry search "uipath.core.human-task" --output json
-```
-
-**In-solution (local, no login required):**
-
-```bash
-uip maestro flow registry list --local --output json
-uip maestro flow registry get "<nodeType>" --local --output json
-```
-
-Run from inside the flow project directory. Discovers sibling projects in the same `.uipx` solution.
-
-### Registry Validation
-
-```bash
-# Published (tenant registry)
-uip maestro flow registry get "uipath.core.human-task.{key}" --output json
-
-# In-solution (local, no login required)
-uip maestro flow registry get "uipath.core.human-task.{key}" --local --output json
-```
-
-Confirm:
-
-- Input port: `input`
-- Output port: `output`
-- `model.serviceType` — `Actions.HITL`
-- `model.bindings.resourceSubType` — the app type
-- `model.bindings.resourceKey` — the `<FolderPath>.<AppName>` string used to scope binding resolution
-
-### Node JSON
-
-For step-by-step add, delete, and wiring procedures, see [editing-operations.md](../../editing-operations.md). Use the JSON structure below for the node-specific `inputs`.
-
-The human task node's output (`$vars.{nodeId}.output`) contains the form data submitted by the user.
-
-**Node instance (inside `nodes[]`):**
-
-The instance carries only per-instance data (`inputs`, `outputs`, `display`). BPMN type, serviceType, version, and binding/context templates come from the definition in `definitions[]`.
-
-```json
-{
-  "id": "reviewExtraction",
-  "type": "uipath.core.human-task.abc123",
-  "typeVersion": "<DEFINITION_VERSION>",
-  "display": { "label": "Review Extraction" },
-  "inputs": {},
-  "outputs": {
     "output": {
       "type": "object",
-      "source": "=result.response",
-      "var": "output"
+      "description": "Task result data",
+      "source": "=result",
+      "var": "output",
+      "properties": {
+        "decision": { "type": "string" },
+        "Action":   { "type": "string", "enum": ["Approve", "Reject"], "default": "Approve" }
+      }
     },
-    "error": {
-      "type": "object",
-      "source": "=result.Error",
-      "var": "error"
+    "status": {
+      "type": "string",
+      "description": "Task completion status",
+      "source": "=result.Action",
+      "var": "status",
+      "enum": ["Approve", "Reject"],
+      "default": "Approve"
     }
   }
 }
 ```
 
-> `resourceKey` takes the form `<FolderPath>.<AppName>` and `resourceSubType` is the app type — confirm both from `uip maestro flow registry get` output. Both values come from the definition's `model.bindings`, never from the node instance.
+**Field format rules:**
+- **Input fields**: `binding: "vars.<nodeId>.output.<field>"` (raw path, no `=js:$` prefix). No `variable` property on input fields.
+- **Output fields**: `variable: "vars.<globalName>"` (with `vars.` prefix). No `binding`.
+- **InOut fields**: both `binding` and `variable`, same formats as above.
+- `schemaId` (not `id`) at the schema level — generate a fresh UUID.
+- `typeVersion: "1.0"` (not `"1.0.0"`).
+- No `model` block on node instances — only the definition carries it.
 
-**Top-level `bindings[]` entries (sibling of `nodes`/`edges`/`definitions`):**
+**outputs block**: only `output` (with `properties` for output/inOut fields + `Action` outcome) and `status` (with `enum`/`default` from outcomes). No per-field `custom: true` entries.
 
-Add one entry per `(resourceKey, propertyAttribute)` pair. Share entries across node instances that reference the same app — do NOT create duplicates.
+**Ports:** `input` (target) → `completed` (source)
 
-```json
-"bindings": [
-  {
-    "id": "bReviewExtractionName",
-    "name": "name",
-    "type": "string",
-    "resource": "process",
-    "resourceKey": "Shared.Review Form App",
-    "default": "Review Form App",
-    "propertyAttribute": "name",
-    "resourceSubType": "<appType>"
-  },
-  {
-    "id": "bReviewExtractionFolderPath",
-    "name": "folderPath",
-    "type": "string",
-    "resource": "process",
-    "resourceKey": "Shared.Review Form App",
-    "default": "Shared",
-    "propertyAttribute": "folderPath",
-    "resourceSubType": "<appType>"
-  }
-]
+**Output variables:**
+- `$vars.{nodeId}.output` — object with all `output` / `inOut` field values, keyed by **field `id`**
+- `$vars.{nodeId}.output.{fieldId}` — individual field value (e.g. `$vars.hitlReview1.output.decision`)
+- `$vars.{nodeId}.status` — selected outcome name (e.g. `"Approve"`, `"Reject"`)
+- `$vars.{globalId}` — workflow-global variable for output/inOut fields; `globalId` is derived from `field.variable` (strip `vars.` prefix)
+
+---
+
+## Option 2 — App-Based HITL (`uipath.human-in-the-loop` with `inputs.type = "custom"`)
+
+Use when there is an existing deployed Action Center app that should serve as the task form. Same node type as Option 1 — only `inputs.type`, `inputs.app`, and `inputs.appInputBindings` differ.
+
+### Discovery
+
+**CLI (primary path):**
+
+```bash
+uip solution resource list --kind App --output json
 ```
 
-> For the resolution mechanics and why these entries are required, see [file-format.md — Bindings](../../../../shared/file-format.md#bindings--orchestrator-resource-bindings-top-level-bindings).
+Returns all Action Center app types (`vB Action`, `workflow Action`, `Coded Action`, `JS Action`). Filter by app name. Then retrieve the configuration:
+
+```bash
+uip solution resource get <key> --output json
+```
+
+**Direct API fallback (if CLI unavailable):**
+
+```
+GET {BASE_URL}/{ORG}/studio_/backend/api/resourcebuilder/solutions/{SOLUTION_ID}/resources/search
+  ?kind=app&pageSize=25&projectKey={PROJECT_KEY}&includeSolutionResources=true
+  &types=VB%20Action&types=Workflow%20Action&types=Coded%20Action&types=CodedAction&types=JS%20Action
+```
+
+Full step-by-step (app search → retrieve-configuration → resource files → reference registration → debug overwrites) → **[hitl-node-apptask.md](../../../../../../uipath-human-in-the-loop/references/hitl-node-apptask.md)**
+
+### Node JSON (Quick Reference)
+
+```json
+{
+  "id": "invoiceReview1",
+  "type": "uipath.human-in-the-loop",
+  "typeVersion": "1.0",
+  "display": { "label": "Invoice Review" },
+  "inputs": {
+    "type": "custom",
+    "recipient": { "channels": ["ActionCenter"], "connections": {}, "assignee": { "type": "group" } },
+    "app": {
+      "displayName": "Invoice Approval",
+      "name": "Invoice Approval",
+      "key": "<app.key>",
+      "folderPath": "Shared",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "<paramName>": { "type": "string" }
+        }
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "<outputName>": { "type": "string" }
+        }
+      }
+    },
+    "appInputBindings": {
+      "<inputParamName>": "=vars.<nodeId>.output.<field>",
+      "<inputParamName2>": "=metadata.InstanceId"
+    },
+    "schema": {
+      "fields": [],
+      "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }]
+    },
+    "priority": "Medium"
+  },
+  "outputs": {
+    "output": {
+      "type": "object",
+      "description": "Task result data",
+      "source": "=result",
+      "var": "output",
+      "properties": {
+        "Action": { "type": "string", "enum": ["Submit"], "default": "Submit" }
+      }
+    },
+    "status": {
+      "type": "string",
+      "description": "Task completion status",
+      "source": "=result.Action",
+      "var": "status",
+      "enum": ["Submit"],
+      "default": "Submit"
+    }
+  }
+}
+```
+
+**`inputs.app`**: `inputSchema` and `outputSchema` are JSON Schema objects (`{ "type": "object", "properties": { ... } }`), **not arrays**.
+
+**`inputs.appInputBindings`** — maps app input parameter names to binding expressions. Format: `"=vars.<path>"` (with `=` prefix, no `js:`). Key = parameter name from `inputSchema.properties`. Without this, all input fields appear blank.
 
 ### If the app does not exist yet
 


### PR DESCRIPTION
## Summary

- **QuickForm**: typeVersion `1.0`, `schemaId` key, input fields no `variable`, output fields `variable: "vars.<name>"`, outcomes use `action:Continue/End` (not `outcomeType`), outputs block has `properties`+`enum`+`default` (no `custom:true` entries), no `model` on node instances
- **AppTask**: `inputSchema`/`outputSchema` are JSON Schema objects (`{type:object, properties:{…}}`), not arrays; `appInputBindings` format is `"=vars.<path>"` (not `"=js:\$vars.*"`); outputs block added with `properties`/`enum`/`default`
- All formats verified against the workbench-generated ground truth file

## Test plan
- [ ] Generate a flow with a HITL QuickForm node using `uip maestro flow hitl add` and confirm the CLI output matches the reference JSON in this doc
- [ ] Generate a flow with an AppTask HITL node and confirm `appInputBindings` pre-populate correctly in Action Center

🤖 Generated with [Claude Code](https://claude.com/claude-code)