### PR TITLE
fix(maestro-case): always emit intsvcActivityConfig: v2 in v20 metadata

### DIFF
--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -28,6 +28,7 @@ Structural reference for the case definition JSON. Shared across all node types.
     "caseAppEnabled": false,
     "publishVersion": 2,
     "caseUnifiedSchemaEnabled": true,
+    "intsvcActivityConfig": "v2",
     "slaRules": [ ... ],
     "caseExitRules": [ ... ]
   },
@@ -62,7 +63,7 @@ Structural reference for the case definition JSON. Shared across all node types.
 | `root.data.uipath.bindings` | top-level `bindings` |
 | `root.data.uipath.variables` | top-level `variables` |
 | `root.caseExitConditions` | `metadata.caseExitRules` *(field renamed)* |
-| `root.data.intsvcActivityConfig` | dropped — not in v20 metadata schema |
+| `root.data.intsvcActivityConfig` | `metadata.intsvcActivityConfig` |
 | `nodes` | `nodes` *(unchanged shape — see § 2 below)* |
 | `edges` | `edges` *(unchanged shape — see § 3 below)* |
 | — | `layout: {}` *(new top-level — see § 7 below)* |

--- a/skills/uipath-maestro-case/references/plugins/case/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/case/impl-json.md
@@ -261,7 +261,8 @@ Pure skeleton: top-level fields + `metadata` block + empty `bindings: []` + empt
         "caseIdentifierType": "<constant|external — defaults to constant>",
         "caseAppEnabled": <true|false — defaults to false>,
         "publishVersion": 2,
-        "caseUnifiedSchemaEnabled": true
+        "caseUnifiedSchemaEnabled": true,
+        "intsvcActivityConfig": "v2"
     },
     "bindings": [],
     "variables": {
@@ -290,7 +291,8 @@ Adds top-level `description` field (NOT inside `metadata`):
         "caseIdentifierType": "<constant|external>",
         "caseAppEnabled": <true|false>,
         "publishVersion": 2,
-        "caseUnifiedSchemaEnabled": true
+        "caseUnifiedSchemaEnabled": true,
+        "intsvcActivityConfig": "v2"
     },
     "bindings": [],
     "variables": {
@@ -304,7 +306,7 @@ Adds top-level `description` field (NOT inside `metadata`):
 }
 ```
 
-> **`intsvcActivityConfig` dropped in v20** — not present in `CaseManagementMetadataSchema`. Do not emit it under `metadata` or anywhere else.
+> **`intsvcActivityConfig` always emitted in v20** — set `metadata.intsvcActivityConfig: "v2"` on every v20 caseplan. Mirrors the v19 `root.data.intsvcActivityConfig` field, relocated under `metadata`.
 
 ## Formatting
 
@@ -342,6 +344,7 @@ Cheap sanity checks only — full validation runs after all plugins are done, pe
    - `version === "20.0.0"`
    - `metadata.caseUnifiedSchemaEnabled === true`
    - `metadata.publishVersion === 2`
+   - `metadata.intsvcActivityConfig === "v2"`
    - `bindings` is an array of length 0
    - `variables.inputs`, `variables.outputs`, `variables.inputOutputs` are all arrays of length 0
 3. **Empty node/edge arrays + layout.**
@@ -351,7 +354,7 @@ Cheap sanity checks only — full validation runs after all plugins are done, pe
 4. **No v19 leakage.**
    - No `root` key at top level
    - No `version === "v19"` anywhere
-   - No `data.intsvcActivityConfig`
+   - No `data.intsvcActivityConfig` (v20 emits it under `metadata`, not `data`)
 
 If any check fails, halt and report — do not proceed to downstream plugins.
 

--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -95,6 +95,7 @@ After grouping T-entries by target, compose the `slaRules` array and write it in
   "metadata": {
     "caseIdentifier": "<...>",
     "caseUnifiedSchemaEnabled": true,
+    "intsvcActivityConfig": "v2",
     "slaRules": [ <composed array above> ]
   },
   "...": "..."


### PR DESCRIPTION
## Summary
- Restore `intsvcActivityConfig: "v2"` under `metadata` in the v20 caseplan schema (previously documented as dropped).
- Update v20 recipes in the `case` plugin (minimal + with-description) and the v20 root-target shape in the `sla` plugin example to include the field.
- Update the v19→v20 mapping table and v20 post-write validation to require `metadata.intsvcActivityConfig === "v2"`.

## Test plan
- [ ] Re-run case skill in v20 mode and confirm generated `caseplan.json` has `metadata.intsvcActivityConfig: "v2"`.
- [ ] Confirm v20 post-write validation passes against the updated rule set.
- [ ] Spot-check that no v19 recipe was inadvertently altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)