### PR TITLE
fix: maestro CLI commands to use bpmn/flow/case subcommands for diagnostic agent

### DIFF
--- a/skills/uipath-diagnostics/references/products/maestro/investigation_guide.md
+++ b/skills/uipath-diagnostics/references/products/maestro/investigation_guide.md
@@ -37,15 +37,16 @@ Quick routing by range:
 
 After the Orchestrator job data bundle (job details, logs, history) is collected:
 
-1. **Determine runtime type** — check the job's `RuntimeType` or `Source` field. If it's a ProcessOrchestration job (Maestro BPMN), gather Maestro-specific data below. Standard Orchestrator jobs don't need these steps.
-2. **Resolve the Maestro instance ID** — for ProcessOrchestration jobs, the **Orchestrator job key IS the Maestro instance ID**. They are the same GUID. Do NOT use `ParentJobKey` — that is the parent Orchestrator job, not the Maestro instance.
-   - **User provided a job key and `RuntimeType` is `ProcessOrchestration`**: the job key is the instance ID. Go directly to `uip maestro instance get <job-key> -f <folder-key>`.
-   - **User provided a job key and `RuntimeType` is NOT `ProcessOrchestration`** (standard child job): the child job was spawned by a Maestro service task. Check `ParentJobKey` — that parent job's key may be the instance ID. Try `uip maestro instance get <parent-job-key> -f <folder-key>`.
-   - **Neither works**: search with `uip maestro incident summary --output json` to find the `processKey`, then `uip maestro processes incidents <process-key> --folder-key <folder-key>` to find incident records containing the `instanceId`.
-   - **`instances list` may return empty** for completed or faulted instances. Always try `instances get` directly before concluding an instance doesn't exist. Do NOT rely on `instances list` alone.
-3. **Full incident details** — `uip maestro instance incidents <instance-id> -f <folder-key>`. This returns `errorDetails` with stack traces. Do NOT use `uip maestro incident summary` — that returns summaries only without error details.
-4. **Element executions** — `uip maestro instance element-executions <instance-id> -f <folder-key>` to see what each BPMN element did and where execution stopped
-5. **Child jobs** — if the BPMN process has service tasks, list child jobs and check their state and error messages. The child's failure reason is often the actual root cause.
+1. **Determine runtime type** — check the job's `RuntimeType` or `Source` field. If it's a ProcessOrchestration job (Maestro), gather Maestro-specific data below. Standard Orchestrator jobs don't need these steps.
+2. **Determine the Maestro process type** — `bpmn`, `flow`, or `case`. Every Maestro CLI invocation requires this segment (`uip maestro bpmn ...`, `uip maestro flow ...`, `uip maestro case ...`). Identify the type from the source artifact (`.bpmn`, `.flow`, Case JSON), the `processType` field on the instance/incident, or by asking the user. Examples below use `<type>` as a placeholder — substitute the actual type.
+3. **Resolve the Maestro instance ID** — for ProcessOrchestration jobs, the **Orchestrator job key IS the Maestro instance ID**. They are the same GUID. Do NOT use `ParentJobKey` — that is the parent Orchestrator job, not the Maestro instance.
+   - **User provided a job key and `RuntimeType` is `ProcessOrchestration`**: the job key is the instance ID. Go directly to `uip maestro <type> instance get <job-key> -f <folder-key>`.
+   - **User provided a job key and `RuntimeType` is NOT `ProcessOrchestration`** (standard child job): the child job was spawned by a Maestro service task. Check `ParentJobKey` — that parent job's key may be the instance ID. Try `uip maestro <type> instance get <parent-job-key> -f <folder-key>`.
+   - **Neither works**: search with `uip maestro <type> incident summary --output json` to find the `processKey`, then `uip maestro <type> processes incidents <process-key> --folder-key <folder-key>` to find incident records containing the `instanceId`. If the process type is unknown, try each (`bpmn`, `flow`, `case`) in turn.
+   - **`instance list` may return empty** for completed or faulted instances. Always try `instance get` directly before concluding an instance doesn't exist. Do NOT rely on `instance list` alone.
+4. **Full incident details** — `uip maestro <type> instance incidents <instance-id> -f <folder-key>`. This returns `errorDetails` with stack traces. Do NOT use `uip maestro <type> incident summary` — that returns summaries only without error details.
+5. **Element executions** — `uip maestro <type> instance element-executions <instance-id> -f <folder-key>` to see what each element did and where execution stopped.
+6. **Child jobs** — if the process has service tasks, list child jobs and check their state and error messages. The child's failure reason is often the actual root cause.
 
 ## Testing Prerequisites
 

--- a/skills/uipath-diagnostics/references/products/maestro/overview.md
+++ b/skills/uipath-diagnostics/references/products/maestro/overview.md
@@ -1,8 +1,12 @@
 # Maestro
 
