### PR TITLE
MST-9734 MST-9735: fix flow eval checker drift

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -63,6 +63,12 @@ initial_prompt: |
   are NOT registry keys. Confirm the key with
   `uip maestro flow registry search "azureactivedirectory"` before adding
   the node.
+  Exact connector node type: use
+  `uipath.connector.uipath-microsoft-azureactivedirectory.list-groups` for
+  the List Groups operation. If registry search or `flow node add` cannot
+  retrieve connector metadata in this no-live sandbox, hand-author that exact
+  node type with empty `inputs` per the no-live connector guidance. Do not
+  substitute generic `list-records` for this task.
 
   Add a Decision node to check whether the call succeeded.
   Route failure to a Terminate node with error message "CeqlWhere test failed".

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
@@ -11,10 +11,12 @@ from _shared.flow_check import (  # noqa: E402
     run_debug,
 )
 
+PROJECT_GLOB = "CountLettersCoded/CountLettersCoded/project.uiproj"
+
 
 def main():
-    assert_flow_has_node_type(["uipath.core.agent"])
-    payload = run_debug(timeout=240)
+    assert_flow_has_node_type(["uipath.core.agent"], project_glob=PROJECT_GLOB)
+    payload = run_debug(timeout=240, project_glob=PROJECT_GLOB)
     # 3 r's in 'counterrevolutionary'.
     assert_output_value(payload, 3)
     print("OK: Coded-agent node present; output contains 3")

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/test_check_coded_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/test_check_coded_agent_flow.py
@@ -1,0 +1,49 @@
+"""Tests for the CountLetters coded-agent checker."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+CHECKER = Path(__file__).with_name("check_coded_agent_flow.py")
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_coded_agent_flow", CHECKER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checker_targets_flow_project_when_solution_has_agent_sibling(monkeypatch) -> None:
+    checker = _load_checker()
+    calls: list[tuple] = []
+
+    def fake_assert_flow_has_node_type(hints, *, project_glob="**/project.uiproj"):
+        calls.append(("node_type", tuple(hints), project_glob))
+
+    def fake_run_debug(*, timeout=240, project_glob="**/project.uiproj", inputs=None):
+        calls.append(("debug", timeout, project_glob, inputs))
+        return {"variables": {"globals": {"count": 3}}}
+
+    def fake_assert_output_value(payload, expected):
+        calls.append(("output", payload, expected))
+
+    monkeypatch.setattr(checker, "assert_flow_has_node_type", fake_assert_flow_has_node_type)
+    monkeypatch.setattr(checker, "run_debug", fake_run_debug)
+    monkeypatch.setattr(checker, "assert_output_value", fake_assert_output_value)
+
+    checker.main()
+
+    assert calls == [
+        (
+            "node_type",
+            ("uipath.core.agent",),
+            "CountLettersCoded/CountLettersCoded/project.uiproj",
+        ),
+        ("debug", 240, "CountLettersCoded/CountLettersCoded/project.uiproj", None),
+        ("output", {"variables": {"globals": {"count": 3}}}, 3),
+    ]

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
@@ -11,14 +11,16 @@ from _shared.flow_check import (  # noqa: E402
     run_debug,
 )
 
+PROJECT_GLOB = "CountLettersLowCode/CountLettersLowCode/project.uiproj"
+
 
 def main():
     # Coded and low-code agents share the `uipath.core.agent.{guid}` node-type
     # family on this tenant — distinguished only by registry DisplayName, not
     # by node-type prefix. The prompt drives the coded-vs-lowcode choice;
     # this check just verifies an agent node was used.
-    assert_flow_has_node_type(["uipath.core.agent"])
-    payload = run_debug(timeout=240)
+    assert_flow_has_node_type(["uipath.core.agent"], project_glob=PROJECT_GLOB)
+    payload = run_debug(timeout=240, project_glob=PROJECT_GLOB)
     # 2 r's in 'arrow'.
     assert_output_value(payload, 2)
     print("OK: Low-code agent node present; output contains 2")

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/test_check_lowcode_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/test_check_lowcode_agent_flow.py
@@ -1,0 +1,49 @@
+"""Tests for the CountLetters low-code-agent checker."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+CHECKER = Path(__file__).with_name("check_lowcode_agent_flow.py")
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location("check_lowcode_agent_flow", CHECKER)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_checker_targets_flow_project_when_solution_has_agent_sibling(monkeypatch) -> None:
+    checker = _load_checker()
+    calls: list[tuple] = []
+
+    def fake_assert_flow_has_node_type(hints, *, project_glob="**/project.uiproj"):
+        calls.append(("node_type", tuple(hints), project_glob))
+
+    def fake_run_debug(*, timeout=240, project_glob="**/project.uiproj", inputs=None):
+        calls.append(("debug", timeout, project_glob, inputs))
+        return {"variables": {"globals": {"count": 2}}}
+
+    def fake_assert_output_value(payload, expected):
+        calls.append(("output", payload, expected))
+
+    monkeypatch.setattr(checker, "assert_flow_has_node_type", fake_assert_flow_has_node_type)
+    monkeypatch.setattr(checker, "run_debug", fake_run_debug)
+    monkeypatch.setattr(checker, "assert_output_value", fake_assert_output_value)
+
+    checker.main()
+
+    assert calls == [
+        (
+            "node_type",
+            ("uipath.core.agent",),
+            "CountLettersLowCode/CountLettersLowCode/project.uiproj",
+        ),
+        ("debug", 240, "CountLettersLowCode/CountLettersLowCode/project.uiproj", None),
+        ("output", {"variables": {"globals": {"count": 2}}}, 2),
+    ]


### PR DESCRIPTION
## Summary
- Scope CountLetters coded/low-code agent checkers to their Flow project paths so sibling agent projects do not trip the shared project glob.
- Add focused checker tests for the explicit project glob behavior.
- Pin the CEQL where no-live prompt to the exact Azure AD List Groups node type required by the checker.

## Verification
- `uv run --with pytest pytest tests/tasks/uipath-maestro-flow/single_node/coded_agent/test_check_coded_agent_flow.py tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/test_check_lowcode_agent_flow.py`
- `uv run --with pytest pytest tests/tasks/uipath-maestro-flow/single_node/coded_agent tests/tasks/uipath-maestro-flow/single_node/lowcode_agent tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py`
- `validate_yaml.py tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml` from the coder_eval environment
- `uv run python -m py_compile tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py`
- `git diff --check`

## Jira
- MST-9734
- MST-9735