### PR TITLE
fix(maestro-flow): align file-format examples with v1.1 scaffold output [MST-9265]

### DIFF
--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -7,7 +7,7 @@ The `.flow` file is a JSON document at `<ProjectName>.flow` in the project root.
 ```json
 {
   "id": "<uuid>",
-  "version": "1.0.0",
+  "version": "1.1",
   "name": "MyFlow",
   "nodes": [],
   "edges": [],
@@ -19,6 +19,10 @@ The `.flow` file is a JSON document at `<ProjectName>.flow` in the project root.
   }
 }
 ```
+
+The **top-level `version`** is the workflow file-format version, currently `"1.1"`. This is what `uip maestro flow init` scaffolds and what the Zod `workflowFileSchema` (`workflowSchemaV1_1`) accepts. It is *not* a semver string — the file-format schema gates against a literal (`z.literal("1.1")`). Do not change it to `"1.0.0"`, `"1.0"`, or any other value when authoring new flows; older values exist only so the parser can still read legacy files.
+
+> **Don't confuse top-level `version` with `definitions[].version` / `typeVersion`.** Node-definition `version` (and the matching node-instance `typeVersion`) ARE governed by a strict semver schema (`versionSchema`, `/^\d+\.\d+\.\d+$/`) — a *different* Zod schema from the workflow file-format version. Mixing them up produces `Schema validation failed: Version must be in semver format` reported at `(root)`, which is the workflow-version layer's error message — but the actual offender may be a stale top-level value, not a node version. Audit the top-level `version` first.
 
 `solutionId` and `projectId` may also appear at the top level — these are auto-populated by `uip maestro flow init` and packaging. Do not add them manually.
 
@@ -317,7 +321,7 @@ Replace `<uuid>` with any generated UUID (e.g. `crypto.randomUUID()` in Node.js,
 ```json
 {
   "id": "3d4a8c34-5682-4ebe-a6bc-d92a18830bb5",
-  "version": "1.0.0",
+  "version": "1.1",
   "name": "DiceRoller",
   "nodes": [
     {

--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -20,9 +20,9 @@ The `.flow` file is a JSON document at `<ProjectName>.flow` in the project root.
 }
 ```
 
-The **top-level `version`** is the workflow file-format version, currently `"1.1"`. This is what `uip maestro flow init` scaffolds and what the Zod `workflowFileSchema` (`workflowSchemaV1_1`) accepts. It is *not* a semver string — the file-format schema gates against a literal (`z.literal("1.1")`). Do not change it to `"1.0.0"`, `"1.0"`, or any other value when authoring new flows; older values exist only so the parser can still read legacy files.
+**Top-level `version`** = workflow file-format version, currently `"1.1"` — what `uip maestro flow init` scaffolds and what Zod `workflowFileSchema` (`workflowSchemaV1_1`) accepts. Not a semver string; schema gates on a literal (`z.literal("1.1")`). Do not use `"1.0.0"`, `"1.0"`, or other values for new flows; older values exist only for legacy parser compatibility.
 
-> **Don't confuse top-level `version` with `definitions[].version` / `typeVersion`.** Node-definition `version` (and the matching node-instance `typeVersion`) ARE governed by a strict semver schema (`versionSchema`, `/^\d+\.\d+\.\d+$/`) — a *different* Zod schema from the workflow file-format version. Mixing them up produces `Schema validation failed: Version must be in semver format` reported at `(root)`, which is the workflow-version layer's error message — but the actual offender may be a stale top-level value, not a node version. Audit the top-level `version` first.
+> **Don't confuse top-level `version` with `definitions[].version` / `typeVersion`.** Node-definition `version` (and matching node-instance `typeVersion`) use a strict semver schema (`versionSchema`, `/^\d+\.\d+\.\d+$/`) — a different Zod schema. Mixing them up produces `Schema validation failed: Version must be in semver format` at `(root)` — workflow-version layer's error, but the actual offender may be a stale top-level value. Audit the top-level `version` first.
 
 `solutionId` and `projectId` may also appear at the top level — these are auto-populated by `uip maestro flow init` and packaging. Do not add them manually.
 


### PR DESCRIPTION
## Summary

- Update `references/shared/file-format.md` top-level workflow examples from `"version": "1.0.0"` → `"version": "1.1"`, matching what `uip maestro flow init` actually scaffolds today.
- Add a callout that the **top-level `version`** is a Zod literal (`z.literal("1.1")` in `workflowSchemaV1_1`), *not* a semver string, and contrast it with `definitions[].version` / `typeVersion` (which are strict semver `x.y.z`).
- Leave node-definition `"version": "1.0.0"` examples elsewhere (e.g. `data-fabric/impl.md`) untouched — those correctly use the semver schema.

## Why

During [MST-9265](https://uipath.atlassian.net/browse/MST-9265) triage (e2e run `2026-05-13_03-38-18`), 26+ flow tasks failed at the eval criterion's `uip maestro flow validate` step with `Schema validation failed: Version must be in semver format`. The agents had faithfully copied `"version": "1.0.0"` from this skill's example — but `uip maestro flow init` scaffolds `"1.1"`, the file-format schema demands the literal `"1.1"`, and the older bundled flow-schema on the eval host rejected anything else (including the docs' `"1.0.0"`).

The eval-side PATH-skew root cause is fixed in [coder_eval#249](https://github.com/UiPath/coder_eval/pull/249). This PR closes the **docs side** of the same triage:

- Future agents reading the skill see the scaffold's actual output (`"1.1"`).
- The new callout pre-empts the most common misread of the error, which is: *strict-semver error reported at `(root)` → assume it's a node-definition issue → chase the wrong field*. The note tells the reader to audit top-level first.

## Test plan

- [x] No build/lint pipeline — repo is pure markdown
- [x] `grep -rn '"version":' skills/uipath-maestro-flow/references/shared/file-format.md` shows only `"1.1"` at the workflow layer
- [x] Node-definition examples (`data-fabric/impl.md`, etc.) still show `"1.0.0"` and are correct (strict-semver schema)
- [ ] Re-run the affected e2e tasks (`skill-flow-calculator`, `skill-flow-dice-roller`, …) once coder_eval#249 lands and confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-9265]: https://uipath.atlassian.net/browse/MST-9265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