-Agentic orchestration platform built on top of Orchestrator. Enables BPMN-based process design with human-in-the-loop tasks, AI agent tasks, and service tasks orchestrated across multiple swimlanes.
+Agentic orchestration platform built on top of Orchestrator. Maestro supports three process authoring styles, each with its own CLI subcommand:
 
-Maestro processes are designed in Studio Web using a BPMN editor, deployed as solutions to Orchestrator, and managed through the Maestro Instance Management UI.
+- **BPMN** (`uip maestro bpmn`) — formal BPMN 2.0 process design with swimlanes, gateways, boundary events, service tasks, and multi-instance markers. Authored in Studio Web's BPMN editor (`.bpmn` files). Best for orchestrating long-running, multi-actor business processes with rich exception flow.
+- **Flow** (`uip maestro flow`) — lightweight node-and-edge process design (`.flow` files). Lower ceremony than BPMN; emphasizes connectors, scripts, sub-flows, and human-in-the-loop nodes. Best for connector-heavy automations and quick agent-orchestrated flows.
+- **Case Management** (`uip maestro case`) — case-centric workflows with stages, tasks, SLAs, escalations, triggers, and edges (Case definition JSON). Best for human-driven, evolving work where progress is tracked per case rather than per linear process run.
+
+Processes are designed in Studio Web, deployed as solutions to Orchestrator, and managed through the Maestro Instance Management UI.
 
 ## Dependencies
 
@@ -47,11 +51,11 @@ Organization (cloud.uipath.com)
 
 Maestro CLI commands are namespaced by process type. Pick the subcommand that matches the process:
 
-| Process type | Subcommand | Source artifacts |
-|--------------|------------|------------------|
-| BPMN process | `uip maestro bpmn ...` | `.bpmn` files (Studio Web BPMN editor) |
-| Flow process | `uip maestro flow ...` | `.flow` files |
-| Case Management | `uip maestro case ...` | Case definition JSON |
+| Process type | Subcommand | Source artifacts | One-liner |
+|--------------|------------|------------------|-----------|
+| BPMN | `uip maestro bpmn ...` | `.bpmn` files (Studio Web BPMN editor) | Formal BPMN 2.0 with swimlanes, gateways, boundary events, service/human/agent tasks |
+| Flow | `uip maestro flow ...` | `.flow` files | Lightweight node-and-edge orchestration; connector-heavy, lower ceremony than BPMN |
+| Case | `uip maestro case ...` | Case definition JSON | Case-centric work with stages, tasks, SLAs, escalations, and triggers |
 
 **Identify the process type first** — check the source artifact, the `processType` field on incidents/instances, or ask the user. Running `uip maestro bpmn instance get <id>` against a Flow instance returns no data. Substitute `<type>` below with `bpmn`, `flow`, or `case`.
 

--- a/skills/uipath-diagnostics/references/products/maestro/overview.md
+++ b/skills/uipath-diagnostics/references/products/maestro/overview.md
@@ -45,29 +45,41 @@ Organization (cloud.uipath.com)
 
 ## CLI
 
+Maestro CLI commands are namespaced by process type. Pick the subcommand that matches the process:
+
+| Process type | Subcommand | Source artifacts |
+|--------------|------------|------------------|
+| BPMN process | `uip maestro bpmn ...` | `.bpmn` files (Studio Web BPMN editor) |
+| Flow process | `uip maestro flow ...` | `.flow` files |
+| Case Management | `uip maestro case ...` | Case definition JSON |
+
+**Identify the process type first** — check the source artifact, the `processType` field on incidents/instances, or ask the user. Running `uip maestro bpmn instance get <id>` against a Flow instance returns no data. Substitute `<type>` below with `bpmn`, `flow`, or `case`.
+
 ```
-uip maestro process list|get|run                    — list/get/run Maestro processes
-uip maestro job traces|status <job-key>             — stream traces or get status for a Maestro job
-uip maestro instance list [-f <folder-key>]        — list instances. Filters: --process-key, --error-code, --limit, --offset
-uip maestro instance get <id> [-f <folder-key>]    — get instance details
-uip maestro instance incidents <id> [-f <fk>]      — full incidents with errorDetails and stack traces
-uip maestro instance element-executions <id> [-f <fk>] — element execution history
-uip maestro instance variables <id> [-f <fk>]      — instance variables. Filter: --parent-element-id
-uip maestro instance asset <id> [-f <fk>]          — BPMN XML asset
-uip maestro instance cursors <id> [-f <fk>]        — current execution cursor positions
-uip maestro instance retry <id> [-f <fk>]          — retry a faulted instance
-uip maestro instance pause|resume|cancel <id> [-f <fk>] — lifecycle control
-uip maestro processes incidents <key> [--folder-key <fk>] — incidents across all instances of a process
-uip maestro incident summary                         — tenant-level incident SUMMARIES ONLY (no errorDetails)
-uip maestro incident get <incident-id>               — get a single incident by ID
+uip maestro <type> process list|get|run                          — list/get/run processes
+uip maestro <type> job traces|status <job-key>                   — stream traces or get status for a job
+uip maestro <type> instance list [-f <folder-key>]               — list instances. Filters: --process-key, --error-code, --limit, --offset
+uip maestro <type> instance get <id> [-f <folder-key>]           — get instance details
+uip maestro <type> instance incidents <id> [-f <fk>]             — full incidents with errorDetails and stack traces
+uip maestro <type> instance element-executions <id> [-f <fk>]    — element execution history
+uip maestro <type> instance variables <id> [-f <fk>]             — instance variables. Filter: --parent-element-id
+uip maestro <type> instance asset <id> [-f <fk>]                 — process definition asset (BPMN XML, Flow JSON, Case JSON)
+uip maestro <type> instance cursors <id> [-f <fk>]               — current execution cursor positions
+uip maestro <type> instance retry <id> [-f <fk>]                 — retry a faulted instance
+uip maestro <type> instance pause|resume|cancel <id> [-f <fk>]   — lifecycle control
+uip maestro <type> processes incidents <key> [--folder-key <fk>] — incidents across all instances of a process
+uip maestro <type> incident summary                              — tenant-level incident SUMMARIES ONLY (no errorDetails)
+uip maestro <type> incident get <incident-id>                    — get a single incident by ID
 ```
 
