### PR TITLE
fix(tests): remove @uipath/cli from sandbox env_packages; add lint rule

### DIFF
--- a/.claude/commands/lint-task.md
+++ b/.claude/commands/lint-task.md
@@ -158,6 +158,16 @@ Severity:
 
 **Description-rationale carve-out.** If the task's `description` field explicitly documents the rationale for skipping `flow debug` (e.g. "validate-only because no live tenant", "skipping debug due to trigger-fired execution unreliability"), downgrade the severity by one level (High → Medium, Medium → Low) and quote the rationale in the issue. Authors who document deliberate trade-offs should not be punished as harshly as silent omissions.
 
+### Redundant or pinned uip CLI in sandbox
+
+**Raise a High issue if** `sandbox.node.env_packages` contains any entry matching `@uipath/cli` (with or without a version specifier, e.g. `"@uipath/cli"`, `"@uipath/cli@0.1.21"`, `"@uipath/cli@latest"`).
+
+**Why it's wrong:** The GH smoke runner installs `@uipath/cli@latest` globally before any task runs (see `smoke-skills.yml` step "Install uip CLI (public npm @latest)"). Listing it again in `env_packages` is redundant — it installs a second copy into the sandbox's local `node_modules`, potentially shadowing the global one. A pinned version (e.g. `@0.1.21`) is worse: it freezes the CLI at a specific release and silently diverges from the runner's `@latest` install, causing version skew across runs.
+
+**Fix:** Remove the `env_packages` block (or the `@uipath/cli` entry from it). If `node:` has no other packages, collapse to `node: {}`.
+
+Severity: **High** — always. No carve-outs; there is no valid reason to re-install the CLI the runner already provides.
+
 ## Phase 4 — Compose Per-Task Report
 
 For each task, print:

