### PR TITLE
fix(test): make outlook trigger checker tolerant of CLI verb skew [MST-9674]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -27,10 +27,7 @@ TRIGGER_TYPE_MARKER = "uipath.connector.trigger.uipath-microsoft-outlook365.emai
 TEST_FOLDER_PATH = "Shared/uipath-maestro-flow"
 
 
-def _uip_json(args: list[str]) -> dict:
-    """Run a uip CLI command and return parsed JSON. Fails the test on
-    non-zero exit or invalid JSON."""
-    result = subprocess.run(args, capture_output=True, text=True, timeout=120)
+def _parse_uip_stdout(args: list[str], result: subprocess.CompletedProcess) -> dict:
     if result.returncode != 0:
         sys.exit(
             f"FAIL: {' '.join(args)} exit={result.returncode}\n"
@@ -45,6 +42,36 @@ def _uip_json(args: list[str]) -> dict:
         return json.loads(out[idx:])
     except json.JSONDecodeError as e:
         sys.exit(f"FAIL: JSON parse error on {' '.join(args)}: {e}\n{out}")
+
+
+def _uip_json(args: list[str]) -> dict:
+    """Run a uip CLI command and return parsed JSON. Fails the test on
+    non-zero exit or invalid JSON."""
+    return _parse_uip_stdout(args, subprocess.run(args, capture_output=True, text=True, timeout=120))
+
+
+def _uip_resources_run(tail_args: list[str]) -> dict:
+    """Invoke ``uip is resources <verb> <tail...>`` tolerating both the
+    post-rename verb (``run``, current) and the legacy verb (``execute``).
+
+    Sandboxes can carry either CLI version depending on which
+    @uipath/integrationservice-tool install ranks first in Node's
+    parent-walking module resolution. The fallback on
+    ``unknown command 'run'`` keeps the checker green across both shapes
+    until the sandbox PATH is fully isolated (see coder_eval companion
+    PR).
+    """
+    primary = ["uip", "is", "resources", "run", *tail_args]
+    result = subprocess.run(primary, capture_output=True, text=True, timeout=120)
+    needs_fallback = (
+        result.returncode != 0
+        and "unknown command 'run'" in (result.stdout + result.stderr)
+    )
+    if needs_fallback:
+        legacy = ["uip", "is", "resources", "execute", *tail_args]
+        result = subprocess.run(legacy, capture_output=True, text=True, timeout=120)
+        return _parse_uip_stdout(legacy, result)
+    return _parse_uip_stdout(primary, result)
 
 
 def _read_flow() -> tuple[dict, str]:
@@ -124,15 +151,14 @@ def check_folder_id_fresh():
         )
 
     conn_id, _folder_key, _conn_name = _find_default_outlook_connection()
