### PR TITLE
fix(tests): defaults.post_run cleanup for node_modules [MST-9674]

### DIFF
--- a/tests/experiments/activation.yaml
+++ b/tests/experiments/activation.yaml
@@ -30,5 +30,12 @@ defaults:
         path: $SKILLS_REPO_PATH
     ignore_patterns: []
 
+  # Drop <sandbox>/{node_modules,.npm-prefix} so preserved artifacts stay slim
+  # and Node module resolution can't leak across concurrent sandboxes
+  # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
+  post_run:
+    - command: "rm -rf node_modules .npm-prefix"
+      timeout: 30
+
 variants:
   - variant_id: default

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -25,5 +25,12 @@ defaults:
         path: "$SKILLS_REPO_PATH"
     ignore_patterns: []
 
+  # Drop <sandbox>/{node_modules,.npm-prefix} so preserved artifacts stay slim
+  # and Node module resolution can't leak across concurrent sandboxes
+  # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
+  post_run:
+    - command: "rm -rf node_modules .npm-prefix"
+      timeout: 30
+
 variants:
   - variant_id: default

--- a/tests/experiments/e2e.yaml
+++ b/tests/experiments/e2e.yaml
@@ -19,11 +19,15 @@ defaults:
         path: "$SKILLS_REPO_PATH"
     ignore_patterns: []
 
-  # Append default post_run to every e2e task: delete Studio Web solutions
-  # uploaded by `uip maestro flow debug` (no-op for tasks that don't produce .uipx).
+  # Append default post_run to every e2e task. Order matters: solution cleanup
+  # talks to the tenant (still needs npm-installed CLIs), then sandbox-local
+  # cleanup wipes <sandbox>/{node_modules,.npm-prefix} so preserved artifacts
+  # stay slim (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
   post_run:
     - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
       timeout: 120
+    - command: "rm -rf node_modules .npm-prefix"
+      timeout: 30
 
 variants:
   - variant_id: default

--- a/tests/experiments/integration.yaml
+++ b/tests/experiments/integration.yaml
@@ -19,5 +19,12 @@ defaults:
         path: "$SKILLS_REPO_PATH"
     ignore_patterns: []
 
+  # Drop <sandbox>/{node_modules,.npm-prefix} so preserved artifacts stay slim
+  # and Node module resolution can't leak across concurrent sandboxes
+  # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
+  post_run:
+    - command: "rm -rf node_modules .npm-prefix"
+      timeout: 30
+
 variants:
   - variant_id: default

--- a/tests/experiments/sherif-skill-comparison.yaml
+++ b/tests/experiments/sherif-skill-comparison.yaml
@@ -31,6 +31,13 @@ defaults:
       In particular, do NOT access the plugin directories — those are loaded by
       the skill system and you do not need to read them directly.
 
+  # Drop <sandbox>/{node_modules,.npm-prefix} so preserved artifacts stay slim
+  # and Node module resolution can't leak across concurrent sandboxes
+  # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
+  post_run:
+    - command: "rm -rf node_modules .npm-prefix"
+      timeout: 30
+
 variants:
   - variant_id: bare
 

--- a/tests/experiments/skill-comparison-template.yaml
+++ b/tests/experiments/skill-comparison-template.yaml
@@ -36,6 +36,13 @@ defaults:
       In particular, do NOT access the plugin directories — those are loaded by
       the skill system and you do not need to read them directly.
 
+  # Drop <sandbox>/{node_modules,.npm-prefix} so preserved artifacts stay slim
+  # and Node module resolution can't leak across concurrent sandboxes
+  # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
+  post_run:
+    - command: "rm -rf node_modules .npm-prefix"
+      timeout: 30
+
 # ---------------------------------------------------------------------------
 # Variants — one entry per condition you're comparing.
 #


### PR DESCRIPTION
## Summary

Follow-up to **coder_eval [#253](https://github.com/UiPath/coder_eval/pull/253)** — same npm cleanup hook, applied at the **experiment-defaults** layer of every experiment YAML under `tests/experiments/`. The resolver appends `experiment.defaults.post_run` to each task's own `post_run`, so every task under `tests/tasks/` inherits the cleanup without per-task duplication.

### Why

coder_eval [#250](https://github.com/UiPath/coder_eval/pull/250) sandbox-scopes Node/npm installs to `<sandbox>/{node_modules,.npm-prefix}` (via `NPM_CONFIG_PREFIX`) so concurrent sandboxes can't poison each other.

- **Non-preserved runs** — `Sandbox.cleanup` already `shutil.rmtree`s the tempdir, so this is a no-op.
- **`preserve_sandbox=true` runs** — `Sandbox.preserve_to` does `shutil.copytree(sandbox_dir, ...)` with no `ignore=` filter ([sandbox.py:617](https://github.com/UiPath/coder_eval/blob/main/src/coder_eval/sandbox.py#L617)), so without this hook a preserved task's `node_modules` (hundreds of MB) ships into `runs/<id>/artifacts/<task>/`. Post_run runs **before** `_cleanup` ([orchestrator.py:459 finally block](https://github.com/UiPath/coder_eval/blob/main/src/coder_eval/orchestrator.py#L459)), so the cleanup lands ahead of `preserve_to`'s copytree.

### Files touched

| File | Change |
|---|---|
| `tests/experiments/activation.yaml` | new `defaults.post_run` block |
| `tests/experiments/default.yaml` | new `defaults.post_run` block |
| `tests/experiments/e2e.yaml` | appended to **existing** post_run list, **after** `cleanup_solutions.py` — solution cleanup talks to the tenant and still needs npm-installed CLIs |
| `tests/experiments/integration.yaml` | new `defaults.post_run` block |
| `tests/experiments/sherif-skill-comparison.yaml` | new `defaults.post_run` block |
| `tests/experiments/skill-comparison-template.yaml` | new `defaults.post_run` block so every copy of the template inherits the cleanup by default |

## Verified

- All 5 non-template experiments load cleanly via `coder_eval.orchestration.experiment.load_experiment()`.
- `resolve_task_for_variant()` against real tasks shows the cleanup is appended:
  - `default.yaml` + `activity_discovery.yaml` → 1 post_run cmd
  - `integration.yaml` + `connection_lifecycle.yaml` → 1 post_run cmd
  - `e2e.yaml` + `api_workflow.yaml` → 2 post_run cmds (`cleanup_solutions.py` first, then `rm -rf`)
- `skill-comparison-template.yaml` still errors on its placeholder `experiment_id: skill-comparison-<short-name>` — pre-existing, expected (template is meant to be copied + renamed before use).

## Jira

- MST-9674

## Companion

- coder_eval [#250](https://github.com/UiPath/coder_eval/pull/250) — sandbox isolation (merged)
- coder_eval [#253](https://github.com/UiPath/coder_eval/pull/253) — same cleanup, applied to coder_eval's own `experiments/*.yaml`