### PR TITLE
fix(test): accept manual+graph fallback in customer escalation checker [MST-9751]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
@@ -5,13 +5,22 @@ Checks the .flow file the agent produced. Static-only because the prompt is
 validate-only (no live Outlook / Slack tenant). Mirrors the
 check_devcon_expense_approval.py shape.
 
+The trigger type is intentionally NOT pinned to Outlook: when no
+`uipath-microsoft-outlook365` connection exists in the sandbox, the flow
+skill's documented Tier-3 fallback is `core.trigger.manual` plus Graph
+API HTTP replies. The flow's semantic intent ("talks to Outlook") is
+already proved by the non-trigger Outlook-or-Graph reference assertion
+below.
+
 Asserts:
   1. Total node count >= 5 (trigger + 2 scripts + decision + at least one branch action)
-  2. Outlook-typed trigger node present
+  2. Exactly one trigger node present (any type — manual fallback is legitimate)
   3. >=2 script nodes (urgency + VIP classifier)
   4. Exactly one core.logic.decision node, with >=2 outgoing edges (two branches)
   5. Slack connector referenced somewhere in the flow (VIP branch DM)
-  6. Outlook referenced by at least one *non-trigger* node (reply on either branch)
+  6. Outlook reply referenced by at least one *non-trigger* node — matches
+     `outlook`, `office365`, or `graph.microsoft.com` (Graph API replies
+     are the same surface the connector wraps).
 """
 
 from __future__ import annotations
@@ -20,16 +29,17 @@ import glob
 import json
 import sys
 from pathlib import Path
+from typing import Any, NoReturn
 
 
 FLOW_GLOB = "CustomerEscalation/CustomerEscalation/CustomerEscalation.flow"
 
 
-def fail(msg: str) -> None:
+def fail(msg: str) -> NoReturn:
     sys.exit(f"FAIL: {msg}")
 
 
-def load_flow() -> dict:
+def load_flow() -> dict[str, Any]:
     matches = glob.glob(FLOW_GLOB)
     if not matches:
         fail(f"No flow file matching {FLOW_GLOB}")
@@ -72,9 +82,11 @@ def main() -> None:
     if len(nodes) < 5:
         fail(f"Expected >=5 nodes (trigger + 2 scripts + decision + branch action(s)), found {len(nodes)}")
 
-    outlook_trigger = [n for n in nodes if is_trigger(n) and references(n, "outlook")]
-    if not outlook_trigger and not any(is_trigger(n) and references(n, "office365") for n in nodes):
-        fail("No Outlook (or office365) trigger node found")
+    triggers = [n for n in nodes if is_trigger(n)]
+    if not triggers:
+        fail("No trigger node found")
+    if len(triggers) > 1:
+        fail(f"Expected exactly one trigger node, found {len(triggers)}")
 
     scripts = [n for n in nodes if node_type(n) == "core.action.script"]
     if len(scripts) < 2:
@@ -97,9 +109,16 @@ def main() -> None:
     if not any(references(n, "slack") for n in nodes):
         fail("No Slack connector reference found anywhere in flow (VIP branch should DM via Slack)")
 
-    non_trigger_outlook = [n for n in nodes if not is_trigger(n) and (references(n, "outlook") or references(n, "office365"))]
+    outlook_needles = ("outlook", "office365", "graph.microsoft.com")
+    non_trigger_outlook = [
+        n for n in nodes
+        if not is_trigger(n) and any(references(n, needle) for needle in outlook_needles)
+    ]
     if not non_trigger_outlook:
-        fail("No non-trigger Outlook reference found (expected reply-to-sender action on at least one branch)")
+        fail(
+            "No non-trigger Outlook reply reference found "
+            f"(expected one of {outlook_needles} on a reply-to-sender action on at least one branch)"
+        )
 
     print(
         f"PASS: {len(nodes)} nodes, {len(scripts)} scripts, decision with {len(out_edges)} branches, "

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
@@ -48,7 +48,6 @@ def load_flow() -> dict[str, Any]:
         return json.loads(path.read_text())
     except json.JSONDecodeError as exc:
         fail(f"{path} is not valid JSON: {exc}")
-    return {}
 
 
 def node_type(node: dict) -> str:

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
@@ -1,0 +1,154 @@
+"""Unit tests for check_customer_escalation_flow.py.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/multi_node/customer_escalation``.
+
+These tests pin down the contract that:
+- A manual trigger plus Graph-API HTTP reply nodes is a legitimate shape
+  (the skill's documented Tier-3 fallback when no Outlook connection
+  exists in the sandbox).
+- An Outlook-connector trigger plus a connector reply remains the
+  happy path.
+- Structural requirements (>=5 nodes, exactly one decision with >=2
+  branches, >=2 scripts, Slack reference, non-trigger Outlook/Graph
+  reference) are still enforced.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CHECKER = Path(__file__).resolve().parent / "check_customer_escalation_flow.py"
+Node = dict[str, Any]
+Edge = dict[str, Any]
+
+
+def _flow_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "CustomerEscalation" / "CustomerEscalation"
+    d.mkdir(parents=True)
+    return d
+
+
+def _write_flow(tmp_path: Path, nodes: list[Node], edges: list[Edge]) -> None:
+    payload = {"version": "1.0.0", "nodes": nodes, "edges": edges}
+    (_flow_dir(tmp_path) / "CustomerEscalation.flow").write_text(json.dumps(payload))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _manual_trigger_with_graph_replies() -> tuple[list[Node], list[Edge]]:
+    nodes = [
+        {"id": "start", "type": "core.trigger.manual"},
+        {"id": "classify", "type": "core.action.script", "inputs": {"src": "urgency"}},
+        {"id": "vip", "type": "core.action.script", "inputs": {"src": "vip"}},
+        {"id": "decide", "type": "core.logic.decision"},
+        {
+            "id": "reply_vip",
+            "type": "core.action.http.v2",
+            "inputs": {"detail": {"url": "https://graph.microsoft.com/v1.0/me/messages/{id}/reply"}},
+        },
+        {
+            "id": "reply_standard",
+            "type": "core.action.http.v2",
+            "inputs": {"detail": {"url": "https://graph.microsoft.com/v1.0/me/messages/{id}/reply"}},
+        },
+        {
+            "id": "slack",
+            "type": "core.action.http.v2",
+            "inputs": {"detail": {"bodyParameters": {"targetConnector": "uipath-salesforce-slack"}}},
+        },
+        {"id": "end", "type": "core.control.end"},
+    ]
+    edges = [
+        {"sourceNodeId": "decide", "targetNodeId": "reply_vip"},
+        {"sourceNodeId": "decide", "targetNodeId": "reply_standard"},
+    ]
+    return nodes, edges
+
+
+def _outlook_connector_shape() -> tuple[list[Node], list[Edge]]:
+    nodes = [
+        {"id": "start", "type": "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"},
+        {"id": "urgency", "type": "core.action.script"},
+        {"id": "vip", "type": "core.action.script"},
+        {"id": "decide", "type": "core.logic.decision"},
+        {"id": "reply", "type": "uipath.connector.uipath-microsoft-outlook365.send-reply"},
+        {"id": "slack", "type": "uipath.connector.uipath-salesforce-slack.send-direct-message"},
+        {"id": "end", "type": "core.control.end"},
+    ]
+    edges = [
+        {"sourceNodeId": "decide", "targetNodeId": "reply"},
+        {"sourceNodeId": "decide", "targetNodeId": "slack"},
+    ]
+    return nodes, edges
+
+
+def test_manual_trigger_with_graph_replies_passes(tmp_path: Path) -> None:
+    """The Tier-3 fallback shape (the failing-run pattern) should PASS."""
+    nodes, edges = _manual_trigger_with_graph_replies()
+    _write_flow(tmp_path, nodes, edges)
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_outlook_connector_happy_path_passes(tmp_path: Path) -> None:
+    """The original IS-connector shape (Tier 1) should still PASS."""
+    nodes, edges = _outlook_connector_shape()
+    _write_flow(tmp_path, nodes, edges)
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_missing_outlook_reference_fails(tmp_path: Path) -> None:
+    """Flow with NO outlook/office365/graph reference on any reply node FAILS."""
+    nodes, edges = _manual_trigger_with_graph_replies()
+    # Strip Graph URLs from both reply nodes — now there's no Outlook
+    # surface anywhere except trigger (which is just `manual`).
+    for n in nodes:
+        if n["id"].startswith("reply"):
+            n["inputs"] = {"detail": {"url": "https://example.com/notify"}}
+    _write_flow(tmp_path, nodes, edges)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "non-trigger Outlook reply reference" in result.stderr or "non-trigger Outlook reply reference" in result.stdout
+
+
+def test_no_trigger_fails(tmp_path: Path) -> None:
+    nodes, edges = _manual_trigger_with_graph_replies()
+    nodes = [n for n in nodes if n["id"] != "start"]
+    _write_flow(tmp_path, nodes, edges)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "trigger" in combined.lower()
+
+
+def test_no_slack_reference_fails(tmp_path: Path) -> None:
+    nodes, edges = _manual_trigger_with_graph_replies()
+    nodes = [n for n in nodes if n["id"] != "slack"]
+    _write_flow(tmp_path, nodes, edges)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "Slack" in combined or "slack" in combined
+
+
+def test_decision_with_single_branch_fails(tmp_path: Path) -> None:
+    nodes, edges = _manual_trigger_with_graph_replies()
+    edges = [e for e in edges if e["targetNodeId"] != "reply_standard"]
+    _write_flow(tmp_path, nodes, edges)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert ">=2 outgoing edges" in combined or "branches" in combined.lower()


