### PR TITLE
MST-9610: restore static RPA flow checker

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
@@ -1,24 +1,54 @@
 #!/usr/bin/env python3
-"""ProjectEulerTitle: an RPA-workflow node executes; output holds the title."""
+"""ProjectEulerTitle: an RPA-workflow node is wired to return the title."""
 
-import os
+from __future__ import annotations
+
+import glob
+import json
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
-    assert_outputs_contain,
-    run_debug,
-)
+
+def _fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
 
 
-def main():
-    assert_flow_has_node_type(["uipath.core.rpa-workflow"])
-    # RPA workflows are slow: spin up robot, launch Chrome, scrape. 4 min
-    # is routinely not enough on this tenant.
-    payload = run_debug(timeout=540)
-    assert_outputs_contain(payload, "prime square remainders")
-    print("OK: RPA node present; output contains 'prime square remainders'")
+def _load_single_flow() -> dict:
+    flows = sorted(glob.glob("**/ProjectEulerTitle.flow", recursive=True))
+    if not flows:
+        _fail("No ProjectEulerTitle.flow found")
+    if len(flows) > 1:
+        _fail(f"Multiple ProjectEulerTitle.flow files found: {flows}")
+    with open(flows[0], encoding="utf-8") as flow_file:
+        return json.load(flow_file)
+
+
+def main() -> None:
+    flow = _load_single_flow()
+    nodes = flow.get("nodes") or []
+    rpa_nodes = [
+        node for node in nodes if "uipath.core.rpa-workflow" in node.get("type", "")
+    ]
+    if len(rpa_nodes) != 1:
+        _fail(f"Expected exactly one RPA node, found {len(rpa_nodes)}")
+
+    rpa_node = rpa_nodes[0]
+    if (rpa_node.get("inputs") or {}).get("problemId") != 123:
+        _fail("RPA node must pass problemId=123")
+
+    bindings_text = json.dumps(flow.get("bindings") or [])
+    if "ProjectEuler RPA" not in bindings_text or "RPA Workflow" not in bindings_text:
+        _fail("RPA process bindings must reference ProjectEuler RPA.RPA Workflow")
+
+    end_nodes = [node for node in nodes if node.get("type") == "core.control.end"]
+    output_sources = json.dumps([node.get("outputs") or {} for node in end_nodes])
+    rpa_node_id = rpa_node.get("id")
+    if not rpa_node_id:
+        _fail("RPA node is missing id")
+    expected_source = f"$vars.{rpa_node_id}.output.title"
+    if expected_source not in output_sources:
+        _fail(f"End node output must map from {expected_source}")
+
+    print("OK: RPA node present; problemId and title output are wired")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -2,7 +2,8 @@ task_id: skill-flow-rpa
 description: >
   Create a UiPath Flow that uses the ProjectEuler RPA workflow to retrieve the
   title for problem 123. Exercises RPA resource node discovery, registry get,
-  and node wiring.
+  and node wiring. Validate-only: RPA runtime requires attended browser
+  (SW-28504).
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 max_iterations: 1
 
@@ -21,7 +22,7 @@ initial_prompt: |
   ProjectEuler RPA workflow to retrieve the title for problem 123 and
   return it as an output.
 
-  Validate the flow.
+  Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
@@ -37,9 +38,9 @@ success_criteria:
 
   # ── Execution checks ──────────────────────────────────────────────────
   - type: run_command
-    description: "Flow has an RPA node and debug returns the problem title"
+    description: "Flow has an RPA node wired to return the problem title"
     command: "python3 $TASK_DIR/check_rpa_flow.py"
-    timeout: 600
+    timeout: 60
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/test_check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/test_check_rpa_flow.py
@@ -1,0 +1,56 @@
+"""Tests for the ProjectEuler RPA flow checker."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+CHECKER = Path(__file__).with_name("check_rpa_flow.py")
+
+
+def test_accepts_static_rpa_node_contract(tmp_path: Path) -> None:
+    project = tmp_path / "ProjectEulerTitle" / "ProjectEulerTitle"
+    project.mkdir(parents=True)
+    flow = project / "ProjectEulerTitle.flow"
+    flow.write_text(
+        json.dumps(
+            {
+                "nodes": [
+                    {
+                        "id": "getTitle",
+                        "type": "uipath.core.rpa-workflow.1234",
+                        "inputs": {"problemId": 123},
+                    },
+                    {
+                        "id": "end",
+                        "type": "core.control.end",
+                        "outputs": {
+                            "title": {
+                                "source": "=js:$vars.getTitle.output.title"
+                            }
+                        },
+                    },
+                ],
+                "bindings": [
+                    {
+                        "resourceName": "ProjectEuler RPA",
+                        "resourceSubType": "RPA Workflow",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

`skill-flow-rpa` had regressed back to live `flow debug`, which makes the eval depend on tenant debug auth and attended browser runtime state instead of the authored RPA flow contract.

This PR restores the static checker from the prior MST-9460 fix: one RPA workflow node, `problemId=123`, ProjectEuler RPA binding evidence, and an End output wired from the RPA title output. The task prompt and criterion wording are aligned to validate-only behavior again.

## Validation

- `uv run --with pytest pytest tests/tasks/uipath-maestro-flow/single_node/rpa/test_check_rpa_flow.py`
- Ran the updated checker against the captured `ProjectEulerTitle.flow` artifact from run `2026-05-11_04-04-06`
- YAML TaskDefinition validation for `tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml`
- `uv run python -m py_compile tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py tests/tasks/uipath-maestro-flow/single_node/rpa/test_check_rpa_flow.py`
- `git diff --cached --check`

Jira: https://uipath.atlassian.net/browse/MST-9610
