### PR TITLE
docs(uipath-rpa): clarify UIA reference locations + Autopilot skill-path note

### DIFF
--- a/agents/uipath-project-discovery-agent.md
+++ b/agents/uipath-project-discovery-agent.md
@@ -296,6 +296,10 @@ Show 1-2 representative code skeletons that demonstrate how to write new code in
 - **Run**: `uip rpa run-file --file-path "{{MAIN_FILE}}" --project-dir "{{PROJECT_DIR}}"`
 - **Validate**: `uip rpa get-errors --project-dir "{{PROJECT_DIR}}"`
 - **Key files to read first**: {{TOP_3_FILES}}
+
+## Skill Availability (Autopilot)
+
+The `uipath-rpa` skill is a **Claude Code plugin skill**, loaded by its host (Claude Code, Autopilot, or other agent runtime) from the plugin registry — NOT from this project. It is NOT installed at `<PROJECT_ROOT>\.local\autopilot\skills\uipath-rpa\` or any other path under this project. Do not attempt to read its `SKILL.md` or reference files from `.local\autopilot\skills\` — those paths will not exist. Rely on the skill content already loaded by the host.
 ````
 
 ### Metadata Line
@@ -318,6 +322,7 @@ Example: `<!-- discovery-metadata: cs=47 xaml=0 deps=3 -->`
 6. **Conventions section**: Only include patterns that were actually observed in sampled code. If a convention couldn't be determined, omit that bullet.
 7. **Code Patterns section**: Pick the most representative patterns. For test projects, show the test skeleton. For process projects, show the main workflow pattern. Max 2 skeletons.
 8. **Base class infrastructure**: If the project uses a custom base class beyond CodedWorkflow, document its key fields, methods, and services — this is critical context for writing new code.
+9. **Always include the `Skill Availability (Autopilot)` section verbatim.** This is a static notice, not data-dependent — emit it on every regeneration. It tells Autopilot's runtime not to probe `.local/autopilot/skills/uipath-rpa/`, which does not exist.
 
 ---
 

--- a/agents/uipath-project-discovery-agent.md
+++ b/agents/uipath-project-discovery-agent.md
@@ -296,10 +296,6 @@ Show 1-2 representative code skeletons that demonstrate how to write new code in
 - **Run**: `uip rpa run-file --file-path "{{MAIN_FILE}}" --project-dir "{{PROJECT_DIR}}"`
 - **Validate**: `uip rpa get-errors --project-dir "{{PROJECT_DIR}}"`
 - **Key files to read first**: {{TOP_3_FILES}}
-
-## Skill Availability (Autopilot)
-
-The `uipath-rpa` skill is a **Claude Code plugin skill**, loaded by its host (Claude Code, Autopilot, or other agent runtime) from the plugin registry — NOT from this project. It is NOT installed at `<PROJECT_ROOT>\.local\autopilot\skills\uipath-rpa\` or any other path under this project. Do not attempt to read its `SKILL.md` or reference files from `.local\autopilot\skills\` — those paths will not exist. Rely on the skill content already loaded by the host.
 ````
 
 ### Metadata Line
@@ -322,7 +318,6 @@ Example: `<!-- discovery-metadata: cs=47 xaml=0 deps=3 -->`
 6. **Conventions section**: Only include patterns that were actually observed in sampled code. If a convention couldn't be determined, omit that bullet.
 7. **Code Patterns section**: Pick the most representative patterns. For test projects, show the test skeleton. For process projects, show the main workflow pattern. Max 2 skeletons.
 8. **Base class infrastructure**: If the project uses a custom base class beyond CodedWorkflow, document its key fields, methods, and services — this is critical context for writing new code.
-9. **Always include the `Skill Availability (Autopilot)` section verbatim.** This is a static notice, not data-dependent — emit it on every regeneration. It tells Autopilot's runtime not to probe `.local/autopilot/skills/uipath-rpa/`, which does not exist.
 
 ---
 

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -333,13 +333,36 @@ uip rpa packages install --packages '[{"id":"<PackageId>","version":"<LATEST_VER
 
 ## UI Automation References
 
-**MUST read [references/ui-automation-guide.md](references/ui-automation-guide.md) before any UI automation work** — mode-specific UIA patterns (coded vs XAML).
+UIA references live in two locations. Always cite by location so the reader knows which tree to open:
 
-Additional UIA procedures and guides:
-- [uia-prerequisites.md](references/uia-prerequisites.md) — Package version requirements
+- **This skill** (`skills/uipath-rpa/references/`) — policy, decision logic, target-capture orchestration, debug/recovery flows.
+- **UIA activity pack** (`{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/`, installed via `uip rpa packages install`) — concrete `uip rpa uia` CLI syntax, per-activity property surfaces, coded API surface, and the UIA skill internal procedures. Co-versioned with the package, so always source-of-truth over anything in this skill when they diverge.
+
+### In this skill (`skills/uipath-rpa/references/`)
+
+**MUST read [ui-automation-guide.md](references/ui-automation-guide.md) before any UI automation work** — mode-specific UIA patterns (coded vs XAML), prohibited-tool list, exploration-tool boundaries.
+
+- [uia-prerequisites.md](references/uia-prerequisites.md) — Package version requirements, upgrade-consent rules
+- [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) — Target-capture orchestration, multi-step UI flows, indication-fallback routing
 - [uia-debug-workflow.md](references/uia-debug-workflow.md) — Running and debugging UI automation workflows
 - [uia-selector-recovery.md](references/uia-selector-recovery.md) — Fixing selectors that fail at runtime
-- [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) — Target configuration workflow, multi-step UI flows, and indication fallback
+
+### In the UIA activity pack (`{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/`)
+
+- `overview.md` — Package overview and entry point
+- `references/cli-reference.md` — Full `uip rpa uia` CLI: subcommands, flags, accepted values, artifact filenames
+- `references/object-repository.md` — Object Repository concepts and CLI flows
+- `references/selector-variables.md` — Selector variable substitution
+- `references/uia-target-attachment-guide.md` — Attaching OR targets to XAML activities (TargetApp / TargetAnchorable)
+- `references/indication-fallback-workflow.md` — Indication-mode capture when `uia-configure-target` is unavailable
+- `coded/coded-api.md` — Coded API surface for `uiAutomation.*` service calls
+- `activities/<Activity>.md` — Per-activity property surface (`NClick`, `NTypeInto`, `NApplicationCard`, …)
+- `activities/common/<Type>.md` — Shared enums and types (`NHealingAgentBehavior`, `Target`, `NClickType`, …)
+- `skills/uia-configure-target/{SKILL.md,USAGE.md}` — Target-configuration skill: procedure + invocation modes
+- `skills/uia-improve-selector/{SKILL.md,USAGE.md}` — Selector recovery / improvement skill
+- `skills/uia-interact/SKILL.md` + `references/special-keys.md` — Live UI interaction skill
+
+Pack docs are reference material to read and follow — NOT invocable as slash commands.
 
 ## Completion Output
 

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -360,9 +360,6 @@ UIA references live in two locations. Always cite by location so the reader know
 - `activities/common/<Type>.md` — Shared enums and types (`NHealingAgentBehavior`, `Target`, `NClickType`, …)
 - `skills/uia-configure-target/{SKILL.md,USAGE.md}` — Target-configuration skill: procedure + invocation modes
 - `skills/uia-improve-selector/{SKILL.md,USAGE.md}` — Selector recovery / improvement skill
-- `skills/uia-interact/SKILL.md` + `references/special-keys.md` — Live UI interaction skill
-
-Pack docs are reference material to read and follow — NOT invocable as slash commands.
 
 ## Completion Output
 


### PR DESCRIPTION
## Summary

- **SKILL.md** — Split the *UI Automation References* section into two clearly labeled groups: refs that live in this skill (`skills/uipath-rpa/references/`) vs. refs that ship with the UIA activity pack (`{PROJECT_DIR}/.local/docs/packages/UiPath.UIAutomation.Activities/`). Lists every UIA pack doc the latest package brings (verified against `~/Dev/Activities/UIAutomation/UiPath.UIAutomation.Activities.Package/docs/`).
- **Discovery agent output template** — Adds a static *Skill Availability (Autopilot)* section so every regenerated `AGENTS.md` carries an explicit note that the `uipath-rpa` skill ships as a Claude Code plugin and is **not** installed under `<PROJECT_ROOT>\.local\autopilot\skills\uipath-rpa\`. Stops Autopilot's runtime from probing that nonexistent path on every routing decision.
- Adds a matching template guideline (rule 9) so the static section is always emitted verbatim, not omitted under the "Omit empty sections" rule.

## Why

- The old *UI Automation References* section only listed 5 RPA-skill-local files with no location context. Agents had no scanable cue that most concrete UIA syntax (CLI flags, per-activity property tables, OR concepts) lives in the activity pack — they'd either ask, or fabricate.
- Studio Autopilot was reporting `Directory path does not exist: C:\...\.local\autopilot\skills\uipath-rpa.` on every RPA task because its runtime speculatively reads the per-project skill bundle. The bundle never exists for plugin-loaded skills. `AGENTS.md` is what Autopilot reads at project root — putting the note there is the most direct path to silencing the probe.

## Test plan

- [ ] Verify `validate-skill-descriptions.sh` still passes (no frontmatter changes, expected pass).
- [ ] Re-trigger project discovery in a sample UiPath project and confirm the regenerated `AGENTS.md` contains the *Skill Availability (Autopilot)* section.
- [ ] Open an Autopilot session against that project and confirm the "directory path does not exist" error no longer surfaces for `.local/autopilot/skills/uipath-rpa/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)