### PR TITLE
Added healing agent post process recommendation

### DIFF
--- a/skills/uipath-diagnostics/SKILL.md
+++ b/skills/uipath-diagnostics/SKILL.md
@@ -147,7 +147,23 @@ The presenter:
 
 Present the presenter's output verbatim to the user. After presenting:
 
-**If root cause found** — offer to help implement the fix or clean up `.investigation/`.
+**Execute Post-presentation actions FIRST.** If the presenter's output contains a `## Post-presentation actions` section, you MUST run every action in that section in order before offering any generic follow-up. For each action:
+
+1. Print the "Print as plain text" block exactly as written (raw selectors and other XML/HTML render poorly inside `AskUserQuestion` options or previews — always print as plain text first, separate from the question).
+2. Print the warning string verbatim if non-empty.
+3. Call `AskUserQuestion` with the question and options the action specifies. Ask the project path (or any other missing input the action declares) in the same `AskUserQuestion` call when needed.
+4. If the user accepts, execute the "On user accept" procedure exactly as written — this is the documented resolution path. Do not improvise an alternative. If the procedure references a sub-skill (e.g., `uia-improve-selector`), check for it and follow its USAGE.md. Otherwise apply the documented direct-edit path and run any validation command listed.
+5. If the user declines, stop the action; do not modify files. Move to the next action.
+6. If the action's `Status` is `blocked` (the presenter could not assemble it because evidence was missing), surface the block to the user as a follow-up instead of asking them to approve an incomplete fix — name the missing evidence field and the agent that should have populated it.
+
+Do NOT skip the Post-presentation actions block when:
+- The matched playbook was downgraded from `high` to `medium` by depth-check (the resolution procedure is preserved across confidence downgrades — see `agents/depth-verifier.md` on textual gaps).
+- The depth-verifier flagged a cause-name mismatch (textual gap). A reclassified cause does NOT invalidate the playbook's interactive resolution; both can be reported together.
+- The recovered/recommended data was produced in a recommendation-only or unproven mode (`InferredRecoveryInfo`, `RecoverySuccessful: false`). The action carries a warning string for exactly this case — present it and let the user decide.
+
+Only after all actions are complete (accepted, declined, or surfaced as blocked) proceed to the generic follow-up:
+
+**If root cause found** — offer to help implement any further changes or clean up `.investigation/`.
 
 **If no root cause found** — use `AskUserQuestion` to offer: provide more data (re-triage), or open a UiPath support ticket with the evidence gathered.
 

--- a/skills/uipath-diagnostics/agents/depth-verifier.md
+++ b/skills/uipath-diagnostics/agents/depth-verifier.md
@@ -127,6 +127,20 @@ worth the cost.
   accepting the hypothesis at reduced confidence and surfacing the gap
   to the user via the presenter, rather than re-running tests.
 
