### PR TITLE
fix(tests): migrate experiment YAMLs to run_limits schema

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -148,12 +148,14 @@ Groupings under a skill are advisory — pick the ones that map to how the skill
 
 Experiment files define shared agent defaults per test type. Tasks inherit these defaults and should only override what differs.
 
-| Experiment | Used by | max_iterations | max_turns | task_timeout | turn_timeout |
-|------------|---------|----------------|-----------|--------------|--------------|
-| `default.yaml` | Smoke | 1 | 20 | 600s | 300s |
-| `integration.yaml` | Integration | 2 | 30 | 900s | 300s |
-| `e2e.yaml` | E2E | 2 | 40 | 1200s | 300s |
-| `activation.yaml` | Skill activation classifier | 1 | 1 | 120s | 120s |
+Run-time caps live under `defaults.run_limits` (see coder_eval `RunLimits`).
+
+| Experiment | Used by | max_turns | task_timeout | turn_timeout |
+|------------|---------|-----------|--------------|--------------|
+| `default.yaml` | Smoke | 40 | 900s | 900s |
+| `integration.yaml` | Integration | 30 | 900s | 300s |
+| `e2e.yaml` | E2E | 200 | 1200s | 300s |
+| `activation.yaml` | Skill activation classifier | 1 | 120s | 120s |
 
 `activation.yaml` is a different shape from the tiered configs above — it runs the agent for exactly one turn against single-prompt rows to measure whether the right skill fires (precision/recall/F1 per skill). It's an opt-in benchmark, not a smoke gate. See [`tasks/activation/README.md`](tasks/activation/README.md).
 
@@ -291,7 +293,7 @@ success_criteria:
 
 Key patterns to note:
 - **No `agent:` block** — inherits everything from `experiments/default.yaml`
-- **No `max_iterations` or `llm_reviewer`** — inherited from the experiment config
+- **No `run_limits:` block** — inherits turn / timeout caps from the experiment config
 - **Minimal prompt** — describes the goal ("create and validate"), not the steps
 - **Behavior-only criteria** — `command_executed` and `file_exists` verify real operations, not agent self-reports
 - **Weighted scoring** — core commands (`weight: 1.5`) matter more than supporting checks (`weight: 1.0`)

--- a/tests/experiments/activation.yaml
+++ b/tests/experiments/activation.yaml
@@ -6,20 +6,20 @@ description: >
 
 defaults:
   # Activation is a one-shot decision per prompt — short timeouts are fine.
-  max_iterations: 1
-  task_timeout: 120
-  turn_timeout: 120
-
-  agent:
-    type: claude-code
-    permission_mode: acceptEdits
-    model: claude-sonnet-4-6
+  run_limits:
     # Activation is a recognition decision, not a work loop — the agent must
     # decide from the prompt + skill descriptions alone, with zero sandbox
     # discovery. 1 turn forces invoke-or-don't on the first response. Higher
     # limits would let the agent compensate for a weak skill description by
     # exploring, masking the signal we want to measure.
     max_turns: 1
+    task_timeout: 120
+    turn_timeout: 120
+
+  agent:
+    type: claude-code
+    permission_mode: acceptEdits
+    model: claude-sonnet-4-6
     # Skill must be allowed so the agent can invoke a skill when it decides
     # to. Read/Write/Bash included so the agent isn't starved of basic tools
     # when it decides NOT to use Skill — removing them would bias the

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -2,21 +2,21 @@ experiment_id: skill-tests-default
 description: "Default experiment for smoke tests — loads the full UiPath skills plugin"
 
 defaults:
-  max_iterations: 1
-  # Helm-backed `uip rpa` ops (install-or-update-packages, get-analyzer-rules,
-  # build) regularly take 30-90s each on a cold runner. The before/after-hooks
-  # task chains several such calls, so the agent's single turn needs headroom.
-  task_timeout: 900
-  turn_timeout: 900
+  run_limits:
+    # Coded RPA tasks (hooks setup + test case + project.json edits +
+    # `uip rpa` calls) routinely take 25-30 turns end-to-end. 20 was
+    # cutting before/after-hooks and coded-test-case off mid-task.
+    max_turns: 40
+    # Helm-backed `uip rpa` ops (install-or-update-packages, get-analyzer-rules,
+    # build) regularly take 30-90s each on a cold runner. The before/after-hooks
+    # task chains several such calls, so the agent's single turn needs headroom.
+    task_timeout: 900
+    turn_timeout: 900
 
   agent:
     type: claude-code
     permission_mode: acceptEdits
     model: claude-sonnet-4-6
-    # Coded RPA tasks (hooks setup + test case + project.json edits +
-    # `uip rpa` calls) routinely take 25-30 turns end-to-end. 20 was
-    # cutting before/after-hooks and coded-test-case off mid-task.
-    max_turns: 40
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
     system_prompt: |
       You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
@@ -24,25 +24,6 @@ defaults:
       - type: "local"
         path: "$SKILLS_REPO_PATH"
     ignore_patterns: []
