### PR TITLE
docs(uipath-platform): align `users import` guidance with CLI #2028

### DIFF
--- a/skills/uipath-platform/references/orchestrator/setup-environment.md
+++ b/skills/uipath-platform/references/orchestrator/setup-environment.md
@@ -117,6 +117,8 @@ Role types:
 - **Tenant** — Applies across the entire tenant. Assigned via `uip or users assign-roles`.
 - **Folder** — Applies only within specific folders. Assigned via `uip or users assign` or `uip or roles assign`.
 
+> **⚠️ All three role-assign commands are destructive.** `users assign-roles`, `users assign`, and `roles assign` each **replace** the user's role list at their respective scope (tenant or per-folder). Roles not in `--role-keys` are removed silently. Always read the current roles first with `uip or roles user-roles list <user-key> --output json` and pass the full desired union. For purely additive *user* membership on a single role, use `uip or roles users <role-key> --add-users <user-key>` — that command does NOT replace the role's other assignees.
+
 #### Inspect / Audit / Delete Roles
 
 ```bash
@@ -216,6 +218,8 @@ Key flags on `users edit`:
 
 `DirectoryRobot` principals don't need `--unattended-username` / `--unattended-password` on import — the robot identity already carries its own credentials in IS. Use `users edit --license-type Unattended` on the robot key to set the license profile.
 
+> **`users edit` does NOT expose role assignments.** It only touches tenant-side flags (license, session flags, unattended credentials). To change roles, use `uip or users assign` (folder roles), `uip or users assign-roles` (tenant roles), or `uip or roles users <role-key> --add-users/--remove-users` (single-role membership). Identity attributes like `--name`, `--surname`, `--email` on directory principals are sourced from Identity Service via sync — editing them via `users edit` only updates the Orchestrator-side cached copy and may be overwritten on the next IS sync.
+
 ### Step 5: Assign Users to Folders
 
 Assign the user to a folder, optionally with folder-level roles. This is what grants them access to the folder's resources.
@@ -232,6 +236,8 @@ Key details:
 - `--role-keys` is optional. Users can be assigned to a folder without roles (the API's `RoleId` is nullable). They will have access to the folder but no specific permissions until roles are added.
 - Use `--folder-path` (e.g., `"Finance"` or `"Finance/Invoicing"`) or `--folder-key` (GUID).
 - To verify: `uip or users list-in-folder --folder-path "Finance" --output json`.
+
+> **⚠️ Destructive — REPLACE semantics.** `users assign` (and the equivalent `roles assign`) **replaces** the user's folder-level role list in the target folder with whatever you pass in `--role-keys`. Roles not in the payload are removed silently. To **add** a role without dropping others, first read the existing folder roles with `uip or roles user-roles list <user-key> --output json`, then pass the full desired union to `--role-keys`. The same applies to `users assign-roles` for tenant-level roles.
 
 ### Step 6: Create Machines
 

--- a/skills/uipath-platform/references/orchestrator/setup-environment.md
+++ b/skills/uipath-platform/references/orchestrator/setup-environment.md
@@ -144,24 +144,45 @@ uip or roles delete <role-key> --output json
 
 ### Step 4: Import Users from Identity Service
 
-Principals are managed in Identity Service (IS), not in Orchestrator. `users import` references an existing IS principal so the tenant can grant it folder access. (The legacy `users create` / `users delete` commands are gone — they called endpoints reserved for `ProvisionType=Manual`, which is not how cloud or IS-backed users are managed.)
+Principals are managed in Identity Service (IS), not in Orchestrator. `users import` is the **single integration point** between IS and the tenant: it references an existing IS principal and provisions the matching tenant user record. Everything downstream (`users assign`, `users assign-roles`, `roles assign`, etc.) takes the resolved Orchestrator user-key — no further IS round-trips. (The legacy `users create` / `users delete` commands are gone — they called endpoints reserved for `ProvisionType=Manual`, which is not how cloud or IS-backed users are managed.)
 
 ```bash
