### PR TITLE
chore(tasks): clean up deprecated/invalid fields across task YAMLs

### DIFF
--- a/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
+++ b/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
@@ -7,14 +7,15 @@ description: >
   Command-construction only — no live tenant available for
   side-effect verification.
 tags: [uipath-admin, e2e, lifecycle:generate, lifecycle:edit]
-max_iterations: 2
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   max_turns: 40
   turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
@@ -6,14 +6,15 @@ description: >
   Command-construction only — no live tenant available for
   side-effect verification.
 tags: [uipath-admin, e2e, onboarding]
-max_iterations: 2
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   max_turns: 40
   turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
@@ -9,14 +9,15 @@ description: >
   Platform note: runs without an authenticated tenant — commands will
   fail with auth errors. That is acceptable.
 tags: [uipath-admin, e2e, onboarding]
-max_iterations: 2
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   max_turns: 40
   turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/antipattern_build_system/antipattern_build_system.yaml
+++ b/tests/tasks/uipath-agents/antipattern_build_system/antipattern_build_system.yaml
@@ -6,12 +6,13 @@ description: >
   the skill must drive the agent to detect the violation and remove
   the section before any further work.
 tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/antipattern_module_level_llm/antipattern_module_level_llm.yaml
+++ b/tests/tasks/uipath-agents/antipattern_module_level_llm/antipattern_module_level_llm.yaml
@@ -6,12 +6,13 @@ description: >
   and the skill must drive the agent to refactor the construction
   inside a node body before `uip codedagent init` is run.
 tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
+++ b/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
@@ -5,12 +5,13 @@ description: >
   at module-import time. The correct path is `from uipath.platform
   import UiPath`. The skill must drive the agent to fix the import.
 tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/bindings_asset_subtypes/bindings_asset_subtypes.yaml
+++ b/tests/tasks/uipath-agents/bindings_asset_subtypes/bindings_asset_subtypes.yaml
@@ -8,12 +8,13 @@ description: >
   the type annotation (`stringAsset` / `integerAsset` /
   `booleanAsset`).
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
+++ b/tests/tasks/uipath-agents/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
@@ -9,12 +9,13 @@ description: >
   fabricated `EntryPointUniqueId` that doesn't match either real
   entrypoint.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/bindings_queue_app_index/bindings_queue_app_index.yaml
+++ b/tests/tasks/uipath-agents/bindings_queue_app_index/bindings_queue_app_index.yaml
@@ -7,12 +7,13 @@ description: >
   construction (`<name>.<folder_path>` for most, bare
   `<connection_key>` for connections) and metadata fields.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/builtin_tool/builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/builtin_tool/builtin_tool.yaml
@@ -8,12 +8,13 @@ description: >
   tool keys (analyze-attachments, load-attachments, deep-rag,
   batch-transform).
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -9,12 +9,13 @@ description: >
   `bindings[]` entry — no duplicates per
   `(resourceKey, propertyAttribute)` pair.
 tags: [uipath-agents, e2e, mode:build, lifecycle:generate, shape:single-node, resource]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/coded_in_flow_register/coded_in_flow_register.yaml
+++ b/tests/tasks/uipath-agents/coded_in_flow_register/coded_in_flow_register.yaml
@@ -9,15 +9,16 @@ description: >
   `uip maestro flow registry list --local` surfaces the agent as a
   `uipath.core.agent.<resourceKey>` node type.
 tags: [uipath-agents, smoke, mode:build, lifecycle:generate, resource, feature:registry]
-max_iterations: 1
-task_timeout: 1200
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
+  task_timeout: 1200
   max_turns: 60
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/context_index/context_index.yaml
@@ -7,12 +7,13 @@ description: >
   valid value, and that `uip agent validate` accepts the resource and
   regenerates `.agent-builder/`.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/deploy_my_workspace/deploy_my_workspace.yaml
+++ b/tests/tasks/uipath-agents/deploy_my_workspace/deploy_my_workspace.yaml
@@ -7,12 +7,13 @@ description: >
   job and surface the monitoring URL. Exercises the entire production
   packaging path the existing test suite never reaches.
 tags: [uipath-agents, e2e, coded, lifecycle:deploy, feature:deploy]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/dispute_analyst_agent/dispute_analyst_agent.yaml
+++ b/tests/tasks/uipath-agents/dispute_analyst_agent/dispute_analyst_agent.yaml
@@ -9,12 +9,13 @@ description: >
   sync, field presence, contentTokens for every input, and a
   domain-specific system prompt.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/edit_roundtrip/edit_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/edit_roundtrip/edit_roundtrip.yaml
