### PR TITLE
feat(coded-apps-skill) : Update coded-apps skill

### DIFF
--- a/skills/uipath-coded-apps/SKILL.md
+++ b/skills/uipath-coded-apps/SKILL.md
@@ -39,7 +39,12 @@ Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps usi
 7. **Never pass access tokens as CLI flags.** JWTs are too long — use the `UIPATH_ACCESS_TOKEN` environment variable instead.
 8. **Base URL must use the API subdomain.** `https://api.uipath.com` not `https://cloud.uipath.com`. See the table below.
 9. **`vite.config.ts` must always set `base: './'`.** The platform handles URL routing — apps must use relative asset paths. Do not use a routing name or a sub-path here.
-10. **Use `getAppBase()` for client-side router basename.** Import from `@uipath/uipath-typescript`. It reads `uipath:app-base` at runtime and falls back to `'/'` locally. Never hardcode a path as the router basename.
+10. **Use `getAppBase()` from `@uipath/uipath-typescript` for any absolute URL constructed at runtime** — router basename, image `src`, `fetch` paths. Deployed apps mount at a non-root prefix; `/`-rooted paths work locally but 404 after deploy. Vite's `base: './'` only fixes import-time references.
+11. **`uip codedapp deploy` must run non-interactively.** Pass the folder key as `--folder-key <GUID>` (or as `UIPATH_FOLDER_KEY=<GUID>` env-var prefix — either works). The interactive folder picker fails in non-TTY contexts (CI, agent shells). If the user provides a folder **name**, resolve it to a key with `uip or folders list --output json` and match on the `Name` field (output rows are `{ Key, Name, Path, Description, Type, ParentKey }`). The `uip or ...` commands require the Orchestrator tool — install once via `uip tools install @uipath/orchestrator-tool` (check first with `uip tools list`).
+12. **Guard against text overflow in every UI.** See [patterns.md](references/patterns.md) "Preventing Text Overflow".
+13. **Inspect the DF schema before writing analytics, filters, or seeds.** Call `entities.getById(<id>)` from inside the app's authenticated session — NOT a CLI script with `~/.uipath/.auth` (different scopes, will 401). DF doesn't behave like a typical RDBMS; see [sdk/data-fabric.md](references/sdk/data-fabric.md) "Anti-shapes & gotchas".
+14. **Every list call returns ONE page — even with no options. There is no "give me everything" path.** Applies to `getAll`, `getAllRecords`, `queryRecordsById`, `getFileMetaData`, etc. `getAll()` with no options does NOT return all rows; the SDK sends no `pageSize` and the **server** applies its own cap, wrapped in a misleadingly-named `NonPaginatedResponse`. To list every row from a source that may exceed the cap, you MUST loop the cursor: `while (page.hasNextPage) { page = await getAll({ cursor: page.nextCursor }) }` and accumulate `items`. Reading `result.items.length` after a single call is almost always a bug. See [sdk/pagination.md](references/sdk/pagination.md).
+15. **Tables of dynamic data must paginate, not dump all rows in one scroll.** Page size 25–50 with next/prev/page-number controls and a "Showing X–Y of Z" summary. Top-N + "see all" is acceptable for explicitly summary panels (e.g., "Top 10 oldest"). Infinite-scroll-of-N-rows is unusable for operational dashboards. Applies to any table backed by any service (DF entities, Tasks, Jobs, Conversations, Process Instances, etc.). See [patterns.md](references/patterns.md) "Tabular Data".
 
 ## Task Navigation
 
@@ -58,8 +63,9 @@ Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps usi
 | **SDK: Maestro (Processes, Cases)** | [references/sdk/maestro.md](references/sdk/maestro.md) |
 | **SDK: Action Center (Tasks)** | [references/sdk/action-center.md](references/sdk/action-center.md) |
 | **SDK: Conversational Agent** | [references/sdk/conversational-agent.md](references/sdk/conversational-agent.md) |
+| **SDK: Agent Feedback** | [references/sdk/feedback.md](references/sdk/feedback.md) |
 | **SDK: Pagination** | [references/sdk/pagination.md](references/sdk/pagination.md) |
-| **UI Patterns (polling, BPMN, HITL)** | [references/patterns.md](references/patterns.md) |
+| **UI Patterns (polling, BPMN, HITL, text overflow, table pagination)** | [references/patterns.md](references/patterns.md) |
 
 ## CLI Setup
 
@@ -69,6 +75,12 @@ npm install -g @uipath/cli
 
 # Install the coded apps tool
 uip tools install @uipath/codedapp-tool
+
+# Install the Orchestrator tool (needed to resolve folder name → key for deploy)
+uip tools install @uipath/orchestrator-tool
+
+# Verify both are installed
+uip tools list
 
 # Resolve uip if not on PATH
 UIP=$(command -v uip 2>/dev/null || npm root -g 2>/dev/null | sed 's|/node_modules$||')/bin/uip
@@ -108,9 +120,9 @@ uip login --authority https://alpha.uipath.com   # non-production environments
 
 1. **Auth** — `uip login status --output json`. If not logged in, ask the user for their environment and run `uip login`.
 2. **Build** — `npm run build`. Verify `ls dist/`.
-3. **Pack** — `uip codedapp pack dist -n <name> -v <version>`. Produces `.uipath/<name>.<version>.nupkg`. Bump version if previously published.
+3. **Pack** — `uip codedapp pack dist -n <name> --version <version>`. Produces `.uipath/<name>.<version>.nupkg`. Bump version if previously published.
 4. **Publish** — `uip codedapp publish` (add `-t Action` for action apps). Verify `cat .uipath/app.config.json`.
-5. **Deploy** — `uip codedapp deploy`. Share the app URL with the user.
+5. **Deploy** — `uip codedapp deploy -n <name> --folder-key <GUID>`. Resolve the GUID from a user-provided folder name via `uip or folders list --output json`. Never let the command go interactive. Share the app URL with the user.
 
 ## SDK Module Imports
 
@@ -135,12 +147,12 @@ See [references/debug.md](references/debug.md) for detailed diagnosis steps.
 | `Not authenticated` | No valid session | Run `uip login` |
 | `dist/ not found` | App not built | Run `npm run build` |
 | `Version already exists` | Same version re-published | Bump version in `pack` |