-uip or users import --username "jane.doe@example.com" --output json
+# Human user (cloud SSO or AD)
+uip or users import --username "jane.doe@example.com" --type DirectoryUser --domain "uipath" --output json
+
+# Robot account — requires --directory-id (the IS UUID)
+uip admin robot-accounts create "InvoiceRunner" --output json   # capture .Data.id
+uip or users import --directory-id <id-from-above> --type DirectoryRobot --domain autogen --output json
+
+# External application — requires --directory-id (the IS UUID)
+uip admin external-apps list --search "MyApp" --output json   # capture .id
+uip or users import --directory-id <id-from-above> --type DirectoryExternalApplication --domain autogen --output json
 ```
 
-Key options:
+Required options:
 
-- `--directory-id <id>` — Use the IS directory identifier (OIDC subject) instead of `--username`. Pass exactly one of the two.
-- `--domain <domain>` — IS directory domain. Defaults to `default`. List configured domains via `GET /api/DirectoryService/GetDomains` if your tenant uses on-prem AD or a non-default IS realm.
-- `--type <type>` — IS principal type. Four supported:
-  - `DirectoryUser` (default) — a real human user.
+- `--type <type>` — **Required**, no default. The CLI refuses to guess what kind of principal you're importing (otherwise a robot might silently land as a DirectoryUser in the tenant). Four values:
+  - `DirectoryUser` — a real human user.
   - `DirectoryGroup` — a directory group; folder grants apply to every member.
-  - `DirectoryRobot` — a **robot account** in IS. This is the standard way to give a folder an unattended robot identity. The robot account is created in IS first (separate flow); `users import --type DirectoryRobot` brings it into the tenant so it can be assigned to a folder and licensed for unattended execution. Without an imported `DirectoryRobot` (or a `DirectoryUser` with unattended permissions), `jobs start` returns `HTTP 409: Couldn't find any user with unattended robot permissions in the current folder.`
-  - `DirectoryExternalApplication` — an IS-registered external app (client credentials principal). Used for service-to-service tenants; folder grants apply to whoever holds the client secret.
-- `--folder-path <path>` / `--folder-key <key>` + `--role-keys <guids>` — Optional one-shot. Imports the principal **and** assigns folder roles in a single call. Both must be present together; pass neither for an import-only call. The next step covers folder assignment as a separate flow.
+  - `DirectoryRobot` — a **robot account** in IS. Standard way to give a folder an unattended robot identity. Without it (or a `DirectoryUser` with unattended permissions), `jobs start` returns `HTTP 409: Couldn't find any user with unattended robot permissions in the current folder.`
+  - `DirectoryExternalApplication` — an IS-registered external app (client-credentials principal) for service-to-service flows.
 
