### PR TITLE
MST-9509: accept HTTP v2 bodyParameters URL in path-param checker

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py
@@ -7,6 +7,7 @@ Usage:
 Looks for <expected_value> in either:
   - Any node's `inputs.detail.pathParameters` dict values (native connector path)
   - Any node's `inputs.detail.url` or `inputs.detail.endpoint` (managed HTTP path)
+  - Any node's `inputs.detail.bodyParameters.url` (HTTP v2 CLI-configured path)
 """
 
 from __future__ import annotations
@@ -46,13 +47,25 @@ def main() -> None:
                 if str(value) == needle:
                     print(f"OK: {needle!r} found in pathParameters of node {node.get('id')!r}")
                     return
-        for key in ("url", "endpoint"):
-            target = str(detail.get(key, "") or "")
+        candidates = [
+            ("url", detail.get("url", "")),
+            ("endpoint", detail.get("endpoint", "")),
+        ]
+        body_parameters = detail.get("bodyParameters", {}) or {}
+        if isinstance(body_parameters, dict):
+            candidates.append(
+                ("bodyParameters.url", body_parameters.get("url", ""))
+            )
+        for label, value in candidates:
+            target = str(value or "")
             if needle in target:
-                print(f"OK: {needle!r} found in {key} of node {node.get('id')!r}")
+                print(f"OK: {needle!r} found in {label} of node {node.get('id')!r}")
                 return
 
-    _fail(f"{needle!r} not found in any node's pathParameters, url, or endpoint")
+    _fail(
+        f"{needle!r} not found in any node's pathParameters, url, endpoint, "
+        "or bodyParameters.url"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/connector_features/test_check_path_param_value.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/test_check_path_param_value.py
@@ -1,0 +1,66 @@
+"""Tests for the path-parameter value checker."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+CHECKER = Path(__file__).with_name("check_path_param_value.py")
+
+
+def _write_flow(tmp_path: Path, detail: dict) -> Path:
+    project = tmp_path / "PathParamsTest"
+    project.mkdir()
+    flow = project / "PathParamsTest.flow"
+    flow.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "getIssue",
+                        "type": "core.action.http.v2",
+                        "inputs": {"detail": detail},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return flow
+
+
+def _run_checker(flow: Path, expected_value: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), str(flow), expected_value],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_finds_value_in_body_parameters_url(tmp_path: Path) -> None:
+    flow = _write_flow(
+        tmp_path,
+        {
+            "bodyParameters": {
+                "url": "https://your-domain.atlassian.net/rest/api/2/issue/ENGCE-00000"
+            }
+        },
+    )
+
+    result = _run_checker(flow, "ENGCE-00000")
+
+    assert result.returncode == 0, result.stderr
+    assert "bodyParameters.url" in result.stdout
+
+
+def test_finds_value_in_native_path_parameters(tmp_path: Path) -> None:
+    flow = _write_flow(tmp_path, {"pathParameters": {"issueIdOrKey": "ENGCE-00000"}})
+
+    result = _run_checker(flow, "ENGCE-00000")
+
+    assert result.returncode == 0, result.stderr
+    assert "pathParameters" in result.stdout


### PR DESCRIPTION
## Summary

`skill-flow-ipe-path-params` can validly use the managed HTTP fallback path. The CLI stores that request URL in `inputs.detail.bodyParameters.url`, but the checker only inspected `pathParameters`, `detail.url`, and `detail.endpoint`.

This PR teaches the checker to inspect `bodyParameters.url` and adds regression coverage for both the HTTP fallback URL and the native connector `pathParameters` path.

## Validation

- `uv run --with pytest pytest tests/tasks/uipath-maestro-flow/connector_features/test_check_path_param_value.py`
- Ran the updated checker against the captured `PathParamsTest.flow` artifact from run `2026-05-11_04-04-06`
- YAML TaskDefinition validation for `tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml`
- `uv run python -m py_compile tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py tests/tasks/uipath-maestro-flow/connector_features/test_check_path_param_value.py`
- `git diff --cached --check`

Jira: https://uipath.atlassian.net/browse/MST-9509
