### PR TITLE
fix(tests): accept `uip solution init` in flow init-validate smoke

### DIFF
--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -31,9 +31,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created a solution with uip solution new"
+    description: "Agent created a solution with uip solution init (or legacy new)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+solution\s+new'
+    command_pattern: '(uip|\$UIP)\s+solution\s+(init|new)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

The `skill-flow-init-validate` smoke task's `command_pattern` matched only `uip solution new`, but the closed-verb-set rename ([#710](https://github.com/UiPath/skills/pull/710)) moved skills to `uip solution init`. Legacy CLIs still accept `new`, so the maestro-flow skill teaches a probe-and-fallback pattern at [`SKILL.md:76`](https://github.com/UiPath/skills/blob/main/skills/uipath-maestro-flow/SKILL.md#L76) — agents running against the current CLI invoke `init` and were being penalized for not running the renamed-away verb.

Loosens the pattern to `(init|new)` so the criterion matches both verbs, mirroring the skill's documented probe.

## Evidence

**Ran `skill-flow-init-validate` on this branch and it passed.** Smoke run [25885904772](https://github.com/UiPath/skills/actions/runs/25885904772): **6/6 succeeded**, `skill-flow-init-validate` `status=SUCCESS score=1.000`. Same agent behavior as the failing run on PR #767 — agent probes `uip solution init --help`, runs `uip solution init "WeatherAlert"`, criterion now matches.

Original failure on [PR #767's smoke run](https://github.com/UiPath/skills/actions/runs/25884949755):

- Task `skill-flow-init-validate` scored 0.81 (5/6 other criteria pass).
- Failing criterion: `command_executed` against `(uip|\$UIP)\s+solution\s+new` — matched 0/1.
- Agent transcript shows it correctly probed `uip solution init --help`, got `Success`, then ran `uip solution init "WeatherAlert"` per the skill's `init`-first guidance.
- Confirmed against the local CLI: only `uip solution init` exists; there is no `solution new` subcommand.

Not a regression from PR #767 (transform docs only). This is leftover fallout from #710's rename.

## Test plan

- [x] Pattern change verified locally against the agent transcript on `25884949755`
- [x] Smoke run on this branch turns the task green — [25885904772](https://github.com/UiPath/skills/actions/runs/25885904772), 6/6 succeeded
- [x] Confirms no other maestro-flow smoke task references the old verb (grep clean on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)