### PR TITLE
fix(maestro-flow): quarantine eval tasks blocked on public CLI [MST-9675]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
@@ -11,9 +11,10 @@ description: >
   uipath-maestro-flow skill.
 tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:execute]
 skip: true
-# Blocked until `uip maestro flow eval` is available in the public CLI used by
-# CI. The PR smoke workflow currently installs public @uipath/cli@latest
-# (0.9.1), which does not expose Flow eval commands.
+# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
+# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
+# under `maestro flow`). Re-enable once a release exposes the Flow eval
+# surface to the public registry used by CI. See MST-9675.
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -8,10 +8,12 @@ description: >
   similarity → json-similarity, substring presence → contains. The
   `command_executed` regexes pin each `--type` value, so the agent has to
   both pick correctly and run the CLI to pass.
-# BLOCKED: `uip maestro flow eval` is not available in public @uipath/cli@latest
-# (currently 0.9.1 in PR smoke CI). Re-enable the smoke tag once CLI >= 1.0.0
-# with Flow eval support is published to the public npm registry used by CI.
 tags: [uipath-maestro-flow, smoke-blocked, mode:build, lifecycle:discover]
+skip: true
+# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
+# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
+# under `maestro flow`). Re-enable once a release exposes the Flow eval
+# surface to the public registry used by CI. See MST-9675.
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -6,10 +6,12 @@ description: >
   no upload, no run. Tests whether the skill teaches the correct local-CRUD
   workflow and `--output json` discipline on every `uip maestro flow eval`
   command.
-# BLOCKED: `uip maestro flow eval` is not available in public @uipath/cli@latest
-# (currently 0.9.1 in PR smoke CI). Re-enable the smoke tag once CLI >= 1.0.0
-# with Flow eval support is published to the public npm registry used by CI.
 tags: [uipath-maestro-flow, smoke-blocked, mode:build, lifecycle:generate]
+skip: true
+# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
+# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
+# under `maestro flow`). Re-enable once a release exposes the Flow eval
+# surface to the public registry used by CI. See MST-9675.
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -6,10 +6,12 @@ description: >
   requires the agent to refuse auto-upload, surface the missing prerequisite,
   and ask the user to authorize an upload. The agent must NOT run
   `uip solution upload` and MUST record its decision in `report.json`.
-# BLOCKED: `uip maestro flow eval` is not available in public @uipath/cli@latest
-# (currently 0.9.1 in PR smoke CI). Re-enable the smoke tag once CLI >= 1.0.0
-# with Flow eval support is published to the public npm registry used by CI.
 tags: [uipath-maestro-flow, smoke-blocked, mode:operate, lifecycle:execute]
+skip: true
+# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
+# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
+# under `maestro flow`). Re-enable once a release exposes the Flow eval
+# surface to the public registry used by CI. See MST-9675.
 
 agent:
   type: claude-code


### PR DESCRIPTION
## Summary

- Sets `skip: true` on the three blocked `skill-flow-eval-*` task YAMLs in `tests/tasks/uipath-maestro-flow/evaluate/` (matching `eval_run.yaml`'s precedent).
- Refreshes the blocker comment across all four files: cites `@uipath/cli@1.0.0` (was `0.9.1`), describes the actual gap (`eval` subcommand missing under `maestro flow`), and links MST-9675.

## Why

MST-9675 ([Jira](https://uipath.atlassian.net/browse/MST-9675)). In the 2026-05-12_06-30-23 run the four `skill-flow-eval-*` tasks all hit `error: unknown command 'eval'` on `uip maestro flow eval evaluator add ...`. Three failed; one (`run-e2e`) errored at the 1200s turn-timeout. The CLI source registers the command in `~/root/cli/packages/flow-tool/src/commands/eval.ts` at v1.1.0, but the latest npm-published `@uipath/cli` is 1.0.0 and its bundle does not include the `eval` surface — verified by `node dist/index.js maestro flow eval --help`.

This PR is paired with coder_eval [PR #242](https://github.com/UiPath/coder_eval/pull/242), which makes `skip: true` actually honored by the task loader. Until #242 lands the field is a silent no-op (which is also why `eval_run.yaml`'s pre-existing `skip: true` did not stop it from running on 2026-05-12).

## Test plan

- [x] All four YAMLs parse cleanly (`yaml.safe_load`) and report `skip=True` with tags intact
- [x] `skip: true` placed directly after `tags:` to match `eval_run.yaml` precedent and stay grep-friendly
- [x] Each comment cites the actual CLI version (1.0.0) and links MST-9675
- [ ] After coder_eval #242 merges: a coder_eval run with `--filter 'skill-flow-eval-*'` reports the four tasks in `run.json.skipped_tasks` and produces no `FAILURE` / `ERROR` rows for them
- [ ] Re-enable each task by deleting its `skip: true` line once a future `@uipath/cli` release publishes the Flow eval surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)