### PR TITLE
docs(uipath-platform): clarify `--feed-type` semantics on `folders create`

### DIFF
--- a/skills/uipath-platform/references/orchestrator/setup-environment.md
+++ b/skills/uipath-platform/references/orchestrator/setup-environment.md
@@ -50,6 +50,10 @@ Key options:
 - `--parent <key-or-path>` -- Nest inside an existing folder (GUID key or path like `"Shared"`).
 - `--description <text>` -- Human-readable description.
 - `--permission-model <model>` -- `FineGrained` (default, per-folder RBAC) or `InheritFromTenant`.
+- `--feed-type <type>` -- Package feed scope. The names don't describe the behavior, read them as:
+  - `Processes` (default) -- folder shares the **tenant-level** processes feed.
+  - `FolderHierarchy` -- folder has its **own folder-scoped** feed, inherited by sub-folders.
+  - `Libraries` -- folder is backed by the tenant libraries feed (libraries instead of processes).
 
 Save the `Key` from the response -- you will use it as `--folder-path` or `--folder-key` in later steps.
 


### PR DESCRIPTION
## Summary

The three accepted values for `uip or folders create --feed-type` — `Processes`, `FolderHierarchy`, `Libraries` — don't self-describe. The names invite agents to guess what each does, especially the difference between `Processes` (which actually means "share the *tenant-level* feed") and `FolderHierarchy` (which means "use a *folder-scoped* feed, inherited by sub-folders").

This adds one bullet under Step 1 of \`setup-environment.md\` that spells out the scope of each value, so agents reaching for the flag make an informed choice instead of pattern-matching on the names.

## Diff

```diff
Key options:
 - `--parent <key-or-path>` -- Nest inside an existing folder (GUID key or path like `"Shared"`).
 - `--description <text>` -- Human-readable description.
 - `--permission-model <model>` -- `FineGrained` (default, per-folder RBAC) or `InheritFromTenant`.
+- `--feed-type <type>` -- Package feed scope. The names don't describe the behavior, read them as:
+  - `Processes` (default) -- folder shares the **tenant-level** processes feed.
+  - `FolderHierarchy` -- folder has its **own folder-scoped** feed, inherited by sub-folders.
+  - `Libraries` -- folder is backed by the tenant libraries feed (libraries instead of processes).
```

## Pairs with

CLI PR: https://github.com/UiPath/cli/pull/2034 — adds the same clarification to the CLI's `--help` text.

## Test plan

- [x] `hooks/validate-skill-descriptions.sh` — passes (no frontmatter changes).
- [x] Manual review of rendered Markdown — bullet renders correctly, no broken anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)