### PR TITLE
fix(test): replace PIMS-coupled debug with structural API workflow check [MST-9611]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -3,6 +3,15 @@ description: >
   Create a UiPath Flow that invokes the name-to-age API workflow with the
   name 'tomasz' and returns his age. Exercises API workflow resource node
   discovery and wiring.
+
+  Skipping flow debug: `uip maestro flow debug` is inherently a live-tenant
+  operation (uploads to Studio Web, creates a PIMS debug instance) and the
+  maestro-flow skill itself forbids it as a validation step (SKILL.md). The
+  published API-workflow binding `Shared/uipath-maestro-flow/NameToAge APIWF`
+  is also unreliable across no-tenant sandboxes — PIMS returns
+  PIMS-100003/500. Structural checks against the produced `.flow` artifact
+  (node type, published binding shape, prompt-required input) cover the
+  agent-side correctness without the tenant dependency (MST-9611).
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 max_iterations: 1
 

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -34,11 +34,11 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  # ── Execution checks ──────────────────────────────────────────────────
+  # ── Structural checks (no live tenant required) ───────────────────────
   - type: run_command
-    description: "Flow has an API workflow node and debug returns an age"
+    description: "Flow has an api-workflow node, published binding, and inputs.name='tomasz'"
     command: "python3 $TASK_DIR/check_api_workflow_flow.py"
-    timeout: 300
+    timeout: 60
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/check_api_workflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/check_api_workflow_flow.py
@@ -1,22 +1,110 @@
 #!/usr/bin/env python3
-"""NameToAge: an API-workflow node executes and the output holds a plausible age."""
+"""NameToAge API-workflow flow: structural assertions.
 
+The previous checker ran ``uip maestro flow debug``. That command is a
+live-tenant operation by CLI design — it uploads the flow to Studio Web,
+creates a debug instance in PIMS, and polls until completion. The
+maestro-flow skill itself bans this exact pattern:
+
+    SKILL.md: "Never run `flow debug` as a validation step — debug
+    executes the flow with real side effects. Use `flow validate` for
+    checking correctness."
+
+Under no-tenant or transient conditions, PIMS returned ``PIMS-100003`` /
+500 against the published binding
+``Shared/uipath-maestro-flow/NameToAge APIWF.API Workflow``, sinking the
+score for skill-flow-api-workflow even when the agent built a perfectly
+valid flow.
+
+Move to a fully static structural check that asserts the flow has the
+right shape for an API-workflow invocation:
+
+1. An ``uipath.core.api-workflow.*`` node is present (delegated to
+   ``assert_flow_has_node_type`` so we share the manifest-aware glob).
+2. The flow declares at least one published API-workflow binding —
+   ``bindings[]`` entry with ``resource == "process"``,
+   ``resourceSubType == "Api"``, and a non-empty ``resourceKey``.
+3. The api-workflow node sets the prompt-required input
+   ``inputs.name == "tomasz"`` (case-insensitive).
+"""
+
+from __future__ import annotations
+
+import glob
+import json
 import os
 import sys
