### PR TITLE
docs(uipath-data-fabric): document server-side aggregates in records query

### DIFF
--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -19,6 +19,7 @@ All operations go through `uip df <subject> <verb> --output json`.
 - Creating or modifying entity schemas (add fields, update metadata)
 - Reading, inserting, updating, or deleting records
 - Filtering records with complex predicates
+- Computing aggregate metrics for dashboards / KPIs (counts, sums, averages, group-by) — see [references/records-query.md](references/records-query.md#aggregates-server-side)
 - Importing bulk data from CSV files
 - Uploading or downloading file attachments on records
 
@@ -53,7 +54,7 @@ Respond that the operation is not supported. Do not try to work around it.
 
 ## Critical Rules
 
-1. **Install the tool first.** If `uip df` returns "unknown command": `uip tools install @uipath/data-fabric-tool` (min version `0.2.0`).
+1. **Install the tool first.** If `uip df` returns "unknown command": `uip tools install @uipath/data-fabric-tool`. See *Tool Version Requirements* below for the floor needed per feature.
 
 2. **Verify login and tenant first.** Run `uip login status --output json`. Switch with `uip login tenant set <tenant>` if needed. For full login/environment setup, see the `uipath-platform` skill.
 
@@ -77,6 +78,17 @@ Respond that the operation is not supported. Do not try to work around it.
 
 ---
 
+## Tool Version Requirements
+
+| Feature | Required `@uipath/data-fabric-tool` |
+|---------|--------------------------------------|
+| `entities` / `records` CRUD, `query` with filters/sort, `records import`, `files` | `0.9.0+` |
+| Server-side `aggregates` and `groupBy` on `records query` | `1.0.1+` |
+
+Upgrade with `uip tools install @uipath/data-fabric-tool@latest` when a feature appears to silently no-op (e.g. aggregate body keys returning raw record lists).
+
+---
+
 ## Quick Start
 
 ```bash
@@ -95,6 +107,11 @@ uip df records insert <entity-id> --body '{"Name":"Alice","Score":95}' --output 
 # Query with a filter
 uip df records query <entity-id> \
   --body '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"Status","operator":"=","value":"active"}]}}' \
+  --output json
+
+# Aggregate query — count of records per Status (server-side groupBy)
+uip df records query <entity-id> \
+  --body '{"selectedFields":["Status"],"groupBy":["Status"],"aggregates":[{"function":"COUNT","field":"Id","alias":"total"}]}' \
   --output json
 ```
 
@@ -119,6 +136,7 @@ uip df records query <entity-id> \
 | Batch update | `records update <entity-id> --body '[{"Id":"<id1>","field":"val"},{"Id":"<id2>","field":"val"}]'` |
 | Delete records | `records delete <entity-id> <id1> <id2>` |
 | Filter/search records | `records query <entity-id> --body '{...}'` |
+| Aggregate / group-by metrics | `records query <entity-id> --body '{"aggregates":[{"function":"COUNT","field":"Id","alias":"total"}],"groupBy":["FieldName"]}'` |
 | Bulk import from CSV | `records import <entity-id> --file data.csv` |
 | Upload file to record | `files upload <entity-id> <record-id> <field-name> --file path` |
 | Download file | `files download <entity-id> <record-id> <field-name> --destination path` |

--- a/skills/uipath-data-fabric/references/records-query.md
+++ b/skills/uipath-data-fabric/references/records-query.md
@@ -100,6 +100,90 @@ uip df records query <entity-id> \
 }
 ```
 
+## Aggregates (server-side)
+
+Add `aggregates` and optional `groupBy` to the query body to return aggregated rows instead of records. Each entry in `aggregates` produces one column on each result row, keyed by `alias`.
+
+> **Field names are case-sensitive.** Examples below use `Status` as a placeholder — substitute the exact casing from the target entity's schema (`uip df entities get <entity-id>` lists the real names).
+
+```bash
+# Total count of records (no grouping → single result row)
+uip df records query <entity-id> \
+  --body '{"aggregates":[{"function":"COUNT","field":"Id","alias":"total"}]}' \
+  --output json
+```
+
+Response:
+
+```json
+{
+  "Result": "Success",
+  "Code": "RecordQuery",
+  "Data": {
+    "TotalCount": 1,
+    "Records": [{ "total": 250 }],
+    "HasNextPage": false
+  }
+}
+```
+
+```bash
+# Count per group (one result row per distinct value)
+uip df records query <entity-id> \
+  --body '{"selectedFields":["Status"],"groupBy":["Status"],"aggregates":[{"function":"COUNT","field":"Id","alias":"total"}]}' \
+  --output json
+```
+
+Response shape (one row per group, each row contains the group fields + every aggregate alias):
+
+```json
+{
+  "Result": "Success",
+  "Code": "RecordQuery",
+  "Data": {
+    "TotalCount": 2,
+    "Records": [
+      { "Status": "Open",   "total": 12 },
+      { "Status": "Closed", "total":  5 }
+    ],
+    "HasNextPage": false
+  }
+}
+```
+
+### Functions
+
+| `function` | Applies to | Notes |
+|------------|-----------|-------|
+| `COUNT` | Any field | Counts non-null values. For total row count use `field: "Id"` |
+| `SUM`   | Numeric only | |
+| `AVG`   | Numeric only | |
+| `MIN`   | Numeric / date | |
+| `MAX`   | Numeric / date | |
+
+Values are the **uppercase strings** above — `"COUNT"` not `"Count"`.
+
+### Aggregate Body Schema
+
+```json
+{
+  "selectedFields": ["Status"],
+  "groupBy": ["Status"],
+  "aggregates": [
+    { "function": "COUNT", "field": "Id",     "alias": "total" },
+    { "function": "AVG",   "field": "amount", "alias": "avgAmount" }
+  ]
+}
+```
+
+- `aggregates[].alias` is optional. When omitted, the server returns the column keyed as `{FUNCTION}_{field}` (for example `COUNT_Id`, `AVG_amount`). Provide an `alias` for stable, readable keys in your downstream code.
+- When `selectedFields` is present alongside `aggregates`, every entry in `selectedFields` must also appear in `groupBy` — otherwise the API rejects the request. The shortcut: use the same array for both, as in the examples above.
+- `groupBy` and `selectedFields` may reference root-entity fields only — expansions are not supported in aggregate mode.
+- The same `filterGroup`, `sortOptions`, and pagination flags (`--limit`, `--cursor`) work alongside aggregates. Filters are applied **before** grouping (SQL `WHERE`).
+- Choice-set fields in `groupBy` / filters require the numeric `numberId`, not the display label. Discover via the choice-set lookup if you need to filter / group by a choice value.
+
+> Tooling requirement: server-side aggregates ship in version `1.0.1`+ of `@uipath/data-fabric-tool` only. Older versions silently strip `aggregates` / `groupBy` from the body (the SDK they bundle prefixes unknown keys with OData `$`, which the API ignores) and the query falls back to a plain record list. If aggregates aren't returning the expected one-row-per-group shape, re-run `uip tools install @uipath/data-fabric-tool@latest` to pick up the latest.
+
 ## Insert Records
 
 The CLI routes by body shape: a JSON object (or 1-element array) calls the single-record endpoint; a JSON array with 2+ elements calls the batch endpoint.


### PR DESCRIPTION
## Summary

Documents the new server-side aggregate query support (`COUNT` / `SUM` / `AVG` / `MIN` / `MAX` + `groupBy`) on `entities.queryRecordsById`, exposed via `uip df records query --body`. The CLI's body is forwarded verbatim to the SDK, so the new keys work the moment the bundled SDK whitelists `aggregates` / `groupBy` from the OData `$`-prefix transform (landed in [UiPath/cli#1907](https://github.com/UiPath/cli/pull/1907), SDK `^1.3.7`).

This skill update teaches coding agents to reach for server-side aggregation when computing dashboard / KPI metrics, instead of paginating raw records and aggregating in client code.

## Files changed

- **`skills/uipath-data-fabric/SKILL.md`**
  - new "When to Use" bullet for dashboard / KPI metrics, linking to the references section
  - new Quick Start example showing `COUNT` + `groupBy`
  - new Task Navigation row for aggregate / group-by metrics
- **`skills/uipath-data-fabric/references/records-query.md`** — new "Aggregates (server-side)" section covering:
  - Body shape for no-group `COUNT` (single result row) and `groupBy` `COUNT` (one row per distinct value), with exact response shapes
  - Functions table (`COUNT` / `SUM` / `AVG` / `MIN` / `MAX`, uppercase strings)
  - `alias` auto-naming rule (`{FUNCTION}_{field}` when omitted)
  - `selectedFields` ↔ `groupBy` alignment rule
  - Root-entity-only constraint (no expansion fields)
  - Choice-set `numberId` reminder for `groupBy` / filter on choice fields
  - Tooling reminder to re-run `uip tools install` on older bundles that strip aggregate keys

## Not in this PR
- **No eval tests** (smoke / integration / e2e) — following the precedent of [PR #157](https://github.com/UiPath/skills/pull/157) where docs landed first and evals followed in [PR #306](https://github.com/UiPath/skills/pull/306). Will open a follow-up PR adding smoke + integration + e2e aggregate tasks.

## Verification

- `bash hooks/validate-skill-descriptions.sh` ✓ exits 0
- Live-tested the documented body shapes end-to-end against the staging `Tickets` entity (`cbcc0a09-6b49-f111-8ef3-000d3a261acd`) using a local build of `UiPath/cli` `main`:
  - `COUNT(Id)` no-group → `{Records: [{total: 250}]}`
  - `groupBy: ["assignee"], COUNT(Id)` → 8 rows, one per agent
  - `AVG(resolutionMinutes)` matches `SUM(resolutionMinutes) / 250`

## Linked

- SDK: [UiPath/uipath-typescript#417](https://github.com/UiPath/uipath-typescript/pull/417) — published as `@uipath/uipath-typescript@1.3.7`
- CLI: [UiPath/cli#1907](https://github.com/UiPath/cli/pull/1907) — merged
- Jira: [DS-8357](https://uipath.atlassian.net/browse/DS-8357)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DS-8357]: https://uipath.atlassian.net/browse/DS-8357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Screenshots
Prompt:
`What's the average resolution time per category? Tell me which category is the bottleneck.`

Output:
<img width="1509" height="430" alt="Screenshot 2026-05-11 at 12 46 50 PM" src="https://github.com/user-attachments/assets/1321482e-8733-4a4c-95e1-d68d6f3b3733" />
