### PR TITLE
fix(maestro-flow): honor UIPATH_FLOW_DEBUG_FOLDER_ID in flow_check [MST-9638]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -36,9 +36,21 @@ def run_debug(
     project_glob: str = "**/project.uiproj",
 ) -> dict:
     """Locate the project, run ``uip maestro flow debug --output json``, and return the
-    parsed ``Data`` payload. Exits on any step failing."""
+    parsed ``Data`` payload. Exits on any step failing.
+
+    When the ``UIPATH_FLOW_DEBUG_FOLDER_ID`` environment variable is set, its
+    value is passed through as ``--folder-id`` so the CLI uses the targeted
+    folder via ``/odata/Folders({id})`` and skips personal-workspace discovery.
+    That discovery hits ``/api/Folders/GetAllForCurrentUser``, which requires
+    ``Folders.Read.PersonalWorkspace`` — a permission the eval service account
+    routinely lacks (HTTP 403). With the env var set, debug works without
+    that permission as long as the account can read the targeted folder.
+    """
     project_dir = _find_project(project_glob)
     cmd = ["uip", "maestro", "flow", "debug", project_dir, "--output", "json"]
+    folder_id = os.environ.get("UIPATH_FLOW_DEBUG_FOLDER_ID")
+    if folder_id:
+        cmd.extend(["--folder-id", folder_id])
     if inputs is not None:
         cmd.extend(["--inputs", json.dumps(inputs)])
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -38,13 +38,9 @@ def run_debug(
     """Locate the project, run ``uip maestro flow debug --output json``, and return the
     parsed ``Data`` payload. Exits on any step failing.
 