@@ -8,14 +8,15 @@ description: >
   sync), plus `.agent-builder/` regeneration on incremental edits —
   none of which are covered by create-from-scratch tests.
 tags: [uipath-agents, smoke, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
   max_turns: 30
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/eval_exact_match/eval_exact_match.yaml
+++ b/tests/tasks/uipath-agents/eval_exact_match/eval_exact_match.yaml
@@ -8,12 +8,13 @@ description: >
   deterministic Simple Function agent. All test cases must score 1.0
   and report PASSED in the output file.
 tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/eval_llm_judges/eval_llm_judges.yaml
+++ b/tests/tasks/uipath-agents/eval_llm_judges/eval_llm_judges.yaml
@@ -9,12 +9,13 @@ description: >
   a LangGraph classifier with `--no-report` and `--mocker-cache` so
   the judges are reproducible.
 tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/external_agent_tool/external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/external_agent_tool/external_agent_tool.yaml
@@ -7,12 +7,13 @@ description: >
   real `folderPath` (not "solution_folder"). Distinct from
   `solution_agent_tool` which uses `location: "solution"`.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/external_apiworkflow_tool/external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/external_apiworkflow_tool/external_apiworkflow_tool.yaml
@@ -7,12 +7,13 @@ description: >
   `location: "external"`, and a real `folderPath` (not
   "solution_folder").
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/external_escalation/external_escalation.yaml
@@ -8,12 +8,13 @@ description: >
   from `solution_escalation` which targets a solution-internal
   ActionCenter app.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/external_maestro_tool/external_maestro_tool.yaml
@@ -7,12 +7,13 @@ description: >
   `location: "external"`, and a real `folderPath` (not
   "solution_folder").
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/external_rpa_tool/external_rpa_tool.yaml
@@ -8,12 +8,13 @@ description: >
   `referenceKey` empty pre-validate. Distinct from `solution_rpa_tool`
   which uses `location: "solution"`.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/guardrail_custom_word/guardrail_custom_word.yaml
+++ b/tests/tasks/uipath-agents/guardrail_custom_word/guardrail_custom_word.yaml
@@ -6,12 +6,13 @@ description: >
   guardrail uses correct discriminator fields ($guardrailType, $ruleType,
   $selectorType, $actionType), PascalCase scope values, and a unique UUID.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/guardrail_discovery/guardrail_discovery.yaml
+++ b/tests/tasks/uipath-agents/guardrail_discovery/guardrail_discovery.yaml
@@ -9,14 +9,15 @@ description: >
 # (currently 0.9.0 on public npm). Re-enable smoke tag once CLI >= 1.0.0
 # is published.
 tags: [uipath-agents, smoke-blocked, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
   max_turns: 40
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
@@ -9,14 +9,15 @@ description: >
   correctly authors the escalate action with $actionType, app.name,
   app.version, app.folderName, and a recipient.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
   max_turns: 40
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/guardrail_escalation_app_validation/guardrail_escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app_validation/guardrail_escalation_app_validation.yaml
@@ -7,14 +7,15 @@ description: >
   The agent must validate the action schema and reject the app with the
   error message instead of writing the guardrail.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
   max_turns: 40
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/guardrail_pii_detection/guardrail_pii_detection.yaml
+++ b/tests/tasks/uipath-agents/guardrail_pii_detection/guardrail_pii_detection.yaml
@@ -7,12 +7,13 @@ description: >
   PascalCase entity names, enum-list and map-enum parameter types, and
   PascalCase scope values.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/guardrail_prompt_injection/guardrail_prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/guardrail_prompt_injection/guardrail_prompt_injection.yaml
@@ -6,12 +6,13 @@ description: >
   scopes to ["Llm"] only (not Agent or Tool), uses $parameterType "number"
   for the threshold parameter, and does not add it to PostExecution stage.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/hitl_create_task/hitl_create_task.yaml
+++ b/tests/tasks/uipath-agents/hitl_create_task/hitl_create_task.yaml
@@ -6,12 +6,13 @@ description: >
   graph with a `MemorySaver` checkpointer, and emits the `app`
   binding for the Action Center app the escalation targets.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:hitl-coded]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/init_validate.yaml
+++ b/tests/tasks/uipath-agents/init_validate.yaml
@@ -4,14 +4,15 @@ description: >
   a new low-code agent inside a solution and validate it. Tests whether
   the skill teaches the correct solution-first workflow and CLI usage.
 tags: [uipath-agents, smoke, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
   max_turns: 30
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_builtin_tool/inline_builtin_tool.yaml
@@ -9,12 +9,13 @@ description: >
   tool keys. Verifies a `uipath.agent.resource.tool.*` flow node is
   wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/inline_context_index/inline_context_index.yaml
@@ -9,12 +9,13 @@ description: >
   node is wired to the autonomous agent node's `context` handle.
   Indexes always live externally to the solution.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -9,12 +9,13 @@ description: >
   `uipath.agent.resource.tool.agent.<process-key>` flow node is wired
   to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -8,12 +8,13 @@ description: >
   real `folderPath`, and that a `uipath.agent.resource.tool.*` flow
   node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/inline_external_escalation/inline_external_escalation.yaml
@@ -8,12 +8,13 @@ description: >
   subdirectory + a `uipath.agent.resource.escalation` flow node wired
   to the autonomous agent node's `escalation` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -9,12 +9,13 @@ description: >
   `uipath.agent.resource.tool.*` flow node is wired to the autonomous
   agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -8,12 +8,13 @@ description: >
   real `folderPath`, and that a `uipath.agent.resource.tool.rpa` flow
   node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_in_flow/inline_in_flow.yaml
+++ b/tests/tasks/uipath-agents/inline_in_flow/inline_in_flow.yaml
@@ -8,12 +8,13 @@ description: >
   subdirectory layout (no entry-points.json, no project.uiproj,
   empty flow-layout.json).
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -13,12 +13,13 @@ description: >
   required — depends on the staging tenant having the
   `uipath-uipath-airdk` (GenAI Activities) connector available.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -8,12 +8,13 @@ description: >
   the documented sparse shape, and that a `uipath.agent.resource.mcp.*`
   flow node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -9,12 +9,13 @@ description: >
   `uipath.agent.resource.tool.agent.<process-key>` flow node is wired
   to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -8,12 +8,13 @@ description: >
   "solution_folder"`, and that a `uipath.agent.resource.tool.*` flow
   node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_escalation/inline_solution_escalation.yaml
@@ -8,12 +8,13 @@ description: >
   subdirectory + a `uipath.agent.resource.escalation` flow node wired
   to the autonomous agent node's `escalation` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -8,12 +8,13 @@ description: >
   "solution_folder"`, and that a `uipath.agent.resource.tool.*` flow
   node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -9,12 +9,13 @@ description: >
   `uipath.agent.resource.tool.rpa` flow node is wired to the
   autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/is_connector_tool/is_connector_tool.yaml
@@ -11,12 +11,13 @@ description: >
   the staging tenant having the `uipath-uipath-airdk` (GenAI
   Activities) connector available.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/langgraph_classifier/langgraph_classifier.yaml
+++ b/tests/tasks/uipath-agents/langgraph_classifier/langgraph_classifier.yaml
@@ -9,12 +9,13 @@ description: >
   from the actual code, and runs the classifier end-to-end via
   `uip codedagent run agent`.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-langgraph, feature:schema-sync]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/llamaindex_workflow/llamaindex_workflow.yaml
+++ b/tests/tasks/uipath-agents/llamaindex_workflow/llamaindex_workflow.yaml
@@ -8,12 +8,13 @@ description: >
   (Critical Rule C4), and runs the workflow end-to-end via
   `uip codedagent run`.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-llamaindex]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/mcp_server_tool/mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/mcp_server_tool/mcp_server_tool.yaml
