### PR TITLE
feat(uipath-admin): skills for admin authz, OMS, and APMS commands [PLT-102888][PLT-102517]

### DIFF
--- a/skills/uipath-admin/SKILL.md
+++ b/skills/uipath-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-admin
-description: "Always invoke for `uip admin` commands or audit-investigation prompts (who/when/where on a resource, login history, compliance dumps). UiPath Admin via `uip admin <subject> <verb>` — Identity Server (users, groups, robot accounts, external OAuth2 apps, credential generation) and Audit Service (event sources, paginated event queries, long-term-store ZIP exports). For Orchestrator folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
+description: "UiPath Admin via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps, secrets), Authorization (custom roles, role assignments, permission catalog, effective-access via check-access PDP), OMS (org read/update, tenant lifecycle, service provisioning, regions, async operation polling), IP Restriction (allowlist, enforcement switch, bypass rules, lockout safety), Audit (event sources, paginated queries, ZIP exports — login history, compliance dumps, who-did-what-when-where on a resource). For Orchestrator-specific roles/permissions/folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -8,7 +8,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 
 > **Preview** — Under active development. Command coverage will expand.
 
-Administrative operations on UiPath via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps) and Audit Service (event sources, event queries, long-term-store ZIP exports).
+Administrative operations on UiPath via `uip admin` — Identity Server, Authorization, OMS, IP Restriction, Audit. Per-area workflows, command references, and procedures are in the linked files below — this file is the entry contract.
 
 ## When to Use This Skill
 
