### PR TITLE
feat(maestro-case): add SLA identity resolver to Phase 1 planning

### DIFF
--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -2,7 +2,7 @@
 
 Generate reviewable task plan (`tasks.md`) from design document (`sdd.md`). Discovers registry resources, resolves task type IDs, produces declarative specification that downstream execution phases (Phase 2 Prototyping → Phase 3 Implementation → Phase 4 Validate → Phase 5 Debug → Phase 6 Publish) consume via direct JSON writes to `caseplan.json`. See [implementation.md](implementation.md) for execution detail and [phased-execution.md](phased-execution.md) for phase contracts.
 
-> **Output:** `tasks/tasks.md` + `tasks/registry-resolved.json` in the same directory as the sdd.md file.
+> **Output:** `tasks/tasks.md` + `tasks/registry-resolved.json` in the same directory as the sdd.md file. When SLA escalations are present, also `tasks/recipients-resolved.json` — see [`plugins/sla/planning.md` § Identity Resolution](plugins/sla/planning.md#identity-resolution).
 >
 > **Exit gate:** User must explicitly approve `tasks.md` before Phase 2 begins.
 

--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -141,13 +141,13 @@ Emission rules:
 
 ## Unresolved recipients (placeholder-style)
 
-When sdd gives an email but no UUID, emit the recipient with a sentinel `target`:
+Phase 1 runs the identity resolver (see [`planning.md` § Identity Resolution](planning.md#identity-resolution)) and normally writes a UUID into `tasks.md`. When `tasks.md` still carries an `<UNRESOLVED: ...>` sentinel for a recipient (resolver failed, user declined, or sdd input was unresolvable), emit the recipient with a sentinel `target`:
 
 ```json
 { "scope": "User", "target": "<UNRESOLVED: user-uuid for manager@corp.com>", "value": "manager@corp.com" }
 ```
 
-List every unresolved recipient in the completion report (per SKILL.md § Completion Output step 4) so the user can patch externally. Do not call an identity service from the JSON path — that capability is out of scope for this milestone.
+List every unresolved recipient in the completion report (per SKILL.md § Completion Output step 4) so the user can patch externally. Do not call an identity service from the JSON path — resolution is Phase 1's responsibility; Phase 3 just transcribes whatever `tasks.md` carries.
 
 ## Expression translation
 

--- a/skills/uipath-maestro-case/references/plugins/sla/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/planning.md
@@ -58,11 +58,74 @@ Rules are evaluated in insertion order — first truthy expression wins. The def
 | `trigger-type` | sdd.md | `at-risk` \| `sla-breached` |
 | `at-risk-percentage` | sdd.md | Required when `trigger-type: at-risk` (1–99) |
 | `recipient-scope` | sdd.md | `User` \| `UserGroup` |
-| `recipient-target` | sdd.md | Recipient UUID. Mark `<UNRESOLVED: user-uuid for <email>>` / `<UNRESOLVED: group-uuid for <name>>` when sdd gives an email / group name but no UUID. |
+| `recipient-target` | sdd.md → resolver | Recipient UUID. When sdd gives an email or group name, run [§ Identity Resolution](#identity-resolution) — resolved UUID written inline. On resolver failure or user decline, mark `<UNRESOLVED: user-uuid for <email>>` / `<UNRESOLVED: group-uuid for <name>>`. |
 | `recipient-value` | sdd.md | Display value (typically the email for User, group name for UserGroup). |
 | `display-name` | sdd.md (optional) | |
 | `target` | sdd.md target (root vs stage) | `"root"` or `"<stage-name>"` |
 | `attach-to` | sdd.md | `default` (attach to the `=js:true` rule) or `T<m>` pointing to the conditional-rule T-entry the escalation fires under. |
+
+## Identity Resolution
+
+When sdd gives an escalation recipient as an email (`User: manager@corp.com`) or group name (`UserGroup: "Order Management Team"`), resolve to a directory UUID via `uip admin` while authoring the T-entry. Resolved UUIDs land inline in `tasks.md`; [`impl-json.md`](impl-json.md) writes them straight into `escalationRule[].action.recipients[].target` — no sentinel needed. Resolution runs **Phase 1 only** — Phase 0 still records email / group name as a string in sdd.md.
+
+### Skip — UUID pass-through
+
+Recipient value already matches `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$` → skip CLI. Write `<uuid> / <uuid>` in tasks.md. Audit rationale: `uuid-pass-through`.
+
+### Resolve `User`
+
+1. `uip admin users list --search "<email>" --output json`
+2. **Auto-accept** when response has exactly 1 entry AND `entry.email` equals sdd's email case-insensitively. Write `User: <id> / <email>`. Rationale: `auto-exact-email`.
+3. **Fallback** on any other shape (0, >1, partial). If sdd carries a display name, retry `--search "<display-name>"`. Merge results, dedupe by `id`.
+4. **Ask** via AskUserQuestion with up to 3 candidates. Each option: label `<displayName>`, description `<email> · id=<uuid-first-8>...`. Final option: `Keep as <UNRESOLVED>`. Rationale: `user-picked-from-N` or `user-declined-keep-unresolved`.
+
+### Resolve `UserGroup`
+
+`uip admin groups list` has **no `--search` flag**. Filter client-side.
+
+1. **Pull once.** First group lookup in the planning session: `uip admin groups list --output json`. Cache the array in memory for the rest of Phase 1.
+2. **Exact match** — entries where `name` OR `displayName` equals sdd's group name case-insensitively. Exactly 1 match → write `UserGroup: <id> / "<group-name>"`. Rationale: `auto-exact-name`.
+3. **Substring fallback** — case-insensitive substring on `name` / `displayName`. Any hits → AskUserQuestion with top 3 (alphabetical by `name`) + `Keep as <UNRESOLVED>`.
+4. **Empty** — both filters return 0 → AskUserQuestion with closest fuzzy candidates or `Keep as <UNRESOLVED>`.
+
+### Session cache
+
+In-memory, scoped to the Phase 1 run. Key: lowercased sdd input. **Positive resolutions only** — auto-accept results and user-picked UUIDs. Do NOT cache `Keep as <UNRESOLVED>` decisions; same recipient appearing in a later T-entry re-asks.
+
+### CLI failure (auth / network / 403)
+
+Non-zero exit from `uip admin ...` → AskUserQuestion:
+
+```
+Question: Identity resolution failed (<stderr first line>). How should we proceed?
+Header:   Resolver failed
+Options:
+  - Retry
+      → re-run the same `uip admin ...`. Continue on success.
+  - Skip resolution for this build
+      → leave every recipient as <UNRESOLVED: ...>, log to tasks/build-issues.md, surface in completion report. Subsequent recipient lookups in this Phase 1 skip the CLI.
+  - Abort planning
+      → halt Phase 1.
+```
+
+### Audit — `tasks/recipients-resolved.json`
+
+Append one object per resolution attempt (incremental Edit, mirroring `registry-resolved.json` discipline):
+
+```json
+{
+  "sddInput": "manager@corp.com",
+  "kind": "user",
+  "searchTerm": "manager@corp.com",
+  "allCandidates": [
+    {"id": "a1b2c3d4-0000-0000-0000-000000000000", "email": "manager@corp.com", "displayName": "Anne Manager"}
+  ],
+  "selected": "a1b2c3d4-0000-0000-0000-000000000000",
+  "rationale": "auto-exact-email"
+}
+```
+
+Rationale values: `auto-exact-email`, `auto-exact-name`, `user-picked-from-N`, `user-declined-keep-unresolved`, `uuid-pass-through`, `cli-failed-skipped`.
 
 ## Ordering
 
@@ -105,14 +168,14 @@ SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each t
 - trigger-type: at-risk
 - at-risk-percentage: 80
 - recipients:
-  - User: <UNRESOLVED: user-uuid for manager@corp.com> / manager@corp.com
+  - User: a1b2c3d4-0000-0000-0000-000000000000 / manager@corp.com
   - UserGroup: <UNRESOLVED: group-uuid for "Order Management Team"> / "Order Management Team"
 - display-name: "Notify Manager"
 - order: after T<m>
 - verify: Confirm Result: Success, capture EscalationRuleId
 ```
 
-**Recipient format:** `<target> / <value>` where `<target>` is the UUID (or `<UNRESOLVED: …>` sentinel when sdd only has an email / group name) and `<value>` is the display string. Placeholder recipients stay in `tasks.md` through execution; the user patches the UUID externally after the build and the completion report lists every unresolved recipient.
+**Recipient format:** `<target> / <value>` where `<target>` is the resolved UUID (per [§ Identity Resolution](#identity-resolution)) — or `<UNRESOLVED: …>` sentinel when the resolver failed or the user declined — and `<value>` is the display string. Unresolved recipients survive into execution; the user patches the UUID externally after the build and the completion report lists every unresolved recipient.
 
 **`attach-to: default`** is the default. Use `T<m>` when sdd.md attaches an escalation to a specific conditional SLA rule.
 
@@ -121,3 +184,6 @@ SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each t
 - **Do not fabricate expression syntax.** Describe conditional SLA rules in natural language during planning; the execution phase handles the exact syntax.
 - **Do not put conditional SLA rules on stages.** Conditional SLA rules live in the root SLA rules array only (v19: `root.data.slaRules[]`; v20: `metadata.slaRules[]`). Flag to the user if the sdd.md describes a per-stage conditional SLA.
 - **Do not invert rule order.** Conditional rules are evaluated in insertion order — insert them in the priority order the sdd.md specifies.
+- **Do not skip the resolver to save a CLI call.** Email / group-name recipients MUST go through [§ Identity Resolution](#identity-resolution). Writing `<UNRESOLVED: ...>` directly without attempting `uip admin users/groups list` is a planning bug.
+- **Do not fabricate UUIDs.** When the resolver returns 0 / multi / partial matches, AskUserQuestion or keep `<UNRESOLVED>` — never guess a UUID, never auto-pick the first candidate without the exact-email / exact-name gate.
+- **Do not cache user declines.** Session cache holds positive resolutions only. Re-ask on each T-entry occurrence of the same unresolved recipient.

--- a/skills/uipath-maestro-case/references/plugins/sla/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/planning.md
@@ -86,7 +86,7 @@ Recipient value already matches `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4
 1. **Pull once.** First group lookup in the planning session: `uip admin groups list --output json`. Cache the array in memory for the rest of Phase 1.
 2. **Exact match** — entries where `name` OR `displayName` equals sdd's group name case-insensitively. Exactly 1 match → write `UserGroup: <id> / "<group-name>"`. Rationale: `auto-exact-name`.
 3. **Substring fallback** — case-insensitive substring on `name` / `displayName`. Any hits → AskUserQuestion with top 3 (alphabetical by `name`) + `Keep as <UNRESOLVED>`.
-4. **Empty** — both filters return 0 → AskUserQuestion with closest fuzzy candidates or `Keep as <UNRESOLVED>`.
+4. **Empty** — both filters return 0 → AskUserQuestion: `No matching group found for "<group-name>". Keep as <UNRESOLVED>?` with a single `Keep as <UNRESOLVED>` option. Do NOT fabricate "fuzzy candidates"; the user patches the UUID externally per the standard decline path. Rationale: `user-declined-keep-unresolved`.
 
 ### Session cache
 
@@ -100,8 +100,8 @@ Non-zero exit from `uip admin ...` → AskUserQuestion:
 Question: Identity resolution failed (<stderr first line>). How should we proceed?
 Header:   Resolver failed
 Options:
-  - Retry
-      → re-run the same `uip admin ...`. Continue on success.
+  - Retry (max 2 attempts)
+      → re-run the same `uip admin ...`. Continue on success. After 2 failed retries the resolver auto-routes to "Skip resolution for this build" — do not loop further.
   - Skip resolution for this build
       → leave every recipient as <UNRESOLVED: ...>, log to tasks/build-issues.md, surface in completion report. Subsequent recipient lookups in this Phase 1 skip the CLI.
   - Abort planning


### PR DESCRIPTION
## Summary

- Adds an identity-resolver workflow to `plugins/sla/planning.md` that turns sdd.md emails / group names into directory UUIDs via `uip admin users list --search` and `uip admin groups list` (no `--search` on groups — pulled once per session and filtered client-side).
- Resolved UUIDs now land inline in `tasks.md` as `User: <uuid> / <email>` and `UserGroup: <uuid> / "<group-name>"`, so `impl-json.md` consumes them directly instead of relying on `<UNRESOLVED: ...>` sentinels. The sentinel path remains as the explicit fallback for resolver failures and user declines.
- Adds a new conditional Phase 1 artifact `tasks/recipients-resolved.json` (search query, all candidates, selected, rationale) mirroring the existing `registry-resolved.json` discipline.

## Design decisions (captured during /grill-me)

- **Scope:** SLA escalation recipients only. Action-task `data.recipient` keeps its current `<UNRESOLVED>` flow — out of scope this iteration.
- **Phase split:** Phase 0 stays CLI-free (still records email / group name as a string in sdd.md). Phase 1's SLA plugin owns all resolution.
- **Timing:** Inline at each escalation T-entry, with an in-session positive-resolution cache. Declines are NOT cached — same recipient appearing in a later T-entry re-asks.
- **User auto-accept gate:** Exactly 1 search result AND `entry.email` matches sdd's email case-insensitively. Anything else routes through AskUserQuestion (top 3 candidates + "Keep as `<UNRESOLVED>`").
- **Group lookup:** Pull-once-per-session, then tiered client filter — exact name/displayName → substring → empty. Auto-accept only on single exact match.
- **CLI failure:** AskUserQuestion (Retry / Skip resolution for this build / Abort planning). Skip leaves every recipient as `<UNRESOLVED>` and logs to `tasks/build-issues.md`.
- **Skip rule:** UUID-shaped inputs pass through without a CLI call.

## Files touched

- `skills/uipath-maestro-case/references/plugins/sla/planning.md` — new `Identity Resolution` section, updated `recipient-target` row, updated tasks.md Entry Format example + Recipient format paragraph, 3 new anti-patterns.
- `skills/uipath-maestro-case/references/plugins/sla/impl-json.md` — clarifies that `<UNRESOLVED>` sentinel is now strictly a fallback emitted only when `tasks.md` still carries the marker.
- `skills/uipath-maestro-case/references/planning.md` — Output line now mentions the conditional `tasks/recipients-resolved.json` artifact.

## Test plan

- [ ] Plan a case whose sdd.md has an escalation with a known directory email — confirm Phase 1 auto-resolves on exact email match and writes `User: <uuid> / <email>` in `tasks.md`, with the search recorded in `tasks/recipients-resolved.json`.
- [ ] Plan a case whose sdd.md uses a display name with multiple directory matches — confirm AskUserQuestion fires with top-3 candidates + "Keep as `<UNRESOLVED>`".
- [ ] Plan a case with a group recipient — confirm `uip admin groups list` is called once per session and client-side exact / substring tiers route correctly.
- [ ] Force `uip admin users list` to fail (logged-out CLI) — confirm Retry / Skip / Abort prompt fires and Skip leaves every recipient as `<UNRESOLVED>`.
- [ ] Re-run Phase 1 with a UUID already in `tasks.md` — confirm the UUID-shaped pass-through skip rule fires without a CLI call.
- [ ] Phase 3 implementation phase consumes a resolved `User: <uuid> / <email>` line — confirm `escalationRule[].action.recipients[].target` carries the UUID, not a sentinel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)