### PR TITLE
fix: correct trigger-bound  access pattern and low-code agent icon de…

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/agent/impl.md
@@ -108,7 +108,7 @@ Confirm all three from `registry get` before wiring.
 }
 ```
 
-`<AGENT_ICON>` depends on the agent's implementation type: `"coded-agent"` for Python-coded agents, `"autonomous-agent"` for low-code (`agent.json`) agents. Read the correct value from `uip maestro flow registry get <nodeType> --local --output json` (`.display.icon` on the manifest).
+`<AGENT_ICON>` depends on the agent's implementation type: `"coded-agent"` for Python-coded agents, `"autonomous-agent"` for low-code (`agent.json`) agents. Detect the type by inspecting the sibling agent project directory: if `agent.json` exists at its root, use `"autonomous-agent"`; otherwise use `"coded-agent"`. Do NOT copy `.display.icon` from `uip maestro flow registry get --local` — that manifest returns `"coded-agent"` for every in-solution agent regardless of implementation type, and the value must be corrected here.
 
 Same shape as the published variant — no `model` on the instance.
 

--- a/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
+++ b/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
@@ -130,6 +130,7 @@ Workflow variables are declared in `variables.globals`. Each has a **direction**
   "triggerNodeId": "start"
 }
 ```
+Accessed in expressions as `$vars.{triggerNodeId}.output.{id}` (the variable is nested under the trigger node's output — NOT `$vars.{id}`).
 
 ### Type Reference
 
@@ -356,11 +357,12 @@ These variables are available in all expression contexts:
 ### `$vars` Access Patterns
 
 ```javascript
-// Workflow input variable
+// Workflow global
 $vars.customerName
-
-// State variable
 $vars.counter
+
+// Trigger-associated flow input (triggerNodeId set)
+$vars.{triggerNodeId}.output.{id}
 
 // Node output (script node)
 $vars.script1.output


### PR DESCRIPTION
Fixes two doc bugs in the uipath-maestro-flow skill that caused the agent to emit broken flows when wiring in-solution agents. 
(1) Trigger-bound flow inputs (globals with `triggerNodeId`) were accessed as `$vars.{id}` instead of `$vars.{triggerNodeId}.output.{id}`, which Studio Web rejects as a type error. The fix adds the correct access pattern next to the existing declaration example and as an explicit branch in the `$vars` Access Patterns block. 

(2) In-solution agent nodes were always emitted with `icon: "coded-agent"` because the doc told the skill to copy `.display.icon` from the registry manifest, which returns `"coded-agent"` for every in-solution agent. The fix replaces that instruction with filesystem-based detection: presence of `agent.json` in the sibling project -> `autonomous-agent`, otherwise `coded-agent`.
