### PR TITLE
test(uipath-diagnostics): bump turn_timeout to 1800s across scenarios

### DIFF
--- a/tests/tasks/uipath-diagnostics/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-diagnostics/_shared/scripts/generate_scenario.py
@@ -77,7 +77,7 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
   max_turns: 60
-  turn_timeout: 1200
+  turn_timeout: 1800
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-diagnostics/faulted_excel_o365/task.yaml
+++ b/tests/tasks/uipath-diagnostics/faulted_excel_o365/task.yaml
@@ -20,7 +20,7 @@ agent:
   # the diagnostic skill orchestrates sub-agents.
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
   max_turns: 60
-  turn_timeout: 800   # ~13 min per turn; observed runs land around 9-10 min for this single-root case
+  turn_timeout: 1800
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-diagnostics/maestro-stuck-rpa-job/task.yaml
+++ b/tests/tasks/uipath-diagnostics/maestro-stuck-rpa-job/task.yaml
@@ -10,7 +10,7 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
   max_turns: 60
-  turn_timeout: 1000
+  turn_timeout: 1800
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-diagnostics/rpa-selector-healing-disabled/task.yaml
+++ b/tests/tasks/uipath-diagnostics/rpa-selector-healing-disabled/task.yaml
@@ -10,7 +10,7 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
   max_turns: 60
-  turn_timeout: 900
+  turn_timeout: 1800
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
It seems that the system running tests can take a while