### PR TITLE
docs(maestro-case): empty action placeholder — omit every sdd-derived field

### DIFF
--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -127,7 +127,7 @@ For each task entry in `tasks.md §4.6`, open matching plugin's `impl-json.md`. 
 
 When a task entry's `taskTypeId` (or `typeId` / `connectionId` for connector tasks) is `<UNRESOLVED: …>`, create a **placeholder task** instead of halting. See [placeholder-tasks.md](placeholder-tasks.md) for the canonical reference.
 
-For every task class (process / agent / rpa / action / api-workflow / case-management / connector-activity / connector-trigger): follow the Unresolved Fallback section of the matching `plugins/tasks/<type>/planning.md` and write a task with `type` + `displayName` + `id` + `elementId` + `isRequired`, `data: {}`, and no `taskTypeId` / `connectionId` keys directly to `caseplan.json` per `plugins/tasks/<type>/impl-json.md`. For `action` placeholders, **`data.taskTitle` is required** (validator rejects empty — source from sdd.md task-title hint or fall back to `displayName`); include `data.priority` and `data.recipient` if known. Omit `data.context`, `data.inputs`, `data.outputs`.
+For every task class (process / agent / rpa / action / api-workflow / case-management / connector-activity / connector-trigger): follow the Unresolved Fallback section of the matching `plugins/tasks/<type>/planning.md` and write a task with `type` + `displayName` + `id` + `elementId` + `isRequired`, `data: {}`, and no `taskTypeId` / `connectionId` keys directly to `caseplan.json` per `plugins/tasks/<type>/impl-json.md`.
 
 **Skip all input binding for placeholder tasks** — they have no input schema. Capture the intended wiring from the fenced `wiring notes` code block in `tasks.md` into the completion report so the user knows what to hook up after registering the resource.
 

--- a/skills/uipath-maestro-case/references/placeholder-tasks.md
+++ b/skills/uipath-maestro-case/references/placeholder-tasks.md
@@ -67,7 +67,7 @@ A placeholder task in `caseplan.json.nodes[<stage>].data.tasks[<lane>][]`:
 
 Note the empty `data: {}` — no `taskTypeId`, no folder path, no input/output wiring. Connector placeholders follow the same shape with `type` set to `connector-activity` or `connector-trigger` and no `data.typeId` / `data.connectionId` keys.
 
-> **`action` placeholders MUST include `data.taskTitle`** — validator rejects empty per [`plugins/tasks/action/impl-json.md`](plugins/tasks/action/impl-json.md). Source from sdd.md's task-title hint or fall back to `displayName`. Include `data.priority` and `data.recipient` if known from planning; otherwise omit those keys. Other placeholder fields (`data.context`, `data.inputs`, `data.outputs`, `data.actionCatalogName`) stay omitted until the action-app is attached.
+> **`action` placeholders follow the same shape as every other task class — `data: {}`, nothing populated.** Omit `data.taskTitle`, `data.priority`, `data.recipient`, `data.context`, `data.inputs`, `data.outputs`, `data.actionCatalogName` — even when sdd.md provides values for them. The sdd-stated values are captured in the planning entry's wiring text block and re-applied during the upgrade procedure (§ Step 4).
 
 ### In-stage timer
 