@@ -18,40 +18,107 @@ Administrative operations on UiPath via `uip admin` — Identity Server (users, 
 - **Manage groups** — CRUD + add/remove members
 - **Manage robot accounts** — create, update, delete unattended robot identities
 - **Manage external apps** — OAuth2 clients, generate/rotate secrets
+- **Manage external apps** — OAuth2 clients, secrets, federated credentials
+- **Manage personal access tokens (PATs)** — create, list, revoke, regenerate
+- **Configure SMTP** — get, update, test, delete email settings
+- **Browse OAuth2 scopes** — list available scopes for external apps and PATs
 - **Onboard human user** — invite, assign to groups
 - **Onboard robot account** — create account, assign to groups
 - **Identity concepts** — partitions, organizations, OAuth2 scopes
 - **Generate Client ID/Secret** — credentials for API or robot authentication
+
+### Authz
+
+- **Manage custom roles** — CRUD on Authorization service role definitions (scope shapes: `Organization`, `TenantGlobal`, `Tenant`, `Project`)
+- **Manage role assignments** — assign roles to users/groups/robot accounts at `Organization`, `Tenant`, `TenantGlobal`, `Project`, `Folder`, or `App` scope
+- **List permission definitions** — read-only catalog of permissions across services
+- **Check effective access** — compute what a principal can actually do at a given scope (Policy Decision Point)
+- **Grant permission(s) to a principal** — ad-hoc "grant me X" / "give <user> Y, Z" requests resolved via the scope/service intersection flow
+
+### OMS
+
+- **Inspect / update the current organization** — `uip admin organizations` (read + update only; no CLI create/delete)
+- **Manage tenant lifecycle** — create, enable, disable, delete tenants in the caller's org
+- **Provision org-level or tenant-level services** — `services list`, `list-available`, `add`, `enable`, `disable`, `remove`
+- **Poll async OMS operations** — `tenants` mutations return `operationId`; poll via `organizations operation get <id>` (the canonical poll endpoint)
+- **List available regions** — discover provisioning regions before `tenants create`
+
+### IP Restriction
+
+- **Manage IP allowlisting** — add / update / delete CIDR entries that gate inbound access
+- **Toggle IP-restriction enforcement** — turn the org-wide allowlist switch on or off (with lockout safety)
+- **Manage bypass rules** — URL-pattern exceptions to IP allowlisting
+- **Look up the caller's public IP** — sanity check before enabling enforcement
 
 ### Audit
 
 Activate on both **explicit audit requests** and **natural-language investigation intent** — users rarely say "audit events" by name.
 
 - **Explicit** — `uip admin audit` commands; list sources / targets / types; query, filter, paginate, or export events; CSV/ZIP dump of audit history for a window.
-- **Investigation intent** — "Who deleted the X folder last Tuesday?", "Show me failed logins for user Y this month.", "What changed on tenant Z between Jan 1 and Feb 1?", "Give me the audit log for the last 30 days.", "Was the API key rotated by someone in our org?", "Export everything for compliance for Q4."
+- **Query audit events** — list event sources, filter events by source / target / type / user / status / time window at org or tenant scope
+- **Export audit events** — chunked ZIP download from the long-term store, per UTC day, with atomic abort on any chunk failure
+- **Membership / license phrasings** — "who joined / left the organization", "who was made an admin", "license changes", "cross-tenant audit"
+- **Sign-in / authentication phrasings** — "failed/successful logins", "login history for user X", "who's been signing in"
+- **Tenant-activity phrasings** — "what happened on tenant X", "asset/queue/folder edits", "queue items processed", "job failures", "Action Center task changes", "Apps / AgentHub / Document Understanding / Integration Service / Test Manager activity"
+- **Cross-scope phrasings** — "everything everywhere" (run the flow once per scope and present combined)
+- **Investigation intent** (full-sentence form) — "Who deleted the X folder last Tuesday?", "Show me failed logins for user Y this month.", "What changed on tenant Z between Jan 1 and Feb 1?", "Give me the audit log for the last 30 days.", "Was the API key rotated by someone in our org?", "Export everything for compliance for Q4."
+
+> **Scope routing** (which phrasing → `org` vs `tenant`, and why) lives in [audit-workflow-guide.md → Audit scope disambiguation](references/audit-workflow-guide.md#audit-scope-disambiguation--route-by-user-phrasing). Critical Rule 23 governs the stop-and-ask requirement when scope is ambiguous.
 
 ## Critical Rules
 
+Each rule is the agent contract. Per-area detail is in the linked reference files.
+
+### Universal
+
+1. **Route Orchestrator-specific role/permission requests to `uip or roles`** (`uipath-platform` skill). `uip admin authorization` does NOT own Orchestrator's role catalog.
+2. **Verify login first.** `uip login status --output json`. If not logged in: `uip login`. Org id is resolved from the active session.
+3. **Use `--output json` on every command.** Parse programmatically; present conversationally.
+4. **Stop on error.** Show the error verbatim. Never retry auth failures — ask the user to `uip login`.
+5. **Resolve every named principal before high-risk ops.** Any command that touches a named user / group / robot account / external app — `roles assignments create/delete`, `users delete`, `groups delete`, `groups members add/revoke`, `robot-accounts delete`, `external-apps delete`, `external-apps generate-secret` — MUST first search the directory and echo `Principal: <displayName> (<userName>) — <id>` back before the mutation runs. Zero matches → stop and ask; never fall back to the current login user. Multiple matches → numbered list, wait for a digit. Procedure: [role-assignment-management.md → Resolving Principal IDs](references/authorization/role-assignment-management.md#resolving-principal-ids).
+
 ### Identity
 
-1. **Verify login first.** Run `uip login status --output json`. If not logged in: `uip login`.
-2. **Organization ID is resolved automatically from login.** CLI reads org ID from active session.
-3. **Discover before creating.** `list` before `create` to avoid duplicates. Applies to robot accounts, groups, and external apps — not to `users invite`.
-4. **Use `--output json` on all commands.** Parse programmatically. Present results conversationally.
-5. **Secrets shown only once.** When creating external apps or generating secrets, secret value appears only in creation response. Warn user to save immediately.
-6. **External apps require scopes at creation.** `--scope` is required. Common scopes: `OR.Folders`, `OR.Assets`, `OR.Queues`, `OR.Jobs`, `OR.Machines`.
-7. **Group membership uses user IDs, not usernames.** Resolve IDs via `users list` before `groups members add` or `groups members revoke`.
-8. **Confirm before delete.** Always confirm with user before running `delete` on users, groups, robot accounts, or external apps.
-9. **Stop on error (interactive use).** If any command fails, show error to user. Do not retry auth failures — ask user to run `uip login`.
+6. **Discover before creating.** `list` before `create` to avoid duplicates (robot accounts, groups, external apps — `users invite` excepted).
+7. **Secrets shown only once** on external-app create and `generate-secret` — warn the user to save immediately.
+8. **External apps require scopes at creation** — `--scope` is required (e.g., `OR.Folders`, `OR.Assets`, `OR.Queues`, `OR.Jobs`, `OR.Machines`).
+9. **Group membership uses user IDs.** Resolve via `users list` per Rule 5, then `groups members add/revoke`.
+10. **Confirm before delete** on users / groups / robot accounts / external apps — after resolving the named target per Rule 5.
+
+### Authz
+
+11. **Built-in roles are read-only.** Only `Custom` roles can be created / updated / deleted. CLI also rejects authoring against service-managed and platform-level services. Service lists: [role-management.md → Services That Manage Their Own Roles](references/authorization/role-management.md#services-that-manage-their-own-roles).
+12. **`roles create` / `roles update` are PUT-style upserts.** Body is assembled from inline flags + `--file ./actions.json`. Always `roles get` first before updating — omitted flags overwrite that field.
+13. **`--service` infers scope** (e.g., `--service studio` → `Tenant`; `--service apps` → `Organization`). Combine with `--scope` only to override.
+14. **Listing works for every service; authoring is what's blocked.** `roles list --service <svc>` and `roles assignments list --service <svc>` accept every service. For effective access on a principal use `check-access` (PDP).
+15. **Scope vocab differs across verbs.** `roles create --scope`: `Organization|TenantGlobal|Tenant|Project`. `roles assignments create --scope`: those + `Folder|App`. `roles assignments list --scope`: excludes `TenantGlobal`. `check-access --scope`: only `Tenant|Folder`.
+16. **`roles assignments create/delete` MUST resolve the principal first** per Rule 5 — `--identity-id` is a raw UUID the CLI does not name-check.
+17. **`roles assignments create` MUST match the role's `ownerServiceName` to the scope-path service segment.** `CentralizedAccess` → no service segment (`/` or `/tenant/<tid>`); anything else → path must include `lowercase(ownerServiceName)`. Display-name mapping (e.g., `Reinfer` → "IXP") + full procedure: [role-assignment-management.md → Validate Role's Owning Service](references/authorization/role-assignment-management.md#validate-roles-owning-service-vs-assignment-scope-path).
+
+### OMS
+
+18. **Async lifecycle: auto-poll, then hand off.** `tenants create/update/delete/enable/disable` return `operationId`. Auto-poll `organizations operation get <OP_ID>` 3× at 5 s; on terminal status stop and report; still in-progress after 3 polls → numbered menu, never indefinite loop. **`organizations create` and `organizations delete` are not exposed by the CLI** — Portal / support flow only. Procedure: [organization-management.md → Polling procedure](references/organization-management.md#polling-procedure-auto-poll-then-hand-off).
+19. **`tenants delete` is soft-only.** No hard-delete flag; restoration is via support.
+20. **Tenant commands default to the login tenant.** Always pass an explicit `<TENANT_ID>` for destructive ops (`tenants delete`, `tenants disable`, `tenants services remove`).
+21. **Resolve region before tenant create.** `--region` is required on `tenants create` — run `organizations regions list` first. Tenant service catalog is region-aware.
+22. **`services disable` / `remove` may no-op despite Success** on certain services. Always re-list after mutating. Gap list: [tenants-commands.md → Concepts](references/tenants-commands.md#concepts).
 
 ### Audit
 
-10. **Pick scope before any other audit call — and don't silently default.** Use the [Disambiguation rule](#audit-scope-disambiguation) below: if the prompt is vague about `org` vs `tenant` AND there's no prior conversational context, **ask** which scope (and which tenant if `tenant`). `tenant` requires either a tenant in the login context or `--tenant-id <guid>`. `org` ignores `--tenant-id`.
-11. **Discover source IDs with `sources` before filtering `events`.** Never invent GUIDs for `--source`/`--target`/`--type` — the SDK won't help you guess.
-12. **`events` returns `{ auditEvents, next, previous }` — NOT a bare array.** Cursor naming is **chronological**: `next` = newer, `previous` = older. The default newest-backward walk follows `previous`.
-13. **`events` server-clamps `maxCount` to `[10, 200]`.** When the user wants more than 200, the tool paginates internally — pass `--limit N` and the tool fetches `ceil(N/200)` pages. Do **not** re-implement pagination in the agent.
-14. **`export` writes a ZIP from the long-term store.** `--from-date`, `--to-date`, and `--output-file` are required and ISO 8601 (for the dates). Never overwrite a path the user did not explicitly approve.
-15. **ISO 8601 for time bounds, UTC by default.** Date-only (`2026-04-01`) or with time (`2026-04-01T14:30:00Z`). `--to-date` is inclusive of the exact instant — pass the start of the next day (or `T23:59:59.999Z`) to capture a full final day.
+23. **Disambiguate `org` vs `tenant` scope before querying.** If the prompt is vague AND no prior turn fixed the scope, **stop and ask once** — never silently default to `tenant`. Routing table (user-phrasing → scope + why it lives where) and investigation playbooks: [audit-workflow-guide.md → Audit scope disambiguation](references/audit-workflow-guide.md#audit-scope-disambiguation--route-by-user-phrasing).
+24. **`audit <scope> events` returns an object, not a bare array.** Shape is `{auditEvents, next, previous}`. Do not index `Data[0]`; read `Data.auditEvents[]`. **Cursor semantics are chronological**: `next` = newer events, `previous` = older events. The default newest-backward walk follows `previous`.
+25. **`--limit` paginates internally — never loop on `--from-date` / `--to-date` to "paginate".** The server clamps `maxCount` to `[10, 200]` per request; when the user wants more than 200, the CLI fetches `ceil(N/200)` pages under the hood. Pass `--limit 500` (or larger) — do NOT re-implement pagination in the agent.
+26. **Discover via `audit <scope> sources` first — never invent source / target / type GUIDs.** The catalog response gives the GUIDs you pass to `events --source / --target / --type`.
+27. **Bound the time window, ISO 8601 in UTC.** Don't call `audit <scope> events` without `--from-date` and `--to-date` on a noisy tenant. Accepted formats: date-only (`2026-04-01`) or with time (`2026-04-01T14:30:00Z`). **`--to-date` is inclusive of the exact instant** — to capture a full final day, pass the start of the next day or `T23:59:59.999Z`.
+28. **`--tenant-id` is silently ignored on `org`-scoped audit commands.** If you find yourself reaching for it on `audit org events`, switch to `audit tenant` instead.
+29. **On 401 from audit, do NOT retry.** The token is missing the `Audit.Read` scope; tell the user to `uip logout && uip login`.
+30. **`audit <scope> export` writes a ZIP from the long-term store.** `--from-date`, `--to-date`, and `--output-file` are all required; dates per Rule 27. **Never overwrite a path the user did not explicitly approve** — surface the resolved `--output-file` and confirm before running.
+
+### IP Restriction
+
+31. **`enforcement enable` is lockout-sensitive — prompt + impact statement required.** Run `ip-restriction my-ip` and verify the caller's IP is covered by an entry in `ip-ranges list`. **Then prompt the user with the impact** before flipping: *"After enabling IP restriction, any caller (Portal, CLI, robot, external app) whose source IP is not in `ip-ranges list` will be blocked from this org. Misconfiguration locks you out and requires platform-side recovery. Proceed?"* `--confirm` is required; `ip-ranges delete` while enforcement is on also requires `--confirm`. Procedure: [enforcement-management.md](references/ip-restriction/enforcement-management.md).
+32. **Recovery from IP lockout requires platform-side action.** No CLI bypass — either access from an in-allowlist IP and `enforcement disable`, or use the Portal recovery flow.
+33. **"APMS" is internal — never expose to the user.** "APMS" (Access Policy Management Service) is the platform's internal name for IP Restriction. Use "IP Restriction" in every user-facing surface.
 
 ## What NOT to Do
 
@@ -62,102 +129,32 @@ Activate on both **explicit audit requests** and **natural-language investigatio
 5. **Do NOT silently default audit scope** to `tenant` or `org` when the prompt is ambiguous. Ask once, then proceed.
 6. **Do NOT invent audit source/target/type GUIDs.** Always discover via `sources` first.
 7. **Do NOT call audit `events` with no time bound** on a noisy tenant — default to a bounded window.
-8. **Do NOT pass `--tenant-id` to `org`-scoped audit commands** — it's silently ignored. If you find yourself doing this, you probably meant `tenant` scope.
-9. **Do NOT retry on 401 auth errors.** The token is missing the required scope (`Audit.Read` for audit). Tell the user to `uip logout && uip login` so the new scope is included.
+8. **Do NOT pass `--tenant-id` to `org`-scoped audit commands** — it's silently ignored.
+9. **Do NOT retry on 401 auth errors.** The token is missing the required scope (`Audit.Read` for audit). Tell the user to `uip logout && uip login`.
+10. **Do NOT call `roles update` with only the flag you want to change.** Re-fetch first; the upsert body overwrites omitted fields (Rule 12).
+11. **Do NOT present authz results without provenance** — role name, `scopeType`, `ownerServiceName`, tenant-binding (names not UUIDs). Detail: [authorization-commands.md → Provenance contract](references/authorization/authorization-commands.md#provenance-contract-for-completion-output).
+12. **Do NOT conflate provisioned services with the available catalog.** `services list` returns provisioned with status; `services list-available` is the catalog. Present them as separate sections.
+13. **Do NOT run an OMS mutation without naming the target.** Echo org name / tenant name + UUID / service type + region before running.
 
-## Quick Start — Identity
+## Quick Start
 
-The most common identity flow is **user management** — inviting users, assigning them to groups, and managing access.
+One row per common goal. Per-area workflows are in the reference files.
 
-### Step 0 — Verify login
-
-```bash
-uip login status --output json
-```
-
-If not logged in: `uip login`. The CLI reads org ID from the active session automatically.
-
-### Step 1 — Invite a user
-
-```bash
-uip admin users invite \
-  --email "<USER_EMAIL>" \
-  --name "<FIRST_NAME>" \
-  --surname "<LAST_NAME>" \
-  --output json
-```
-
-### Step 2 — Find the user once they accept
-
-```bash
-uip admin users list \
-  --search "<USER_EMAIL>" --output json
-```
-
-### Step 3 — Assign to a group
-
-```bash
-uip admin groups list --output json
-uip admin groups members add <GROUP_ID> \
-  --user-ids "<USER_ID>" \
-  --output json
-```
-
-## Quick Start — Audit
-
-For the canonical "find events in a window then export" flow. For specific scenarios jump to the [Task Navigation](#task-navigation) table.
-
-### Audit scope disambiguation
-
-The `org` vs `tenant` choice matters — they hit different basePaths and surface different events.
-
-| User says... | Likely scope | Why |
-|---|---|---|
-| "who joined / left the organization", "who was made an admin", "license changes", "cross-tenant audit", **"failed/successful logins"**, **"login history for user X"**, **"who's been signing in"** | **org** | Org-level events (memberships, license, tenant lifecycle, **Identity Server / IdP authentication including User Login**) live under `/orgaudit_`. |
-| "what happened on tenant X", "asset/queue/folder edits", "queue items processed", "job failures", "Action Center task changes", "Apps / AgentHub / Document Understanding / Integration Service / Test Manager activity" | **tenant** | Tenant-scoped events (Orchestrator, Action Center, Apps, AgentHub, Document Understanding, Integration Service, Test Manager, Data Fabric, Process Mining, Relay, Hypervisor, tenant-side Admin) live under `/{tenantId}/tenantaudit_`. Note: governance/AOps policies, source control, and pipelines are **org**-scoped despite the AOps name. |
-| "everything everywhere" | **both** — run the same flow once per scope and present combined results. |
-
-If the prompt is **vague about scope** AND no prior turn has established it, **stop and ask** (one yes/no question, two clarifications max). Don't assume `tenant` just because it's the more common case.
-
-### Step 1 — Verify scope, then discover sources
-
-```bash
-# Tenant-scoped (most common)
-uip admin audit tenant sources --output json > sources.json
-
-# Org-scoped (admin events: tenant lifecycle, license, memberships)
-uip admin audit org sources --output json > sources-org.json
-```
-
-Each entry has `id` (a GUID — pass to `events --source`), `name` (human-readable), and `eventTargets[]` (each with their own GUIDs and `eventTypes[]`).
-
-### Step 2 — Query events with filters
-
-```bash
-uip admin audit tenant events \
-  --source <SOURCE_GUID_FROM_STEP_1> \
-  --from-date 2026-04-22T00:00:00Z \
-  --to-date   2026-04-29T00:00:00Z \
-  --limit 50 \
-  --output json
-```
-
-The response is `{ "auditEvents": [...], "next": null, "previous": "..." }`. For more than 200 events, pass `--limit 500` (or larger) — the tool paginates internally. Do **not** write a manual loop in the agent.
-
-### Step 3 — Export for compliance / sharing
-
-```bash
-uip admin audit tenant export \
-  --from-date 2026-01-01 \
-  --to-date   2026-02-01 \
-  --output-file ./audit-jan.zip
-```
-
-One HTTP call per UTC day inside the window, aggregated into a single flat ZIP at `--output-file`. The result envelope reports `{Path, Bytes, Format: "zip", Days, NonEmptyDays}`. On any chunk failure (e.g. HTTP 504), no file is written and the error identifies which day failed.
+| Goal | Entry command(s) |
+|---|---|
+| **Invite a user → assign to group** | [user-management.md](references/user-management.md) + [group-management.md](references/group-management.md) |
+| **Create a custom role** | `uip admin authorization roles create --scope <Organization\|TenantGlobal\|Tenant\|Project> --name "<NAME>" --file ./actions.json --output json` (actions.json = `["STUDIO.X.Y", ...]`) |
+| **Grant permission(s) to a principal** ("grant me X", "give alice Y, Z") | [grant-permissions.md](references/authorization/grant-permissions.md) — intersection-and-menu flow |
+| **Assign a role to a principal** | (1) Resolve principal per Rule 5. (2) `roles get <ROLE_ID>` → echo `ownerServiceName` + verify scope-path service segment matches (Rule 17). (3) `roles assignments create --role-id <ROLE_ID> --identity-id <ID> --identity-type <User\|Group\|Robot\|ExternalApplication> --output json` |
+| **See what a principal can do** | `uip admin authorization check-access <USER_GUID_OR_EMAIL> --scope <Tenant\|Folder> --output json` (Rule 15) |
+| **Create a tenant** | `organizations regions list` → `tenants create --name <N> --region <R>` → poll `organizations operation get <OP_ID>` (Rule 18) |
+| **Add a tenant service** | `tenants services list-available --region <R>` → `tenants services add --tenant-id <TID> --service <SVC>` (verify post-state per Rule 22) |
+| **Enable IP allowlist enforcement** | `ip-restriction my-ip` → verify covered by `ip-ranges list` → `ip-restriction enforcement enable --confirm` (Rule 31) |
+| **Query audit events / export** | [audit-workflow-guide.md](references/audit-workflow-guide.md) — scope disambiguation + 4 investigation playbooks (who-did-X, login history, date-range dump, overview) |
 
 ## Key Concepts
 
-### Organization Hierarchy
+### Organization hierarchy
 
 ```
 Organization (org)
@@ -168,75 +165,54 @@ Organization (org)
         └── External Apps   ← OAuth2 clients (Client ID + Secret)
 ```
 
-### Robot Accounts vs External Apps
+### Robot accounts vs external apps
 
-These are separate concepts — do not conflate them.
-
-| Concept | Purpose | Managed By |
-|---------|---------|------------|
+| Concept | Purpose | Managed by |
+|---|---|---|
 | **Robot account** | Identity — who the robot is | Identity Server (`uip admin`) |
 | **Robot credentials** | Per-robot Client ID + Secret for machine auth | Orchestrator (machine connection) |
 | **External app** | OAuth2 client for API integrations, CI/CD | Identity Server (`uip admin`) |
 
-Robot credentials are provisioned automatically by Orchestrator when connecting a robot to a machine — not by creating external apps.
+Robot credentials are provisioned automatically by Orchestrator on machine connect — not by creating external apps.
 
-### Audit scope → basePath
+## Output Etiquette
 
-- `org`    → `{baseUrl}/{orgId}/orgaudit_/api/Query/...`
-- `tenant` → `{baseUrl}/{orgId}/{tenantId}/tenantaudit_/api/Query/...`
+What to surface after each verb. Per-area detail in the reference files; this is the contract.
 
-Same `QueryApi` underneath; the only difference is which segment the SDK puts in the URL.
-
-### Audit `Data` shape varies by verb
-
-| Verb | `Data` shape |
+| Area | Always surface |
 |---|---|
-| `audit <scope> sources` | array of `AuditEventSourceDto` |
-| `audit <scope> events` | object `{auditEvents, next, previous}` |
-| `audit <scope> export` | object `{Path, Bytes, Format, Days, NonEmptyDays}` |
+| **Identity** mutations | Result + new resource id; for external-app create / `generate-secret`, **highlight the secret + warn to save**; offer a next step (assign to group, generate another secret, etc.). |
+| **Authz** reads + mutations | Provenance: role name, `scopeType`, `ownerServiceName` (read directly from response — translate to display name per Rule 17, e.g., `Reinfer`→"IXP"), tenant binding (resolve UUID → name). **`check-access`: label each row as `direct` or `inherited from <Group name>`** by inspecting the nested `roleAssignments[].securityPrincipalType`. Full contract: [authorization-commands.md → Provenance contract](references/authorization/authorization-commands.md#provenance-contract-for-completion-output). |
+| **OMS** reads | Separate **provisioned** (with status) from **available catalog** (no status). Lead with `Organization: <ORG_NAME>` (and tenant name + UUID + lifecycle status for tenant reads). |
+| **OMS** mutations | Echo the resolved target before running (Anti-pattern 13). Async: auto-poll 3× at 5 s, then numbered menu (Rule 18). Sync services: re-list to verify post-state (Rule 22). |
+| **Audit** queries | Disambiguate `org` vs `tenant` first (Rule 23). Discover via `sources` (Rule 26). Bound the window (Rule 27). Operation summary (count, scope, time window, filters, cursor state). Wait for the user's next-step choice; do not chain mutations. Investigation playbooks: [audit-workflow-guide.md](references/audit-workflow-guide.md). |
+| **IP Restriction** mutations | Before `enforcement enable`: state the impact, require explicit user confirmation (Rule 31). After: confirm caller's IP is still covered (re-run `my-ip` + `ip-ranges list`). Never use the internal name "APMS" in user-facing output. |
 
-`events` is the one verb that legitimately returns an object — pagination cursors live alongside the rows.
-
-## Completion Output
-
-### After identity mutations (create, update, delete, invite, members add/revoke, generate-secret)
-
-1. Show the command result (success or failure)
-2. For creates: display the new resource ID
-3. For external-app create or generate-secret: **highlight the secret value and warn user to save it**
-4. Offer logical next steps:
-   - After creating a robot account → "Assign to a group for role-based access?"
-   - After creating an external app → "Generate an additional secret?"
-   - After inviting a user → "Check user list to see when they accept?"
-
-### After an audit query or export
-
-1. **Operation & result** — e.g. `Found 47 audit events on tenant T in the last 7 days` or `Wrote 123,456 bytes to /path/to/audit.zip (3 days, 2 non-empty)`.
-2. **Scope used** (`org` or `tenant`) and any `--tenant-id` override.
-3. **Time window** — explicit ISO bounds, even if they came from a relative phrase ("last 7 days").
-4. **Filters applied** — sources, types, users, status.
-5. **Cursor state** — for `events`, mention whether `Data.previous` is null (start of audit history) or populated (more older events available — re-run with a larger `--limit`).
-6. **Next step** — "Want me to widen the window?", "Want me to export this slice?", "Want me to filter by user X?". Wait for the user's choice; do not chain mutations.
+For per-area full checklists, follow the table's inline links: Identity → [identity-commands.md](references/identity-commands.md#output-etiquette--after-any-identity-mutation); Authz → [authorization-commands.md](references/authorization/authorization-commands.md#provenance-contract-for-completion-output); Audit → [audit-workflow-guide.md](references/audit-workflow-guide.md#output-etiquette--after-an-audit-query-or-export).
 
 ## Task Navigation
 
 | I need to... | Read first |
 |---|---|
-| **Full CLI command reference (identity)** | [references/identity-commands.md](references/identity-commands.md) |
-| **Manage users** (list, create, invite, update, delete) | [references/user-management.md](references/user-management.md) |
-| **Manage groups** (CRUD + membership) | [references/group-management.md](references/group-management.md) |
-| **Manage robot accounts** | [references/robot-account-management.md](references/robot-account-management.md) |
-| **Manage external apps** (OAuth2 + secrets) | [references/external-app-management.md](references/external-app-management.md) |
-| **Full CLI command reference (audit)** | [references/audit-commands.md](references/audit-commands.md) |
-| **Investigation playbooks** (who-did-X / login-history / date-range dump / overview) | [references/audit-workflow-guide.md](references/audit-workflow-guide.md) |
-| **Paginate audit events beyond 200** | [references/audit-commands.md](references/audit-commands.md) (events flag table) + Critical Rule #13 |
-
-## References
-
-- **[identity-commands.md](references/identity-commands.md)** — Complete CLI reference for all `uip admin` identity commands with flags, arguments, and output codes
-- **[user-management.md](references/user-management.md)** — User lifecycle workflows: discover, create, invite, update, delete, pagination, sorting
-- **[group-management.md](references/group-management.md)** — Group CRUD, membership management (add/remove members), built-in vs custom groups
-- **[robot-account-management.md](references/robot-account-management.md)** — Robot account lifecycle, relationship to external apps
-- **[external-app-management.md](references/external-app-management.md)** — OAuth2 client management, secret generation/rotation, scope reference
-- **[audit-commands.md](references/audit-commands.md)** — Single source of truth for every `uip admin audit` subcommand: signature, every flag with required/optional, the `Code` value, and the exact `Data` shape returned
-- **[audit-workflow-guide.md](references/audit-workflow-guide.md)** — Narrative playbook for the four canonical investigations: who-did-X, login-history, date-range-dump, and org-vs-tenant comparison
+| Identity CLI reference | [references/identity-commands.md](references/identity-commands.md) |
+| Manage users (list / create / invite / update / delete) | [references/user-management.md](references/user-management.md) |
+| Manage groups (CRUD + membership) | [references/group-management.md](references/group-management.md) |
+| Manage robot accounts | [references/robot-account-management.md](references/robot-account-management.md) |
+| Manage external apps (OAuth2 + secrets) | [references/external-app-management.md](references/external-app-management.md) |
+| Authorization CLI reference | [references/authorization/authorization-commands.md](references/authorization/authorization-commands.md) |
+| Manage custom roles | [references/authorization/role-management.md](references/authorization/role-management.md) |
+| Grant permission(s) to a principal — scope/service intersection flow | [references/authorization/grant-permissions.md](references/authorization/grant-permissions.md) |
+| Manage role assignments (incl. role-service vs scope-path validation, Rule 17) | [references/authorization/role-assignment-management.md](references/authorization/role-assignment-management.md) |
+| List permission definitions | [references/authorization/permission-catalog.md](references/authorization/permission-catalog.md) |
+| Check effective access for a principal | [references/authorization/check-access.md](references/authorization/check-access.md) |
+| Organizations CLI reference | [references/organizations-commands.md](references/organizations-commands.md) |
+| Tenants CLI reference | [references/tenants-commands.md](references/tenants-commands.md) |
+| Manage the organization (read + update, polling, regions, org services read-only) | [references/organization-management.md](references/organization-management.md) |
+| Manage tenants (CRUD, enable/disable, tenant services) | [references/tenant-management.md](references/tenant-management.md) |
+| IP-restriction CLI reference | [references/ip-restriction/ip-restriction-commands.md](references/ip-restriction/ip-restriction-commands.md) |
+| Manage IP allowlist entries | [references/ip-restriction/ip-range-management.md](references/ip-restriction/ip-range-management.md) |
+| Toggle enforcement (+ `my-ip` safety check) | [references/ip-restriction/enforcement-management.md](references/ip-restriction/enforcement-management.md) |
+| Manage bypass rules | [references/ip-restriction/bypass-rule-management.md](references/ip-restriction/bypass-rule-management.md) |
+| Audit CLI reference | [references/audit-commands.md](references/audit-commands.md) |
+| Audit investigation workflows (scope disambiguation, who-did-X, login history, date-range dump, overview) | [references/audit-workflow-guide.md](references/audit-workflow-guide.md) |
+| Paginate audit events beyond 200 | [references/audit-commands.md](references/audit-commands.md) + Rule 25 |

--- a/skills/uipath-admin/references/audit-commands.md
+++ b/skills/uipath-admin/references/audit-commands.md
@@ -20,6 +20,16 @@ uip admin audit
 
 `org` and `tenant` are **subject subgroups**. Same three verbs under each. The two trees are 100% verb-symmetric — any flag valid on `tenant events` is also valid on `org events` (except `--tenant-id`, which is tenant-only).
 
+## Output `Data` shape varies by verb — quick reference
+
+| Verb | `Data` shape |
+|---|---|
+| `audit <scope> sources` | array of `AuditEventSourceDto` |
+| `audit <scope> events` | object `{auditEvents, next, previous}` |
+| `audit <scope> export` | object `{Path, Bytes, Format, Days, NonEmptyDays}` |
+
+`events` is the one verb that legitimately returns an object — pagination cursors live alongside the rows. Full shape detail per verb in the sections below.
+
 ---
 
 ## uip admin audit `<scope>` sources

--- a/skills/uipath-admin/references/audit-workflow-guide.md
+++ b/skills/uipath-admin/references/audit-workflow-guide.md
@@ -4,6 +4,18 @@ Four canonical investigations the `uipath-audit` skill should drive. Each starts
 
 > Every command below assumes the user has run `uip login` and the active token includes the `Audit.Read` scope. Every command should pass `--output json` so the agent can parse the envelope.
 
+## Audit scope disambiguation — route by user phrasing
+
+Pick `org` vs `tenant` BEFORE any `audit` call. They hit different basePaths and surface different events. Use this table to route a user query (SKILL.md Critical Rule 23 is the contract; this is the decision tool):
+
+| User says... | Likely scope | Why |
+|---|---|---|
+| "who joined / left the organization", "who was made an admin", "license changes", "cross-tenant audit", **"failed/successful logins"**, **"login history for user X"**, **"who's been signing in"** | **org** | Org-level events (memberships, license, tenant lifecycle, **Identity Server / IdP authentication including User Login**) live under `/orgaudit_`. |
+| "what happened on tenant X", "asset/queue/folder edits", "queue items processed", "job failures", "Action Center task changes", "Apps / AgentHub / Document Understanding / Integration Service / Test Manager activity" | **tenant** | Tenant-scoped events (Orchestrator, Action Center, Apps, AgentHub, Document Understanding, Integration Service, Test Manager, Data Fabric, Process Mining, Relay, Hypervisor, tenant-side Admin) live under `/{tenantId}/tenantaudit_`. Note: governance/AOps policies, source control, and pipelines are **org**-scoped despite the AOps name. |
+| "everything everywhere" | **both** — run the same flow once per scope and present combined results. |
+
+If the prompt is **vague about scope** AND no prior turn has established it, **stop and ask** (one yes/no question, two clarifications max). Don't assume `tenant` just because it's the more common case.
+
 ---
 
 ## Investigation 1 — "Who did X to resource Y?"
@@ -265,3 +277,14 @@ Two or more signals? Run them in sequence and stitch the results in the final re
 - **Date-only ISO strings are interpreted as UTC midnight.** `--from-date 2026-01-01` means `2026-01-01T00:00:00Z`. To capture the full final day in `--to-date`, use `2026-02-01` (exclusive next day) or `2026-01-31T23:59:59.999Z`.
 - **The export ZIP's per-day files are JSON, not CSV, and use PascalCase keys.** Different from the camelCase live `events` endpoint. Don't paste an export directly into a parser expecting the live shape.
 - **Org sources and tenant sources are different sets.** Don't reuse a GUID from `org sources` in a `tenant events` query — the filter will silently match nothing.
+
+## Output Etiquette — after an audit query or export
+
+After every `events` or `export` call, surface the following before waiting for the user's next-step choice. Do not chain mutations.
+
+1. **Operation & result** — e.g. `Found 47 audit events on tenant T in the last 7 days` or `Wrote 123,456 bytes to /path/to/audit.zip (3 days, 2 non-empty)`.
+2. **Scope used** (`org` or `tenant`) and any `--tenant-id` override.
+3. **Time window** — explicit ISO bounds, even if they came from a relative phrase ("last 7 days").
+4. **Filters applied** — sources, types, users, status.
+5. **Cursor state** — for `events`, mention whether `Data.previous` is null (start of audit history) or populated (more older events available — re-run with a larger `--limit`).
+6. **Next step** — "Want me to widen the window?", "Want me to export this slice?", "Want me to filter by user X?". Wait for the user's choice.

--- a/skills/uipath-admin/references/authorization/authorization-commands.md
+++ b/skills/uipath-admin/references/authorization/authorization-commands.md
@@ -1,0 +1,443 @@
+# Authorization CLI Command Reference
+
+Complete reference for all `uip admin authorization` commands — custom-role CRUD, role assignments, permission catalog, and effective-access lookups (Authorization service).
+
+For workflow-level guidance, see [role-management.md](role-management.md), [role-assignment-management.md](role-assignment-management.md), [permission-catalog.md](permission-catalog.md), and [check-access.md](check-access.md).
+
+## Global Flags
+
+Every command accepts these flags (omitted from per-command tables):
+
+| Flag | Description |
+|------|-------------|
+| `--output <format>` | Output format: `json`, `table`, `yaml`, `plain` (default: json) |
+| `--output-filter <expression>` | JMESPath expression to filter output |
+| `--log-level <level>` | Log level: `debug`, `info`, `warn`, `error` (default: info) |
+| `--log-file <path>` | Write logs to file instead of stderr |
+| `--login-validity <minutes>` | Override token validity — forces refresh if token expires within this window |
+
+Organization is resolved automatically from the active login session.
+
+## Prerequisites
+
+```bash
+uip login status --output json
+```
+
+If not logged in: `uip login`.
+
+## Concepts
+
+- **PAP vs PDP.** Roles and role assignments live at the Policy Administration Point. `check-access` is the Policy Decision Point — it computes effective access for a principal at a scope, including services that don't expose assignments via `roles assignments list`.
+- **Role shape values** (`--scope` on `roles create/update`): `Organization`, `TenantGlobal`, `Tenant`, `Project`. **No `Folder`** — folder-level scoping is expressed only on assignments, not on the role definition.
+- **`TenantGlobal` vs `Tenant`.** `Tenant` = role is bound to one specific tenant UUID. `TenantGlobal` = role is a reusable template, available in every tenant of the org.
+- **Service-managed roles.** `orchestrator`, `dataservice`, `insights`, `taskmining`, `testmanager`, `automationops`, `casemanagement`, `processmining` own their role catalogs server-side. `roles list --service <svc>` and `roles assignments list --service <svc>` **do** surface their roles and assignments; only `roles create / update / delete` is blocked against these services. Mutate them via the service's own CLI (e.g. `uip or roles ...` for Orchestrator). Use `check-access` for *effective* access (PDP — includes server-side rules not visible via the catalog).
+- **Platform-level services** — `authz`, `oms`, `platform`, `identity`, `licensing` — reject custom-role authoring (same as service-managed). Listing works.
+- **`--service` infers scope** on `roles create/update/list` and `permissions list`. E.g. `--service studio` resolves to `Tenant`; `--service apps` to `Organization`. Combine `--service` with `--scope` only to override the registry default.
+- **No `--service centralizedaccess`.** The CLI rejects this value on `roles create/list`, `roles assignments list`, and `permissions list` with `'centralizedaccess' is not a valid --service value`. For the multi-service "Centralized Access" tenant/org role and the matching listings, **omit `--service`** and use `--scope <Tenant|Organization|TenantGlobal>` alone.
+- **PUT-style upsert.** `roles create` and `roles update` share an endpoint. The CLI assembles the full role body from your inline flags + the `--file` actions array; submitting `update` with only some inline flags still rewrites the entire role (re-fetch first).
+- **Built-in roles** (`type: BuiltIn`) cannot be created, updated, or deleted.
+- **Principal types** (`--identity-type` on assignments): `User | Group | Robot | ExternalApplication`.
+
+---
+
+## Roles — `uip admin authorization roles`
+
+### `roles list`
+
+List roles in the organization.
+
+```bash
+uip admin authorization roles list --output json
+uip admin authorization roles list --scope Organization --output json
+uip admin authorization roles list --scope Tenant --output json                     # multi-service tenant roles (no --service)
+uip admin authorization roles list --service studio --filter Admin --output json
+uip admin authorization roles list --role-type Custom --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--filter <fragment>` | No | Substring match on role name |
+| `--service <name>` | No | Restrict to one service's role definitions; sets `--scope` from registry when used alone. See Concepts → no `--service centralizedaccess` |
+| `--scope <type>` | No | Filter by role shape: `Organization`, `TenantGlobal`, `Tenant`, `Project`, or `Folder` (case-insensitive). Optional when `--service` is provided |
+| `--role-type <BuiltIn\|Custom>` | No | Restrict by type |
+| `--tenant-id <guid>` | No | Restrict to roles scoped to a specific tenant. Resolve via `uip admin tenants list --filter <name>` |
+| `-l, --limit <number>` | No | Items per page |
+| `--offset <number>` | No | Items to skip |
+
+**Output code:** `AuthzRolesList`.
+
+### `roles get`
+
+Fetch a role by id. Response includes `ownerServiceId` + **`ownerServiceName`** — the role's permanent service binding (e.g., `Reinfer`, `DocumentUnderstanding`, `CentralizedAccess`). Read these before creating assignments — see [role-assignment-management.md — Validate Role's Owning Service vs. Assignment Scope-Path](role-assignment-management.md#validate-roles-owning-service-vs-assignment-scope-path).
+
+```bash
+uip admin authorization roles get <ROLE_ID> --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<ROLE_ID>` | Yes | Role UUID. Obtain from `roles list` |
+
+**Output code:** `AuthzRoleGet`.
+
+### `roles create`
+
+Create a custom role. Inline flags carry the role metadata; `--file` carries the granted actions as a JSON string array.
+
+```bash
+# Multi-service tenant role ("Centralized Access") — NO --service, omit it
+uip admin authorization roles create \
+  --scope Tenant \
+  --tenant-id <TENANT_ID> \
+  --name "Tenant Reader" \
+  --file ./actions.json --output json
+
+# Organization-shape role — multi-service org role (no --service)
+uip admin authorization roles create \
+  --scope Organization \
+  --name "Org Reader" \
+  --description "Read-only org admin" \
+  --file ./actions.json --output json
+
+# Service-specific role — scope inferred from the service registry (studio → Tenant)
+uip admin authorization roles create \
+  --service studio \
+  --name "Studio Author" \
+  --file ./actions.json --output json
+
+# Tenant-global template — reusable across every tenant in the org (no --service)
+uip admin authorization roles create \
+  --scope TenantGlobal \
+  --name "Tenant Reader Template" \
+  --file ./actions.json --output json
+
+# Project-scope role for a service that registers Project-shape permissions
+uip admin authorization roles create \
+  --scope Project \
+  --service documentunderstanding \
+  --name "DU Project Editor" \
+  --file ./actions.json --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name <name>` | Yes | Role display name |
+| `--description <text>` | No | Human-readable description |
+| `--service <name>` | Conditional | Owning service; required for `--scope Project`. Used alone, infers scope from the registry. See Concepts → no `--service centralizedaccess` |
+| `--scope <type>` | Conditional | Role shape: `Organization`, `TenantGlobal`, `Tenant`, `Project` (case-insensitive). Optional when `--service` is provided |
+| `--tenant-id <guid>` | No | Tenant UUID. Only valid when the resolved scope is `Tenant` or `Project`. Defaults to the login tenant |
+| `--file <path>` | Yes | Path to a JSON file containing the granted actions as a string array |
+
+> **Summary etiquette:** when reporting `roles create` results to the user, always state the resolved service explicitly — `service: <name>` if `--service` was passed, or `service: none — multi-service <scope> role` if omitted.
+
+`./actions.json`:
+
+```json
+["STUDIO.X.Y", "STUDIO.A.B", "STUDIO.NUGET.LIST"]
+```
+
+Each string is a permission `name` resolved via `permissions list`. **Permission names, not UUIDs.**
+
+**Output code:** `AuthzRoleCreated`.
+
+### `roles update`
+
+Update an existing custom role. Same endpoint as `create` (PUT-style upsert). The CLI assembles the full body from the positional `<ID>` + your inline flags + the `--file` actions array — re-fetch the role first, edit, then submit, so you don't lose fields.
+
+```bash
+uip admin authorization roles update <ROLE_ID> \
+  --scope Tenant \
+  --name "Tenant Reader v2" \
+  --file ./actions.json --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<ROLE_ID>` | Yes | Role UUID. Positional id always wins over any body-side id |
+| `--name <name>` | No | Role display name |
+| `--description <text>` | No | New description |
+| `--service <name>` | Conditional | Owning service; required for `--scope Project`. See Concepts → no `--service centralizedaccess` |
+| `--scope <type>` | Conditional | Role shape: `Organization`, `TenantGlobal`, `Tenant`, `Project` |
+| `--tenant-id <guid>` | No | Tenant UUID. Valid only for `Tenant`/`Project` scopes |
+| `--file <path>` | No | Replacement actions array (string array). Omitting it preserves the current action set |
+
+**Output code:** `AuthzRoleUpdated`.
+
+### `roles delete`
+
+Delete a custom role. Only `type: Custom` roles can be deleted.
+
+```bash
+uip admin authorization roles delete <ROLE_ID> --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<ROLE_ID>` | Yes | Role UUID |
+
+The CLI pre-fetches and refuses service-managed / platform-owned roles with a redirect.
+
+**Output code:** `AuthzRoleDeleted`.
+
+---
+
+## Role Assignments — `uip admin authorization roles assignments`
+
+An assignment is the triple **(principal, role, scope)**.
+
+### `roles assignments list`
+
+List assignments grouped by identity.
+
+```bash
+uip admin authorization roles assignments list --output json
+uip admin authorization roles assignments list --scope Organization --output json
+uip admin authorization roles assignments list --scope Tenant --tenant-id <TENANT_ID> --output json
+uip admin authorization roles assignments list --scope Folder --scope-id Insights --output json
+uip admin authorization roles assignments list --scope Project --scope-id <PROJECT_ID> --output json
+uip admin authorization roles assignments list --scope Tenant --output json    # multi-service tenant assignments (no --service)
+uip admin authorization roles assignments list --identity-id <PRINCIPAL_ID> --output json
+uip admin authorization roles assignments list --include-inherited --output json
+uip admin authorization roles assignments list --scope-path "/tenant/<TID>/Reinfer" --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--identity-id <id>` | No | Filter by principal UUID (server-side) |
+| `--service <name>` | No | Filter by service (server-side); combines with `--scope` or sets the scope path from the registry. See Concepts → no `--service centralizedaccess` |
+| `--scope <type>` | No | `Organization`, `Tenant`, `Project`, `Folder`, or `App`. Default: `Tenant`. **`TenantGlobal` is not valid here.** Project/Folder/App require `--service` and `--scope-id` |
+| `--scope-id <id>` | Conditional | Project id / folder name or id / app id when `--scope` is Project/Folder/App. Combined with `--service` to build the sub-scope path |
+| `--scope-path <path>` | No | Advanced: send the exact path verbatim. Overrides `--scope`, `--tenant-id`, `--scope-id` |
+| `--tenant-id <guid>` | No | Tenant UUID. Defaults to the login tenant when scope is Tenant/Project/Folder/App |
+| `--include-inherited` | No | Also surface assignments inherited from parent scopes (default: direct only) |
+| `-l, --limit <number>` | No | Server caps at 10 assignment groups per page |
+| `--offset <number>` | No | Items to skip |
+
+**Output code:** `AuthzAssignmentsList`.
+
+### `roles assignments create`
+
+Create one (inline) or many (`--file`) assignments.
+
+> **Pre-flight required: role-service must match scope-path service segment.** Before submitting, fetch the role via `roles get <ROLE_ID>` and validate that the scope-path you're about to send matches the role's `ownerServiceName` (case-insensitive `lowercase(ownerServiceName) == <svc>` segment in the path). For `ownerServiceName == "CentralizedAccess"`, the path must NOT include a service segment. Full procedure: [role-assignment-management.md — Validate Role's Owning Service vs. Assignment Scope-Path](role-assignment-management.md#validate-roles-owning-service-vs-assignment-scope-path).
+
+```bash
+# Inline — tenant id auto-fills from the login session
+uip admin authorization roles assignments create \
+  --role-id <ROLE_ID> \
+  --identity-id <PRINCIPAL_ID> \
+  --identity-type User --output json
+
+# Specific tenant
+uip admin authorization roles assignments create \
+  --role-id <ROLE_ID> \
+  --identity-id <PRINCIPAL_ID> \
+  --identity-type User \
+  --tenant-id <TENANT_ID> --output json
+
+# Folder / Project / App scope — pass the exact scope path
+uip admin authorization roles assignments create \
+  --role-id <ROLE_ID> \
+  --identity-id <GROUP_ID> \
+  --identity-type Group \
+  --scope-path "/tenant/<TID>/Reinfer/project/<PID>" --output json
+
+# Batch — array of AddRoleAssignmentRequest
+uip admin authorization roles assignments create --file ./assignments.json --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--role-id <id>` | Yes (inline) | Role UUID |
+| `--identity-id <id>` | Yes (inline) | Principal UUID |
+| `--identity-type <type>` | Yes (inline) | `User`, `Group`, `Robot`, `ExternalApplication` |
+| `--service <name>` | No | Owning service; combines with `--scope`, or used alone sets the scope path from the registry |
+| `--scope <type>` | No | `Organization`, `TenantGlobal`, `Tenant`, `Project`, `Folder`, or `App`. Project/Folder/App require `--service` and `--scope-id` |
+| `--scope-id <id>` | Conditional | Project id / folder name or id / app id for `--scope Project|Folder|App` |
+| `--scope-path <path>` | No | Advanced: send the exact path verbatim. Overrides `--scope`, `--service`, `--scope-id`, `--tenant-id` |
+| `--tenant-id <guid>` | No | Tenant UUID for Tenant / TenantGlobal / Project / Folder / App scopes. Defaults to the login tenant |
+| `--file <path>` | Alternative | Batch — JSON array of `AddRoleAssignmentRequest` |
+
+Inline auto-fills scope path from the role's `scopeType` when no `--scope`/`--scope-path` is given:
+
+| Role scope | Auto-filled path |
+|------------|------------------|
+| `Organization` | `/` |
+| `Tenant` / `TenantGlobal` | `/tenant/<TENANT_ID>` (defaults to login tenant) |
+| `Project` / `Folder` / `App` | **Not auto-filled** — pass `--scope` + `--service` + `--scope-id`, or use `--scope-path` |
+
+Batch `assignments.json`:
+
+```json
+[
+  {
+    "roleId": "<ROLE_ID>",
+    "securityPrincipalId": "<PRINCIPAL_ID>",
+    "securityPrincipalType": "User",
+    "scope": "/tenant/<TENANT_ID>"
+  }
+]
+```
+
+The bulk endpoint is atomic — partial failure rolls back the whole batch.
+
+**Output code:** `AuthzAssignmentCreated`.
+
+### `roles assignments delete`
+
+Delete one (positional) or many (`--file`) assignments.
+
+```bash
+uip admin authorization roles assignments delete <ASSIGNMENT_ID> --output json
+uip admin authorization roles assignments delete --file ./assignment-ids.json --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<ASSIGNMENT_ID>` | No (with `--file`) | Single assignment UUID |
+| `--file <path>` | Alternative | JSON array of UUID strings |
+
+Batch `assignment-ids.json`:
+
+```json
+["0fae98e1-0f2e-4f8d-bdab-7ce1cf475676", "1aab33cf-..."]
+```
+
+**Idempotency caveat:** the bulk endpoint silently no-ops on unknown / already-deleted ids and still returns Success. To confirm a deletion took effect, list before and after.
+
+**Output code:** `AuthzAssignmentDeleted`.
+
+---
+
+## Permissions — `uip admin authorization permissions`
+
+### `permissions list`
+
+Read-only catalog of permission definitions across services. Each record carries `id`, `name`, `namespace`, `serviceDisplayName`, `resourceType`, `resourceAction`, `resourceGroup`, `scopeType`.
+
+```bash
+uip admin authorization permissions list --output json
+uip admin authorization permissions list --scope Organization --output json
+uip admin authorization permissions list --scope Tenant --output json                       # multi-service tenant catalog (no --service)
+uip admin authorization permissions list --service studio --output json
+uip admin authorization permissions list --scope Project --service documentunderstanding --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--service <name>` | No | Restrict to one service. Combines with `--scope`, or used alone sets the scope from the service registry. Known: `apps, authz, automationops, casemanagement, dataservice, documentunderstanding, identity, insights, licensing, oms, orchestrator, platform, processmining, reinfer, studio, taskmining, testmanager`. Other names accepted free-form. See Concepts → no `--service centralizedaccess` |
+| `--scope <type>` | No | Filter by role shape: `Organization`, `TenantGlobal`, `Tenant`, or `Project` (case-insensitive). Optional when `--service` is provided |
+
+`authz` cross-cutting permissions are filtered out by default — pass `--service authz` to surface them.
+
+**Output code:** `AuthzPermissionsList`.
+
+> Permission `name` strings (e.g., `STUDIO.X.Y`) — not UUIDs — are what go into `roles create --file ./actions.json`.
+
+---
+
+## Check Access — `uip admin authorization check-access`
+
+Compute the effective permissions a principal has at a scope (Policy Decision Point). Includes services that manage their own roles and do NOT surface via `roles assignments list`.
+
+```bash
+# Default scope = Tenant, defaults to login tenant
+uip admin authorization check-access <USER_GUID> --output json
+
+# Resolve the user by email substring — the identity API does the lookup
+uip admin authorization check-access alice@example.com --output json
+
+# Non-login tenant
+uip admin authorization check-access <USER_GUID> --tenant-id <TENANT_ID> --output json
+
+# Restrict to one service
+uip admin authorization check-access <USER_GUID> --service orchestrator --output json
+
+# Folder scope
+uip admin authorization check-access <USER_GUID> --scope Folder --folder-id <FOLDER_ID> --output json
+
+# Advanced — file body for filters not exposed inline (e.g. RoleNameStartsWith)
+uip admin authorization check-access --file ./check-access.json --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<identity>` | Yes (inline) | User UUID, name, or email. Positional. Required unless `--file` is supplied |
+| `--scope <type>` | No | Scope at which to evaluate access. Accepts **`Tenant`** (default) or **`Folder`** only — no `Organization` / `Project` |
+| `--tenant-id <guid>` | No | Tenant UUID. Defaults to login tenant. For `Tenant` scope it is used as both `Id` and `ParentId`; for `Folder` scope it is the `ParentId` |
+| `--folder-id <guid>` | Conditional | Folder UUID. Required when `--scope Folder`. Used as the scope `Id` |
+| `--service <name>` | No | Restrict to a specific service (useful for services that manage their own roles) |
+| `--file <path>` | Alternative | Full request body. Mutually exclusive with the positional identity and scope flags |
+
+`--file ./check-access.json`:
+
+```json
+{
+  "SecurityPrincipalId": "<PRINCIPAL_ID>",
+  "RoleNameStartsWith": "Admin",
+  "ServiceName": "orchestrator",
+  "ScopeIdentifier": {
+    "ScopeType": "Tenant",
+    "Value": { "Id": "<TENANT_ID>", "ParentId": "<TENANT_ID>" }
+  }
+}
+```
+
+For Folder scope, `Value.Id` is the folder UUID and `Value.ParentId` is the owning tenant UUID.
+
+Returned `Data`:
+- `roleAssignments` — paginated effective assignments
+- `grantedServicesMetadata` — services the principal has any access to
+- `grantedRolesMetadata` — roles contributing to the result
+
+**Output code:** `AuthzCheckAccess`.
+
+---
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `cannot create roles for service X` | Service is service-managed or platform-level | Use the service's own CLI (e.g., `uip or roles create` for Orchestrator) |
+| `role not found` | Invalid role id | Run `roles list` to find the correct id |
+| `cannot delete built-in role` | Target is `BuiltIn` | Only `Custom` roles can be deleted |
+| Updated role lost actions | `--file` omitted on update | Re-run `update` with `--file ./actions.json` populated, or fetch + edit + resubmit |
+| `invalid action name` | Permission name not in catalog | Re-resolve via `permissions list --service <SERVICE>` and copy the `name` value verbatim |
+| `principal not found` | Invalid identity id / email | Resolve via `uip admin users list --search <EMAIL>` or the matching identity command |
+| `scope path required` | Folder/Project/App role with no `--scope-path` and no `--scope`/`--service`/`--scope-id` triple | Pass `--scope Folder --service <svc> --scope-id <id>`, or pass `--scope-path` explicitly |
+| `folder-id required` | `check-access --scope Folder` without `--folder-id` | Pass the folder UUID; `--tenant-id` defaults to login tenant for the ParentId |
+| Empty `roleAssignments` | Principal has no effective access at this scope | Confirm via `roles assignments list --identity-id <ID>` |
+| Auth error | Login expired | `uip login status`, then `uip login` |
+
+---
+
+## Provenance contract for completion output
+
+Authz entitlements are anchored to a specific **organization**, **tenant** (or `TenantGlobal` template), and **service**. Every authz result the agent surfaces must show those three coordinates with UUIDs resolved to human-readable names — never leave a raw `tenantId` or `roleId` in user-facing output.
+
+| Verb | Always surface alongside the result |
+|---|---|
+| `roles list` / `roles get` | role name; `scopeType` (`Organization` / `TenantGlobal` / `Tenant` / `Project`); **owning service** read directly as `ownerServiceName`; **display name** for user-facing output (see mapping below); **tenant binding** (`tenantId` → tenant name; zero-GUID → "TenantGlobal / unbound") |
+| `roles create` / `roles update` | the role summary above, plus permission count, derived from a follow-up `roles get <id>` |
+| `roles assignments list` | role name; principal type + name (resolve UUIDs); **scope path with names**, not UUIDs (e.g., `/tenant/Prod-East/IXP/project/Invoices-AP`, not `/tenant/abc.../Reinfer/project/def...`) |
+| `roles assignments create` / `delete` | the assignment summary above; for batch, summarize per role + scope |
+| `permissions list` | group rows by `serviceDisplayName`; show `name`, `scopeType`, and a per-service row-count summary up front (e.g., "Studio (24), Identity (12), Apps (8)") |
+| `check-access` | the **tenant** the check ran against (login tenant or `--tenant-id` override); group `roleAssignments.results[]` rows **by `serviceName`** (which is already the display name) with a one-line "spans N services: A, B, C" summary up front; **for each role, label as `direct` or `inherited from <Group name>`** by inspecting the nested `roleAssignments[].securityPrincipalType` — `User` (with id matching the query) → direct; `Group` → inherited (resolve the `securityPrincipalId` to its `displayName` via `uip admin groups get <id>`) |
+
+### Service display-name mapping (CLI `ownerServiceName` → user-facing label)
+
+`ownerServiceName` returns a slug-like value; the user-facing **display name** is different for several services. Always translate before surfacing:
+
+| `ownerServiceName` (response) | Display name (use in user-facing output) | Slug for `--service` / scope-path |
+|---|---|---|
+| `Reinfer` | **IXP** | `reinfer` |
+| `DocumentUnderstanding` | Document Understanding | `documentunderstanding` |
+| `ProcessMining` | Process Mining | `processmining` |
+| `AutomationOps` | Automation Ops | `automationops` |
+| `CentralizedAccess` | Centralized Access | (omit `--service` — CLI rejects this slug) |
+| `Orchestrator`, `Insights`, `Apps`, `AuthZ`, `OMS`, `Platform`, etc. | (same as `ownerServiceName`) | `lowercase(ownerServiceName)` |
+
+The `serviceName` field on `check-access` `roleAssignments.results[]` already returns the display-name form (e.g., `"Data Service"`, `"IXP"`) — surface it verbatim. Use this mapping when the field you have is `ownerServiceName` instead.
+
+After any authz **mutation**: (1) show the command result + new resource id; (2) apply the contract above to the post-mutation state by re-fetching via `roles get` / `roles assignments list --identity-id <ID>`; (3) offer a next step ("assign this role?", "run `check-access` to verify?").

--- a/skills/uipath-admin/references/authorization/check-access.md
+++ b/skills/uipath-admin/references/authorization/check-access.md
@@ -1,0 +1,139 @@
+# Check Access (Effective Permissions)
+
+Conceptual guide and scope-specific workflows for `uip admin authorization check-access`. For the full flag/argument table and output code, see [authorization-commands.md — Check Access](authorization-commands.md#check-access--uip-admin-authorization-check-access).
+
+## Concept
+
+`check-access` is the **Policy Decision Point (PDP)**. It answers: *"What can this principal actually do at this scope, right now?"*
+
+Unlike `roles assignments list` (which reads stored assignments from the PAP catalog), `check-access` evaluates **effective** access — it folds in server-side rules from services that manage their own role catalogs (`orchestrator`, `dataservice`, `insights`, `taskmining`, `testmanager`, `automationops`, `casemanagement`, `processmining`) that the PAP catalog alone may not reflect. The catalog *does* surface these services' roles and assignments (`roles list --service <svc>` / `roles assignments list --service <svc>`), but the PDP is the source of truth for "what permissions resolve right now".
+
+Returned `Data`:
+
+- `roleAssignments.results[]` — list of effective roles the principal has at the scope. Each row is a role with metadata (`roleId`, `roleName`, `serviceName` (display-name form), `roleType`) **and a nested `roleAssignments[]` array** recording each underlying grant.
+- `grantedServicesMetadata` — services the principal has any access to.
+- `grantedRolesMetadata` — roles contributing to the result.
+
+## Direct vs. Inherited — Always Surface the Distinction
+
+`check-access` aggregates effective permissions from **direct** user grants AND grants the user **inherits via group membership**. The user needs to see which is which — revoking a direct grant means targeting the user's own assignment; revoking an inherited grant means changing group membership (or the group's role binding).
+
+For every role in `roleAssignments.results[]`, inspect the nested `roleAssignments[]`:
+
+| Nested entry | Interpretation | Label to render |
+|---|---|---|
+| `securityPrincipalType: "User"` AND `securityPrincipalId == queried-user-id` | Role assigned directly to this user | `direct` |
+| `securityPrincipalType: "Group"` | Role assigned to a group the user is a member of | `inherited from <Group displayName>` — resolve the `securityPrincipalId` via `uip admin groups get <id> --output json` (cache lookups within one report) |
+| `securityPrincipalType: "Robot"` / `"ExternalApplication"` | Cross-principal grant (rare on a user `check-access`) | `via <Robot\|ExternalApplication> <name>` |
+
+Multiple entries under one role's `roleAssignments[]` mean the user has the role via multiple paths — list **all** of them; do not collapse.
+
+### Example presentation
+
+```
+Effective access for alice@example.com at tenant Prod-East — spans 3 services: IXP, Orchestrator, Apps
+
+IXP (ownerServiceName: Reinfer)
+  • IXP Tenant Admin     — inherited from Tenant Admins
+  • IXP Project Reader   — direct
+
+Orchestrator
+  • Orchestrator Folder Admin — inherited from Tenant Admins
+
+Apps
+  • App User — direct
+```
+
+The response's `serviceName` field is already the display name (e.g., `"IXP"`, `"Data Service"`) — surface verbatim. When you only have `ownerServiceName` from a companion `roles get`, translate via [authorization-commands.md — Service display-name mapping](authorization-commands.md#service-display-name-mapping-cli-ownerservicename--user-facing-label).
+
+## Identity Argument
+
+The principal is the **positional** first argument — UUID, name, or email. The CLI resolves names and emails via the identity API.
+
+```bash
+uip admin authorization check-access <USER_GUID>
+uip admin authorization check-access alice@example.com
+uip admin authorization check-access "Alice Smith"
+```
+
+There is no `--identity-id` flag. With `--file`, the identity is set in the request body (`SecurityPrincipalId`) and the positional argument is omitted.
+
+## Choosing the Scope
+
+`check-access --scope` accepts only **`Tenant`** (default) or **`Folder`** — narrower than the scope vocab on `roles create` or `roles assignments create`.
+
+| Scope | When to use | Required flags beyond identity |
+|-------|-------------|--------------------------------|
+| `Tenant` (default if omitted) | Per-tenant access | `--tenant-id <GUID>` optional (defaults to login tenant) |
+| `Folder` | Folder-scoped access | `--scope Folder --folder-id <FOLDER_ID>`. `--tenant-id` becomes the owning tenant ParentId (defaults to login tenant) |
+
+> **No `Organization` / `Project` scope on `check-access`.** The PDP doesn't expose those directly. To approximate:
+> - **Org-wide entitlement check** — loop `check-access <USER> --tenant-id <TID>` over every tenant (`tenants list`), then aggregate `grantedRolesMetadata` per service.
+> - **Project-level access** — use `--scope Folder` with the project's owning folder, or filter the default `Tenant` result to the service that owns the project (`--service documentunderstanding` etc.).
+
+> `--folder-id` replaces the older `--scope-id` / `--parent-folder-id` pair. For Folder scope, `--folder-id` is the Folder's `Id` and `--tenant-id` is the owning tenant's `ParentId`.
+
+## Workflow: Check a User's Effective Access at the Login Tenant
+
+```bash
+uip admin authorization check-access <USER_GUID> --output json
+```
+
+Default scope is `Tenant`, default tenant is the login tenant.
+
+## Workflow: Check Across Tenants
+
+```bash
+uip admin authorization check-access <USER_GUID> --tenant-id <OTHER_TENANT_ID> --output json
+```
+
+## Workflow: Restrict to One Service
+
+Especially useful for services that manage their own roles, where the PAP catalog may not reflect server-side rules:
+
+```bash
+uip admin authorization check-access <USER_GUID> --service orchestrator --output json
+```
+
+Known service names: `apps, authz, automationops, casemanagement, dataservice, documentunderstanding, identity, insights, licensing, oms, orchestrator, platform, processmining, reinfer, studio, taskmining, testmanager`. Other names are accepted free-form (passed through verbatim as `ServiceName`).
+
+> **`--service centralizedaccess` is not in the list.** `check-access` does pass arbitrary `--service` values through verbatim, but the PDP has no separate "centralizedaccess" service to score — querying it returns no useful access info. For the multi-service / Centralized Access view, omit `--service` and let the default Tenant evaluation return every role the principal holds across services.
+
+## Workflow: Folder Scope
+
+```bash
+uip admin authorization check-access <USER_GUID> \
+  --scope Folder \
+  --folder-id <FOLDER_ID> \
+  --output json
+```
+
+`--tenant-id` defaults to the login tenant for the ParentId; override only when targeting a folder in a different tenant.
+
+## Workflow: Advanced — File-Based Request
+
+Use `--file <PATH>` for filters not exposed inline (e.g. `RoleNameStartsWith`). With `--file`, omit the positional identity and the inline scope flags — they're set in the body.
+
+`check-access.json`:
+
+```json
+{
+  "SecurityPrincipalId": "<PRINCIPAL_ID>",
+  "RoleNameStartsWith": "Admin",
+  "ServiceName": "orchestrator",
+  "ScopeIdentifier": {
+    "ScopeType": "Tenant",
+    "Value": { "Id": "<TENANT_ID>", "ParentId": "<TENANT_ID>" }
+  }
+}
+```
+
+For Folder scope, `Value.Id` is the folder UUID and `Value.ParentId` is the owning tenant UUID.
+
+```bash
+uip admin authorization check-access --file ./check-access.json --output json
+```
+
+## Resolving Principal IDs
+
+If you only have a UUID and want to verify the identity exists first, or if you need IDs for non-User principals, see [role-assignment-management.md — Resolving Principal IDs](role-assignment-management.md#resolving-principal-ids).

--- a/skills/uipath-admin/references/authorization/grant-permissions.md
+++ b/skills/uipath-admin/references/authorization/grant-permissions.md
@@ -1,0 +1,132 @@
+# Grant Permission(s) to a Principal
+
+Workflow for the ad-hoc **"grant me X"** / **"give <PRINCIPAL> permissions Y, Z"** request — a shortcut over the full Create-Role + Create-Assignment pair, optimized for the common case where the user names *permissions*, not a role shape.
+
+For per-command flag tables and output codes, see [authorization-commands.md](authorization-commands.md). For shared role-shape concepts (Centralized Access, service-inference rules, scope modes), see [role-management.md](role-management.md).
+
+## When to Use This Workflow
+
+The user names **one or more permissions** without naming a role or a scope. Examples:
+
+- *"grant me DOCUMENTUNDERSTANDING.PROJECTS.READ"*
+- *"give alice DU projects read and update"*
+- *"what's the minimal grant for licensing reads?"*
+
+If the user names a **role shape first** (e.g., *"create a tenant role for DU"*, *"make a custom role with DU permissions"*), use [role-management.md — Workflow: Create a Custom Role](role-management.md#workflow-create-a-custom-role) instead — those Step 1a-1d substeps cover the role-first entry path.
+
+> **Sibling workflow.** [Step 1b of Workflow: Create a Custom Role](role-management.md#step-1b--hoist-check-prefer-the-umbrella-when-permissions-overlap) is the binary (service vs. umbrella) form of the same scope-selection problem this workflow solves with a full N-scope intersection (Steps G2-G3). Keep them in sync if either changes.
+
+> **Never skip the scope menu.** The same permission name (e.g., `DOCUMENTUNDERSTANDING.PROJECTS.UPDATE`) almost always appears in *both* the service catalog *and* the Tenant / TenantGlobal umbrella catalogs. Defaulting to `--service <svc>` silently locks the role to one service and loses the multi-service reuse the umbrella offers. Always probe every applicable scope and let the user pick.
+
+## Step G1 — Identify the permission(s)
+
+Resolve the user's wording to one or more concrete permission `name` values (e.g., "DU projects update" → `DOCUMENTUNDERSTANDING.PROJECTS.UPDATE`; "DU projects read and update" → `[…PROJECTS.READ, …PROJECTS.UPDATE]`). If any token is ambiguous (no exact match), grep the catalog:
+
+```bash
+uip admin authorization permissions list --output json \
+  --output-filter "Data[?contains(name, '<TOKEN>')].{name:name,resourceType:resourceType,scopeType:scopeType}"
+```
+
+If multiple candidates remain for any token, render a numbered Markdown menu and stop until disambiguated. End of this step: a confirmed list of one or more permission `name` strings.
+
+## Step G2 — Probe which scopes admit each permission
+
+Always run the Tenant and TenantGlobal probes; gate the other two on the permission set. The CLI tells you which scopes each permission is valid in:
+
+| Probe | Run when |
+|---|---|
+| `permissions list --scope Tenant` | Always |
+| `permissions list --scope TenantGlobal` | Always |
+| `permissions list --service <SERVICE>` | Every selected permission shares the same service prefix (one probe per distinct prefix) |
+| `permissions list --scope Organization` | Any selected permission has an org-scope service prefix (e.g., `APPS.*`, `IDENTITY.*`) |
+
+```bash
+uip admin authorization permissions list --scope Tenant --output json > tenant.json
+uip admin authorization permissions list --scope TenantGlobal --output json > tg.json
+uip admin authorization permissions list --service <SERVICE> --output json > svc-<SERVICE>.json    # conditional
+uip admin authorization permissions list --scope Organization --output json > org.json            # conditional
+```
+
+Membership rule: a permission is "valid in scope X" iff its `name` appears in the catalog returned for that scope. Many tenant-services share the same catalog between `--scope Tenant` and `--scope TenantGlobal` — treat them as two distinct menu options.
+
+## Step G2.5 — Compute the intersection of valid scopes/services across all selected permissions
+
+A role can hold a permission only if **every** permission in the set is valid at that role shape. Build the intersection across **five** candidate shapes — four umbrella scopes (Tenant, TenantGlobal, Organization, Project) **plus** the Service shape (`--service <SERVICE>`, scope inferred). The Service shape is always a row in the matrix when every selected permission shares one service prefix — never drop it silently just because an umbrella also admits the perm.
+
+1. For each candidate permission, record the set of shapes where it appears: e.g., `DOCUMENTUNDERSTANDING.PROJECTS.UPDATE = {Tenant, TenantGlobal, Service:documentunderstanding}`.
+2. **Intersect** the shape-sets across all candidates. The result is the set of role shapes the role can take.
+
+Branch on the intersection:
+
+| Intersection | Action |
+|--------------|--------|
+| **Empty** (no shape holds all candidates) | The permissions cannot live on one role. Surface the per-permission scope matrix to the user and offer: (a) split into multiple roles by scope group, (b) drop the outliers, (c) reconsider the set. Do not silently downshift to a single role that omits permissions. |
+| **One shape** | Skip the menu — proceed to Step G4 with that shape. State the resolution in the summary. |
+| **≥2 shapes** | Render the matrix and menu in Step G3. |
+
+> **Project-scope-only permissions** (e.g., `DOCUMENTUNDERSTANDING.DOCUMENTTYPE.*`) have **no umbrella** — they appear *only* in `permissions list --scope Project --service <svc>`. If every candidate is Project-scope and they share the same service, the intersection is `{Project:<service>}`; skip the menu and use `--scope Project --service <svc>`. If the set mixes Project with Tenant/Org, the intersection is empty — apply the split rule above.
+
+## Step G3 — Render the intersection matrix and scope menu (Tenant Recommended when present)
+
+When the intersection has ≥2 shapes, render **two artifacts**: a presence matrix (so the user sees why each option is offered) followed by a numbered menu (so the user replies with a digit). Mark **Tenant** as Recommended when present. Show only shapes that survived the intersection — never list an option the role can't take.
+
+**Decide which rows to render before drafting either artifact:**
+
+| Row in `Scope/Service` column | Owning service for the created role | Render when |
+|---|---|---|
+| Tenant | `CentralizedAccess` | Intersection includes `Tenant`. Mark **Recommended**. |
+| TenantGlobal | `CentralizedAccess` | Intersection includes `TenantGlobal`. |
+| Organization | `CentralizedAccess` | Intersection includes `Organization` (i.e., every selected permission has an org-scope service prefix). |
+| Service | `<SERVICE>` (e.g., `DocumentUnderstanding`) | Intersection includes the service catalog AND every selected permission shares one service prefix. Omit when permissions span multiple services or are cross-cutting (e.g., `AUTHZ.*`). |
+| Project | `<SERVICE>` | Intersection is `{Project:<service>}` only — handled by the project-only branch in Step G2.5; usually not shown alongside umbrella rows. |
+
+> **Owning Service** is the value `roles get` will return as `ownerServiceName` after creation — umbrella scopes (no `--service`) resolve to `CentralizedAccess`; a service-shape role resolves to the named service. See [role-management.md — Step 6](role-management.md#step-6--summarize-highlight-the-resolved-service).
+
+**Artifact 1 — Intersection matrix.** First column is `Scope/Service`; second column is `Owning Service`; third column is presence (✅ for shapes in the intersection, ❌ for shapes that were probed but excluded). Always include the **Service** row when every selected permission shares one service prefix — its absence was the gap that motivated this column layout. Example for `DOCUMENTUNDERSTANDING.PROJECTS.UPDATE` (single perm, single service):
+
+```
+| Scope/Service | Owning Service        | Perm present? |
+|---------------|-----------------------|---------------|
+| Tenant        | CentralizedAccess     | ✅            |
+| TenantGlobal  | CentralizedAccess     | ✅            |
+| Service       | DocumentUnderstanding | ✅            |
+| Organization  | CentralizedAccess     | ❌            |
+| Project       | DocumentUnderstanding | ❌            |
+```
+
+**Artifact 2 — Numbered menu** built from the ✅ rows above, renumbered from `1`:
+
+```
+`<PERMISSION_NAME_1>` (+ N more) are valid in multiple role shapes. Pick:
+
+1. **Tenant** (Recommended) — multi-service role bound to one tenant. Owning service: `CentralizedAccess`. Built with `--scope Tenant` and no `--service`. Reusable across every tenant-service in this tenant.
+2. TenantGlobal — multi-service template visible/assignable in every tenant of the org. Owning service: `CentralizedAccess`. Built with `--scope TenantGlobal` and no `--service`.
+3. Organization — multi-service org-scope role. Owning service: `CentralizedAccess`. Built with `--scope Organization` and no `--service`.
+4. Service — bound to `<SERVICE>` only. Owning service: `<SERVICE>` (e.g., `DocumentUnderstanding`). Built with `--service <SERVICE>` (scope inferred).
+
+Reply with the digit of your choice.
+```
+
+**Why Tenant is the default recommendation:** the Tenant-shape role can bundle additional tenant-scope permissions from any other service later (`LICENSING.*`, `IDENTITY.*`, etc.) without re-authoring; the service-shape role cannot. The Service option is still listed (with its `Owning Service` made explicit) so the user can deliberately pick strict service isolation when that's what they want.
+
+## Step G4 — Map the pick to the create-call shape
+
+| Pick | `roles create` flags |
+|------|----------------------|
+| Tenant | `--scope Tenant` (no `--service`; `--tenant-id` defaults to login) |
+| TenantGlobal | `--scope TenantGlobal` (no `--service`) |
+| Organization | `--scope Organization` (no `--service`) |
+| Service | `--service <SERVICE>` (no `--scope`; registry infers) |
+| Project | `--scope Project --service <SERVICE>` |
+
+Author `actions.json` as a JSON array containing **every** permission `name` confirmed in Step G1 — not just one. Then run [Steps 2-5 of Workflow: Create a Custom Role](role-management.md#step-2--suggest-a-role-name) (name suggestion, action-file authoring, create, verify). After the role exists, run [Workflow: Create a Single Assignment](role-assignment-management.md#workflow-create-a-single-assignment) — including the [Echo-before-mutate protocol](role-assignment-management.md#echo-before-mutate-protocol) for the principal.
+
+## Step G5 — Summarize: state the resolved scope, service, and full permission list
+
+In the post-create / post-assign summary, include:
+
+- The scope path the assignment landed on.
+- The resolved `--service` value (or "no `--service` — multi-service <scope> role" when omitted).
+- The **full list of permissions** in the role — not just the one the user named first. This matters when the role bundles several permissions; silently omitting some from the summary hides the actual grant scope.
+
+Same rule as [Step 6 of Workflow: Create a Custom Role](role-management.md#step-6--summarize-highlight-the-resolved-service).

--- a/skills/uipath-admin/references/authorization/permission-catalog.md
+++ b/skills/uipath-admin/references/authorization/permission-catalog.md
@@ -1,0 +1,62 @@
+# Permission Catalog
+
+Conceptual guide for the read-only catalog at `uip admin authorization permissions`. For per-command flag tables, output codes, and single-command examples, see [authorization-commands.md](authorization-commands.md).
+
+## Concept
+
+The catalog is the master list of permission definitions across all services. Permissions are referenced **by `name`** (the dotted string, e.g. `STUDIO.X.Y`) when authoring custom roles — see [role-management.md — Workflow: Create a Custom Role](role-management.md#workflow-create-a-custom-role).
+
+Each permission record:
+
+| Field | Example | Used for |
+|-------|---------|----------|
+| `id` | UUID | Internal — not required for role authoring |
+| `name` | `IDENTITY.GROUP.UPDATE` | **What goes into `roles create --file ./actions.json`** |
+| `namespace` | `IDENTITY` | Grouping / display |
+| `serviceDisplayName` | `Identity Service` | Grouping / display |
+| `resourceType` | `Group` | Grouping / display |
+| `resourceAction` | `Update` | Grouping / display |
+| `resourceGroup` | `Identity` | Grouping / display |
+| `scopeType` | `ORGANIZATION` / `TENANT` / `PROJECT` / `ANY` | Determines which role-scope mode the permission belongs in |
+
+> The `--file` payload for `roles create`/`roles update` is a **JSON array of permission `name` strings**, not UUIDs. The CLI resolves names to ids server-side.
+
+## Scope Behavior
+
+Each service registers its permissions at a specific scope. Examples:
+
+- Studio permissions register at `Tenant` (per the service registry — `--service studio` infers `Tenant`).
+- Apps permissions register at `Organization`.
+- Document Understanding registers Project-shape permissions (queryable with `--scope Project --service documentunderstanding`).
+
+Passing `--scope <TYPE>` may surface or hide service-specific entries depending on where the service registered.
+
+## `--service` Infers Scope
+
+When you call `permissions list` with `--service <NAME>` and **no `--scope`**, the CLI consults the service registry and applies the inferred scope automatically. To override, pass both `--service` and `--scope` explicitly (used by Project-shape services like Document Understanding and Reinfer).
+
+```bash
+uip admin authorization permissions list --service studio --output json
+uip admin authorization permissions list --service documentunderstanding --scope Project --output json
+```
+
+## Cross-Cutting `authz` Permissions
+
+`authz` permissions appear alongside every service's permissions and are filtered out of `permissions list` by default. Pass `--service authz` to surface them.
+
+## Workflow: Find Permission Names for Role Authoring
+
+To build a custom role's actions file:
+
+1. List candidate permissions for the target service:
+   ```bash
+   uip admin authorization permissions list --service <SERVICE> --output json
+   ```
+2. Extract `name` values for the actions the role should grant (e.g. `STUDIO.X.Y`, `IDENTITY.GROUP.READ`).
+3. Write them to `actions.json` as a flat string array:
+   ```json
+   ["STUDIO.X.Y", "STUDIO.A.B", "IDENTITY.GROUP.READ"]
+   ```
+4. Pass via `--file ./actions.json` to `roles create` or `roles update`. See [role-management.md](role-management.md).
+
+When the user is selecting permissions interactively, present them as a **single numbered table grouped by `serviceDisplayName`** with columns `# | Service | Permission | Scope | Description` — see [role-management.md — Step 3](role-management.md#step-3--present-permissions-as-a-numbered-menu). Map the user's picked numbers to permission `name` strings internally; never ask the user to copy UUIDs.

--- a/skills/uipath-admin/references/authorization/role-assignment-management.md
+++ b/skills/uipath-admin/references/authorization/role-assignment-management.md
@@ -1,0 +1,178 @@
+# Role Assignment Management
+
+Multi-step workflows for managing **who has what role at what scope** via `uip admin authorization roles assignments`. For per-command flag tables, output codes, and single-command examples, see [authorization-commands.md](authorization-commands.md).
+
+## Concept
+
+An assignment is the triple **(principal, role, scope)**:
+
+- **Principal** — User, Group, Robot, or ExternalApplication (UUID).
+- **Role** — id of a role visible via `roles list`.
+- **Scope** — where the role applies: `Organization`, `Tenant`, `TenantGlobal`, `Project`, `Folder`, `App`.
+
+Assignments live at the Policy Administration Point (PAP). Effective access at a scope is computed by `check-access` (the Policy Decision Point) — see [check-access.md](check-access.md).
+
+> **Scope vocab difference** between roles and assignments:
+> - `roles create --scope` accepts: `Organization`, `TenantGlobal`, `Tenant`, `Project`. (No `Folder`, no `App`.)
+> - `roles assignments create --scope` accepts: `Organization`, `TenantGlobal`, `Tenant`, `Project`, `Folder`, `App`.
+> - `roles assignments list --scope` accepts: `Organization`, `Tenant`, `Project`, `Folder`, `App`. (No `TenantGlobal`.)
+
+## Resolving Principal IDs
+
+**Mandatory:** before any `assignments create` or `assignments delete`, search the directory for the named principal and echo the resolved identity back to the user. Never accept a name-only request and silently substitute a UUID — `--identity-id` is a raw GUID the CLI does not validate against the human-readable name in the prompt. Granting a role to the wrong principal is a security incident (SKILL.md → *"Resolve every named principal before high-risk ops"* Critical Rule — covers zero-match-stop, multi-match-menu, and the no-silent-fallback-to-login-user requirement).
+
+| Principal Type | Search command | Identity flag |
+|----------------|----------------|---------------|
+| `User` | `uip admin users list --search "<NAME_OR_EMAIL>" --output json` ([user-management.md](../user-management.md)) | `--identity-type User` |
+| `Group` | `uip admin groups list --filter "<NAME>" --output json` ([group-management.md](../group-management.md)) | `--identity-type Group` |
+| `Robot` | `uip admin robot-accounts list --filter "<NAME>" --output json` ([robot-account-management.md](../robot-account-management.md)) | `--identity-type Robot` |
+| `ExternalApplication` | `uip admin external-apps list --output json` (filter client-side) ([external-app-management.md](../external-app-management.md)) | `--identity-type ExternalApplication` |
+
+### Echo-before-mutate protocol
+
+1. Run the search command above for the name in the user's request.
+2. Branch on hit count:
+   - **0 hits** → stop. Tell the user the name didn't match and ask them to confirm spelling or provide a UUID. Do not fall back to the current login user. Do not guess at fuzzy matches.
+   - **>1 hits** → present a numbered list (`displayName — userName — id`) and stop. Wait for the user's digit.
+   - **1 hit** → proceed.
+3. Echo a line of the form `Principal: <displayName> (<userName>) — <id>` to the user before running the assignment mutation.
+4. Only then run `assignments create` / `assignments delete` with the verified `--identity-id`.
+
+This protocol is required even when the user explicitly disables clarifying questions — security verification is a safety floor, not a clarification.
+
+## Validate Role's Owning Service vs. Assignment Scope-Path
+
+`roles list` and `roles get` return `ownerServiceId` and `ownerServiceName` on every role. The **`ownerServiceName`** is the role's permanent service binding — set when the role was authored (`roles create --service <svc>` or `--scope <Org|Tenant|TenantGlobal>` without `--service` → `CentralizedAccess`). When creating an assignment, the role's `ownerServiceName` must align with the scope-path:
+
+| Role `ownerServiceName` | Required scope-path shape | How to build it |
+|---|---|---|
+| `CentralizedAccess` (multi-service umbrella) | Path **must not** include a service segment: `/` (Organization) or `/tenant/<tid>` (Tenant / TenantGlobal) | Omit `--service`; use `--scope Organization` or `--scope Tenant` |
+| Anything else (e.g., `Reinfer`, `DocumentUnderstanding`, `Apps`, `Orchestrator`) | Path **must include** the service segment matching `lowercase(ownerServiceName)`: `/tenant/<tid>/<svc>[/...]` for tenant-services, `/<svc>` for org-services | Pass `--service <slug>` (slug = `lowercase(ownerServiceName)`) — or use `--scope-path` verbatim |
+
+**Slug mapping rule:** `slug = lowercase(ownerServiceName)`. Empirical examples: `Reinfer` → `reinfer`, `DocumentUnderstanding` → `documentunderstanding`, `ProcessMining` → `processmining`, `AutomationOps` → `automationops`, `AuthZ` → `authz`. The CLI rejects `--service centralizedaccess` — for the umbrella, omit `--service` entirely.
+
+**User-facing display-name mapping:** the `ownerServiceName` slug is for the CLI; user-facing summaries must use the display name. Most-common rewrites: `Reinfer` → **IXP**, `DocumentUnderstanding` → **Document Understanding**, `ProcessMining` → **Process Mining**, `AutomationOps` → **Automation Ops**, `CentralizedAccess` → **Centralized Access**. When surfacing a role to the user (e.g., echoing `Role: <name> — ownerServiceName: <X>`), translate `<X>` to the display name; keep the slug in any scope-path you echo for clarity. Full mapping: [authorization-commands.md — Service display-name mapping](authorization-commands.md#service-display-name-mapping-cli-ownerservicename--user-facing-label).
+
+### Pre-flight check (mandatory before `assignments create`)
+
+1. Fetch the role: `uip admin authorization roles get <ROLE_ID> --output json`. Extract `ownerServiceName` and `scopeType`.
+2. Compute the expected scope-path:
+   - `ownerServiceName == "CentralizedAccess"` → path is `/` (if role `scopeType == Organization`) or `/tenant/<tid>` (if `Tenant` / `TenantGlobal`). No `<svc>` segment.
+   - Otherwise → path must include `lowercase(ownerServiceName)` as the segment immediately after `/tenant/<tid>` (or as the root for org-services).
+3. If the user's intended assignment scope-path doesn't match, **stop and surface the mismatch** — never silently substitute a different service or coerce the path. Example: a role with `ownerServiceName: "Reinfer"` cannot be assigned at `/tenant/<tid>/documentunderstanding/project/<pid>`; offer to (a) target the correct service, (b) pick a different role that owns the intended service, or (c) reauthor the role under the correct service.
+4. Echo the resolved role binding alongside the principal echo: `Role: <name> — ownerServiceName: <ownerServiceName> (scopeType: <scopeType>)` so the user sees the binding before the mutation runs.
+
+## Scope Path Construction
+
+Inline `assignments create` auto-fills the scope path from the role's `scopeType`:
+
+| Role scope | Auto-filled path | Override |
+|------------|------------------|----------|
+| `Organization` | `/` | — |
+| `Tenant` / `TenantGlobal` | `/tenant/<TENANT_ID>` (defaults to login tenant) | `--tenant-id <GUID>` |
+| `Project` / `Folder` / `App` | **Not auto-filled** | Either `--scope` + `--service` + `--scope-id`, OR `--scope-path <PATH>` |
+
+Two ways to specify a sub-scope assignment:
+
+1. **Structured** — let the CLI build the path from the registry: `--scope Project --service reinfer --scope-id <PROJECT_ID>`.
+2. **Verbatim** — pass the exact path: `--scope-path /tenant/<TID>/Reinfer/project/<PID>`. Overrides `--scope`, `--service`, `--scope-id`, `--tenant-id`.
+
+Platform scope-path shape: `/tenant/<TENANT_ID>/<SERVICE_OR_FOLDER>/project/<PROJECT_ID>` — e.g. `/tenant/aaa.../Reinfer/project/bbb...`.
+
+## Workflow: Create a Single Assignment
+
+1. **Resolve and echo the principal id** following the [Echo-before-mutate protocol](#echo-before-mutate-protocol) above. Do not skip — the assignment endpoint takes a raw UUID and will happily grant the role to the wrong identity if the lookup is wrong.
+2. Resolve role id:
+   ```bash
+   uip admin authorization roles list --filter "<ROLE_NAME>" --output json
+   ```
+3. **Fetch the role and validate its service binding** per [Validate Role's Owning Service vs. Assignment Scope-Path](#validate-roles-owning-service-vs-assignment-scope-path) — extract `ownerServiceName` + `scopeType`, derive the expected scope-path, and confirm the intended assignment matches. Echo `Role: <name> — ownerServiceName: <X> (scopeType: <Y>)` before the create call.
+4. Create inline. Pick the shape that matches the role's `scopeType`:
+
+   **Organization / Tenant / TenantGlobal roles** — scope path auto-fills:
+   ```bash
+   uip admin authorization roles assignments create \
+     --role-id <ROLE_ID> \
+     --identity-id <PRINCIPAL_ID> \
+     --identity-type User --output json
+   ```
+
+   **Tenant role on a non-login tenant**:
+   ```bash
+   uip admin authorization roles assignments create \
+     --role-id <ROLE_ID> \
+     --identity-id <PRINCIPAL_ID> \
+     --identity-type User \
+     --tenant-id <TENANT_ID> --output json
+   ```
+
+   **Project / Folder / App role — structured form**:
+   ```bash
+   uip admin authorization roles assignments create \
+     --role-id <ROLE_ID> \
+     --identity-id <GROUP_ID> \
+     --identity-type Group \
+     --scope Project \
+     --service reinfer \
+     --scope-id <PROJECT_ID> --output json
+   ```
+
+   **Project / Folder / App role — verbatim path** (advanced):
+   ```bash
+   uip admin authorization roles assignments create \
+     --role-id <ROLE_ID> \
+     --identity-id <GROUP_ID> \
+     --identity-type Group \
+     --scope-path "/tenant/<TID>/Reinfer/project/<PID>" --output json
+   ```
+
+## Workflow: Create Assignments in Batch
+
+Use `--file` with a JSON array of `AddRoleAssignmentRequest`:
+
+```json
+[
+  {
+    "roleId": "<ROLE_ID>",
+    "securityPrincipalId": "<PRINCIPAL_ID>",
+    "securityPrincipalType": "User",
+    "scope": "/tenant/<TENANT_ID>"
+  }
+]
+```
+
+```bash
+uip admin authorization roles assignments create --file ./assignments.json --output json
+```
+
+**The bulk endpoint is atomic** — partial failure rolls back the whole batch.
+
+## Workflow: Delete Assignments in Batch
+
+`assignment-ids.json` is a JSON array of UUID strings:
+
+```json
+["0fae98e1-0f2e-4f8d-bdab-7ce1cf475676", "1aab33cf-..."]
+```
+
+```bash
+uip admin authorization roles assignments delete --file ./assignment-ids.json --output json
+```
+
+**Idempotency caveat:** the bulk endpoint silently no-ops on unknown / already-deleted ids and still returns Success. To confirm a deletion took effect, list before and after.
+
+Discover assignment ids via `roles assignments list`.
+
+## Pagination & Filter Caveats
+
+- Server caps `--limit` at 10 assignment groups per page.
+- With `--scope Folder|Project|App --scope-id`, results are filtered client-side after the page is fetched. Post-filter count can be smaller than `--limit` even when more matches exist on later pages. Use `--scope-path` for strict server-side pagination math.
+- When client-side filtering is active, `totalCount` reflects the post-filter group count, not the org-wide total.
+- `--scope TenantGlobal` is **not valid on list** (only on create). Use `--scope Tenant` to surface tenant-scope assignments; the role's TenantGlobal vs Tenant binding is recorded on the role itself.
+- `--include-inherited` walks up the scope tree (Org → Tenant → sub-scope). Default is **direct only** (`noInheritance=true`) — pass this flag when the question is "what does this principal effectively have here, including inherited grants?".
+
+## Listing Service-Managed and Platform Services
+
+`roles assignments list --service <svc>` works for every service — including service-managed (`orchestrator`, `dataservice`, `insights`, `taskmining`, `testmanager`, `automationops`, `casemanagement`, `processmining`) and platform-level (`authz`, `oms`, `platform`, `identity`, `licensing`). The endpoint may return `403 Forbidden` when the caller lacks the service's read permission, but the CLI does **not** filter these services client-side.
+
+Authoring (`assignments create` with `--service <svc>`) **is** rejected for those services. Use `--scope-path` to bypass the registry check when you need to assign roles against a service the registry won't accept — but only do so if you already have the role's scope path from another source.

--- a/skills/uipath-admin/references/authorization/role-management.md
+++ b/skills/uipath-admin/references/authorization/role-management.md
@@ -1,0 +1,308 @@
+# Role Management
+
+Multi-step workflows for managing custom role definitions via `uip admin authorization roles`. For per-command flag tables, output codes, and single-command examples, see [authorization-commands.md](authorization-commands.md).
+
+## Services That Manage Their Own Roles
+
+Listing always works; authoring is what's blocked.
+
+- **Service-managed:** `orchestrator`, `dataservice`, `insights`, `taskmining`, `testmanager`, `automationops`, `casemanagement`, `processmining`. The Authorization service surfaces their roles in `roles list --service <svc>` and their assignments in `roles assignments list --service <svc>`, but `roles create / update / delete` against these services is rejected. Mutate them via the service's own CLI (e.g., `uip or roles create` for Orchestrator).
+- **Platform-level:** `authz`, `oms`, `platform`, `identity`, `licensing`. Same shape — listing works, authoring is rejected.
+
+For *effective* access on a principal (PDP — includes server-side rules not visible via the catalog), use [check-access.md](check-access.md).
+
+## Role Shape (Scope) Modes
+
+`roles create --scope <type>` accepts:
+
+| Mode | When | `--service` semantics | `--tenant-id` semantics |
+|------|------|----------------------|--------------------------|
+| `Organization` | Role grants org-wide access (typical for `apps`, `studio`, `identity` permissions) | Optional. Used alone, infers `Organization` from the registry. **Omit** for a multi-service org role | Ignored |
+| `TenantGlobal` | Reusable template — visible/assignable inside every tenant in the org | Optional. **Omit** for a multi-service template | Ignored |
+| `Tenant` | Bound to one specific tenant — only assignable there | Optional. Used alone with a tenant-shape service, infers `Tenant`. **Omit** for a multi-service "Centralized Access" tenant role | Defaults to login tenant; pass explicitly for a non-login tenant |
+| `Project` | Project-shape role (Document Understanding, Reinfer) | **Required** | Defaults to login tenant |
+
+**`Folder` is not a valid `--scope` for `roles create/update`.** Folder-level scoping is expressed on the *assignment* (see [role-assignment-management.md](role-assignment-management.md)).
+
+> `--service` infers the scope from the service registry when `--scope` is omitted. Example: `roles create --service studio --name "..."` resolves to `Tenant`. Combine `--service` with `--scope` only to override the registry default (e.g., `--service documentunderstanding --scope Project`).
+
+### Centralized Access — the "no --service" tenant role
+
+When the user asks for a **"tenant role"** or **"create role in Tenant scope"** without naming a specific service, the correct shape is `--scope Tenant` **with no `--service` flag**. This is the multi-service "Centralized Access" tenant role and can carry any `TENANT`-scope permission across services in the catalog.
+
+- **CLI rejects `--service centralizedaccess`** with `'centralizedaccess' is not a valid --service value`. The same rejection applies on `roles list`, `roles assignments list`, and `permissions list`. Drop the flag entirely.
+- Same rule for `Organization` and `TenantGlobal`: omit `--service` for the multi-service variant; pass it only when the role wraps one specific service's catalog.
+- `Project` is the one exception — `--service` is **required**.
+
+### Service inference — split
+
+| User intent | Resolution |
+|-------------|------------|
+| Names a service, or asks for a permission only one service registers (e.g., "DU documents delete") | Pass `--service <svc>`. The registry infers `--scope` unless overridden. |
+| Says "tenant role" / "tenant scope" / "centralized access" with no service named | **Omit `--service`.** Pass `--scope Tenant` (or `Organization` / `TenantGlobal`) alone. |
+| Project-shape service (Document Understanding, Reinfer) | `--scope Project` + `--service <svc>` (required). |
+
+> **Always highlight the resolved service when summarizing a `roles create` call.** Quote the exact `--service <name>` you used, or state "no `--service` — multi-service tenant role" when it was omitted. Never silently swap services or scopes.
+
+## Workflow: Grant Permission(s) to a Principal (shortcut)
+
+When the user names *permissions* without naming a role or scope (*"grant me X"*, *"give alice Y, Z"*), use [grant-permissions.md](grant-permissions.md) — a multi-step intersection-and-menu flow that picks the right role shape across the service catalog and umbrella scopes. This page covers the **role-first** entry path: user names a role shape, then we author the role and assignments.
+
+## Workflow: Create a Custom Role
+
+This is an interactive flow. Do NOT prompt the user with empty `<ROLE_NAME>` / `<PERMISSION_NAMES>` placeholders. Propose a name and a numbered permission menu, then confirm.
+
+### Step 1 — Gather intent and pick a scope mode
+
+Ask the user (free-form) what the role is for: target service(s) and the kind of access (read-only, operator, admin, etc.).
+
+#### Step 1a — Service-bound role (the common case)
+
+If the role wraps **one** service's permissions, do not ask the user about org vs tenant scope. Probe the catalog:
+
+```bash
+uip admin authorization permissions list --service <SERVICE> --output json
+```
+
+The catalog response includes `scopeType` per record. Use it to pick the mode for Step 4:
+
+| Records' `scopeType` | Service shape | Use this for the rest of the flow |
+|----------------------|---------------|-----------------------------------|
+| All `ORGANIZATION` (e.g., `apps`, `studio`, `identity`) | Org-level service | **Organization** mode |
+| All `TENANT` (e.g., `documentunderstanding`, most Orchestrator-adjacent) | Tenant-level service | **Tenant** mode — then ask: bound to current tenant vs `TenantGlobal` template |
+| All `PROJECT` | Project-shape service | **Project** mode (requires `--service`) |
+| Mixed | Multi-scope service | Ask the user which scope to target; only show permissions for the chosen scope |
+
+> **Override:** if the user explicitly says "Tenant scope" / "tenant role" / "centralized access" — even when the permission's catalog `scopeType` is `PROJECT` — switch to the **no-`--service`** Tenant path (Step 1d). Do not silently substitute a different permission to satisfy a service-bound shape. Surface the mismatch and let the user choose.
+
+> **Casing quirk** — the *response field* `scopeType` returns ALL CAPS (`ORGANIZATION`, `TENANT`, `PROJECT`, `ANY`). The matching `--scope` *flag value* uses PascalCase (`Organization`, `Tenant`, `Project`, `TenantGlobal`). Map response → flag when constructing the create call: `ORGANIZATION` → `--scope Organization`, `TENANT` → `--scope Tenant` (or `TenantGlobal`), `PROJECT` → `--scope Project`.
+
+#### Step 1b — Hoist check: prefer the umbrella when permissions overlap
+
+> **Sibling workflow.** This is the binary (service vs. umbrella) form of the same scope-selection problem the [Grant Permission(s) shortcut](grant-permissions.md) solves with a full N-scope intersection (Steps G2-G3). Use Step 1b when the user named the role shape first; use the Grant shortcut when the user named permissions only. Keep them in sync if either changes.
+
+**Run this between Step 1a and Step 1c** unless the candidate shape is `Project` (which has no umbrella). When the permissions a user wants are available at **both** the service-bound catalog AND the umbrella scope (`Tenant` / `TenantGlobal` for tenant-services, `Organization` for org-services), the umbrella role is the better default — it can carry permissions from any other service in the same scope, so it's reusable beyond the single service the user originally named.
+
+1. Probe the umbrella catalog at the umbrella scope (no `--service`):
+   ```bash
+   # Tenant-service candidate (Step 1a returned `TENANT` scopeType)
+   uip admin authorization permissions list --scope Tenant --output json > umbrella.json
+
+   # Org-service candidate (Step 1a returned `ORGANIZATION` scopeType)
+   uip admin authorization permissions list --scope Organization --output json > umbrella.json
+   ```
+2. Compare the candidate's permission `name` values (from `permissions list --service <SERVICE>` in Step 1a) against the umbrella's `name` values:
+   - **No overlap** — candidate permissions live only in the service catalog. Lock in the service-bound shape (`--service <SERVICE>`); go to Step 1c if the candidate is Tenant-shape, else Step 2.
+   - **Full overlap** — every candidate permission also exists in the umbrella. Surface the menu below and let the user pick.
+   - **Partial overlap** — some candidate permissions appear in the umbrella, others don't. Stop and show the user the split; do not silently drop the service-only permissions to fit the umbrella, and do not silently expand into umbrella-only permissions.
+
+3. On full overlap, render a numbered next-step menu and **recommend the umbrella** (numbered Markdown list so the user replies with a digit):
+
+   **Tenant-service candidate** (umbrella is Tenant):
+   ```
+   The permissions you picked are available at both the service level AND the umbrella Tenant scope. The umbrella role can carry permissions from any tenant-service, so it's more reusable. Pick:
+
+   1. **Tenant level** (Recommended) — multi-service role bound to one tenant. Reusable across every tenant-service in this tenant.
+   2. Service level — bound to <SERVICE> only. Use when you want strict service isolation.
+   3. Tenant Global scope — multi-service template visible in every tenant of the org.
+
+   Reply with 1, 2, or 3.
+   ```
+
+   **Org-service candidate** (umbrella is Organization):
+   ```
+   The permissions you picked are available at both the service level AND the umbrella Organization scope. The umbrella role can carry permissions from any org-service, so it's more reusable. Pick:
+
+   1. **Org level** (Recommended) — multi-service role at organization scope. Reusable across every org-service.
+   2. Service level — bound to <SERVICE> only. Use when you want strict service isolation.
+
+   Reply with 1 or 2.
+   ```
+
+4. Map the user's pick to the create-call shape:
+
+   | Pick | Create-call shape | Continue at |
+   |------|--------------------|--------------|
+   | Tenant level | `--scope Tenant` **without** `--service` (`--tenant-id` defaults to login) | Step 2 — Tenant binding is already decided, skip Step 1c |
+   | Org level | `--scope Organization` **without** `--service` | Step 2 |
+   | Service level | `--service <SERVICE>` (registry infers `--scope`) | Step 1c if Tenant-shape; else Step 2 |
+   | Tenant Global scope | `--scope TenantGlobal` **without** `--service` | Step 2 |
+
+> **Project-scope permissions have no umbrella.** `--scope Project` requires `--service` (see the "Centralized Access — the no --service tenant role" section above). Skip Step 1b entirely when Step 1a's `scopeType` is `PROJECT`.
+
+#### Step 1c — Tenant-bound vs TenantGlobal
+
+When Step 1a (or Step 1b's "Service level" pick on a Tenant-shape service) lands on Tenant-shape permissions, follow up: should the role be **bound to a single tenant** (`--scope Tenant --tenant-id <UUID>`) or **available across every tenant** (`--scope TenantGlobal`)?
+
+> Step 1b's "Tenant level" and "Tenant Global scope" picks **bypass** this step — they have already chosen the binding.
+
+- **Tenant** = bound to one tenant UUID. Assignable only inside that tenant.
+- **TenantGlobal** = reusable template. Visible/assignable in every tenant.
+
+> Resolving the current tenant UUID: `uip login status --output json` gives the tenant *name*; map it to a UUID with `uip admin tenants list --filter <name> --output json`.
+
+#### Step 1d — Multi-service tenant role ("Centralized Access")
+
+If the user said **"tenant role"** / **"tenant scope"** / **"centralized access"** without naming a service — or pivoted into Tenant scope from a service-bound flow — drop `--service` entirely and probe the multi-service catalog:
+
+```bash
+uip admin authorization permissions list --scope Tenant --output json
+```
+
+This is the umbrella the UI calls *Centralized Access*. The resulting role can carry any `TENANT`-scope permission across services (Document Understanding `PROJECTS.*`, Licensing, IXP, Authz, etc.). Render the menu in Step 3 from this catalog.
+
+> If the user previously named a single permission that is `PROJECT`-scope only (e.g., `DOCUMENTUNDERSTANDING.DOCUMENTS.DELETE`) and then asks for "Tenant scope", state the mismatch — the permission cannot live on a Tenant-scope role — and offer:
+> 1. Closest TENANT-scope analog (e.g., `DOCUMENTUNDERSTANDING.PROJECTS.DELETE`)
+> 2. Keep the existing Project-scope role
+> 3. A different permission set
+>
+> Never silently downshift to a similar-looking permission.
+
+### Step 2 — Suggest a role name
+
+Propose **one** name derived from the intent. Pattern: `<Service><Scope>-<Capability>` in PascalCase or kebab-case, e.g. `OrchestratorTenant-ReadOnly`, `IdentityOrg-GroupAdmin`. Check for collisions before presenting:
+
+```bash
+uip admin authorization roles list --role-type Custom --filter "<SUGGESTED_NAME>" --output json
+```
+
+If the filter returns a match, append a numeric suffix (`-2`, `-3`) and re-check until unique. Present the final suggestion to the user and let them accept or override with a single reply.
+
+### Step 3 — Present permissions as a numbered menu
+
+Pull the catalog for each service named in Step 1, using the `--scope` from Step 1's mode:
+
+```bash
+# Organization mode
+uip admin authorization permissions list --service <SERVICE> --scope Organization --output json
+
+# Tenant (or TenantGlobal — same catalog)
+uip admin authorization permissions list --service <SERVICE> --scope Tenant --output json
+
+# Project mode (service required)
+uip admin authorization permissions list --service <SERVICE> --scope Project --output json
+```
+
+Render **one Markdown table grouped by `serviceDisplayName`**, with a global running number so the user can reply with digits (`"1, 4, 7-9"`). Columns:
+
+| # | Service | Permission | Scope | Description |
+|---|---------|------------|-------|-------------|
+
+- `#` — global 1-based index across all rows.
+- `Service` — `serviceDisplayName`. Repeat the value only on the first row of each group; leave blank on continuation rows so groups are visually distinct.
+- `Permission` — the `name` field (e.g., `IDENTITY.GROUP.UPDATE`). **This is the string that goes into `actions.json`.**
+- `Scope` — `scopeType` from the record.
+- `Description` — the record's `description` field verbatim. If missing, fall back to `<resourceAction> <resourceType>`.
+
+Sort rows by `serviceDisplayName`, then `resourceType`, then `resourceAction`. Keep the table to one screen where possible — if a single service exceeds ~30 entries, ask the user which `resourceType`(s) to narrow to before rendering.
+
+After the table, prompt: *"Reply with the numbers to include (e.g. `1, 3, 5-7`)."* Map the selection back to permission **`name` strings** internally — never ask the user to copy UUIDs.
+
+### Step 4 — Author the actions file (`actions.json`)
+
+The `--file` for `roles create` is a **flat JSON array of permission `name` strings** — not a full role body. The CLI assembles the role envelope from `--name` / `--description` / `--service` / `--scope` / `--tenant-id`; you only supply the action set.
+
+```json
+["STUDIO.X.Y", "STUDIO.A.B", "IDENTITY.GROUP.READ"]
+```
+
+### Step 5 — Create and verify
+
+Pick the inline shape that matches Step 1's mode:
+
+```bash
+# Multi-service tenant role ("Centralized Access") — NO --service
+uip admin authorization roles create \
+  --scope Tenant \
+  --tenant-id <TENANT_ID> \
+  --name "<CONFIRMED_NAME>" \
+  --file ./actions.json --output json
+
+# Service-bound tenant role — scope inferred from the service registry
+uip admin authorization roles create \
+  --service documentunderstanding \
+  --tenant-id <TENANT_ID> \
+  --name "<CONFIRMED_NAME>" \
+  --file ./actions.json --output json
+
+# Organization — multi-service org role (no --service)
+uip admin authorization roles create \
+  --scope Organization \
+  --name "<CONFIRMED_NAME>" \
+  --description "<DESCRIPTION>" \
+  --file ./actions.json --output json
+
+# TenantGlobal — reusable template across every tenant (no --service)
+uip admin authorization roles create \
+  --scope TenantGlobal \
+  --name "<CONFIRMED_NAME>" \
+  --file ./actions.json --output json
+
+# Service-inferred — let the registry pick scope (studio → Tenant)
+uip admin authorization roles create \
+  --service studio \
+  --name "<CONFIRMED_NAME>" \
+  --file ./actions.json --output json
+
+# Project — service required
+uip admin authorization roles create \
+  --scope Project \
+  --service documentunderstanding \
+  --name "<CONFIRMED_NAME>" \
+  --file ./actions.json --output json
+```
+
+> **Never pass `--service centralizedaccess`** — the CLI rejects it (`'centralizedaccess' is not a valid --service value`). For the Centralized Access umbrella, omit `--service`.
+
+Verify:
+
+```bash
+uip admin authorization roles get <NEW_ROLE_ID> --output json
+```
+
+The endpoint is a PUT-style upsert. The CLI carries the role identity in the positional `<ID>` (on update) or generates one (on create); you never put `id` in the actions file.
+
+### Step 6 — Summarize: highlight the resolved service
+
+After `roles create` succeeds, your reply to the user MUST quote the resolved service explicitly so the role's shape is unambiguous. Run a `roles get <NEW_ROLE_ID>` and read `ownerServiceName` directly from the response — that is the canonical service binding the platform will use to validate future assignments. Include a row for `Service` in the summary table:
+
+| Source | Render as |
+|---|---|
+| `ownerServiceName` from `roles get` | `service: <ownerServiceName>` (e.g., `service: DocumentUnderstanding`) |
+| `ownerServiceName == "CentralizedAccess"` | `service: CentralizedAccess — multi-service <scope> role` (any assignment scope-path must omit the service segment) |
+
+This field is what [role-assignment-management.md — Validate Role's Owning Service vs. Assignment Scope-Path](role-assignment-management.md#validate-roles-owning-service-vs-assignment-scope-path) checks against on every `assignments create`. Surface it early to avoid surprises later.
+
+Same applies on `roles update`.
+
+## Workflow: Update a Custom Role
+
+The endpoint is the same upsert. The CLI assembles the body from the positional `<ID>` + inline flags + `--file` actions array. Re-fetch before editing — otherwise inline flags overwrite fields you didn't intend to change.
+
+1. Fetch the current role to see `name`, `description`, `scopeType`, `tenantId`, and the current actions:
+   ```bash
+   uip admin authorization roles get <ROLE_ID> --output json
+   ```
+2. Decide what to change. If you're only changing the action set, regenerate `actions.json` from a fresh `permissions list` query (Step 3 above) and skip the metadata flags:
+   ```bash
+   uip admin authorization roles update <ROLE_ID> --file ./actions.json --output json
+   ```
+3. If you're changing metadata too, **pass the metadata flags you want to keep along with the ones you're changing** — the CLI does not merge the current role's fields back in automatically:
+   ```bash
+   uip admin authorization roles update <ROLE_ID> \
+     --scope Tenant \
+     --tenant-id <TENANT_ID> \
+     --name "<NEW_NAME>" \
+     --description "<NEW_DESC>" \
+     --file ./actions.json --output json
+   ```
+
+## Workflow: Delete a Custom Role
+
+1. Confirm the role is custom:
+   ```bash
+   uip admin authorization roles get <ROLE_ID> --output json
+   ```
+   Verify `type` is `Custom`. The CLI also pre-fetches and refuses service-managed / platform-owned roles with a redirect.
+2. Confirm with user.
+3. Run `roles delete <ROLE_ID>`.

--- a/skills/uipath-admin/references/identity-commands.md
+++ b/skills/uipath-admin/references/identity-commands.md
@@ -415,3 +415,17 @@ uip admin external-apps delete-secret <SECRET_ID> --output json
 | `<SECRET_ID>` | Yes | Secret ID (numeric) |
 
 **Output code:** `ExternalClientSecretDeleted`
+
+---
+
+## Output Etiquette — after any identity mutation
+
+Applies to every identity-side mutation: `users create / update / invite / delete`, `groups create / update / delete`, `groups members add / revoke`, `robot-accounts create / update / delete`, `external-apps create / update / delete / generate-secret / delete-secret`.
+
+1. Show the command result (success or failure).
+2. For creates: display the new resource ID.
+3. For `external-apps create` or `generate-secret`: **highlight the secret value and warn user to save it** — it appears only once in the creation response.
+4. Offer logical next steps:
+   - After creating a robot account → "Assign to a group for role-based access?"
+   - After creating an external app → "Generate an additional secret?"
+   - After inviting a user → "Check user list to see when they accept?"

--- a/skills/uipath-admin/references/ip-restriction/bypass-rule-management.md
+++ b/skills/uipath-admin/references/ip-restriction/bypass-rule-management.md
@@ -1,0 +1,80 @@
+# Bypass Rule Management
+
+Multi-step workflows for managing URL-pattern bypass rules via `uip admin ip-restriction bypass-rules`. For per-command flag tables, output codes, and single-command examples, see [ip-restriction-commands.md](ip-restriction-commands.md).
+
+## Concept
+
+Bypass rules carve out **URL-pattern exceptions** to IP allowlisting. Use them when the org has enforcement on but needs a specific App / folder / tenant URL pattern to remain reachable from outside the allowed IP ranges.
+
+Each rule's regex pattern (`regexEntry`) is compiled server-side from the supplied string. Optional metadata (`appName`, tenant association) can travel with the rule.
+
+Bypass rules only matter when [enforcement](enforcement-management.md) is `Enabled`. When enforcement is `Disabled`, they have no effect.
+
+## Workflow: List & Inspect Rules
+
+Use these read patterns before any create / update / delete to confirm what's already in place.
+
+### List all rules
+
+```bash
+uip admin ip-restriction bypass-rules list --output json
+```
+
+### Search by pattern fragment or app name
+
+`--filter` runs a case-insensitive substring match on each rule's `regexEntry` *and* `appName`. Useful when you remember a domain fragment but not the rule id.
+
+```bash
+uip admin ip-restriction bypass-rules list --filter "<FRAGMENT>" --output json
+```
+
+### Inspect one rule by id
+
+```bash
+uip admin ip-restriction bypass-rules get <RULE_ID> --output json
+```
+
+Returns `regexEntry`, `appName`, tenant association, and timestamps. Use this before update/delete to confirm you're targeting the right rule.
+
+## Workflow: Create a Bypass Rule
+
+Create is file-only (no inline shortcut for the create body).
+
+1. Author the rule body (`bypass-rule.json`):
+   ```json
+   {
+     "regexEntry": "^.*\\.contoso\\.com$",
+     "appName": "<OPTIONAL_APP_NAME>"
+   }
+   ```
+   Refer to UiPath docs for the full `AddRegexBypassRequest` schema (tenant fields, etc.).
+2. Create:
+   ```bash
+   uip admin ip-restriction bypass-rules create --file ./bypass-rule.json --output json
+   ```
+3. Verify:
+   ```bash
+   uip admin ip-restriction bypass-rules get <NEW_RULE_ID> --output json
+   ```
+
+## Authoring Tips
+
+- **Escape dots in regex.** A pattern like `.contoso.com` matches `Xcontoso.com` too. Use `\.contoso\.com`.
+- **Anchor with `^` and `$`.** Otherwise the pattern matches any URL containing the fragment.
+- **Test before deploying broadly.** Add the rule, verify it via UiPath app access, then promote.
+
+## Workflow: Update a Rule
+
+- **Regex-only change** — pass `--regex-entry "<NEW_PATTERN>"` inline.
+- **Tenant / app metadata** — pass `--file ./bypass-rule-update.json` with the full `UpdateRegexBypassRequest` body.
+
+## Workflow: Delete a Rule
+
+1. Confirm the rule to delete:
+   ```bash
+   uip admin ip-restriction bypass-rules get <RULE_ID> --output json
+   ```
+2. Confirm with the user.
+3. Run `bypass-rules delete <RULE_ID>`.
+
+No `--confirm` flag required (unlike `ip-ranges delete`) — bypass-rule deletion only narrows access, never widens it.

--- a/skills/uipath-admin/references/ip-restriction/enforcement-management.md
+++ b/skills/uipath-admin/references/ip-restriction/enforcement-management.md
@@ -1,0 +1,86 @@
+# Enforcement Management
+
+Multi-step workflows for the org-wide IP-restriction enforcement switch (`uip admin ip-restriction enforcement`) and the `my-ip` lookup that supports it. For per-command flag tables, output codes, and single-command examples, see [ip-restriction-commands.md](ip-restriction-commands.md).
+
+## Concept
+
+`enforcement` is a singleton switch per organization:
+
+- **Disabled** (default) — platform default access rules apply; `ip-ranges list` is just data, no enforcement.
+- **Enabled** — only IP networks in `ip-ranges list` can reach this org. Everything else is blocked.
+
+Toggling the switch is **idempotent** on both sides — flipping twice is a safe no-op.
+
+**Lockout risk is real.** Enabling enforcement with the caller's IP outside the allowlist locks the caller out (and possibly the whole org). The CLI has two safety rails:
+
+1. `enforcement enable` runs a `my-ip` pre-flight and **rejects** the call if the caller's IP is not covered by any entry in `ip-ranges list`.
+2. `--confirm` is required to acknowledge the lockout risk.
+
+## Workflow: Pre-Flight Before Enabling Enforcement
+
+Before flipping `enforcement enable`, confirm the caller's IP is in the allowlist. The CLI runs the same check server-side and will reject otherwise — front-loading it lets you fix the allowlist explicitly instead of guessing from a rejected call.
+
+1. Check current state:
+   ```bash
+   uip admin ip-restriction enforcement get --output json
+   ```
+2. Look up the caller's public IP:
+   ```bash
+   uip admin ip-restriction my-ip --output json
+   ```
+3. List allowlist entries and verify the IP is covered:
+   ```bash
+   uip admin ip-restriction ip-ranges list --output json
+   ```
+   Compare `my-ip`'s `ipAddress` against each entry's `ipNetwork` CIDR. If no entry covers your IP, add one before enabling — see [ip-range-management.md — Workflow: Add an Entry](ip-range-management.md#workflow-add-an-entry-idempotent-on-cidr).
+
+## Workflow: Enable Enforcement
+
+1. Run the pre-flight above.
+2. **State the impact and prompt for an explicit confirmation.** Do not run `enforcement enable` until the user has acknowledged the impact in this turn. Render verbatim:
+
+   ```
+   ⚠️ About to enable IP Restriction for this organization.
+
+   Impact:
+   • Any caller — Portal session, CLI session, robot, external app, integration —
+     whose source IP is not in `ip-ranges list` will be BLOCKED from this org
+     starting immediately.
+   • If the allowlist is misconfigured, you (and other admins) can be locked out.
+     Recovery requires either an in-allowlist IP and `enforcement disable`,
+     OR the UiPath Portal recovery flow — there is no CLI bypass.
+
+   Pre-flight summary:
+   • Caller IP (from `my-ip`):  <IP>
+   • Allowlist entries covering it: <N>  (e.g., <CIDR-1>, <CIDR-2>)
+
+   Proceed?  (yes / no)
+   ```
+
+   On "no" → stop. On "yes" → run the command. **Never substitute the prompt with a one-line "are you sure".** The full impact statement is required because of the lockout severity.
+
+3. Enable:
+   ```bash
+   uip admin ip-restriction enforcement enable --confirm --output json
+   ```
+
+The CLI runs its own `my-ip` pre-flight and rejects the call if the caller is not covered. If rejected, do NOT retry until the allowlist is fixed.
+
+4. **Post-state check.** Re-run `enforcement get` and `my-ip` immediately after. If the caller's IP is still covered, report success. If something looks off, instruct the user to use the recovery flow before they lose access.
+
+## Workflow: Disable Enforcement
+
+Safe and idempotent — restores platform default access:
+
+```bash
+uip admin ip-restriction enforcement disable --output json
+```
+
+No `--confirm` required. Use to recover from a near-lockout, or to bypass the `ip-ranges delete` safety pre-flight.
+
+## Recovery from Lockout
+
+If `enforcement enable` succeeded but a subsequent change locked the caller out:
+
+1. Access UiPath from an IP already in the allowlist (e.g., a different VPN or office network), then run `enforcement disable`.
+2. If no such IP is available, the org owner must use the UiPath Portal lockout-recovery flow or contact support — there is no CLI bypass.

--- a/skills/uipath-admin/references/ip-restriction/ip-range-management.md
+++ b/skills/uipath-admin/references/ip-restriction/ip-range-management.md
@@ -1,0 +1,125 @@
+# IP Range Management
+
+Multi-step workflows for managing IP allowlist entries via `uip admin ip-restriction ip-ranges`. For per-command flag tables, output codes, and single-command examples, see [ip-restriction-commands.md](ip-restriction-commands.md).
+
+## Concept
+
+Each entry is one of:
+- A **CIDR block** (e.g., `10.0.0.0/16`) — preferred shape.
+- A **start/end IP range** (e.g., `10.0.0.1`–`10.0.0.50`) — legacy shape, still supported.
+- A **list of CIDRs** under one named entry (pass `--cidr` multiple times).
+
+Entries can carry an `--expires` duration (`<INTEGER><m|h|d|w>` — e.g. `15m`, `2h`, `30d`, `1w`).
+
+When `enforcement get` returns `Enabled`, only addresses inside these entries can reach the org. See [enforcement-management.md](enforcement-management.md) for the switch.
+
+## Workflow: Add an Entry (idempotent on CIDR)
+
+`create` is idempotent on CIDR — running it twice with the same `--cidr` is a safe no-op.
+
+### Single CIDR
+
+```bash
+uip admin ip-restriction ip-ranges create \
+  --name "<DISPLAY_NAME>" \
+  --cidr "<CIDR>" \
+  --output json
+```
+
+### Multiple CIDRs under one entry
+
+```bash
+uip admin ip-restriction ip-ranges create \
+  --name "<DISPLAY_NAME>" \
+  --cidr "<CIDR_1>" \
+  --cidr "<CIDR_2>" \
+  --output json
+```
+
+### With expiry
+
+```bash
+uip admin ip-restriction ip-ranges create \
+  --name "<DISPLAY_NAME>" \
+  --cidr "<CIDR>" \
+  --expires 30d \
+  --output json
+```
+
+### Legacy start/end range
+
+```bash
+uip admin ip-restriction ip-ranges create \
+  --name "<DISPLAY_NAME>" \
+  --start-ip "<START_IP>" \
+  --end-ip "<END_IP>" \
+  --output json
+```
+
+### Full body via JSON file
+
+```bash
+uip admin ip-restriction ip-ranges create --file ./entry.json --output json
+```
+
+The body is `AddIpConfigurationRequest`.
+
+## Workflow: Update an Entry
+
+Patch an existing entry — rename, swap CIDRs, extend / shorten expiry, or migrate between CIDR and start/end shapes. Common scenarios: extending an expiring contractor allowlist, replacing a stale office CIDR after an ISP change.
+
+1. Fetch the current entry so you can see what's there:
+   ```bash
+   uip admin ip-restriction ip-ranges get <ENTRY_ID> --output json
+   ```
+   Or lookup by CIDR if you only know that:
+   ```bash
+   uip admin ip-restriction ip-ranges get --cidr "<CURRENT_CIDR>" --output json
+   ```
+2. Apply the patch — only the flags you pass are updated:
+
+   **Rename:**
+   ```bash
+   uip admin ip-restriction ip-ranges update <ENTRY_ID> --name "<NEW_NAME>" --output json
+   ```
+
+   **Replace CIDR(s):**
+   ```bash
+   uip admin ip-restriction ip-ranges update <ENTRY_ID> --cidr "<NEW_CIDR>" --output json
+   ```
+
+   **Swap to a start/end IP range:**
+   ```bash
+   uip admin ip-restriction ip-ranges update <ENTRY_ID> --start-ip "<IP>" --end-ip "<IP>" --output json
+   ```
+
+   **Full body via `--file`** (for fields not exposed inline):
+   ```bash
+   uip admin ip-restriction ip-ranges update <ENTRY_ID> --file ./entry-update.json --output json
+   ```
+
+> **Replacing a CIDR while enforcement is on is lockout-sensitive.** If you're swapping the CIDR that currently covers your IP, the new value must also cover it — verify against `my-ip` first. The CLI does not run a pre-flight on `update` (unlike `delete`).
+
+## Workflow: Delete an Entry (lockout-sensitive)
+
+**Lockout warning** — removing the wrong entry while enforcement is enabled can lock the caller (or the whole org) out of UiPath.
+
+1. Confirm the entry to delete:
+   ```bash
+   uip admin ip-restriction ip-ranges get <ENTRY_ID> --output json
+   ```
+2. Check enforcement state — and mention it when confirming with the user:
+   ```bash
+   uip admin ip-restriction enforcement get --output json
+   ```
+3. Confirm with the user explicitly.
+4. Delete with `--confirm`:
+   ```bash
+   uip admin ip-restriction ip-ranges delete <ENTRY_ID> --confirm --output json
+   ```
+   Or by CIDR:
+   ```bash
+   uip admin ip-restriction ip-ranges delete --cidr "<CIDR>" --confirm --output json
+   ```
+
+If enforcement is on, the CLI also runs a server-side safety pre-flight (`only-entry` / `caller-IP-uniquely-covered`) and may reject the delete. To bypass that check, run `enforcement disable` first — but only if you understand the consequences. See [enforcement-management.md](enforcement-management.md).

--- a/skills/uipath-admin/references/ip-restriction/ip-restriction-commands.md
+++ b/skills/uipath-admin/references/ip-restriction/ip-restriction-commands.md
@@ -1,0 +1,318 @@
+# IP-Restriction CLI Command Reference
+
+Complete reference for all `uip admin ip-restriction` commands — org-wide IP allowlisting, the enforcement switch, URL-pattern bypass rules, and the `my-ip` lookup.
+
+> **Internal acronym: `APMS`** (Access Policy Management Service). This is the platform's internal name for IP Restriction. **Never surface `APMS` in user-facing output** — always say "IP Restriction".
+
+For workflow-level guidance, see [ip-range-management.md](ip-range-management.md), [enforcement-management.md](enforcement-management.md), and [bypass-rule-management.md](bypass-rule-management.md).
+
+## Global Flags
+
+Every command accepts these flags (omitted from per-command tables):
+
+| Flag | Description |
+|------|-------------|
+| `--output <format>` | Output format: `json`, `table`, `yaml`, `plain` (default: json) |
+| `--output-filter <expression>` | JMESPath expression to filter output |
+| `--log-level <level>` | Log level: `debug`, `info`, `warn`, `error` (default: info) |
+| `--log-file <path>` | Write logs to file instead of stderr |
+| `--login-validity <minutes>` | Override token validity — forces refresh if token expires within this window |
+
+Organization is resolved automatically from the active login session.
+
+## Prerequisites
+
+```bash
+uip login status --output json
+```
+
+If not logged in: `uip login`.
+
+## Concepts
+
+- **Allowlist semantics.** When `enforcement` is `Enabled`, only IP networks in `ip-ranges list` can reach the org. Everything else is blocked.
+- **Lockout risk is the dominant concern.** Removing the wrong CIDR or enabling enforcement with the caller's IP outside the list locks the caller (and possibly the whole org) out of UiPath. Safety rails:
+  - `enforcement enable` runs a `my-ip` pre-flight and rejects the call if the caller's IP is not covered.
+  - `ip-ranges delete` runs a server-side safety pre-flight (only-entry / caller-IP-uniquely-covered) when enforcement is on.
+  - Both `ip-ranges delete` and `enforcement enable` require `--confirm`.
+- **Idempotent ops.** `ip-ranges create` upserts on CIDR (safe to re-run). `enforcement enable` / `disable` are idempotent.
+- **Bypass rules are server-compiled.** The CLI sends `regexEntry`; the platform compiles the regex.
+- **Bypass rules only matter when enforcement is `Enabled`.** With enforcement disabled they have no effect.
+
+---
+
+## IP Ranges — `uip admin ip-restriction ip-ranges`
+
+Each entry is one of:
+- A **CIDR block** (e.g., `10.0.0.0/16`) — preferred shape.
+- A **start/end IP range** (e.g., `10.0.0.1`–`10.0.0.50`) — legacy shape.
+- A **list of CIDRs** under one named entry (pass `--cidr` multiple times).
+
+Entries can carry an `--expires` duration (`15m`, `2h`, `30d`, `1w`).
+
+### `ip-ranges list`
+
+List allowlist entries.
+
+```bash
+uip admin ip-restriction ip-ranges list --output json
+uip admin ip-restriction ip-ranges list --filter "<NAME_FRAGMENT>" --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--filter <fragment>` | No | Case-insensitive substring match on entry `name` (client-side) |
+
+**Output code:** `ApmsIpRangesList`.
+
+### `ip-ranges get`
+
+Fetch an entry by id or by CIDR.
+
+```bash
+uip admin ip-restriction ip-ranges get <ENTRY_ID> --output json
+uip admin ip-restriction ip-ranges get --cidr "<CIDR>" --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<ENTRY_ID>` | Conditional | Entry UUID (positional) — required unless `--cidr` |
+| `--cidr <cidr>` | Conditional | Lookup by CIDR value instead of id |
+
+**Output code:** `ApmsIpRangeGet`.
+
+### `ip-ranges create`
+
+Add an allowlist entry. **Idempotent on CIDR** — re-running with the same `--cidr` is a safe no-op.
+
+```bash
+uip admin ip-restriction ip-ranges create \
+  --name "<DISPLAY_NAME>" \
+  --cidr "<CIDR>" \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name <name>` | Yes (inline) | Display name for the entry |
+| `--cidr <cidr>` | Conditional | CIDR block. Repeatable for multiple CIDRs under one entry |
+| `--start-ip <ip>` | Conditional | Start of legacy IP range. Requires `--end-ip` |
+| `--end-ip <ip>` | Conditional | End of legacy IP range. Requires `--start-ip` |
+| `--expires <duration>` | No | Expiry: `<INTEGER><m\|h\|d\|w>` (e.g., `30d`, `2h`) |
+| `--file <path>` | Alternative | Full `AddIpConfigurationRequest` body |
+
+Either `--cidr` (one or more) **or** the `--start-ip`/`--end-ip` pair is required.
+
+**Output code:** `ApmsIpRangeCreated`.
+
+### `ip-ranges update`
+
+Patch an entry.
+
+```bash
+uip admin ip-restriction ip-ranges update <ENTRY_ID> --name "<NEW_NAME>" --output json
+uip admin ip-restriction ip-ranges update <ENTRY_ID> --cidr "<NEW_CIDR>" --output json
+uip admin ip-restriction ip-ranges update <ENTRY_ID> --start-ip "<IP>" --end-ip "<IP>" --output json
+uip admin ip-restriction ip-ranges update <ENTRY_ID> --file ./entry-update.json --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<ENTRY_ID>` | Yes | Entry UUID |
+| `--name <name>` | No | New display name |
+| `--cidr <cidr>` | No | Replace CIDR(s) |
+| `--start-ip <ip>` | No | New range start |
+| `--end-ip <ip>` | No | New range end |
+| `--file <path>` | Alternative | Full update body |
+
+**Output code:** `ApmsIpRangeUpdated`.
+
+### `ip-ranges delete`
+
+Remove an entry. **Lockout-sensitive — requires `--confirm`.**
+
+```bash
+uip admin ip-restriction ip-ranges delete <ENTRY_ID> --confirm --output json
+uip admin ip-restriction ip-ranges delete --cidr "<CIDR>" --confirm --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<ENTRY_ID>` | Conditional | Entry UUID (positional) — required unless `--cidr` |
+| `--cidr <cidr>` | Conditional | Delete by CIDR value instead of id |
+| `--confirm` | Yes | Acknowledge lockout risk |
+
+If enforcement is on, the CLI also runs a server-side safety pre-flight (only-entry / caller-IP-uniquely-covered) and may reject the delete. To bypass: run `enforcement disable` first (only if you understand the consequences).
+
+**Output code:** `ApmsIpRangeDeleted`.
+
+---
+
+## Enforcement Switch — `uip admin ip-restriction enforcement`
+
+Singleton per organization. **Idempotent** on both sides — flipping twice is a safe no-op.
+
+### `enforcement get`
+
+Current enforcement state.
+
+```bash
+uip admin ip-restriction enforcement get --output json
+```
+
+Returns `Data.status`: `Enabled` or `Disabled`.
+
+**Output code:** `ApmsEnforcementGet`.
+
+### `enforcement enable`
+
+Turn enforcement on. **Lockout-sensitive — requires `--confirm` and a `my-ip` pre-flight.**
+
+```bash
+uip admin ip-restriction enforcement enable --confirm --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--confirm` | Yes | Acknowledge lockout risk |
+
+The CLI runs its own `my-ip` pre-flight and rejects the call if the caller is not covered by any entry in `ip-ranges list`. If rejected, do NOT retry until the allowlist is fixed — see [enforcement-management.md](enforcement-management.md).
+
+**Output code:** `ApmsEnforcementEnabled`.
+
+### `enforcement disable`
+
+Turn enforcement off. **Safe and idempotent.** No `--confirm` required.
+
+```bash
+uip admin ip-restriction enforcement disable --output json
+```
+
+Use this to recover from a near-lockout, or to bypass the `ip-ranges delete` safety pre-flight.
+
+**Output code:** `ApmsEnforcementDisabled`.
+
+---
+
+## Bypass Rules — `uip admin ip-restriction bypass-rules`
+
+URL-pattern exceptions to IP allowlisting. Each rule's `regexEntry` is compiled server-side.
+
+### `bypass-rules list`
+
+List rules.
+
+```bash
+uip admin ip-restriction bypass-rules list --output json
+uip admin ip-restriction bypass-rules list --filter "<FRAGMENT>" --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--filter <fragment>` | No | Case-insensitive substring match on `regexEntry` or `appName` (client-side) |
+
+**Output code:** `ApmsBypassRulesList`.
+
+### `bypass-rules get`
+
+Fetch a rule by id.
+
+```bash
+uip admin ip-restriction bypass-rules get <RULE_ID> --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<RULE_ID>` | Yes | Rule UUID |
+
+**Output code:** `ApmsBypassRulesGet`.
+
+### `bypass-rules create`
+
+Create a rule. **File-only** — no inline shortcut.
+
+```bash
+uip admin ip-restriction bypass-rules create --file ./bypass-rule.json --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--file <path>` | Yes | `AddRegexBypassRequest` body |
+
+`./bypass-rule.json`:
+
+```json
+{
+  "regexEntry": "^.*\\.contoso\\.com$",
+  "appName": "<OPTIONAL_APP_NAME>"
+}
+```
+
+Authoring tips: escape dots (`\.`), anchor with `^` and `$`.
+
+**Output code:** `ApmsBypassRulesCreated`.
+
+### `bypass-rules update`
+
+Patch a rule.
+
+```bash
+uip admin ip-restriction bypass-rules update <RULE_ID> --regex-entry "<NEW_PATTERN>" --output json
+uip admin ip-restriction bypass-rules update <RULE_ID> --file ./bypass-rule-update.json --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<RULE_ID>` | Yes | Rule UUID |
+| `--regex-entry <pattern>` | No | Replace the stored regex pattern |
+| `--file <path>` | Alternative | Full `UpdateRegexBypassRequest` body (use for tenant / app metadata updates) |
+
+**Output code:** `ApmsBypassRulesUpdated`.
+
+### `bypass-rules delete`
+
+Delete a rule. **No `--confirm`** — bypass-rule deletion only narrows access.
+
+```bash
+uip admin ip-restriction bypass-rules delete <RULE_ID> --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<RULE_ID>` | Yes | Rule UUID |
+
+**Output code:** `ApmsBypassRulesDeleted`.
+
+---
+
+## My IP — `uip admin ip-restriction my-ip`
+
+### `my-ip`
+
+Return the public IP the platform sees for the current caller. Use before `enforcement enable` to verify the allowlist covers your IP.
+
+```bash
+uip admin ip-restriction my-ip --output json
+```
+
+Returns `Data.ipAddress`.
+
+**Output code:** `ApmsMyIpGet`.
+
+---
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `--confirm required` | `ip-ranges delete` or `enforcement enable` called without `--confirm` | Re-run with `--confirm` after user confirmation |
+| Safety pre-flight rejected delete | Enforcement on + entry is the only / caller's covering entry | Add a new covering entry first, OR disable enforcement, OR target a different entry |
+| `my-ip pre-flight failed` | Caller's IP is not in any `ip-ranges` entry | Add a covering CIDR with `ip-ranges create`, then retry |
+| `entry not found` | Invalid id / CIDR not in allowlist | Run `ip-ranges list` to confirm available entries |
+| `cidr already exists` (no error — create is idempotent) | Already-present CIDR | None — `create` is upsert-on-CIDR |
+| `invalid expires` | Bad duration string | Use `<INTEGER><m\|h\|d\|w>` (e.g., `2h`, `30d`) |
+| `invalid regex` | Server failed to compile `regexEntry` | Fix the regex in the body file |
+| `rule not found` | Invalid rule UUID | Run `bypass-rules list` |
+| Bypass rule has no effect | Enforcement is `Disabled` | Bypass rules only apply when `enforcement get` returns `Enabled` |
+| `enforcement already <state>` (no error — idempotent) | Already in target state | None |
+| Auth error | Login expired | `uip login status`, then `uip login` |

--- a/skills/uipath-admin/references/organization-management.md
+++ b/skills/uipath-admin/references/organization-management.md
@@ -1,0 +1,146 @@
+# Organization Management
+
+Multi-step workflows for managing the caller's organization via `uip admin organizations`. For per-command flag tables, output codes, and single-command examples, see [organizations-commands.md](organizations-commands.md).
+
+## Concept
+
+The Organization Management Service (OMS) owns the org record, the region catalog, org-level service catalog (read-only), and the shared async-operation poll endpoint that tenant lifecycle ops use.
+
+- **Org surface is read + update only.** `uip admin organizations` exposes `get`, `update`, `regions list`, `services list / list-available`, and `operation get`. **No `create` / `delete`** — those are not exposed by the CLI; org creation/deletion goes through the UiPath Portal or support flow.
+- **All org commands are synchronous.** Async polling on this command tree is for *tenant* lifecycle ops (see [tenant-management.md](tenant-management.md)) — the poll endpoint just happens to live under `organizations operation get`. See [Polling procedure](#polling-procedure-auto-poll-then-hand-off).
+- **Login-tenant default** does NOT apply to org commands — they always operate on the caller's organization.
+
+## Workflow: Inspect the Organization
+
+The common read-side scenario — show the caller their org record.
+
+### Compact view (just the org record)
+
+```bash
+uip admin organizations get --output json
+```
+
+Returns the organization name, id, region, country, language, lifecycle state, and timestamps.
+
+When surfacing the result to the user, lead with **`Organization: <ORG_NAME> (region: <REGION>)`** so they see at a glance which org the session is on. Do not show the raw `id` field alone — pair it with the name.
+
+### Bundled view (org + tenants + service catalog in one call)
+
+```bash
+uip admin organizations get --full --output json
+```
+
+Use `--full` when you need to answer a follow-up about tenants or services in the same response — it avoids the second round-trip to `tenants list` or `services list`.
+
+### Discover provisioning regions for `tenants create`
+
+```bash
+uip admin organizations regions list --output json
+```
+
+The returned region names go directly into `--region` on `tenants create`.
+
+## Workflow: Update the Organization
+
+Two shapes:
+
+- **Inline** for one or two simple fields (`--name`, `--logical-name`, `--language`).
+- **File** for the full `UpdateOrganizationCommand` body when changing multiple structured fields.
+
+See [organizations-commands.md — `organizations update`](organizations-commands.md#organizations-update). Synchronous — the response carries the final state.
+
+> **No CLI `organizations create` / `delete`.** If a user asks to create or delete an organization, redirect them to the UiPath Portal or support flow — the CLI does not expose those verbs.
+
+## Workflow: Poll an Async Operation
+
+Canonical poll endpoint for OMS async operations. Today every async op comes from a `tenants` lifecycle verb (`create / update / delete / enable / disable`); the endpoint lives under `organizations operation get` and works for any future async ops as well:
+
+```bash
+uip admin organizations operation get <OPERATION_ID> --output json
+```
+
+### Polling procedure (auto-poll then hand off)
+
+Auto-poll briefly, then hand control back to the user. Bounded — never indefinite.
+
+1. **Echo the operationId and the resume command** so the user can always pick up later:
+   ```bash
+   uip admin organizations operation get <OPERATION_ID> --output json
+   ```
+2. **Auto-poll up to 3 times at 5-second intervals** (≈15 s total). Between polls, sleep 5 s. After each call, surface the current status — e.g. *"Poll 2/3: status=`Running`"*. Never loop silently.
+3. **Stop polling on any terminal status.** Treat anything that is not `Pending` / `Running` / `InProgress` as terminal (`Succeeded`, `Failed`, `Cancelled`). On terminal, report final state and re-fetch the affected resource (`organizations get` / `tenants get <ID>`).
+4. **Still non-terminal after 3 polls → hand off with a numbered menu** (`<ROUND>` starts at 1; increment each time the user picks `1`):
+   ```
+   Operation <OP_ID> is still `<STATUS>` after round <ROUND> (3 × 5 s polls). Choose:
+     1. Keep polling (another 3 × 5 s)
+     2. Poll once more
+     3. Stop and return the operationId for later
+   ```
+   - `1` → resume one more auto-poll cycle; increment `<ROUND>`. After **round 2 (≈30 s total)**, drop option `1` from the menu — only `2` and `3` remain. The user cannot extend auto-polling beyond ~30 s.
+   - `2` → one more `operation get` call, then re-prompt with the same menu (option `1` still gated by the round cap).
+   - `3` → print the resume command and exit; the user can come back and run `operation get <OP_ID>` later.
+5. **Never auto-poll indefinitely.** Total auto-poll window is capped at ~30 s (2 rounds). Beyond that the user must drive every additional poll via option `2` or walk away via `3`.
+
+### Status vocabulary
+
+The response's `status` field uses these values (treat case-insensitively in match logic, but show the user the exact case from the response):
+
+| Family | Examples | Action |
+|---|---|---|
+| In-progress | `Pending`, `Running`, `InProgress` | Continue polling (within the 3-poll cap) |
+| Terminal — success | `Succeeded` | Stop, re-fetch the resource, report success |
+| Terminal — failure | `Failed`, `Cancelled` | Stop, surface the error payload (`Data.error` / `Data.message`), do NOT retry the original mutation automatically — ask the user |
+
+If the response lacks a `status` field altogether, treat the operation as in-progress for that poll and try once more; if the field is missing across all 3 polls, surface the raw response to the user and stop.
+
+## Workflow: List Org-Level Services — Provisioned vs. Available
+
+Two distinct surfaces — never merge them:
+
+| Verb | Returns | Has lifecycle status? |
+|---|---|---|
+| `organizations services list` | **Provisioned** org-level service instances (what currently exists on this org) | Yes — `Enabled`, `Disabled`, or `Deleted` (soft-deleted) |
+| `organizations services list-available` | **Catalog** of service types that *can* be provisioned at the org level | No — catalog entries are not provisioned |
+
+### Currently provisioned (with status)
+
+```bash
+uip admin organizations services list --output json
+```
+
+Surface to the user as **"Provisioned services on `<ORG_NAME>`"**. For each row, show: service type, **status** (`Enabled` / `Disabled` / `Deleted`), region. Flag any soft-deleted (`Deleted`) entries explicitly so the user knows they were removed but are still recoverable.
+
+If the result is empty, say so explicitly: *"No org-level services are currently provisioned."* — do not show an empty table.
+
+Optional filters (client-side, applied after the API call):
+
+```bash
+uip admin organizations services list --status Enabled --output json
+uip admin organizations services list --service orchestrator --output json
+uip admin organizations services list --region "<REGION>" --output json
+```
+
+### Available to provision (catalog only)
+
+```bash
+uip admin organizations services list-available --output json
+```
+
+Surface to the user as **"Available service catalog (org-level)"**. Do NOT add a status column — catalog entries have no lifecycle state. Visually separate this from the provisioned list (different header, ideally a different table).
+
+### When the user's intent is ambiguous
+
+If the user says "show me the services" without specifying provisioned vs. available, run both and present them in two clearly labeled sections so they can pick.
+
+## Before Mutating the Organization — Name the Target
+
+Before `organizations update`, echo the resolved target back so the user knows exactly which organization will change:
+
+```
+Organization: <ORG_NAME> (region: <REGION>, id: <ORG_ID>)
+Action: update
+```
+
+`organizations get --output json` returns the name and region — resolve them up-front; do not run the mutation against just the active login session implicitly.
+
+> The CLI does not expose `organizations delete`, so this echo only ever covers `update`. If the user asks to delete the org, redirect to the Portal / support flow.

--- a/skills/uipath-admin/references/organizations-commands.md
+++ b/skills/uipath-admin/references/organizations-commands.md
@@ -1,0 +1,175 @@
+# Organizations CLI Command Reference
+
+Complete reference for all `uip admin organizations` commands — caller's organization read + update, async-operation polling (for tenant lifecycle ops), region catalog, and org-level service catalog (read-only). Part of the Organization Management Service (OMS).
+
+For tenant commands, see [tenants-commands.md](tenants-commands.md). For workflow-level guidance, see [organization-management.md](organization-management.md).
+
+## Global Flags
+
+Every command accepts these flags (omitted from per-command tables):
+
+| Flag | Description |
+|------|-------------|
+| `--output <format>` | Output format: `json`, `table`, `yaml`, `plain` (default: json) |
+| `--output-filter <expression>` | JMESPath expression to filter output |
+| `--log-level <level>` | Log level: `debug`, `info`, `warn`, `error` (default: info) |
+| `--log-file <path>` | Write logs to file instead of stderr |
+| `--login-validity <minutes>` | Override token validity — forces refresh if token expires within this window |
+
+Organization is resolved automatically from the active login session — no `--organization` flag.
+
+## Prerequisites
+
+```bash
+uip login status --output json
+```
+
+If not logged in: `uip login`.
+
+## Concepts
+
+### OMS sync vs async — quick reference
+
+| Operation | Sync/Async | Confirm completion |
+|---|---|---|
+| `organizations get`, `update` | **Sync** | Response. No CLI `create` / `delete` — Portal / support flow only. |
+| `tenants create / update / delete / enable / disable` | **Async** — returns `operationId` | Poll `organizations operation get <OP_ID>` (single endpoint for all OMS async ops) |
+| `tenants services add / enable / disable / remove` | **Sync** | Response — except `disable` (Integration Service, Data Fabric, Insights) and `remove` (Orchestrator, Maestro, Integration Service, Data Fabric, Insights, Test Manager), which return Success but no-op. Re-list. |
+| All `*list*`, `get`, `regions list`, `services list-available` | **Sync** | — |
+
+### Notes
+
+- **Org surface is read + update only.** This command tree exposes `get`, `update`, `regions list`, `services list / list-available`, and `operation get`. **There is no `organizations create` or `organizations delete` in the CLI** — those are not exposed; org creation/deletion goes through the UiPath Portal / support flow.
+- **All org verbs are synchronous.** `update`, `get`, `regions list`, and all `services` reads complete in a single round-trip and carry the final state in the response.
+- **Single poll endpoint for the platform.** `operation get` lives here for historical reasons, but it polls async **tenant** lifecycle ops (`tenants create / update / delete / enable / disable`). Use it whenever those return an `operationId`.
+- **No login-tenant default here.** Org commands always operate on the caller's organization (resolved from the active login).
+- **Region is required for tenant create.** Run `regions list` here, then pass `--region` to `tenants create` (see [tenants-commands.md](tenants-commands.md)).
+
+---
+
+## Organization — `uip admin organizations`
+
+### `organizations get`
+
+Fetch the caller's organization record.
+
+```bash
+uip admin organizations get --output json
+uip admin organizations get --full --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--full` | No | Return bundle: org + tenants + service catalog in one call |
+
+**Output code:** `OmsOrganizationGet`
+
+### `organizations update`
+
+Patch editable fields on the caller's organization. **Synchronous** — response carries the final state.
+
+```bash
+uip admin organizations update --name "<NEW_NAME>" --output json
+uip admin organizations update --logical-name "<NEW_SLUG>" --output json
+uip admin organizations update --language "<LANGUAGE_CODE>" --output json
+uip admin organizations update --file ./org-update.json --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name <name>` | No | New display name |
+| `--logical-name <slug>` | No | New URL slug |
+| `--language <code>` | No | New language code |
+| `--file <path>` | Alternative | Full `UpdateOrganizationCommand` body |
+
+At least one field flag (or `--file`) is required. **Output code:** `OmsOrganizationUpdated`.
+
+> **No `create` / `delete` here.** The CLI does not expose `organizations create` or `organizations delete`; both return `ValidationError: unknown command`. For org provisioning or removal, use the UiPath Portal or the support flow.
+
+---
+
+## Async Operations — `uip admin organizations operation`
+
+### `operation get`
+
+Poll the status of an async OMS operation (tenant lifecycle today; org create/delete are not exposed by the CLI).
+
+```bash
+uip admin organizations operation get <OPERATION_ID> --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<OPERATION_ID>` | Yes | Operation UUID returned by a `tenants` lifecycle command (`create`, `update`, `delete`, `enable`, `disable`) |
+
+The response carries a `status` field. Treat `Pending` / `Running` / `InProgress` as in-progress; anything else (`Succeeded`, `Failed`, `Cancelled`) as terminal.
+
+**Polling cadence — auto-poll up to 3× at 5-second intervals, then ask the user.** Surface each intermediate status; never loop silently and never auto-poll indefinitely. For the full procedure (including the numbered next-step menu the agent presents after the 3-poll auto-window), see [organization-management.md — Polling procedure](organization-management.md#polling-procedure-auto-poll-then-hand-off).
+
+**Output code:** `OmsOperationGet`.
+
+---
+
+## Regions — `uip admin organizations regions`
+
+### `regions list`
+
+List provisioning regions in which Portal can stand up tenants (and orgs via the Portal). Run before `tenants create` to confirm `--region` accepts the desired value.
+
+```bash
+uip admin organizations regions list --output json
+```
+
+Returned region names go directly into `--region` on `tenants create`.
+
+**Output code:** `OmsRegionsList`.
+
+---
+
+## Org-Level Services — `uip admin organizations services`
+
+> **Read-only at the org surface.** Only `list` and `list-available` exist here — there is no `add` / `enable` / `disable` / `remove` at the org level. To provision / mutate services on a specific tenant, use [`tenants services` →](tenants-commands.md#tenant-level-services--uip-admin-tenants-services).
+
+> **`list` vs `list-available` are different sets — never merge them.** `services list` returns the **currently provisioned** org-level instances (each with a `status`: `Enabled` / `Disabled` / `Deleted`). `services list-available` returns the **catalog** of provisionable service types (no status — catalog entries are not provisioned). Always present them as two clearly labeled sections when surfacing results to the user. See [organization-management.md — List Org-Level Services](organization-management.md#workflow-list-org-level-services--provisioned-vs-available).
+
+### `services list`
+
+List **currently provisioned** org-level service instances. Each row carries a lifecycle `status` — `Enabled`, `Disabled`, or `Deleted` (soft-deleted). Surface the status field in any presentation; flag `Deleted` entries explicitly.
+
+```bash
+uip admin organizations services list --output json
+uip admin organizations services list --service orchestrator --output json
+uip admin organizations services list --status Enabled --output json
+uip admin organizations services list --region "<REGION>" --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--service <type>` | No | Filter by service type (client-side) |
+| `--status <state>` | No | Filter by lifecycle status, e.g. `Enabled`, `Disabled` (client-side) |
+| `--region <region>` | No | Filter by region (client-side) |
+
+All filters are client-side after the API call (no server-side filters).
+
+**Output code:** `OmsOrgServicesList`.
+
+### `services list-available`
+
+List the **catalog** of services that can be provisioned at the org level. Catalog only — entries are not provisioned and have no lifecycle status. Do not show a status column when surfacing results.
+
+```bash
+uip admin organizations services list-available --output json
+```
+
+**Output code:** `OmsOrgServicesAvailable`.
+
+---
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `region not allowed` | `--region` value not in available regions (only relevant via `tenants create`) | Run `regions list` and use a returned value |
+| Operation never completes | Async op stuck or failed | Inspect `Data` from `operation get <OPERATION_ID>`; retry or escalate |
+| Empty service list | Filter mismatch (all filters client-side) | Drop a filter or try a different value |
+| Auth error | Login expired | `uip login status`, then `uip login` |

--- a/skills/uipath-admin/references/tenant-management.md
+++ b/skills/uipath-admin/references/tenant-management.md
@@ -1,0 +1,258 @@
+# Tenant Management
+
+Multi-step workflows for managing tenants and their services via `uip admin tenants`. For per-command flag tables, output codes, and single-command examples, see [tenants-commands.md](tenants-commands.md).
+
+## Concept
+
+A tenant lives inside an organization. Each tenant has its own lifecycle status (`Enabled`, `Disabled`, `Updating`, `Deleted`) and its own service provisioning surface.
+
+> **Two `status` fields, don't confuse them.** Tenant *lifecycle* status (`Enabled` / `Disabled` / `Updating` / `Deleted`) lives on the tenant record. Async *operation* status (`Pending` / `Running` / `InProgress` / `Succeeded` / `Failed` / `Cancelled`) lives on the `operationId` response. The poll endpoint reports operation status; the tenant `status` only flips after the operation reaches `Succeeded`.
+
+- **Tenant lifecycle is async.** `create`, `update`, `delete`, `enable`, `disable` all return an `operationId`. Auto-poll per the [shared Polling procedure](organization-management.md#polling-procedure-auto-poll-then-hand-off) (3 × 5 s, then ask the user). Every async workflow below assumes this procedure — `(poll)` in a step means "follow the shared procedure".
+- **Service provisioning is synchronous.** `services add`, `enable`, `disable`, `remove` return immediately. No polling required.
+- **Soft-delete only.** No hard-delete flag. Reversible via the restore flow.
+- **Positional tenant id defaults to the login tenant.** Convenient for read ops; dangerous for destructive ops — always pass the explicit `<TENANT_ID>` for `delete`, `disable`, and `services remove`.
+
+## Workflow: Resolve a Tenant UUID by Name
+
+Standard pattern across `uip admin`:
+
+```bash
+uip admin tenants list --filter "<NAME>" --output json
+```
+
+Extract `id` from the result before calling `get`, `update`, `delete`, `enable`, `disable`, or `services` commands that take an explicit tenant id.
+
+## Workflow: List Tenants — Surface Lifecycle Status
+
+When showing tenants to the user, always include each tenant's `status` (`Enabled`, `Disabled`, `Updating`, or `Deleted`). A `Deleted` tenant is soft-deleted and still visible until purged — call this out so the user knows it is recoverable but not active.
+
+```bash
+uip admin tenants list --output json
+uip admin tenants list --status Enabled --output json
+```
+
+For each row: tenant name, UUID (so the user can copy it into the next command), region, status. If the user asked "what tenants exist?" do not silently filter out `Disabled` or `Deleted` tenants — show all and label them.
+
+## Workflow: List Tenant Services — Provisioned vs. Available
+
+Two distinct surfaces — never merge them:
+
+| Verb | Returns | Has lifecycle status? |
+|---|---|---|
+| `tenants services list` | **Provisioned** service instances on the tenant (what currently exists) | Yes — `Enabled`, `Disabled`, or `Deleted` (soft-deleted) |
+| `tenants services list-available --region <R>` | **Catalog** of service types that *can* be provisioned in that region | No — catalog entries are not provisioned |
+
+### Currently provisioned on a tenant (with status)
+
+```bash
+uip admin tenants services list --tenant-id <TENANT_ID> --output json
+```
+
+Surface to the user as **"Provisioned services on tenant `<TENANT_NAME>`"**. Per row: service type, **status** (`Enabled` / `Disabled` / `Deleted`), region. Flag any soft-deleted (`Deleted`) entries explicitly — they are removed but still recoverable.
+
+If the result is empty, say so explicitly. Do not show an empty table.
+
+Optional filters (client-side):
+
+```bash
+uip admin tenants services list --tenant-id <TENANT_ID> --service orchestrator --output json
+uip admin tenants services list --tenant-id <TENANT_ID> --region "<REGION>" --output json
+```
+
+If `--tenant-id` is omitted, the CLI uses the **login tenant**. Always resolve and state which tenant the listing covers so the user is not guessing.
+
+### Available to provision on a tenant (catalog only)
+
+```bash
+uip admin tenants services list-available --region "<REGION>" --output json
+```
+
+Surface to the user as **"Available service catalog for region `<REGION>`"**. Do NOT add a status column — catalog entries have no lifecycle state. The catalog is **region-aware**: a service can appear in one region's catalog and not another's.
+
+### When the user's intent is ambiguous
+
+If the user says "show services on this tenant" without specifying, run both `services list` and `services list-available --region <TENANT_REGION>` and present them in two clearly labeled sections.
+
+## Before Mutating a Tenant or Tenant Service — Name the Target
+
+Before any tenant lifecycle or tenant-service mutation, echo the resolved target back so the user knows exactly which resource will change:
+
+| Mutation | Echo this |
+|---|---|
+| `tenants create` | `Organization: <ORG_NAME>` + `New tenant name: <NAME>` + `Region: <REGION>` |
+| `tenants update / enable / disable / delete` | `Tenant: <TENANT_NAME> (<TENANT_UUID>)` + the action. If `<TENANT_ID>` was omitted and the CLI defaults to the login tenant, state: `Tenant: <LOGIN_TENANT_NAME> (login-tenant default)` and confirm with the user before any destructive verb. |
+| `services add / enable / disable / remove` | `Tenant: <TENANT_NAME>` + `Service: <SERVICE_TYPE>` + (for `add`) `Region: <TENANT_REGION>`. For multi-service `--file` payloads, list every service. |
+
+Resolve UUIDs to names — never leave a raw `tenantId` in the echo. `tenants get <TENANT_ID> --output json` gives you both name and region.
+
+## Workflow: Create a Tenant
+
+1. Confirm available regions:
+   ```bash
+   uip admin organizations regions list --output json
+   ```
+2. **Validate the tenant name client-side.** OMS rejects display names with `-`, `_`, spaces, or special chars — must start with a letter, be 2–32 chars, alphanumeric only. Reject hyphenated names before sending.
+3. **Propose default services to provision.** Query the regional catalog, then filter to the default-provision set — services with `provisioningMode === "Implicit"` AND `isVisible === true` AND `isAlwaysProvision === false`. Services with `isAlwaysProvision === true` are auto-provisioned by the platform (don't list as a choice); `isVisible === false` are platform-internal (don't surface); `provisioningMode === "Explicit"` are optional opt-ins (offer separately on request).
+   ```bash
+   uip admin tenants services list-available --region "<REGION>" --output json \
+     --output-filter "Data[?provisioningMode=='Implicit' && isVisible==\`true\` && isAlwaysProvision==\`false\`].{id:id,name:name}"
+   ```
+   Render this list to the user; let them remove any they don't want before submitting. Build the `services{}` map in the create body from the confirmed set.
+4. Create from a file (recommended once a services list is involved):
+   ```bash
+   uip admin tenants create --file ./tenant.json --output json
+   ```
+   Where `./tenant.json` is a `CreateTenantRequestDto`:
+   ```json
+   {
+     "name": "<TENANT_NAME>",
+     "region": "<REGION>",
+     "environment": "<ENV>",
+     "services": { "orchestrator": true, "du": true, "actions": true, "automationhub": true, "processes": true, "taskmining": true }
+   }
+   ```
+   For the bare no-services case use inline: `uip admin tenants create --name "<NAME>" --region "<REGION>" --environment "<ENV>"` (the platform still auto-provisions every `isAlwaysProvision === true` service).
+5. Response includes both the new `id` and an `operationId`. `(poll)`
+
+## Workflow: Update a Tenant
+
+Two shapes:
+
+- **Inline** for simple fields (`--name`, `--region`, `--environment`).
+- **File** for `services{}`, `customProperties`, `color` — pass `--file ./tenant-patch.json` (TenantUpdateDto).
+
+Response includes `operationId`. `(poll)`
+
+## Workflow: Enable or Disable a Tenant
+
+Tenant activation toggle. Both verbs are **async** — capture the `operationId`. `(poll)`
+
+### Enable
+
+```bash
+uip admin tenants enable <TENANT_ID> --output json
+```
+
+Activates a `Disabled` tenant. Idempotent — calling on an already-`Enabled` tenant is a safe no-op.
+
+### Disable
+
+Disabling a tenant blocks all access to its services until re-enabled. **Confirm with the user before running.**
+
+1. Resolve the tenant id explicitly. Do not rely on the login-tenant default for disable.
+2. Confirm with user. State explicitly: *"This will block all access to tenant `<NAME>` until re-enabled."*
+3. Disable, recording an audit reason:
+   ```bash
+   uip admin tenants disable <TENANT_ID> --reason "<FREE_TEXT_REASON>" --output json
+   ```
+4. Capture `operationId`. `(poll)`
+
+`--reason` is optional but recommended — it lands in the audit trail.
+
+## Workflow: Soft-Delete a Tenant
+
+1. Resolve the tenant id explicitly. Do not rely on the login-tenant default.
+2. Confirm with user.
+3. Run `tenants delete <TENANT_ID>`.
+4. Capture `operationId`. `(poll)` Reversible via the restore flow.
+
+## Workflow: Add Tenant Services
+
+Synchronous — no polling.
+
+### Single service (inline)
+
+```bash
+uip admin tenants services add \
+  --tenant-id <TENANT_ID> \
+  --service <SERVICE_TYPE> \
+  --output json
+```
+
+### Multiple services (`--file`)
+
+`add-services.json`:
+
+```json
+{ "services": { "orchestrator": true, "studio": true } }
+```
+
+All file entries must be `true` (use `services remove` for `false`).
+
+```bash
+uip admin tenants services add --tenant-id <TENANT_ID> --file ./add-services.json --output json
+```
+
+## After a Service Mutation — Verify Post-State
+
+`services add / enable / disable / remove` return 200 OK / `Success` regardless of whether server-side state actually changed. After every mutation, re-list and confirm:
+
+```bash
+uip admin tenants services list --tenant-id <TENANT_ID> --output json
+```
+
+Or, when you need a single service's status, filter the tenant record:
+
+```bash
+uip admin tenants get <TENANT_ID> --output-filter "tenantServiceInstances[?serviceType=='<SVC>']" --output json
+```
+
+Surface the resulting `status` to the user. For `disable`, confirm the row now reads `Disabled`; for `remove`, confirm it reads `Disabled` / `Deleted` rather than disappearing silently. See [tenants-commands.md — Concepts](tenants-commands.md#concepts) for the list of services where `disable` / `remove` is a no-op despite the Success code.
+
+## Workflow: Soft-Remove Tenant Services
+
+Synchronous. Server-side soft-delete (no hard-delete option).
+
+> **Pre-flight: prompt the user if the target service cannot actually be removed.** The CLI returns Success on every `services remove` call, but for a fixed set of services the server-side state never changes (`isAlwaysProvision === true` or otherwise platform-pinned). **Before sending the call, check the target list against this set and tell the user — do not silently submit a no-op.**
+>
+> **Cannot be removed (any call is a server-side no-op):**
+> - Orchestrator (`orchestrator`)
+> - Maestro (`maestro`)
+> - Integration Service (`connections`)
+> - Data Fabric (`dataservice`)
+> - Insights (`insights`)
+> - Test Manager (`testmanager`)
+>
+> If any of those appears in the user's request, render: *"Service `<X>` cannot be removed via the CLI — it's pinned by the platform. The call will return Success but the service will stay provisioned. To deprovision, revoke the org entitlement via the UiPath Portal. Continue anyway, or skip `<X>`?"* On "skip", drop it from the file/flag; on "continue anyway", run the call AND warn in the post-state summary that the verification will show the service still present.
+
+### Single service
+
+```bash
+uip admin tenants services remove \
+  --tenant-id <TENANT_ID> \
+  --service <SERVICE_TYPE> \
+  --output json
+```
+
+### Multiple services
+
+`remove-services.json`:
+
+```json
+{ "services": { "orchestrator": false, "studio": false } }
+```
+
+All file entries must be `false`.
+
+```bash
+uip admin tenants services remove --tenant-id <TENANT_ID> --file ./remove-services.json --output json
+```
+
+## Workflow: Disable Tenant Services
+
+Synchronous. **Pre-flight: prompt the user if the target service cannot actually be disabled.** Same pattern as `remove`: the CLI returns Success but the server-side `status` never flips.
+
+> **Cannot be disabled (any call is a server-side no-op):**
+> - Integration Service (`connections`)
+> - Data Fabric (`dataservice`)
+> - Insights (`insights`)
+>
+> If any of those appears in the user's request, render: *"Service `<X>` cannot be disabled via the CLI — it's pinned by the platform. The call will return Success but the service will stay `Enabled`. To deprovision, revoke the org entitlement via the UiPath Portal. Continue anyway, or skip `<X>`?"* On "skip", drop it; on "continue anyway", proceed and warn in the post-state summary.
+
+```bash
+uip admin tenants services disable \
+  --tenant-id <TENANT_ID> \
+  --service <SERVICE_TYPE> \
+  --output json
+```

--- a/skills/uipath-admin/references/tenants-commands.md
+++ b/skills/uipath-admin/references/tenants-commands.md
@@ -1,0 +1,335 @@
+# Tenants CLI Command Reference
+
+Complete reference for all `uip admin tenants` commands — tenant lifecycle and tenant-level service provisioning (Organization Management Service / OMS).
+
+For organization commands, see [organizations-commands.md](organizations-commands.md). For workflow-level guidance, see [tenant-management.md](tenant-management.md).
+
+## Global Flags
+
+Every command accepts these flags (omitted from per-command tables):
+
+| Flag | Description |
+|------|-------------|
+| `--output <format>` | Output format: `json`, `table`, `yaml`, `plain` (default: json) |
+| `--output-filter <expression>` | JMESPath expression to filter output |
+| `--log-level <level>` | Log level: `debug`, `info`, `warn`, `error` (default: info) |
+| `--log-file <path>` | Write logs to file instead of stderr |
+| `--login-validity <minutes>` | Override token validity — forces refresh if token expires within this window |
+
+Organization is resolved automatically from the active login session.
+
+## Prerequisites
+
+```bash
+uip login status --output json
+```
+
+If not logged in: `uip login`.
+
+## Concepts
+
+- **Async vs synchronous.** Tenant lifecycle (`create`, `update`, `delete`, `enable`, `disable`) is async — every mutation returns an `operationId`. `list` / `get` and all `services` subcommands are synchronous (200 OK with no body for service mutations).
+- **Single poll endpoint.** All async OMS operations are polled through `uip admin organizations operation get <OPERATION_ID>` — there is no `tenants operation get`.
+- **Soft-delete only.** `tenants delete` has no hard-delete flag. Reversible via the restore flow.
+- **Login-tenant default.** `tenants get`, `update`, `delete`, `enable`, `disable` accept the tenant id positionally — omit it to target the login tenant. Convenient for read ops; **always pass an explicit `<TENANT_ID>` for `delete`, `disable`, and `services remove`** to avoid targeting the wrong tenant.
+- **Region matters at create.** `tenants create` requires `--region`; run `organizations regions list` first to confirm acceptable values.
+- **Tenant service catalog is region-aware.** `tenants services list-available --region <REGION>` returns a per-region catalog.
+- **Service capability gaps — disable / remove are not universal.** Some services accept the call and return `Success` but the state never changes server-side:
+  - **Disable not honored** (no-op): Integration Service (`connections`), Data Fabric (`dataservice`), Insights (`insights`).
+  - **Remove not honored** (rejected or no-op): Orchestrator (`orchestrator`), Maestro (`maestro`), Integration Service (`connections`), Data Fabric (`dataservice`), Insights (`insights`), Test Manager (`testmanager`).
+
+  **Pre-flight: warn the user before submitting.** Don't silently issue a no-op. Render: *"Service `<X>` cannot be {disabled|removed} via the CLI — it's pinned by the platform. The call will return Success but the service will stay {Enabled|provisioned}. To deprovision, revoke the org entitlement via the UiPath Portal. Continue anyway, or skip `<X>`?"* Skip → drop from the call. Continue → run AND warn in the post-state summary.
+
+  Because the CLI returns 200 OK either way, the success code is never proof of state change. After any `services disable` / `services remove`, verify with `tenants get <TENANT_ID> --output-filter "tenantServiceInstances[?serviceType=='<SVC>']"` and inspect the `status` field on the returned instance.
+
+---
+
+## Tenant Lifecycle — `uip admin tenants`
+
+### `tenants list`
+
+List tenants in the caller's organization.
+
+```bash
+uip admin tenants list --output json
+uip admin tenants list --filter "<NAME_FRAGMENT>" --output json
+uip admin tenants list --status Enabled --service orchestrator --output json
+uip admin tenants list --include-services --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--filter <fragment>` | No | Case-insensitive substring match on tenant name (client-side) |
+| `--service <type>` | No | Only tenants with the given service provisioned |
+| `--status <status>` | No | Exact match on lifecycle status (`Enabled`, `Disabled`, `Updating`, `Deleted`) |
+| `--environment <env>` | No | Filter by environment tag (client-side) |
+| `--include-services` | No | Return each tenant's `services` array inline (saves a second call) |
+
+**Output code:** `OmsTenantsList`.
+
+### `tenants get`
+
+Fetch a tenant by id (or the login tenant if omitted).
+
+```bash
+uip admin tenants get <TENANT_ID> --output json
+uip admin tenants get --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<TENANT_ID>` | No | Tenant UUID — defaults to login tenant |
+
+**Output code:** `OmsTenantGet`.
+
+### `tenants create`
+
+Create a new tenant. **Async** — returns both the new `id` and an `operationId`.
+
+```bash
+uip admin tenants create \
+  --name "<TENANT_NAME>" \
+  --region "<REGION>" \
+  --environment "<ENV>" \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--name <name>` | Yes (inline) | Tenant display name |
+| `--region <region>` | Yes (inline) | Provisioning region — resolve via `organizations regions list` |
+| `--environment <env>` | No | Environment tag (e.g., `Production`, `Development`) |
+| `--file <path>` | Alternative | Full `CreateTenantRequestDto` body (required for `services[]`, `customProperties`, `color`, `isDefaultTenant`) |
+
+**Output code:** `OmsTenantCreated`.
+
+### `tenants update`
+
+Patch editable fields on a tenant. **Async** — returns `operationId`.
+
+```bash
+uip admin tenants update <TENANT_ID> \
+  --name "<NEW_NAME>" \
+  --region "<NEW_REGION>" \
+  --environment "<NEW_ENV>" \
+  --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<TENANT_ID>` | No | Tenant UUID — defaults to login tenant |
+| `--name <name>` | No | New display name |
+| `--region <region>` | No | New region |
+| `--environment <env>` | No | New environment tag |
+| `--file <path>` | Alternative | Full `TenantUpdateDto` body (required for `services{}`, `customProperties`, `color`) |
+
+At least one field flag (or `--file`) is required. **Output code:** `OmsTenantUpdated`.
+
+### `tenants delete`
+
+Soft-delete a tenant. **Async** — returns `operationId`. No hard-delete flag.
+
+```bash
+uip admin tenants delete <TENANT_ID> --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<TENANT_ID>` | No | Tenant UUID — defaults to login tenant. **Always pass explicitly for delete.** |
+
+Confirm with user. Restoration goes through the support / restore flow.
+
+**Output code:** `OmsTenantDeleted`.
+
+### `tenants enable`
+
+Activate a tenant. **Async** — returns `operationId`.
+
+```bash
+uip admin tenants enable <TENANT_ID> --output json
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<TENANT_ID>` | No | Tenant UUID — defaults to login tenant |
+
+**Output code:** `OmsTenantEnabled`.
+
+### `tenants disable`
+
+Disable a tenant. **Async** — returns `operationId`.
+
+```bash
+uip admin tenants disable <TENANT_ID> --reason "<FREE_TEXT_REASON>" --output json
+```
+
+| Argument/Flag | Required | Description |
+|---------------|----------|-------------|
+| `<TENANT_ID>` | No | Tenant UUID — defaults to login tenant. **Always pass explicitly for disable.** |
+| `--reason <text>` | No | Free-text reason — recorded with the action for audit |
+
+**Output code:** `OmsTenantDisabled`.
+
+---
+
+## Tenant-Level Services — `uip admin tenants services`
+
+All service subcommands are **synchronous** (200 OK with no body, no polling).
+
+> **`list` vs `list-available` are different sets — never merge them.** `services list` returns the **currently provisioned** tenant instances (each with a `status`: `Enabled` / `Disabled` / `Deleted`). `services list-available --region <R>` returns the **region-aware catalog** of provisionable service types (no status). Always present them as two clearly labeled sections. See [tenant-management.md — List Tenant Services](tenant-management.md#workflow-list-tenant-services--provisioned-vs-available).
+
+> **Always name the tenant before any service mutation.** `services add/enable/disable/remove` default `--tenant-id` to the **login tenant** — silently. Resolve `<TENANT_ID>` to a name (`tenants get <ID> --output json`) and echo it to the user before running the command, especially for `remove`.
+
+### `services list`
+
+List **currently provisioned** tenant-level service instances. Each row carries a lifecycle `status` — `Enabled`, `Disabled`, or `Deleted` (soft-deleted). Surface the status field in any presentation; flag `Deleted` entries explicitly.
+
+```bash
+uip admin tenants services list --output json
+uip admin tenants services list --tenant-id <TENANT_ID> --output json
+uip admin tenants services list --service orchestrator --output json
+uip admin tenants services list --region "<REGION>" --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--tenant-id <id>` | No | Tenant UUID — defaults to login tenant |
+| `--service <type>` | No | Filter by service type (client-side) |
+| `--region <region>` | No | Filter by region (client-side) |
+
+All filters are client-side. **Output code:** `OmsTenantServicesList`.
+
+### `services list-available`
+
+List the **catalog** of services that can be provisioned for a tenant in a given region. **Region-aware** — the catalog varies by region. Catalog only: entries are not provisioned and have no lifecycle status. Do not show a status column when surfacing results.
+
+```bash
+uip admin tenants services list-available --region "<REGION>" --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--region <region>` | Yes | Provisioning region — required |
+
+Each catalog entry carries provisioning metadata. The agent uses these fields to decide what to propose by default on `tenants create`:
+
+| Field | Meaning | Effect on tenant-create defaults |
+|---|---|---|
+| `provisioningMode` | `Implicit` (auto-provisioned when listed) or `Explicit` (must be deliberately added) | **Defaults set:** filter to `Implicit` only. `Explicit` services are optional opt-ins — offer only on user request. |
+| `isVisible` | `true` if the service is end-user-facing | **Defaults set:** filter to `true`. `false` services are platform-internal (don't surface in any user-facing list). |
+| `isAlwaysProvision` | `true` if the platform automatically provisions this service on every tenant | **Defaults set:** filter to `false`. `true` services are auto-provisioned by the platform — no need to include in the user's choice; they will be there regardless. |
+| `supportedRegions[]`, `defaultRegion`, `entitlement`, `serviceLicenseStatus` | informational | — |
+
+**Default-provision filter** (use for new-tenant proposals): `provisioningMode === "Implicit" && isVisible === true && isAlwaysProvision === false`. From the current US catalog this yields: Task Mining (`taskmining`), Document Understanding (`du`), Actions (`actions`), Processes (`processes`), Automation Hub (`automationhub`). Render those as the default services on `tenants create`; let the user remove unwanted entries and add Explicit services explicitly.
+
+**Output code:** `OmsTenantServicesAvailable`.
+
+### `services add`
+
+Provision one or more services on a tenant. **Synchronous.**
+
+```bash
+uip admin tenants services add \
+  --tenant-id <TENANT_ID> \
+  --service <SERVICE_TYPE> \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--tenant-id <id>` | No | Tenant UUID — defaults to login tenant. **Always pass explicitly for service mutations on non-login tenants.** |
+| `--service <type>` | Yes (inline) | Single service type |
+| `--file <path>` | Alternative | JSON body for multiple services |
+
+`--file ./add-services.json`:
+
+```json
+{ "services": { "orchestrator": true, "studio": true } }
+```
+
+All file entries must be `true` (use `services remove` for `false`).
+
+**Output code:** `OmsTenantServicesAdded`.
+
+### `services enable`
+
+Enable a single service instance on a tenant. **Synchronous.**
+
+```bash
+uip admin tenants services enable \
+  --tenant-id <TENANT_ID> \
+  --service <SERVICE_TYPE> \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--tenant-id <id>` | No | Tenant UUID — defaults to login tenant. **Always pass explicitly for non-login tenants.** |
+| `--service <type>` | Yes | Service type |
+
+**Output code:** `OmsTenantServiceEnabled`.
+
+### `services disable`
+
+Disable a single service instance on a tenant. **Synchronous.**
+
+```bash
+uip admin tenants services disable \
+  --tenant-id <TENANT_ID> \
+  --service <SERVICE_TYPE> \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--tenant-id <id>` | No | Tenant UUID — defaults to login tenant. **Always pass explicitly for non-login tenants.** |
+| `--service <type>` | Yes | Service type |
+
+**Output code:** `OmsTenantServiceDisabled`.
+
+> **Not supported on every service.** Integration Service (`connections`), Data Fabric (`dataservice`), and Insights (`insights`) accept the call and return `OmsTenantServiceDisabled` / `Success`, but the service-side `status` never flips to `Disabled`. Verify with `tenants get <TENANT_ID> --output-filter "tenantServiceInstances[?serviceType=='<SVC>']"` and warn the user upfront if they target one of these services.
+
+### `services remove`
+
+Soft-remove one or more services from a tenant. **Synchronous.** Server-side soft-delete (no hard-delete option).
+
+```bash
+uip admin tenants services remove \
+  --tenant-id <TENANT_ID> \
+  --service <SERVICE_TYPE> \
+  --output json
+```
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--tenant-id <id>` | No | Tenant UUID — defaults to login tenant. **Always pass explicitly for service-remove on non-login tenants.** |
+| `--service <type>` | Yes (inline) | Single service type |
+| `--file <path>` | Alternative | JSON body for multiple services |
+
+`--file ./remove-services.json`:
+
+```json
+{ "services": { "orchestrator": false, "studio": false } }
+```
+
+All file entries must be `false`.
+
+**Output code:** `OmsTenantServicesRemoved`.
+
+> **Not supported on every service.** Orchestrator (`orchestrator`), Maestro (`maestro`), Integration Service (`connections`), Data Fabric (`dataservice`), Insights (`insights`), and Test Manager (`testmanager`) cannot be soft-removed — the CLI may return `Success` but the service stays provisioned. Verify with `tenants get` and warn the user upfront if they target one of these services.
+
+---
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `tenant not found` | Invalid tenant UUID | Resolve via `tenants list --filter <NAME>` |
+| `region not allowed` | `--region` not in available regions | Run `organizations regions list` and use a returned value |
+| `service not available in region` | Service type not in regional catalog | Run `tenants services list-available --region <REGION>` first |
+| `service already provisioned` | Trying to `add` a service that exists | Use `enable` instead, or list current state with `services list` |
+| Operation stuck `Updating` | Async op pending or failed | Poll `organizations operation get <OPERATION_ID>` for status / error |
+| Destructive op targeted login tenant unintentionally | `<TENANT_ID>` omitted | Always pass an explicit tenant id for `delete`, `disable`, `services remove` |
+| `services disable` returned `Success` but `status` still `Enabled` | Service does not support disable (Integration Service, Data Fabric, Insights) | Expected — service-side limitation, not a CLI bug. Inform the user the service cannot be disabled |
+| `services remove` returned `Success` but instance still present | Service does not support remove (Orchestrator, Maestro, Integration Service, Data Fabric, Insights, Test Manager) | Expected — service-side limitation. Inform the user the service cannot be soft-removed |
+| Auth error | Login expired | `uip login status`, then `uip login` |

--- a/skills/uipath-admin/references/user-management.md
+++ b/skills/uipath-admin/references/user-management.md
@@ -2,6 +2,46 @@
 
 Workflows for managing users via `uip admin users`. For full command syntax and flags, see [identity-commands.md](identity-commands.md#users--uip-admin-users).
 
+## Workflow: Onboard a User (canonical flow)
+
+The most common identity flow: invite the user, find them once they accept, and assign them to a group.
+
+### Step 0 — Verify login
+
+```bash
+uip login status --output json
+```
+
+If not logged in: `uip login`. The CLI reads org ID from the active session automatically.
+
+### Step 1 — Invite a user
+
+```bash
+uip admin users invite \
+  --email "<USER_EMAIL>" \
+  --name "<FIRST_NAME>" \
+  --surname "<LAST_NAME>" \
+  --output json
+```
+
+### Step 2 — Find the user once they accept
+
+```bash
+uip admin users list \
+  --search "<USER_EMAIL>" --output json
+```
+
+### Step 3 — Assign to a group
+
+```bash
+uip admin groups list --output json
+uip admin groups members add <GROUP_ID> \
+  --user-ids "<USER_ID>" \
+  --output json
+```
+
+Apply the principal-resolution protocol before the `members add` call — echo `Principal: <displayName> (<userName>) — <id>` from the `users list` result (SKILL.md Rule 5).
+
 ## Workflow: Discover Existing Users
 
 ```bash

--- a/tests/tasks/uipath-admin/apms_get_enforcement_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_enforcement_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-apms-get-enforcement-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to check
+  the current IP-restriction enforcement state. Tests correct CLI
+  namespace (`uip admin ip-restriction enforcement get`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, get, apms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Is IP-restriction enforcement currently enabled on my UiPath organization?
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran ip-restriction enforcement get with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+enforcement\s+get\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-apms-get-my-ip-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to look up
+  the caller's public IP as the platform sees it. Tests correct CLI
+  namespace (`uip admin ip-restriction my-ip`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, get, apms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  What public IP does the UiPath platform see for me right now?
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran ip-restriction my-ip with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+my-ip\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_list_bypass_rules_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_list_bypass_rules_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-apms-list-bypass-rules-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  IP-restriction bypass rules. Tests correct CLI namespace
+  (`uip admin ip-restriction bypass-rules list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, apms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Show me all IP-restriction bypass rules configured for my UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran ip-restriction bypass-rules list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+bypass-rules\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_list_ip_ranges_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_list_ip_ranges_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-apms-list-ip-ranges-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  IP allowlist entries. Tests correct CLI namespace
+  (`uip admin ip-restriction ip-ranges list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, apms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  List all the IP range allowlist entries configured for my UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran ip-restriction ip-ranges list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+ip-ranges\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
@@ -1,0 +1,103 @@
+task_id: skill-admin-authz-assignment-lifecycle-org-e2e
+description: >
+  End-to-end test: full lifecycle of an Organization-scope role
+  assignment using an existing built-in role. Resolves the current
+  user, finds an Org-scope built-in role, creates the assignment,
+  verifies via `assignments list`, deletes the assignment, verifies
+  removal.
+
+  Validates: `--identity-id` / `--identity-type User` (NOT
+  `--principal-*`), Org-scope path auto-fill, cleanup at end of test.
+  Uses an existing built-in role — no new role created.
+
+  Command-construction only — no live tenant available.
+tags: [uipath-admin, e2e, authz, assignment-lifecycle, scope:organization]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Grant me organization-wide access by giving my account an existing
+  organization-level built-in role. After it's assigned, confirm it
+  shows up on my account. Then please clean up by removing the
+  assignment and confirming it's gone.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent resolved the current user (login status or users list/search)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(?:login\s+status|admin\s+users\s+list)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed built-in Org-scope roles (`--role-type BuiltIn --scope Organization`)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--scope\s+Organization\b'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the assignment with --role-id, --identity-id, --identity-type User, and --scope Organization"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+create\s+.*--role-id\s+[a-f0-9-]{8,}.*--identity-id\s+[a-f0-9-]{8,}.*--identity-type\s+User\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the assignment appeared via `assignments list --identity-id`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list\s+.*--identity-id\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent cleaned up via `roles assignments delete <id>`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+delete\s+(?:[a-f0-9-]{8,}|--file\s+\S+)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified removal via a second `assignments list`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT use legacy --principal-id flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+(?:create|delete)\s+.*--principal-id'
+    weight: 2.0
+
+  - type: command_not_executed
+    description: "Agent must NOT use lowercase 'user' for --identity-type"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+create\s+.*--identity-type\s+user\b'
+    weight: 1.5

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_e2e.yaml
@@ -1,0 +1,94 @@
+task_id: skill-admin-authz-assignment-lifecycle-tenant-e2e
+description: >
+  End-to-end test: full lifecycle of a Tenant-scope role assignment
+  using an existing built-in role bound to the current login tenant.
+
+  Validates: tenant resolution before assignment, `--scope Tenant`
+  (default) auto-fill of `/tenant/<TENANT_ID>`, identity flags,
+  cleanup.
+
+  Command-construction only — no live tenant available.
+tags: [uipath-admin, e2e, authz, assignment-lifecycle, scope:tenant]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Give my account a built-in tenant-level role on the tenant I'm
+  logged into. Pick an appropriate existing one. After it's assigned,
+  confirm it shows up on my account. Then clean up by removing the
+  assignment.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent resolved the current user"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(?:login\s+status|admin\s+users\s+list)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed built-in Tenant-scope roles"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--scope\s+Tenant\b'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the assignment with --role-id/--identity-id/--identity-type User"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+create\s+.*--role-id\s+[a-f0-9-]{8,}.*--identity-id\s+[a-f0-9-]{8,}.*--identity-type\s+User\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the assignment via `assignments list --identity-id`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list\s+.*--identity-id\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent cleaned up via `roles assignments delete <id>`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+delete\s+(?:[a-f0-9-]{8,}|--file\s+\S+)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified removal via a second `assignments list`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT use legacy --principal-id flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+(?:create|delete)\s+.*--principal-id'
+    weight: 2.0

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
@@ -1,0 +1,103 @@
+task_id: skill-admin-authz-assignment-lifecycle-tenant-global-e2e
+description: >
+  End-to-end test: full lifecycle of a role assignment for a built-in
+  TenantGlobal-scope role. TenantGlobal roles are reusable templates
+  available across every tenant — the assignment auto-fills the
+  scope path to `/tenant/<TENANT_ID>` (login tenant).
+
+  Validates: `--scope TenantGlobal` is valid on `assignments create`
+  (unlike on `assignments list`); identity flags
+  (`--identity-id`/`--identity-type User`); cleanup.
+
+  Command-construction only — no live tenant available.
+tags: [uipath-admin, e2e, authz, assignment-lifecycle, scope:tenant-global]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  My account needs a built-in global template role that's available
+  across every tenant in the organization. Pick an appropriate
+  existing one and assign it to me. After it's assigned, confirm it
+  appears on my account. Then clean up by removing the assignment
+  and confirming it's gone.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent resolved the current user"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(?:login\s+status|admin\s+users\s+list)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed built-in TenantGlobal-scope roles (flag order-insensitive)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--scope\s+TenantGlobal\b'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the assignment with --identity-id/--identity-type User; --scope TenantGlobal or default auto-fill"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+create\s+.*--role-id\s+[a-f0-9-]{8,}.*--identity-id\s+[a-f0-9-]{8,}.*--identity-type\s+User\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the assignment via `assignments list --identity-id`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list\s+.*--identity-id\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent cleaned up via `roles assignments delete` (positional id or --file batch form)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+delete\s+(?:[a-f0-9-]{8,}|--file\s+\S+)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified removal via a second `assignments list`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT pass --scope TenantGlobal to `assignments list` (server rejects it; only valid on create)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list\s+.*--scope\s+TenantGlobal\b'
+    weight: 1.5
+
+  - type: command_not_executed
+    description: "Agent must NOT use legacy --principal-id flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+(?:create|delete)\s+.*--principal-id'
+    weight: 2.0

--- a/tests/tasks/uipath-admin/authz_check_access_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_check_access_smoke.yaml
@@ -1,0 +1,57 @@
+task_id: skill-admin-authz-check-access-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to look
+  up effective access for a principal. Tests the `check-access` CLI
+  shape — positional `<identity>` argument (NOT a `--identity-id` or
+  `--principal-id` flag, which are both legacy/non-existent).
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, authz, check-access]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  What can the user with id b44fc962-d544-4c99-b520-71121070ec17 do
+  right now?
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip admin authorization check-access` with the user id positional"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+check-access\s+\S*b44fc962-d544-4c99-b520-71121070ec17'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent passed --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+check-access\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT use the legacy --identity-id flag (replaced by positional identity)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+check-access\s+.*--identity-id'
+    weight: 2.0
+
+  - type: command_not_executed
+    description: "Agent must NOT use the legacy --principal-id flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+check-access\s+.*--principal-id'
+    weight: 2.0

--- a/tests/tasks/uipath-admin/authz_get_role_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_get_role_smoke.yaml
@@ -1,0 +1,51 @@
+task_id: skill-admin-authz-get-role-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to fetch
+  a single authorization role's details by id. Tests the
+  `roles get <id>` command — positional id argument and
+  `--output json` convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, authz, role]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I have a role with id 1782e940-8926-4d2d-aca7-465ba9eff474.
+  Show me what's in it.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip admin authorization roles get` with the id as positional argument"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\s+1782e940-8926-4d2d-aca7-465ba9eff474'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent passed --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT pass the id as a flag (`--id`, `--role-id`) — it is positional"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\s+.*--(?:id|role-id)\b'
+    weight: 2.0

--- a/tests/tasks/uipath-admin/authz_list_permissions_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_list_permissions_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-authz-list-permissions-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  the permission catalog. Tests correct CLI namespace
+  (`uip admin authorization permissions list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, authz]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  List the catalog of available permission definitions for my UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran authorization permissions list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+permissions\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_list_role_assignments_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_list_role_assignments_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-authz-list-role-assignments-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  role assignments. Tests correct CLI namespace
+  (`uip admin authorization roles assignments list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, authz]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Show me all role assignments in my UiPath organization (who has what role).
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran authorization roles assignments list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_list_roles_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_list_roles_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-authz-list-roles-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  authorization roles. Tests correct CLI namespace
+  (`uip admin authorization roles list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, authz]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  List all authorization roles in my UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran authorization roles list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_org_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_org_e2e.yaml
@@ -1,0 +1,113 @@
+task_id: skill-admin-authz-role-lifecycle-org-e2e
+description: >
+  End-to-end test: full lifecycle of an Organization-scope custom
+  role — discover org-shape permissions, check for name collision,
+  create the role with `--scope Organization`, verify via `roles get`,
+  then delete and verify removal.
+
+  Validates: `--scope Organization`, actions.json uses permission
+  `name` strings (not UUIDs), positional id on get/delete, cleanup at
+  end of test.
+
+  Command-construction only — no live tenant available.
+tags: [uipath-admin, e2e, authz, role-lifecycle, scope:organization]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I need a read-only role that applies to my whole organization — not
+  to any single tenant — for auditors who should only be able to view
+  identity-related records (users, groups). Call it "OrgAuditor".
+
+  Once you've made it, show me the role's contents so I can confirm
+  it looks right. Then please clean up by removing the role and
+  confirming it's gone.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed Organization-scope permissions to discover the catalog"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+permissions\s+list\s+.*(?:--scope\s+Organization\b|--service\s+identity\b)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent checked name collision via `roles list --filter`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--filter\s+\S*OrgAuditor'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent wrote an actions.json file (action-name array)"
+    tool_name: "Write"
+    command_pattern: 'actions\.json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the role with --scope Organization and --name OrgAuditor"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+create\s+.*--scope\s+Organization\b.*--name\s+\S*OrgAuditor.*--file\s+\S+'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the new role via `roles get <id>` (positional id)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent cleaned up by calling `roles delete <id>`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+delete\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the role was removed (second `roles get` or `roles list --filter`)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+(?:get\s+[a-f0-9-]{8,}|list\s+.*--filter\s+\S*OrgAuditor)'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT pass --tenant-id on an Organization-scope role"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+create\s+.*--scope\s+Organization\b.*--tenant-id'
+    weight: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT use --scope Folder (invalid for role creation)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+create\s+.*--scope\s+Folder\b'
+    weight: 1.0

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
@@ -1,0 +1,113 @@
+task_id: skill-admin-authz-role-lifecycle-tenant-e2e
+description: >
+  End-to-end test: full lifecycle of a Tenant-scope custom role bound
+  to one specific tenant — discovers Tenant-shape permissions,
+  resolves the login tenant's UUID, creates with `--scope Tenant`
+  AND `--tenant-id <UUID>`, verifies, deletes.
+
+  Validates: `--scope Tenant`, presence of `--tenant-id` (binding to
+  one tenant), tenant resolution before create, cleanup.
+
+  Command-construction only — no live tenant available.
+tags: [uipath-admin, e2e, authz, role-lifecycle, scope:tenant]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Create a read-only Studio role called "TenantStudioReader" that
+  only applies to the tenant I'm currently logged into — not the
+  whole organization, not other tenants.
+
+  After it's created, show me the role's contents so I can verify it.
+  Then please remove it and confirm it's gone.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent resolved the current login tenant's UUID before binding the role"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(?:login\s+status|admin\s+tenants\s+(?:list|get))'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed Tenant-shape Studio permissions"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+permissions\s+list\s+.*--service\s+studio'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent checked name collision via `roles list --filter`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--filter\s+\S*TenantStudioReader'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent wrote an actions.json file"
+    tool_name: "Write"
+    command_pattern: 'actions\.json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the role with --scope Tenant, --tenant-id <UUID>, and --name TenantStudioReader"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+create\s+.*--scope\s+Tenant\b.*--tenant-id\s+[a-f0-9-]{8,}.*--name\s+\S*TenantStudioReader.*--file\s+\S+'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the new role via `roles get <id>`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent cleaned up by calling `roles delete <id>`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+delete\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the role was removed"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+(?:get\s+[a-f0-9-]{8,}|list\s+.*--filter\s+\S*TenantStudioReader)'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT use --scope TenantGlobal when binding to one specific tenant"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+create\s+.*--scope\s+TenantGlobal\b'
+    weight: 1.5

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_global_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_global_e2e.yaml
@@ -1,0 +1,107 @@
+task_id: skill-admin-authz-role-lifecycle-tenant-global-e2e
+description: >
+  End-to-end test: full lifecycle of a TenantGlobal-shape custom
+  role — a reusable template assignable in every tenant of the org.
+  Discovers Tenant-shape permissions, creates with
+  `--scope TenantGlobal` (no `--tenant-id`), verifies, deletes.
+
+  Validates: `--scope TenantGlobal` (the new shape, not in the legacy
+  full-body schema), absence of `--tenant-id` (TenantGlobal is not
+  bound to one tenant), cleanup at end of test.
+
+  Command-construction only — no live tenant available.
+tags: [uipath-admin, e2e, authz, role-lifecycle, scope:tenant-global]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Set up a reusable read-only role template called "StudioViewer"
+  that should be available across every tenant in our organization —
+  not bound to any single tenant. It should cover viewing Studio
+  projects.
+
+  After it's created, show me the role's details. Then please clean
+  up by removing it and confirming it's gone.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed Tenant-shape permissions for studio"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+permissions\s+list\s+.*(?:--service\s+studio\b|--scope\s+Tenant\b)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent checked name collision via `roles list --filter`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--filter\s+\S*StudioViewer'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent wrote an actions.json file"
+    tool_name: "Write"
+    command_pattern: 'actions\.json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the role with --scope TenantGlobal and --name StudioViewer"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+create\s+.*--scope\s+TenantGlobal\b.*--name\s+\S*StudioViewer.*--file\s+\S+'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the new role via `roles get <id>`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent cleaned up by calling `roles delete <id>`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+delete\s+[a-f0-9-]{8,}'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the role was removed (second `roles get` or `roles list --filter`)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+(?:get\s+[a-f0-9-]{8,}|list\s+.*--filter\s+\S*StudioViewer)'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT pass --tenant-id (TenantGlobal is not bound to one tenant)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+create\s+.*--scope\s+TenantGlobal\b.*--tenant-id'
+    weight: 1.5

--- a/tests/tasks/uipath-admin/oms_get_organization_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_get_organization_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-oms-get-organization-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to fetch
+  the caller's organization record. Tests correct CLI namespace
+  (`uip admin organizations get`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, get, oms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Show me details about my current UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran organizations get with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+organizations\s+get\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_org_services_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_org_services_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-oms-list-org-services-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  provisioned org-level services. Tests correct CLI namespace
+  (`uip admin organizations services list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, oms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  List the organization-level services currently provisioned in my UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran organizations services list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+organizations\s+services\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_regions_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_regions_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-oms-list-regions-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  available regions. Tests correct CLI namespace
+  (`uip admin organizations regions list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, oms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  List the regions where my UiPath organization can provision services.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran organizations regions list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+organizations\s+regions\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_tenant_services_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_tenant_services_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-oms-list-tenant-services-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  provisioned tenant-level services. Tests correct CLI namespace
+  (`uip admin tenants services list`) and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, oms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  List the services currently provisioned on the default tenant in my UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran tenants services list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+tenants\s+services\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_tenants_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_tenants_smoke.yaml
@@ -1,0 +1,36 @@
+task_id: skill-admin-oms-list-tenants-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to list
+  tenants. Tests correct CLI namespace (`uip admin tenants list`)
+  and --output json convention.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, list, oms]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  List all tenants in my UiPath organization.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+
+  - type: command_executed
+    description: "Agent ran tenants list with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+tenants\s+list\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Extends the `uipath-admin` skill from Identity-only coverage to three additional `uip admin` subcommand groups, with every reference written against the **CLI 1.1.0** shape (verified via `--help` and live calls):

- **Authorization service (authz)** — `uip admin authorization`: custom roles + assignments (PAP), permissions catalog, `check-access` (PDP)
- **Organization Management Service (OMS)** — `uip admin organizations` and `uip admin tenants`: org read/update, tenant lifecycle, async-operation polling, region catalog, service provisioning
- **Access Policy Management Service (APMS)** — `uip admin ip-restriction`: IP allowlisting, enforcement switch + `my-ip` safety pre-flight, URL-pattern bypass rules

## Layout

```
skills/uipath-admin/
├── SKILL.md                                            (MODIFIED — simplified to ~210 lines; 24 Critical Rules grouped by area; rich When-to-Use signals preserved)
└── references/
    ├── organizations-commands.md                       (NEW — `uip admin organizations` CLI reference)
    ├── tenants-commands.md                             (NEW — `uip admin tenants` CLI reference)
    ├── organization-management.md                      (NEW — workflow guide)
    ├── tenant-management.md                            (NEW — workflow guide)
    ├── authorization/                                  (NEW subfolder)
    │   ├── authorization-commands.md                   (full CLI reference + Provenance contract for completion output)
    │   ├── role-management.md                          (Create / Update / Delete workflows; actions.json = permission `name` strings)
    │   ├── grant-permissions.md                        (NEW — \"grant me X\" / \"give alice Y, Z\" shortcut: scope/service intersection across Tenant / TenantGlobal / Organization / Service / Project with Tenant recommended)
    │   ├── role-assignment-management.md               (inline + batch; Project/Folder/App scope shapes; role.ownerServiceName ↔ scope-path validation)
    │   ├── permission-catalog.md                       (permission `name` strings, not UUIDs)
    │   └── check-access.md                             (PDP; scope is `Tenant | Folder` only)
    └── ip-restriction/                                 (NEW subfolder)
        ├── ip-restriction-commands.md
        ├── ip-range-management.md
        ├── enforcement-management.md                   (folds in `my-ip` safety helper)
        └── bypass-rule-management.md

tests/tasks/uipath-admin/                               (20 new tasks: 14 smoke + 6 e2e lifecycle)
```

## CLI 1.1.0 sync

- **No `organizations create` / `organizations delete` in the CLI** — both return `ValidationError: unknown command`. Docs route the user to the UiPath Portal / support flow for org provisioning or removal. Org surface is now read + update only.
- **`--service centralizedaccess` is rejected** by `roles create / list`, `roles assignments list`, and `permissions list`. For the multi-service \"Centralized Access\" role, omit `--service` and use `--scope Organization | TenantGlobal | Tenant` alone.
- **`check-access --scope` accepts only `Tenant | Folder`** — not Organization or Project. For org-wide entitlement loops use `Tenant` against each tenant; for project-level use a Folder scope under the owning tenant.
- **`enforcement get`** subcommand documented (new in CLI; returns `{organizationId, status}`).
- **Async OMS lifecycle** (`tenants create/update/delete/enable/disable`) returns `operationId`; **`organizations get/update`** is synchronous; org-level services are read-only.

## Authz validation rules (load-bearing)

- **Role's `ownerServiceName` must match the assignment scope-path service segment.** Critical Rule 17. `roles list` / `roles get` return `ownerServiceId` + `ownerServiceName` (e.g., `Reinfer`, `DocumentUnderstanding`, `CentralizedAccess`). Before `roles assignments create`: fetch the role, then verify:
  - `ownerServiceName == CentralizedAccess` → scope-path must NOT include a service segment (use `/` or `/tenant/<tid>`)
  - any other value → scope-path MUST include `lowercase(ownerServiceName)` (e.g., `/tenant/<tid>/reinfer/project/<pid>`)
  - mismatch → stop and surface; never silently substitute a different service
- **Resolve every named principal before high-risk ops.** Critical Rule 5. Search via `users|groups|robot-accounts|external-apps list --search "<NAME>"` first, echo `Principal: <displayName> (<userName>) — <id>`, then run the mutation. Zero matches → stop and ask; never fall back to the current login user. Multiple matches → numbered list, wait for a digit.
- **PUT-style upserts** on `roles create/update` — re-fetch via `roles get` before update; omitted inline flags overwrite that field on the body.
- **`--service` infers scope** from the service registry (e.g., `--service studio` → `Tenant`, `--service apps` → `Organization`).
- **Scope vocab differs per verb**: `roles create` and `assignments create` and `assignments list` and `check-access` each accept a different set — Rule 15 has the full matrix.
- **Listing works for every service; authoring is what's blocked.** Service-managed (`orchestrator`, `dataservice`, `insights`, `taskmining`, `testmanager`, `automationops`, `casemanagement`, `processmining`) and platform-level (`authz`, `oms`, `platform`, `identity`, `licensing`) reject only `roles create/update/delete`.

## OMS bounded polling

- Tenant async ops: auto-poll `organizations operation get <OP_ID>` **3 times at 5 s intervals (~15 s)**, then **hand off to a numbered menu**. Option 1 (keep polling) is capped at 2 rounds (~30 s total); beyond that the user must drive every additional poll via option 2 or stop via option 3. No indefinite loops.
- Single poll endpoint for every OMS async op.
- **Provisioned vs Available services are distinct surfaces** — `services list` returns provisioned instances with status (`Enabled` / `Disabled` / `Deleted`); `services list-available` returns the catalog of provisionable types (no status). Docs require presenting them as two clearly labeled sections.
- **`services disable` / `remove` may no-op despite Success** on certain services (Integration Service, Data Fabric, Insights for disable; Orchestrator, Maestro, Integration Service, Data Fabric, Insights, Test Manager for remove). Always re-list after mutating.
- **Before-mutating echo** — every OMS mutation echoes the resolved org name + tenant name + UUID + service type + region before running. Resolve every UUID to a name.

## APMS lockout safety

- `ip-ranges delete` and `enforcement enable` both require `--confirm`. Before `enforcement enable`: run `ip-restriction my-ip`, then verify the caller's IP is covered by an entry in `ip-ranges list`. The CLI also runs server-side pre-flights.
- Recovery from lockout requires platform-side action — access from an in-allowlist IP and run `enforcement disable`, or use the UiPath Portal recovery flow.

## SKILL.md simplification

- **24 Critical Rules** grouped by area (Universal / Identity / Authz / OMS / APMS); each rule is 1-3 lines with a link to the per-area reference for detail.
- **13 What-NOT-to-Do items**, deduplicated against Critical Rules.
- **One unified Quick Start table** (9 rows) replacing the previous three sectioned Quick Starts.
- **Rich `When to Use This Skill` section preserved** — per-area bulleted activation signals across Identity / Authz / OMS / APMS / Audit (deliberately not compressed; preserves skill-routing strength).
- **Output Etiquette table** — 6 rows, one per area, listing what to surface after each operation.
- **Task Navigation table** — 21 rows, single index to every reference file.
- Provenance contract for authz completion output lives in `authorization-commands.md#provenance-contract-for-completion-output`; full polling procedure in `organization-management.md#polling-procedure-auto-poll-then-hand-off`; role-service validation procedure in `role-assignment-management.md#validate-roles-owning-service-vs-assignment-scope-path`.

## Tests (20 new tasks)

- **14 smoke tasks** — one per read-only command across all three areas (APMS: 4; authz: 5; OMS: 5).
- **6 e2e lifecycle tasks** — full create-then-verify-then-delete cycles for roles (Organization / Tenant / TenantGlobal) and assignments (Organization / Tenant / TenantGlobal).
- All follow the existing `identity_list_*_smoke.yaml` schema; smokes grade `command_pattern` regex and tolerate auth failures; no `@uipath/cli` re-install in `env_packages` (per `.claude/rules/task-authoring.md`).

## Test plan

- [ ] Live CLI spot-checks pass for read-only commands (authz: `roles list`, `roles get`, `roles assignments list`, `permissions list`, `check-access`; OMS: `organizations get`, `regions list`, `services list`, `services list-available`, `tenants list`, `tenants get`, `tenants services list`; APMS: `my-ip`, `ip-ranges list`, `enforcement get`, `bypass-rules list`)
- [ ] Live verification: `--service centralizedaccess` is rejected with the documented error message on `roles list / create`, `roles assignments list`, `permissions list`
- [ ] Live verification: `organizations create` and `organizations delete` return `ValidationError: unknown command`
- [ ] Live verification: `enforcement get` returns `{organizationId, status}` with output code `ApmsEnforcementGet`
- [ ] Output codes verified against live `--help --output json` for every leaf command (`AuthzAssignmentCreated` singular; `ApmsBypassRulesGet` plural; `OmsOrganizationGet`; `ApmsEnforcementGet`)
- [ ] `bash hooks/validate-skill-descriptions.sh` — exit 0, SKILL.md description 610/1024 chars
- [ ] All reference links in `SKILL.md` resolve to existing files / anchors
- [ ] 24 Critical Rules sequence 1..24, no gaps; all in-file cross-references (\"per Rule N\") point to the right concept
- [ ] 20 task YAMLs follow the existing schema; no `@uipath/cli` in `env_packages`
- [ ] No CODEOWNERS update needed — existing `/skills/uipath-admin/` and `/tests/tasks/uipath-admin/` folder-level entries cover the new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)