### PR TITLE
fix(uipath-troubleshoot): use namespaced uip maestro CLI in playbooks

### DIFF
--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/argument-mismatch-400.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/argument-mismatch-400.md
@@ -24,9 +24,12 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Pull the inputs sent to the failing activity: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json`
-3. Compare against the activity's argument definitions in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull the inputs sent to the failing activity: `uip maestro <type> instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json`
+3. Compare against the activity's argument definitions in the BPMN: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/expression-evaluation-errors.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/expression-evaluation-errors.md
@@ -29,10 +29,13 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — `errorDetails` includes the full expression
-2. Pull the variables snapshot at the failing element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — confirm whether the referenced variable exists and what's defined
-3. Walk element executions to find an upstream branch that should have initialized the variable: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
-4. Inspect the expression in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — `errorDetails` includes the full expression
+2. Pull the variables snapshot at the failing element: `uip maestro <type> instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — confirm whether the referenced variable exists and what's defined
+3. Walk element executions to find an upstream branch that should have initialized the variable: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
+4. Inspect the expression in the BPMN: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/file-field-required.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/file-field-required.md
@@ -24,9 +24,12 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — incident `elementId` identifies the failing activity
-2. Pull the variables for that element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — confirm the file variable is null
-3. Trace upstream element executions to see where the file should have been produced: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — incident `elementId` identifies the failing activity
+2. Pull the variables for that element: `uip maestro <type> instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — confirm the file variable is null
+3. Trace upstream element executions to see where the file should have been produced: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
 4. If the file came from a previous job, check whether job retention has elapsed (see [attachment-not-found](attachment-not-found.md))
 
 ## Resolution

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/folder-not-accessible.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/folder-not-accessible.md
@@ -26,7 +26,10 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
 2. Verify the folder exists: `uip or folders list --output json` — search by `Key`
 3. List users on that folder: `uip or folders users list <folder-key> --output json` — is the robot account assigned?
 4. Check the underlying bindings — request `bindings_v2.json` (deployed) or `debug_overwrites.json` (debug)

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/foreground-unattended-robot.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/foreground-unattended-robot.md
@@ -24,7 +24,10 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
 2. Confirm the user has Unattended Robot enabled: Orchestrator UI → **Tenant > Manage Access > Users** → select user → license tab
 3. Check that machine credentials are set (domain\username + password)
 4. Confirm the folder type — "My Workspace" cannot host unattended robots

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/gateway-no-outgoing-flow.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/gateway-no-outgoing-flow.md
@@ -24,11 +24,14 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
 2. **If `IncludeGatewayDebugInfoInIncidents` is enabled** ([PO.BpmnEngine PR #3092](https://github.com/UiPath/PO.BpmnEngine/pull/3092)): `errorDetails` already lists each outgoing flow's condition expression, the default flow config, and variable values at evaluation time — no further data gathering needed
-3. **If the flag is not enabled:** pull the BPMN XML to read gateway conditions: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
-4. Pull the variables snapshot just before the gateway element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <gateway-id> --output json`
-5. Walk element executions to confirm which gateway: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+3. **If the flag is not enabled:** pull the BPMN XML to read gateway conditions: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
+4. Pull the variables snapshot just before the gateway element: `uip maestro <type> instance variables <instance-id> -f <folder-key> --parent-element-id <gateway-id> --output json`
+5. Walk element executions to confirm which gateway: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/generic-error-400.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/generic-error-400.md
@@ -25,8 +25,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — capture any HTTP body returned upstream
-2. Pull the activity inputs to see what was actually sent: `uip maestro instance variables <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — capture any HTTP body returned upstream
+2. Pull the activity inputs to see what was actually sent: `uip maestro <type> instance variables <instance-id> -f <folder-key> --output json`
 3. If the failing element is an Action App task with actionable messages enabled, jump straight to the `MST-4535` resolution
 4. For HA setups, request platform logs from the Maestro service — generic 400 here often points to token-signing certificate mismatch across nodes
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/index-out-of-bounds.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/index-out-of-bounds.md
@@ -24,8 +24,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — preserve the full stack trace
-2. Walk element executions: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json` — note the element that faulted
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — preserve the full stack trace
+2. Walk element executions: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json` — note the element that faulted
 3. Check whether the workflow attempted to re-enter a multi-instance subprocess that already completed
 4. If reproducible, gather: Orchestrator URL config, exact `.bpmn`, sample inputs
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/input-schema-mismatch.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/input-schema-mismatch.md
@@ -25,8 +25,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Pull the actual inputs and the schema: `uip maestro instance variables <instance-id> -f <folder-key> --output json` — compare values vs `inputDefinitions`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull the actual inputs and the schema: `uip maestro <type> instance variables <instance-id> -f <folder-key> --output json` — compare values vs `inputDefinitions`
 3. Identify the failing parameter from `errorDetails` — the schema validator names the offending field/type
 4. Check the package version that introduced the breaking change — list releases and diff schemas
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/insufficient-funds.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/insufficient-funds.md
@@ -23,7 +23,10 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — error message is self-explanatory
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — error message is self-explanatory
 2. Confirm the element type: agent/GenAI vs other
 3. Check AU balance: Orchestrator UI → **Admin > Tenant > Licenses > Consumption > Agent Units**
 4. Verify debug-mode behaviour against the latest Maestro release notes — the debug-consumes-AU bug had a planned fix in late Feb / mid-March 2026

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/integration-service-400.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/integration-service-400.md
@@ -25,9 +25,12 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — capture upstream connector error body
-2. Identify the failing connector activity and connection: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
-3. Pull the activity inputs: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — look for empty strings where nulls are expected, missing required fields, or wrong types
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — capture upstream connector error body
+2. Identify the failing connector activity and connection: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
+3. Pull the activity inputs: `uip maestro <type> instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — look for empty strings where nulls are expected, missing required fields, or wrong types
 4. Check the connection's health in Orchestrator UI → **Integration Service > Connections** — re-authenticate if expired
 5. Look up the connector version and compare against the version when the workflow was last published
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/integration-service-404.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/integration-service-404.md
@@ -26,8 +26,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Identify the failing connector activity: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
+2. Identify the failing connector activity: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
 3. Check the IS connection: Orchestrator UI → **Integration Service > Connections** — verify exists, not expired
 4. Confirm IS is enabled on the tenant
 5. For Data Fabric writes, verify the target entity/instance exists in the destination folder and the robot has permission

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/job-operation-timeout.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/job-operation-timeout.md
@@ -23,8 +23,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Pull element executions and capture start/complete times of the timing-out activity: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull element executions and capture start/complete times of the timing-out activity: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
 3. Locate the child Orchestrator job ID from the incident `errorDetails` and check its final state: `uip or jobs get <child-job-key> --output json`
 4. If the child job is `Successful` but Maestro 502'd, the gateway timed out before Orchestrator's response landed
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/loop-detected.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/loop-detected.md
@@ -23,10 +23,13 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — captures element ID and iteration count
-2. Walk element executions to see what each iteration produced: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
-3. Pull the variables snapshot near the loop element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — look for the loop counter / exit condition variable
-4. Read the loop condition from the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — captures element ID and iteration count
+2. Walk element executions to see what each iteration produced: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
+3. Pull the variables snapshot near the loop element: `uip maestro <type> instance variables <instance-id> -f <folder-key> --parent-element-id <element-id> --output json` — look for the loop counter / exit condition variable
+4. Read the loop condition from the BPMN: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/marker-input-null.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/marker-input-null.md
@@ -23,10 +23,13 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Pull variables scoped to the marker element: `uip maestro instance variables <instance-id> -f <folder-key> --parent-element-id <marker-element-id> --output json` — verify the "Items" variable is null
-3. Walk element executions to find the upstream task that was supposed to produce the collection: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
-4. Inspect the marker's "Items" expression in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
+2. Pull variables scoped to the marker element: `uip maestro <type> instance variables <instance-id> -f <folder-key> --parent-element-id <marker-element-id> --output json` — verify the "Items" variable is null
+3. Walk element executions to find the upstream task that was supposed to produce the collection: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
+4. Inspect the marker's "Items" expression in the BPMN: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/marker-invalid-cast.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/marker-invalid-cast.md
@@ -21,8 +21,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — confirm `InvalidCastException` and `ExpressionList`
-2. Check the marker's "Items" expression language in the BPMN: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — confirm `InvalidCastException` and `ExpressionList`
+2. Check the marker's "Items" expression language in the BPMN: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
 
 ## Resolution
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/missing-required-parameter.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/missing-required-parameter.md
@@ -25,9 +25,12 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json` — error message names the missing parameter
-2. Pull the activity inputs: `uip maestro instance variables <instance-id> -f <folder-key> --output json`
-3. Compare to the activity's `inputDefinitions` in the BPMN/`.bpmn` asset: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json` — error message names the missing parameter
+2. Pull the activity inputs: `uip maestro <type> instance variables <instance-id> -f <folder-key> --output json`
+3. Compare to the activity's `inputDefinitions` in the BPMN/`.bpmn` asset: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
 4. Check the Maestro UI for the failing activity — is the missing field even visible? If not, suspect a Maestro frontend bug
 5. Verify the input JSON size — over 10,000 characters indicates truncation
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/no-message-events.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/no-message-events.md
@@ -24,8 +24,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Inspect the BPMN to confirm the Message Start Event configuration: `uip maestro instance asset <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
+2. Inspect the BPMN to confirm the Message Start Event configuration: `uip maestro <type> instance asset <instance-id> -f <folder-key> --output json`
 3. Check the Integration Service connection's health in Orchestrator UI → **Integration Service > Connections**
 4. Trigger a test event from the external system that meets the configured filter; confirm via the connector's event log
 5. If user is in debug, ask whether the same trigger works in the published flow

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/no-suitable-runtime-machine.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/no-suitable-runtime-machine.md
@@ -24,7 +24,10 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
 2. List machines in the folder: `uip or machines list --folder-key <folder-key> --output json` — check runtime slot types
 3. Check tenant runtime license allocation: Orchestrator UI → **Tenant > License Management**
 4. Check the Maestro process's package requirements for the configured runtime type

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/personal-automation-quota.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/personal-automation-quota.md
@@ -22,7 +22,10 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
 2. Confirm error text matches the quota wording above. If error code is `170002`, drill into the child Orchestrator job to see the underlying quota response
 3. Check tenant consumption: Orchestrator UI → **Admin > Tenant > Licenses > Consumption**
 4. If the user is running agents, also confirm Agentic Units are available (separate quota)

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/process-not-found-404.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/process-not-found-404.md
@@ -24,8 +24,11 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
-2. Find the failing service task in element executions: `uip maestro instance element-executions <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
+2. Find the failing service task in element executions: `uip maestro <type> instance element-executions <instance-id> -f <folder-key> --output json`
 3. Pull the binding for the failing task — request `bindings_v2.json` (deployed) or `debug_overwrites.json` (debug) from the user
 4. Look up the `ReleaseKey` in Orchestrator: `uip or releases get <release-key> --folder-key <folder-key> --output json`
 5. Verify the folder key in the binding matches the folder the instance is actually running in

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/unattended-robot-permissions.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/unattended-robot-permissions.md
@@ -23,7 +23,10 @@ What to look for:
 
 ## Investigation
 
