### PR TITLE
MST-9676: specify Google Tasks HTTP fallback endpoint

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -29,7 +29,9 @@ initial_prompt: |
   Route success to a final action that logs "QueryParams test passed".
   Validate the final flow file.
   If the Google Tasks connector operation is not present in the registry, use
-  a managed HTTP fallback for the same REST call and finish after validation.
+  a managed HTTP fallback for the same REST call: GET
+  https://tasks.googleapis.com/tasks/v1/lists/@default/tasks with query
+  parameter showHidden=true. Finish after validation.
   Do not keep searching for a connector node that the registry does not expose.
 
 success_criteria:


### PR DESCRIPTION
## Summary

Clarifies the `skill-flow-ipe-query-params` managed HTTP fallback prompt with the exact Google Tasks `tasks.list` endpoint shape the existing checker grades: `GET https://tasks.googleapis.com/tasks/v1/lists/@default/tasks` with `showHidden=true`.

The task still asks the agent to discover and use the native connector when available. This only removes third-party REST endpoint guesswork when the connector is absent from the registry.

Jira: https://uipath.atlassian.net/browse/MST-9676

## Root Cause

Run `2026-05-12_06-30-23` showed the agent correctly falling back to `core.action.http.v2`, but it guessed `https://tasks.googleapis.com/tasks/v1/users/@me/lists/@default/tasks`. That URL is not the Google Tasks `tasks.list` endpoint the checker expects, so the current checker failure is a valid rejection rather than an MST-9509-style false negative.

## Validation

- Captured run artifact fails the existing query-param checker with the old guessed URL
- TaskDefinition validation for `tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml`
- Existing checker passes when the captured artifact URL is changed to the documented `tasks.list` endpoint
- `git diff --check`
