### PR TITLE
fix(maestro-flow): require registry get for OOTB action nodes [MST-9752]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/references/planning-arch.md
@@ -4,7 +4,8 @@ Discover available capabilities, then design the flow topology — select node t
 
 > **Registry rules for this phase:**
 > - **`registry search` and `registry list` are ALLOWED** — use them to discover what connectors, resources, and operations exist before committing to a topology.
-> - **`registry get` is NOT allowed** — detailed metadata, connection binding, and reference field resolution are handled in [Planning Phase 2: Implementation](planning-impl.md).
+> - **`registry get` IS REQUIRED for any OOTB action node** the flow will use — `core.action.http`, `core.action.http.v2`, `core.action.script`, `core.action.transform`, queue actions, etc. These nodes have no connection-id; their full input/output schema, port names, and required fields are only visible via `registry get <nodeType> --output json`. Run `get` once per OOTB action node type during discovery so the topology and ports are grounded in real metadata.
+> - **`registry get` is DEFERRED for connector and resource nodes** — those require a `--connection-id` (connector) or `--local` resolution that belongs to [Planning Phase 2: Implementation](planning-impl.md).
 
 ---
 
@@ -35,6 +36,11 @@ uip maestro flow registry search outlook --output json       # example: does an 
 uip maestro flow registry search "invoice process" --output json  # example: is an RPA process published?
 uip maestro flow registry search agent --output json         # example: what agents are available?
 uip maestro flow registry list --output json                 # list all available node types
+
+# OOTB action nodes — fetch full schema during discovery (no --connection-id needed):
+uip maestro flow registry get core.action.http --output json    # full HTTP request schema, headers/auth shape
+uip maestro flow registry get core.action.script --output json  # script node inputs/outputs and language options
+# Repeat for every OOTB action node the flow will use (transform, queue actions, etc.)
 ```
 
 > **Auth note:** Without `uip login`, the registry shows OOTB nodes only. After login, tenant-specific connector and resource nodes are also available. If the flow requires connectors or resources, verify login status first: `uip login status --output json`.
@@ -65,7 +71,7 @@ uip is connections list "<connector-key>" --output json
 
 Use these findings to select the right node types from the [Plugin Index](#plugin-index). If a connector doesn't exist, fall back to `core.action.http` or note it as a gap in Open Questions.
 
-> **Do NOT run `registry get` during discovery.** Search results give you node type names — enough to know what connectors and operations exist. `is connections list` confirms connection availability. Detailed field metadata (required fields, types, enums, reference resolution) requires `registry get --connection-id` and belongs to Phase 2.
+> **Run `registry get` for OOTB action nodes during discovery; defer for connector and resource nodes.** OOTB nodes (HTTP, Script, Transform, queue actions, etc.) have no `--connection-id` dependency — fetch their full schemas now so the planned topology references real ports and fields. Connector field metadata (required fields, enums, reference resolution) requires `registry get --connection-id` and belongs to Phase 2; resource schemas (RPA, agent, flow, API workflow) require `--local` or published resolution and also belong to Phase 2. `is connections list` is enough to confirm connector connection availability in this phase.
 
 ---
 


### PR DESCRIPTION
## Summary

The Phase 1 (discovery) skill text in `planning-arch.md` forbade `registry get` outright. That is correct for connector and resource nodes (their full metadata needs `--connection-id` or `--local` and genuinely belongs to Phase 2), but **OOTB action nodes** — `core.action.http`, `core.action.http.v2`, `core.action.script`, `core.action.transform`, queue actions — have no such dependency. Their port names, input requirements, and output schemas are static and only visible via `registry get`. Without that in Phase 1, the planned topology references guessed ports and the eval task `skill-flow-registry-discovery` never satisfies its `registry get .* core.action.http|script` criteria.

Carve out the rule along that line:
- `registry get` is **REQUIRED** in Phase 1 for OOTB action nodes (with concrete example commands in the discovery code block).
- `registry get` is **DEFERRED** for connector / resource nodes.

The updated callout near "What to record from discovery" mirrors the same distinction so the rule reads consistently throughout the page. `CAPABILITY.md` already said "use `registry get` for detailed metadata" — this PR makes `planning-arch.md` agree with it.

## Test plan
- [x] Skill markdown only; no code or tests touched.
- [x] Re-read `planning-impl.md` to confirm Phase 2 wording remains consistent (Step 1a still asks for registry validation on all nodes including OOTB; that step is now a re-confirmation of work done in Phase 1).
- [ ] Reviewer: confirm the new wording matches reviewer intent for OOTB vs. connector vs. resource distinction.

## Root cause (from run 2026-05-13_03-38-18)
`skill-flow-registry-discovery/00/task.log` shows the agent ran `registry search`, `registry list`, etc., then stopped before any `registry get`. Its ThinkingBlock at the relevant turn cites the skill's own Phase 1 prohibition ("Do NOT run `registry get` during discovery"). The agent did exactly what the skill said — the skill was wrong.

## Jira
- MST-9752

🤖 Generated with [Claude Code](https://claude.com/claude-code)