### PR TITLE
docs(diagnostics): align maestro playbooks with top-20 production errors

### DIFF
--- a/skills/uipath-diagnostics/references/products/maestro/error_codes.md
+++ b/skills/uipath-diagnostics/references/products/maestro/error_codes.md
@@ -2,6 +2,8 @@
 
 Source: `UiPath.PO.Errors/ErrorCode.cs` + `ErrorCodeMessages.resx`
 
+For high-volume production errors, see the **Top-20 Production Errors** table at the bottom of this file. It links engine codes (and Orchestrator codes for non-engine surfaces) to ranked playbooks.
+
 ## Error Code Ranges
 
 | Range | Subsystem |
@@ -260,7 +262,7 @@ Source: `UiPath.PO.Errors/ErrorCode.cs` + `ErrorCodeMessages.resx`
 | 400006 | BpmnGenericWorkflowFailure | BPMN generic workflow failure |
 | 400007 | BpmnMarkerInputNullError | Input collection for the marker element must not be null |
 | 400008 | BpmnMarkerInputEvaluationFailure | Failed to evaluate the input collection variable for the marker element |
-| 400009 | ElementExecutionLoopDetected | This element has executed an abnormal number of times. Potential loop detected. |
+| 400009 | ElementExecutionLoopDetected | Possible loop detected: element 'X' has been executed more than 100 times. Failing the instance to prevent infinite loop. |
 | 400010 | CaseManagementInvalidJson | Invalid case management process metadata JSON format |
 | 400020 | CreateTriggersForEventSubProcessFailed | Failed to create triggers for Event SubProcess |
 | 400023 | CasePlanOverviewParseError | Failed to retrieve the case plan overview |
@@ -308,3 +310,32 @@ Source: `UiPath.PO.Errors/ErrorCode.cs` + `ErrorCodeMessages.resx`
 | 450011 | MaestroMessageSendEventBlobFailure | Failed to handle message publish |
 | 450012 | MaestroMessageSendFailure | Failed to send maestro message |
 | 450013 | MaestroMessageReceiverNotFound | Message receiver not found |