-1. Get the incident: `uip maestro instance incidents <instance-id> -f <folder-key> --output json`
+> Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.
+
+
+1. Get the incident: `uip maestro <type> instance incidents <instance-id> -f <folder-key> --output json`
 2. Extract `folderKey` from `errorDetails`
 3. List users assigned to that folder: `uip or folders users list <folder-key> --output json`
 4. Inspect license assignments: Orchestrator UI → **Tenant > Manage Access > Users** for the relevant user


### PR DESCRIPTION
## Summary

22 Maestro playbooks issued `uip maestro instance …` commands that the Maestro overview (`references/products/maestro/overview.md`) explicitly warns are invalid — every operation requires the `bpmn`, `flow`, or `case` segment before `instance` (e.g., `uip maestro bpmn instance incidents …`). Per `agents/shared.md` invariant #5 (No CLI discovery), a tester reading these would refuse to execute the command and the investigation would stall.

**Stacks on #776 (the rename).** Base is `feat/rename-uipath-diagnostics-to-troubleshoot`.

## Changes

- Replaced **50 occurrences** of `uip maestro instance ` with `uip maestro <type> instance ` across **22 playbooks**.
- Prepended a one-line reminder under each affected `## Investigation` heading:

  > Substitute `<type>` with `bpmn`, `flow`, or `case` per the [Maestro investigation guide](../investigation_guide.md) § Determine the Maestro process type.

- `service-task-child-job-faulted.md` was already correctly namespaced — left untouched.

## Files touched (22)

argument-mismatch-400, expression-evaluation-errors, file-field-required, folder-not-accessible, foreground-unattended-robot, gateway-no-outgoing-flow, generic-error-400, index-out-of-bounds, input-schema-mismatch, insufficient-funds, integration-service-400, integration-service-404, job-operation-timeout, loop-detected, marker-input-null, marker-invalid-cast, missing-required-parameter, no-message-events, no-suitable-runtime-machine, personal-automation-quota, process-not-found-404, unattended-robot-permissions.

## Verification

- `grep -rnE "uip maestro instance " skills/uipath-troubleshoot/references/products/maestro/playbooks/` → **0 results**.
- All 50 substitutions visible as `uip maestro <type> instance`.

## Source

Static rubric review of the renamed skill — top priority fix #1 in `skills/uipath-troubleshoot-workspace/REVIEW.md` (overall 3.8/5, Consistency 2/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)