-    live = _uip_json(
-        [
-            "uip", "is", "resources", "run", "list", CONNECTOR_KEY, "MailFolder",
-            "--connection-id", conn_id, "--output", "json",
-        ]
+    live = _uip_resources_run(
+        ["list", CONNECTOR_KEY, "MailFolder", "--connection-id", conn_id, "--output", "json"]
     )
     live_ids = {f.get("id") for f in _extract_list_items(live)}
     if not live_ids:
-        sys.exit("FAIL: resources run list MailFolder returned no folders on the bound connection")
+        sys.exit(
+            "FAIL: resources run/execute list MailFolder returned no folders on the bound connection"
+        )
 
     if flow_folder_id not in live_ids:
         # Truncate the IDs in the error to avoid leaking full Exchange IDs while

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -69,7 +69,10 @@ success_criteria:
     tool_name: "Bash"
     # `[\s\S]` matches across newlines — agents often split `uip` commands with
     # backslash line-continuation, which `.*` would miss.
-    command_pattern: 'uip\s+is\s+resources\s+run\s+list[\s\S]+?MailFolder[\s\S]+?--connection-id'
+    # Verb alternation tolerates both the post-rename verb ("run", current)
+    # and the legacy "execute" verb that older CLIs in the sandbox PATH may
+    # still expose (MST-9674).
+    command_pattern: 'uip\s+is\s+resources\s+(?:run|execute)\s+list[\s\S]+?MailFolder[\s\S]+?--connection-id'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
@@ -1,9 +1,18 @@
-"""Tests for the Outlook trigger checker."""
+"""Tests for the Outlook trigger checker.
+
+Exercises the verb-tolerant `_uip_resources_run` helper that backs
+``check_folder_id_fresh`` so the checker keeps working across both the
+post-rename CLI (``uip is resources run``) and any sandbox that still
+ships the legacy CLI (``uip is resources execute``). See MST-9674.
+"""
 
 from __future__ import annotations
 
 import importlib.util
+import json
+import subprocess
 from pathlib import Path
+from typing import Any
 
 
 CHECKER = Path(__file__).with_name("check_outlook_trigger_inbox.py")
@@ -18,22 +27,14 @@ def _load_checker():
     return module
 
 
-def test_check_folder_id_fresh_uses_resources_run_list(monkeypatch) -> None:
-    checker = _load_checker()
-    calls: list[list[str]] = []
-
+def _patch_static(monkeypatch, checker, folder_id: str = "mail-folder-1") -> None:
+    """Stub the non-CLI dependencies so we can focus on the verb path."""
     monkeypatch.setattr(checker, "_read_flow", lambda: ({}, "OutlookTriggerInbox.flow"))
     monkeypatch.setattr(
         checker,
         "_find_trigger_node",
         lambda _flow: {
-            "inputs": {
-                "detail": {
-                    "eventParameters": {
-                        "parentFolderId": "mail-folder-1",
-                    }
-                }
-            }
+            "inputs": {"detail": {"eventParameters": {"parentFolderId": folder_id}}}
         },
     )
     monkeypatch.setattr(
@@ -42,26 +43,93 @@ def test_check_folder_id_fresh_uses_resources_run_list(monkeypatch) -> None:
         lambda: ("connection-1", "folder-key-1", "connection-name"),
     )
 
-    def fake_uip_json(args: list[str]) -> dict:
+
+def _fake_proc(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _success_payload(folder_id: str = "mail-folder-1") -> str:
+    return json.dumps({"Data": [{"id": folder_id}]})
+
+
+def test_uses_run_verb_when_cli_supports_it(monkeypatch) -> None:
+    """Happy path: post-rename CLI accepts `run`; no fallback issued."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker)
+    calls: list[list[str]] = []
+
+    def fake_run(args, **_kwargs):
         calls.append(args)
-        return {"Data": [{"id": "mail-folder-1"}]}
+        return _fake_proc(0, stdout=_success_payload())
 
-    monkeypatch.setattr(checker, "_uip_json", fake_uip_json)
-
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
     checker.check_folder_id_fresh()
 
-    assert calls == [
-        [
-            "uip",
-            "is",
-            "resources",
-            "run",
-            "list",
-            checker.CONNECTOR_KEY,
-            "MailFolder",
-            "--connection-id",
-            "connection-1",
-            "--output",
-            "json",
-        ]
-    ]
+    assert len(calls) == 1, calls
+    assert calls[0][:5] == ["uip", "is", "resources", "run", "list"]
+
+
+def test_falls_back_to_execute_on_unknown_command_run(monkeypatch) -> None:
+    """Legacy CLI: rejects `run` with 'unknown command' — retry with `execute`."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker)
+    calls: list[list[str]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        if args[3] == "run":
+            return _fake_proc(
+                1,
+                stdout=json.dumps(
+                    {"Result": "ValidationError", "Message": "error: unknown command 'run'"}
+                ),
+            )
+        return _fake_proc(0, stdout=_success_payload())
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    checker.check_folder_id_fresh()
+
+    assert len(calls) == 2, calls
+    assert calls[0][:5] == ["uip", "is", "resources", "run", "list"]
+    assert calls[1][:5] == ["uip", "is", "resources", "execute", "list"]
+
+
+def test_does_not_fall_back_on_unrelated_failure(monkeypatch) -> None:
+    """A genuine CLI error (auth, network) must not be retried — fail fast."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker)
+    calls: list[list[str]] = []
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return _fake_proc(1, stdout="", stderr="403 Forbidden")
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit:
+        pass
+    else:
+        raise AssertionError("expected SystemExit on a 403")
+
+    assert len(calls) == 1, calls
+    assert calls[0][3] == "run"
+
+
+def test_folder_id_mismatch_fails_with_pr348_signature(monkeypatch) -> None:
+    """If the flow's parentFolderId is not in the live ID set, the checker
+    fails with the PR #348 regression marker (independent of the verb)."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="stale-id-from-old-connection")
+
+    def fake_run(_args, **_kwargs):
+        return _fake_proc(0, stdout=_success_payload(folder_id="fresh-id"))
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        message: Any = exc.code
+        assert "PR #348 regression" in str(message)
+    else:
+        raise AssertionError("expected SystemExit on a stale folder id")


### PR DESCRIPTION
## Summary

[PR #708](https://github.com/UiPath/skills/pull/708) updated the checker to call `uip is resources run list` after the CLI rename `execute` → `run` landed in [cli PR #1941](https://github.com/UiPath/cli/pull/1941). Run **2026-05-13_03-38-18** (~7 hours after #708 merged) still failed with:

```
uip is resources run list ... exit=3
{ "Result": "ValidationError",
  "Message": "error: unknown command 'run'" }
```

The sandbox had a stale `@uipath/integrationservice-tool@0.9.0` in `/home/azureuser/node_modules/...` written by a concurrent task's `npm install @uipath/auth --save`. Node's parent-walking resolution ranks that copy above the bun-global 1.1.0-alpha CLI, so the sandbox oscillates between the two verbs depending on which task's install finished last. The full SPOF fix is sandbox-level isolation in coder_eval ([companion PR #250](https://github.com/UiPath/coder_eval/pull/250)); the checker can stop being a single point of failure on its own.

Replace the single-verb call site with `_uip_resources_run(...)`, which tries `run` first and falls back to `execute` IFF stdout/stderr contain the literal `"unknown command 'run'"` signature. Any other failure (auth, network, validation) is reported immediately — no retry storms. The YAML's `command_pattern` regression regex is broadened to `(?:run|execute)` so the `command_executed` criterion no longer silently flips on the same skew.

Rewrote `test_check_outlook_trigger_inbox.py` to mock `subprocess.run` directly so the test actually exercises both verb paths plus the no-retry rule and the PR #348 stale-id detection.

## Verification

- **Unit tests** (4 passed, see Test plan): exercise the verb-tolerant fallback by mocking `subprocess.run` at the subprocess boundary, covering both the "post-rename CLI" and "legacy CLI" paths plus the no-retry rule.
- **E2E in smoke suite (CI)**: the `Run skill smoke tests` job for this PR ran the full `uipath-maestro-flow` fan-out — which includes `skill-flow-outlook-trigger-inbox` — and **passed in 12m18s** at `2026-05-13T18:23:34Z` ([job](https://github.com/UiPath/skills/actions/runs/25817614081/job/75850157773)). The smoke suite gates on an `llm_review >= 0.7` threshold per task, so the green verdict means the `outlook-trigger-inbox` task achieved that score with the verb-tolerant checker in place.
- **Failing-run signature**: the literal fallback trigger string `"unknown command 'run'"` is taken verbatim from the failing run's task.log (`runs/2026-05-13_03-38-18/.../skill-flow-outlook-trigger-inbox/00/task.log`); not a speculative match.

## Test plan
- [x] `pytest tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py` — 4 passed (run-verb happy path, fallback to execute, no-retry on unrelated failure, PR #348 stale-id detection)
- [x] Verified `command_pattern` regex matches both `uip is resources run list` and `uip is resources execute list`.
- [x] Smoke suite e2e (CI): `skill-flow-outlook-trigger-inbox` runs as part of the `uipath-maestro-flow` fan-out and passes.

## Companion
This PR is the **uipath-skills layer** of the MST-9674 three-layer fix (per `feedback_partial_pull_three_layer_fix`). The **coder_eval sandbox-isolation layer** is in [coder_eval#250](https://github.com/UiPath/coder_eval/pull/250). PR #708 already shipped the docs layer.

## Jira
- MST-9674

🤖 Generated with [Claude Code](https://claude.com/claude-code)