@@ -6,12 +6,13 @@ description: >
   "mcp"` (distinct from `$resourceType: "tool"`) and the documented
   MCP shape (id, name, description, isEnabled, tools).
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/openai_agents_handoff/openai_agents_handoff.yaml
+++ b/tests/tasks/uipath-agents/openai_agents_handoff/openai_agents_handoff.yaml
@@ -9,12 +9,13 @@ description: >
   (Critical Rule C4 — module-level setup breaks
   `uip codedagent init`), and runs the triage agent end-to-end.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-openai-agents]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/process_invoke/process_invoke.yaml
+++ b/tests/tasks/uipath-agents/process_invoke/process_invoke.yaml
@@ -6,12 +6,13 @@ description: >
   `name` and `process_folder_path` set, and emits the `process`
   binding for the invoked process.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:process-invocation]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/rag_langgraph/rag_langgraph.yaml
+++ b/tests/tasks/uipath-agents/rag_langgraph/rag_langgraph.yaml
@@ -6,12 +6,13 @@ description: >
   `folder_path` set, and emits the `index` binding for the targeted
   Context Grounding index.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:rag-coded]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/resolution_drafter_agent/resolution_drafter_agent.yaml
+++ b/tests/tasks/uipath-agents/resolution_drafter_agent/resolution_drafter_agent.yaml
@@ -8,12 +8,13 @@ description: >
   input/output field presence, contentTokens for every input, and
   domain coverage in the system prompt.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/schema_update/schema_update.yaml
+++ b/tests/tasks/uipath-agents/schema_update/schema_update.yaml
@@ -7,14 +7,15 @@ description: >
   syntax, and contentTokens construction. A check script verifies
   deep equivalence of the two schema files.
 tags: [uipath-agents, smoke, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
   max_turns: 30
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/simple_echo/simple_echo.yaml
+++ b/tests/tasks/uipath-agents/simple_echo/simple_echo.yaml
@@ -7,18 +7,19 @@ description: >
   `uip codedagent run main` to execute deterministically (no LLM,
   no cloud auth needed).
 tags: [uipath-agents, smoke, coded, lifecycle:generate, lifecycle:execute, feature:framework-simple]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
   # Default smoke max_turns is 20, but the full scaffold -> init -> run
   # loop (uv venv, uv sync, uip codedagent setup, uip codedagent new,
   # rewrite main.py, init, run, write marker) lands at ~25 turns even
   # without an LLM call. Bumping headroom to 40.
+
+run_limits:
   max_turns: 40
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/solution_agent_tool/solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_agent_tool/solution_agent_tool.yaml
@@ -8,12 +8,13 @@ description: >
   format, location/folderPath conventions, referenceKey resolution,
   and distinct projectId UUIDs across agents.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
@@ -6,12 +6,13 @@ description: >
   uses `type: "api"`, `location: "solution"`, and
   `folderPath: "solution_folder"`.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/solution_escalation/solution_escalation.yaml
@@ -9,12 +9,13 @@ description: >
   `.agent-builder/`. Distinct from `external_escalation` which targets
   an ActionCenter app that lives externally in Orchestrator.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_maestro_tool/solution_maestro_tool.yaml
@@ -6,12 +6,13 @@ description: >
   uses `type: "processOrchestration"`, `location: "solution"`, and
   `folderPath: "solution_folder"`.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/solution_rpa_tool/solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_rpa_tool/solution_rpa_tool.yaml
@@ -6,12 +6,13 @@ description: >
   resource.json uses `type: "process"`, `location: "solution"`, and
   `folderPath: "solution_folder"`.
 tags: [uipath-agents, e2e, low-code]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-agents/subtype_credential_asset/subtype_credential_asset.yaml
+++ b/tests/tasks/uipath-agents/subtype_credential_asset/subtype_credential_asset.yaml
@@ -9,14 +9,15 @@ description: >
   placeholder (not a string asset) when the asset doesn't yet exist
   in Orchestrator.
 tags: [uipath-agents, e2e, coded, bindings]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+
+run_limits:
   max_turns: 30
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/tracing_redaction/tracing_redaction.yaml
+++ b/tests/tasks/uipath-agents/tracing_redaction/tracing_redaction.yaml
@@ -5,12 +5,13 @@ description: >
   a function that handles sensitive data so both the input and the
   output are redacted before they reach the trace store.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:trace]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
@@ -12,6 +12,8 @@ tags: [uipath-data-fabric, e2e, employee-directory]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, e2e, product-catalogue]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
@@ -9,6 +9,8 @@ tags: [uipath-data-fabric, integration, records, import]
 
 agent:
   type: claude-code
+
+run_limits:
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, integration, entity-scope]
 
 agent:
   type: claude-code
+
+run_limits:
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
@@ -14,6 +14,8 @@ tags: [uipath-data-fabric, integration, error-paths]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/integration_files.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_files.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, integration, files]
 
 agent:
   type: claude-code
+
+run_limits:
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, integration, entities, records]
 
 agent:
   type: claude-code
+
+run_limits:
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/integration_large_pagination.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_large_pagination.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, integration, bulk-pagination]
 
 agent:
   type: claude-code
+
+run_limits:
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
@@ -11,6 +11,8 @@ tags: [uipath-data-fabric, integration, pre-seeded, discover]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, integration, records]
 
 agent:
   type: claude-code
+
+run_limits:
   turn_timeout: 600
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
@@ -8,6 +8,8 @@ tags: [uipath-data-fabric, smoke, records, import]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/smoke_entities.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_entities.yaml
@@ -9,6 +9,8 @@ tags: [uipath-data-fabric, smoke, entities]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/smoke_files.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_files.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, smoke, files]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, smoke, entities, records]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:

--- a/tests/tasks/uipath-data-fabric/smoke_records.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_records.yaml
@@ -10,6 +10,8 @@ tags: [uipath-data-fabric, smoke, records]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:

--- a/tests/tasks/uipath-diagnostics/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-diagnostics/_shared/scripts/generate_scenario.py
@@ -41,7 +41,6 @@ def _find_repo_root() -> Path:
         p = p.parent
     raise RuntimeError("Could not locate repo root (no .git ancestor found)")
 
-
 REPO_ROOT = _find_repo_root()
 EXTRACT_SCRIPT = Path(__file__).with_name("extract_session.py")
 DEFAULT_OUTPUT_BASE = REPO_ROOT / "tests" / "tasks" / "uipath-diagnostics"
@@ -61,7 +60,6 @@ EMPTY_STDOUT_PATTERNS = (
 )
 EMPTY_STDOUT_RE = re.compile("|".join(EMPTY_STDOUT_PATTERNS), re.IGNORECASE)
 
-
 # ---------- text artifact templates ----------
 
 TASK_YAML_TEMPLATE = """\
@@ -76,6 +74,9 @@ tags: [uipath-diagnostics, e2e, faithful-replay]
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 2400
   max_turns: 60
   turn_timeout: 1800
 
@@ -139,9 +140,6 @@ success_criteria:
 
       Return JSON: {{"score": <float>, "rationale": "<one sentence>"}}
 
-max_iterations: 1
-task_timeout: 2400
-
 # Auto-answer the diagnostic skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /
 # affirmative option, and never invents data — keeps the diagnostic flow
@@ -164,11 +162,7 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-
-llm_reviewer:
-  enabled: false
 """
-
 
 README_TEMPLATE = """\
 # {scenario_title} — Faithful Replay
@@ -208,7 +202,6 @@ python tests/tasks/uipath-diagnostics/_shared/scripts/generate_scenario.py \\
 ```
 """
 
-
 # ---------- ignore patterns for project snapshot ----------
 
 PROJECT_SNAPSHOT_IGNORE_DIRS = {
@@ -233,14 +226,11 @@ PROJECT_SNAPSHOT_IGNORE_DIRS = {
 }
 PROJECT_SNAPSHOT_IGNORE_SUFFIXES = {".pyc", ".pdb"}
 
-
 # ---------- helpers ----------
-
 
 def _slugify(text: str) -> str:
     out = re.sub(r"[^A-Za-z0-9]+", "-", text).strip("-").lower()
     return out or "diagnostic-scenario"
-
 
 def _backfill_redirect_stdouts(uip_calls: list[dict], investigation: Path) -> dict:
     """For calls with empty stdout and a redirect target, load the file.
@@ -289,7 +279,6 @@ def _backfill_redirect_stdouts(uip_calls: list[dict], investigation: Path) -> di
             missing += 1
     return {"backfilled": backfilled, "missing": missing, "skipped": skipped}
 