+
+## Top-20 Production Errors → Playbook Mapping
+
+Ranked by production telemetry volume. Source: [PO.BpmnEngine PR #3092 — `docs/error-catalog.md`](https://github.com/UiPath/PO.BpmnEngine/pull/3092). API-debuggability column tells you whether PIMS APIs alone are enough.
+
+| # | Error | HTTP | Engine code | Orch / connector code | API debug | Playbook |
+|---|-------|:----:|-------------|-----------------------|:---------:|----------|
+| 1 | Personal Automation quota exceeded | 502 | — | 170002 (propagated) | Full | [personal-automation-quota.md](./playbooks/personal-automation-quota.md) |
+| 2 | Job's associated process could not be found | 404 | — | 170007 | Partial | [process-not-found-404.md](./playbooks/process-not-found-404.md) |
+| 3 | No unattended robot permissions in folder | 409 | — | #1671 | Full | [unattended-robot-permissions.md](./playbooks/unattended-robot-permissions.md) |
+| 4 | Job Operation Timeout | 502 | — | — | Partial | [job-operation-timeout.md](./playbooks/job-operation-timeout.md) |
+| 5 | Input does not conform to schema | 400 | — | — | Full | [input-schema-mismatch.md](./playbooks/input-schema-mismatch.md) |
+| 6 | Missing value for required parameter | 400 | — | — | Full | [missing-required-parameter.md](./playbooks/missing-required-parameter.md) |
+| 7 | Generic Error_400 | 400 | — | — | None | [generic-error-400.md](./playbooks/generic-error-400.md) |
+| 8 | Expression evaluation — property not found | 400 | 400300 / 400301 / 400302 | — | Full | [expression-evaluation-errors.md](./playbooks/expression-evaluation-errors.md) |
+| 9 | No outgoing flow condition met | 400 | **400001 (NoOutgoingFlow)** | — | None* | [gateway-no-outgoing-flow.md](./playbooks/gateway-no-outgoing-flow.md) |
+| 10 | Loop detected (>100 executions) | 400 | **400009 (ElementExecutionLoopDetected)** | — | Partial | [loop-detected.md](./playbooks/loop-detected.md) |
+| 11 | 'File' field required | 502 | — | DAP-RT-1003 | Full | [file-field-required.md](./playbooks/file-field-required.md) |
+| 12 | Integration Services 404 | 404 | 102001 (IntSvcResourceNotFound) | — | None | [integration-service-404.md](./playbooks/integration-service-404.md) |
+| 13 | Insufficient funds / Agent Units | 400 | — | — | Full | [insufficient-funds.md](./playbooks/insufficient-funds.md) |
+| 14 | Marker element input collection is null | 400 | **400007 (BpmnMarkerInputNullError)** | — | Partial | [marker-input-null.md](./playbooks/marker-input-null.md) |
+| 15 | Integration Services 400 | 400 | 102003 (IntSvcBadRequest) | — | None | [integration-service-400.md](./playbooks/integration-service-400.md) |
+| 16 | Folder does not exist or no access | 400 | — | #1100 | Full | [folder-not-accessible.md](./playbooks/folder-not-accessible.md) |
+| 17 | No machine with Unattended/NonProduction runtimes | 409 | — | #2818 | Partial | [no-suitable-runtime-machine.md](./playbooks/no-suitable-runtime-machine.md) |
+| 18 | No Message events found | 400 | (450010 if `MaestroMessageReceiveFromBlobFailed`) | — | None | [no-message-events.md](./playbooks/no-message-events.md) |
+| 19 | Foreground job requires unattended robot | 409 | — | #1230 | Full | [foreground-unattended-robot.md](./playbooks/foreground-unattended-robot.md) |
+| 20 | Index outside bounds of array | 502 | — | — | None | [index-out-of-bounds.md](./playbooks/index-out-of-bounds.md) |
+
+> *\* Error #9 (`NoOutgoingFlow`) becomes Fully Diagnosable once [PR #3092](https://github.com/UiPath/PO.BpmnEngine/pull/3092) lands and the `IncludeGatewayDebugInfoInIncidents` targeted feature flag is enabled — incident `errorDetails` then includes all outgoing flow conditions, the default flow config, and variable values (truncated to 200 chars) at evaluation time.*

--- a/skills/uipath-diagnostics/references/products/maestro/investigation_guide.md
+++ b/skills/uipath-diagnostics/references/products/maestro/investigation_guide.md
@@ -20,6 +20,8 @@ Error codes appear in the Maestro incident detail view. Ask the user for the inc
 
 Full error code reference: [error_codes.md](./error_codes.md) — all error codes by subsystem with numeric values and messages.
 
+**Always check [summary.md](./summary.md) Top-20 table first** — it lists the highest-volume Maestro errors (by production telemetry) with direct playbook links and marks each one's API debuggability (Full / Partial / None). Route there before walking the range table below.
+
 Quick routing by range:
 
 | Range | Subsystem | Common action |
@@ -46,6 +48,33 @@ After the Orchestrator job data bundle (job details, logs, history) is collected
 3. **Full incident details** — `uip maestro instance incidents <instance-id> -f <folder-key>`. This returns `errorDetails` with stack traces. Do NOT use `uip maestro incident summary` — that returns summaries only without error details.
 4. **Element executions** — `uip maestro instance element-executions <instance-id> -f <folder-key>` to see what each BPMN element did and where execution stopped
 5. **Child jobs** — if the BPMN process has service tasks, list child jobs and check their state and error messages. The child's failure reason is often the actual root cause.
+
+## Top-20 Error Quick Route
+
+Match the error text/code in the incident to one of the highest-volume Maestro errors before doing a full investigation. Full table with playbook links: [summary.md](./summary.md).
+
+| Symptom hint | Playbook |
+|--------------|----------|
+| `Personal Automation quota` | [personal-automation-quota.md](./playbooks/personal-automation-quota.md) |
+| `job's associated process could not be found` / 170007 | [process-not-found-404.md](./playbooks/process-not-found-404.md) |
+| `unattended robot permissions in the current folder` / #1671 | [unattended-robot-permissions.md](./playbooks/unattended-robot-permissions.md) |
+| `Job Operation Timeout` | [job-operation-timeout.md](./playbooks/job-operation-timeout.md) |
+| `Input does not conform to schema` / `InputArgumentsSchema` | [input-schema-mismatch.md](./playbooks/input-schema-mismatch.md) |
+| `Missing value for required parameter` | [missing-required-parameter.md](./playbooks/missing-required-parameter.md) |
+| `Error_400` (no specific name) | [generic-error-400.md](./playbooks/generic-error-400.md) |
+| `Property 'X' not found against object of type ExpressionDictionary` | [expression-evaluation-errors.md](./playbooks/expression-evaluation-errors.md) |
+| `No condition for an outgoing flow was met` / 400001 | [gateway-no-outgoing-flow.md](./playbooks/gateway-no-outgoing-flow.md) |
+| `Possible loop detected` / 400009 | [loop-detected.md](./playbooks/loop-detected.md) |
+| `"File" field is required` / DAP-RT-1003 | [file-field-required.md](./playbooks/file-field-required.md) |
+| `Request to Integration Services failed with status code '404'` | [integration-service-404.md](./playbooks/integration-service-404.md) |
+| `Insufficient funds` / Agent Units | [insufficient-funds.md](./playbooks/insufficient-funds.md) |
+| `Input collection for the marker element must not be null` / 400007 | [marker-input-null.md](./playbooks/marker-input-null.md) |
+| `Request to Integration Services failed with status code '400'` | [integration-service-400.md](./playbooks/integration-service-400.md) |
+| `Folder does not exist or the user does not have access` / #1100 | [folder-not-accessible.md](./playbooks/folder-not-accessible.md) |
+| `Could not find a machine with Unattended or NonProduction runtimes` / #2818 | [no-suitable-runtime-machine.md](./playbooks/no-suitable-runtime-machine.md) |
+| `No Message events found` / `No File events found` | [no-message-events.md](./playbooks/no-message-events.md) |
+| `Foreground job requires an unattended robot` / #1230 | [foreground-unattended-robot.md](./playbooks/foreground-unattended-robot.md) |
+| `Index was outside the bounds of the array` | [index-out-of-bounds.md](./playbooks/index-out-of-bounds.md) |
 
 ## Testing Prerequisites
 

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/argument-mismatch-400.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/argument-mismatch-400.md
@@ -1,5 +1,5 @@
 ---
-confidence: high
+confidence: medium
 ---
 
 # Invalid Status Code 400 — Argument Mismatch
@@ -7,19 +7,29 @@ confidence: high
 ## Context
 
 What this looks like:
-- HTTP 400 error
-- "Argument values did not match definitions"
+- HTTP 400 with `Argument values did not match definitions` or similar
+- Often a sibling of the more specific top-20 errors:
+  - [input-schema-mismatch](input-schema-mismatch.md) — full payload schema mismatch on workflow/agent start
+  - [missing-required-parameter](missing-required-parameter.md) — a single named required field is absent
 
 What can cause it:
-- Arguments supplied do not match expected types or schema
-- Incorrect number or order of arguments passed to a service task or API call
+- Arguments do not match the consuming activity's expected types or schema
+- Wrong number or order of arguments passed to a service task or API call
+- A workflow input renamed without updating callers
+
+What to look for:
+- Whether the error names a single field (→ [missing-required-parameter](missing-required-parameter.md))
+- Whether the error mentions schema conformance broadly (→ [input-schema-mismatch](input-schema-mismatch.md))
+- Otherwise, the activity's argument signature vs what's being passed
 
 ## Investigation
 
-1. Compare the argument definitions in the workflow against what is being passed
-2. Check argument types and order
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull the inputs sent to the failing activity: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json`
+3. Compare against the activity's argument definitions in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 
-- Fix argument definitions in the workflow or consuming activities to match the expected schema
-- Validate payload structure before API or activity calls
+- Fix the argument mapping in the workflow or consuming activity to match the expected definitions
+- Validate payload structure (types, order, names) before API or activity calls
+- For more specific failures, route to [input-schema-mismatch](input-schema-mismatch.md) or [missing-required-parameter](missing-required-parameter.md)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/expression-evaluation-errors.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/expression-evaluation-errors.md
@@ -1,37 +1,49 @@
 ---
-confidence: medium
+confidence: high
 ---
 
-# Expression Evaluation and Input Errors
+# Expression Evaluation — Property Not Found
 
 ## Context
 
 What this looks like:
-- Errors during evaluation of activity inputs
-- Missing or null parameters at runtime
-- Job faulted due to null input value during GUID parsing
+- HTTP 400 with `Error evaluating expression in activity inputs for element: ...`
+- `Property 'X' not found against object of type ExpressionDictionary`
+- "Expression could not be parameterized" in parallel multi-instance subprocesses
+- Job faulted due to null input during GUID parsing
+- Ternary expressions failing in C# due to type erasure in Dynamic Expresso
+- Underlying engine codes: `400300` (`InputVariablesEvaluationError`), `400301` (`ExpressionEvaluationError`), `400302` (`FlowExpressionEvaluationError` — gateway flows)
 
 What can cause it:
-- Input arguments not passed from previous activities
-- Null or empty values from data sources
-- Incorrect variable assignments or missing default values
-- Upstream activity failed to set or fetch a required value
+- Expression references a variable/property that does not exist in the variable dictionary at evaluation time (typo, never assigned, conditionally assigned on a path not taken)
+- Property casing — objects wrapped in `ExpressionDictionary` expose lowercase property accessors (e.g., `vars.error.detail` works, `vars.error.Detail` does not)
+- Iterator references inside parallel multi-instance subprocesses were not supported historically — known workaround was to use embedded subprocess
+- C# ternary type-erasure bug in Dynamic Expresso — known workaround is to switch to JS expressions (`=js:` prefix)
+- Script Task iterator references unresolved by the engine (fix shipped in alpha and rolled forward)
+- Upstream activity failed silently and left the consumed variable unset
 
 What to look for:
-- Check which activity input is failing
-- Trace the data flow from the source activity to the failing activity
-- Check for null checks on critical values
+- The exact property/variable name in `errorDetails`
+- Whether the variable is initialized on every execution path that leads to this expression
+- Whether the expression is C# or JS — both have distinct known bugs
 
 ## Investigation
 
-1. Identify the exact error and which input/variable is null or missing
-2. Trace the input data flow through the workflow — which activity should have set the value
-3. Check if the upstream activity completed successfully and produced the expected output
-4. Check for default values on critical input arguments
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — `errorDetails` includes the full expression
+2. Pull the variables snapshot at the failing element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — confirm whether the referenced variable exists and what's defined
+3. Walk element executions to find an upstream branch that should have initialized the variable: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+4. Inspect the expression in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 
-- **If missing input:** fix the variable mapping between the source and consuming activities
-- **If null value:** add null checks before parsing values such as GUIDs
-- **If upstream failure:** fix the upstream activity that should have set the value
-- **If no default:** set default values for critical input arguments
+- **If typo / missing variable:** correct the name; use Maestro Expression Editor autocomplete (Ctrl+Space). The "Fix variables" dialog flags broken references
+- **If casing mismatch on `ExpressionDictionary`:** access nested properties in lowercase (e.g., `vars.error.detail`)
+- **If variable conditionally assigned:** initialize the variable on all paths or default it at the process start
+- **If parallel multi-instance + iterator reference fails:** switch to embedded subprocess, or upgrade to a Maestro version where the parallel marker on the subprocess is supported
+- **If C# ternary type-erasure:** rewrite as JS expression with `=js:` prefix
+- **If null on GUID parse:** add a null check before parsing
+- **If upstream silently failed:** fix the upstream task or add a boundary error event so the failure surfaces
+
+## References
+
+- [Docs: Variables and Expression Editor](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/variables-and-expression-editor)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/file-field-required.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/file-field-required.md
@@ -1,0 +1,42 @@
+---
+confidence: high
+---
+
+# 'File' Field Required — DAP-RT-1003 (502)
+
+## Context
+
+What this looks like:
+- HTTP 502 surfaced by Maestro
+- Error message: `The "File" field is required. Error code: DAP-RT-1003.`
+- Always raised by an Integration Service activity that expects a file input (typically Document Understanding or GenAI activities)
+
+What can cause it:
+- The `File` input on the activity is unmapped or mapped to a variable that is `null`/empty at runtime
+- The upstream activity that should have produced the file failed silently and left the file variable unset
+- File was previously linked to an Orchestrator job whose retention expired (orphaned attachment — see [attachment-not-found](attachment-not-found.md))
+- File variable defined as a process variable instead of an argument, breaking the binding in deployed mode
+
+What to look for:
+- The activity's `elementId` from the incident → confirm it's a DU/GenAI step
+- Variables API: is the file variable `null`?
+- The upstream activity's status — did it actually produce a file?
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — incident `elementId` identifies the failing activity
+2. Pull the variables for that element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — confirm the file variable is null
+3. Trace upstream element executions to see where the file should have been produced: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+4. If the file came from a previous job, check whether job retention has elapsed (see [attachment-not-found](attachment-not-found.md))
+
+## Resolution
+
+- **If unmapped input:** map the activity's `File` input to a non-null variable in the BPMN task's input mapping
+- **If upstream failure:** fix the upstream activity that should have populated the file; add a boundary error event or a null check before the DU/GenAI step
+- **If null on optional path:** add an exclusive gateway before the DU/GenAI step that skips it when the file is null
+- **If attachment orphaned by retention:** redesign so files come from a stable source (Data Fabric, storage bucket) rather than from a job attachment — see [attachment-not-found](attachment-not-found.md)
+- **If file modeled as a variable:** convert it to an argument so binding resolution works in deployed mode
+
+## References
+
+- [Docs: About Integration Service Activities](https://docs.uipath.com/activities/other/latest/integration-service/about-the-integration-service-activities)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/folder-not-accessible.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/folder-not-accessible.md
@@ -1,0 +1,45 @@
+---
+confidence: high
+---
+
+# Folder Does Not Exist or No Access (400, #1100)
+
+## Context
+
+What this looks like:
+- HTTP 400 (sometimes 403) from Orchestrator surfaced by Maestro
+- Error message: `Operation returned invalid status code '400'. Folder does not exist or the user does not have access to the folder.`
+- Orchestrator error code `#1100`
+
+What can cause it:
+- Robot/user account is not assigned to the target folder
+- Folder name contains characters Maestro's folder-path resolver historically chokes on — e.g., commas (`"Autopilot, Agentic, and Gen AI"` triggered `PLT-82739`)
+- Folder was renamed or deleted; bindings still reference the old path or key
+- Solution imported across environments (staging → alpha) where folder keys differ — keys were baked into the solution
+- API call missing or pointing the `X-UIPATH-OrganizationUnitId` header at the wrong folder
+- Modern folder permissions missing at tenant level (need both tenant-level access and folder-level role)
+
+What to look for:
+- `folderKey` in the incident — does it actually exist in Orchestrator?
+- Whether the folder name contains commas or other unusual characters
+- Whether the solution was recently imported from another environment
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Verify the folder exists: `uip or folders list --output json` — search by `Key`
+3. List users on that folder: `uip or folders users list <folder-key> --output json` — is the robot account assigned?
+4. Check the underlying bindings — request `bindings_v2.json` (deployed) or `debug_overwrites.json` (debug)
+5. If the folder contains commas in its name, suspect the historical path-resolver bug
+
+## Resolution
+
+- **If user/robot not assigned:** assign with the appropriate role at Orchestrator → **Folder > Manage Access > Assign**
+- **If folder name contains comma:** rename the folder to remove the comma; re-publish so bindings refresh
+- **If solution cross-imported:** update bindings to the destination folder keys; re-deploy
+- **If API call:** include the correct `X-UIPATH-OrganizationUnitId` header
+- **If modern folder permissions:** ensure tenant-level access AND folder-level role for the account
+
+## References
+
+- [Forum: Error code #1100](https://forum.uipath.com/t/folder-does-not-exist-or-the-user-does-not-have-access-to-the-folder-error-code-1100/541536)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/foreground-unattended-robot.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/foreground-unattended-robot.md
@@ -1,0 +1,43 @@
+---
+confidence: high
+---
+
+# Foreground Job Requires Unattended Robot (409, #1230)
+
+## Context
+
+What this looks like:
+- HTTP 409 from Orchestrator surfaced by Maestro
+- Error message: `Operation returned invalid status code '409'. Foreground job requires an unattended robot to be defined on your user`
+- Orchestrator error code `#1230`
+
+What can cause it:
+- The user triggering a foreground (UI-interactive) unattended job has no unattended robot configured
+- Underlying RPA project is a Studio (desktop) project running in **My Workspace**, which doesn't allow assigning bots/machines
+- User has Unattended runtime license at tenant level but no machine credentials configured
+- Debug-only manifestation — deployed flows running under a different identity work fine
+
+What to look for:
+- Whether the underlying RPA project is Studio (desktop, `.xaml`) or Studio Web (Agentless/Serverless)
+- Whether the folder is "My Workspace" vs a standard folder
+- Whether the user has unattended machine credentials configured
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Confirm the user has Unattended Robot enabled: Orchestrator UI → **Tenant > Manage Access > Users** → select user → license tab
+3. Check that machine credentials are set (domain\username + password)
+4. Confirm the folder type — "My Workspace" cannot host unattended robots
+5. Identify the underlying RPA project type from the service task's binding
+
+## Resolution
+
+- **If user lacks Unattended enabled:** enable "Unattended Robot" on the user and assign valid machine credentials
+- **If running from My Workspace:** move the process to a standard folder where unattended bots can be assigned
+- **If Studio (desktop) project:** rebuild in Studio Web so the workflow runs on Agentless/Serverless and no unattended bot is needed
+- **If runtime license missing:** assign an Unattended runtime license to the user
+- **If debug-only and deployed works:** debug runs under the user's identity, deployed under the robot's — provision an unattended robot on the user, or run via deployed mode
+
+## References
+
+- [Forum: Error #1230](https://forum.uipath.com/t/foreground-job-requires-an-unattended-robot-to-be-defined-on-your-user-1230/718082)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/gateway-no-outgoing-flow.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/gateway-no-outgoing-flow.md
@@ -1,0 +1,51 @@
+---
+confidence: high
+---
+
+# No Outgoing Flow Condition Met (400001)
+
+## Context
+
+What this looks like:
+- HTTP 400, Maestro error code `400001` (`NoOutgoingFlow`)
+- Error message: `No condition for an outgoing flow was met. At least one outgoing flow condition needs to evaluate to true or have a default flow.`
+- Always raised by an Exclusive or Inclusive Gateway
+
+What can cause it:
+- All outgoing sequence flow conditions evaluated to `false` and no default flow was configured
+- Variable ID mismatch — designer-side bug where renaming a variable leaves expressions bound to the old variable ID, so they read the wrong value
+- Boolean variable populated via Actionable Messages (email approval) arriving in an unexpected shape
+- Condition expressions reference a variable that is uninitialized on some execution paths
+
+What to look for:
+- The gateway name in `errorDetails` and the variables it depends on
+- Whether a default flow is configured on the gateway in the BPMN XML
+- Whether any variable was renamed recently in Studio Web
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. **If `IncludeGatewayDebugInfoInIncidents` is enabled** ([PO.BpmnEngine PR #3092](https://github.com/UiPath/PO.BpmnEngine/pull/3092)): `errorDetails` already lists each outgoing flow's condition expression, the default flow config, and variable values at evaluation time — no further data gathering needed
+3. **If the flag is not enabled:** pull the BPMN XML to read gateway conditions: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+4. Pull the variables snapshot just before the gateway element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <gateway-id> --output json`
+5. Walk element executions to confirm which gateway: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+
+## Resolution
+
+- **If no default flow:** add a default flow on the gateway in the BPMN modeler — set one outgoing sequence flow as the default; this path is taken when no conditions match
+- **If conditions are not exhaustive:** broaden the conditions to cover all possible runtime values
+- **If variable ID mismatch after rename:** open the gateway in Studio Web and **re-select** the correct variable in each condition expression; do not just retype the name
+- **If variable is uninitialized on some paths:** assign a default earlier in the flow so the variable is always defined before reaching the gateway
+- **If actionable messages payload:** verify the boolean comes back in the expected shape; consider routing through Action Center if Actionable Messages keeps yielding unexpected values
+
+## Notes
+
+- Pre-PR #3092: this error is **Not Diagnosable** from PIMS API alone — agents had to ask the user for the `.bpmn` and walk variables manually
+- Post-PR #3092 with the targeted feature flag enabled: this error is **Fully Diagnosable** — incident `errorDetails` contains everything needed
+- Variable values in enriched `errorDetails` are truncated to 200 chars per variable
+
+## References
+
+- [PR #3092 — Enrich NoOutgoingFlow incident with gateway debug info](https://github.com/UiPath/PO.BpmnEngine/pull/3092)
+- [Docs: Gateways and Flow Logic](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/gateways-flow-logic)
+- [Docs: Gateways](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/gateways)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/generic-error-400.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/generic-error-400.md
@@ -1,0 +1,48 @@
+---
+confidence: low
+---
+
+# Generic Error_400 — Bad Request With No Details
+
+## Context
+
+What this looks like:
+- Error code: `400`, error name: `Error_400` (no specific name)
+- Incident `errorDetails` is empty or non-actionable
+- API data alone is not enough to root-cause — must inspect upstream response body
+
+What can cause it:
+- Malformed JSON payload
+- Request headers too long (HA setups with mismatched token-signing certs)
+- Invalid `Content-Type` (must be `application/json`)
+- Expired auth token
+- Maestro frontend bug — historically `MST-4535` "actionable messages" feature surfaced as generic 400 when a new app version was available
+
+What to look for:
+- Whether actionable messages toggle is enabled on the failing app — if yes, this is the known frontend bug
+- Whether the workflow uses a custom HTTP request task with hand-crafted headers/body
+- Whether the issue is tied to a specific HA tenant
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — capture any HTTP body returned upstream
+2. Pull the activity inputs to see what was actually sent: `uip maestro instance variables <instance-id> -f <folder-key> --output json`
+3. If the failing element is an Action App task with actionable messages enabled, jump straight to the `MST-4535` resolution
+4. For HA setups, request platform logs from the Maestro service — generic 400 here often points to token-signing certificate mismatch across nodes
+
+## Resolution
+
+- **If actionable messages bug (`MST-4535`):** turn OFF the "Enable actionable messages" toggle on the Action App task. Frontend fix is deployed to disable by default — re-publish to pick it up
+- **If malformed JSON:** validate the payload structure
+- **If Content-Type:** set `application/json`
+- **If expired token:** rotate the auth token and retry
+- **If HA token-signing mismatch:** sync the token-signing certificates across all nodes (platform/infra owner)
+
+## Notes
+
+- This error is **Not Diagnosable** from PIMS API alone — full root cause typically requires ADX logs or Temporal history
+- When the incident gives nothing useful, ask the user for the failing element name and whether they recently re-published the app
+
+## References
+
+- [Forum: 400 Bad Request](https://forum.uipath.com/t/400-bad-request/506399)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/index-out-of-bounds.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/index-out-of-bounds.md
@@ -1,0 +1,46 @@
+---
+confidence: low
+---
+
+# Index Outside Bounds of Array (502)
+
+## Context
+
+What this looks like:
+- HTTP 502 surfaced by Maestro with `System.IndexOutOfRangeException`
+- Error message: `Index was outside the bounds of the array.`
+- No actionable detail in `errorDetails` beyond the stack trace
+
+What can cause it:
+- Server-side bug — engine accessed an array slot that doesn't exist
+- Incorrect Orchestrator URL (trailing slash, wrong tenant path) causing client init to read past expected segments
+- Culture data initialization failure on the host
+- Re-entry into an already-executed parallel multi-instance subprocess — historical case where a follow-up workflow updated files and tried to re-run prior steps
+
+What to look for:
+- Stack trace in `errorDetails` — what component is throwing
+- Whether the workflow loops back into a parallel multi-instance subprocess
+- Whether the Orchestrator URL in the tenant settings is well-formed
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — preserve the full stack trace
+2. Walk element executions: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json` — note the element that faulted
+3. Check whether the workflow attempted to re-enter a multi-instance subprocess that already completed
+4. If reproducible, gather: Orchestrator URL config, exact `.bpmn`, sample inputs
+
+## Resolution
+
+- **If re-entry into completed multi-instance subprocess:** redesign so the follow-up path uses a fresh subprocess instead of re-entering the original
+- **If bad Orchestrator URL:** correct the tenant URL (no trailing slash, correct tenant path)
+- **If stack trace points at culture data:** escalate to platform/infra — server-side fix needed
+- **If no actionable root cause from the stack trace:** open a UiPath support ticket with the full stack trace, the `.bpmn`, the instance ID, and a minimal repro
+
+## Notes
+
+- This error is **Not Diagnosable** to a user-actionable fix from PIMS API alone — it almost always indicates a platform bug. Capture the stack trace and escalate
+
+## References
+
+- [Docs: Orchestrator Exceptions](https://docs.uipath.com/orchestrator/standalone/2024.10/installation-guide/orchestrator-exceptions)
+- [Forum: Index was outside the bounds](https://forum.uipath.com/t/could-not-create-orchestrator-client-exception-index-was-outside-the-bounds-of-the-array/799616)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/input-schema-mismatch.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/input-schema-mismatch.md
@@ -1,0 +1,44 @@
+---
+confidence: high
+---
+
+# Input Does Not Conform to Schema (400)
+
+## Context
+
+What this looks like:
+- HTTP 400 at workflow/agent start
+- Error message: `Input does not conform to schema` or `Agent.InputArgumentsSchema` error
+- Variants: `"Value is 'null' but should be 'object'"` when an optional file/attachment is null
+- Used to work, suddenly fails after a new version was published
+
+What can cause it:
+- Provided inputs do not match the JSON schema declared on the process/agent: wrong types, missing required fields, extra fields, or unsupported types
+- For queue transactions: `DateTime` must be passed as string; arrays are not supported
+- Optional file/attachment parameters passed as `null` — schema rejects `null` where it expects an `object`
+- Newly published version added a required parameter (e.g., `modelName` on GenAI activities) that older callers don't pass
+- Stale agent metadata from a previous publish — Maestro still references the old `InputArgumentsSchema`
+
+What to look for:
+- Compare the actual payload (Variables API) against the agent's/process's declared input schema (`inputDefinitions`)
+- Confirm whether the failure started after a new package version was deployed
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull the actual inputs and the schema: `uip maestro instance variables <instance-id> -f <folder-key> --output json` — compare values vs `inputDefinitions`
+3. Identify the failing parameter from `errorDetails` — the schema validator names the offending field/type
+4. Check the package version that introduced the breaking change — list releases and diff schemas
+
+## Resolution
+
+- **If type/field mismatch:** correct the payload to match the schema exactly (types, required fields, no extras)
+- **If null optional file/attachment:** either omit the field entirely or pass a valid empty-shaped object the schema accepts
+- **If queue payload:** convert `DateTime` to string; flatten arrays
+- **If new required parameter added:** make it optional with a default value, or update all callers
+- **If stale agent metadata:** delete the deployed agent and let the next solution publish re-create it (last-resort workaround)
+
+## References
+
+- [Docs: About Input and Output Arguments](https://docs.uipath.com/orchestrator/standalone/2023.4/user-guide/about-input-and-output-arguments)
+- [Docs: About Queues and Transactions](https://docs.uipath.com/orchestrator/standalone/2024.10/user-guide/about-queues-and-transactions)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/insufficient-funds.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/insufficient-funds.md
@@ -1,0 +1,41 @@
+---
+confidence: high
+---
+
+# Insufficient Funds / Agent Units (400)
+
+## Context
+
+What this looks like:
+- HTTP 400 from an agent or GenAI activity
+- Error message: `Insufficient funds: Your account doesn't have enough credits for execution. Please add funds or contact your administrator for assistance.`
+
+What can cause it:
+- Tenant has exhausted its Agent Units (AU) allocation — agents and GenAI activities consume AU on every LLM call
+- Community Edition free-tier credits exhausted (reset monthly)
+- Enterprise subscription on a Flex license without AU allocated
+- Known bug (~early 2026): Maestro debug incorrectly required AU even though standalone Agent debug did not; impacted customers without AU even when they expected debug to be free
+
+What to look for:
+- Whether the failing element is an Agent or GenAI activity — non-agent processes do not consume AU
+- Tenant AU balance — exhausted vs not allocated
+- Debug vs deployed — historical bug only affected debug mode
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — error message is self-explanatory
+2. Confirm the element type: agent/GenAI vs other
+3. Check AU balance: Orchestrator UI → **Admin > Tenant > Licenses > Consumption > Agent Units**
+4. Verify debug-mode behaviour against the latest Maestro release notes — the debug-consumes-AU bug had a planned fix in late Feb / mid-March 2026
+
+## Resolution
+
+- **If AU exhausted on Enterprise:** purchase / allocate more via **Admin > Organization > Subscriptions** or contact the UiPath account manager
+- **If Community / Flex with no AU:** request promo units or upgrade to a plan that includes AU
+- **If only failing in debug:** confirm the Maestro deploy includes the fix for the debug-mode AU bug; if not, request rollout or escalate to the Maestro team
+- **If the process should not need AU at all:** verify no Agent/GenAI activities are accidentally present in the path being executed
+
+## References
+
+- [Docs: Purchasing a Plan](https://docs.uipath.com/automation-cloud/automation-cloud/latest/admin-guide/purchasing-a-plan)
+- [Forum: Insufficient funds](https://forum.uipath.com/t/agent-baseerror-insufficient-funds-your-account-doesnt-have-enough-credits-for-execution/5726606)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/integration-service-400.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/integration-service-400.md
@@ -1,0 +1,48 @@
+---
+confidence: medium
+---
+
+# Integration Services 400 — Bad Request to Connector
+
+## Context
+
+What this looks like:
+- HTTP 400 from an Integration Service call
+- Error message: `Request to Integration Services failed with status code '400'`
+- Often paired with a connector-side error body (multipart parse failure, schema mismatch, etc.)
+
+What can cause it:
+- Malformed or invalid request body for the connector action
+- Connector update changed expected `Content-Type` (e.g., Outlook moved from `application/json` to `multipart/form-data` for attachments) breaking already-published activities — historical bug `ENGCE-46376`
+- A previously-bound variable was removed but the connector activity still references it, sending an empty string `""` instead of `null` (Office 365 Send Email historical issue, `PLT-77820`)
+- Mismatched connector input schema after a connector version bump
+- Bad connection state (token, scopes) — connection should be re-provisioned
+
+What to look for:
+- Connector name / action from `errorDetails` and element executions
+- Whether the failure started after a connector update or Maestro publish
+- Whether the same action works against a freshly-recreated connector activity
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — capture upstream connector error body
+2. Identify the failing connector activity and connection: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+3. Pull the activity inputs: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — look for empty strings where nulls are expected, missing required fields, or wrong types
+4. Check the connection's health in Orchestrator UI → **Integration Service > Connections** — re-authenticate if expired
+5. Look up the connector version and compare against the version when the workflow was last published
+
+## Resolution
+
+- **If empty string from removed variable:** delete and re-add the connector step so it stops referencing the orphaned variable
+- **If `Content-Type` / multipart mismatch after connector update:** delete and re-add the activity to pick up the new schema
+- **If schema bump:** update the inputs to match the new schema or pin to the prior connector version where supported
+- **If connection in bad state:** re-provision the connection, then re-publish or rebind the activity
+- **If genuinely malformed payload:** validate the input JSON against the connector spec
+
+## Notes
+
+- This error is **Not Diagnosable** from PIMS API alone — incident lacks the actual HTTP request that went to IS and the connector configuration details. Plan to log a connector telemetry ask if this becomes common in your investigation
+
+## References
+
+- [Docs: Connections Troubleshooting](https://docs.uipath.com/integration-service/automation-cloud/latest/user-guide/connections-troubleshooting)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/integration-service-404.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/integration-service-404.md
@@ -7,20 +7,45 @@ confidence: medium
 ## Context
 
 What this looks like:
-- HTTP 404 during an Integration Service call
-- Resource or endpoint not found
+- HTTP 404 from an Integration Service call
+- Error message: `Request to Integration Services failed with status code '404'`
+- Sometimes seen with a related text like `Invalid Element Instance Id provided.` or `Missing instance` (Data Fabric writes)
 
 What can cause it:
-- Incorrect or outdated endpoint URL in the connection configuration
-- Target resource does not exist or is misconfigured in the external service
+- Connector or action was deleted/renamed since publish
+- Integration Service connection expired or was removed
+- Tenant doesn't have Integration Service enabled (**Admin > Tenant > Services**)
+- Webhook config references a non-existent object on the external side
+- Solution cross-imported between environments (staging → alpha) where the folder key embedded in the solution doesn't exist in the destination — surfaces as 404/403
+- For Data Fabric writes: missing instance, folder, or tenant permission on the target
+
+What to look for:
+- The connector name and action attempted — Variables API + element executions
+- Whether the failure started right after a solution import or connector rename
+- Connection state in the IS UI
 
 ## Investigation
 
-1. Verify the endpoint URL in the Integration Service connection configuration
-2. Check if the target resource exists in the external service
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Identify the failing connector activity: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+3. Check the IS connection: Orchestrator UI → **Integration Service > Connections** — verify exists, not expired
+4. Confirm IS is enabled on the tenant
+5. For Data Fabric writes, verify the target entity/instance exists in the destination folder and the robot has permission
 
 ## Resolution
 
-- Update endpoint URLs in the connection configuration
-- Ensure target resources are available and correctly named in the external service
-- Coordinate with integration service owners for API changes
+- **If connection expired:** re-authenticate; re-publish the process if needed
+- **If connector deleted/renamed:** re-create the activity against the current connector and re-publish
+- **If IS not enabled on the tenant:** enable via **Admin > Tenant > Services**
+- **If webhook config stale:** regenerate the webhook URL and update the external system
+- **If solution cross-imported with stale keys:** update bindings to the destination folder keys and re-deploy
+- **If Data Fabric target missing:** create the entity/instance in the destination folder, or fix the binding
+
+## Notes
+
+- This error is **Not Diagnosable** from PIMS API alone — incident lacks the connector name, connection ID, and action attempted. Expect to ask the user for the failing element name; planned enrichment in incident data would move this to "Full"
+
+## References
+
+- [Forum: IS resource not found in Community Cloud](https://forum.uipath.com/t/persistent-integration-services-resource-not-found-error-in-community-cloud/5712850)
+- [Docs: Connections Troubleshooting](https://docs.uipath.com/integration-service/automation-cloud/latest/user-guide/connections-troubleshooting)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/job-operation-timeout.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/job-operation-timeout.md
@@ -1,0 +1,41 @@
+---
+confidence: medium
+---
+
+# Job Operation Timeout (502)
+
+## Context
+
+What this looks like:
+- HTTP 502 with error message `Job Operation Timeout`
+- Job appears completed in Orchestrator logs but Maestro reports timeout
+- Instance stuck several minutes past the underlying job's actual end time
+
+What can cause it:
+- A gateway/proxy (Azure Application Gateway, Cloudflare, nginx) times out before Orchestrator returns. Typical with synchronous call mode where the HTTP connection is held until the job completes
+- Many concurrent action-center tasks each spawning a job — resource contention pushes individual call latency past the gateway threshold
+- Serverless/coded RPA timing out at the serverless layer ("automation cancelled because it reached the time limit") — root cause is on the robot side, not Maestro (tracked in past Slack threads as `MST-6379`)
+
+What to look for:
+- Whether the underlying child job is actually `Successful` in Orchestrator while Maestro reports timeout — indicates gateway timeout, not runtime failure
+- Whether the same workflow times out on subsequent runs — points at sustained gateway/proxy limits
+- Concurrent task volume on the folder
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull element executions and capture start/complete times of the timing-out activity: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+3. Locate the child Orchestrator job ID from the incident `errorDetails` and check its final state: `uip or jobs get <child-job-key> --output json`
+4. If the child job is `Successful` but Maestro 502'd, the gateway timed out before Orchestrator's response landed
+
+## Resolution
+
+- **If using synchronous call mode:** switch to **asynchronous** call mode — Maestro polls the status URI instead of holding a connection
+- **If behind a reverse proxy:** increase the request timeout on the backend (Application Gateway / nginx / Cloudflare)
+- **If serverless/coded RPA timeout:** check the serverless robot logs, raise the time limit on the coded automation, or split the workflow
+- **If many concurrent jobs:** stagger the triggers or add a multi-instance marker with a smaller batch instead of one job per task
+
+## References
+
+- [Docs: Call modes explained](https://docs.uipath.com/orchestrator/automation-cloud/latest/user-guide/call-modes-explained)
+- [Docs: Frequently Encountered Orchestrator Errors](https://docs.uipath.com/orchestrator/docs/frequently-encountered-orchestrator-errors)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/loop-detected.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/loop-detected.md
@@ -1,0 +1,41 @@
+---
+confidence: high
+---
+
+# Element Execution Loop Detected (400009)
+
+## Context
+
+What this looks like:
+- HTTP 400, Maestro error code `400009` (`ElementExecutionLoopDetected`)
+- Error message: `Possible loop detected: element 'X' has been executed more than 100 times. Failing the instance to prevent infinite loop.`
+- Process was making progress, then engine kills the instance at iteration 101
+
+What can cause it:
+- Element exceeded `MaxElementExecutionCount` (default: 100)
+- A control-loop exit condition never evaluates `true` (counter not incrementing, wrong comparison, variable not updated inside loop body)
+- Legitimate large-batch workflow (e.g., 2000 queue items processed via gateway loop instead of marker)
+
+What to look for:
+- Element name and iteration count from `errorDetails`
+- The exit condition expression — does it actually reference the variable that the loop body updates?
+- Whether the workflow uses an explicit gateway loop or a multi-instance marker
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — captures element ID and iteration count
+2. Walk element executions to see what each iteration produced: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+3. Pull the variables snapshot near the loop element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — look for the loop counter / exit condition variable
+4. Read the loop condition from the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+
+## Resolution
+
+- **If counter not incrementing or wrong operator:** fix the loop body so the exit condition can eventually evaluate `true`
+- **If legitimate large-batch processing:** redesign with a multi-instance marker (parallel or sequential) instead of a gateway loop — markers avoid loop detection entirely because there is no explicit loop element in the BPMN
+- **If process genuinely needs >100 iterations of one element:** request the server-side `MaxElementExecutionCount` be raised via an environment-level feature flag (platform team)
+- **If variable not updated inside loop body:** ensure the assignment happens before the gateway re-evaluates
+
+## References
+
+- [Docs: Looping](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/repetition)
+- [Docs: BPMN Patterns and Practices](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/common-modeling-patterns)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/marker-input-null.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/marker-input-null.md
@@ -1,0 +1,42 @@
+---
+confidence: high
+---
+
+# Marker Input Collection Is Null (400007)
+
+## Context
+
+What this looks like:
+- HTTP 400, Maestro error code `400007` (`BpmnMarkerInputNullError`)
+- Error message: `Input collection for the marker element must not be null`
+- Sometimes seen alongside the related evaluation error `400008` (`BpmnMarkerInputEvaluationFailure`) — see [marker-invalid-cast](marker-invalid-cast.md) for the JS array cast bug
+
+What can cause it:
+- The variable referenced in the multi-instance marker's "Items" property is `null` at runtime (never assigned, or upstream task didn't produce the list)
+- A `NullReferenceException` in `BpmnExecution.cs` where a marker input was assumed non-null but the underlying success value was null (known internal bug; tracked historically — fix replaces `!` null-forgiving with `?? throw`)
+- User Task multi-instance "items" passed a malformed JSON array (e.g., a stringified array instead of a real array)
+
+What to look for:
+- The marker's `elementId` from the incident
+- Variables API: confirm the collection variable is actually `null` (vs empty array, which behaves differently)
+- Upstream element that should have produced the collection
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull variables scoped to the marker element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <marker-element-id> --output json` — verify the "Items" variable is null
+3. Walk element executions to find the upstream task that was supposed to produce the collection: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+4. Inspect the marker's "Items" expression in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+
+## Resolution
+
+- **If upstream task produced nothing:** fix the upstream task or add an exclusive gateway that skips the marker when the collection is null/empty
+- **If variable was renamed / unbound:** re-select the collection variable in the marker's "Items" property
+- **If malformed JSON array on User Task:** ensure callers construct a real JSON array, not a stringified one
+- **If you suspect the internal null-forgiving bug:** request the Maestro engine team confirm the `BpmnExecution.cs` fix is deployed in your region; in the meantime ensure the upstream activity never returns a null wrapper
+- **If using JS expression and seeing `InvalidCastException`:** switch to C# expressions and see [marker-invalid-cast](marker-invalid-cast.md)
+
+## References
+
+- [Docs: Multi-instance markers](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/markers-implementation)
+- [Docs: Markers](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/markers)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/marker-invalid-cast.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/marker-invalid-cast.md
@@ -2,23 +2,34 @@
 confidence: high
 ---
 
-# Multi-Instance Marker InvalidCastException
+# Multi-Instance Marker InvalidCastException (400008)
 
 ## Context
 
 What this looks like:
-- "Failed to evaluate the input collection variable for the marker element"
-- InvalidCastException: System.Object[] to ExpressionList
+- HTTP 400, Maestro error code `400008` (`BpmnMarkerInputEvaluationFailure`)
+- Error message: `Failed to evaluate the input collection variable for the marker element`
+- Inner exception: `InvalidCastException: System.Object[] to ExpressionList`
+- Sibling: see [marker-input-null](marker-input-null.md) when the collection is null (error `400007`)
 
 What can cause it:
-- Bug in Jint-based JS expression evaluator where JS arrays cannot be cast to the internal ExpressionList type expected by the BPMN engine
+- Bug in `JavaScriptEvaluator.cs` — JS expression returns `Object[]` which cannot be cast to the internal `ExpressionList` type the BPMN engine expects on a multi-instance marker
+
+What to look for:
+- Whether the marker's "Items" expression uses `=js:` (JavaScript) — that's the trigger
+- Whether the same logic written as C# works
 
 ## Investigation
 
-1. Confirm the marker input collection uses a JavaScript expression
-2. Check if the error is InvalidCastException referencing ExpressionList
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — confirm `InvalidCastException` and `ExpressionList`
+2. Check the marker's "Items" expression language in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 
-- Switch the marker input collection expression from JavaScript to C# expressions
-- Verify the parallel marker executes successfully with all list items
+- Switch the marker's "Items" expression from JavaScript to a C# expression that returns a typed list/array
+- Re-publish and re-run; the parallel marker should iterate all items
+- If switching to C# is not feasible, work around by materializing the JS array into a typed collection variable in a preceding Script task
+
+## References
+
+- [Docs: Multi-instance markers](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/markers-implementation)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/missing-required-parameter.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/missing-required-parameter.md
@@ -1,0 +1,45 @@
+---
+confidence: high
+---
+
+# Missing Value for Required Parameter (400)
+
+## Context
+
+What this looks like:
+- HTTP 400 at activity execution
+- Error message: `Missing value for required parameter 'id'` (or `'worksheetID'`, `'modelName'`, etc.)
+- Often appears immediately after an Integration Service connector update or a Maestro release
+
+What can cause it:
+- An API call has a URL template `{id}` placeholder that wasn't substituted
+- A required input argument named in the schema was not included in the payload
+- Maestro UI is missing a property that exists in Studio/Studio Web (UI bug) — user can't set the value because the field isn't shown
+- A connector or activity update added a new required property (e.g., GenAI `modelName`), breaking already-published workflows
+- Input argument JSON exceeded the 10,000-character limit and got truncated, dropping the parameter
+
+What to look for:
+- Match the missing parameter name from the error to the activity's expected inputs
+- Compare actual inputs (Variables API) vs `inputDefinitions`
+- Whether the workflow worked before a recent connector/Maestro release
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — error message names the missing parameter
+2. Pull the activity inputs: `uip maestro instance variables <instance-id> -f <folder-key> --output json`
+3. Compare to the activity's `inputDefinitions` in the BPMN/`.bpmn` asset: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+4. Check the Maestro UI for the failing activity — is the missing field even visible? If not, suspect a Maestro frontend bug
+5. Verify the input JSON size — over 10,000 characters indicates truncation
+
+## Resolution
+
+- **If parameter genuinely missing:** add it to the activity's input mapping
+- **If URL `{id}` placeholder:** ensure the ID value is substituted, not the literal placeholder
+- **If Maestro UI doesn't expose the field:** workaround — manually edit the `.bpmn` to add the property, or wait for the FE fix
+- **If new required property from connector update:** make it optional with a default (connector owner) or update all callers to pass the value; check that pre-hook defaults are deployed in the target region
+- **If JSON truncation:** reduce input size or split into multiple smaller arguments
+
+## References
+
+- [Docs: Building API Requests](https://docs.uipath.com/orchestrator/automation-cloud/latest/api-guide/building-api-requests)
+- [Forum: StartJobs API call error code 400](https://forum.uipath.com/t/startjobs-api-call-error-code-400/469915)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/no-message-events.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/no-message-events.md
@@ -1,0 +1,48 @@
+---
+confidence: high
+---
+
+# No Message Events Found (400)
+
+## Context
+
+What this looks like:
+- HTTP 400 at Message Start Event or Message Receive Event
+- Error message: `No Message events found. Generate a trigger event that matches the expected format and try again.`
+- Variants name a specific source — `No File events found` for OneDrive/SharePoint file triggers
+
+What can cause it:
+- The trigger event was never generated at the source (e.g., no new file in SharePoint)
+- The event was generated but does not match the configured connector/action/object filter
+- Integration Service connection backing the trigger is misconfigured or expired
+- Debug mode does not always exercise triggers — known design-time limitation for SharePoint and similar triggers
+
+What to look for:
+- Message Start Event's Implementation: connector, action ("Wait for connector event"), event type
+- Whether the user is debugging vs running the deployed workflow
+- Whether the inbound event matches the configured filter (folder, file extension, mailbox, etc.)
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Inspect the BPMN to confirm the Message Start Event configuration: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+3. Check the Integration Service connection's health in Orchestrator UI → **Integration Service > Connections**
+4. Trigger a test event from the external system that meets the configured filter; confirm via the connector's event log
+5. If user is in debug, ask whether the same trigger works in the published flow
+
+## Resolution
+
+- **If trigger config wrong:** set the Implementation to "Wait for connector event"; pick the right connector and event type
+- **If connection expired:** re-authenticate the IS connection
+- **If filter mismatch:** generate an event that satisfies the filter (correct folder, file type, channel)
+- **If debug-only limitation:** publish the workflow and run it deployed; design-time debug has known limitations for some triggers
+- **If using a custom webhook:** regenerate the webhook URL on the connector and re-register it in the external system
+
+## Notes
+
+- This error is **Not Diagnosable** from PIMS API alone — incident lacks the trigger configuration details and the inbound event format. Expect to ask the user for the failing element name and to share the trigger config
+
+## References
+
+- [Docs: Events in BPMN](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/events-in-bpmn-modeling-perspective)
+- [Docs: Events](https://docs.uipath.com/maestro/automation-cloud/latest/user-guide/events)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/no-suitable-runtime-machine.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/no-suitable-runtime-machine.md
@@ -2,25 +2,41 @@
 confidence: high
 ---
 
-# No Suitable Runtime Machine (409)
+# No Machine With Unattended/NonProduction Runtimes (409, #2818)
 
 ## Context
 
 What this looks like:
-- HTTP 409 error
-- "No suitable runtime machine" or no available machine with required runtimes
+- HTTP 409 from Orchestrator surfaced by Maestro
+- Error message: `Operation returned invalid status code '409'. Could not find a machine with Unattended or NonProduction runtimes in the current folder`
+- Orchestrator error code `#2818`
 
 What can cause it:
-- No Unattended or NonProduction robots available in the folder
-- All machines are currently busy or disconnected
+- Folder has no machine templates with Unattended or NonProduction runtime slots assigned
+- Folder only has Test Runtimes but Maestro defaults to NonProduction runtime type (tracked historically as `MST-6775`)
+- Tenant has no available runtime licenses
+- Machines exist but are all currently busy or disconnected
+
+What to look for:
+- Folder `Machines` tab — what runtime types are assigned
+- Tenant `License Management` — runtime allocation
+- Package requirements in the Maestro process — which runtime type is selected
 
 ## Investigation
 
-1. Check robot/machine availability in the target folder
-2. Check machine connectivity to Orchestrator
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. List machines in the folder: `uip or machines list --folder-key <folder-key> --output json` — check runtime slot types
+3. Check tenant runtime license allocation: Orchestrator UI → **Tenant > License Management**
+4. Check the Maestro process's package requirements for the configured runtime type
 
 ## Resolution
 
-- Provision additional Unattended/NonProduction robots in the folder
-- Check and resolve connectivity issues with Orchestrator machines
-- Review and optimize robot allocation policies
+- **If folder has no compatible runtimes:** add a machine template with Unattended or NonProduction slots via **Folder > Machines**
+- **If tenant only has Test Runtimes:** change the Maestro process's package requirements to a runtime type that matches what the tenant has — see [Managing Package Requirements](https://docs.uipath.com/orchestrator/automation-cloud/latest/user-guide/managing-package-requirements#linking-execution-settings)
+- **If no runtime licenses available:** allocate more in Tenant License Management or contact the UiPath account manager
+- **If all machines busy/disconnected:** verify machine connectivity to Orchestrator; reduce concurrent load
+
+## References
+
+- [Forum: Error #2818](https://forum.uipath.com/t/could-not-find-a-machine-with-unattended-or-nonproduction-runtimes-in-the-current-folder-2818/297757)
+- [Docs: Managing Package Requirements](https://docs.uipath.com/orchestrator/automation-cloud/latest/user-guide/managing-package-requirements#linking-execution-settings)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/personal-automation-quota.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/personal-automation-quota.md
@@ -1,0 +1,39 @@
+---
+confidence: high
+---
+
+# Personal Automation Quota Exceeded (502)
+
+## Context
+
+What this looks like:
+- HTTP 502 surfaced by Maestro when starting a job
+- Error message: `Automation cannot be started. Your user's monthly Personal Automation quota has been exceeded.`
+- Often reported as Orchestrator error code `170002` propagated through a Maestro service task
+
+What can cause it:
+- User is on a Personal Automation license plan and has consumed the monthly Robot Unit allocation
+- Agentic Unit allocation expired (free trial ended) on the user/tenant
+- Concurrent Personal Automation usage across multiple workspaces
+
+What to look for:
+- Incident `errorMessage` is self-explanatory — quota text appears verbatim
+- Affects only the user/owner of the workspace, not the tenant
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Confirm error text matches the quota wording above. If error code is `170002`, drill into the child Orchestrator job to see the underlying quota response
+3. Check tenant consumption: Orchestrator UI → **Admin > Tenant > Licenses > Consumption**
+4. If the user is running agents, also confirm Agentic Units are available (separate quota)
+
+## Resolution
+
+- **If Personal Automation quota exhausted:** request a license upgrade via [self-service license increase](https://uipath.atlassian.net/wiki/spaces/LIC/pages/2834596253), or wait for the monthly quota reset
+- **If Agentic Units expired:** allocate AU from **Admin > Organization > Subscriptions** or contact the UiPath account manager
+- **If recurring:** redesign the workflow to use a tenant-level Unattended robot instead of Personal Automation so quotas come from the shared pool
+
+## Notes
+
+- This is not a Maestro platform bug. Quota enforcement happens in Orchestrator's job execution layer; Maestro surfaces it as 502
+- The incident `errorMessage` already contains everything needed — no PIMS deep-dive required

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/process-not-found-404.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/process-not-found-404.md
@@ -1,0 +1,44 @@
+---
+confidence: high
+---
+
+# Job's Associated Process Not Found (404)
+
+## Context
+
+What this looks like:
+- HTTP 404 from Orchestrator surfaced by Maestro
+- Error message: `Operation returned invalid status code '404'. The job's associated process could not be found`
+- Often reported as Maestro error code `170007` (`OrchestratorRpaJobFailedToStart`) when the failure occurs at job-start time
+
+What can cause it:
+- Stale or incorrect `ReleaseKey` in the service task binding
+- Process was deleted, renamed, or moved to a different folder
+- Solution imported across environments (staging → alpha) where folder keys / release keys were baked in
+- API call missing the `X-UIPATH-OrganizationUnitId` header (folder context)
+- Debug binding override pointing at a folder where the dependency was not deployed (the "Will be deployed in Debug folder" trap)
+
+What to look for:
+- Compare `bindings_v2.json` (deployed) or `debug_overwrites.json` (debug) with the actual processes in the target folder
+- Check whether the solution was re-imported from another environment recently
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Find the failing service task in element executions: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+3. Pull the binding for the failing task — request `bindings_v2.json` (deployed) or `debug_overwrites.json` (debug) from the user
+4. Look up the `ReleaseKey` in Orchestrator: `uip or releases get <release-key> --folder-key <folder-key> --output json`
+5. Verify the folder key in the binding matches the folder the instance is actually running in
+
+## Resolution
+
+- **If ReleaseKey is stale or missing:** re-publish the solution against the correct folder; update bindings; re-deploy
+- **If solution was cross-imported:** re-create the folder mapping or re-bind dependencies in the destination environment
+- **If debug mode:** change the debug config from "Will be deployed in Debug folder" to use the already-deployed dependency in the target folder
+- **If API call:** include the `X-UIPATH-OrganizationUnitId` header pointing at the correct folder
+- **If process was moved/renamed:** update the ReleaseKey, robot account, environment, and machine config in the binding
+
+## References
+
+- [Forum: Start job via API in Modern Folders](https://forum.uipath.com/t/start-job-process-via-api-in-modern-folders-the-jobs-associated-process-could-not-be-found/478483)
+- [Forum: StartJobs API error](https://forum.uipath.com/t/startjobs-api-the-jobs-associated-process-could-not-be-found-error/29637)

--- a/skills/uipath-diagnostics/references/products/maestro/playbooks/unattended-robot-permissions.md
+++ b/skills/uipath-diagnostics/references/products/maestro/playbooks/unattended-robot-permissions.md
@@ -1,0 +1,41 @@
+---
+confidence: high
+---
+
+# No Unattended Robot Permissions in Folder (409, #1671)
+
+## Context
+
+What this looks like:
+- HTTP 409 from Orchestrator surfaced by Maestro at job-start time
+- Error message: `Operation returned invalid status code '409'. Couldn't find any user with unattended robot permissions in the current folder.`
+- Orchestrator error code `#1671`
+
+What can cause it:
+- No user with an Unattended Robot license is assigned to the Orchestrator folder where the Maestro service task runs
+- The "Unattended Automations" permission is missing on the folder role even though the license is granted at tenant level
+- Process was built in classic Studio (desktop) where unattended robots are required, but the deployment folder has none — switching to Studio Web (Agentless/Serverless runtime) is a workaround
+- API call missing or pointing the `OrganizationUnitId` header at the wrong folder
+
+What to look for:
+- Incident `folderKey` — tells you exactly which folder to inspect
+- Is the underlying RPA project a Studio (desktop, `.xaml`) or Studio Web project? Studio Web runs on serverless and does not need an unattended robot
+
+## Investigation
+
+1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+2. Extract `folderKey` from `errorDetails`
+3. List users assigned to that folder: `uip or folders users list <folder-key> --output json`
+4. Inspect license assignments: Orchestrator UI → **Tenant > Manage Access > Users** for the relevant user
+5. Confirm the underlying RPA project type — Studio (desktop) vs Studio Web
+
+## Resolution
+
+- **If user has no Unattended license:** Orchestrator UI → **Tenant > Manage Access > Users** → enable "Unattended Robot" for the user
+- **If permission missing on the folder:** assign the user to the folder with a role that includes "Unattended Automations"
+- **If using a Studio (desktop) project unnecessarily:** rebuild the workflow in Studio Web so it runs on Agentless/Serverless
+- **If API call:** make sure `X-UIPATH-OrganizationUnitId` points at the folder where the unattended user is assigned
+
+## References
+
+- [Forum: Error #1671](https://forum.uipath.com/t/couldnt-find-any-user-with-unattended-robot-permissions-in-the-current-folder-1671/417804)

--- a/skills/uipath-diagnostics/references/products/maestro/summary.md
+++ b/skills/uipath-diagnostics/references/products/maestro/summary.md
@@ -2,6 +2,39 @@
 
 **Investigation guide:** [investigation_guide.md](./investigation_guide.md) — data correlation rules and testing prerequisites for Maestro investigations
 
+**Top-20 production errors (telemetry-ranked, last 7 days as of 2026-03-19):** the table below covers the highest-volume Maestro errors first, with a generic table after for additional symptoms. Source: [PO.BpmnEngine PR #3092](https://github.com/UiPath/PO.BpmnEngine/pull/3092).
+
+## Top 20 Production Errors
+
+| # | Error | Status | Error Code | Playbook |
+|---|-------|:------:|------------|----------|
+| 1 | Personal Automation quota exceeded | 502 | — | [personal-automation-quota.md](./playbooks/personal-automation-quota.md) |
+| 2 | Job's associated process could not be found | 404 | 170007 | [process-not-found-404.md](./playbooks/process-not-found-404.md) |
+| 3 | No unattended robot permissions in folder | 409 | #1671 | [unattended-robot-permissions.md](./playbooks/unattended-robot-permissions.md) |
+| 4 | Job Operation Timeout | 502 | — | [job-operation-timeout.md](./playbooks/job-operation-timeout.md) |
+| 5 | Input does not conform to schema | 400 | — | [input-schema-mismatch.md](./playbooks/input-schema-mismatch.md) |
+| 6 | Missing value for required parameter | 400 | — | [missing-required-parameter.md](./playbooks/missing-required-parameter.md) |
+| 7 | Generic Error_400 | 400 | — | [generic-error-400.md](./playbooks/generic-error-400.md) |
+| 8 | Expression evaluation — property not found | 400 | 400300–400302 | [expression-evaluation-errors.md](./playbooks/expression-evaluation-errors.md) |
+| 9 | No outgoing flow condition met | 400 | 400001 | [gateway-no-outgoing-flow.md](./playbooks/gateway-no-outgoing-flow.md) |
+| 10 | Loop detected (>100 executions) | 400 | 400009 | [loop-detected.md](./playbooks/loop-detected.md) |
+| 11 | 'File' field required (DAP-RT-1003) | 502 | DAP-RT-1003 | [file-field-required.md](./playbooks/file-field-required.md) |
+| 12 | Integration Services 404 | 404 | 102001 | [integration-service-404.md](./playbooks/integration-service-404.md) |
+| 13 | Insufficient funds / credits | 400 | — | [insufficient-funds.md](./playbooks/insufficient-funds.md) |
+| 14 | Marker element input collection is null | 400 | 400007 | [marker-input-null.md](./playbooks/marker-input-null.md) |
+| 15 | Integration Services 400 | 400 | 102003 | [integration-service-400.md](./playbooks/integration-service-400.md) |
+| 16 | Folder does not exist or no access | 400 | #1100 | [folder-not-accessible.md](./playbooks/folder-not-accessible.md) |
+| 17 | No machine with Unattended/NonProduction runtimes | 409 | #2818 | [no-suitable-runtime-machine.md](./playbooks/no-suitable-runtime-machine.md) |
+| 18 | No Message events found | 400 | — | [no-message-events.md](./playbooks/no-message-events.md) |
+| 19 | Foreground job requires unattended robot | 409 | #1230 | [foreground-unattended-robot.md](./playbooks/foreground-unattended-robot.md) |
+| 20 | Index outside bounds of array | 502 | — | [index-out-of-bounds.md](./playbooks/index-out-of-bounds.md) |
+
+> **API debuggability:** errors #1, #3, #5, #6, #8, #11, #13, #16, #19 are **Fully Diagnosable** from PIMS API alone. Errors #2, #4, #10, #14, #17 are **Partially Diagnosable** — incident gives a starting point but needs Orchestrator or BPMN inspection. Errors #7, #9, #12, #15, #18, #20 are **Not Diagnosable** from API alone today; ask the user for additional artifacts (`.bpmn`, bindings, full stack trace).
+>
+> Error #9 (`NoOutgoingFlow`) becomes Fully Diagnosable once [PR #3092](https://github.com/UiPath/PO.BpmnEngine/pull/3092) lands and the `IncludeGatewayDebugInfoInIncidents` targeted feature flag is enabled.
+
+## Additional Symptoms (Lower Volume)
+
 | Issue | Confidence | Description | Playbook |
 |-------|:---:|-------------|----------|
 | Maestro Service Disabled | High | Designer pane blank or errors after license change — service silently disabled | [maestro-service-disabled.md](./playbooks/maestro-service-disabled.md) |
@@ -12,15 +45,12 @@
 | Autopilot 429 Too Many Requests | High | HTTP 429 rate limiting on Autopilot features | [autopilot-429.md](./playbooks/autopilot-429.md) |
 | Multi-Instance Marker InvalidCastException | High | JS array cannot be cast to ExpressionList — switch to C# expressions | [marker-invalid-cast.md](./playbooks/marker-invalid-cast.md) |
 | Attachment Not Found After Retention | High | Files disappear when job retention deletes the owning job | [attachment-not-found.md](./playbooks/attachment-not-found.md) |
-| No Suitable Runtime Machine (409) | High | HTTP 409, no Unattended/NonProduction robots available in folder | [no-suitable-runtime-machine.md](./playbooks/no-suitable-runtime-machine.md) |
-| Argument Mismatch (400) | High | HTTP 400, argument values did not match definitions | [argument-mismatch-400.md](./playbooks/argument-mismatch-400.md) |
+| Argument Mismatch (400) — Generic | Medium | Generic 400 argument mismatch; route to #5 or #6 for specifics | [argument-mismatch-400.md](./playbooks/argument-mismatch-400.md) |
 | Service Task Child Job Faulted (170002) | High | Error 170002, child job faulted — chase child error as root cause, add boundary error event | [service-task-child-job-faulted.md](./playbooks/service-task-child-job-faulted.md) |
-| Integration Service Failure (404) | Medium | HTTP 404 during IS call, resource or endpoint not found | [integration-service-404.md](./playbooks/integration-service-404.md) |
 | Debug vs Deploy Mismatch | Medium | Process works in debug but fails after deploy — identity, permissions, or bindings | [debug-vs-deploy.md](./playbooks/debug-vs-deploy.md) |
 | Deployment Failure | Medium | Solution deployment fails — duplicate entry points, trigger conflicts, or stale references | [deployment-failure.md](./playbooks/deployment-failure.md) |
 | Variable and Expression Errors | Medium | Missing output variables, assignment errors, case sensitivity in gateway conditions | [variable-expression-errors.md](./playbooks/variable-expression-errors.md) |
 | Boundary Event / Duplicate Task | Medium | Task running twice, boundary events firing unexpectedly, missing incident logging | [boundary-event-duplicate-task.md](./playbooks/boundary-event-duplicate-task.md) |
 | File Handling Issues | Medium | Files not passed correctly, attachment not found, file type incompatibility | [file-handling.md](./playbooks/file-handling.md) |
 | Multi-Instance Parallel Marker | Medium | Parallel marker failures, collection size limits, NoneType errors | [multi-instance-parallel.md](./playbooks/multi-instance-parallel.md) |
-| Expression Evaluation and Input Errors | Medium | Null inputs, missing parameters, GUID parse errors | [expression-evaluation-errors.md](./playbooks/expression-evaluation-errors.md) |
 | BPMN Job Stuck | Low | Instance stuck with no progress or error — disconnected connection, child job not created, or backend delay | [bpmn-job-stuck.md](./playbooks/bpmn-job-stuck.md) |


### PR DESCRIPTION
## Summary

Rewires `uipath-diagnostics` Maestro playbooks against the **top-20 production errors** identified in [PO.BpmnEngine PR #3092](https://github.com/UiPath/PO.BpmnEngine/pull/3092) (`docs/error-catalog.md`). The catalog ranks the highest-volume Maestro incidents from the last 7 days of ADX telemetry plus #help-maestro Slack threads and UiPath forums.

- **16 new playbooks** — one per top-20 error not previously covered.
- **5 existing playbooks updated** — sharper symptoms, error codes, and CLI-driven investigation steps.
- **Metadata refreshed** — `summary.md`, `investigation_guide.md`, and `error_codes.md` now front-load the ranked top-20 with API-debuggability flags.

## What changed

### New playbooks

| # | Error | File |
|---|---|---|
| 1 | Personal Automation quota exceeded (502) | `personal-automation-quota.md` |
| 2 | Job process not found (404, 170007) | `process-not-found-404.md` |
| 3 | No unattended robot permissions (409, #1671) | `unattended-robot-permissions.md` |
| 4 | Job Operation Timeout (502) | `job-operation-timeout.md` |
| 5 | Input does not conform to schema (400) | `input-schema-mismatch.md` |
| 6 | Missing value for required parameter (400) | `missing-required-parameter.md` |
| 7 | Generic Error_400 (400) | `generic-error-400.md` |
| 9 | No outgoing flow condition met (400, **400001**) | `gateway-no-outgoing-flow.md` |
| 10 | Loop detected (>100 executions, **400009**) | `loop-detected.md` |
| 11 | 'File' field required (DAP-RT-1003) | `file-field-required.md` |
| 13 | Insufficient funds / Agent Units (400) | `insufficient-funds.md` |
| 14 | Marker input collection is null (**400007**) | `marker-input-null.md` |
| 15 | Integration Services 400 (102003) | `integration-service-400.md` |
| 16 | Folder does not exist or no access (400, #1100) | `folder-not-accessible.md` |
| 18 | No Message events found (400) | `no-message-events.md` |
| 19 | Foreground job requires unattended robot (409, #1230) | `foreground-unattended-robot.md` |
| 20 | Index outside bounds of array (502) | `index-out-of-bounds.md` |

### Existing playbooks updated

- `integration-service-404.md` — adds error code `102001`, cross-environment import case, Data Fabric variant, API-debuggability note.
- `no-suitable-runtime-machine.md` — adds Orchestrator code `#2818`, NonProduction-vs-Test-Runtime workaround, links Managing Package Requirements docs.
- `expression-evaluation-errors.md` — engine codes `400300–400302`, ExpressionDictionary casing rule, C# ternary type-erasure workaround, iterator references in parallel multi-instance subprocesses.
- `argument-mismatch-400.md` — narrowed to "generic 400" and routes to the new specific playbooks.
- `marker-invalid-cast.md` — adds engine code `400008`, cross-link to `marker-input-null` (`400007`).

### Metadata

- `summary.md` — leads with a ranked **Top-20 Production Errors** table with playbook links and per-error API-debuggability marker (Full / Partial / None). Lower-volume issues moved to a second table.
- `investigation_guide.md` — new **Top-20 Error Quick Route** symptom→playbook table; pointer to `summary.md` in the First Step section.
- `error_codes.md` — new **Top-20 Production Errors → Playbook Mapping** section ties engine codes (400001/400007/400008/400009/102001/102003/400300–400302) and Orchestrator codes (#1100/#1230/#1671/#2818/170007/DAP-RT-1003) to the new playbooks. Fixes the `400009` message text to match what the engine emits.

## Notes on PR #3092 integration

Error #9 (`NoOutgoingFlow`) is the case PR #3092 actually fixes: with the `IncludeGatewayDebugInfoInIncidents` targeted feature flag enabled, incident `errorDetails` will contain every outgoing flow condition, the default flow config, and variable values (truncated to 200 chars) at evaluation time. The `gateway-no-outgoing-flow.md` playbook calls out the pre/post-flag investigation path and links to the upstream PR. Once that flag is on by default, this error moves from "Not Diagnosable" to "Fully Diagnosable" from PIMS API alone.

## Test plan

- [ ] `summary.md` table renders correctly on GitHub and every playbook link resolves.
- [ ] `investigation_guide.md` quick-route table links resolve.
- [ ] `error_codes.md` top-20 section links resolve.
- [ ] Spot-check that engine codes in playbooks (400001, 400007, 400008, 400009, 400300–400302, 102001, 102003) match `UiPath.PO.Errors/ErrorCode.cs`.
- [ ] Run the diagnostics skill against a recent NoOutgoingFlow incident and confirm the agent routes to `gateway-no-outgoing-flow.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