-    When the ``UIPATH_FLOW_DEBUG_FOLDER_ID`` environment variable is set, its
-    value is passed through as ``--folder-id`` so the CLI uses the targeted
-    folder via ``/odata/Folders({id})`` and skips personal-workspace discovery.
-    That discovery hits ``/api/Folders/GetAllForCurrentUser``, which requires
-    ``Folders.Read.PersonalWorkspace`` — a permission the eval service account
-    routinely lacks (HTTP 403). With the env var set, debug works without
-    that permission as long as the account can read the targeted folder.
+    If ``UIPATH_FLOW_DEBUG_FOLDER_ID`` is set, passes it as ``--folder-id`` to
+    bypass personal-workspace discovery — which requires
+    ``Folders.Read.PersonalWorkspace`` and 403s on service-principal accounts.
     """
     project_dir = _find_project(project_glob)
     cmd = ["uip", "maestro", "flow", "debug", project_dir, "--output", "json"]

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -18,6 +18,7 @@ from flow_check import (  # noqa: E402
     assert_output_value,
     assert_outputs_contain,
     collect_outputs,
+    run_debug,
 )
 
 
@@ -169,3 +170,70 @@ def test_assert_outputs_contain_fails_when_missing():
     payload = _payload(globals_=[{"value": "hello"}])
     with pytest.raises(SystemExit, match="missing"):
         assert_outputs_contain(payload, ["world"])
+
+
+# ── run_debug --folder-id env-var override ─────────────────────────────────
+
+
+def _stub_run_debug_subprocess(tmp_path, monkeypatch):
+    """Set up a minimal project layout and capture the constructed CLI command.
+
+    Returns the list captured by ``subprocess.run`` so each test can assert on
+    the exact argv shape (including or excluding ``--folder-id``).
+    """
+    import json
+    import subprocess
+
+    proj = tmp_path / "MyFlow"
+    proj.mkdir()
+    (proj / "project.uiproj").write_text("{}")
+    (proj / "MyFlow.flow").write_text("{}")
+    monkeypatch.chdir(tmp_path)
+
+    captured: dict[str, list[str]] = {}
+
+    class _Completed:
+        returncode = 0
+        stdout = json.dumps(
+            {"Data": {"finalStatus": "Completed", "variables": {"globals": {}}}}
+        )
+        stderr = ""
+
+    def fake_run(cmd, *_args, **_kwargs):
+        captured["cmd"] = list(cmd)
+        return _Completed()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return captured
+
+
+def test_run_debug_passes_folder_id_when_env_set(tmp_path, monkeypatch):
+    captured = _stub_run_debug_subprocess(tmp_path, monkeypatch)
+    monkeypatch.setenv("UIPATH_FLOW_DEBUG_FOLDER_ID", "12345")
+
+    run_debug(timeout=5)
+
+    assert "--folder-id" in captured["cmd"]
+    idx = captured["cmd"].index("--folder-id")
+    assert captured["cmd"][idx + 1] == "12345"
+
+
+def test_run_debug_omits_folder_id_when_env_unset(tmp_path, monkeypatch):
+    captured = _stub_run_debug_subprocess(tmp_path, monkeypatch)
+    monkeypatch.delenv("UIPATH_FLOW_DEBUG_FOLDER_ID", raising=False)
+
+    run_debug(timeout=5)
+
+    assert "--folder-id" not in captured["cmd"]
+
+
+def test_run_debug_omits_folder_id_when_env_blank(tmp_path, monkeypatch):
+    # Treat empty string the same as unset — the env var must contain a real
+    # folder id, otherwise the CLI would error with "--folder-id must be a
+    # positive number" and mask real eval failures.
+    captured = _stub_run_debug_subprocess(tmp_path, monkeypatch)
+    monkeypatch.setenv("UIPATH_FLOW_DEBUG_FOLDER_ID", "")
+
+    run_debug(timeout=5)
+
+    assert "--folder-id" not in captured["cmd"]


### PR DESCRIPTION
## Summary

- \`_shared/flow_check.run_debug()\` shelled out to \`uip maestro flow debug\` without a folder, so the CLI fell back to personal-workspace discovery via \`/api/Folders/GetAllForCurrentUser\` and died with HTTP 403 whenever the eval account lacked \`Folders.Read.PersonalWorkspace\` — what hit 17 of 20 \`uipath-maestro-flow\` tasks in coder_eval run \`2026-05-11_04-04-06\`.
- \`run_debug()\` now reads \`UIPATH_FLOW_DEBUG_FOLDER_ID\` from the environment and forwards it as \`--folder-id\` if set. Opt-in: unset/blank → behavior unchanged.

## Why this matters

Paired with [UiPath/cli#1948](https://github.com/UiPath/cli/pull/1948) (which makes \`--folder-id\` actually bypass personal-workspace discovery), eval ops can flip a single env var on the eval VM to unblock 16 of the 17 still-broken maestro-flow tasks without per-task migration. (The 17th, \`skill-flow-rpa\`, is already handled by the static-checker fix in MST-9610 / PR #689.)

This is also the right structural fix for any future service-principal / CI scenario where the SP has access to a specific folder but no personal workspace.

## What changed

- **\`tests/tasks/uipath-maestro-flow/_shared/flow_check.py\`** — \`run_debug()\` appends \`--folder-id <UIPATH_FLOW_DEBUG_FOLDER_ID>\` to the CLI argv if the env var is set. Comment explains the SP / 403 scenario and the companion CLI fix.

## Test plan

- [x] \`pytest tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py\` — 22 tests pass, including 3 new:
  - \`test_run_debug_passes_folder_id_when_env_set\` — argv contains \`--folder-id 12345\`
  - \`test_run_debug_omits_folder_id_when_env_unset\` — no \`--folder-id\` in argv
  - \`test_run_debug_omits_folder_id_when_env_blank\` — empty string treated as unset (prevents CLI from erroring with \"must be a positive number\")
- [ ] Manual smoke (post-merge, after companion CLI ships): set \`UIPATH_FLOW_DEBUG_FOLDER_ID=<folder-id>\` on the eval VM and rerun one of the previously-failing maestro-flow tasks (e.g. \`skill-flow-add-node\`); confirm \`flow debug\` succeeds end-to-end.

## Related

- MST-9638 (this fix) — https://uipath.atlassian.net/browse/MST-9638
- MST-9610 — RPA static checker (PR #689) — already covers \`skill-flow-rpa\`; this PR covers the other 16
- MST-9637 — checker drift for 3 outlier tasks (separate scope) — https://uipath.atlassian.net/browse/MST-9637
- Companion: UiPath/cli branch \`fix-MST-9610-cli-folder-id\` — the CLI side that actually consumes \`--folder-id\` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)