-
 def _is_empty_stdout(stdout: str) -> bool:
     """True if `stdout` is just bash-trailer noise (no real content)."""
     if not stdout.strip():
@@ -299,7 +288,6 @@ def _is_empty_stdout(stdout: str) -> bool:
     if not lines:
         return True
     return all(EMPTY_STDOUT_RE.fullmatch(l.strip()) for l in lines)
-
 
 def _run_extract(transcript: Path) -> dict:
     """Invoke extract_session.py as a subprocess and return its parsed JSON."""
@@ -312,7 +300,6 @@ def _run_extract(transcript: Path) -> dict:
     if proc.returncode != 0:
         raise RuntimeError(f"extract_session.py failed: {proc.stderr.strip()}")
     return json.loads(proc.stdout)
-
 
 def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
     """Auto-detect emails and personal Windows paths across all sampled text.
@@ -356,7 +343,6 @@ def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
 
     return mapping
 
-
 def _apply_scrub(text: str, mapping: "OrderedDict[str, str]") -> str:
     if not isinstance(text, str):
         return text
@@ -366,13 +352,11 @@ def _apply_scrub(text: str, mapping: "OrderedDict[str, str]") -> str:
         out = out.replace(key, mapping[key])
     return out
 
-
 def _scrub_path(path: Path, mapping: "OrderedDict[str, str]") -> Path:
     """Apply scrub mapping to each path component (filenames containing real emails)."""
     parts = list(path.parts)
     new_parts = [_apply_scrub(p, mapping) for p in parts]
     return Path(*new_parts) if new_parts else path
-
 
 def _build_manifest_rules(uip_calls: list[dict]) -> tuple[list[dict], dict[str, str]]:
     """One rule per unique `args`. Returns (rules, fixture_filename_by_args).