--- a/.claude/rules/task-authoring.md
+++ b/.claude/rules/task-authoring.md
@@ -1,0 +1,33 @@
+# Task Authoring Rules
+
+Standards for coder-eval task YAMLs under `tests/tasks/`.
+
+## Sandbox Configuration
+
+### Never install `@uipath/cli` via `env_packages`
+
+The GH smoke runner (`smoke-skills.yml`) installs `@uipath/cli@latest` globally before any task runs. Do **not** list it under `sandbox.node.env_packages`.
+
+**Forbidden patterns:**
+```yaml
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/cli"          # redundant
+      - "@uipath/cli@0.1.21"   # pinned — version skew
+      - "@uipath/cli@latest"   # redundant
+```
+
+**Correct:**
+```yaml
+sandbox:
+  node: {}
+```
+
+Or omit `node:` entirely if no other Node packages are needed.
+
+**Why:** Re-installing the CLI installs a second copy into `node_modules`, potentially shadowing the global binary. A pinned version freezes the CLI at a specific release and silently diverges from the runner's `@latest` install, causing version skew between local runs and CI.
+
+## Template
+
+Base every new task on `tests/templates/test-task-template.yaml`. The template does not include `env_packages` — do not add it unless installing a package other than `@uipath/cli`.

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,8 @@ Tests that verify AI agents can correctly use skills from this repository. Tests
    npm install -g @uipath/cli
    ```
 
+   > **Do not add `@uipath/cli` to `sandbox.node.env_packages` in task YAMLs.** The GH smoke runner installs it globally before any task runs. Listing it in `env_packages` is redundant and, when pinned to a version, causes skew against the runner's `@latest` install.
+
 4. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for environment setup (`.env`, API keys, etc.).
 
 ## Running Tests

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -20,9 +20,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 initial_prompt: |
   Use the `uipath-maestro-flow` skill. Do NOT run `uip flow node configure`
   or any command that requires a live connection — this sandbox has no

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "ComplexArrayTest" with a manual trigger.
   You need a flow that records a sales interaction in Act! 365 and associates it

--- a/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
@@ -16,10 +16,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "DriveToSlackTest" with a manual trigger.
   It should download a file from Google Drive and then post that file into a 

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "DTLLoadByDefaultFalseTest" with a manual trigger.
   You need a flow that lists WooCommerce products filtered by an attribute term

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "DTLLoadByDefaultTrueTest" with a manual trigger.
   You need a flow that provisions a new Azure resource group in a chosen region.

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "EnhancedEnumTest" with a manual trigger.
   You need a flow that retrieves WooCommerce product reviews sorted either

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "EnumTest" with a manual trigger.
   You need a flow that provisions a new Azure Storage Account and chooses a

--- a/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "FieldActionsTest" with a manual trigger.
   You need a flow that lists products from a WooCommerce store filtered by a

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -17,10 +17,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "GenerateSchemaTest" with a manual trigger
   that runs the Atlassian Jira "Create Issue" connector activity

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "MultiselectTest" with a manual trigger.
   You need a flow that creates a new contact in Act! 365 and assigns the contact

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -17,10 +17,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "PathParamsTest" with a manual trigger.
   Build a flow that retrieves a single Jira issue using the Jira "Get Issue"

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "QueryParamsTest" with a manual trigger.
   You need a flow that lists all Google Tasks including hidden ones. Discover

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "RequiredGroupsTest" with a manual trigger.
   You need a flow that replies to a Microsoft Teams channel message with one or

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -15,10 +15,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    # Pin shared across all connector_features tasks — bump in lockstep.
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 initial_prompt: |
   Create a new Flow project called "SearchableJoinsTest" with a manual trigger.
   You need a flow that queries Salesforce accounts and returns each account

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -21,9 +21,7 @@ task_timeout: 2400
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli@0.1.21"
+  node: {}
 
 initial_prompt: |
   Build a Maestro Flow called "CustomerEscalation" that triggers on new

--- a/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
@@ -9,9 +9,7 @@ tags: [uipath-platform, smoke, integration-service, activities]
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -10,9 +10,7 @@ tags: [uipath-platform, smoke, integration-service, connections]
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
@@ -9,9 +9,7 @@ tags: [uipath-platform, smoke, integration-service, connectors]
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
@@ -9,9 +9,7 @@ tags: [uipath-platform, smoke, integration-service, resources, describe]
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -9,9 +9,7 @@ tags: [uipath-platform, smoke, integration-service, resources, execute]
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-test/auth_project_discovery.yaml
+++ b/tests/tasks/uipath-test/auth_project_discovery.yaml
@@ -11,9 +11,7 @@ tags: [uipath-test, smoke, mode:operate, lifecycle:discover]
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
       - "@uipath/test-manager-tool"
 
 initial_prompt: |

--- a/tests/tasks/uipath-test/auth_project_discovery.yaml
+++ b/tests/tasks/uipath-test/auth_project_discovery.yaml
@@ -11,7 +11,8 @@ tags: [uipath-test, smoke, mode:operate, lifecycle:discover]
 sandbox:
   driver: tempdir
   python: {}
-  node: {}
+  node:
+    env_packages:
       - "@uipath/test-manager-tool"
 
 initial_prompt: |

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -24,7 +24,8 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node: {}
+  node:
+    env_packages:
       - "@uipath/test-manager-tool"
 
 initial_prompt: |

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -24,9 +24,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
       - "@uipath/test-manager-tool"
 
 initial_prompt: |

--- a/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
@@ -17,9 +17,7 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node:
-    env_packages:
-      - "@uipath/cli"
+  node: {}
       - "@uipath/test-manager-tool"
 
 initial_prompt: |

--- a/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
@@ -17,7 +17,8 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
-  node: {}
+  node:
+    env_packages:
       - "@uipath/test-manager-tool"
 
 initial_prompt: |


### PR DESCRIPTION
The GH smoke runner installs @uipath/cli@latest globally before tasks run, so listing it in sandbox.node.env_packages is redundant. Pinned versions (e.g. @0.1.21) caused silent version skew against the runner's @latest.

- Remove env_packages blocks from 23 task YAMLs
- Add lint-task axis: flag any @uipath/cli in env_packages as High
- Add .claude/rules/task-authoring.md with the canonical rule
- Add blockquote warning to tests/README.md

These are sandbox config-only changes — no task prompts, success criteria, or skill content changed. The removed entries were no-ops (the CLI was already on PATH from the runner step), so task behavior is unchanged. No local re-run needed; the changes are verified by inspection.