### PR TITLE
feat(uipath-platform): add platform licensing reference [PLT-103133]

### DIFF
--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -33,6 +33,7 @@ Load this skill BEFORE writing any code that talks to UiPath. Specific triggers:
 - **Integration Service**: connectors, connections (OAuth flow), activities, IS triggers, agent-workflow reference resolution
 - **Solutions**: `solution new/pack/publish/deploy run/deploy activate/deploy status/deploy uninstall/upload/resource list/refresh/get`, deploy config
 - **Traces**: `uip traces spans get [trace-id]` (LLM/agentic execution observability)
+- **Platform licensing**: tenant license allocations, user/group bundle assignments, consumables reporting (`uip platform tenants licenses`, `users licenses`, `groups rules`, `licenses consumables`)
 - **CI/CD**: pipeline that builds, publishes, and deploys UiPath solutions
 - **CLI tooling itself**: `uip tools list/search/install`, `uip mcp serve`
 
@@ -117,6 +118,10 @@ Choose the appropriate operation from the Task Navigation table below.
 | **Debug LLM/agent traces (spans)** | [references/traces/traces.md](references/traces/traces.md) |
 | **Annotate traces with feedback** | [references/traces/feedback.md](references/traces/feedback.md) |
 | **Use Integration Service** | [references/integration-service/integration-service.md](references/integration-service/integration-service.md) |
+| **Allocate licenses to tenants** | [references/licensing/tenant-allocations.md](references/licensing/tenant-allocations.md) |
+| **Assign user/group license bundles** | [references/licensing/user-licenses-allocations.md](references/licensing/user-licenses-allocations.md) |
+| **Report on license consumption** | [references/licensing/consumables-report.md](references/licensing/consumables-report.md) |
+| **Understand licensing concepts** | [references/licensing/licensing.md](references/licensing/licensing.md) |
 | **Full CLI command reference** | [references/uip-commands.md](references/uip-commands.md) |
 | **Build/run/validate coded workflows** | [/uipath:uipath-rpa](/uipath:uipath-rpa) |
 
