### PR TITLE
docs(maestro-case): make edge label optional, blank when no rule applies

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/edges/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/edges/impl-json.md
@@ -20,7 +20,7 @@ The same recipe covers add / edit / remove — direct JSON writes state declarat
 |---|---|---|
 | `source` | yes | Trigger ID (e.g., `trigger_1`) or Stage ID. Resolved from `id-map.json`. |
 | `target` | yes | Stage ID. Resolved from `id-map.json`. Never an ExceptionStage — see Guardrails. |
-| `label` | yes | Display label on the connector (Studio Web "Name"). Always present — planning auto-derives when sdd.md does not state one. See [`planning.md` § Labels](planning.md#labels). |
+| `label` | no | Display label on the connector (Studio Web "Name"). Optional — emit when sdd.md states one or planning's inference rules apply; otherwise emit `data.label: ""`. See [`planning.md` § Labels](planning.md#labels). |
 | `sourceHandle` direction | no | `right` (default) \| `left` \| `top` \| `bottom` |
 | `targetHandle` direction | no | `left` (default) \| `right` \| `top` \| `bottom` |
 | `zIndex` | no | Integer. Omit the key entirely when unset. |
@@ -118,7 +118,7 @@ Find the edge by `id` in `schema.edges` and mutate in place:
 | `source` | no | Immutable. To rewire, remove + re-add. |
 | `target` | no | Immutable. To rewire, remove + re-add. |
 | `type` | no | Derived from `source`. Immutable. |
-| `data.label` | yes | Mutable but never absent — must always carry a non-empty string. Replace with new value; do not delete. |
+| `data.label` | yes | Mutable; may be `""` when no rule applies. Always emit the key so the JSON shape stays consistent — write `""` to clear. |
 | `sourceHandle` | yes | Re-construct with new direction, keep same `source` ID. |
 | `targetHandle` | yes | Re-construct with new direction, keep same `target` ID. |
 | `zIndex` | yes | Set or `delete` to clear. |
@@ -145,7 +145,7 @@ After writing, confirm:
 - `edges[].type` matches the inference (`TriggerEdge` iff source is a Trigger)
 - `edges[].sourceHandle` and `edges[].targetHandle` use exactly 4 underscores each side
 - `edges[].source` and `edges[].target` resolve to existing `schema.nodes` entries
-- `edges[].data.label` is present and non-empty (planning guarantees every edge has a label)
+- `edges[].data.label` key is present (value may be `""` when no rule applies — see [`planning.md` § Labels](planning.md#labels))
 - `edges[].zIndex` is present iff the T-entry declared one
 
 Run `uip maestro case validate <file> --output json` after all edges for this plugin's batch are added.

--- a/skills/uipath-maestro-case/references/plugins/edges/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/edges/planning.md
@@ -38,7 +38,7 @@ This constraint is also documented in the [stages plugin](../stages/planning.md#
 |-------|--------|-------|
 | `source` | sdd.md flow arrow origin | Trigger ID or stage name |
 | `target` | sdd.md flow arrow destination | Stage name |
-| `label` | inferred (see § Labels) | Required. Always emit. Auto-derived when sdd.md does not state one. |
+| `label` | inferred (see § Labels) | Optional. Emit when sdd.md states one or an inference rule applies; otherwise leave blank. |
 | `source-handle` | sdd.md (rarely specified) | `right` (default) \| `left` \| `top` \| `bottom` |
 | `target-handle` | sdd.md (rarely specified) | `left` (default) \| `right` \| `top` \| `bottom` |
 
@@ -46,21 +46,20 @@ This constraint is also documented in the [stages plugin](../stages/planning.md#
 
 Edge labels are **display-only** — they do not control routing. Routing conditions live on the source stage's `exitConditions`, not on the edge. Labels annotate intent so the diagram in Studio Web is readable (Studio Web renders this as the connector's "Name").
 
-**Every edge MUST carry a `label`.** sdd.md rarely declares edge labels explicitly, so derive one during planning. Never omit.
+Labels may be blank. Emit one only when sdd.md states it explicitly or an inference rule below applies.
 
 ### Inference rules (apply in order)
 
 1. **TriggerEdge** (source is a Trigger node) → label = `"Start"`. For multi-trigger cases, label = trigger displayName (e.g., `"Manual"`, `"On timer"`, `"On <event>"`).
 2. **Stage→Stage with branching exit conditions in sdd.md** → label = matching branch outcome from the source stage's exit-condition text. Examples: `"Approved"`, `"Rejected"`, `"Timeout"`, `"Escalated"`. One edge per outcome → one label per outcome.
-3. **Stage→Stage, single outbound, no branching** → label = target stage name.
 
-If sdd.md states an explicit edge label, use it verbatim and skip inference.
+If sdd.md states an explicit edge label, use it verbatim and skip inference. Otherwise (e.g., Stage→Stage with single outbound and no branching), leave the label blank.
 
 ### Anti-patterns
 
-- **Do NOT emit an edge T-entry without a `label:` line.**
 - **Do NOT infer from edge index** (`"Edge 1"`, `"Edge 2"`) — meaningless to the user.
 - **Do NOT read exit-condition text from another T-entry** — read directly from sdd.md, preserve plugin isolation.
+- **Do NOT fabricate a label** when no inference rule applies — leave it blank.
 
 ## Handles
 
@@ -76,7 +75,7 @@ Edges are created **after** all stages exist so both endpoints can resolve. Each
 ## T<n>: Add edge "<source>" → "<target>"
 - source: "<trigger-id-or-stage-name>"
 - target: "<stage-name>"
-- label: "<inferred or sdd.md-stated label>"   # required, always present
+- label: "<inferred or sdd.md-stated label>"   # optional, omit line when blank
 - source-handle: right      # optional
 - target-handle: left       # optional
 - order: after T<m>


### PR DESCRIPTION
## Summary
- Drop the inference rule `Stage→Stage, single outbound, no branching → label = target stage name` from the case edges planning reference.
- Relax the "every edge MUST carry a label" mandate — labels are now optional and left blank when neither sdd.md nor an inference rule supplies one.
- Update the Required Fields table, anti-patterns, and tasks.md entry-format comment to match.
- **Follow-up commit (9913f666):** align `edges/impl-json.md` with the same contract. The Input spec marks `label` as optional (emit `data.label: ""` when no rule applies), the Edit table loosens "never absent" to "may be `""`", and the post-write checklist accepts a blank-value label. Without this, planning and impl-json contradicted each other.

Inference rules still in force:
1. TriggerEdge → `"Start"` (or trigger displayName for multi-trigger cases).
2. Stage→Stage with branching exit conditions → matching branch outcome.

Explicit sdd.md labels continue to win over inference.

## Test plan
- [x] Verify rendered planning doc reads cleanly (`skills/uipath-maestro-case/references/plugins/edges/planning.md`).
- [x] Spot-check a single-outbound flow planning run produces an edge T-entry without a `label:` line — verified end-to-end in a TestEdgeAndAction test case (T06 `Intake → Review` emitted blank).
- [x] Confirm impl-json behavior in the edges plugin still tolerates a missing/blank label — now explicit in `edges/impl-json.md` after follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)