-| `Folder key required` | Missing folder for CLI deploy | Set `UIPATH_FOLDER_KEY` or pass `--folderKey`. See note below. |
+| `Folder key required` / deploy hangs on prompt | Missing folder for CLI deploy | Resolve folder name → key via `uip or folders list --output json` (match on `Name`, read `Key`), then run `uip codedapp deploy --folder-key <GUID> ...`. See [pack-publish-deploy.md](references/pack-publish-deploy.md#folder-key). |
 | `No packages found` | No `.nupkg` in `.uipath/` | Run `pack` first |
 | Login fails / redirect error | OAuth misconfiguration | See [debug.md](references/debug.md) |
 | API calls fail with 401/CORS | Wrong base URL | Use `https://api.uipath.com` not `cloud.uipath.com` |
 
-> **Folder identifier names differ across CLI and SDK.** The CLI uses `UIPATH_FOLDER_KEY` / `--folderKey` (string) and applies only to `uip codedapp deploy`. SDK methods use different parameters: Maestro services (`MaestroProcesses`, `ProcessInstances`, `Cases`) take `folderKey` (string GUID), Orchestrator services (`Assets`, `Queues`, `Buckets`, `Processes`) take `folderId` (number). Do not pass the CLI env var into SDK calls. To bridge from a Maestro `folderKey` to an Orchestrator `folderId`, see [sdk/maestro.md](references/sdk/maestro.md) — and **never** `parseInt(folderKey)`, the GUID is not numeric.
+> **Folder identifier names differ across CLI and SDK.** The CLI uses `UIPATH_FOLDER_KEY` / `--folder-key` (string) and applies only to `uip codedapp deploy`. SDK methods use different parameters: Maestro services (`MaestroProcesses`, `ProcessInstances`, `Cases`) take `folderKey` (string GUID), Orchestrator services (`Assets`, `Queues`, `Buckets`, `Processes`) take `folderId` (number). Do not pass the CLI env var into SDK calls. To bridge from a Maestro `folderKey` to an Orchestrator `folderId`, see [sdk/maestro.md](references/sdk/maestro.md) — and **never** `parseInt(folderKey)`, the GUID is not numeric.
 
 ## Completion Output
 

--- a/skills/uipath-coded-apps/references/commands-reference.md
+++ b/skills/uipath-coded-apps/references/commands-reference.md
@@ -21,12 +21,12 @@ uip codedapp push [project-id] [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `[project-id]` | WebApp Project ID | From `UIPATH_PROJECT_ID` env var |
-| `--buildDir <dir>` | Build output directory | `dist` |
-| `--ignoreResources` | Skip importing referenced resources | `false` |
-| `--baseUrl <url>` | UiPath base URL | From `.env` |
-| `--orgId <id>` | Organization ID | From `.env` |
-| `--tenantId <id>` | Tenant ID | From `.env` |
-| `--accessToken <token>` | Access token | From `.env` |
+| `--build-dir <dir>` | Build output directory | `dist` |
+| `--ignore-resources` | Skip importing referenced resources | `false` |
+| `--base-url <url>` | UiPath base URL | From `.env` |
+| `--org-id <id>` | Organization ID | From `.env` |
+| `--tenant-id <id>` | Tenant ID | From `.env` |
+| `--access-token <token>` | Access token | From `.env` |
 
 **Examples:**
 
@@ -38,10 +38,10 @@ uip codedapp push
 uip codedapp push my-project-id
 
 # Push a custom build directory
-uip codedapp push my-project-id --buildDir build
+uip codedapp push my-project-id --build-dir build
 
 # Push without importing resources
-uip codedapp push --ignoreResources
+uip codedapp push --ignore-resources
 ```
 
 **Auto-create project flow:**
@@ -70,11 +70,11 @@ uip codedapp pull [project-id] [options]
 |--------|-------------|---------|
 | `[project-id]` | WebApp Project ID | From `UIPATH_PROJECT_ID` env var |
 | `--overwrite` | Allow overwriting existing local files without prompting | `false` |
-| `--targetDir <dir>` | Local directory to write pulled files | Current directory |
-| `--baseUrl <url>` | UiPath base URL | From `.env` |
-| `--orgId <id>` | Organization ID | From `.env` |
-| `--tenantId <id>` | Tenant ID | From `.env` |
-| `--accessToken <token>` | Access token | From `.env` |
+| `--target-dir <dir>` | Local directory to write pulled files | Current directory |
+| `--base-url <url>` | UiPath base URL | From `.env` |
+| `--org-id <id>` | Organization ID | From `.env` |
+| `--tenant-id <id>` | Tenant ID | From `.env` |
+| `--access-token <token>` | Access token | From `.env` |
 
 **Examples:**
 
@@ -86,7 +86,7 @@ uip codedapp pull
 uip codedapp pull my-project-id
 
 # Pull to a specific directory
-uip codedapp pull my-project-id --targetDir ./my-app
+uip codedapp pull my-project-id --target-dir ./my-app
 
 # Pull and overwrite without prompting
 uip codedapp pull --overwrite
@@ -116,10 +116,10 @@ uip codedapp pack <dist> [options]
 | `--content-type <type>` | Content type: `webapp`, `library`, `process` | `webapp` |
 | `--dry-run` | Preview packaging without creating the file | `false` |
 | `--reuse-client` | Reuse existing clientId from uipath.json | `false` |
-| `--baseUrl <url>` | UiPath base URL | From `.env` |
-| `--orgId <id>` | Organization ID | From `.env` |
-| `--tenantId <id>` | Tenant ID | From `.env` |
-| `--accessToken <token>` | Access token | From `.env` |
+| `--base-url <url>` | UiPath base URL | From `.env` |
+| `--org-id <id>` | Organization ID | From `.env` |
+| `--tenant-id <id>` | Tenant ID | From `.env` |
+| `--access-token <token>` | Access token | From `.env` |
 
 **Examples:**
 
@@ -128,7 +128,7 @@ uip codedapp pack <dist> [options]
 uip codedapp pack dist
 
 # Pack with explicit name and version
-uip codedapp pack dist -n my-webapp -v 2.0.0
+uip codedapp pack dist -n my-webapp --version 2.0.0
 
 # Pack to a custom output directory
 uip codedapp pack dist -o ./packages
@@ -137,7 +137,7 @@ uip codedapp pack dist -o ./packages
 uip codedapp pack dist --dry-run
 
 # Pack with all options
-uip codedapp pack dist -n my-webapp -v 1.0.0 -a "My Team" --description "Production app" --main-file app.html
+uip codedapp pack dist -n my-webapp --version 1.0.0 -a "My Team" --description "Production app" --main-file app.html
 ```
 
 **Output:**
@@ -170,12 +170,12 @@ uip codedapp publish [options]
 | `-n, --name <name>` | Package name (non-interactive selection) | Auto-select or prompted |
 | `-v, --version <version>` | Package version (requires `--name`) | Latest |
 | `-t, --type <type>` | App type: `Web` or `Action` | `Web` |
-| `--uipathDir <dir>` | Directory containing `.nupkg` files | `./.uipath` |
-| `--baseUrl <url>` | UiPath base URL | From `.env` |
-| `--orgId <id>` | Organization ID | From `.env` |
-| `--tenantId <id>` | Tenant ID | From `.env` |
-| `--tenantName <name>` | Tenant name (required for registration) | From `.env` |
-| `--accessToken <token>` | Access token | From `.env` |
+| `--uipath-dir <dir>` | Directory containing `.nupkg` files | `./.uipath` |
+| `--base-url <url>` | UiPath base URL | From `.env` |
+| `--org-id <id>` | Organization ID | From `.env` |
+| `--tenant-id <id>` | Tenant ID | From `.env` |
+| `--tenant-name <name>` | Tenant name (required for registration) | From `.env` |
+| `--access-token <token>` | Access token | From `.env` |
 
 **Examples:**
 
@@ -187,13 +187,13 @@ uip codedapp publish
 uip codedapp publish -n my-webapp
 
 # Publish a specific version
-uip codedapp publish -n my-webapp -v 2.0.0
+uip codedapp publish -n my-webapp --version 2.0.0
 
 # Publish as an Action app type
 uip codedapp publish -t Action
 
 # Publish from a custom directory
-uip codedapp publish --uipathDir ./packages
+uip codedapp publish --uipath-dir ./packages
 ```
 
 **Output:**
@@ -231,12 +231,13 @@ uip codedapp deploy [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-n, --name <name>` | App name | From `.uipath/app.config.json` or prompted |
-| `--baseUrl <url>` | UiPath base URL | From `.env` |
-| `--orgId <id>` | Organization ID | From `.env` |
-| `--orgName <name>` | Organization name (used for app URL) | From `.env` |
-| `--tenantId <id>` | Tenant ID | From `.env` |
-| `--folderKey <key>` | UiPath folder key | From `UIPATH_FOLDER_KEY` env var |
-| `--accessToken <token>` | Access token | From `.env` |
+| `-v, --version <version>` | Target a specific **published** version (different semantic from `pack`/`publish` `-v`, which is the package version) | Latest |
+| `--base-url <url>` | UiPath base URL | From `.env` |
+| `--org-id <id>` | Organization ID | From `.env` |
+| `--org-name <name>` | Organization name (used for app URL) | From `.env` |
+| `--tenant-id <id>` | Tenant ID | From `.env` |
+| `--folder-key <key>` | UiPath folder key | From `UIPATH_FOLDER_KEY` env var |
+| `--access-token <token>` | Access token | From `.env` |
 
 **Examples:**
 
@@ -248,7 +249,7 @@ uip codedapp deploy
 uip codedapp deploy -n my-webapp
 
 # Deploy with folder key
-uip codedapp deploy -n my-webapp --folderKey my-folder-key
+uip codedapp deploy -n my-webapp --folder-key my-folder-key
 ```
 
 **Fresh deploy output:**
@@ -277,7 +278,7 @@ All cloud commands accept these override options (values default to `.env` file)
 
 | Option | Description |
 |--------|-------------|
-| `--baseUrl <url>` | UiPath base URL |
-| `--orgId <id>` | Organization ID |
-| `--tenantId <id>` | Tenant ID |
-| `--accessToken <token>` | Access token |
+| `--base-url <url>` | UiPath base URL |
+| `--org-id <id>` | Organization ID |
+| `--tenant-id <id>` | Tenant ID |
+| `--access-token <token>` | Access token |

--- a/skills/uipath-coded-apps/references/file-sync.md
+++ b/skills/uipath-coded-apps/references/file-sync.md
@@ -59,10 +59,10 @@ uip codedapp push
 uip codedapp push abc-123-def
 
 # Push a custom build directory (default: dist)
-uip codedapp push --buildDir build
+uip codedapp push --build-dir build
 
 # Skip importing referenced resources
-uip codedapp push --ignoreResources
+uip codedapp push --ignore-resources
 ```
 
 ### What Gets Pushed
@@ -72,7 +72,7 @@ The command uploads the contents of the build directory (default: `dist/`) to St
 - Static assets (images, fonts, etc.)
 - Any other files in the build output
 
-The `--ignoreResources` flag skips importing referenced resources (connections, assets) that may be declared in the app.
+The `--ignore-resources` flag skips importing referenced resources (connections, assets) that may be declared in the app.
 
 ## Pull Workflow
 
@@ -89,7 +89,7 @@ uip codedapp pull abc-123-def
 ### Pull to a Specific Directory
 
 ```bash
-uip codedapp pull --targetDir ./my-app
+uip codedapp pull --target-dir ./my-app
 ```
 
 ### Handling File Conflicts
@@ -128,7 +128,7 @@ uip codedapp push
 uip login
 
 # 2. Pull the project (get project ID from Studio Web URL)
-uip codedapp pull <project-id> --targetDir ./my-app
+uip codedapp pull <project-id> --target-dir ./my-app
 
 # 3. Install dependencies
 cd my-app

--- a/skills/uipath-coded-apps/references/oauth-scopes.md
+++ b/skills/uipath-coded-apps/references/oauth-scopes.md
@@ -16,6 +16,7 @@ Use this reference to:
 |--------|----------------|
 | `getAll()` | `OR.Assets` or `OR.Assets.Read` |
 | `getById()` | `OR.Assets` or `OR.Assets.Read` |
+| `getByName()` | `OR.Assets` or `OR.Assets.Read` |
 
 ---
 
@@ -26,6 +27,9 @@ Use this reference to:
 | `getAll()` | `OR.Jobs` or `OR.Jobs.Read` |
 | `getById()` | `OR.Jobs` or `OR.Jobs.Read` |
 | `getOutput()` | `OR.Jobs` or `OR.Jobs.Read` **plus** `OR.Folders` or `OR.Folders.Read` (required because `getOutput` internally calls the Attachments API to resolve file-type output arguments) |
+| `stop()` | `OR.Jobs` |
+| `resume()` | `OR.Jobs` or `OR.Jobs.Write` |
+| `restart()` | `OR.Jobs` |
 
 ---
 
@@ -60,8 +64,10 @@ Use this reference to:
 | `insertRecordById()` / `insertRecord()` | `DataFabric.Data.Write` |
 | `insertRecordsById()` / `insertRecords()` | `DataFabric.Data.Write` |
 | `deleteRecordsById()` / `deleteRecords()` | `DataFabric.Data.Write` |
+| `deleteRecordById()` / `deleteRecord()` | `DataFabric.Data.Write` |
 | `updateRecordById()` / `updateRecord()` | `DataFabric.Data.Write` |
 | `updateRecordsById()` / `updateRecords()` | `DataFabric.Data.Write` |
+| `queryRecordsById()` / `queryRecords()` | `DataFabric.Data.Read` |
 | `downloadAttachment()` | `DataFabric.Data.Read` |
 | `uploadAttachment()` | `DataFabric.Data.Write` |
 | `deleteAttachment()` | `DataFabric.Data.Write` |
@@ -83,6 +89,7 @@ Use this reference to:
 |--------|----------------|
 | `getAll()` | `OR.Execution` or `OR.Execution.Read` |
 | `getById()` | `OR.Execution` or `OR.Execution.Read` |
+| `getByName()` | `OR.Execution` or `OR.Execution.Read` |
 | `start()` | `OR.Jobs` or `OR.Jobs.Write` |
 
 ---
@@ -174,7 +181,7 @@ Combined scopes required: `OR.Execution` · `OR.Folders` · `OR.Jobs` · `Conver
 | `getAll()` / `getById()` | `OR.Execution.Read`, `OR.Jobs.Read` |
 | `updateById()` / `deleteById()` | `OR.Execution`, `OR.Jobs` |
 | `startSession()` | `OR.Execution`, `OR.Jobs`, `ConversationalAgents` |
-| `uploadAttachment()` | `OR.Execution`, `OR.Jobs` |
+| `uploadAttachment()` / `getAttachmentUploadUri()` | `OR.Execution`, `OR.Jobs` |
 
 ### Exchanges
 
@@ -188,6 +195,15 @@ Combined scopes required: `OR.Execution` · `OR.Folders` · `OR.Jobs` · `Conver
 | Method | Required Scope |
 |--------|----------------|
 | `getById()` / `getContentPartById()` | `OR.Execution.Read`, `OR.Jobs.Read` |
+
+---
+
+## Agent Feedback
+
+| Method | Required Scope |
+|--------|----------------|
+| `getAll()` | `Traces.Api` |
+| `getById()` | `Traces.Api` |
 
 ---
 

--- a/skills/uipath-coded-apps/references/pack-publish-deploy.md
+++ b/skills/uipath-coded-apps/references/pack-publish-deploy.md
@@ -29,7 +29,7 @@ Package the app build output into a `.nupkg` file with UiPath metadata.
 uip codedapp pack dist
 
 # Pack with all options specified
-uip codedapp pack dist -n my-webapp -v 1.0.0 -a "My Team" --description "Production app"
+uip codedapp pack dist -n my-webapp --version 1.0.0 -a "My Team" --description "Production app"
 ```
 
 ### Options
@@ -104,7 +104,7 @@ Upload the `.nupkg` to UiPath Orchestrator and register the coded app with the A
 uip codedapp publish
 
 # Select specific package
-uip codedapp publish -n my-webapp -v 1.0.0
+uip codedapp publish -n my-webapp --version 1.0.0
 ```
 
 ### Options
@@ -114,7 +114,7 @@ uip codedapp publish -n my-webapp -v 1.0.0
 | `-n, --name <name>` | Package name (skip interactive selection) | Auto or prompted |
 | `-v, --version <version>` | Package version (requires `--name`) | Latest |
 | `-t, --type <type>` | App type: `Web` or `Action` | `Web` |
-| `--uipathDir <dir>` | Directory containing `.nupkg` files | `./.uipath` |
+| `--uipath-dir <dir>` | Directory containing `.nupkg` files | `./.uipath` |
 
 ### App Types
 
@@ -158,7 +158,7 @@ If multiple `.nupkg` files exist in `.uipath/`, the command will prompt for sele
 uip codedapp publish -n my-webapp
 
 # Select specific version
-uip codedapp publish -n my-webapp -v 2.0.0
+uip codedapp publish -n my-webapp --version 2.0.0
 ```
 
 ---
@@ -182,8 +182,9 @@ uip codedapp deploy -n my-webapp
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-n, --name <name>` | App name | From `app.config.json` or prompted |
-| `--folderKey <key>` | UiPath folder key | From `UIPATH_FOLDER_KEY` env var |
-| `--orgName <name>` | Organization name (for app URL) | From `.env` |
+| `-v, --version <version>` | Target a **specific published version** to deploy (different semantic from `pack`/`publish`'s `-v`, which is the package version) | Latest |
+| `--folder-key <key>` | UiPath folder **key** (GUID, not the name). **Always pass explicitly** — see below. | From `UIPATH_FOLDER_KEY` env var, else interactive (avoid) |
+| `--org-name <name>` | Organization name (for app URL) | From `.env` |
 
 ### Fresh Deploy vs. Upgrade
 
@@ -199,18 +200,52 @@ The command resolves the app name from:
 
 ### Folder Key
 
-The `deploy` command requires a folder key, resolved from:
-1. `--folderKey` flag
-2. `UIPATH_FOLDER_KEY` environment variable
-3. Interactive folder selection (if neither is set)
+The `deploy` command requires a folder **key** (GUID), not a folder name. Users typically know the folder name only — resolve the key via `uip or folders list` before calling `deploy`.
 
-Set it during auth or manually:
+Resolution order:
+1. `--folder-key <key>` flag — explicit, idiomatic
+2. `UIPATH_FOLDER_KEY=<key>` env-var prefix — equivalent to the flag, useful in CI/CD where the value is already in env
+3. Interactive folder selection (**must avoid** — see warning below)
+
+> **Pass the folder key explicitly via the flag or env var.** Running `uip codedapp deploy` with neither drops the command into an interactive folder picker that fails in non-TTY contexts (CI, agent shells, IDE terminals piped to a runner). When invoked from an agent, you MUST resolve the key up-front and pass it.
+
+#### Resolving folder name → folder key
+
+When the user provides a folder **name** (e.g., `"Shared"`), resolve it to a key with `uip or folders list --output json` and match on the `Name` field (or `Path` for nested paths).
+
+> **Prerequisite:** `uip or ...` commands require the Orchestrator tool. Run `uip tools list` first; if `orchestrator-tool` is missing, install it once: `uip tools install @uipath/orchestrator-tool`.
+
 ```bash
-# Set in .env
-echo "UIPATH_FOLDER_KEY=my-folder-key" >> .env
+# 0. Ensure the Orchestrator tool is installed (idempotent — skip if already present)
+uip tools list --output json | grep -q '"orchestrator-tool"' || uip tools install @uipath/orchestrator-tool
 
-# Or pass directly
-uip codedapp deploy --folderKey my-folder-key
+# 1. List folders the current user has access to (includes Personal, Solution, Standard)
+uip or folders list --output json > /tmp/folders.json
+
+# 2. Resolve "Shared" → key (GUID)
+FOLDER_KEY=$(python3 -c "
+import json
+with open('/tmp/folders.json') as f:
+    d = json.load(f)
+match = next((x for x in d['Data'] if x['Name'] == 'Shared'), None)
+print(match['Key'] if match else '')
+")
+
+# 3. Deploy with the resolved key
+uip codedapp deploy -n my-webapp --folder-key "$FOLDER_KEY"
+```
+
+If the name is ambiguous (multiple matches) or not found, surface an error to the user — do NOT fall through to interactive selection.
+
+`uip or folders list` returns folders the **current user** has access to (personal workspaces, solution folders, and standard folders). Add `--all` if you need every folder in the tenant — but for `deploy` resolution, the default view is what you want.
+
+Each folder JSON object includes: `Key` (GUID — pass this to `--folder-key`), `Name`, `Path`, `Description`, `Type` (`Personal` / `Solution` / `Standard`), `ParentKey`.
+
+#### Storing the resolved key
+
+```bash
+# Persist for re-use across deploys
+echo "UIPATH_FOLDER_KEY=$FOLDER_KEY" >> .env
 ```
 
 ### Output
@@ -259,7 +294,7 @@ uip codedapp deploy
 npm run build
 
 # 2. Pack with bumped version
-uip codedapp pack dist -n my-webapp -v 2.0.0
+uip codedapp pack dist -n my-webapp --version 2.0.0
 
 # 3. Publish new version
 uip codedapp publish
@@ -271,12 +306,25 @@ uip codedapp deploy
 ### CI/CD Pipeline
 
 ```bash
-# Non-interactive flow with explicit options
-uip login --clientId $CLIENT_ID --clientSecret $CLIENT_SECRET
+# Non-interactive flow with explicit options — every flag passed, no prompts
+uip login --client-id $CLIENT_ID --client-secret $CLIENT_SECRET
 npm run build
-uip codedapp pack dist -n my-webapp -v $VERSION
-uip codedapp publish -n my-webapp -v $VERSION
-uip codedapp deploy -n my-webapp --folderKey $FOLDER_KEY
+uip codedapp pack dist -n my-webapp --version $VERSION
+uip codedapp publish -n my-webapp --version $VERSION
+uip codedapp deploy -n my-webapp --folder-key $FOLDER_KEY
+```
+
+### Agent flow (user provides folder name only)
+
+```bash
+# 1. Resolve folder name → key
+FOLDER_KEY=$(uip or folders list --output json \
+  | python3 -c "import json,sys;d=json.load(sys.stdin);m=next((x for x in d['Data'] if x['Name']=='$USER_FOLDER_NAME'),None);print(m['Key'] if m else '')")
+
+[ -z "$FOLDER_KEY" ] && { echo "Folder '$USER_FOLDER_NAME' not found"; exit 1; }
+
+# 2. Deploy non-interactively with the resolved key
+uip codedapp deploy -n my-webapp --folder-key "$FOLDER_KEY"
 ```
 
 ---
@@ -288,7 +336,7 @@ uip codedapp deploy -n my-webapp --folderKey $FOLDER_KEY
 | `No packages found` | Missing `.nupkg` | Run `uip codedapp pack` first |
 | `Version already exists` | Same version published | Bump version: `-v 2.0.0` |
 | `App not found` on deploy | App not published | Run `uip codedapp publish` first |
-| `Folder key required` | Missing `UIPATH_FOLDER_KEY` | Set in `.env` or pass `--folderKey` |
-| `Missing tenant name` on publish | `UIPATH_TENANT_NAME` not set | Set in `.env` or pass `--tenantName` |
+| `Folder key required` / deploy hangs on prompt | Missing folder key | Resolve via `uip or folders list --output json`, then run `uip codedapp deploy --folder-key <key> ...` (or `UIPATH_FOLDER_KEY=<key>` env-var prefix). |
+| `Missing tenant name` on publish | `UIPATH_TENANT_NAME` not set | Set in `.env` or pass `--tenant-name` |
 | `dist/ not found` | App not built | Run `npm run build` |
 | Pack shows wrong clientId | Stale `uipath.json` | Use `--reuse-client` or delete `uipath.json` |

--- a/skills/uipath-coded-apps/references/patterns.md
+++ b/skills/uipath-coded-apps/references/patterns.md
@@ -1001,3 +1001,23 @@ export const TaskEmbed = ({ taskLink, onClose }: TaskEmbedProps) => (
 - **HITL detection**: Use `getVariables()` + `getBpmn()` to detect if the current element is a user task (see "HITL Detection" section above). Do NOT rely on `latestRunStatus`.
 - **Use `apiToCloudUrl()`** — never manually convert API URLs to cloud URLs with string replacement.
 - **Use a modal overlay**: Render the iframe in a modal (like the example above) so the user can close it and return to the app.
+
+## Tabular Data: Don't Dump Every Row in One Scroll
+
+Operational dashboards routinely list 100–10,000+ rows (tickets, jobs, instances, queue items). Rendering all of them as one long scroll makes the table unusable: the user can't see totals, can't navigate to a specific row, and large DOMs slow down sort/filter interactions. Pick one of these patterns:
+
+- **Paginated rows** (default for >50 rows) — page size 25–50 with next/prev/page-number controls and a "Showing X–Y of Z" summary. Works for any tabular data.
+- **Virtualized scroll** (for very large lists, 5k+) — `react-window` or `@tanstack/react-virtual`. Use only if you genuinely have that many rows; otherwise pagination is simpler and faster to ship.
+- **Top-N + "see all"** — when the table is informational rather than navigational (e.g., "Top 10 oldest open"), render only the top N and link to a full view.
+
+For a single screen with mixed panels (KPIs + charts + a table), prefer pagination. The scroll-everything pattern is fine for a CSV export, never for a dashboard.
+
+## Preventing Text Overflow
+
+Long emails, subjects, and choice value names break layouts. Apply these rules whenever rendering dynamic strings:
+
+- **Flex/grid children with text:** add `min-w-0` to the parent AND `truncate` (or `line-clamp-N`) to the text. `truncate` alone does nothing without `min-w-0` because flex children default to intrinsic width.
+- **Pair every truncation with `title={fullValue}`** so the user can hover to read the full string.
+- **Chart axis labels (SVG):** CSS truncation does NOT apply. Shorten via the library's `tickFormatter` and keep the full value in the tooltip. For long choice values, prefer `displayName` over `name`, or switch to a horizontal bar chart.
+- **Tables:** use `table-fixed` + explicit column widths + `max-w-0` on `<td>`, then `truncate` the inner content.
+- **Fixed-height cards:** add `overflow-hidden` on the card and `line-clamp-N` on the text.

--- a/skills/uipath-coded-apps/references/sdk/conversational-agent.md
+++ b/skills/uipath-coded-apps/references/sdk/conversational-agent.md
@@ -14,6 +14,7 @@ Combined scopes needed: `OR.Execution` `OR.Folders` `OR.Jobs` `ConversationalAge
 - Conversations (create): `OR.Execution`, `OR.Folders`, `OR.Jobs`
 - Conversations (read): `OR.Execution` or `OR.Execution.Read`, `OR.Jobs` or `OR.Jobs.Read`
 - Conversations (update/delete): `OR.Execution`, `OR.Jobs`
+- Conversations (uploadAttachment / getAttachmentUploadUri): `OR.Execution`, `OR.Jobs`
 - startSession: `OR.Execution`, `OR.Jobs`, `ConversationalAgents`
 - Exchanges (read): `OR.Execution` or `OR.Execution.Read`, `OR.Jobs` or `OR.Jobs.Read`
 - Feedback: `OR.Execution`, `OR.Jobs`, `Traces.Api`
@@ -43,6 +44,7 @@ import type {
   ConversationUpdateOptions,
   ConversationSessionOptions,
   ConversationAttachmentUploadResponse,
+  ConversationAttachmentCreateResponse,
 } from '@uipath/uipath-typescript/conversational-agent';
 
 // Exchange types
@@ -164,6 +166,23 @@ Returns `Promise<ConversationDeleteResponse>`.
 ### uploadAttachment(id: string, file: File)
 
 Returns `Promise<ConversationAttachmentUploadResponse>` with `{ uri, name, mimeType }`. Handles the two-step upload (create attachment entry, then upload to blob storage).
+
+### getAttachmentUploadUri(conversationId: string, fileName: string)
+
+Returns `Promise<ConversationAttachmentCreateResponse>` with `{ uri, name, fileUploadAccess }`. Lower-level alternative to `uploadAttachment` — registers the attachment and returns a pre-signed upload URL but does NOT upload bytes. Use this when you need to stream large files yourself or upload from a non-`File` source. Service-level only (no conversation-attached shorthand).
+
+```typescript
+const { uri, fileUploadAccess } = await conversationalAgent.conversations
+  .getAttachmentUploadUri(conversationId, file.name);
+
+await fetch(fileUploadAccess.url, {
+  method: fileUploadAccess.verb,
+  body: file,
+  headers: { 'Content-Type': file.type },
+});
+
+// Reference `uri` in subsequent messages
+```
 
 ### startSession(conversationId: string, options?: ConversationSessionOptions)
 

--- a/skills/uipath-coded-apps/references/sdk/data-fabric.md
+++ b/skills/uipath-coded-apps/references/sdk/data-fabric.md
@@ -6,6 +6,19 @@
 import { Entities, ChoiceSets } from '@uipath/uipath-typescript/entities';
 ```
 
+## Anti-shapes & gotchas (read first)
+
+Data Fabric does NOT behave like a typical RDBMS. These differences trip up agents that pattern-match on familiar SQL/ORM shapes. Before writing analytics, filters, or update logic, call `entities.getById(id)` and inspect `fields[].name` + `fieldDataType`. Pick your data strategy from what's actually there — do NOT assume.
+
+1. **Choice values come back as `numberId` integers on every read path.** Including ungrouped `getRecordById` and `queryRecordsById` items, not just `groupBy` results. Code like `record.Priority.toLowerCase()` will throw or produce `"5"`. Build `numberId → name` maps via `choiceSets.getById(<csId>)` and translate every read.
+2. **DF auto-creates audit fields that look like domain fields but aren't.** Every entity has `CreateTime`, `UpdateTime`, `CreatedBy`, `UpdatedBy`, `Id`, `RecordOwner` — these are **row metadata** (when DF inserted/wrote the row), not the business event the row represents. When you need a domain-level "created at" / "updated at" / "owner", look for a custom field with a domain-specific name; if none exists, flag it back to the user rather than silently using the audit column. When writing your own historical timestamp field, name it something distinct from `CreateTime` / `UpdateTime` to avoid the conflict at write time.
+3. **Unknown keys on insert are silently dropped.** A typo in a field name in `insertRecordsById` does NOT raise an error — the value is just discarded. Always introspect the schema and validate keys before bulk operations.
+4. **No `IsNull` filter operator.** `queryRecordsById` filters can't ask "where field is null". Filter client-side after fetching, or design queries with explicit non-null sentinels.
+5. **Field name casing is preserved verbatim on writes.** If the entity field is `Subject` (PascalCase), record payloads must use `Subject`, not `subject`. The SDK does NOT pascalize keys for you — DF rejects mismatched casing as missing required field.
+6. **Filter `value` for choice fields must be the `numberId` as a string.** `{ fieldName: 'Status', operator: Equals, value: 'Resolved' }` matches nothing — use `value: String(numberIdForResolved)`.
+7. **Aggregates require server-side `aggregates` + `groupBy`.** Don't fetch raw rows and `.length` / `.reduce` client-side — every list call returns one page (see [pagination.md](pagination.md)) and you'll silently truncate. Use `{ aggregates: [{ function: EntityAggregateFunction.Count, field: 'Id' }] }` (string literal `'COUNT'` works equivalently).
+8. **`field.fieldDataType` is an OBJECT, not a string.** It's `{ name: 'DECIMAL', lengthLimit?: ..., maxValue?: ..., ... }`. Code like `String(field.fieldDataType).toUpperCase()` produces `"[object Object]"` and silently rejects every field. Always read `field.fieldDataType?.name`. Same applies to `field.fieldDisplayType` — but that one IS a plain string enum (`'ChoiceSetSingle'`, `'File'`, etc.).
+9. **File-type fields (`fieldDisplayType === 'File'`) aren't strings.** The record carries only metadata (`{ id, name, size, contentType }`); stringifying gives `"[object Object]"`. To display, call `entities.downloadAttachment(entityId, recordId, fieldName)` → `Blob` → `URL.createObjectURL` for an `<img src>`. **Neither `contentType` nor filename extension is reliable for detecting kind** — DF often returns `application/octet-stream`, and the stored `name` is frequently a bare UUID with no extension. To decide whether to render inline or fall back to a download link, either (a) sniff the blob's magic bytes after download (PNG starts `89 50 4E 47`, JPEG `FF D8 FF`, GIF `47 49 46 38`, PDF `25 50 44 46`, etc.), or (b) optimistically attempt `<img src={objectUrl}>` and swap to a download link in `onError`. Writes: `uploadAttachment(entityId, recordId, fieldName, file)`, not `insertRecordById` / `updateRecordById`.
 ## Scopes
 
 - Schema reads: `DataFabric.Schema.Read`
@@ -37,6 +50,12 @@ import type {
   EntityUploadAttachmentResponse,
   EntityDeleteAttachmentResponse,
   EntityOperationResponse,
+  EntityQueryRecordsOptions,
+  EntityQueryRecordsResponse,
+  EntityQueryFilter,
+  EntityQueryFilterGroup,
+  EntityQuerySortOption,
+  EntityAggregate,
   FailureRecord,
   ChoiceSetGetAllResponse,
   ChoiceSetGetResponse,
@@ -48,9 +67,12 @@ import type {
 
 ```typescript
 import {
-  EntityFieldDataType,   // UUID, STRING, INTEGER, DATETIME, DATETIME_WITH_TZ, DECIMAL, FLOAT, DOUBLE, DATE, BOOLEAN, BIG_INTEGER, MULTILINE_TEXT
-  EntityType,            // Entity, ChoiceSet, InternalEntity, SystemEntity
-  FieldDisplayType,      // Basic, Relationship, File, ChoiceSetSingle, ChoiceSetMultiple, AutoNumber
+  EntityFieldDataType,     // UUID, STRING, INTEGER, DATETIME, DATETIME_WITH_TZ, DECIMAL, FLOAT, DOUBLE, DATE, BOOLEAN, BIG_INTEGER, MULTILINE_TEXT
+  EntityType,              // Entity, ChoiceSet, InternalEntity, SystemEntity
+  FieldDisplayType,        // Basic, Relationship, File, ChoiceSetSingle, ChoiceSetMultiple, AutoNumber
+  LogicalOperator,         // And, Or
+  QueryFilterOperator,     // Equals, NotEquals, GreaterThan, LessThan, ... (used in queryRecordsById filters)
+  EntityAggregateFunction, // Count, Sum, Avg, Min, Max — string-valued enum ('COUNT', 'SUM', ...)
 } from '@uipath/uipath-typescript/entities';
 ```
 
@@ -80,6 +102,14 @@ Returns `Promise<EntityInsertResponse>` (which is `EntityRecord` — the inserte
 
 Returns `Promise<EntityBatchInsertResponse>` with `{ successRecords, failureRecords }`. Does NOT trigger events. Options: `expansionLevel`, `failOnFirst`.
 
+> **Choice-set fields take the integer `numberId`, not the value name.** Sending `status: "Open"` fails with `Single choiceset value Open is not integer`. Build a `name → numberId` map from `choiceSets.getById(<choiceSetId>)`; get the `<choiceSetId>` from `entities.getById(id).fields[].referenceChoiceSet?.id` (or `.choiceSetId`).
+
+> **Record keys must match the schema's exact casing.** The SDK does NOT pascalize record keys. If your entity's fields are `Subject`, `Status`, `CustomerEmail` (PascalCase, the DF UI default), you must send `{ Subject: …, Status: 1, CustomerEmail: … }` — sending `{ subject, status, customerEmail }` produces `Required field "Subject" is not provided` because DF's required-field check is case-sensitive. Read the schema via `entities.getById(id)` and use `field.name` verbatim as the record key.
+
+> **Unknown keys are silently dropped.** If your record contains a key that isn't in the entity schema (typo, removed field, audit-column name conflict), `insertRecordsById` does NOT error — the field is just ignored. Always introspect the schema with `entities.getById(id)` before seeding bulk data; keys that don't show up in `entity.fields` will be discarded without warning.
+
+> **DF auto-manages `CreateTime` / `UpdateTime` / `CreatedBy` / `UpdatedBy` / `Id` audit columns.** They appear in the entity schema but you cannot write to them — DF sets `CreateTime` to the moment of insert and `UpdateTime` to the moment of last write. If you need to seed historical timestamps (e.g., for an analytics demo where tickets must look 1–21 days old), add a **custom** `DATETIME_WITH_TZ` field (e.g., `OriginalCreatedTime`) and write to that. Do NOT name your custom field `CreateTime` or `CreatedTime` — the audit name conflict will cause silent drops or schema rejection.
+
 ### updateRecordById(entityId: string, recordId: string, data: Record<string, any>, options?: EntityUpdateRecordOptions)
 
 Returns `Promise<EntityUpdateRecordResponse>` — the updated single record. **Triggers Data Fabric trigger events** (unlike the bulk `updateRecordsById`). Use this when you need trigger events to fire for the updated record. Options: `expansionLevel`.
@@ -90,7 +120,63 @@ Returns `Promise<EntityUpdateResponse>` with `{ successRecords, failureRecords }
 
 ### deleteRecordsById(id: string, recordIds: string[], options?: EntityDeleteRecordsOptions)
 
-Returns `Promise<EntityDeleteResponse>` with `{ successRecords, failureRecords }`. Options: `failOnFirst`.
+Returns `Promise<EntityDeleteResponse>` with `{ successRecords, failureRecords }`. Options: `failOnFirst`. **Does NOT trigger events** — use `deleteRecordById` if you need trigger events.
+
+### deleteRecordById(entityId: string, recordId: string)
+
+Returns `Promise<void>`. **Triggers Data Fabric trigger events.** Use this for single deletes when triggers must fire (the bulk `deleteRecordsById` does not fire triggers).
+
+### queryRecordsById(id: string, options?: EntityQueryRecordsOptions)
+
+Returns `NonPaginatedResponse<EntityRecord>` or `PaginatedResponse<EntityRecord>` when pagination options are passed. Supports server-side filters, sort, field selection, aggregates, and group-by.
+
+> **For counts and chart data, use server-side `aggregates` + `groupBy`.** Don't fetch raw rows and aggregate in JS — every list call returns one page (see [pagination.md](pagination.md)), so `result.items.length` after `queryRecordsById({ filter })` returns at most one page's worth, no matter how many rows match. Use `aggregates: [{ function: 'COUNT', field: 'Id' }]` (with `groupBy` for per-bucket counts).
+
+> **Choice-set values come back as `numberId` integers in read responses — translate them yourself.** This applies to `groupBy` results AND ungrouped `queryRecordsById`/`getRecordById` items. Build a `numberId → name` map per choice field from `choiceSets.getById(<choiceSetId>)` once on app load and translate every time you read a choice field for display, comparison, or filter logic. Do NOT assume the SDK has already converted to a string name — it has not. A common silent failure: code that does `if (record.Status === "Resolved")` always evaluates false because `record.Status` is `5` (the numberId). Same for any logic doing `record.Priority.toLowerCase()` — it'll read `(5).toLowerCase`, throw, or coerce to `"5"` and miss every lookup keyed on names.
+
+> **Filter `value` for a choice field must be the `numberId`** (as a string, per the operator type). `{ fieldName: 'Status', operator: Equals, value: 'Resolved' }` matches nothing — use `value: String(numberIdForResolved)`. This rule applies to **every** filter touching a choice-set field, including `NotEquals`, `In`, `NotIn`. Failing to translate filter values is silent: the API returns 0 rows or all rows depending on operator, so a "0 records" or "all records" symptom that ignores your filter usually means a missing translation.
+
+> **Three paths require choice-value translation. Don't miss any.**
+> | Path | Direction | What to do |
+> |---|---|---|
+> | Writes (`insertRecordsById`, `updateRecordById`, `updateRecordsById`) | name → `numberId` | translate before sending |
+> | Filter values (any `queryRecordsById` filter on a choice field) | name → `numberId` (as a string) | translate before sending |
+> | `groupBy` result keys | `numberId` → name | translate after receiving for display |
+>
+> Best practice: on app load, fetch each choice set once and build **both** maps (`byName` and `byNumberId`). Reuse across all paths.
+
+`EntityQueryRecordsOptions`:
+- `filterGroup?: EntityQueryFilterGroup` — `{ logicalOperator?: LogicalOperator.And | Or, queryFilters?: EntityQueryFilter[], filterGroups?: EntityQueryFilterGroup[] }` (nested groups allowed). Each filter: `{ fieldName, operator: QueryFilterOperator, value?: string, valueList?: string[] }`.
+- `selectedFields?: string[]` — fields to return (omit for all)
+- `sortOptions?: EntityQuerySortOption[]` — `[{ fieldName, isDescending }]`
+- `aggregates?: EntityAggregate[]` — `[{ function: EntityAggregateFunction.Count | Sum | Avg | Min | Max, field, alias }]` (string literals `'COUNT'` / `'SUM'` / etc. also work — the enum is string-valued). For `Count`, any non-null field works — typically `'Id'`.
+- `groupBy?: string[]` — group aggregate results
+- `expansionLevel?: number` — default 0
+- Pagination (`pageSize`, `cursor`, `jumpToPage`) — when supplied, returns `PaginatedResponse`
+
+`QueryFilterOperator` values: `Equals` `'='`, `NotEquals` `'!='`, `GreaterThan` `'>'`, `LessThan` `'<'`, `GreaterThanOrEqual` `'>='`, `LessThanOrEqual` `'<='`, `Contains` `'contains'`, `NotContains` `'not contains'`, `StartsWith` `'startswith'`, `EndsWith` `'endswith'`, `In` `'in'`, `NotIn` `'not in'`.
+
+> **`value` is always a string.** For numeric, boolean, or date fields, pass the string form (e.g., `"42"`, `"true"`, `"2026-05-01T00:00:00Z"`). For `In`/`NotIn`, use `valueList: string[]` instead of `value`.
+
+```typescript
+import { LogicalOperator, QueryFilterOperator, EntityAggregateFunction } from '@uipath/uipath-typescript/entities';
+
+// Filter + sort
+const result = await entities.queryRecordsById(entityId, {
+  filterGroup: {
+    logicalOperator: LogicalOperator.And,
+    queryFilters: [{ fieldName: 'status', operator: QueryFilterOperator.Equals, value: 'active' }],
+  },
+  sortOptions: [{ fieldName: 'createdTime', isDescending: true }],
+});
+
+// Aggregate: count per status
+await entities.queryRecordsById(entityId, {
+  selectedFields: ['status'],
+  groupBy: ['status'],
+  aggregates: [{ function: EntityAggregateFunction.Count, field: 'Id', alias: 'total' }],
+});
+```
 
 ### downloadAttachment(entityId: string, recordId: string, fieldName: string)
 
@@ -112,9 +198,11 @@ Returned by `getAll()` and `getById()` on each `EntityGetResponse`:
 - `entity.insertRecords(data[], options?)` -> `Promise<EntityBatchInsertResponse>` (no trigger events)
 - `entity.updateRecord(recordId, data, options?)` -> `Promise<EntityUpdateRecordResponse>` (fires trigger events)
 - `entity.updateRecords(data: EntityRecord[], options?)` -> `Promise<EntityUpdateResponse>` (no trigger events)
-- `entity.deleteRecords(recordIds: string[], options?)` -> `Promise<EntityDeleteResponse>`
+- `entity.deleteRecords(recordIds: string[], options?)` -> `Promise<EntityDeleteResponse>` (no trigger events)
+- `entity.deleteRecord(recordId)` -> `Promise<void>` (fires trigger events)
 - `entity.getAllRecords(options?)` -> `NonPaginatedResponse<EntityRecord>` or `PaginatedResponse<EntityRecord>`
 - `entity.getRecord(recordId, options?)` -> `Promise<EntityRecord>`
+- `entity.queryRecords(options?)` -> `NonPaginatedResponse<EntityRecord>` or `PaginatedResponse<EntityRecord>` (filters, sort, aggregates — see `queryRecordsById` above)
 - `entity.uploadAttachment(recordId, fieldName, file, options?)` -> `Promise<EntityUploadAttachmentResponse>`
 - `entity.downloadAttachment(recordId, fieldName)` -> `Promise<Blob>`
 - `entity.deleteAttachment(recordId, fieldName)` -> `Promise<EntityDeleteAttachmentResponse>`

--- a/skills/uipath-coded-apps/references/sdk/feedback.md
+++ b/skills/uipath-coded-apps/references/sdk/feedback.md
@@ -1,0 +1,80 @@
+# Agent Feedback Reference
+
+Feedback allows you to collect and manage user feedback on AI agent responses, including positive/negative ratings, comments, and categorized feedback. This is useful for monitoring agent quality, identifying areas for improvement, and building datasets for fine-tuning.
+
+## Import
+
+```typescript
+import { Feedback } from '@uipath/uipath-typescript/feedback';
+```
+
+## Scopes
+
+`Traces.Api` — for both `getAll()` and `getById()`.
+
+## Types to Import
+
+```typescript
+import type {
+  FeedbackGetResponse,
+  FeedbackGetAllOptions,
+  FeedbackOptions,
+  FeedbackCategory,
+} from '@uipath/uipath-typescript/feedback';
+```
+
+## Enums
+
+```typescript
+import { FeedbackStatus } from '@uipath/uipath-typescript/feedback';
+// FeedbackStatus.Pending = 0, Approved = 1, Dismissed = 2
+```
+
+## Feedback Service
+
+### getAll(options?: FeedbackGetAllOptions)
+
+Returns `NonPaginatedResponse<FeedbackGetResponse>` or `PaginatedResponse<FeedbackGetResponse>`. As with every list method, this returns one page — see [pagination.md](pagination.md) for cursor-loop retrieval if the source has more rows than the server's default cap.
+
+`FeedbackGetAllOptions` filters: `agentId?`, `agentVersion?`, `status?: FeedbackStatus`, `traceId?`, `spanId?`. Plus `PaginationOptions` (`pageSize`, `cursor`, `jumpToPage`).
+
+### getById(id: string, options: FeedbackOptions)
+
+Returns `Promise<FeedbackGetResponse>`. **`options.folderKey` is required** — get it from a `getAll()` item or wherever the feedback originated.
+
+`FeedbackGetResponse` fields: `id`, `traceId`, `spanId`, `agentId`, `agentVersion?`, `comment?`, `metadata?`, `isPositive`, `feedbackCategories: FeedbackCategory[]`, `folderKey?`, `userEmail?`, `status: FeedbackStatus`, `createdTime`, `updatedTime`.
+
+`FeedbackCategory` fields: `id`, `category`, `createdAt`, `isDefault`, `isPositive`, `isNegative`. Default categories (Output, Agent Error, Agent Plan Execution) are auto-created per tenant.
+
+## Usage Example
+
+```typescript
+import { useMemo, useEffect, useState } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { Feedback, FeedbackStatus } from '@uipath/uipath-typescript/feedback';
+import type { FeedbackGetResponse } from '@uipath/uipath-typescript/feedback';
+
+function FeedbackInbox({ agentId }: { agentId: string }) {
+  const { sdk } = useAuth();
+  const feedback = useMemo(() => new Feedback(sdk), [sdk]);
+  const [items, setItems] = useState<FeedbackGetResponse[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const result = await feedback.getAll({
+        agentId,
+        status: FeedbackStatus.Pending,
+        pageSize: 25,
+      });
+      setItems(result.items);
+    };
+    load();
+  }, [feedback, agentId]);
+
+  const openDetail = async (item: FeedbackGetResponse) => {
+    if (!item.folderKey) return;
+    const detail = await feedback.getById(item.id, { folderKey: item.folderKey });
+    console.log(detail.comment, detail.feedbackCategories);
+  };
+}
+```

--- a/skills/uipath-coded-apps/references/sdk/imports.md
+++ b/skills/uipath-coded-apps/references/sdk/imports.md
@@ -18,6 +18,7 @@ Read this when writing TypeScript code that imports classes, types, or options f
 | `@uipath/uipath-typescript/jobs` | `Jobs` |
 | `@uipath/uipath-typescript/attachments` | `Attachments` |
 | `@uipath/uipath-typescript/conversational-agent` | `ConversationalAgent`, `Exchanges`, `Messages` |
+| `@uipath/uipath-typescript/feedback` | `Feedback` |
 
 ## Type Imports
 

--- a/skills/uipath-coded-apps/references/sdk/orchestrator.md
+++ b/skills/uipath-coded-apps/references/sdk/orchestrator.md
@@ -15,7 +15,11 @@ import { Attachments } from '@uipath/uipath-typescript/attachments';
 
 Assets, Queues, Buckets, and Processes are folder-scoped. Many methods require a `folderId` parameter.
 
-**No bound methods**: These are read-only response objects. Unlike Entities, Tasks, or Maestro instances, the responses from Orchestrator services do not have attached methods. Use the service directly for all operations.
+**Bound methods**: `Jobs.getById()` and `Jobs.getAll()` items return response objects with attached methods (`getOutput()`, `stop()`, `resume()`, `restart()`). Assets, Queues, Buckets, Processes, and Attachments responses do **not** have attached methods — use the service directly.
+
+## `getByName` folder identifiers
+
+`Assets.getByName` and `Processes.getByName` accept `FolderScopedOptions` — supply one of `folderId`, `folderKey`, or `folderPath` (e.g., `'Shared/Finance'`). If multiple are supplied, server precedence is `folderPath` > `folderKey` > `folderId`.
 
 ## Types to Import
 
@@ -25,6 +29,7 @@ import type {
   AssetGetResponse,
   AssetGetAllOptions,
   AssetGetByIdOptions,
+  AssetGetByNameOptions,
   CustomKeyValuePair,
 } from '@uipath/uipath-typescript/assets';
 
@@ -54,6 +59,7 @@ import type {
   ProcessGetResponse,
   ProcessGetAllOptions,
   ProcessGetByIdOptions,
+  ProcessGetByNameOptions,
   ProcessStartRequest,
   ProcessStartResponse,
 } from '@uipath/uipath-typescript/processes';
@@ -63,6 +69,9 @@ import type {
   JobGetResponse,
   JobGetAllOptions,
   JobGetByIdOptions,
+  JobStopOptions,
+  JobResumeOptions,
+  JobMethods,
 } from '@uipath/uipath-typescript/jobs';
 
 // Attachments
@@ -107,6 +116,16 @@ Returns `NonPaginatedResponse<AssetGetResponse>` or `PaginatedResponse<AssetGetR
 ### getById(id: number, folderId: number, options?: AssetGetByIdOptions)
 
 Returns `Promise<AssetGetResponse>`. The `folderId` is required.
+
+### getByName(name: string, options: AssetGetByNameOptions)
+
+Returns `Promise<AssetGetResponse>`. Resolves an asset by display name within a folder. Supply one of `folderId` (number), `folderKey` (GUID string), or `folderPath` (e.g., `'Shared/Finance'`). Throws `NotFoundError` if no asset matches.
+
+```typescript
+await assets.getByName('ApiKey', { folderId: 123 });
+await assets.getByName('ApiKey', { folderKey: '5f6dadf1-3677-49dc-8aca-c2999dd4b3ba' });
+await assets.getByName('ApiKey', { folderPath: 'Shared/Finance', expand: 'keyValueList' });
+```
 
 `AssetGetResponse` fields: `key`, `name`, `id`, `canBeDeleted`, `valueScope`, `valueType`, `value`, `credentialStoreId`, `keyValueList`, `hasDefaultValue`, `description`, `foldersCount`, `lastModifiedTime`, `createdTime`, `creatorUserId`. **Note:** Additional fields may be available. Check the TypeScript types for the complete list.
 
@@ -156,6 +175,14 @@ Returns `NonPaginatedResponse<ProcessGetResponse>` or `PaginatedResponse<Process
 
 Returns `Promise<ProcessGetResponse>`.
 
+### getByName(name: string, options: ProcessGetByNameOptions)
+
+Returns `Promise<ProcessGetResponse>`. Resolves a process release by name within a folder. Supply one of `folderId`, `folderKey`, or `folderPath`. Throws `NotFoundError` if no process matches.
+
+```typescript
+await processes.getByName('MyProcess', { folderPath: 'Shared/Finance', expand: 'entryPoints' });
+```
+
 `ProcessGetResponse` fields: `key`, `packageKey`, `packageVersion`, `isLatestVersion`, `description`, `name`, `packageType`, `targetFramework`, `robotSize`, `autoUpdate`, `id`, `folderId`, `folderName`, `folderKey`, `createdTime`, `lastModifiedTime`.
 
 ### start(request: ProcessStartRequest, folderId: number, options?: RequestOptions)
@@ -178,7 +205,39 @@ Returns `Promise<JobGetResponse>`. The `folderId` is required. **Note:** `id` is
 
 Returns `Promise<Record<string, unknown> | null>` — the job's parsed output arguments, or `null` if unavailable. Use after a job has finished; output is not populated while the job is still running.
 
+### stop(jobKeys: string[], folderId: number, options?: JobStopOptions)
+
+Returns `Promise<void>`. Stops one or more jobs (pass an array even for a single job). Throws if any keys cannot be resolved. `JobStopOptions`: `{ strategy?: StopStrategy }` — `StopStrategy.SoftStop` (default, graceful) or `StopStrategy.Kill` (immediate).
+
+### resume(jobKey: string, folderId: number, options?: JobResumeOptions)
+
+Returns `Promise<void>`. Resumes a job currently in `Suspended` state. `JobResumeOptions`: `{ inputArguments?: Record<string, unknown> }`.
+
+### restart(jobKey: string, folderId: number)
+
+Returns `Promise<JobGetResponse>` — a **new** job with a new `key`, in `Pending` state. The original job must be in a final state (`Successful`, `Faulted`, or `Stopped`). Inputs are inherited from the original.
+
 `JobGetResponse` fields: `key`, `id`, `state`, `createdTime`, `startTime`, `endTime`, `lastModifiedTime`, `resumeTime`, `processName`, `entryPointPath`, `processVersionId`, `hostMachineName`, `inputArguments`, `outputArguments`, `environmentVariables`, `type`, `packageType`, `runtimeType`, `serverlessJobType`, `jobPriority`, `specificPriorityValue`, `stopStrategy`, `remoteControlAccess`, `batchExecutionKey`, `parentJobKey`, `traceId`, `parentSpanId`, `errorCode`, `jobError`, `subState`, `machine`, `robot`, `process`. The `machine`, `robot`, and `process` fields are populated only when requested via `expand`.
+
+## Job-Attached Methods (JobMethods)
+
+Returned by `getById()` and `getAll()` items on each `JobGetResponse`. These are bound to the job's `key` and `folderId`, so you don't need to pass them again:
+
+- `job.getOutput()` -> `Promise<Record<string, unknown> | null>`
+- `job.stop(options?)` -> `Promise<void>`
+- `job.resume(options?)` -> `Promise<void>`
+- `job.restart()` -> `Promise<JobGetResponse>` (new job)
+
+```typescript
+const all = await jobs.getAll({ folderId, pageSize: 20 });
+const running = all.items.find(j => j.state === 'Running');
+if (running) await running.stop();             // bound — no folderId needed
+const completed = all.items.find(j => j.state === 'Successful');
+if (completed) {
+  const output = await completed.getOutput();   // bound
+  const newJob = await completed.restart();     // bound
+}
+```
 
 ## Attachments Service (Scopes: `OR.Folders` or `OR.Folders.Read`)
 

--- a/skills/uipath-coded-apps/references/sdk/pagination.md
+++ b/skills/uipath-coded-apps/references/sdk/pagination.md
@@ -1,5 +1,25 @@
 # Pagination Reference
 
+> **Foot-gun: every "list" call returns ONE page, even when you pass no pagination options.** `getAll`, `getAllRecords`, `queryRecordsById`, `getFileMetaData`, etc. all make exactly one HTTP call. Whether the response is typed as `PaginatedResponse` or `NonPaginatedResponse` is purely about whether you passed pagination options — it does NOT control how many rows you get back.
+>
+> - `getAll()` (no options) → `NonPaginatedResponse` → SDK sends no `pageSize` param; the **server** applies its own default cap and returns one page. You can't override it client-side without explicitly paginating. Despite the name, `NonPaginatedResponse` is NOT "all rows in one shot."
+> - `getAll({ pageSize: 200 })` → `PaginatedResponse` → API returns up to 200, plus `hasNextPage` / `nextCursor`.
+>
+> **There is no "give me everything" call.** To list every row from a source that may have more than the cap, you MUST loop the cursor:
+>
+> ```typescript
+> const all: T[] = [];
+> let cursor: PaginationCursor | undefined;
+> while (true) {
+>   const page = await service.getAll(cursor ? { pageSize: 100, cursor } : { pageSize: 100 });
+>   all.push(...page.items);
+>   if (!page.hasNextPage || !page.nextCursor) break;
+>   cursor = page.nextCursor;
+> }
+> ```
+>
+> Code that does `result.items.length` after a single call is almost always a bug — it returns at most the page size, not the total. Use `totalCount` for cardinality, the cursor loop for full retrieval. If the source has fewer rows than the default cap (e.g., 30 of a 100-cap), a single call works but you cannot rely on that as data grows.
+
 ## Imports
 
 Import pagination types from `@uipath/uipath-typescript/core`:
@@ -20,8 +40,8 @@ import type {
 
 ## Behavior
 
-- No pagination options passed -> returns `NonPaginatedResponse<T>`
-- Any pagination option passed (pageSize, cursor, or jumpToPage) -> returns `PaginatedResponse<T>`
+- No pagination options passed → returns `NonPaginatedResponse<T>` (response wrapper has no pagination metadata; data is still capped at the **server's** default page limit, applied on the API side because the SDK sends no `pageSize`; see foot-gun above).
+- Any pagination option passed (pageSize, cursor, or jumpToPage) → returns `PaginatedResponse<T>` with `hasNextPage`/`nextCursor` for cursor-loop retrieval.
 
 ## Cursor Navigation
 


### PR DESCRIPTION
## 1. New SDK methods documented                                                                                                                                
                                                                            
  ### Feedback service (new subpath)
  - `Feedback.getAll(options?)` — list feedback across the tenant with filters by `agentId`, `status`, `traceId`
  - `Feedback.getById(id, { folderKey })` — fetch a single feedback record                                                                                     
  - New file: `references/sdk/feedback.md`
  - Added `@uipath/uipath-typescript/feedback` to `imports.md`                                                                                                 
  - Added scope rows to `oauth-scopes.md`                                   
                                                                                                                                                               
  ### Jobs (new control-plane methods)                                      
  - `Jobs.stop(jobKeys[], folderId, options?)`                                                                                                                 
  - `Jobs.resume(jobKey, folderId, options?)`                               
  - `Jobs.restart(jobKey, folderId)`                                                                                                                           
  - `JobMethods` bound on `JobGetResponse` — `job.getOutput()`, `job.stop()`, `job.resume()`, `job.restart()`
  - New types: `JobStopOptions`, `JobResumeOptions`, `JobMethods`                                                                                              
                                                                            
  ### Entities (Data Fabric)                                                                                                                                   
  - `Entities.deleteRecordById(entityId, recordId)` — single delete, fires triggers
  - `Entities.queryRecordsById(id, options)` — filter / sort / aggregate / group-by                                                                            
  - Bound: `entity.deleteRecord(recordId)`, `entity.queryRecords(options)`                                                                                     
  - Filter types: `EntityQueryFilter`, `EntityQueryFilterGroup`, `EntityQuerySortOption`, `EntityAggregate`
  - Enums: `LogicalOperator`, `QueryFilterOperator`, `EntityAggregateFunction` (runtime-exported in 1.3.7)                                                     
                                                                                                                                                               
  ### Assets / Processes                                                                                                                                       
  - `Assets.getByName(name, options)` — resolve by name within a folder (accepts `folderId`, `folderKey`, or `folderPath`; supply exactly one)                 
  - `Processes.getByName(name, options)` — same shape                                                                                                          
  
  ### Conversational Agent                                                                                                                                     
  - `Conversations.getAttachmentUploadUri(conversationId, fileName)` — lower-level alternative to `uploadAttachment` for streaming/non-`File` sources. Example shows the complete upload (merges `fileUploadAccess.headers`, adds `x-ms-blob-type: BlockBlob`, conditionally attaches `Authorization` when `requiresAuth`)  
                                                                            
  ## 2. Deploy loop updated to take `--folder-key`                                                                                                                
                                                                            
  - `uip codedapp deploy --folder-key <GUID>` is now the documented path; `UIPATH_FOLDER_KEY=<GUID>` env var is documented as the equivalent alternative       
  - Folder name → key resolution recipe added: `uip or folders list --output json`, match on the `Name` field (output rows are `{ Key, Name, Path, Description, Type, ParentKey }` — PascalCase)                                                                                                                            
  - All CLI flags switched from camelCase to kebab-case across `pack-publish-deploy.md` and `commands-reference.md` (`--folder-key`, `--base-url`,`--client-id`, `--build-dir`, `--main-file`, `--access-token`, etc.)                                                                                         
  - Documented `-v, --version` alias on `pack`, `publish`, and `deploy` (deploy's `-v` is the **target published version**, different semantic from pack/publish's package version)                                                                                                                              
  - `uip or folders list-current-user` → `uip or folders list` (CLI consolidation; default behavior is "current user's folders," `--all` for tenant-wide)
                                                                                                                                                               
  ## 3. Data Fabric anti-shapes section                                        
                                                                                                                                                               
  New "read first" section at the top of `references/sdk/data-fabric.md` documenting nine DF behaviors:

  1. Choice values come back as `numberId` integers on every read path                                                                                         
  2. Auto-created audit fields (`CreateTime`/`UpdateTime`/etc.) are row metadata, not domain fields
  3. Unknown keys silently dropped on insert                                                                                                                   
  4. No `IsNull` filter operator                                            
  5. Field name casing preserved verbatim on writes                                                                                                            
  6. Filter `value` for choice fields = `numberId` as string                
  7. Aggregates require server-side `aggregates` + `groupBy`                                                                                                   
  8. `field.fieldDataType` is an object, not a string — read `.name`
  9. File-type fields are metadata-only — `downloadAttachment` to render; detect kind by magic-byte sniffing or optimistic `<img>` + `onError` fallback (neither `contentType` nor filename is reliable — DF returns generic `application/octet-stream` and stores `name` as a bare UUID) 