+from pathlib import Path
+from typing import Any, NoReturn
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
-    assert_output_int_in_range,
-    run_debug,
-)
+from _shared.flow_check import assert_flow_has_node_type  # noqa: E402
 
 
-def main():
-    assert_flow_has_node_type(["uipath.core.api-workflow"])
-    payload = run_debug(timeout=240)
-    age = assert_output_int_in_range(payload, 40, 60)
-    print(f"OK: API workflow node present; age = {age}")
+FLOW_GLOB = "NameToAge/NameToAge/NameToAge.flow"
+API_WORKFLOW_NODE_PREFIX = "uipath.core.api-workflow"
+
+
+def fail(msg: str) -> NoReturn:
+    sys.exit(f"FAIL: {msg}")
+
+
+def load_flow() -> dict[str, Any]:
+    matches = glob.glob(FLOW_GLOB)
+    if not matches:
+        fail(f"No flow file matching {FLOW_GLOB}")
+    path = Path(matches[0])
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"{path} is not valid JSON: {exc}")
+
+
+def assert_api_workflow_binding(flow: dict[str, Any]) -> None:
+    bindings = flow.get("bindings")
+    if not isinstance(bindings, list) or not bindings:
+        fail("Flow has no top-level bindings[] — API workflow resource is not wired up.")
+    api_bindings = [
+        b for b in bindings
+        if isinstance(b, dict)
+        and b.get("resource") == "process"
+        and b.get("resourceSubType") == "Api"
+        and b.get("resourceKey")
+    ]
+    if not api_bindings:
+        fail(
+            "No published API-workflow binding found "
+            "(expected bindings[] entry with resource='process', "
+            "resourceSubType='Api', and a non-empty resourceKey)."
+        )
+
+
+def assert_name_input(flow: dict[str, Any]) -> None:
+    nodes = flow.get("nodes")
+    if not isinstance(nodes, list):
+        fail("Flow has no nodes[] array.")
+    api_nodes = [
+        n for n in nodes
+        if isinstance(n, dict)
+        and isinstance(n.get("type"), str)
+        and n["type"].lower().startswith(API_WORKFLOW_NODE_PREFIX)
+    ]
+    if not api_nodes:
+        fail(f"No api-workflow node (type starts with '{API_WORKFLOW_NODE_PREFIX}') found.")
+    for node in api_nodes:
+        inputs = node.get("inputs") or {}
+        name = inputs.get("name")
+        if isinstance(name, str) and name.strip().lower() == "tomasz":
+            return
+    fail("API workflow node does not set inputs.name = 'tomasz' as the prompt requires.")
+
+
+def main() -> None:
+    assert_flow_has_node_type([API_WORKFLOW_NODE_PREFIX])
+    flow = load_flow()
+    assert_api_workflow_binding(flow)
+    assert_name_input(flow)
+    print("OK: API workflow node present, published binding wired, inputs.name='tomasz'")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/test_check_api_workflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/test_check_api_workflow_flow.py
@@ -1,0 +1,127 @@
+"""Unit tests for check_api_workflow_flow.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/single_node/api_workflow``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CHECKER = Path(__file__).resolve().parent / "check_api_workflow_flow.py"
+
+
+def _flow_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "NameToAge" / "NameToAge"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
+    d = _flow_dir(tmp_path)
+    (d / "NameToAge.flow").write_text(json.dumps(payload))
+    # assert_flow_has_node_type needs a Flow project.uiproj alongside the .flow.
+    (d / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _well_formed() -> dict[str, Any]:
+    """Mirror the actual failing-run artifact shape."""
+    return {
+        "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "core.trigger.manual"},
+            {
+                "id": "callApiWorkflow",
+                "type": "uipath.core.api-workflow.84e2a2f6-50d1-4753-bae2-d873eda90b61",
+                "inputs": {"name": "tomasz"},
+            },
+            {"id": "end", "type": "core.control.end"},
+        ],
+        "edges": [
+            {"sourceNodeId": "start", "targetNodeId": "callApiWorkflow"},
+            {"sourceNodeId": "callApiWorkflow", "targetNodeId": "end"},
+        ],
+        "bindings": [
+            {
+                "id": "bCallApiWorkflowName",
+                "name": "name",
+                "resource": "process",
+                "resourceKey": "Shared/uipath-maestro-flow/NameToAge APIWF.API Workflow",
+                "resourceSubType": "Api",
+            },
+            {
+                "id": "bCallApiWorkflowFolderPath",
+                "name": "folderPath",
+                "resource": "process",
+                "resourceKey": "Shared/uipath-maestro-flow/NameToAge APIWF.API Workflow",
+                "resourceSubType": "Api",
+            },
+        ],
+    }
+
+
+def test_well_formed_flow_passes(tmp_path: Path) -> None:
+    _write_flow(tmp_path, _well_formed())
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_missing_api_workflow_node_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"] = [n for n in payload["nodes"] if "api-workflow" not in n["type"]]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_missing_binding_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["bindings"] = []
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "binding" in (result.stdout + result.stderr).lower()
+
+
+def test_binding_without_resource_key_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["bindings"] = [
+        {"id": "b1", "resource": "process", "resourceSubType": "Api", "resourceKey": ""},
+    ]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_wrong_name_input_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if "api-workflow" in n["type"]:
+            n["inputs"] = {"name": "alice"}
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "tomasz" in (result.stdout + result.stderr)
+
+
+def test_name_input_case_insensitive_passes(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if "api-workflow" in n["type"]:
+            n["inputs"] = {"name": "Tomasz"}
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
## Summary

The api_workflow checker called `run_debug(...)` which delegates to `uip maestro flow debug`. That CLI command is inherently a live-tenant operation by design — it uploads the flow to Studio Web, creates a debug instance in PIMS, and polls until completion. The maestro-flow skill itself explicitly forbids this exact pattern:

> SKILL.md: "Never run `flow debug` as a validation step — debug executes the flow with real side effects. Use `flow validate` for checking correctness."

Under no-tenant or transient conditions, PIMS rejected the published binding `Shared/uipath-maestro-flow/NameToAge APIWF.API Workflow` with `PIMS-100003 / 500`, sinking the test even when the agent shipped a perfectly valid flow.

Replace the debug step with three static structural assertions against the produced `.flow` artifact:

1. An `uipath.core.api-workflow.*` node exists (already covered by `assert_flow_has_node_type`; kept).
2. The top-level `bindings[]` array contains a published API-workflow binding — `resource == "process"`, `resourceSubType == "Api"`, non-empty `resourceKey`. This is the agent-side wiring; if it isn't there, the flow couldn't run under any tenant.
3. The api-workflow node sets `inputs.name == "tomasz"` (the prompt-specified value, case-insensitive).

Dropped the age-in-range assertion that depended on actually executing the flow; the prompt-required input check above is the proxy for "the agent plumbed the right call."

## Family-wide note (not in this PR)

`run_debug` is called by ~10 single-node checkers under `tests/tasks/uipath-maestro-flow/single_node/`. The PIMS-100003 cascade is most visible in api_workflow but other single-node checkers carry the same fragility. Filing as a separate meta-improvement ticket — keeping this PR scoped to MST-9611.

## Verification

End-to-end run against the actual `.flow` artifact from run 2026-05-13_03-38-18 (skill-flow-api-workflow/00):
- **Before:** PIMS-100003 / 500 internal server error
- **After:** `OK: API workflow node present, published binding wired, inputs.name='tomasz'`

## Test plan
- [x] `pytest tests/tasks/uipath-maestro-flow/single_node/api_workflow/test_check_api_workflow_flow.py` — 6 passed (well-formed flow, missing node, missing binding, empty resourceKey, wrong name, case-insensitive name match)
- [x] End-to-end against actual failing-run artifact — PASS
- [x] YAML criterion timeout dropped 300s → 60s (debug no longer needed)

## Jira
- MST-9611

🤖 Generated with [Claude Code](https://claude.com/claude-code)