### PR TITLE
fix(test): accept raw HITL bindings in DevCon checker [MST-9609]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -38,6 +38,12 @@ def field_text(field: dict, key: str) -> str:
     return value.lower() if isinstance(value, str) else ""
 
 
+def is_upstream_output_binding(binding: str) -> bool:
+    return (
+        binding.startswith("vars.") or binding.startswith("=js:$vars.")
+    ) and ".output." in binding
+
+
 def main() -> None:
     flow = load_flow()
     nodes = flow.get("nodes")
@@ -101,8 +107,11 @@ def main() -> None:
     ]
     if not input_bindings:
         fail("HITL input fields must be bound to upstream script output")
-    if not any(binding.startswith("=js:$vars.") and ".output." in binding for binding in input_bindings):
-        fail("HITL input bindings must use =js:$vars.<node>.output.<field>")
+    if not any(is_upstream_output_binding(binding) for binding in input_bindings):
+        fail(
+            "HITL input bindings must use vars.<node>.output.<field> "
+            "or =js:$vars.<node>.output.<field>"
+        )
 
     if not any(e.get("sourceNodeId") == hitl_id and e.get("sourcePort") == "completed" for e in edges):
         fail("HITL completed handle must be wired")

--- a/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
@@ -11,7 +11,7 @@ from pathlib import Path
 CHECKER = Path(__file__).with_name("check_devcon_expense_approval.py")
 
 
-def _write_flow(tmp_path: Path, binding: str) -> Path:
+def _write_flow(tmp_path: Path, binding: str) -> None:
     project = tmp_path / "ExpenseApproval" / "ExpenseApproval"
     project.mkdir(parents=True)
     flow = project / "ExpenseApproval.flow"
@@ -74,7 +74,6 @@ def _write_flow(tmp_path: Path, binding: str) -> Path:
         ),
         encoding="utf-8",
     )
-    return flow
 
 
 def _run_checker(tmp_path: Path) -> subprocess.CompletedProcess[str]:
@@ -101,3 +100,21 @@ def test_accepts_expression_hitl_input_binding(tmp_path: Path) -> None:
     result = _run_checker(tmp_path)
 
     assert result.returncode == 0, result.stderr
+
+
+def test_rejects_hardcoded_hitl_input_binding(tmp_path: Path) -> None:
+    _write_flow(tmp_path, "hardcoded-value")
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode != 0
+    assert "HITL input bindings must use" in result.stderr
+
+
+def test_rejects_hitl_input_binding_without_output_segment(tmp_path: Path) -> None:
+    _write_flow(tmp_path, "vars.fetchExpense.amount")
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode != 0
+    assert "HITL input bindings must use" in result.stderr

--- a/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
@@ -1,0 +1,103 @@
+"""Tests for the DevCon expense approval semantic checker."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+CHECKER = Path(__file__).with_name("check_devcon_expense_approval.py")
+
+
+def _write_flow(tmp_path: Path, binding: str) -> Path:
+    project = tmp_path / "ExpenseApproval" / "ExpenseApproval"
+    project.mkdir(parents=True)
+    flow = project / "ExpenseApproval.flow"
+    flow.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "fetchExpense",
+                        "type": "core.action.script",
+                        "inputs": {
+                            "script": "return { amount: 42, category: 'Travel' };"
+                        },
+                    },
+                    {
+                        "id": "reviewExpense",
+                        "type": "uipath.human-in-the-loop",
+                        "typeVersion": "1.0",
+                        "inputs": {
+                            "schema": {
+                                "fields": [
+                                    {
+                                        "id": "amount",
+                                        "label": "Amount",
+                                        "type": "number",
+                                        "direction": "input",
+                                        "binding": binding,
+                                    },
+                                    {
+                                        "id": "rejectionreason",
+                                        "label": "Rejection Reason",
+                                        "type": "text",
+                                        "direction": "output",
+                                    },
+                                ],
+                                "outcomes": [
+                                    {"id": "approve", "name": "Approve"},
+                                    {"id": "reject", "name": "Reject"},
+                                ],
+                            }
+                        },
+                    },
+                    {
+                        "id": "logOutcome",
+                        "type": "core.action.script",
+                        "inputs": {
+                            "script": "return $vars.reviewExpense.output.rejectionreason;"
+                        },
+                    },
+                ],
+                "edges": [
+                    {
+                        "sourceNodeId": "reviewExpense",
+                        "sourcePort": "completed",
+                        "targetNodeId": "logOutcome",
+                        "targetPort": "input",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return flow
+
+
+def _run_checker(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_accepts_documented_raw_hitl_input_binding(tmp_path: Path) -> None:
+    _write_flow(tmp_path, "vars.fetchExpense.output.amount")
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_accepts_expression_hitl_input_binding(tmp_path: Path) -> None:
+    _write_flow(tmp_path, "=js:$vars.fetchExpense.output.amount")
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

The DevCon expense approval semantic checker required HITL input bindings to use expression syntax: `=js:$vars.<node>.output.<field>`.

Inline HITL QuickForm fields use raw binding paths (`vars.<node>.output.<field>`) per the HITL docs. This PR accepts both raw HITL paths and expression-style paths while keeping the `.output` requirement and existing schema/wiring checks.

## Validation

- `uv run --with pytest pytest tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py`
- Ran the updated checker against the captured `ExpenseApproval.flow` artifact from run `2026-05-11_04-04-06`
- YAML TaskDefinition validation for `tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml`
- `uv run python -m py_compile tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py`
- `git diff --cached --check`

Jira: https://uipath.atlassian.net/browse/MST-9609
