### PR TITLE
MST-9510: clarify Slack weather HTTP output paths

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -21,6 +21,14 @@ sandbox:
 initial_prompt: |
   Create a flow called "SlackWeatherPipeline". Read the #office-bellevue Slack channel description to find out which city the office is in, then fetch the current weather for that city from open-meteo. If it's above 60F output 'warm office today', otherwise 'cold office today'.
 
+  The Slack channel description is an office address; normalize it to the city
+  name "Bellevue" before calling the geocoding API. When chaining HTTP action
+  results, read response JSON from `.output.body`; for example, use
+  `$vars.geocodeCity.output.body.results[0].latitude` and
+  `$vars.geocodeCity.output.body.results[0].longitude` for the weather request,
+  and use `$vars.fetchWeather.output.body.current.temperature_2m` for the
+  temperature decision.
+
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.


### PR DESCRIPTION
## Summary

- Clarify that the Slack office topic should be normalized to Bellevue before geocoding.
- Document the `.output.body` paths for chaining geocode and weather HTTP responses.

## Run evidence

Latest e2e run `2026-05-15_07-29-17` showed `skill-flow-slack-weather-pipeline` now reaches Slack and geocoding, but the generated weather request used `$vars.geocodeCity.output.results[0]...` instead of `$vars.geocodeCity.output.body.results[0]...`.

Jira: https://uipath.atlassian.net/browse/MST-9510

## Verification

- TaskDefinition YAML validation for the edited task YAML.
- `git diff --check`.
