### PR TITLE
fix(uipath-troubleshoot): triage step renumber + Pass-2 high-confidence rule

### DIFF
--- a/skills/uipath-troubleshoot/agents/triage.md
+++ b/skills/uipath-troubleshoot/agents/triage.md
@@ -47,9 +47,9 @@ Goal: get the error message and match playbooks as fast as possible.
 
 Goal: collect richer data for medium/low confidence matching and hypothesis generation.
 
-8. **Deep data gathering** — follow each matched domain's investigation guide "Domain-Specific Data Gathering" section for additional commands beyond the initial fetch (e.g., logs, traces, Healing Agent data, connection pings, element executions). Write each to raw/, write evidence summaries.
-9. **Re-match playbooks** — with the richer data, some high/medium/low playbooks may now match that didn't match on error message alone. Update `state.json.matched_playbooks`.
-10. **Write evidence summary** — consolidate findings from both passes into `triage-initial.json`. Return to orchestrator.
+7. **Deep data gathering** — follow each matched domain's investigation guide "Domain-Specific Data Gathering" section for additional commands beyond the initial fetch (e.g., logs, traces, Healing Agent data, connection pings, element executions). Write each to raw/, write evidence summaries.
+8. **Re-match playbooks** — with the richer data, some high/medium/low playbooks may now match that didn't match on error message alone. Update `state.json.matched_playbooks`. If Pass 2 surfaces a new `high`-confidence playbook, append it to `matched_playbooks` but do NOT return to Pass 1 — continue to the next step.
+9. **Write evidence summary** — consolidate findings from both passes into `triage-initial.json`. Return to orchestrator.
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary

`agents/triage.md` had two related issues:
- Pass 1 ended at step 6, Pass 2 started at step **8** — step 7 was missing.
- Pass 2 did not specify what to do if its re-match surfaced a NEW high-confidence playbook. Re-trigger Pass 1? Continue? Without a rule, the agent could loop or exit prematurely.

**Stacks on #776 (the rename).**

## Changes

`agents/triage.md`:
- Renumbered Pass 2 from `8 / 9 / 10` → `7 / 8 / 9`.
- Appended to step 8 (Re-match playbooks): *"If Pass 2 surfaces a new `high`-confidence playbook, append it to `matched_playbooks` but do NOT return to Pass 1 — continue to the next step."*

## Source

Static rubric review — top priority fix #4 in `skills/uipath-troubleshoot-workspace/REVIEW.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)