-Save the `UserName` from the response and look up the `Key` via `users list` for the next step.
+- `--domain <domain>` — IS directory domain. `autogen` for `DirectoryRobot` / `DirectoryExternalApplication`. For `DirectoryUser` / `DirectoryGroup`, the tenant's IS directory domain (typically the cloud org slug or the on-prem AD domain).
+
+Principal identifier — provide exactly one of:
+
+- `--username <name>` — IS principal name. Works for `DirectoryUser` / `DirectoryGroup` when the principal resolves as `<domain>\<name>` in IS (on-prem AD setups, classic IS configurations). For cloud SSO users this lookup typically fails — use `--directory-id` instead.
+- `--directory-id <uuid>` — IS UUID. **Required for `DirectoryRobot` and `DirectoryExternalApplication`** — the server-side `UserService.CreateAsync` rejects these types with HTTP 400 unless the tenant user-record `Key` matches the IS identifier, and `Key` is only populated when `--directory-id` is set. Find the UUID via:
+  - `uip admin robot-accounts create <name>` — returns the new robot's `.Data.id`.
+  - `uip admin robot-accounts list --search <name>` — `.Data[].id` of an existing robot.
+  - `uip admin external-apps list` — `.Data[].appId` for IS-registered external apps.
+  - `uip admin users list --search <name>` — `.Data[].id` for human users (when you'd prefer the UUID over `--username`).
+
+Optional one-shot folder assignment:
+
+- `--folder-path <path>` / `--folder-key <key>` + `--role-keys <guids>` — Imports the principal **and** assigns folder roles in a single call. Pass both together; pass neither for an import-only call.
+
+Save the `Key` from the response (returned via `users list --username "<imported-name>"` once import succeeds) — that's the **Orchestrator user-key** you'll use in `users assign`, `users assign-roles`, `roles assign`, and similar commands.
 
 ### Step 4b: Inspect / Edit / Unassign / Remove Users
 
@@ -309,9 +330,9 @@ uip or roles edit r1r2r3r4-... \
   --add-permissions "Assets.View,Assets.Edit,Queues.View,Jobs.Create,Jobs.View,Processes.View" \
   --output json
 
-# 4. Import a user from Identity Service
-uip or users import --username "jane.doe@example.com" --output json
-# (Look up the assigned Key with: uip or users list --search "jane.doe")
+# 4. Import a user from Identity Service (--type is required; --directory-id required for Robot/ExtApp)
+uip or users import --username "jane.doe@example.com" --type DirectoryUser --domain "uipath" --output json
+# (Look up the assigned Key with: uip or users list --username "jane.doe@example.com")
 
 # 5. Assign user to folder with role
 uip or users assign \

--- a/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
+++ b/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
@@ -1,0 +1,71 @@
+task_id: skill-platform-users-import-robot-smoke
+description: >
+  Smoke test: agent uses the uipath-platform skill to import a robot
+  account into the Orchestrator tenant. Verifies the agent (a) finds the
+  IS UUID via `admin robot-accounts list --search` (or remembers it from
+  a prior `admin robot-accounts create`), and (b) calls
+  `uip or users import --directory-id <uuid> --type DirectoryRobot
+  --domain autogen` with all three flags. Without --directory-id the
+  CLI rejects with "Missing --directory-id"; without --type the CLI
+  errors on a required option. Auth/404 errors are acceptable — goal is
+  correct command shape.
+tags: [uipath-platform, smoke, mode:build, lifecycle:setup]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I created a robot account in Identity Service called "InvoiceRunner"
+  with id `f1b2c3d4-0000-0000-0000-000000000001`. I want to import it
+  into the Orchestrator tenant so I can later assign it to folders.
+
+  Use `--output json` on all uip commands.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent called `uip or users import` (the single IS→tenant integration point)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+import'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent passed --type DirectoryRobot"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+import.*--type\s+DirectoryRobot'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent passed --directory-id (required for Robot — server-side Key check)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+import.*--directory-id'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent passed --domain (required; 'autogen' for Robot)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+import.*--domain\s+autogen'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+import.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did NOT omit --type (would default to DirectoryUser → silent corruption)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+users\s+import(?!.*--type)'
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Pairs with [UiPath/cli#2028](https://github.com/UiPath/cli/pull/2028), which fixes `users import` for DirectoryRobot / DirectoryExternalApplication (the bug @aiordan reported in #dev-cli) and tightens the CLI contract:

- `--type` is now **required** (no DirectoryUser default → no silent "robot imported as user" corruption).
- `--directory-id` is **required** for DirectoryRobot / DirectoryExternalApplication (server-side `UserService.CreateAsync` rejects them unless the tenant record `Key` matches the IS identifier; the CLI populates `Key` from `--directory-id`).

This PR aligns the `uipath-platform` skill so agents teach the correct contract.

## Files changed

### `skills/uipath-platform/references/orchestrator/setup-environment.md`

Step 4 ("Import Users from Identity Service") rewritten:

- Framed `users import` as the **single integration point** between IS and the Orchestrator tenant. Everything downstream (`users assign`, `users assign-roles`, `roles assign`) takes the resolved Orchestrator user-key — no further IS round-trips.
- Three concrete examples lead the section: human user via `--username + --domain`, DirectoryRobot via `admin robot-accounts create` → capture `.id` → `users import --directory-id <id> --type DirectoryRobot --domain autogen`, DirectoryExternalApplication via `admin external-apps list` → `--directory-id`.
- `--type` documented as required with the four valid values.
- `--directory-id` documented as required for Robot/ExtApp with **concrete pointers to the admin commands that surface the UUID**: `admin robot-accounts create/list --search`, `admin external-apps list`, `admin users list --search`.
- Complete Example updated: step 4 now passes `--type DirectoryUser --domain uipath` explicitly.

### `tests/tasks/uipath-platform/users_import_robot_smoke.yaml` (new)

Smoke task exercising the canonical robot-import shape:

- Verifies the agent uses `uip or users import` (not the legacy DirectoryUser-as-default path).
- Asserts presence of `--type DirectoryRobot`, `--directory-id`, `--domain autogen`, `--output json`.
- `command_not_executed` rule fails the run if the agent omits `--type` (would silently corrupt as DirectoryUser).

## Why this PR replaces the previous design

Earlier iterations of this PR added two new commands `users assign-folder` / `users assign-tenant` going through the modern `AssignDomainUser` endpoint. Owner pushback (@AlinaH after closer review of the portal's actual network calls): the simpler fix is to keep `users import` as the single integration point and just populate the POST body's `Key` field correctly — same endpoint the portal uses (`POST /odata/Users`), same body shape, no new commands. CLI #2028 was force-pushed to that minimal design; this skill PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)