### PR TITLE
ci(smoke): pin @uipath/cli install to @alpha dist-tag

### DIFF
--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -114,10 +114,15 @@ jobs:
       # Plain `--registry=` does NOT bypass scope mappings; only the
       # scope-specific override does.
       #
-      # Pin `@uipath/rpa-tool` to the `^0.9` line (currently 0.9.1) to
-      # avoid silently picking up `1.0.0-alpha.*` if `latest` ever
-      # shifts. `@uipath/cli` and `@uipath/rpa-legacy-tool` stay on
-      # `latest` (only the rpa-tool line has the alpha divergence).
+      # `@uipath/cli` is pinned to the `alpha` dist-tag — every merge to
+      # cli/main publishes under `alpha` (see cli/.github/workflows/ci.yml),
+      # while `latest` only moves on manual dispatch and was running weeks
+      # behind, so smoke missed regressions in newly-added tools.
+      #
+      # `@uipath/rpa-tool` stays on the `^0.9` line (currently 0.9.1) to
+      # avoid silently picking up `1.0.0-alpha.*` (the rpa-tool line has
+      # its own alpha divergence). `@uipath/rpa-legacy-tool` stays on
+      # `latest`.
       #
       # `npm install -g` runs from a fresh tempdir so any future
       # workspace-aware `package.json` at the repo root cannot pull
@@ -125,7 +130,7 @@ jobs:
       # under `<npm-prefix>/@uipath/`, where uipcli's ToolManager
       # discovers tools, so `uip rpa …` / `uip rpa-legacy …` resolve
       # without triggering auto-install.
-      - name: Install uip CLI + RPA tools (public npm, rpa-tool >=0.9)
+      - name: Install uip CLI + RPA tools (public npm, cli@alpha, rpa-tool >=0.9)
         shell: bash
         run: |
           set -e
@@ -135,7 +140,7 @@ jobs:
           npm config get registry
           npm install -g \
             --@uipath:registry=https://registry.npmjs.org/ \
-            @uipath/cli@latest \
+            @uipath/cli@alpha \
             "@uipath/rpa-tool@>=0.9" \
             @uipath/rpa-legacy-tool@latest
           uip --version

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -205,18 +205,21 @@ jobs:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
         run: uv pip install --system .
 
-      # Install from public npm at @latest. `--@uipath:registry=`
-      # forces the @uipath scope to public npm regardless of any
-      # `.npmrc` scope mapping (e.g., to the internal GitHub Packages
-      # feed, which carries divergent 1.0.0-alpha.* prereleases). See
+      # Install from public npm at the `alpha` dist-tag — every merge to
+      # cli/main publishes under `alpha` (see cli/.github/workflows/ci.yml).
+      # `@latest` only moves on manual dispatch of cli's publish workflows
+      # and was running ~3 weeks behind main, so smoke missed regressions
+      # in newly-added tools (sc-tool, admin-tool, license commands, ...).
+      #
+      # `--@uipath:registry=` forces the @uipath scope to public npm
+      # regardless of any `.npmrc` scope mapping (e.g., to the internal
+      # GitHub Packages feed, which carries divergent prereleases). See
       # smoke-rpa-skills.yml for the full rationale.
-      # NOTE: @uipath/admin-tool is not yet in a stable CLI release;
-      # uipath-admin smoke tests tolerate "unknown command 'admin'".
-      - name: Install uip CLI (public npm @latest)
+      - name: Install uip CLI (public npm @alpha)
         run: |
           npm install -g \
             --@uipath:registry=https://registry.npmjs.org/ \
-            @uipath/cli@latest
+            @uipath/cli@alpha
           uip --version
 
       # Pre-auth uip via the CLI's documented env-var bypass so non-RPA


### PR DESCRIPTION
## Closing — premise was wrong

Originally proposed switching `@uipath/cli@latest` → `@uipath/cli@alpha` in both smoke workflows on the theory that skills smoke was running ~3 weeks behind cli/main. That theory came from a misread of npm dist-tags.

### What I thought was true

`npm view @uipath/cli dist-tags` showed:

```
latest:  1.0.0-alpha.20260422.4672   ← Apr 22 (≈3 weeks stale)
alpha:   1.1.0-alpha.20260513.7140   ← today
```

…and I read this as the state of public npm.

### What is actually true

The output above came from **GitHub Packages**, not public npm — my local `~/.npmrc` has `@uipath:registry=https://npm.pkg.github.com`, so `npm view` silently redirected the scope lookup. Authoritative public-npm state:

```
$ curl https://registry.npmjs.org/-/package/@uipath/cli/dist-tags
{"latest":"1.0.0"}
```

Public npm `@uipath/cli` has **only one dist-tag** (`latest`) and tops out at `1.0.0`, published 2026-05-11 (2 days before this PR). There is no `alpha` or `beta` tag on public npm at all — those only exist on the internal GitHub Packages feed, populated by every cli/main merge via `cli/.github/workflows/ci.yml`.

### Consequences

- Skills smoke is **not stale** — it's installing CLI `1.0.0`, cut 2 days ago.
- Switching to `@uipath/cli@alpha` against public npm cannot work because the tag doesn't exist there. That's why the Windows smoke job failed with `npm error notarget No matching version found for @uipath/cli@alpha`.
- The only real cli/main → skills-smoke lag is "time until the next public-npm release cut", which is bounded by the CLI team's release cadence (intentional, not a bug).

### If we ever want to close that lag

Would require pointing one of the smoke jobs at GitHub Packages with an npm auth token and installing `@uipath/cli@alpha` from there. That's a separate, larger piece of work and not pursued here.