-Key commands for diagnostics:
-- `uip maestro instance incidents <instance-id> -f <folder-key>` — **full incident details** including `errorDetails` with stack traces. Use this, not `incident summary`.
-- `uip maestro instance element-executions <instance-id> -f <folder-key>` — what each BPMN element did
-- `uip maestro processes incidents <process-key> --folder-key <fk>` — incidents across all instances of a process
+Key commands for diagnostics (substitute `<type>` with `bpmn`, `flow`, or `case`):
+- `uip maestro <type> instance incidents <instance-id> -f <folder-key>` — **full incident details** including `errorDetails` with stack traces. Use this, not `incident summary`.
+- `uip maestro <type> instance element-executions <instance-id> -f <folder-key>` — what each element did
+- `uip maestro <type> processes incidents <process-key> --folder-key <fk>` — incidents across all instances of a process
 
-**WARNING:** `uip maestro incident summary` returns only aggregated summaries (counts, error codes) without `errorDetails`. It does NOT contain stack traces or full error messages. Always use instance-level or process-level incident commands for diagnostics.
+**WARNING:** `uip maestro <type> incident summary` returns only aggregated summaries (counts, error codes) without `errorDetails`. It does NOT contain stack traces or full error messages. Always use instance-level or process-level incident commands for diagnostics.
+
+**WARNING:** There is no top-level `uip maestro instance` / `uip maestro process` / `uip maestro incident` command — every operation requires the `bpmn`, `flow`, or `case` segment. Running the old un-namespaced form fails.
 
 ## Features
 

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/service-task-child-job-faulted.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/service-task-child-job-faulted.md
@@ -23,8 +23,10 @@ What to look for:
 
 ## Investigation
 
-1. Get full incident details: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Get element executions to identify the faulted service task: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+Service tasks are a BPMN concept — use the `bpmn` subcommand. For Flow/Case service-equivalent failures, swap `bpmn` for `flow` or `case`.
+
+1. Get full incident details: `uip maestro bpmn instance incidents <instance-id> -f <folder-key> --output json`
+2. Get element executions to identify the faulted service task: `uip maestro bpmn instance element-executions <instance-id> -f <folder-key> --output json`
 3. Find the child job key from the incident's `errorDetails` and inspect it: `uip or jobs get <child-job-key> --output json` — the child's error message drives the root cause investigation
 4. Get child job logs for execution detail: `uip or jobs logs <child-job-key> --level Error --output json`
 5. Check whether a boundary error event is attached to the service task (visible in element executions)


### PR DESCRIPTION
## Summary
- `uip maestro` now requires a process-type segment (`bpmn`, `flow`, or `case`) before `instance`, `process`, `job`, `incident`, etc. The old un-namespaced form (e.g. `uip maestro instance incidents <id>`) is gone.
- Updated `references/products/maestro/overview.md` CLI section to document the three subcommands, when to use each, and the `<type>` placeholder convention; added a warning that the un-namespaced form fails.
- Updated `references/products/maestro/investigation_guide.md` data-gathering steps and `playbooks/service-task-child-job-faulted.md` so the documented commands match the current CLI.

## Test plan
- [ ] Verify each documented command form runs against a real tenant (`uip maestro bpmn instance list`, `uip maestro flow instance list`, `uip maestro case instance list`)
- [ ] Confirm the diagnostics skill still routes the agent correctly when given a Maestro instance ID
- [ ] Spot-check that the overview's process-type identification guidance (source artifact / `processType` field) is accurate

Generated with [Claude Code](https://claude.com/claude-code)
