### PR TITLE
MST-9863: fix maestro-flow drifted task criteria

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -43,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created a solution"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+solution\s+new'
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+solution\s+(new|init)'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/hitl/check_brownfield_insert.py
+++ b/tests/tasks/uipath-maestro-flow/hitl/check_brownfield_insert.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Brownfield HITL insert: validate the flow and insertion invariants."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    sys.exit(f"FAIL: {message}")
+
+
+def find_flow() -> Path:
+    matches = sorted(Path.cwd().glob("**/ContractReview.flow"))
+    if not matches:
+        fail(f"No ContractReview.flow found under {Path.cwd()}")
+    if len(matches) > 1:
+        joined = "\n  - ".join(str(path) for path in matches)
+        fail(
+            "Multiple ContractReview.flow files found; refusing to guess:"
+            f"\n  - {joined}"
+        )
+    return matches[0]
+
+
+def validate_flow(path: Path) -> None:
+    result = subprocess.run(
+        ["uip", "maestro", "flow", "validate", str(path), "--output", "json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        fail(
+            f"uip maestro flow validate failed for {path}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+
+def load_flow(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"{path} is not valid JSON: {exc}")
+
+
+def has_edge(
+    edges: list[dict],
+    source: str,
+    target: str,
+    source_ports: set[str] | None = None,
+) -> bool:
+    for edge in edges:
+        if edge.get("sourceNodeId") != source or edge.get("targetNodeId") != target:
+            continue
+        if source_ports is None or edge.get("sourcePort") in source_ports:
+            return True
+    return False
+
+
+def main() -> None:
+    path = find_flow()
+    validate_flow(path)
+    flow = load_flow(path)
+
+    nodes = flow.get("nodes")
+    edges = flow.get("edges")
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        fail("Flow must contain nodes[] and edges[]")
+
+    nodes_by_id = {node.get("id"): node for node in nodes if node.get("id")}
+    if "extractMeta" not in nodes_by_id:
+        fail("Original script node 'extractMeta' is missing")
+    if "end" not in nodes_by_id:
+        fail("End node 'end' is missing")
+
+    hitl_nodes = [
+        node for node in nodes if node.get("type") == "uipath.human-in-the-loop"
+    ]
+    if len(hitl_nodes) != 1:
+        fail(
+            "Expected exactly one uipath.human-in-the-loop node, "
+            f"found {len(hitl_nodes)}"
+        )
+    hitl = hitl_nodes[0]
+    hitl_id = hitl.get("id")
+    if not hitl_id:
+        fail("HITL node is missing id")
+
+    if has_edge(edges, "extractMeta", "end"):
+        fail("Original extractMeta -> End edge must be removed")
+    if not has_edge(edges, "extractMeta", hitl_id, {"output", "success"}):
+        fail("extractMeta must be wired into the inserted HITL node")
+    if not has_edge(edges, hitl_id, "end", {"completed"}):
+        fail("HITL completed handle must be wired to End")
+
+    schema = hitl.get("inputs", {}).get("schema", {})
+    fields = schema.get("fields")
+    if not isinstance(fields, list) or not fields:
+        fail("HITL schema must define fields")
+    if not any(
+        field.get("direction") in {"output", "inOut"} and field.get("type") == "boolean"
+        for field in fields
+    ):
+        fail("HITL schema must include a boolean reviewer output field")
+
+    print(
+        "OK: ContractReview.flow validates and preserves extractMeta -> HITL "
+        "-> completed -> End with a boolean reviewer output"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
@@ -41,42 +41,9 @@ initial_prompt: |
 
 success_criteria:
   - type: run_command
-    description: "uip maestro flow validate passes after brownfield insert"
-    command: "uip maestro flow validate ContractReview/ContractReview/ContractReview.flow --output json"
+    description: "Flow validates and preserves brownfield HITL insertion invariants"
+    command: "python3 $TASK_DIR/check_brownfield_insert.py"
     timeout: 30
     expected_exit_code: 0
-    weight: 3.0
+    weight: 10.5
     pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Flow contains the original script node"
-    path: "ContractReview/ContractReview/ContractReview.flow"
-    includes:
-      - '"extractMeta"'
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Flow contains the inserted HITL node"
-    path: "ContractReview/ContractReview/ContractReview.flow"
-    includes:
-      - '"uipath.human-in-the-loop"'
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "HITL completed handle is wired"
-    path: "ContractReview/ContractReview/ContractReview.flow"
-    includes:
-      - '"completed"'
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "HITL has a boolean output field for the approval decision"
-    path: "ContractReview/ContractReview/ContractReview.flow"
-    includes:
-      - '"boolean"'
-    weight: 1.5
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/check_switch_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/check_switch_flow.py
@@ -19,9 +19,10 @@ def main():
 
     project_dir = find_project_dir()
     in_vars = read_flow_input_vars(project_dir)
+    if not in_vars:
+        sys.exit("FAIL: No input variable found for quarter")
 
-    inputs = {in_vars[0]: 2} if in_vars else None
-    payload = run_debug(inputs=inputs)
+    payload = run_debug(inputs={in_vars[0]: 2})
 
     # Quarter 2 -> "Summer"
     assert_outputs_contain(payload, "summer")

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -25,6 +25,9 @@ initial_prompt: |
     - 3 -> "Fall"
     - 4 -> "Winter"
 
+  Declare a numeric flow-level input variable named "quarter" and use that
+  variable in the Switch case expressions.
+
   The flow should branch into separate cases for each quarter value.
 
   Validate the flow.


### PR DESCRIPTION
## Summary

- Accept `uip solution init` for the DevCon expense approval solution creation criterion.
- Replace the brownfield HITL fixed-path checks with a semantic checker that locates `ContractReview.flow`, validates it, and verifies insertion invariants.
- Make the switch task require an explicit numeric `quarter` input and fail early when it is missing.

## Run evidence

Latest e2e run `2026-05-15_07-29-17` showed false/task-spec failures for `skill-flow-e2e-devcon-expense-approval`, `skill-flow-hitl-quality-brownfield-insert`, and `skill-flow-switch`.

Jira: https://uipath.atlassian.net/browse/MST-9863

## Verification

- TaskDefinition YAML validation for the edited task YAMLs.
- Python compile for `check_brownfield_insert.py` and `check_switch_flow.py`.
- `git diff --check`.
- Verified the new DevCon command regex matches `uip solution init ExpenseApproval --output json`.
- Ran `check_brownfield_insert.py` against the captured `ContractReview.flow` from run `2026-05-15_07-29-17`.
