### PR TITLE
test(uipath-agents): add 4 coded-agent priority-gap tests

### DIFF
--- a/tests/tasks/uipath-agents/deploy_tenant/check_deploy_tenant.py
+++ b/tests/tasks/uipath-agents/deploy_tenant/check_deploy_tenant.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Deploy-to-tenant artifact + metadata check.
+
+Asserts the agent left behind a project ready for the tenant feed:
+all four pyproject fields required by the deploy guide (`name`,
+`version`, `description`, `authors`), no `[build-system]`, and a
+`.uipath/*.nupkg` proving `pack` ran. The `--tenant` flag itself is
+matched by `command_executed` in the YAML — this script verifies the
+artifacts a successful `deploy` produces alongside it.
+
+Also checks that `uipath.json` configures `packOptions` to exclude the
+`data/` directory from the package. `packOptions` is the documented
+knob for controlling package contents, and is otherwise untested.
+
+Checks:
+  1. `tenant-echo/pyproject.toml` has `name`, `version`, `description`,
+     and `authors`. No `[build-system]` section.
+  2. `tenant-echo/uipath.json` has
+     `packOptions.directoriesExcluded` including `data`.
+  3. `tenant-echo/.uipath/` contains at least one `*.nupkg` file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("tenant-echo")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Critical Rule C1 forbids it."
+        )
+    for needle in ("name", "version", "description", "authors"):
+        if needle not in text:
+            sys.exit(
+                f"FAIL: pyproject.toml is missing `{needle}` — deployment "
+                "guide requires all four fields. Tenant publish will reject "
+                "the package."
+            )
+    print("OK: pyproject.toml has name, version, description, authors")
+
+
+def check_pack_options_excludes_data() -> None:
+    """packOptions.directoriesExcluded must keep `data/` out of the package."""
+    doc = _load_json(ROOT / "uipath.json")
+    pack = doc.get("packOptions") or {}
+    excluded = pack.get("directoriesExcluded") or []
+    if not isinstance(excluded, list):
+        sys.exit(
+            f"FAIL: uipath.json `packOptions.directoriesExcluded` should be "
+            f"a list, got {type(excluded).__name__}"
+        )
+    if "data" not in excluded:
+        sys.exit(
+            f"FAIL: uipath.json `packOptions.directoriesExcluded` does not "
+            f"include `data`. The agent must exclude the local-only `data/` "
+            f"directory from the published package. Got: {excluded!r}"
+        )
+    print(
+        f"OK: uipath.json packOptions.directoriesExcluded = {excluded!r} "
+        f"(keeps data/ out of the package)"
+    )
+
+
+def check_pack_artifacts() -> None:
+    uipath_dir = ROOT / ".uipath"
+    if not uipath_dir.is_dir():
+        sys.exit(
+            f"FAIL: {uipath_dir} does not exist — `uip codedagent deploy` "
+            "did not produce a package directory."
+        )
+    nupkgs = sorted(uipath_dir.glob("*.nupkg"))
+    if not nupkgs:
+        sys.exit(
+            f"FAIL: no .nupkg in {uipath_dir} — pack stage of deploy did "
+            "not produce the expected artifact."
+        )
+    print(
+        f"OK: {uipath_dir.name}/{nupkgs[0].name} exists "
+        f"({len(nupkgs)} package(s) total)"
+    )
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    check_pack_options_excludes_data()
+    check_pack_artifacts()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/deploy_tenant/deploy_tenant.yaml
+++ b/tests/tasks/uipath-agents/deploy_tenant/deploy_tenant.yaml
@@ -1,0 +1,81 @@
+task_id: skill-agent-coded-deploy-tenant
+description: >
+  Coded-agent deploy to the **tenant feed** with `packOptions`. The
+  other two deploy targets (`--my-workspace` and `--folder`) are
+  already covered; `--tenant` is the only documented target with zero
+  coverage. The agent also has to keep a non-source directory
+  (`data/`) out of the package, exercising
+  `packOptions.directoriesExcluded` in `uipath.json` — the documented
+  knob for controlling package contents. **Cloud auth + tenant-level
+  publish permission required** for the host running coder-eval.
+tags: [uipath-agents, e2e, coded, mode:build, feature:deploy]
+max_iterations: 1
+task_timeout: 1500
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 60
+  turn_timeout: 1500
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a Simple Function UiPath coded agent named `tenant-echo`
+  that takes a `message` (string) and returns
+  `{"echoed": message}`. No LLM, no SDK calls.
+
+  Alongside the source, the project includes a `data/` directory
+  with fixture JSON used during local development only — create it
+  as `tenant-echo/data/fixtures.json` containing
+  `{"sample": "value"}`. The `data/` directory must NOT end up in
+  the published package.
+
+  Take the agent through scaffold → init → run locally, then ship
+  it to the tenant feed. The host has UiPath auth pre-configured
+  with permission to publish to the tenant feed.
+
+  Do NOT publish to the personal workspace or to a folder feed.
+  Complete it in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deployed to the tenant feed"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+(deploy|publish)\s+.*--tenant\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Coded agent project exists"
+    path: "tenant-echo/pyproject.toml"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "pyproject.toml + packOptions excludes data/ + .nupkg artifact present"
+    command: "python3 $TASK_DIR/check_deploy_tenant.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/diagnose_deploy_failure/check_diagnose_deploy_failure.py
+++ b/tests/tasks/uipath-agents/diagnose_deploy_failure/check_diagnose_deploy_failure.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Diagnose check: `Project authors cannot be empty` recovery.
+
+Verifies the skill steered the agent to fix the pyproject.toml
+rejection rather than wholesale-rewriting the project. The seed has
+a working `main.py` and `uipath.json` — those should be preserved.
+Only `pyproject.toml` needs to gain a valid `authors` entry.
+
+Checks:
+  1. `daily-digest/pyproject.toml`:
+     - has `[project]`
+     - has a non-empty `authors = [...]` entry
+     - retains `name`, `version`, `description`, `dependencies`
+     - has NO `[build-system]` section (Critical Rule C1)
+  2. `daily-digest/main.py` retains the seeded `@traced()` `main`
+     definition (no rewrite).
+  3. `daily-digest/.uipath/` exists and contains at least one
+     `*.nupkg` — proof that `uip codedagent deploy` got past the
+     pyproject rejection and produced a package.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("daily-digest")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Critical Rule C1 forbids it."
+        )
+    if "[project]" not in text:
+        sys.exit("FAIL: pyproject.toml has no [project] section")
+
+    authors_match = re.search(r"^\s*authors\s*=\s*\[(.*?)\]", text, re.DOTALL | re.MULTILINE)
+    if not authors_match:
+        sys.exit(
+            "FAIL: pyproject.toml has no `authors = [...]` entry — "
+            "the original rejection (`Project authors cannot be empty`) "
+            "would still apply."
+        )
+    inner = authors_match.group(1).strip()
+    if not inner:
+        sys.exit(
+            "FAIL: pyproject.toml `authors` list is empty — same "
+            "rejection would still apply."
+        )
+    if "name" not in inner:
+        sys.exit(
+            f'FAIL: pyproject.toml `authors` entry does not contain a '
+            f'`name` field. Expected something like `[{{ name = "..." }}]`. '
+            f'Got: {inner!r}'
+        )
+
+    for needle in ("name", "version", "description", "dependencies"):
+        if needle not in text:
+            sys.exit(
+                f"FAIL: pyproject.toml lost the `{needle}` field — the "
+                "diagnose flow should not strip existing fields."
+            )
+    print("OK: pyproject.toml has authors[] and all original fields intact")
+
+
+def check_main_preserved() -> None:
+    text = _read_text(ROOT / "main.py")
+    for needle in ("class Input", "class Output", "async def main", "@traced"):
+        if needle not in text:
+            sys.exit(
+                f"FAIL: main.py lost the seeded piece `{needle}` — the "
+                "diagnose flow should not rewrite the working agent."
+            )
+    print("OK: main.py retains the seeded Simple Function shape")
+
+
+def check_pack_artifacts() -> None:
+    uipath_dir = ROOT / ".uipath"
+    if not uipath_dir.is_dir():
+        sys.exit(
+            f"FAIL: {uipath_dir} does not exist — `uip codedagent deploy` "
+            "either never re-ran after the fix or did not produce a "
+            "package directory."
+        )
+    nupkgs = sorted(uipath_dir.glob("*.nupkg"))
+    if not nupkgs:
+        sys.exit(
+            f"FAIL: no .nupkg in {uipath_dir} — pack stage did not "
+            "produce the expected artifact, so the pyproject fix did "
+            "not unblock the deploy."
+        )
+    print(
+        f"OK: {uipath_dir.name}/{nupkgs[0].name} exists "
+        f"({len(nupkgs)} package(s) total)"
+    )
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    check_main_preserved()
+    check_pack_artifacts()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/diagnose_deploy_failure/diagnose_deploy_failure.yaml
+++ b/tests/tasks/uipath-agents/diagnose_deploy_failure/diagnose_deploy_failure.yaml
@@ -1,0 +1,108 @@
+task_id: skill-agent-coded-diagnose-deploy-failure
+description: >
+  Diagnose-mode coverage for the coded path's deploy lifecycle. The
+  Quickstart Troubleshooting table documents `Project authors cannot
+  be empty` as the canonical pyproject hygiene rejection on
+  `uip codedagent deploy`. This seeds a coded agent project whose
+  `pyproject.toml` is missing the `authors` entry and expects the
+  skill to (1) diagnose the rejection from the error wording, (2)
+  add a valid `authors = [...]` entry, and (3) successfully re-ship
+  to the user's personal workspace. **Cloud auth pre-configured.**
+tags: [uipath-agents, e2e, coded, mode:diagnose, feature:deploy]
+max_iterations: 1
+task_timeout: 2100
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 60
+  turn_timeout: 2100
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Recreate the Simple Function UiPath coded agent under
+  `daily-digest/` from the snapshot below. Shipping it to the
+  personal workspace with `uip codedagent deploy --my-workspace`
+  fails with:
+
+      Project authors cannot be empty
+
+  Fix what's blocking the deploy and ship it to the personal
+  workspace.
+
+  **daily-digest/pyproject.toml**:
+  ```toml
+  [project]
+  name = "daily-digest"
+  version = "0.0.1"
+  description = "Returns today's date as a one-line digest"
+  requires-python = ">=3.11"
+  dependencies = ["uipath"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **daily-digest/main.py**:
+  ```python
+  from datetime import datetime
+  from pydantic import BaseModel
+  from uipath.tracing import traced
+
+
+  class Input(BaseModel):
+      label: str = "digest"
+
+
+  class Output(BaseModel):
+      digest: str
+
+
+  @traced()
+  async def main(input: Input) -> Output:
+      today = datetime.utcnow().strftime("%Y-%m-%d")
+      return Output(digest=f"{input.label}: {today}")
+  ```
+
+  **daily-digest/uipath.json**:
+  ```json
+  {"functions": {"main": "main.py:main"}}
+  ```
+
+  The test harness has UiPath auth pre-configured. Do NOT rewrite
+  the agent — it works as-is. Complete it in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran uip codedagent init to refresh entry-points.json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deployed to personal workspace after fixing pyproject"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+(deploy|publish)\s+.*--my-workspace'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Seeded agent code preserved (no rewrite)"
+    path: "daily-digest/main.py"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "pyproject.toml now has authors, code preserved, pack artifact exists"
+    command: "python3 $TASK_DIR/check_diagnose_deploy_failure.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/eval_mocking_mockito/check_eval_mocking_mockito.py
+++ b/tests/tasks/uipath-agents/eval_mocking_mockito/check_eval_mocking_mockito.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Eval-lifecycle check: both documented mocking patterns + JsonSimilarity.
+
+The agent must pin BOTH mocking patterns (the skill documents two of
+them, and a real agent will reach for one or the other depending on
+the call shape):
+
+  - Declarative `mockingStrategy: mockito` on at least one test case,
+    mocking the UiPath SDK asset retrieval helper.
+  - In-code `@mockable(example_calls=[...])` on at least one function
+    in `main.py`, paired with the `ExampleCall` import from
+    `uipath.eval.mocks`. This is what makes the `requests.get`-style
+    helper substitutable at eval time without a real network call.
+
+Output evaluator: `JsonSimilarityEvaluator`
+(`evaluatorTypeId == "uipath-json-similarity"`). The agent's output
+is structured JSON, so JsonSimilarity is the natural fit and it
+exercises a separate evaluator type from `eval_exact_match`.
+
+Checks:
+  1. `secret-peek/pyproject.toml` exists with no `[build-system]`.
+  2. `secret-peek/main.py` imports `mockable` and `ExampleCall` from
+     `uipath.eval.mocks` AND has at least one `@mockable(...)`
+     decorator.
+  3. `secret-peek/evaluations/evaluators/*.json` contains an
+     evaluator with `evaluatorTypeId == "uipath-json-similarity"`.
+  4. `secret-peek/evaluations/eval-sets/*.json` is v1.0; at least
+     one test case carries `mockingStrategy.type == "mockito"` with
+     a non-empty return behavior.
+  5. `secret-peek/eval-results.json` has the documented shape and
+     every recorded evaluator run scored >= 0.5.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("secret-peek")
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def find_single_json(directory: Path) -> Path:
+    if not directory.is_dir():
+        sys.exit(f"FAIL: {directory} does not exist")
+    files = sorted(p for p in directory.glob("*.json") if p.is_file())
+    if not files:
+        sys.exit(f"FAIL: {directory} contains no .json files")
+    return files[0]
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Critical Rule C1 forbids it."
+        )
+    print("OK: pyproject.toml has no [build-system]")
+
+
+def check_in_code_mocking() -> None:
+    """Pattern 2: in-code `@mockable` paired with `ExampleCall`."""
+    main = _read_text(ROOT / "main.py")
+    if "from uipath.eval.mocks" not in main:
+        sys.exit(
+            "FAIL: main.py does not import from `uipath.eval.mocks`. The "
+            "`@mockable`/`ExampleCall` pair is documented as the in-code "
+            "mocking pattern; one of the two external calls should use it."
+        )
+    if "mockable" not in main:
+        sys.exit(
+            "FAIL: main.py imports from `uipath.eval.mocks` but never uses "
+            "`mockable`. The decorator must wrap at least one helper."
+        )
+    if "ExampleCall" not in main:
+        sys.exit(
+            "FAIL: main.py does not reference `ExampleCall`. `@mockable` "
+            "needs `example_calls=[ExampleCall(...)]` to supply mock outputs."
+        )
+    if "@mockable" not in main:
+        sys.exit(
+            "FAIL: main.py imports `mockable` but no function is decorated "
+            "with `@mockable(...)`. The decoration is what makes the "
+            "function substitutable at eval time."
+        )
+    print("OK: main.py wires the in-code @mockable pattern with ExampleCall")
+
+
+def check_json_similarity_evaluator() -> str:
+    """Pattern 1 of two: structured-output evaluator."""
+    evals_dir = ROOT / "evaluations" / "evaluators"
+    if not evals_dir.is_dir():
+        sys.exit(f"FAIL: {evals_dir} does not exist")
+    matched_ids: list[str] = []
+    for path in sorted(evals_dir.glob("*.json")):
+        doc = _load_json(path)
+        if doc.get("evaluatorTypeId") == "uipath-json-similarity":
+            matched_ids.append(doc.get("id") or path.stem)
+    if not matched_ids:
+        sys.exit(
+            "FAIL: no evaluator with `evaluatorTypeId == \"uipath-json-"
+            "similarity\"` found. The agent emits structured JSON output; "
+            "JsonSimilarityEvaluator is the documented fit for this shape."
+        )
+    print(f"OK: JsonSimilarityEvaluator wired (ids: {matched_ids})")
+    return matched_ids[0]
+
+
+def _has_mockito_with_return(case: dict) -> bool:
+    strategy = case.get("mockingStrategy") or {}
+    if strategy.get("type") != "mockito":
+        return False
+    for b in strategy.get("behaviors") or []:
+        if not isinstance(b, dict):
+            continue
+        for step in b.get("then") or []:
+            if isinstance(step, dict) and step.get("type") == "return" and step.get("value") is not None:
+                return True
+    return False
+
+
+def check_eval_set() -> int:
+    """Pattern 1 of mocking: declarative mockito for the asset call."""
+    path = find_single_json(ROOT / "evaluations" / "eval-sets")
+    doc = _load_json(path)
+    if doc.get("version") != "1.0":
+        sys.exit(
+            f'FAIL: {path.name} version should be "1.0", '
+            f'got {doc.get("version")!r}'
+        )
+    cases = doc.get("evaluations") or []
+    if not cases:
+        sys.exit(f"FAIL: {path.name} has no test cases in `evaluations`")
+    cases_with_mocks = [c for c in cases if _has_mockito_with_return(c)]
+    if not cases_with_mocks:
+        sys.exit(
+            f'FAIL: no test case in {path.name} carries a '
+            f'`mockingStrategy.type == "mockito"` with a non-empty return. '
+            f'The asset retrieval must be mocked declaratively for offline '
+            f'evals to pass.'
+        )
+    print(
+        f"OK: {path.name} carries declarative mockito mocks on "
+        f"{len(cases_with_mocks)}/{len(cases)} test case(s)"
+    )
+    return len(cases)
+
+
+def check_results(expected_case_count: int) -> None:
+    path = ROOT / "eval-results.json"
+    doc = _load_json(path)
+    if not isinstance(doc, dict):
+        sys.exit(
+            f"FAIL: {path.name} top-level should be an object, "
+            f"got {type(doc).__name__}"
+        )
+    cases = doc.get("evaluationSetResults")
+    if not isinstance(cases, list) or not cases:
+        sys.exit(
+            f"FAIL: {path.name} is missing a non-empty "
+            f"`evaluationSetResults` list. Top-level keys: {list(doc.keys())}"
+        )
+    if len(cases) != expected_case_count:
+        sys.exit(
+            f"FAIL: expected {expected_case_count} entries in "
+            f"`evaluationSetResults` (one per eval-set test case), "
+            f"got {len(cases)}"
+        )
+    bad = []
+    total_runs = 0
+    for case in cases:
+        if not isinstance(case, dict):
+            continue
+        name = case.get("evaluationName") or "?"
+        runs = case.get("evaluationRunResults") or []
+        if not runs:
+            bad.append(f"{name!r}: no evaluationRunResults entries")
+            continue
+        for r in runs:
+            if not isinstance(r, dict):
+                continue
+            total_runs += 1
+            score = (r.get("result") or {}).get("score")
+            if not isinstance(score, (int, float)) or score < 0.5:
+                bad.append(
+                    f"{name!r}: evaluator {r.get('evaluatorId')!r} scored "
+                    f"{score!r} (expected >= 0.5 — both mocks should make "
+                    f"the agent run deterministically)"
+                )
+    if bad:
+        sys.exit("FAIL: " + " | ".join(bad))
+    print(
+        f"OK: every eval case has at least one evaluator run scoring "
+        f">= 0.5 ({total_runs} run(s) across {len(cases)} case(s))"
+    )
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    check_in_code_mocking()
+    check_json_similarity_evaluator()
+    case_count = check_eval_set()
+    check_results(case_count)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -1,0 +1,98 @@
+task_id: skill-agent-coded-eval-mocking-mockito
+description: >
+  Coded-agent eval lifecycle with the **two documented mocking
+  patterns** (declarative `mockingStrategy: mockito` AND in-code
+  `@mockable`) plus a structured-output evaluator. The agent reads
+  an Orchestrator asset (mocked declaratively per test case) AND
+  looks up a remote label via a helper (mocked in-code via
+  `@mockable` so eval-time substitutes example outputs). Output is
+  structured JSON, eval'd with `JsonSimilarityEvaluator`. The full
+  pipeline runs offline.
+tags: [uipath-agents, e2e, coded, mode:build, feature:eval, feature:eval-mocking, feature:framework-simple]
+max_iterations: 1
+task_timeout: 1800
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  max_turns: 80
+  turn_timeout: 1800
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Build a Simple Function UiPath coded agent named `secret-peek` that
+  returns a structured summary of a UiPath asset: the first 4
+  characters followed by stars to pad out to the original length,
+  alongside a human-readable label looked up from a remote registry.
+
+  The agent has two external calls:
+    1. Reads the asset `api_key` from the `Shared` folder via the
+       UiPath SDK.
+    2. Calls a helper `fetch_label(key_id: str) -> str` that talks
+       to a remote registry (just `requests.get` against a URL).
+
+  Output shape (Pydantic):
+    `{"masked_key": "abcd******", "label": "production-stripe"}`
+
+  Add a smoke evaluation suite with 2–3 cases covering different
+  asset values and run it locally. The evals must pass without
+  `uip login`, without the `api_key` asset existing, and without the
+  remote registry being reachable. Save the eval output to
+  `eval-results.json` in the project root.
+
+  Two constraints on how the mocking is wired (both matter — we use
+  this project as a reference for new joiners learning the eval
+  framework, so it has to demonstrate both approaches):
+    - For the `fetch_label` helper, bake the mock outputs **into the
+      Python code** so reviewers can see the example values right
+      next to the function definition. The mock data should travel
+      with `main.py`.
+    - For the asset retrieval, supply the mock value **from the
+      eval-set definitions** so each test case can use a different
+      asset value without code changes.
+
+  For scoring, use a **structured-output evaluator** — we care
+  about the shape of `{"masked_key": ..., "label": ...}` matching
+  the expected JSON per case, not character-for-character string
+  equality. We want the eval to flag a case where one field is
+  right but the other is subtly wrong.
+
+  Take the agent through scaffold → init → run the eval suite. Do
+  NOT publish, upload, or deploy. Complete it in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project with uip codedagent new"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedagent init to generate entry-points.json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran the eval suite with --no-report (offline)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+eval\s+.*--no-report'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Both mocking patterns wired + JsonSimilarity evaluator + offline eval results"
+    command: "python3 $TASK_DIR/check_eval_mocking_mockito.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/eval_trajectory_empty_history/check_eval_trajectory_empty_history.py
+++ b/tests/tasks/uipath-agents/eval_trajectory_empty_history/check_eval_trajectory_empty_history.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Diagnose check: trajectory-evaluator-on-plain-StateGraph trap.
+
+Quickstart Step 7 documents that
+`uipath-llm-judge-trajectory-similarity` scores 0.0 on plain
+`StateGraph` agents because `AgentRunHistory` is empty. The skill
+proposes two valid fixes:
+
+  Fix A — swap the evaluator for one that matches the user's stated
+  need: "a simple 'did the right keyword end up in the output'
+  check." That's `ContainsEvaluator`
+  (`evaluatorTypeId: "uipath-contains"`). Other output-based
+  evaluators don't fit the user's described semantics.
+
+  Fix B — add `@traced()` decorator (from `uipath.tracing`) to the
+  graph entrypoint so AgentRunHistory spans actually populate.
+  Heuristic signal: `main.py` now imports from `uipath.tracing` and
+  applies `@traced()` to the agent function.
+
+Either fix is acceptable; both is fine. The check fails only if
+NEITHER signal is present — that means the agent walked away with
+the trap still in place, or applied a fix that doesn't match what
+the user asked for.
+
+Beyond the fix, the check also verifies:
+  - the seeded `main.py` was preserved (the routing logic that
+    was working should not have been rewritten),
+  - `evaluatorRefs` and the eval set's per-case `evaluationCriterias`
+    were updated consistently if the evaluator id changed (Fix A),
+    so the eval set still parses.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("ticket-router")
+
+CONTAINS_TYPE = "uipath-contains"
+
+UIPATH_TRACING_HINTS = (
+    "uipath.tracing",
+    "from uipath.tracing import",
+    "@traced(",
+    "@traced()",
+)
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def check_main_preserved() -> None:
+    """The seed main.py routes deterministically. Allow edits but the
+    routing-by-keywords logic must survive — Fix A doesn't touch
+    main.py; Fix B only adds tracing instrumentation."""
+    text = _read_text(ROOT / "main.py")
+    for needle in ("StateGraph", "graph = builder.compile()"):
+        if needle not in text:
+            sys.exit(
+                f"FAIL: main.py lost the structural piece `{needle}` — the "
+                "diagnose flow should not rewrite the working agent."
+            )
+    if "invoice" not in text and "billing" not in text:
+        sys.exit(
+            "FAIL: main.py no longer contains the routing keywords from "
+            "the seed; the agent appears to have been rewritten instead "
+            "of fixed."
+        )
+    print("OK: main.py retains the working routing logic from the seed")
+
+
+def detect_fix_a() -> bool:
+    """Fix A — `ContainsEvaluator` wired in.
+
+    Per the user's stated need ("did the right keyword end up in the
+    output"), the matching evaluator type is `uipath-contains`. Other
+    evaluator types don't capture that exact semantics. If `Fix A` is
+    applied, it must be `ContainsEvaluator` AND the eval set must
+    reference it consistently.
+    """
+    evals_dir = ROOT / "evaluations" / "evaluators"
+    if not evals_dir.is_dir():
+        return False
+    contains_ids: list[str] = []
+    for path in sorted(evals_dir.glob("*.json")):
+        doc = _load_json(path)
+        if doc.get("evaluatorTypeId") == CONTAINS_TYPE:
+            contains_ids.append(doc.get("id") or path.stem)
+    if not contains_ids:
+        return False
+
+    eval_sets_dir = ROOT / "evaluations" / "eval-sets"
+    refs_match = False
+    for path in sorted(eval_sets_dir.glob("*.json")):
+        doc = _load_json(path)
+        refs = set(doc.get("evaluatorRefs") or [])
+        if refs & set(contains_ids):
+            refs_match = True
+            for case in doc.get("evaluations") or []:
+                keys = set((case.get("evaluationCriterias") or {}).keys())
+                if not (keys & set(contains_ids)):
+                    sys.exit(
+                        f'FAIL: eval-set case `{case.get("id")}` does not key '
+                        f'its evaluationCriterias on the ContainsEvaluator '
+                        f'id(s) {contains_ids}. Got keys: {sorted(keys)}'
+                    )
+    if not refs_match:
+        sys.exit(
+            f"FAIL: a ContainsEvaluator was authored ({contains_ids}) but "
+            f"no eval-set's `evaluatorRefs` points at it — Fix A is "
+            f"half-applied."
+        )
+    print(f"OK: Fix A detected — ContainsEvaluator wired (ids: {contains_ids})")
+    return True
+
+
+def detect_fix_b() -> bool:
+    """Fix B — main.py adds @traced() decorator from uipath.tracing to
+    populate AgentRunHistory."""
+    text = _read_text(ROOT / "main.py")
+    has_traced = any(hint in text for hint in UIPATH_TRACING_HINTS)
+    if not has_traced:
+        return False
+    print("OK: Fix B detected — @traced() decorator from uipath.tracing wired into main.py")
+    return True
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_main_preserved()
+    fix_a = detect_fix_a()
+    fix_b = detect_fix_b()
+    if not (fix_a or fix_b):
+        sys.exit(
+            "FAIL: neither documented fix was applied. The trajectory "
+            "evaluator on a plain StateGraph still scores 0.0 because "
+            "AgentRunHistory is empty. Expected one of: (A) replace the "
+            "evaluator with `ContainsEvaluator` (the user's stated need "
+            "was a keyword-in-output check), or (B) add the `@traced()` "
+            "decorator from `uipath.tracing` to main.py."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/eval_trajectory_empty_history/eval_trajectory_empty_history.yaml
+++ b/tests/tasks/uipath-agents/eval_trajectory_empty_history/eval_trajectory_empty_history.yaml
@@ -1,0 +1,153 @@
+task_id: skill-agent-coded-eval-trajectory-empty-history
+description: >
+  Diagnose-mode coverage. Quickstart Step 7 documents that
+  `uipath-llm-judge-trajectory-similarity` scores 0.0 on plain
+  `StateGraph` agents because `AgentRunHistory` is empty — the agent
+  may run fine end-to-end while the trajectory eval reports total
+  failure. This seeds the exact failure state (working agent +
+  trajectory evaluator + eval-results.json showing all 0.0) and
+  expects the skill to guide the agent to diagnose the root cause
+  and apply one of the two documented fixes: (a) switch to an
+  output-based evaluator, or (b) add `@traced()` from `uipath.tracing`
+  to emit AgentRunHistory spans. Runs offline.
+tags: [uipath-agents, e2e, coded, mode:diagnose, feature:eval, feature:framework-langgraph]
+max_iterations: 1
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Recreate the LangGraph coded agent project under `ticket-router/`
+  exactly as below. The agent routes support tickets between
+  `billing` and `technical` queues and works locally —
+  `uip codedagent run` returns the correct category every time.
+  The smoke eval set scores 0.0 on every case (see the seeded
+  `eval-results.json`). Diagnose why and fix it.
+
+  For this classifier, the trace-history check the evaluator does
+  isn't useful — there's nothing interesting in the trajectory.
+  All I need is for the eval to fail when the agent picks the
+  wrong category. A simple "did the right keyword end up in the
+  output" check would tell me everything I need.
+
+  **ticket-router/pyproject.toml**:
+  ```toml
+  [project]
+  name = "ticket-router"
+  version = "0.0.1"
+  description = "Support ticket router"
+  authors = [{ name = "Test" }]
+  requires-python = ">=3.11"
+  dependencies = ["uipath", "uipath-langchain"]
+
+  [dependency-groups]
+  dev = ["uipath-dev"]
+  ```
+
+  **ticket-router/main.py**:
+  ```python
+  from typing_extensions import TypedDict
+  from langgraph.graph import StateGraph, START, END
+  from pydantic import BaseModel
+
+
+  class GraphInput(BaseModel):
+      text: str
+
+
+  class GraphOutput(BaseModel):
+      category: str
+
+
+  class GraphState(TypedDict):
+      text: str
+      category: str
+
+
+  async def route(state: GraphState):
+      lower = state["text"].lower()
+      if any(w in lower for w in ("invoice", "charge", "bill", "refund")):
+          return {"category": "billing"}
+      return {"category": "technical"}
+
+
+  builder = StateGraph(GraphState, input_schema=GraphInput, output_schema=GraphOutput)
+  builder.add_node("route", route)
+  builder.add_edge(START, "route")
+  builder.add_edge("route", END)
+  graph = builder.compile()
+  ```
+
+  **ticket-router/langgraph.json**:
+  ```json
+  {"graphs": {"agent": "./main.py:graph"}}
+  ```
+
+  **ticket-router/evaluations/evaluators/trajectory.json**:
+  ```json
+  {
+    "version": "1.0",
+    "id": "TrajectoryEvaluator",
+    "evaluatorTypeId": "uipath-llm-judge-trajectory-similarity",
+    "evaluatorConfig": {
+      "name": "TrajectoryEvaluator",
+      "model": "gpt-4o-mini-2024-07-18",
+      "defaultEvaluationCriteria": {
+        "expectedAgentBehavior": "Agent should route the ticket to the correct queue."
+      }
+    }
+  }
+  ```
+
+  **ticket-router/evaluations/eval-sets/smoke-test.json**:
+  ```json
+  {
+    "version": "1.0",
+    "id": "smoke-test",
+    "name": "Smoke Test",
+    "evaluatorRefs": ["TrajectoryEvaluator"],
+    "evaluations": [
+      {"id": "t-1", "name": "billing - double charge", "inputs": {"text": "You charged me twice for invoice 123"}, "evaluationCriterias": {"TrajectoryEvaluator": {"expectedAgentBehavior": "Should classify as billing."}}},
+      {"id": "t-2", "name": "technical - login fails", "inputs": {"text": "I can't log in to the portal"}, "evaluationCriterias": {"TrajectoryEvaluator": {"expectedAgentBehavior": "Should classify as technical."}}},
+      {"id": "t-3", "name": "billing - refund request", "inputs": {"text": "Please refund my last payment"}, "evaluationCriterias": {"TrajectoryEvaluator": {"expectedAgentBehavior": "Should classify as billing."}}}
+    ]
+  }
+  ```
+
+  **ticket-router/eval-results.json** (output from the last
+  `uip codedagent eval` run — every case at 0.0):
+  ```json
+  {
+    "evaluationSetName": "Smoke Test",
+    "evaluationSetResults": [
+      {"evaluationName": "billing - double charge", "evaluationRunResults": [{"evaluatorId": "TrajectoryEvaluator", "result": {"score": 0.0}}]},
+      {"evaluationName": "technical - login fails", "evaluationRunResults": [{"evaluatorId": "TrajectoryEvaluator", "result": {"score": 0.0}}]},
+      {"evaluationName": "billing - refund request", "evaluationRunResults": [{"evaluatorId": "TrajectoryEvaluator", "result": {"score": 0.0}}]}
+    ]
+  }
+  ```
+
+  Do NOT call `uip login` or run `uip codedagent eval`. Diagnose
+  from the files and fix it. Complete it in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "Seeded project preserved (main.py)"
+    path: "ticket-router/main.py"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Trajectory-on-plain-StateGraph trap diagnosed and one of the two documented fixes applied"
+    command: "python3 $TASK_DIR/check_eval_trajectory_empty_history.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -67,7 +67,7 @@ success_criteria:
 
   - type: file_exists
     description: "LangGraph project config present"
-    path: "langgraph.json"
+    path: "refund-gate/langgraph.json"
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-agents/hitl_wait_task/hitl_wait_task.yaml
+++ b/tests/tasks/uipath-agents/hitl_wait_task/hitl_wait_task.yaml
@@ -65,7 +65,7 @@ success_criteria:
 
   - type: file_exists
     description: "LangGraph project config present"
-    path: "langgraph.json"
+    path: "purchase-gate/langgraph.json"
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

Four new coded-agent tests, stacked on top of #633, plus two small `file_exists` path fixes on pre-existing HITL tests:

### New tests

| Test | Tier / Mode | What it pins |
|---|---|---|
| `eval_mocking_mockito` | e2e / build | Declarative `mockingStrategy: mockito` paired with in-code `@mockable(example_calls=[ExampleCall(...)])` so smoke evals run offline. Eval-mocking feature area had zero coverage. |
| `deploy_tenant` | e2e / build | `uip codedagent deploy --tenant` — the one deploy target with no test. Also exercises `packOptions.directoriesExcluded`. |
| `eval_trajectory_empty_history` | e2e / diagnose | Trajectory-evaluator-on-plain-\`StateGraph\` 0.0-score trap. Check accepts either documented fix (output evaluator, or OTEL tracing). |
| `diagnose_deploy_failure` | e2e / diagnose | \`Project authors cannot be empty\` rejection recovery. First \`mode:diagnose\` test in the coded-agent suite. |

Each new task ships with a sidecar `check_*.py`.

### `file_exists` path fixes

Two pre-existing HITL tests had `file_exists: \"langgraph.json\"` (sandbox root) but the prompts name a project (`refund-gate` / `purchase-gate`) and the canonical \`uip codedagent new <name>\` flow scaffolds at `<name>/`. \`file_exists\` is literal (no glob support per \`coder_eval.sandbox.file_exists\`), so the criterion missed the file. Updated to the canonical nested path. The check scripts already use \`find_project_root(...)\` and were unaffected.

- \`hitl_create_task_with_app\`: \`langgraph.json\` → \`refund-gate/langgraph.json\`
- \`hitl_wait_task\`: \`langgraph.json\` → \`purchase-gate/langgraph.json\`

## Infrastructure

- **Local-only** (no cloud auth needed): \`eval_mocking_mockito\`, \`eval_trajectory_empty_history\`, the two HITL path fixes.
- **Cloud auth + publish permission**: \`deploy_tenant\` (tenant-feed publish), \`diagnose_deploy_failure\` (personal-workspace publish). Same prerequisites as the existing \`deploy_my_workspace\` and \`deploy_folder_and_rebump\` tests.

## Stacked PR

Base is \`test/fill-coded-agents-tests\` (PR #633). Retarget to \`main\` once #633 lands.

## Test plan

Ran all four new tasks locally with \`coder-eval\` against the e2e experiment; all four pass:
- \`skill-agent-coded-eval-mocking-mockito\` ran locally and it passed.
- \`skill-agent-coded-deploy-tenant\` ran locally and it passed.
- \`skill-agent-coded-eval-trajectory-empty-history\` ran locally and it passed.
- \`skill-agent-coded-diagnose-deploy-failure\` ran locally and it passed.

The two HITL path fixes are one-line edits; the check scripts on those tests pass independently of the corrected \`file_exists\` path (they locate the project via \`find_project_root\` — the criterion fix just removes a redundant false negative).

🤖 Generated with [Claude Code](https://claude.com/claude-code)