+  **A textual gap on check 1 (cause naming) does NOT invalidate the
+  matched playbook's `## Resolution` procedure.** Cause label and
+  remediation path are separable. When the matched playbook's resolution
+  is interactive (e.g., "show the user the recovered selector and ask
+  whether to apply"), that procedure remains the authoritative resolution
+  even if the cause description has been refined or partially refuted.
+  Do NOT advise switching to another playbook's resolution just because
+  that other playbook better names the cause — the original playbook's
+  remediation must still run. Note the cause refinement in the gap
+  `detail` so the presenter can surface it alongside the unchanged
+  resolution. The only situation in which the resolution branch itself
+  should change is a check 3 gap (Resolution alignment) — flag that
+  separately.
+
 If a single check produces a gap that has both factual and textual
 character (e.g., evidence is missing AND the named cause is
 paraphrased), emit two separate gap entries — one of each kind.

--- a/skills/uipath-diagnostics/agents/hypothesis-tester.md
+++ b/skills/uipath-diagnostics/agents/hypothesis-tester.md
@@ -29,8 +29,12 @@ Gather evidence and evaluate ONE specific hypothesis.
 5. **Gather new evidence** using available tools: uip CLI, `uip docsai ask`, source code, user input
 6. **Empty-result detection:** If 3 or more queries against the same folder return empty results (`[]`) or 404 for the target entity, stop gathering evidence. Check whether the folder in `state.json` actually contains the expected entity by running a scoped query (e.g., `jobs get`, `instances get`). If the entity is not in that folder, try other folders from triage evidence or `folders list-current-user`. If no folder works, write `needs_input.json` asking the user to confirm the correct folder. Do NOT continue testing against a folder that consistently returns empty.
 7. **For large result sets:** summarize yourself — group errors by type, count patterns, extract samples
-8. **Before confirming, actively try to disprove.** Scope disproval effort per the confidence-level behavior table in shared.md. Populate `elimination_checks` for all confidence levels. Populate `execution_path_traced` for medium/low only — for each downstream entity, query its actual state, don't infer from upstream.
-9. **Set status:**
+8. **Preserve user-facing data verbatim when the playbook's `## Resolution` is interactive.** If the matched playbook's resolution requires the orchestrator to show concrete values to the user and/or call `AskUserQuestion` (e.g., apply a Healing Agent recovered selector, dismiss a detected popup, replay a specific HTTP request), the tester MUST extract those exact values into the evidence file — not paraphrase them. Examples:
+   - HA selector failures (`selector-failure-healing-fix.md`): write the failed selector XML and the recovered Partial / Fuzzy selector XML to evidence as standalone string fields (`failed_selector_xml`, `recovered_partial_selector_xml`, `recovered_fuzzy_partial_selector_xml`). Source them from `Content.FailedResolvedTarget.PartialSelector` and from the detection's `EnhancedTargetDto.PartialSelector` / `FuzzyPartialSelector` in `uia/*.json` per the playbook's Investigation step.
+   - When the playbook lists specific field paths to extract, use those paths exactly — do not summarize to "matching selector found".
+   The orchestrator will read these fields back during Resolution to drive the interactive prompt; a missing or paraphrased value blocks the documented resolution procedure.
+9. **Before confirming, actively try to disprove.** Scope disproval effort per the confidence-level behavior table in shared.md. Populate `elimination_checks` for all confidence levels. Populate `execution_path_traced` for medium/low only — for each downstream entity, query its actual state, don't infer from upstream.
+10. **Set status:**
 
    | Status | Criteria |
    |---|---|

--- a/skills/uipath-diagnostics/agents/presenter.md
+++ b/skills/uipath-diagnostics/agents/presenter.md
@@ -114,6 +114,44 @@ Check every entity name in the formatted text against the presentation guides an
 | # | Hypothesis | Confidence | Status | Root Cause? | Key Evidence | Resolution |
 |---|------------|------------|--------|-------------|--------------|------------|
 
+### 7. Emit Post-presentation actions block
+
+If any matched playbook in `state.json.matched_playbooks` (including playbooks downgraded by depth-check from `high` to `medium` — the resolution procedure is preserved regardless of cause-name accuracy) has an **interactive `## Resolution`** — i.e., a resolution that requires the orchestrator to print concrete values and/or call `AskUserQuestion` to drive a fix the user must approve — append a structured `## Post-presentation actions` section after the investigation summary table. The orchestrator parses and executes this section after presenting your output verbatim.
+
+Recognize an interactive resolution when the playbook (or a doc it links to, e.g. `interpretations/healing-agent-data.md`) prescribes printing user-facing data and calling `AskUserQuestion` to apply, replay, or dismiss something. The Healing Agent apply-fix flow is the canonical example.
+
+Format:
+
+```
+## Post-presentation actions
+
+The matched playbook's resolution is interactive. Orchestrator: execute the steps below in order; do not skip.
+
+### Action 1 — {short label, e.g. "Apply Healing Agent recovered selector"}
+- Source: {playbook path + linked procedure section, e.g. `selector-failure-healing-fix.md` → `interpretations/healing-agent-data.md` § "Applying Fixes — MUST Ask the User"}
+- Print as plain text (NOT inside AskUserQuestion options or previews):
+  ```
+  Failed selector:
+  {failed_selector_xml from evidence}
+
+  Recovered Partial selector:
+  {recovered_partial_selector_xml from evidence — or "(not available)" if empty}
+
+  Recovered Fuzzy selector:
+  {recovered_fuzzy_partial_selector_xml from evidence — or "(not available)" if empty}
+  ```
+- Warning to include verbatim: {empty string OR "Healing Agent was running in recommendation-only mode (OrchestratorEnableHeal=false) — the recovered selector was inferred from the UI tree after the failure but was not validated at runtime. There is no guarantee it will work." OR analogous warning for RecoverySuccessful=false}
+- AskUserQuestion: {exact question + options the orchestrator should ask, including the "I'll provide the project path" follow-up question if the project path is not already known from prior context}
+- On user accept: {procedure to follow — e.g., "follow `interpretations/healing-agent-data.md` § Applying `update-target` Fixes: check for `uia-improve-selector` skill at `<PROJECT_DIR>/.local/docs/packages/UiPath.UIAutomation.Activities/skills/uia-improve-selector/USAGE.md`; if present, use it; otherwise edit the XAML activity matched by `ActivityRefId` directly, applying XML encoding per the playbook's XAML Selector Encoding rules; then validate with `uip rpa get-errors --file-path "<WORKFLOW_FILE>" --output json --use-studio`."}
+- On user decline: stop; do not modify files.
+
+### Action 2 — ...
+```
+
+Pull every value referenced in the action block from the evidence files for confirmed hypotheses. If a required value (e.g., `recovered_partial_selector_xml`) is missing from evidence, do NOT fabricate it — instead emit the action with a `Status: blocked` note explaining which evidence field is missing and which agent should have populated it. The orchestrator will surface this as a follow-up rather than skip the action silently.
+
+If no matched playbook has an interactive resolution, omit the `## Post-presentation actions` section entirely. Do not emit an empty section.
+
 ## Boundaries
 
 - Do NOT change hypothesis status, evidence, or investigation state

--- a/skills/uipath-diagnostics/references/activity-packages/ui-automation/playbooks/selector-failure-healing-fix.md
+++ b/skills/uipath-diagnostics/references/activity-packages/ui-automation/playbooks/selector-failure-healing-fix.md
@@ -2,29 +2,44 @@
 confidence: high
 ---
 
-# Selector Failure — Healing Agent Fix Available
+# Selector Failure — Healing Agent Recovery Data Available
 
 ## Context
 
-A UI automation activity failed because its selector didn't match any element in the live UI tree. Healing Agent was enabled and has produced a fix in `healing-fixes.json`.
+A UI automation activity failed because its selector didn't match any element in the live UI tree. Healing Agent was enabled and produced recovery data — either a deterministic fix in `healing-fixes.json` (self-healing path) or an `InferredRecoveryInfo` entry inside `uia/*.json` (recommendation-only path).
 
 What this looks like:
-- SelectorNotFoundException, UiElementNotFoundException, ElementNotInteractableException, or NodeNotFoundException during activity execution
-- `healing-fixes.json` exists and contains a matching entry for the faulted activity
+- `SelectorNotFoundException`, `UiElementNotFoundException`, `ElementNotInteractableException`, or `NodeNotFoundException` during activity execution
+- HA was enabled on the run (`AutopilotForRobots.Enabled=true`, `HealingEnabled=true`)
+- One of the following recovery artifacts exists for the faulted activity:
+  - `healing-fixes.json` with a matching entry (self-healing path — proven or attempted at runtime), OR
+  - `uia/*.json` with a non-null `InferredRecoveryInfo` / `RecoveryInfo` containing a recovered target (recommendation-only path when `HealingAgentContext.OrchestratorEnableHeal=false`)
 
 What can cause it:
 - Target application UI changed (redesign, update, dynamic content)
 - Element attribute became dynamic (index shifted, name changed per session)
+- Authoring-time selector mistake against a stable element (typo, wrong attribute value, copy-paste error) — the live element is unchanged but the workflow's selector never matched
+- Element temporarily obscured by a popup or overlapping window (HA may emit a `dismiss-popup` fix instead of `update-target`)
+
+This playbook applies whenever HA recovery data is present for the failing activity, regardless of which specific cause above produced the failure. The cause label affects the user-facing narrative; the **remediation procedure (present HA's recommendation, ask whether to apply it) is the same for all of them** and is the authoritative resolution path even when the cause is later refined (e.g., depth-verifier identifies an authoring typo rather than UI drift).
 
 ## Investigation
 
-1. Match entry by `ActivityRefId` (preferred) or `activityName` + `workflowFile` (fallback)
-2. Extract the `enhancedTarget` (for `update-target` fixes) or `clickTarget` (for `dismiss-popup` fixes)
-3. Compare failed selector vs recommended selector
-4. Check confidence score and strategy name
+1. Identify the recovery channel:
+   - **Self-healing path** — `healing-fixes.json` exists at the job cache root. Match an entry by `ActivityRefId` (preferred) or `activityName` + `workflowFile`.
+   - **Recommendation-only path** — `healing-fixes.json` is absent but `uia/*.json` contains `InferredRecoveryInfo` or `RecoveryInfo` with `RecoveredTarget`/`RecoveredSecondaryTarget`. `HealingAgentContext.OrchestratorEnableHeal=false` is the signature of this mode.
+2. **Extract concrete selector strings** from the recovery data so they can be shown to the user. Do NOT summarize them away — the actual XML strings are required by the resolution procedure:
+   - **Failed selector** — `Content.FailedResolvedTarget.PartialSelector` (and `FuzzyPartialSelector` if present) from the matching `uia/*.json`.
+   - **Recovered selector** — for self-healing: `enhancedTarget` / `clickTarget` from the `healing-fixes.json` entry. For recommendation-only: locate the detection in `Content.AnalysisResult[0].AnalysisInformation[*].Detections[*]` whose `Id` matches `InferredRecoveryInfo.RecoveredTarget.DetectionId` (or, when no DetectionId is set, take the detection from the strategy with the highest-confidence consensus per `interpretations/healing-agent-data.md` § "Detections Without Recovery Entries"). Read its `EnhancedTargetDto.PartialSelector` and `EnhancedTargetDto.FuzzyPartialSelector` (fall back to `InferredTargetDto.*` if `EnhancedTargetDto` is empty).
+3. Compare failed vs recommended selector and note which attributes changed (text, index, role, ancestry, etc.).
+4. Record the recovery channel, the detection's `InferMethod` / confidence score, and whether self-healing actually applied the fix at runtime (`RecoverySuccessful`). These determine the warning attached to the apply-fix prompt.
+
+Persist the exact failed and recovered selector strings to the evidence file for this hypothesis (e.g., as `failed_selector_xml`, `recovered_partial_selector_xml`, `recovered_fuzzy_partial_selector_xml`). The orchestrator's Resolution phase will read them back to drive the `AskUserQuestion` apply-fix flow — they MUST be present verbatim, not paraphrased.
 
 ## Resolution
 
-Follow the fix-application procedures in [interpretations/healing-agent-data.md](../interpretations/healing-agent-data.md) (section "Applying HA Fixes"):
-- For `update-target`: see "Applying `update-target` Fixes" — uses `uia-improve-selector` skill if available, falls back to direct XAML edit
-- For `dismiss-popup`: see "Applying `dismiss-popup` Fixes" — creates a Click activity before the failing activity, validates the workflow compiles
+Follow the fix-application procedures in [interpretations/healing-agent-data.md](../interpretations/healing-agent-data.md) (section "Applying HA Fixes" and "Applying Fixes — MUST Ask the User"):
+- For `update-target` (self-healing) or `InferredRecoveryInfo.RecoveredTarget` (recommendation-only): use `uia-improve-selector` skill if available, otherwise direct XAML edit. When the data is `InferredRecoveryInfo` or `RecoverySuccessful: false`, attach the runtime-not-validated warning to the apply-fix prompt.
+- For `dismiss-popup` / `RecoveredExternally`: create a Click activity before the failing activity, validate the workflow compiles.
+
+This resolution path is **interactive** — it requires `AskUserQuestion` to be called by the orchestrator at the end of the diagnostic to (a) print the Failed / Recovered Partial / Recovered Fuzzy selectors as plain text, (b) ask the user whether to apply the fix and which selector variant. The presenter must emit a `## Post-presentation actions` block declaring this interactive step; the orchestrator must execute it before closing the investigation. Do not collapse this into a generic "fix the selector" recommendation — the recovered selector text and the apply-fix prompt are part of the documented resolution.


### PR DESCRIPTION
Adds a structured handoff from the presenter to the orchestrator so playbooks with interactive resolutions (apply-fix flows requiring user approval) run consistently after the final summary is
  shown.

  What changes

  - presenter.md — new Step 7: when any matched playbook has an interactive ## Resolution, append a ## Post-presentation actions block with the failed/recovered values, verbatim warning string,
  exact AskUserQuestion prompt, and the "on accept" procedure pulled from evidence. Emits Status: blocked instead of fabricating when a required evidence field is missing.
  - SKILL.md — orchestrator now executes the Post-presentation actions block before any generic follow-up. Each action: print raw values as plain text (selectors render poorly inside AskUserQuestion
   previews), print the warning, ask, then run the procedure exactly as written. Explicitly handles depth-check confidence downgrades, cause-name mismatches, and recommendation-only mode.
  - depth-verifier.md, hypothesis-tester.md — preserve the playbook's resolution path across confidence downgrades; surface the evidence fields the presenter needs.
  - selector-failure-healing-fix.md — makes the Resolution section the canonical interactive example (Healing Agent apply-fix), wired to interpretations/healing-agent-data.md § "Applying Fixes".

  Without this, the orchestrator either improvises a fix (sometimes wrong) or drops the interactive step entirely after presenting findings — especially common in recommendation-only mode
  (OrchestratorEnableHeal=false, RecoverySuccessful=false), where the recovered selector exists but the user must explicitly approve applying it.

<img width="3839" height="2240" alt="image" src="https://github.com/user-attachments/assets/718980bd-c6c6-4075-b442-fd692cd1026a" />