--- a/skills/uipath-maestro-case/references/placeholder-tasks.md
+++ b/skills/uipath-maestro-case/references/placeholder-tasks.md
@@ -65,9 +65,7 @@ A placeholder task in `caseplan.json.nodes[<stage>].data.tasks[<lane>][]`:
 }
 ```
 
-Note the empty `data: {}` — no `taskTypeId`, no folder path, no input/output wiring. Connector placeholders follow the same shape with `type` set to `connector-activity` or `connector-trigger` and no `data.typeId` / `data.connectionId` keys.
-
-> **`action` placeholders follow the same shape as every other task class — `data: {}`, nothing populated.** Omit `data.taskTitle`, `data.priority`, `data.recipient`, `data.context`, `data.inputs`, `data.outputs`, `data.actionCatalogName` — even when sdd.md provides values for them. The sdd-stated values are captured in the planning entry's wiring text block and re-applied during the upgrade procedure (§ Step 4).
+Note the empty `data: {}` — no `taskTypeId`, no folder path, no input/output wiring. The shape is uniform across classes: connector placeholders use `type` `connector-activity` / `connector-trigger`; action placeholders too — no exception for `data.taskTitle` or other action-specific keys.
 
 ### In-stage timer
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -33,7 +33,7 @@
 
 | Field | Notes |
 |---|---|
-| `data.taskTitle` | Required, even on placeholders. Validator rejects empty. |
+| `data.taskTitle` | Required on **resolved** action tasks — validator rejects empty. Placeholders omit it (along with every other `data.*` action-specific key); see [placeholder-tasks.md](../../../placeholder-tasks.md). |
 | `data.priority` | `"Low"` \| `"Medium"` (default) \| `"High"` \| `"Critical"` |
 | `data.recipient` | `ActionTaskAssignee` object: `{ "Type": <int>, "Value": "<id-or-email>" }`. See fallback below for unresolved-UUID handling. |
 | `data.actionCatalogName` | `deploymentTitle` from tasks.md |

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
@@ -21,7 +21,7 @@ Pick this plugin when the sdd.md describes a `HITL` task, or any task requiring 
 
 ## Task Title Fallback
 
-`task-title` is what the user sees in the Actions app. Always emit it — the validator requires it even on placeholders. Derive in this order:
+`task-title` is what the user sees in the Actions app. Required on resolved action tasks (placeholders skip — see § Unresolved Fallback). Derive in this order:
 
 1. SDD has an explicit title or question field → use it
 2. SDD has a Description → summarize into a short, concise title
@@ -40,9 +40,11 @@ See [registry-discovery.md](../../../registry-discovery.md#cli-search-gaps) for 
 
 ## Unresolved Fallback
 
-Mark `<UNRESOLVED: action-app "<deploymentTitle>" in folder "<folder>" not found in action-apps-index.json>`. Omit `inputs:` and `outputs:`; capture intended wiring in a fenced ```` ```text ```` code block (not `#` prefixed — it renders as markdown H1). **Keep `task-title:`** — the validator requires it even on placeholder action tasks. Derive via the fallback above. See [placeholder-tasks.md](../../../placeholder-tasks.md).
+Mark `<UNRESOLVED: action-app "<deploymentTitle>" in folder "<folder>" not found in action-apps-index.json>`. Emit only structural fields — drop every action-specific line (`task-title`, `priority`, `recipient`, `inputs`, `outputs`). See [placeholder-tasks.md](../../../placeholder-tasks.md) for the full placeholder entry shape and wiring-block convention.
 
 ## Recipient Handling
+
+> Resolved action tasks only — placeholders skip this entire section (see § Unresolved Fallback).
 
 - If sdd.md **names a specific user email**, record it in `tasks.md`. Sets `assignmentCriteria: "user"` at execution time.
 - If sdd.md **names a group or role**, do **not** record a recipient — group assignment is configured separately via Actions app rules. Record a note in `tasks.md` so the user remembers to configure group assignment externally.
@@ -57,6 +59,8 @@ Mark `<UNRESOLVED: action-app "<deploymentTitle>" in folder "<folder>" not found
 For open-ended inputs like an email address, use a direct prompt rather than AskUserQuestion with a finite option list.
 
 ## tasks.md Entry Format
+
+Resolved action task. For the unresolved placeholder shape, see [placeholder-tasks.md § `tasks.md` Planning-Entry Shape](../../../placeholder-tasks.md#tasksmd-planning-entry-shape).
 
 ```markdown
 ## T<n>: Add action task "<display-name>" to "<stage>"


### PR DESCRIPTION
## Summary
- When an action-app cannot be resolved in `action-apps-index.json`, the placeholder task takes the same `data: {}` shape as every other task class — no action-specific carve-outs.
- The planning entry omits **every** action-specific field — `task-title`, `priority`, `recipient`, `inputs`, `outputs` — even if sdd.md provides them. AskUserQuestion for an unassigned recipient is skipped on the placeholder.
- sdd-stated intent (title, priority, recipient, inputs, outputs) is captured in the fenced `text` wiring block and re-applied during the placeholder-upgrade procedure.
- Aligns four docs so the uniform-shape rule is consistent:
  - `plugins/tasks/action/planning.md` — rewrite **Unresolved Fallback** to a single sentence + marker; scope **Task Title Fallback** and **Recipient Handling** to resolved tasks; point at `placeholder-tasks.md` for the placeholder entry shape (no duplicate example).
  - `placeholder-tasks.md` — drop the action-only callout that required `data.taskTitle`; one short clarifier left where the general shape is described.
  - `plugins/tasks/action/impl-json.md` — scope the `data.taskTitle` "required, validator rejects empty" note to **resolved** action tasks.
  - `implementation.md` Step 9.1 — drop the action-specific clause; the general "every task class is `data: {}` with no `taskTypeId` / `connectionId` keys" rule covers action by definition.

## Test plan
- [ ] Skim the four rendered files for consistency in terminology and shape.
- [ ] Spot-run a planning pass against an sdd.md that references an unregistered action-app — confirm the resulting `tasks.md` entry has only structural fields plus the `text` wiring block.
- [ ] Confirm `uip maestro case validate` behavior on an action placeholder with empty `data: {}` (separate validator change may be needed; out of scope for this doc PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)