### PR DESCRIPTION
## Summary

`check_customer_escalation_flow.py` required the trigger node's JSON to contain literal `outlook` or `office365`, which is impossible to emit when the sandbox has no `uipath-microsoft-outlook365` connection. The maestro-flow skill's *own* documented Tier-3 fallback is `core.trigger.manual` + Graph-API HTTP replies — and that is exactly what the agent did. The checker also had a blind spot on reply detection: a non-trigger Outlook reference was required, but the agent's Graph-API replies (`https://graph.microsoft.com/v1.0/me/messages/{id}/reply`) never matched the `outlook`/`office365` substring even though that endpoint **is** Outlook.

Two narrow checker changes:

1. Drop the trigger-type pin — only require a single trigger node. The remaining structural assertions (>=5 nodes, 2+ scripts, exactly one decision with >=2 branches, Slack reference, non-trigger Outlook reply reference) already prove the flow's semantic intent.
2. Broaden the non-trigger reply needle list to include `graph.microsoft.com` so Graph-API HTTP replies count as Outlook evidence — same surface, different transport.

Also annotate `fail()` as `NoReturn` so Pyright can narrow `nodes` / `edges` after the existence check, and add a focused pytest suite covering both the IS-connector happy path and the manual+Graph fallback shape from the failing run.

## Verification

Verified by running the patched checker against the actual artifact from run 2026-05-13_03-38-18 (skill-flow-customer-escalation/00):
- **Before:** `FAIL: No Outlook (or office365) trigger node found`
- **After:** `PASS: 10 nodes, 3 scripts, decision with 2 branches, Slack and Outlook reply references present`

## Test plan
- [x] `pytest tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py` — 6 passed (manual+Graph, IS-connector happy path, missing-reference, missing-trigger, missing-Slack, single-branch-decision)
- [x] End-to-end against actual failing-run artifact — PASS

## Jira
- MST-9751

🤖 Generated with [Claude Code](https://claude.com/claude-code)