@@ -401,7 +385,6 @@ def _build_manifest_rules(uip_calls: list[dict]) -> tuple[list[dict], dict[str, 
             rule["exit_code"] = call["exit_code"]
         rules.append(rule)
     return rules, fixture_by_args
-
 
 def _snapshot_project(
     src: Path, dst: Path, mapping: "OrderedDict[str, str] | None" = None
@@ -454,7 +437,6 @@ def _snapshot_project(
             plan.append((scrubbed_rel, p.read_bytes()))
     return plan
 
-
 def _format_initial_prompt(extracted: dict, scenario_name: str) -> str:
     """Indented YAML block for task.yaml's initial_prompt field.
 
@@ -468,7 +450,6 @@ def _format_initial_prompt(extracted: dict, scenario_name: str) -> str:
             f"(Generated for scenario {scenario_name} — review and customize.)"
         )
     return "\n".join("  " + line for line in body.splitlines())
-
 
 def _build_resolution_md(extracted: dict, resolution_arg: Path | None) -> str:
     if resolution_arg is not None:
@@ -484,14 +465,12 @@ def _build_resolution_md(extracted: dict, resolution_arg: Path | None) -> str:
         text = "# Final Resolution\n\n" + text.lstrip()
     return text.rstrip() + "\n"
 
-
 def _build_readme_md(scenario_name: str, summary: str) -> str:
     return README_TEMPLATE.format(
         scenario_title=scenario_name.replace("-", " ").title(),
         slug=scenario_name,
         summary=summary or "_Add a 1–3 sentence summary of the original investigation here._",
     )
-
 
 def _build_task_yaml(
     scenario_name: str, initial_prompt_indented: str, has_project: bool
@@ -505,9 +484,7 @@ def _build_task_yaml(
         process_source_block=process_source_block,
     )
 
-
 # ---------- main pipeline ----------
-
 
 def plan_scenario(args: argparse.Namespace) -> dict:
     """Build the in-memory plan. Pure: no file writes."""
@@ -615,7 +592,6 @@ def plan_scenario(args: argparse.Namespace) -> dict:
         "project_files": project_plan_scrubbed,
     }
 
-
 def render_dry_run(plan: dict) -> str:
     out: list[str] = []
     out.append(f"Scenario: {plan['scenario_name']}")
@@ -659,7 +635,6 @@ def render_dry_run(plan: dict) -> str:
     out.append("(dry-run — no files written. Pass --apply to write.)")
     return "\n".join(out)
 
-
 def apply_plan(plan: dict) -> None:
     base: Path = plan["output_dir"]
     if base.exists() and any(base.iterdir()):
@@ -688,7 +663,6 @@ def apply_plan(plan: dict) -> None:
             target.write_text(content, encoding="utf-8")
         else:
             target.write_bytes(content)
-
 
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
@@ -724,7 +698,6 @@ def main(argv: list[str]) -> int:
 
     print(render_dry_run(plan))
     return 0
-
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/tasks/uipath-diagnostics/faulted_excel_o365/task.yaml
+++ b/tests/tasks/uipath-diagnostics/faulted_excel_o365/task.yaml
@@ -19,6 +19,9 @@ agent:
   # Need Skill/Agent/AskUserQuestion/TodoWrite beyond the default's set;
   # the diagnostic skill orchestrates sub-agents.
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 2400
   max_turns: 60
   turn_timeout: 1800
 
@@ -166,11 +169,6 @@ success_criteria:
 
       Return JSON: {"score": <float>, "rationale": "<one sentence covering both playbook and conclusion>"}
 
-max_iterations: 1
 # Override experiments/default.yaml's 600s limit -- the multi-agent diagnostic
 # skill (triage -> hypothesis-generator -> tester -> presenter) routinely takes
 # 10-20 minutes when sub-agents run sequentially.
-task_timeout: 2400   # 40 min total; one extra phase (depth_check) + possible re-test round
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-diagnostics/getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-diagnostics/getasset-folder-scope-mismatch/task.yaml
@@ -13,8 +13,11 @@ tags: [uipath-diagnostics, e2e, faulted-jobs, orchestrator, system-activities, g
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 4500
   max_turns: 60
-  turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir
@@ -138,10 +141,8 @@ success_criteria:
 
       Return JSON: {"score": <float>, "rationale": "<one sentence covering both playbook and conclusion>"}
 
-max_iterations: 1
 # Override experiments/default.yaml's 600s limit -- LLMGW-proxied runs
 # of the diagnostic skill take 25-35 min end-to-end.
-task_timeout: 4500
 
 simulation:
   enabled: true
@@ -161,6 +162,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-diagnostics/getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-diagnostics/getasset-name-mismatch/task.yaml
@@ -14,8 +14,11 @@ tags: [uipath-diagnostics, e2e, faulted-jobs, orchestrator, system-activities, g
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 4500
   max_turns: 60
-  turn_timeout: 3600   # 60 min per turn — LLMGW-proxied runs of this scenario have observed up to ~30 min per turn
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir
@@ -137,13 +140,11 @@ success_criteria:
 
       Return JSON: {"score": <float>, "rationale": "<one sentence covering both playbook and conclusion>"}
 
-max_iterations: 1
 # Override experiments/default.yaml's 600s limit -- the multi-agent
 # diagnostic skill (triage -> hypothesis-generator -> tester -> presenter)
 # takes 25-35 min end-to-end when routed through LLMGW (proxy mode).
 # Direct Anthropic routing is faster (~8-12 min) but the test config
 # defaults to proxy, so we size for the slower path.
-task_timeout: 4500
 
 # Auto-answer the diagnostic skill's AskUserQuestion calls so the test
 # runs end-to-end without a human. The simulator always picks the
@@ -167,6 +168,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-diagnostics/getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-diagnostics/getasset-permission-denied/task.yaml
@@ -12,8 +12,11 @@ tags: [uipath-diagnostics, e2e, faulted-jobs, orchestrator, system-activities, g
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 4500
   max_turns: 60
-  turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir
@@ -145,10 +148,8 @@ success_criteria:
 
       Return JSON: {"score": <float>, "rationale": "<one sentence covering both playbook and conclusion>"}
 
-max_iterations: 1
 # Override experiments/default.yaml's 600s limit -- LLMGW-proxied runs
 # of the diagnostic skill take 25-35 min end-to-end.
-task_timeout: 4500
 
 simulation:
   enabled: true
@@ -168,6 +169,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-diagnostics/maestro-stuck-rpa-job/task.yaml
+++ b/tests/tasks/uipath-diagnostics/maestro-stuck-rpa-job/task.yaml
@@ -9,6 +9,9 @@ tags: [uipath-diagnostics, e2e, faithful-replay, maestro]
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 2400
   max_turns: 60
   turn_timeout: 1800
 
@@ -72,9 +75,6 @@ success_criteria:
 
       Return JSON: {"score": <float>, "rationale": "<one sentence>"}
 
-max_iterations: 1
-task_timeout: 2400
-
 # Auto-answer the diagnostic skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /
 # affirmative option, and never invents data — keeps the diagnostic flow
@@ -97,6 +97,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-diagnostics/rpa-preflight-failure/task.yaml
+++ b/tests/tasks/uipath-diagnostics/rpa-preflight-failure/task.yaml
@@ -9,6 +9,9 @@ tags: [uipath-diagnostics, e2e, faithful-replay, faulted-jobs, integration-servi
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 2400
   max_turns: 60
   turn_timeout: 1800
 
@@ -74,9 +77,6 @@ success_criteria:
 
       Return JSON: {"score": <float>, "rationale": "<one sentence>"}
 
-max_iterations: 1
-task_timeout: 2400
-
 # Auto-answer the diagnostic skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /
 # affirmative option, and never invents data — keeps the diagnostic flow
@@ -99,6 +99,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-diagnostics/rpa-selector-healing-disabled/task.yaml
+++ b/tests/tasks/uipath-diagnostics/rpa-selector-healing-disabled/task.yaml
@@ -9,6 +9,9 @@ tags: [uipath-diagnostics, e2e, faithful-replay, faulted-jobs, ui-automation, rp
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
+
+run_limits:
+  task_timeout: 2400
   max_turns: 60
   turn_timeout: 1800
 
@@ -74,9 +77,6 @@ success_criteria:
 
       Return JSON: {"score": <float>, "rationale": "<one sentence>"}
 
-max_iterations: 1
-task_timeout: 2400
-
 # Auto-answer the diagnostic skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /
 # affirmative option, and never invents data — keeps the diagnostic flow
@@ -99,6 +99,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-diagnostics/smoke/uip_mock_smoke.yaml
+++ b/tests/tasks/uipath-diagnostics/smoke/uip_mock_smoke.yaml
@@ -11,6 +11,8 @@ tags: [uipath-diagnostics, smoke, uip-mock]
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write"]
+
+run_limits:
   max_turns: 5
 
 sandbox:
@@ -76,8 +78,3 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: '(?<![\./\w])uip\s+is\s+connections\s+list'
     min_count: 1
-
-max_iterations: 1
-
-llm_reviewer:
-  enabled: false

--- a/tests/tasks/uipath-governance/access-policy/access-policy_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-governance/access-policy/access-policy_lifecycle_e2e.yaml
@@ -26,6 +26,8 @@ tags: [uipath-governance, e2e, access-policy, mode:build]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 40
 
 sandbox:

--- a/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
@@ -62,6 +62,33 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  - type: command_executed
+    description: "Agent did NOT use the retired `uip or users list` path for User UUID resolution"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+list'
+    min_count: 0
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent did NOT use the retired `uip or users current` subcommand"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+current'
+    min_count: 0
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent did NOT fall back to the REST `orchestrator_/odata/Robots` lookup (retired in favor of `uip admin robot-accounts`)"
+    tool_name: "Bash"
+    command_pattern: 'odata/Robots'
+    min_count: 0
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
@@ -62,33 +62,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent did NOT use the retired `uip or users list` path for User UUID resolution"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+list'
-    min_count: 0
-    max_count: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent did NOT use the retired `uip or users current` subcommand"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+current'
-    min_count: 0
-    max_count: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent did NOT fall back to the REST `orchestrator_/odata/Robots` lookup (retired in favor of `uip admin robot-accounts`)"
-    tool_name: "Bash"
-    command_pattern: 'odata/Robots'
-    min_count: 0
-    max_count: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-governance/aops-policy/aops-policy_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops-policy_lifecycle_e2e.yaml
@@ -20,6 +20,8 @@ tags: [uipath-governance, e2e, aops-policy, mode:build]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 40
 
 sandbox:

--- a/tests/tasks/uipath-governance/aops-policy/deployment_configure_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployment_configure_smoke.yaml
@@ -71,6 +71,42 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  - type: command_executed
+    description: "Agent did NOT use the retired `--user-name` flag on deployment user configure"
+    tool_name: "Bash"
+    command_pattern: 'deployment\s+user\s+configure\s+.*--user-name'
+    min_count: 0
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent did NOT use the retired `--group-name` flag on deployment group configure"
+    tool_name: "Bash"
+    command_pattern: 'deployment\s+group\s+configure\s+.*--group-name'
+    min_count: 0
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent did NOT make a separate `user add` / `add-user` registration call — configure auto-registers"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+(add|add-user)'
+    min_count: 0
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent did NOT make a separate `group add` / `add-group` registration call — configure auto-registers"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+group\s+(add|add-group)'
+    min_count: 0
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-governance/aops-policy/deployment_configure_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployment_configure_smoke.yaml
@@ -71,42 +71,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent did NOT use the retired `--user-name` flag on deployment user configure"
-    tool_name: "Bash"
-    command_pattern: 'deployment\s+user\s+configure\s+.*--user-name'
-    min_count: 0
-    max_count: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent did NOT use the retired `--group-name` flag on deployment group configure"
-    tool_name: "Bash"
-    command_pattern: 'deployment\s+group\s+configure\s+.*--group-name'
-    min_count: 0
-    max_count: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent did NOT make a separate `user add` / `add-user` registration call — configure auto-registers"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+(add|add-user)'
-    min_count: 0
-    max_count: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent did NOT make a separate `group add` / `add-group` registration call — configure auto-registers"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+group\s+(add|add-group)'
-    min_count: 0
-    max_count: 0
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -11,6 +11,8 @@ tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 40
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
@@ -11,6 +11,8 @@ tags: [uipath-human-in-the-loop, e2e, brown-field, escalation, ai-agent]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 40
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -12,6 +12,8 @@ tags: [uipath-human-in-the-loop, e2e, green-field, compliance, gdpr]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 40
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
@@ -11,6 +11,8 @@ tags: [uipath-human-in-the-loop, e2e, brown-field, multi-hitl, hr-onboarding]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
@@ -11,6 +11,8 @@ tags: [uipath-human-in-the-loop, e2e, brown-field]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 70
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
@@ -10,6 +10,8 @@ tags: [uipath-human-in-the-loop, e2e, green-field]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 40
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -17,6 +17,8 @@ skip: true
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
   turn_timeout: 1800
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
@@ -7,6 +7,8 @@ tags: [uipath-human-in-the-loop, integration, edge-wiring]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
 
 sandbox:

--- a/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
@@ -7,6 +7,8 @@ tags: [uipath-human-in-the-loop, integration, options]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
 
 sandbox:

--- a/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
@@ -7,6 +7,8 @@ tags: [uipath-human-in-the-loop, integration, runtime-variables]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
 
 sandbox:

--- a/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
@@ -8,6 +8,8 @@ tags: [uipath-human-in-the-loop, integration, variable-binding]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 75
   turn_timeout: 900
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
@@ -8,6 +8,8 @@ tags: [uipath-human-in-the-loop, integration, schema-design, developer-mistake]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 75
   turn_timeout: 900
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
@@ -8,6 +8,8 @@ tags: [uipath-human-in-the-loop, integration, variable-binding, developer-mistak
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 90
   turn_timeout: 900
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
@@ -8,6 +8,8 @@ tags: [uipath-human-in-the-loop, integration, schema-design, inout, variable-bin
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 90
   turn_timeout: 900
 

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -14,6 +14,8 @@ tags: [uipath-ixp, smoke, lifecycle:execute]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
@@ -7,6 +7,8 @@ tags: [uipath-maestro-bpmn, smoke, mode:build, lifecycle:generate, shape:multi-n
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 80
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
@@ -9,6 +9,8 @@ tags: [uipath-maestro-bpmn, integration, lifecycle:generate, shape:multi-node, n
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 90
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
@@ -3,12 +3,13 @@ description: >
   Author a Maestro BPMN API workflow invocation, covering the
   Orchestrator.ExecuteApiWorkflowAsync service-task row with an eval.
 tags: [uipath-maestro-bpmn, e2e, lifecycle:generate, "node:service-task", "feature:api-workflow"]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/authoring/business_rule_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/business_rule_task.yaml
@@ -4,12 +4,13 @@ description: >
   proving the Orchestrator.BusinessRules row is covered by an eval and not
   only by static fixtures.
 tags: [uipath-maestro-bpmn, e2e, lifecycle:generate, "node:business-rule", "feature:orchestrator"]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
@@ -3,12 +3,13 @@ description: >
   Author a complete Maestro BPMN script-task project, covering the full
   local lifecycle for the Jint-backed script path with package metadata.
 tags: [uipath-maestro-bpmn, e2e, lifecycle:generate, "node:script", "feature:jint"]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-bpmn, integration, mode:build, lifecycle:generate, connect
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 80
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
@@ -9,6 +9,8 @@ tags: [uipath-maestro-bpmn, integration, "lifecycle:inspect", connector, "featur
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 60
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/e2e/author_validate_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/author_validate_pack.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-bpmn, e2e, mode:build, lifecycle:generate]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 80
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
@@ -6,12 +6,13 @@ description: >
   exercises greenfield BPMN source authoring, diagram requirements, and local
   package-file consistency without cloud-side effects.
 tags: [uipath-maestro-bpmn, e2e, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision", "node:hitl", "feature:approval-gate"]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
@@ -9,6 +9,8 @@ tags: [uipath-maestro-bpmn, integration, lifecycle:generate, contract:xml, node:
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 90
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
@@ -7,6 +7,8 @@ tags: [uipath-maestro-bpmn, integration, mode:build, lifecycle:generate, shape:m
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 80
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
@@ -7,6 +7,8 @@ tags: [uipath-maestro-bpmn, smoke, mode:build, lifecycle:generate, shape:single-
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 60
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
@@ -5,12 +5,13 @@ description: >
   diagnostic priority ladder, and recommends the safe next operate action
   without performing lifecycle mutations.
 tags: [uipath-maestro-bpmn, smoke, "mode:diagnose", "lifecycle:execute"]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   max_turns: 20
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
@@ -10,6 +10,8 @@ tags: [uipath-maestro-bpmn, smoke, "lifecycle:inspect", "mode:inspect"]
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 25
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-bpmn, smoke, mode:build, lifecycle:generate, lifecycle:val
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 60
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
@@ -9,6 +9,8 @@ tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:validate", connector
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 20
 
 sandbox:

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:package"]
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 30
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-case/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-case/init_validate.yaml
@@ -10,6 +10,8 @@ tags: [uipath-maestro-case, smoke, init, validate]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 80
 
 sandbox:

--- a/tests/tasks/uipath-maestro-case/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_discovery.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-case, smoke, registry]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 65
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -9,11 +9,13 @@ description: >
   for routing, and pass `uip maestro flow validate`.
 tags: [uipath-maestro-flow, smoke, connector, ceql, filter]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -93,4 +95,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -4,11 +4,13 @@ description: >
   complex array field on the Act! 365 connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -62,4 +64,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
@@ -5,11 +5,13 @@ description: >
   binary file flow between two IS connectors in a single Flow.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, e2e, uipath-google-drive, uipath-salesforce-slack]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -48,4 +50,3 @@ success_criteria:
     weight: 5.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -4,11 +4,13 @@ description: >
   where dropdown values load only on user interaction on the WooCommerce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -63,4 +65,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -4,11 +4,13 @@ description: >
   where a dropdown is pre-populated on the Azure connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -62,4 +64,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -4,11 +4,13 @@ description: >
   enhanced enum field with display labels on the WooCommerce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -68,4 +70,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -4,11 +4,13 @@ description: >
   on the Azure connector for storage account kind.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -63,4 +65,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
@@ -4,11 +4,13 @@ description: >
   field action dependencies on the WooCommerce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -63,4 +65,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -6,11 +6,13 @@ description: >
   fetch, and bodyParameters carries the required fields.summary value.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -67,4 +69,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -4,11 +4,13 @@ description: >
   multiselect field on the Act! 365 connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -62,4 +64,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -6,11 +6,13 @@ description: >
   verify the path-parameter wiring.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -78,4 +80,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -4,11 +4,13 @@ description: >
   query parameter on the Google Tasks connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-google-tasks]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -65,4 +67,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -4,11 +4,13 @@ description: >
   least one field from each required group must be populated on the Teams connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -63,4 +65,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -4,11 +4,13 @@ description: >
   a join on a related object on the Salesforce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector]
 
-task_timeout: 1500
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
   max_turns: 120
   turn_timeout: 1200
 
@@ -62,4 +64,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -11,6 +11,8 @@ tags: [uipath-maestro-flow, uipath-human-in-the-loop, e2e, devcon]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 120
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
@@ -4,12 +4,13 @@ description: >
   temperature from Fahrenheit to Celsius between the HTTP fetch and the
   format-summary step. Exercises inserting a node into an existing edge.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
@@ -3,12 +3,13 @@ description: >
   Add a "location" field to the end node outputs in the BellevueWeather flow.
   Exercises modifying node output mappings.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -5,12 +5,13 @@ description: >
   and the main flow keeps the decision and end nodes. Exercises subflow creation
   from existing nodes.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node, node:subflow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
@@ -3,12 +3,13 @@ description: >
   Move the decision node before formatSummary so both branches merge back into
   formatSummary, then a single end node. Exercises reordering nodes and merging branches.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node, node:decision]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
@@ -4,12 +4,13 @@ description: >
   the decision node to read temperature directly from the HTTP response.
   Exercises deleting a node and reconnecting edges.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
@@ -4,12 +4,13 @@ description: >
   outputs from 'nice day' / 'bring a jacket' to 'amazing day' / 'go home'.
   Exercises script-node update without restructuring the flow.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node, node:decision]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
@@ -18,6 +18,8 @@ skip: true
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 90
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -17,6 +17,8 @@ skip: true
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -15,6 +15,8 @@ skip: true
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 60
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -15,6 +15,8 @@ skip: true
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, n
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 75
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, n
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 47
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -9,6 +9,8 @@ tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, n
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 110
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, n
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 150
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:h
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 80
   turn_timeout: 900
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:hi
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 105
   turn_timeout: 600
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -8,6 +8,8 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:hi
 agent:
   type: claude-code
   permission_mode: acceptEdits
+
+run_limits:
   max_turns: 80
   turn_timeout: 600
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
@@ -4,12 +4,13 @@ description: >
   formats a summary with a script, and branches on temperature: if > 60F output
   'nice day', otherwise 'bring a jacket'. Exercises HTTP, script, and decision nodes.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:decision, feature:http]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -3,12 +3,13 @@ description: >
   Create a UiPath Flow that takes two number inputs and calculates their product
   using a script node. Exercises input variables, script logic, and output mapping.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -13,10 +13,11 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 2400
   max_turns: 120
   turn_timeout: 1200
-
-task_timeout: 2400
 
 sandbox:
   driver: tempdir
@@ -72,4 +73,3 @@ success_criteria:
     weight: 10.0
     pass_threshold: 1.0
 
-max_iterations: 1

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
@@ -5,12 +5,13 @@ description: >
   types via the registry, edit the flow JSON to add dice-rolling logic using a
   Script node, and validate the flow.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
@@ -4,12 +4,13 @@ description: >
   a direction input, using a Switch node to pick the conversion. Exercises
   switch branching, multi-case wiring, and branch convergence on End.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:switch]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
@@ -4,12 +4,13 @@ description: >
   [13, 15, 17] together and return the product (3315). Exercises loop node
   wiring, variable updates, and state accumulation.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:loop]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -4,12 +4,13 @@ description: >
   with a script, collect results. Exercises Loop → HTTP → Script chaining with
   data flowing between nodes across iterations.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:loop, feature:http]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -5,12 +5,13 @@ description: >
   agent selects transform nodes over script nodes for standard data wrangling,
   and correctly configures filter conditions and map transformations.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:transform]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -5,12 +5,13 @@ description: >
   end-to-end test that exercises connector discovery, connection binding,
   reference resolution, node configuration, and cloud debug execution.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, connector]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -4,13 +4,14 @@ description: >
   fetch weather for that city via HTTP, decide warm/cold. Exercises chaining
   Slack connector → Script → HTTP → Decision → End with data flowing between nodes.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:decision, connector, feature:http]
-max_iterations: 1
-task_timeout: 2400 # this is a harder test.
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 2400
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -7,10 +7,11 @@ description: >
   built from flow inputs, the implicit HTTP error port, and a Transform
   filter + aggregate on the response items.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:transform, feature:http]
-max_iterations: 1
 
 agent:
   type: claude-code
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -4,12 +4,13 @@ description: >
   name 'tomasz' and returns his age. Exercises API workflow resource node
   discovery and wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
@@ -8,12 +8,13 @@ description: >
   pre-uploaded Orchestrator attachment and the ECS.BatchTransform service
   backend, neither of which the test sandbox can provision deterministically.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:batch-transform]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
@@ -4,12 +4,13 @@ description: >
   number of r's in 'counterrevolutionary' and return the answer. Exercises agent resource
   node discovery and wiring for coded (vs low-code) agents.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
@@ -5,12 +5,13 @@ description: >
   otherwise return "cool". Exercises Decision node discovery, boolean expression
   configuration, and true/false branch wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:decision]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
@@ -4,12 +4,13 @@ description: >
   number of r's in 'arrow' and return the answer. Exercises agent resource
   node discovery and wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -12,12 +12,13 @@ description: >
   trigger lookback). Adding a debug E2E requires a dedicated service
   mailbox with no rules; tracked as follow-up.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, feature:trigger, connector]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -4,12 +4,13 @@ description: >
   title for problem 123. Exercises RPA resource node discovery, registry get,
   and node wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
@@ -6,12 +6,13 @@ description: >
   discovery, embedded subprocess construction, and variable passing between
   the parent flow and subflow.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:subflow]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
@@ -8,12 +8,13 @@ description: >
   Summarize requires a pre-uploaded Orchestrator attachment and the ECS.DeepRag
   service backend, neither of which the test sandbox can provision deterministically.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:summarize]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -4,12 +4,13 @@ description: >
   to map it to the corresponding season name. Exercises Switch node discovery,
   multi-case routing, and per-branch Script logic.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:switch]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
@@ -6,12 +6,13 @@ description: >
   workflow, the delay branch should be killed before it completes. Exercises
   Terminate as a hard-stop that kills parallel branches.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:terminate]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -7,6 +7,8 @@ tags: [uipath-maestro-flow, smoke, lifecycle:discover, feature:registry]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 28
 
 sandbox:

--- a/tests/tasks/uipath-platform/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces_e2e.yaml
@@ -5,7 +5,6 @@ description: >
   confirm at least one span is returned. Unlike traces_fetch.yaml (smoke),
   this exercises the full round-trip against a real job and real traces.
 tags: [uipath-platform, e2e, lifecycle:discover]
-max_iterations: 1
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-platform/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces_feedback_e2e.yaml
@@ -6,7 +6,6 @@ description: >
   feedback on that trace, then fetches the feedback by ID and verifies the
   round-trip. No hardcoded IDs — all values derived at runtime.
 tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover]
-max_iterations: 1
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-review/review_multi_project_solution.yaml
+++ b/tests/tasks/uipath-review/review_multi_project_solution.yaml
@@ -18,6 +18,8 @@ tags: [uipath-review, e2e, multi-project]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 60
 
 sandbox:

--- a/tests/tasks/uipath-rpa-legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa-legacy/create_and_validate.yaml
@@ -13,7 +13,6 @@ description: >
   commands to succeed at runtime.
 tags: [uipath-rpa-legacy, smoke, create, validate]
 
-task_timeout: 1200
 agent:
   type: claude-code
   # Historically pinned to Opus to dodge a Sonnet content-filter trip
@@ -25,6 +24,9 @@ agent:
   # the override was dropped. The default Sonnet from default.yaml
   # applies; intermittent content-filter blocks are absorbed by the
   # workflow-level 3-attempt retry on content-filter ERRORs.
+
+run_limits:
+  task_timeout: 1200
   max_turns: 40
   turn_timeout: 900
 

--- a/tests/tasks/uipath-rpa/uia_google_search.yaml
+++ b/tests/tasks/uipath-rpa/uia_google_search.yaml
@@ -13,7 +13,6 @@ tags: [uipath-rpa, smoke, uia, xaml]
 # (incl. UIAutomation) + spins up Helm — 60–90s cold start. `validate`
 # on a XAML workflow with UIA activities can run another ~45s. Budget
 # accordingly.
-task_timeout: 1800
 agent:
   type: claude-code
   # Bumped from 40 → 60: CI run 24903966636 hit error_max_turns at 40 on
@@ -21,39 +20,15 @@ agent:
   # auth-retry loops. Prompt now tells the agent to hand-author
   # project.json directly, but give turn headroom for the XAML
   # discovery/edit cycles regardless.
+
+run_limits:
+  task_timeout: 1800
   max_turns: 60
   turn_timeout: 1200
 
 sandbox:
   driver: tempdir
   python: {}
-
-llm_reviewer:
-  enabled: true
-  model: claude-sonnet-4-6
-  temperature: 0.0
-  max_tokens: 600
-  prompt: |
-    Evaluate whether the agent built a correct standard (XAML, VB.NET)
-    UiPath RPA project for this CI task using the canonical skill flow.
-
-    Score on:
-    - GoogleSearch/project.json exists with `"expressionLanguage":
-      "VisualBasic"` and UIA activity packages in dependencies.
-    - GoogleSearch/Main.xaml opens chrome.exe at google.com, types
-      "UiPath automation" into the search box, and clicks the search
-      button, using the three known selectors (chrome.exe URL,
-      textarea name='q', input name='btnK'). Use the modern Nx
-      activities (NApplicationCard + NTypeInto + NClick); the classic
-      OpenBrowser + TypeInto + Click triple is not a clean fit.
-      The Object Repository / configure-target
-      pipeline can't run without an interactive Studio session.
-    - The harness runs `uip rpa build` programmatically; the build's
-      exit code is the compile gate.
-
-    Reply terse, developer-style. Score 1.0 if selectors + query are
-    right and the project compiles.
-
 initial_prompt: |
   Build a standard UiPath RPA project named "GoogleSearch" (XAML
   workflow, VisualBasic expression language) under ./GoogleSearch

--- a/tests/tasks/uipath-solution-design/e2e_rpa_sdd/e2e_rpa_sdd.yaml
+++ b/tests/tasks/uipath-solution-design/e2e_rpa_sdd/e2e_rpa_sdd.yaml
@@ -5,12 +5,13 @@ description: >
   SDD with all template sections populated. A Python check script validates
   structural completeness and content quality.
 tags: [uipath-solution-design, e2e, rpa, sdd]
-max_iterations: 1
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-solution-design/gap_detection.yaml
+++ b/tests/tasks/uipath-solution-design/gap_detection.yaml
@@ -10,6 +10,8 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-solution-design/pdd_to_sdd.yaml
+++ b/tests/tasks/uipath-solution-design/pdd_to_sdd.yaml
@@ -9,6 +9,8 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
   turn_timeout: 1200
 
 sandbox:

--- a/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
+++ b/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
@@ -10,6 +10,8 @@ tags: [uipath-tasks, e2e, discovery, fetch]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -19,6 +19,8 @@ tags: [uipath-test, integration, mode:operate, lifecycle:generate, feature:test-
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 50
 
 sandbox:

--- a/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
@@ -12,6 +12,8 @@ tags: [uipath-test, smoke, mode:operate, lifecycle:discover, feature:test-case]
 
 agent:
   type: claude-code
+
+run_limits:
   max_turns: 30
 
 sandbox:


### PR DESCRIPTION
## What

Mechanical cleanup of deprecated and unsupported fields in `tests/tasks/*.yaml`.

## Why

The new [coder_eval validate-skills-yamls CI gate](https://github.com/UiPath/coder_eval/pull/252) (now soft-gated and merged on coder_eval `main`) loads every task YAML through coder_eval's pydantic schema. That surfaced three classes of drift in this repo:

- **Hard deadline (2026-05-20):** `agent.{max_turns,turn_timeout}` and top-level `task_timeout` were soft-deprecated in coder_eval's `c/2026-05-12-unify-run-limits` migration and turn into hard load failures next week. ~190 task YAMLs were still on the old shape.
- **Dead config (silently dropped today):** top-level `max_iterations:` (122 files) and `llm_reviewer:` blocks (9 files) are unknown fields per coder_eval source comments — leftover from previous schemas, ignored at load time but currently emitting unknown-field warnings.
- **Schema-invalid criteria:** 7 `command_executed` criteria in two governance smoke tasks used `max_count: 0` (negation assertion). `CommandExecutedCriterion` had no `max_count` field, so those entire tasks failed to load — i.e. the negation checks were already not running.

## Changes

- Move `agent.{max_turns,turn_timeout}` → `run_limits.{max_turns,turn_timeout}` (187 files).
- Move top-level `task_timeout` → `run_limits.task_timeout` (27 files; subset of the above).
- Remove top-level `max_iterations:` (122 files).
- Remove top-level `llm_reviewer:` blocks (9 task YAMLs + the `_shared/scripts/generate_scenario.py` template, so future-generated scenarios don't re-introduce it).
- Restore the 7 `max_count: 0` negation criteria. This depends on [coder_eval#254](https://github.com/UiPath/coder_eval/pull/254) which adds `max_count` support to `CommandExecutedCriterion`. The skills criteria are functionally inert until #254 ships, but cause no regression in the meantime: they parse the moment #254 merges and start asserting the negation intent they always carried in prose.

## Cross-repo validation

After this PR + coder_eval#254, `coder-eval plan` over the full skills suite is green:
- 235/235 task YAMLs pass
- 0 DeprecationWarnings
- 0 unknown-field warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)