-
-  # Qualitative LLM review runs after the evaluation loop and its verdict
-  # renders in task.html's reviewer card. Backed by ANTHROPIC_API_KEY in
-  # CI (see smoke workflows); silently degrades when no reviewer backend
-  # is available.
-  llm_reviewer:
-    enabled: true
-    model: claude-sonnet-4-6
-    temperature: 0.0
-    max_tokens: 600
-    prompt: |
-      Evaluate whether the agent produced correct, minimal output for this
-      UiPath skill task and adhered to the skill's Critical Rules. Focus on:
-      - Did the agent pick and invoke the right skill / commands?
-      - Are the required files present with the expected shape and content?
-      - Were the uip CLI flags used correctly (e.g. --output json)?
-      Reply terse, developer-style: what's wrong, if anything, and what to
-      fix next. Score 1.0 if the work is correct and complete, lower
-      otherwise.
 
 variants:
   - variant_id: default

--- a/tests/experiments/e2e.yaml
+++ b/tests/experiments/e2e.yaml
@@ -2,15 +2,15 @@ experiment_id: skill-tests-e2e
 description: "End-to-end tests — full lifecycle with staging tenant connectivity"
 
 defaults:
-  max_iterations: 2
-  task_timeout: 1200
-  turn_timeout: 300
+  run_limits:
+    max_turns: 200
+    task_timeout: 1200
+    turn_timeout: 300
 
   agent:
     type: claude-code
     permission_mode: acceptEdits
     model: claude-sonnet-4-6
-    max_turns: 200
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
     system_prompt: |
       You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
@@ -18,18 +18,6 @@ defaults:
       - type: "local"
         path: "$SKILLS_REPO_PATH"
     ignore_patterns: []
-
-  llm_reviewer:
-    enabled: true
-    model: claude-sonnet-4-6
-    temperature: 0.0
-    max_tokens: 1000
-    prompt: |
-      Evaluate whether the full end-to-end lifecycle completed correctly:
-      project creation, workflow authoring, validation, and platform
-      round-trip where applicable. Call out any step that was skipped,
-      skipped-but-should-have-run, or produced a partial result. Score 1.0
-      if complete and correct, lower otherwise.
 
   # Append default post_run to every e2e task: delete Studio Web solutions
   # uploaded by `uip maestro flow debug` (no-op for tasks that don't produce .uipx).

--- a/tests/experiments/integration.yaml
+++ b/tests/experiments/integration.yaml
@@ -2,15 +2,15 @@ experiment_id: skill-tests-integration
 description: "Integration tests — longer timeouts for complex multi-step scenarios"
 
 defaults:
-  max_iterations: 2
-  task_timeout: 900
-  turn_timeout: 300
+  run_limits:
+    max_turns: 30
+    task_timeout: 900
+    turn_timeout: 300
 
   agent:
     type: claude-code
     permission_mode: acceptEdits
     model: claude-sonnet-4-6
-    max_turns: 30
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
     system_prompt: |
       You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
@@ -18,16 +18,6 @@ defaults:
       - type: "local"
         path: "$SKILLS_REPO_PATH"
     ignore_patterns: []
-
-  llm_reviewer:
-    enabled: true
-    model: claude-sonnet-4-6
-    temperature: 0.0
-    max_tokens: 800
-    prompt: |
-      Evaluate correctness and adherence to the skill's Critical Rules for
-      this integration test. Be terse and specific about any issues. Score
-      1.0 if the final state is correct and complete, lower otherwise.
 
 variants:
   - variant_id: default

--- a/tests/experiments/sherif-skill-comparison.yaml
+++ b/tests/experiments/sherif-skill-comparison.yaml
@@ -21,7 +21,6 @@ experiment_id: skills-eval
 description: "Compare impact of docs and skills on agent SDK coding tasks"
 
 defaults:
-  max_iterations: 1
   repeats: 1
   agent:
     type: claude-code

--- a/tests/experiments/skill-comparison-template.yaml
+++ b/tests/experiments/skill-comparison-template.yaml
@@ -20,15 +20,15 @@ description: "One-sentence hypothesis under test"
 # Pass --repeats N at CLI time to override repeats without editing this file.
 # ---------------------------------------------------------------------------
 defaults:
-  max_iterations: 2
-  task_timeout: 1200
-  turn_timeout: 300
+  run_limits:
+    max_turns: 20
+    task_timeout: 1200
+    turn_timeout: 300
   repeats: 1
   agent:
     type: claude-code
     permission_mode: bypassPermissions
     model: claude-sonnet-4-6
-    max_turns: 20
     allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
     system_prompt: |
       You are a coding agent. Work only inside your current working directory.


### PR DESCRIPTION
## What

Migrate the 6 files under `tests/experiments/` to the post-coder_eval#244 schema:

- Move `task_timeout` / `turn_timeout` / `agent.max_turns` under a single `defaults.run_limits` block
- Drop `max_iterations` (dead since coder_eval#191)
- Drop `llm_reviewer` block (dead since coder_eval#191)
- Update the experiments table and inheritance bullets in `tests/README.md`

## Why

coder_eval#244 (merged 2026-05-13) added `extra="forbid"` to `ExperimentDefaults` / `ExperimentVariant` and removed the legacy top-level timing scalars. The PR's hoist shim covers `tests/tasks/*.yaml` but not `tests/experiments/*.yaml`, so the daily eval run and the smoke-skills CI started failing at experiment load with `4 validation errors for ExperimentDefinition defaults.*`.

All 5 actively-loaded experiments now load cleanly with zero `DeprecationWarning`s. `skill-comparison-template.yaml` remains intentionally invalid (placeholder `experiment_id`) — copied by users, never loaded by CI.

Follow-up suggestion (separate PR on coder_eval): mirror `TaskDefinition`'s hoist shim onto `ExperimentDefaults` / `ExperimentVariant` so future downstream experiment YAMLs survive the migration window.