@@ -285,6 +290,7 @@ The `X-UIPATH-OrganizationUnitId` header is the **folder ID** (get it from `uip 
 - **[Traces — Spans](references/traces/traces.md)** — LLM execution trace observability
 - **[Traces — Feedback](references/traces/feedback.md)** — Annotate traces with sentiment and comments
 - **[Integration Service](references/integration-service/integration-service.md)** — Connectors, connections, activities, resources
+- **[Licensing](references/licensing/licensing.md)** — Tenant allocations, user/group bundles, consumables reporting
 - **[Coded Workflows](/uipath:uipath-rpa)** — Building coded automation projects
 
 > **Trouble?** If something didn't work as expected, use `/uipath-feedback` to send a report.

--- a/skills/uipath-platform/references/licensing/consumables-report.md
+++ b/skills/uipath-platform/references/licensing/consumables-report.md
@@ -1,0 +1,217 @@
+# Consumables Report
+
+Report consumption of consumable license units (`AIU`, `AGU`, `RU`, `PLTU`, `HEAL`, `SPR`, `LU`, etc.) across the organization. Three report shapes: account-wide summary, daily breakdown by service, folder breakdown.
+
+> For full option details, run `uip platform licenses consumables get --help`.
+
+---
+
+## When to Use
+
+- Monthly chargeback / cost-allocation reporting per tenant
+- Capacity planning: confirm allocated vs consumed before bundle renewal
+- Drill into which folders are driving consumption of a specific unit (`folders` mode)
+- Daily trend analysis for a specific tenant × unit (`daily` mode)
+- Compare consumption across tenant pool vs overflow into org pool
+
+## Prerequisites
+
+1. Authenticated: `uip login`
+2. Org admin permissions to read account product allocations
+3. For `daily` / `folders` modes: know the target tenant name and consumable unit code
+
+---
+
+## Modes
+
+| Mode | Scope | Required Flags | Output |
+|------|-------|----------------|--------|
+| `summary` (default) | All active consumables × all tenants (or one tenant if `--tenant`) | None | One row per consumable × tenant; allocation + pool consumption columns |
+| `daily` | One tenant × one unit, day-by-day | `--tenant`, `--unit`, `--start-date`, `--end-date` | One row per (date, service) |
+| `folders` | One tenant × one unit, broken down by folder | `--tenant`, `--unit`, `--start-date`, `--end-date` | One row per folder |
+
+---
+
+## Mode 1: Summary
+
+Default mode. Iterates every active consumable in the account.
+
+```bash
+# All consumables, all tenants, each consumable's bundle window
+uip platform licenses consumables get --output json
+
+# Scope to one tenant
+uip platform licenses consumables get --tenant "<TENANT_NAME>" --output json
+
+# Override every consumable's window with a custom date range
+uip platform licenses consumables get \
+  --start-date 2026-04-01 --end-date 2026-04-30 --output json
+```
+
+```json
+{
+  "Result": "Success",
+  "Code": "LicensesConsumablesSummary",
+  "Data": [
+    {
+      "code": "AIU",
+      "name": "AI Units",
+      "totalUnitsInAccount": 5000,
+      "allocated": 1200,
+      "consumedFromOrgWithoutTenant": 30,
+      "startDate": "2023-11-14T22:13:20.000Z",
+      "endDate": "2027-09-15T18:40:00.000Z",
+      "tenantId": "296b7134-6691-43db-b48a-2d95ed3ab031",
+      "tenantName": "default",
+      "consumedFromTenantPool": 800,
+      "consumedFromOrgPool": 150
+    }
+  ]
+}
+```
+
+Field reference:
+
+| Field | Meaning |
+|-------|---------|
+| `code` / `name` | Product code and friendly name |
+| `totalUnitsInAccount` | Account purchase total for this consumable |
+| `allocated` | Account-level allocation |
+| `consumedFromOrgWithoutTenant` | Consumption not attributable to any tenant (zero when `--tenant` is set) |
+| `startDate` / `endDate` | Window in effect — bundle window by default, override range if `--start-date`/`--end-date` provided |
+| `tenantId` / `tenantName` | Per-tenant breakdown |
+| `consumedFromTenantPool` | Drawn from the tenant's reserved allocation |
+| `consumedFromOrgPool` | Drawn from the remaining account pool (overflow) |
+
+Row-shape rules:
+- **No `--tenant`, consumption across multiple tenants**: one row per (consumable, tenant)
+- **No `--tenant`, no tenant consumption**: single row per consumable with `tenantId: null`, `tenantName: ""`, and pool columns zeroed; `consumedFromOrgWithoutTenant` may be non-zero
+- **With `--tenant`**: one row per consumable for that tenant. Consumables with zero tenant activity still appear with zeroed pool columns
+
+## Mode 2: Daily Breakdown
+
+```bash
+uip platform licenses consumables get \
+  --mode daily \
+  --tenant "<TENANT_NAME>" \
+  --unit AIU \
+  --start-date 2026-04-01 \
+  --end-date 2026-04-30 \
+  --output json
+```
+
+```json
+{
+  "Result": "Success",
+  "Code": "LicensesConsumablesDaily",
+  "Data": [
+    {
+      "code": "AIU",
+      "name": "AI Units",
+      "tenantId": "296b7134-6691-43db-b48a-2d95ed3ab031",
+      "tenantName": "default",
+      "date": "2026-04-15",
+      "service": "orchestrator",
+      "consumedAmount": 24
+    }
+  ]
+}
+```
+
+`date` is `YYYY-MM-DD`. One row per (date, service) inside the range. `service` is the service that emitted the consumption (e.g., `orchestrator`, `aicenter`, `dataservice`).
+
+## Mode 3: Folder Breakdown
+
+```bash
+uip platform licenses consumables get \
+  --mode folders \
+  --tenant "<TENANT_NAME>" \
+  --unit AIU \
+  --start-date 2026-04-01 \
+  --end-date 2026-04-30 \
+  --output json
+```
+
+```json
+{
+  "Result": "Success",
+  "Code": "LicensesConsumablesFolders",
+  "Data": [
+    {
+      "code": "AIU",
+      "name": "AI Units",
+      "tenantId": "296b7134-6691-43db-b48a-2d95ed3ab031",
+      "tenantName": "default",
+      "folderKey": "11111111-1111-1111-1111-111111111111",
+      "folderName": "Shared",
+      "parentFolderKey": null,
+      "consumedBySelf": 42,
+      "processCountSelf": 3
+    }
+  ]
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `folderKey` / `folderName` | Folder GUID and display name |
+| `parentFolderKey` | Parent GUID for nested folders; `null` at the root |
+| `consumedBySelf` | Consumption attributed to this folder only — does not include descendants |
+| `processCountSelf` | Distinct processes in this folder that contributed |
+
+Aggregate descendants client-side if needed — the API returns per-folder rows only.
+
+---
+
+## Flag Reference
+
+| Flag | Required In | Default | Notes |
+|------|-------------|---------|-------|
+| `--mode <summary\|daily\|folders>` | All modes | `summary` | Determines output shape |
+| `--tenant <name>` | `daily`, `folders` | All tenants | Matched by exact tenant name |
+| `--unit <code>` | `daily`, `folders` | All consumables | Case-insensitive product code (`AIU`, `aiu`, `Aiu` all match) |
+| `--start-date <iso>` | `daily`, `folders` | Bundle window | ISO 8601 (e.g., `2026-04-01` or `2026-04-01T00:00:00Z`) |
+| `--end-date <iso>` | `daily`, `folders` | Bundle window | ISO 8601, must be strictly after `--start-date` |
+
+Date range rules:
+- `--start-date` and `--end-date` must be passed together; passing only one is rejected
+- Both must parse as valid ISO 8601
+- `startDate >= endDate` is rejected
+- In `summary` mode, the range overrides each consumable's own bundle window
+- In `daily` / `folders` modes, the range is required
+
+---
+
+## Error Conditions
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `Invalid --mode '<value>'.` | Mode is not summary/daily/folders | Use one of the three allowed values |
+| `--mode daily requires: --tenant, --unit, --start-date, --end-date.` | Missing required flag(s) for the mode | Pass all four |
+| `--start-date and --end-date must be provided together.` | Only one of the pair was supplied | Pass both, or omit both |
+| `Invalid --start-date: '<value>'.` | Date doesn't parse as ISO 8601 | Use `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ` |
+| `--start-date must be strictly before --end-date.` | Range is empty or inverted | Provide a non-empty forward range |
+| `Tenant '<name>' not found in the current organization.` | No tenant with that exact name | Check spelling against `uip login tenant list`; available tenants are listed in the error |
+| `Unit '<code>' is not an active consumable in this organization.` | Code is not a consumable, or its bundle window is not currently active | Error lists available codes; pick one of those |
+
+---
+
+## Gotchas
+
+- **`summary` reports every active consumable.** It is potentially heavy on large accounts — scope with `--tenant` or `--unit` when iterating.
+- **Bundle window vs override.** With no `--start-date`/`--end-date`, every consumable in the summary uses its own window — rows can have different date ranges. The override applies the same range to all rows.
+- **`consumedFromOrgWithoutTenant` is zero under `--tenant`.** The CLI suppresses cross-tenant pool numbers when scoped to a single tenant; only `consumedFromTenantPool` and `consumedFromOrgPool` are populated.
+- **`consumedAmount` and `consumedBySelf` are point-in-time totals over the requested range** — not running totals. Re-running the same query later returns the same value once the window has closed.
+- **`--unit` is case-insensitive**, but other code references (`tenant licenses set`) are exact-case — don't carry the assumption.
+- **No pagination.** `daily` and `folders` modes return all rows in one response. For very large windows or folder counts, consider narrower ranges.
+- **`folders` mode is non-recursive.** `consumedBySelf` excludes child folders. Reconstruct the tree yourself if you need rolled-up totals.
+- **`PLTU` is dual-purpose.** It appears in both runtime allocation (`tenants licenses get`) and consumables reporting. Same code, different reporting axes.
+
+---
+
+## Related
+
+- [Licensing hub](licensing.md) — concepts, product code table, REST fallback
+- [Tenant Allocations](tenant-allocations.md) — set the allocations these reports consume from
+- [User & Group Licenses](user-licenses-allocations.md) — user-bundle allocation (separate license type)
+- [Full CLI command reference](../uip-commands.md)

--- a/skills/uipath-platform/references/licensing/licensing.md
+++ b/skills/uipath-platform/references/licensing/licensing.md
@@ -1,0 +1,103 @@
+# Licensing (`uip platform`)
+
+Manage UiPath organization licensing — tenant allocations, user/group bundle assignments, and consumables reporting.
+
+> For full option details on any command, use `--help` (e.g., `uip platform tenants licenses get --help`).
+
+---
+
+## Common Flags
+
+All `uip platform` licensing commands share a set of cross-cutting options:
+
+| Flag | Scope | Purpose |
+|------|-------|---------|
+| `--organization <account-id>` | All commands | Override org account GUID. Defaults to org from current login. |
+| `--output json` | All commands | Emit structured JSON. Always use when parsing programmatically. |
+| `--input <path>` | `set` commands | Path to JSON file with the desired allocation. Body shape differs per command — see each workflow doc. |
+| `--limit <n>` | `groups rules` list commands | Max results to return (default 50). |
+| `--offset <n>` | `groups rules` list commands | Results to skip (default 0). |
+| `--sort-by <field>` | `groups rules` list commands | Sort field (e.g. `name`). |
+| `--sort-order <Asc\|Desc>` | `groups rules` list commands | Sort direction. Exact strings `Asc` or `Desc` (case-sensitive). |
+
+**Response envelope.** All commands emit `{Result, Code, Data, ...}`. `Code` identifies the payload (`TenantLicenses`, `UserLicensesSet`, `GroupRules`, `LicensesConsumablesSummary`, etc.). Paginated commands add a `Pagination` block — increment `--offset` by `--limit` until `Returned < Limit`.
+
+---
+
+## Workflow References
+
+| Workflow | File | Covers |
+|----------|------|--------|
+| Tenant Allocations | [tenant-allocations.md](tenant-allocations.md) | `tenants licenses get/set` — allocate license units to tenant pools |
+| User & Group Licenses | [user-licenses-allocations.md](user-licenses-allocations.md) | `users licenses get/set/available`, `groups rules get/details/set` — assign bundles directly or via group rules |
+| Consumables Report | [consumables-report.md](consumables-report.md) | `licenses consumables get --mode {summary,daily,folders}` — consumption reporting |
+
+---
+
+## Key Concepts
+
+### License Hierarchy
+
+```
+Account (organization)
+  +-- Total units in account (purchased pool)
+        +-- Tenant allocations         Reserved per tenant from account pool
+        |     +-- Tenant pool consumption    Jobs consume from tenant reservation
+        |     +-- Org pool consumption       Jobs overflow to remaining account pool
+        +-- User bundles               Per-seat licenses (RPA Developer, Attended, etc.)
+              +-- Direct assignment    Allocated to a specific user
+              +-- Group rule lease     Inherited from a group rule with optional quota
+```
+
+Tenant allocations and user bundles are **separate license types**. A tenant runs unattended jobs against its runtime allocation (`UNATT`, `RU`, `PLTU`); a developer uses a user-bundle license (`RPADEVPRONU`) to log into Studio.
+
+### Product Codes
+
+Product codes are the SKU identifier used everywhere in the CLI. The `friendlyName()` helper maps them to readable names:
+
+| Code | Friendly Name | Type |
+|------|---------------|------|
+| `RU` | Robot Units | Runtime |
+| `AIU` | AI Units | Consumable |
+| `AGU` | Agent Units | Consumable |
+| `PLTU` | Platform Units | Runtime/consumable |
+| `TEU` | Test Execution Units | Runtime |
+| `UNATT` | Unattended Robot | Runtime |
+| `UNATT-HOSTING` | Unattended Hosting Robot | Runtime |
+| `NONPR` | NonProduction Robot | Runtime |
+| `TAUNATT` | Test Automation Unattended Robot | Runtime |
+| `APPTESTR` | App Test Robot | Runtime |
+| `HEAL` / `HEALTEST` | Heals / Test Heals | Consumable |
+| `SPR` | ScreenPlay Runs | Consumable |
+| `FCCU` | Financial Crimes Units | Consumable |
+| `MRSU` | Medical Record Summarization Units | Consumable |
+| `LU` | Lending Units | Consumable |
+| `DSU` | Data Service Units | Consumable |
+| `PERFTEST` / `PERFTEST-RUNTIME` | Performance Testing | Runtime |
+
+User-bundle codes (e.g., `RPADEVPRONU`, `ATTUNU`, `TSTNU`) are not in the `friendlyName` table — they pass through unchanged.
+
+Unknown codes are returned verbatim; this is not an error.
+
+### Behavior Details
+
+Each concept is covered authoritatively in the linked workflow guide:
+
+- **Lease source: direct vs group** — `users licenses get` tags each row with `source`. See [user-licenses-allocations.md](user-licenses-allocations.md).
+- **Quotas in group rules** — `groups rules set` accepts optional `quota` per entry. See [user-licenses-allocations.md](user-licenses-allocations.md).
+- **Bundle window vs custom date range** — each consumable has its own window; `--start-date`/`--end-date` overrides. See [consumables-report.md](consumables-report.md).
+- **Idempotent tenant allocation** — `tenants licenses set` is an overlay, not a delta. See [tenant-allocations.md](tenant-allocations.md).
+
+---
+
+## REST API Fallback
+
+When the CLI does not cover an operation, use the License Resource Manager / License Accountant APIs directly with a stored token from `~/.uipath/.auth`. See [orchestrator.md - REST API](../orchestrator/orchestrator.md) for the auth pattern.
+
+---
+
+## Related
+
+- **Orchestrator licenses** — `uip or licenses` covers Orchestrator-scoped license toggles (license slots assigned to user/robot pairs in folders). See [Setup Environment](../orchestrator/setup-environment.md).
+- **Tenant settings** — `uip or settings` covers tenant operational settings (timezone, alerts, trigger behavior), not licensing. See [Tenant Admin](../orchestrator/tenant-admin.md).
+- **Full CLI command reference** — [uip-commands.md](../uip-commands.md)

--- a/skills/uipath-platform/references/licensing/tenant-allocations.md
+++ b/skills/uipath-platform/references/licensing/tenant-allocations.md
@@ -1,0 +1,152 @@
+# Tenant License Allocations
+
+Allocate license units (`UNATT`, `RU`, `PLTU`, `NONPR`, etc.) from the account pool to specific tenants, and inspect what each tenant currently has reserved and consumed.
+
+> For full option details, run `uip platform tenants licenses get --help` or `... set --help`.
+
+---
+
+## When to Use
+
+- Provisioning a new tenant with a runtime allocation (e.g., 5 Unattended Robots)
+- Rebalancing licenses across tenants (move 10 RU from dev to prod)
+- Auditing per-tenant `allocated` vs `consumed` to find under- or over-provisioned tenants
+- Scripting CI/CD pipeline that bumps tenant capacity before a load test
+
+## Prerequisites
+
+1. Authenticated: `uip login`
+2. Org admin permissions to allocate licenses
+3. Tenant key (GUID) of the target tenant — discover with `uip or settings list --tenant <name>` or the Automation Cloud portal
+
+---
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `uip platform tenants licenses get <tenant-key>` | Read current allocation, availability, and consumption per product code |
+| `uip platform tenants licenses set <tenant-key> --input <path>` | Overlay per-product quantities onto the tenant's existing service licenses |
+
+---
+
+## Step 1: Inspect Current Allocation
+
+```bash
+uip platform tenants licenses get <TENANT_KEY> --output json
+```
+
+Returns one row per product currently in an active interval (current time falls between `startDate` and `endDate`):
+
+```json
+{
+  "Result": "Success",
+  "Code": "TenantLicenses",
+  "Data": [
+    {
+      "code": "PLTU",
+      "name": "Platform Units",
+      "allocated": 300,
+      "availableForAllocation": 4700,
+      "allocatedAcrossOtherTenants": 0,
+      "totalUnitsInAccount": 5000,
+      "consumed": 50,
+      "startDate": "2023-11-14T22:13:20.000Z",
+      "endDate": "2027-09-15T18:40:00.000Z"
+    }
+  ]
+}
+```
+
+Field reference:
+
+| Field | Meaning |
+|-------|---------|
+| `allocated` | Units currently reserved for this tenant |
+| `availableForAllocation` | Units still free in the account pool (could be moved to this or any tenant) |
+| `allocatedAcrossOtherTenants` | Units reserved for other tenants |
+| `totalUnitsInAccount` | Account purchase total. Equals `allocated + availableForAllocation + allocatedAcrossOtherTenants` |
+| `consumed` | Units actually used by running jobs (subset of `allocated`) |
+| `startDate` / `endDate` | Bundle window in ISO 8601 |
+
+## Step 2: Prepare the Input File
+
+Create a JSON array of product entries with absolute target quantities:
+
+```json
+[
+  {"code": "UNATT", "quantity": 10},
+  {"code": "PLTU", "quantity": 500}
+]
+```
+
+Validation rules:
+- `code` must be a non-empty string
+- `quantity` must be a finite, non-negative number (zero is allowed — sets the allocation to zero)
+- Each `code` must already exist on the tenant's current service licenses (cannot introduce new product codes)
+
+## Step 3: Apply the Allocation
+
+```bash
+uip platform tenants licenses set <TENANT_KEY> --input ./delta.json --output json
+```
+
+Overlay semantics (`mergeProducts`):
+1. CLI reads the tenant's current per-service allocation
+2. For each input entry, the listed `quantity` replaces the current value for that `code`
+3. Codes already on the tenant but **not** in the input keep their current quantity
+4. The CLI auto-routes each code to the service license that owns it (orchestrator, dataservice, etc.)
+5. Re-running the same input is idempotent — safe to retry
+
+Returns one row per product per touched service license:
+
+```json
+{
+  "Result": "Success",
+  "Code": "TenantLicensesSet",
+  "Data": [
+    {"serviceType": "orchestrator", "code": "UNATT", "name": "Unattended Robot", "quantity": 10},
+    {"serviceType": "orchestrator", "code": "PLTU", "name": "Platform Units", "quantity": 500}
+  ]
+}
+```
+
+## Step 4: Verify
+
+Re-run `get` and confirm the new `allocated` values match the input.
+
+```bash
+uip platform tenants licenses get <TENANT_KEY> --output json
+```
+
+---
+
+## Error Conditions
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `No service licenses found for tenant '<key>'` | Wrong tenant GUID, or tenant has no provisioned services | Verify the tenant key against `uip or` or the portal |
+| `Cannot route product code(s) for tenant '<key>': <code>` | The product code is not already present on this tenant's service licenses | The CLI cannot introduce new codes. Use the UiPath portal to add the SKU first, then re-run `set` |
+| `Ambiguous routing for tenant '<key>': '<code>' (matches service types: ...)` | Same code exists on more than one of the tenant's service licenses | Resolve the duplicate allocation in the portal or via support, then retry |
+| `Invalid input JSON. "quantity" must be a finite, non-negative number.` | Bad input file | Fix the JSON; `quantity` must be ≥ 0 |
+| `Error connecting to the License Resource Manager.` | Auth expired or network issue | Re-run `uip login` |
+
+---
+
+## Gotchas
+
+- **`quantity` is absolute, not delta.** `{"code":"UNATT","quantity":5}` sets the tenant to 5 — it does not add 5 to the current value. Read `get` first to know the starting point.
+- **Codes are overlay, not replace.** A product already on the tenant but missing from the input keeps its current quantity. To zero out a code, include it explicitly with `quantity: 0`.
+- **Cannot add new product codes.** If a tenant doesn't have `AIU` on its service licenses, you cannot introduce it via `set`. Provision the SKU through the portal first.
+- **`availableForAllocation: 0`** means the account pool is exhausted. To allocate more to this tenant, first reduce another tenant's allocation or purchase additional units.
+- **`consumed` lags real-time.** It reflects accountant-side aggregation; expect minutes of delay after a job completes.
+- **Bundle window matters.** `get` filters out products outside the currently active interval — an expired bundle won't appear even if `allocated > 0` historically.
+
+---
+
+## Related
+
+- [Licensing hub](licensing.md) — concepts, product code table, REST fallback
+- [User & Group Licenses](user-licenses-allocations.md) — per-user/group bundle assignment (separate from tenant allocation)
+- [Consumables Report](consumables-report.md) — track consumption drawn from tenant pools
+- [Setup Environment](../orchestrator/setup-environment.md) — `uip or licenses toggle` for Orchestrator-scoped slot assignment

--- a/skills/uipath-platform/references/licensing/user-licenses-allocations.md
+++ b/skills/uipath-platform/references/licensing/user-licenses-allocations.md
@@ -1,0 +1,323 @@
+# User & Group License Allocations
+
+Assign user-bundle licenses (e.g., `RPADEVPRONU`, `ATTUNU`, `TSTNU`) directly to individual users, or via group rules with optional quotas.
+
+> For full option details, run `uip platform users licenses --help` or `uip platform groups rules --help`.
+
+---
+
+## When to Use
+
+- Assigning Studio/Attended licenses to individual developers (`users licenses set`)
+- Auditing what bundles a user currently has and where the lease came from (`users licenses get`)
+- Checking how many seats per bundle remain at the account level (`users licenses available`)
+- Managing license entitlement for an AD/AAD group (`groups rules set`) — every group member auto-leases
+- Capping how many of a bundle a group can consume via quota (`groups rules set` with `quota`)
+- Drilling into who in a group currently holds which bundle (`groups rules details`)
+
+## Prerequisites
+
+1. Authenticated: `uip login`
+2. Org admin permissions for license allocation
+3. For `users licenses set/get`: the user is resolvable from a directory search — name or email prefix must match **exactly one** user
+4. For `groups rules details/set`: the group name prefix must match **exactly one** group
+
+---
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `uip platform users licenses available` | Account-level totals per user-bundle: `total`, `allocated`, `available` |
+| `uip platform users licenses get <user>` | List user-bundle leases a user currently holds, with `source` (`direct` or `group`) |
+| `uip platform users licenses set <user> --input <path>` | Replace the user's direct bundle allocation |
+| `uip platform groups rules get` | List all group rules with quota config and current usage (paginated) |
+| `uip platform groups rules details <group>` | Per-user view of a single group: who holds which bundle, plus quota summary on stderr |
+| `uip platform groups rules set <group> --input <path>` | Replace the bundle entitlement + quotas for a group |
+
+---
+
+## Bundle Code ↔ Friendly Name Resolution
+
+The CLI emits raw codes (`RPADEVPRONU`, `ATTUNU`, `TSTNU`) and a `name` field that is **identical to the code** for user bundles — it is not human-readable. Resolve every code via the authoritative docs page in **both directions**:
+
+> **Source of truth:** [UiPath Licensing Product Codes](https://docs.uipath.com/automation-cloud/automation-cloud/latest/api-guide/license-codes)
+
+Fetch on demand — do not cache the table here, since UiPath revises bundle codes as SKUs are added or discontinued.
+
+### Input: user phrase → code
+
+`users licenses set` and `groups rules set` both require a `code` per entry. The CLI does **not** validate codes against a known list — typos pass through and result in an opaque "not allocated" outcome. Resolve every code before writing the input file.
+
+1. The user names a license (e.g., "give Dan an Attended license").
+2. Fetch the docs page and match the user's phrase to a `code`.
+3. Confirm the code is owned by the account: `uip platform users licenses available --output json | jq '.Data[].code'`. If absent, surface that the account does not own this bundle — do not allocate.
+4. Write the input file with the resolved code and run `users licenses set` or `groups rules set`.
+
+If the phrase is ambiguous (multiple matches) or absent from the docs page, ask the user to clarify or pick from `users licenses available` output.
+
+### Output: code → friendly name (mandatory when reporting to the user)
+
+When relaying CLI output back to the user, **always replace raw codes with the friendly name from the docs page**, keeping the code in parentheses for traceability. The `name` field returned by the CLI for user bundles is the code itself and MUST NOT be shown verbatim.
+
+Format: `<Friendly Name> (<CODE>)` — e.g., `Automation Developer Named User (RPADEVPRONU)`, `Attended Named User (ATTUNU)`, `Tester Named User (TSTNU)`.
+
+Apply to every user-facing summary derived from these commands:
+- `users licenses available` — seat totals per bundle
+- `users licenses get` — a user's current leases
+- `users licenses set` — post-assignment confirmation
+- `groups rules get` / `groups rules details` — group rule listings
+- `groups rules set` — post-write confirmation
+- Error messages that reference a bundle code
+
+If the docs page does not list a returned code (newly added SKU, deprecated code still leased), display the code verbatim and tell the user the friendly name could not be resolved — do not invent one.
+
+Example — raw CLI output:
+
+```json
+{"code": "RPADEVPRONU", "name": "RPADEVPRONU", "total": 100, "allocated": 42, "available": 58}
+```
+
+Reported to the user as: **Automation Developer Named User (`RPADEVPRONU`): 58 of 100 seats available.**
+
+---
+
+## Direct User Assignment
+
+### Check Account-Level Availability
+
+Run this before assignment to confirm the bundle has free seats:
+
+```bash
+uip platform users licenses available --output json
+```
+
+```json
+{
+  "Result": "Success",
+  "Code": "UserLicensesAvailable",
+  "Data": [
+    {"code": "RPADEVPRONU", "name": "RPADEVPRONU", "total": 100, "allocated": 42, "available": 58},
+    {"code": "ATTUNU", "name": "ATTUNU", "total": 50, "allocated": 50, "available": 0}
+  ]
+}
+```
+
+`available = max(0, total - allocated)`. A bundle with `available: 0` cannot be assigned to a new user until existing allocations are revoked or more seats are purchased.
+
+### Inspect a User's Current Leases
+
+```bash
+uip platform users licenses get "<USER_NAME_OR_EMAIL_PREFIX>" --output json
+```
+
+```json
+{
+  "Result": "Success",
+  "Code": "UserLicenses",
+  "Data": [
+    {"source": "direct", "code": "RPADEVPRONU", "name": "RPADEVPRONU", "leasedAt": "2026-04-15T10:30:00.000Z"},
+    {"source": "group",  "code": "ATTUNU",      "name": "ATTUNU",      "leasedAt": "2026-04-20T08:15:00.000Z"}
+  ]
+}
+```
+
+`source` field:
+- `"direct"` — assigned through `users licenses set`
+- `"group"` — leased through a group rule the user belongs to
+
+A user may hold the same `code` from both sources (one row each).
+
+### Assign Bundles to a User
+
+Create the input file:
+
+```json
+[
+  {"code": "RPADEVPRONU"},
+  {"code": "ATTUNU"},
+  {"code": "TSTNU"}
+]
+```
+
+Validation rules:
+- Each entry must be `{"code": "<non-empty-string>"}`
+- At least one entry required (empty array is rejected)
+
+Apply it:
+
+```bash
+uip platform users licenses set "<USER_NAME_OR_EMAIL_PREFIX>" --input ./user-licenses.json --output json
+```
+
+```json
+{
+  "Result": "Success",
+  "Code": "UserLicensesSet",
+  "Data": [
+    {"code": "RPADEVPRONU", "name": "RPADEVPRONU"},
+    {"code": "ATTUNU", "name": "ATTUNU"},
+    {"code": "TSTNU", "name": "TSTNU"}
+  ]
+}
+```
+
+The set is **replace, not merge** — the input fully defines the user's direct allocation. Group-inherited leases are unaffected.
+
+---
+
+## Group Rule-Based Allocation
+
+### List All Group Rules
+
+```bash
+uip platform groups rules get --output json
+
+# Filter to first 20 sorted by name descending
+uip platform groups rules get --limit 20 --sort-by name --sort-order Desc --output json
+```
+
+Returns one row per `(group, bundle)` pair:
+
+```json
+{
+  "Result": "Success",
+  "Code": "GroupRules",
+  "Data": [
+    {
+      "groupId": "35551807-06b1-4cda-90a1-2fb84851eee7",
+      "groupName": "RPA Developers",
+      "code": "RPADEVPRONU",
+      "name": "RPADEVPRONU",
+      "quota": 25,
+      "currentUsage": 12,
+      "useExternalLicense": false
+    }
+  ],
+  "Pagination": {"Returned": 1, "Limit": 50, "Offset": 0, "HasMore": false}
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `quota` | `null` if no quota set (no enforcement); integer if enforced |
+| `currentUsage` | Number of users currently leasing this bundle from the rule |
+| `useExternalLicense` | True if external license source is in effect for the group |
+
+### Drill into One Group
+
+```bash
+uip platform groups rules details "<GROUP_NAME_PREFIX>" --output json
+
+# Page through users
+uip platform groups rules details "<GROUP_NAME_PREFIX>" --limit 100 --offset 0 --output json
+```
+
+The CLI writes a summary header to **stderr** (rule entitlements and quota totals), then emits one row per `(user, bundle leased)` to stdout. Users in the group with no bundle leased appear as a single row with `bundleCode: null`.
+
+```json
+{
+  "Result": "Success",
+  "Code": "GroupRuleDetails",
+  "Data": [
+    {
+      "userDisplayName": "Dan Dinu",
+      "email": "dan.dinu@uipath.com",
+      "lastInUse": "2026-05-10T08:15:00.000Z",
+      "orphan": false,
+      "bundleCode": "RPADEVPRONU",
+      "bundleName": "RPADEVPRONU",
+      "quota": 25,
+      "currentUsage": 12
+    }
+  ],
+  "Pagination": {"Returned": 1, "Limit": 50, "Offset": 0, "HasMore": false}
+}
+```
+
+`orphan: true` means the user still holds a lease but is no longer a member of the group — clean these up by re-running `groups rules set` or removing the user from the group.
+
+### Set a Group Rule
+
+Create the rule file:
+
+```json
+[
+  {"code": "RPADEVPRONU"},
+  {"code": "ATTUNU", "quota": 10}
+]
+```
+
+Validation rules:
+- `code` must be a non-empty string
+- `quota` is optional. When present, must be an integer ≥ 1. `quota: 0` is rejected
+- Omitting `quota` means **no enforcement** — every group member who claims this bundle gets one
+
+Apply it:
+
+```bash
+uip platform groups rules set "<GROUP_NAME_PREFIX>" --input ./group-rule.json --output json
+```
+
+```json
+{
+  "Result": "Success",
+  "Code": "GroupRuleSet",
+  "Data": [
+    {"code": "RPADEVPRONU", "name": "RPADEVPRONU", "quota": null,  "currentUsage": null},
+    {"code": "ATTUNU",      "name": "ATTUNU",      "quota": 10,    "currentUsage": 0}
+  ]
+}
+```
+
+`set` replaces the entire rule — bundles not in the input are removed from the group's entitlement.
+
+---
+
+## Direct vs Group: When to Use Each
+
+| Need | Use |
+|------|-----|
+| Assign a specific developer their Studio license | `users licenses set` (direct) |
+| Entitle the entire RPA Developers AD group to a bundle | `groups rules set` (no quota) |
+| Cap how many users from a group can consume a bundle | `groups rules set` with `quota: N` |
+| Audit who has what right now | `users licenses get` (per user) or `groups rules details` (per group) |
+| Quickly see remaining seats | `users licenses available` |
+
+Both mechanisms can co-exist for the same user; rows appear with separate `source` values in `users licenses get`.
+
+---
+
+## Error Conditions
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `No directory user found matching '<input>'.` | No user with that name/email prefix | Use a more specific or correct prefix |
+| `Multiple directory users matched '<input>'.` | Prefix matches more than one user; CLI shows up to 10 candidates | Use a more specific prefix or the full email |
+| `Input file contains no user license bundles.` | Empty `[]` for `users licenses set` | Add at least one entry |
+| `"quota" for code '<X>' must be an integer >= 1` | `quota: 0` or non-integer in `groups rules set` | Use a positive integer or omit `quota` |
+| `Invalid --sort-order.` | Value other than `Asc` or `Desc` | Case-sensitive; pass exactly `Asc` or `Desc` |
+| `Error connecting to the License Accountant.` | Auth expired or network issue | Re-run `uip login` |
+
+---
+
+## Gotchas
+
+- **User/group resolver requires exactly one match.** The directory search is a "starts with" match; pass enough of the name or email to disambiguate. Email addresses are usually unique.
+- **`users licenses set` replaces, not merges.** Passing one bundle revokes any other direct bundles the user previously held. Group-inherited bundles are unaffected.
+- **`groups rules set` replaces the whole rule.** Any bundle not in the new input file is removed from the group's entitlement.
+- **`quota: 0` is rejected.** To zero a bundle out, exclude it from the input file (which removes the entitlement entirely) rather than setting `quota: 0`.
+- **`quota` only applies to group rules.** Direct user assignment has no quota — it's an explicit per-user grant.
+- **Sort order is case-sensitive.** `Asc`/`Desc` only. `asc`, `ASC`, or `ascending` are all rejected.
+- **`orphan: true` rows** still consume a lease until the rule is re-applied or the user is fully removed.
+- **`useExternalLicense`** in `groups rules get` is informational — set externally, not via these commands.
+- **Group rule summary goes to stderr.** When piping `groups rules details` output, the rule header (entitled bundles, quotas) is on `stderr` so the JSON on `stdout` stays clean for `jq`.
+
+---
+
+## Related
+
+- [Licensing hub](licensing.md) — concepts, product code table, REST fallback
+- [Tenant Allocations](tenant-allocations.md) — separate license type for tenant runtime pools
+- [Consumables Report](consumables-report.md) — consumption tracking
+- [Full CLI command reference](../uip-commands.md)

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -86,6 +86,21 @@ Create, pack, publish, and deploy solutions. See [`uipath-solution`](solution/so
 
 ---
 
+## Platform Tool (`uip platform`)
+
+Manage organization-level licensing — tenant allocations, user/group bundle assignments, and consumables reporting. See [`licensing/licensing.md`](licensing/licensing.md).
+
+| Group | Key Commands | Workflow Guide |
+|---|---|---|
+| **Tenants Licenses** | `tenants licenses get <tenant-key>`, `tenants licenses set <tenant-key> --input <path>` | [Tenant Allocations](licensing/tenant-allocations.md) |
+| **Users Licenses** | `users licenses available`, `users licenses get <user>`, `users licenses set <user> --input <path>` | [User & Group Licenses](licensing/user-licenses-allocations.md) |
+| **Groups Rules** | `groups rules get [--limit --offset --sort-by --sort-order]`, `groups rules details <group>`, `groups rules set <group> --input <path>` | [User & Group Licenses](licensing/user-licenses-allocations.md) |
+| **Consumables** | `licenses consumables get --mode {summary\|daily\|folders} [--tenant --unit --start-date --end-date]` | [Consumables Report](licensing/consumables-report.md) |
+
+All `uip platform` commands accept `--organization <account-id>` to override the org from the current login.
+
+---
+
 ## Traces (`uip traces`)
 
 LLM execution trace observability and feedback annotation. See [traces/traces.md](traces/traces.md) (spans) and [traces/feedback.md](traces/feedback.md) (feedback).

--- a/tests/tasks/uipath-platform/licensing/_shared/licensing_check.py
+++ b/tests/tasks/uipath-platform/licensing/_shared/licensing_check.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Validator for licensing_read_e2e.yaml artifacts.
+
+Each emitted JSON file must be a well-formed `uip platform` response envelope
+with `Result == "Success"` and a `Data` field. `available.json` must have a
+non-empty `Data` list (every account owns at least one user bundle).
+`details.json` is conditional — required only when `rules.json` lists at least
+one group; if rules is empty, details is skipped.
+
+Exit 0 on pass, 1 on fail. Reads from the task sandbox cwd (coder_eval invokes
+run_command criteria with cwd set to the sandbox root).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _load(name: str) -> dict | None:
+    path = Path(name)
+    if not path.exists():
+        print(f"FAIL: {name} does not exist", file=sys.stderr)
+        return None
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        print(f"FAIL: {name} is not valid JSON: {e}", file=sys.stderr)
+        return None
+
+
+def _check_envelope(name: str, data: dict) -> bool:
+    if data.get("Result") != "Success":
+        print(f"FAIL: {name} Result != 'Success' (got {data.get('Result')!r})", file=sys.stderr)
+        return False
+    if "Data" not in data:
+        print(f"FAIL: {name} missing 'Data' field", file=sys.stderr)
+        return False
+    return True
+
+
+def main() -> int:
+    errors = 0
+
+    for fname in ["available.json", "rules.json", "consumables.json"]:
+        data = _load(fname)
+        if data is None or not _check_envelope(fname, data):
+            errors += 1
+
+    available = _load("available.json")
+    if available is not None and not available.get("Data"):
+        print("FAIL: available.json Data is empty — expected at least one user bundle", file=sys.stderr)
+        errors += 1
+
+    rules = _load("rules.json")
+    if rules is not None and rules.get("Data"):
+        details = _load("details.json")
+        if details is None or not _check_envelope("details.json", details):
+            errors += 1
+    else:
+        print("INFO: skipping details.json check — rules.json has no groups", file=sys.stderr)
+
+    if errors:
+        return 1
+    print("OK: all licensing JSON envelopes valid")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
@@ -1,0 +1,37 @@
+task_id: skill-platform-licensing-consumables-daily
+description: >
+  Smoke test: agent uses the uipath-platform skill to fetch a day-by-day
+  consumables breakdown with a custom date range. Verifies the agent calls
+  `uip platform licenses consumables get --mode daily --start-date <iso>
+  --end-date <iso> --output json` with both date flags. CLI auth failure
+  is expected offline.
+tags: [uipath-platform, smoke-blocked, licensing, consumables]
+skip: true
+# Blocked: `uip platform licenses consumables get` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the consumables surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Give me a day-by-day consumption breakdown for the period 2026-04-01
+  through 2026-04-30.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform licenses consumables get --mode daily` with date range and --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+daily.*--start-date\s+2026-04-01.*--end-date\s+2026-04-30.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
@@ -1,0 +1,36 @@
+task_id: skill-platform-licensing-consumables-folders
+description: >
+  Smoke test: agent uses the uipath-platform skill to fetch a per-folder
+  consumables breakdown filtered to a specific tenant. Verifies the agent
+  calls `uip platform licenses consumables get --mode folders --tenant <key>
+  --output json`. CLI auth failure is expected offline.
+tags: [uipath-platform, smoke-blocked, licensing, consumables]
+skip: true
+# Blocked: `uip platform licenses consumables get` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the consumables surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Show me per-folder consumption for tenant
+  `c0ffee00-0000-0000-0000-000000000001`.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform licenses consumables get --mode folders --tenant` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+folders.*--tenant\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -1,0 +1,35 @@
+task_id: skill-platform-licensing-consumables-summary
+description: >
+  Smoke test: agent uses the uipath-platform skill to fetch a consumables
+  summary report (default mode). Verifies the agent calls `uip platform
+  licenses consumables get --mode summary --output json`. CLI auth failure
+  is expected offline.
+tags: [uipath-platform, smoke-blocked, licensing, consumables]
+skip: true
+# Blocked: `uip platform licenses consumables get` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the consumables surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Give me a summary of license consumption for this account.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform licenses consumables get --mode summary` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+summary.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
@@ -1,0 +1,35 @@
+task_id: skill-platform-licensing-groups-rules-details
+description: >
+  Smoke test: agent uses the uipath-platform skill to drill into a single
+  group's license-rule details — who in the group holds which bundle.
+  Verifies the agent calls `uip platform groups rules details <group-name>
+  --output json`. CLI auth failure is expected offline.
+tags: [uipath-platform, smoke-blocked, licensing, groups]
+skip: true
+# Blocked: `uip platform groups rules` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the groups surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Who in the "RPA Developers" group currently holds which license bundle?
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform groups rules details <group>` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+details\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
@@ -1,0 +1,45 @@
+task_id: skill-platform-licensing-groups-rules-list
+description: >
+  Smoke test: agent uses the uipath-platform skill to list all group
+  license-allocation rules across the account, with pagination flags.
+  Verifies (1) the agent calls `uip platform groups rules get --output json`
+  and (2) uses at least one pagination flag (`--limit`, `--sort-by`, or
+  `--sort-order`). CLI auth failure is expected offline.
+tags: [uipath-platform, smoke-blocked, licensing, groups]
+skip: true
+# Blocked: `uip platform groups rules` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the groups surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  List the group license-allocation rules in this account. Sort them by name
+  in descending order and limit to the first 20 results.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform groups rules get` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+get.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --limit or --sort-by/--sort-order pagination flags"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+get.*--(limit|sort-by|sort-order)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
@@ -1,0 +1,69 @@
+task_id: skill-platform-licensing-groups-rules-set
+description: >
+  Smoke test: agent uses the uipath-platform skill to set a group rule that
+  entitles the group to two bundles with one carrying a quota. Verifies
+  (1) the agent fetches the docs page to resolve product names to codes,
+  (2) writes a JSON input file with the resolved codes and a `quota` entry,
+  and (3) calls `uip platform groups rules set <group> --input <path>
+  --output json`. CLI auth failure is expected; this validates command shape
+  only.
+tags: [uipath-platform, smoke-blocked, licensing, groups]
+skip: true
+# Blocked: `uip platform groups rules` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the groups surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Configure the group rule for the "RPA Developers" group so that:
+  - every member gets an Automation Developer Named User license (no quota)
+  - up to 10 members can also get an Attended Named User license
+
+  Save the input JSON file as `group-rule.json` in the current directory,
+  then apply it.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected.
+  - Resolve product names to codes from the UiPath docs license-codes page
+    before writing the input file.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched the UiPath docs license-codes page"
+    tool_name: "WebFetch"
+    command_pattern: 'docs\.uipath\.com.*license-codes'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Agent wrote the input file at group-rule.json"
+    path: "group-rule.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Input JSON contains resolved codes and a quota"
+    path: "group-rule.json"
+    includes: ["RPADEVPRONU", "ATTUNU", "quota"]
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran `uip platform groups rules set` with --input and --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+set\s+\S+.*--input\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
+++ b/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
@@ -1,0 +1,121 @@
+task_id: skill-platform-licensing-read-e2e
+description: >
+  E2E test: agent uses the uipath-platform skill to walk through the
+  read-only licensing queries against the live tenant — seat availability,
+  group rules + per-group details, and a consumables summary. Verifies each
+  CLI call succeeds (`Result: "Success"`), each JSON artifact is written,
+  and the agent's final summary reports at least one bundle using the
+  `<Friendly Name> (<CODE>)` format from the docs page.
+tags: [uipath-platform, e2e, licensing]
+skip: true
+# Blocked: depends on `uip platform users licenses available`,
+# `groups rules get/details`, and `licenses consumables get` — none of
+# which are in the public @uipath/platform-tool (v1.0.0, which ships only
+# `tenants licenses get|set`). Re-enable when the CLI publishes these
+# subcommands. See PLT-103133.
+
+agent:
+  type: claude-code
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "WebFetch"]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Use the `uipath-platform` skill.
+
+  Produce a read-only licensing snapshot of this account. Do NOT run any
+  command that mutates state — only `get`, `available`, `details`, and
+  `consumables get`. Specifically:
+
+  1. Run `uip platform users licenses available --output json` and save the
+     full CLI output (the entire envelope, not just `Data`) to
+     `available.json`.
+  2. Fetch the UiPath docs license-codes page so you can translate bundle
+     codes to friendly names.
+  3. Run `uip platform groups rules get --output json` and save the full
+     output to `rules.json`.
+  4. If `rules.json` contains at least one group, pick the first group's
+     `groupName` and run
+     `uip platform groups rules details "<that-group>" --output json`,
+     saving the full output to `details.json`. If `rules.json` is empty,
+     skip this step (the validator will skip the corresponding check).
+  5. Run `uip platform licenses consumables get --mode summary --output json`
+     and save the full output to `consumables.json`.
+  6. Print a final summary that references at least one bundle code from
+     `available.json` using the `<Friendly Name> (<CODE>)` format — e.g.,
+     `Automation Developer Named User (RPADEVPRONU)`.
+
+  Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran users licenses available"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+available.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran groups rules get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+get.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran consumables get --mode summary"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+summary.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the UiPath docs license-codes page"
+    tool_name: "WebFetch"
+    command_pattern: 'docs\.uipath\.com.*license-codes'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "available.json written to sandbox"
+    path: "available.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "rules.json written to sandbox"
+    path: "rules.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "consumables.json written to sandbox"
+    path: "consumables.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Each JSON artifact has Result=Success and valid envelope shape"
+    command: "python3 $TASK_DIR/_shared/licensing_check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Final reply renders at least one bundle as `<Friendly Name> (<CODE>)`"
+    include_agent_output: true
+    prompt: |
+      Evaluate ONLY the agent's final reply. Score 1.0 if it references at
+      least one license bundle in the form `<Friendly Name> (<CODE>)` —
+      e.g., `Automation Developer Named User (RPADEVPRONU)` or `Attended
+      Named User (ATTUNU)`. Score 0.0 if the reply shows only raw codes,
+      only friendly names without codes, or no bundle references at all.
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
@@ -1,0 +1,33 @@
+task_id: skill-platform-licensing-tenant-allocation-get
+description: >
+  Smoke test: agent uses the uipath-platform skill to inspect a tenant's
+  current license unit allocation. Verifies the agent calls
+  `uip platform tenants licenses get <tenant-key> --output json`. CLI auth
+  failure is expected in this offline environment.
+tags: [uipath-platform, smoke, licensing, tenants]
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Show me the current license unit allocation for tenant
+  `c0ffee00-0000-0000-0000-000000000001`.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected. Run
+    each command once and move on. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform tenants licenses get` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+tenants\s+licenses\s+get\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
@@ -1,0 +1,47 @@
+task_id: skill-platform-licensing-tenant-allocation-set
+description: >
+  Smoke test: agent uses the uipath-platform skill to allocate runtime license
+  units (UNATT, RU) to a tenant. Verifies (1) the agent writes a JSON input
+  file containing the runtime codes with quantities, and (2) the agent calls
+  `uip platform tenants licenses set <key> --input <path> --output json`.
+  CLI auth failure is expected; this validates command shape only.
+tags: [uipath-platform, smoke, licensing, tenants]
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Allocate 5 Unattended Robots and 10 Robot Units to tenant
+  `c0ffee00-0000-0000-0000-000000000001`. Save the input JSON file as
+  `tenant-allocation.json` in the current directory, then apply it.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: file_exists
+    description: "Agent wrote the input file at tenant-allocation.json"
+    path: "tenant-allocation.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Input JSON contains the UNATT and RU codes"
+    path: "tenant-allocation.json"
+    includes: ["UNATT", "RU"]
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran `uip platform tenants licenses set` with --input and --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+tenants\s+licenses\s+set\s+\S+.*--input\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
@@ -1,0 +1,68 @@
+task_id: skill-platform-licensing-users-licenses-available
+description: >
+  Smoke test: agent uses the uipath-platform skill to check account-level seat
+  availability for the Attended Named User bundle and reports the result using
+  the friendly-name format mandated by the skill (`<Friendly Name> (<CODE>)`).
+  Verifies (1) the agent invokes `uip platform users licenses available --output json`,
+  (2) it fetches the UiPath docs license-codes page to resolve the code, and
+  (3) the final reply uses the required friendly-name format. CLI auth failure
+  is expected in this offline environment; the friendly-name rule still applies.
+tags: [uipath-platform, smoke-blocked, licensing, users]
+skip: true
+# Blocked: `uip platform users licenses` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the users surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  How many Attended Named User seats does this account have available right
+  now? When you reply, refer to the bundle by its friendly name AND its code,
+  per the skill's docs-page resolution rule.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected. Run
+    each command once and move on. Do NOT retry or attempt to login.
+  - If the CLI fails, still resolve the bundle name → code mapping from the
+    UiPath docs license-codes page so you can answer in the required format.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform users licenses available` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+available.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the UiPath docs license-codes page"
+    tool_name: "WebFetch"
+    command_pattern: 'docs\.uipath\.com.*license-codes'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent's final reply uses the `<Friendly Name> (<CODE>)` format"
+    include_agent_output: true
+    prompt: |
+      Evaluate ONLY the agent's final reply to the user. Score 1.0 if it
+      references the Attended Named User bundle in the form
+      `<Friendly Name> (<CODE>)` — e.g., `Attended Named User (ATTUNU)` or
+      `Attended Named User (`ATTUNU`)`. Score 0.0 if the reply shows only the
+      raw code (`ATTUNU` alone, no friendly name) or only the friendly name
+      without the code. Ignore whether the CLI call succeeded — the rubric is
+      solely about the reporting format.
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
@@ -1,0 +1,67 @@
+task_id: skill-platform-licensing-users-licenses-get
+description: >
+  Smoke test: agent uses the uipath-platform skill to inspect the bundles a
+  user currently leases and reports the result using the friendly-name format
+  from the docs. Verifies (1) `uip platform users licenses get <user>
+  --output json` shape, (2) docs page fetch for code resolution, and
+  (3) final reply uses `<Friendly Name> (<CODE>)` format. CLI auth failure
+  is expected in this offline environment.
+tags: [uipath-platform, smoke-blocked, licensing, users]
+skip: true
+# Blocked: `uip platform users licenses` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the users surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  What license bundles does user `dan.dinu@uipath.com` currently hold? Tell me
+  each bundle and whether it was assigned directly or inherited from a group.
+  When you reply, refer to each bundle using its friendly name AND its code.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected. Run
+    each command once and move on. Do NOT retry or attempt to login.
+  - If the CLI fails, still resolve the most common user-bundle name → code
+    mappings from the UiPath docs license-codes page so you can demonstrate
+    the required reporting format.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran `uip platform users licenses get` with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+get\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the UiPath docs license-codes page"
+    tool_name: "WebFetch"
+    command_pattern: 'docs\.uipath\.com.*license-codes'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent's final reply uses `<Friendly Name> (<CODE>)` format"
+    include_agent_output: true
+    prompt: |
+      Evaluate ONLY the agent's final reply. Score 1.0 if it references one
+      or more license bundles in the form `<Friendly Name> (<CODE>)` — e.g.,
+      `Automation Developer Named User (RPADEVPRONU)` or `Attended Named User
+      (ATTUNU)`. Score 0.0 if the reply shows only raw codes without friendly
+      names, or only friendly names without codes. Ignore whether the CLI
+      call succeeded — the rubric is solely about reporting format.
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
@@ -1,0 +1,70 @@
+task_id: skill-platform-licensing-users-licenses-set
+description: >
+  Smoke test: agent uses the uipath-platform skill to assign two user bundles
+  (Attended Named User + Automation Developer Named User) to a specific user.
+  Verifies (1) the agent fetches the docs page to resolve product names to
+  codes, (2) writes a JSON input file containing the resolved codes, and
+  (3) calls `uip platform users licenses set <user> --input <path>
+  --output json`. CLI auth failure is expected; this validates command shape
+  only — no live write.
+tags: [uipath-platform, smoke-blocked, licensing, users]
+skip: true
+# Blocked: `uip platform users licenses` is not in the public
+# @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
+# Re-enable when the CLI ships the users surface. See PLT-103133.
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Assign two licenses to user `dan.dinu@uipath.com`:
+  - Attended Named User
+  - Automation Developer Named User
+
+  Save the input JSON file as `user-licenses.json` in the current directory,
+  then run the assignment command.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands may fail with auth errors — that is expected. Run
+    each command once and move on. Do NOT retry or attempt to login.
+  - Resolve product names to codes from the UiPath docs license-codes page
+    before writing the input file.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched the UiPath docs license-codes page"
+    tool_name: "WebFetch"
+    command_pattern: 'docs\.uipath\.com.*license-codes'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Agent wrote the input file at user-licenses.json"
+    path: "user-licenses.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Input JSON contains the resolved ATTUNU and RPADEVPRONU codes"
+    path: "user-licenses.json"
+    includes: ["ATTUNU", "RPADEVPRONU"]
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran `uip platform users licenses set` with --input and --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+set\s+\S+.*--input\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Document `uip platform` commands for tenant license allocations, user/group bundle assignments, and consumables reporting. Adds a new references/licensing/ folder (hub + three workflow guides) and wires it into SKILL.md triggers/navigation and the uip-commands reference. Bundle codes must be resolved via the UiPath docs friendly-name page in both directions when interacting with the user.

[PLT-103133]

[PLT-103133]: https://uipath.atlassian.net/browse/PLT-103133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