### PR TITLE
fix(activation-gate): honor DROP_PP tolerance on task-level failures [PILOT-5233]

### DIFF
--- a/tests/scripts/activation_gate.py
+++ b/tests/scripts/activation_gate.py
@@ -107,16 +107,21 @@ def main() -> int:
             ],
             cwd=repo_root, check=False,
         )
-        if result.returncode != 0:
-            print(
-                f"ERROR: coder-eval exited with code {result.returncode}",
-                file=sys.stderr,
-            )
-            return 2
 
+        # coder-eval returns non-zero whenever any prompt fails its criterion
+        # (a wrong-skill activation, a MAX_TURNS_EXHAUSTED, etc.). That is
+        # exactly the signal the recall threshold is designed to tolerate —
+        # the gate must compute recall from suite.json and compare against
+        # baseline-DROP_PP rather than treating any task-level failure as a
+        # gate failure. Only fall back to "infra failure" exit when no
+        # suite.json was produced (coder-eval crashed before writing it).
         suite_json = run_dir / "default" / f"skill-activation-gate-{skill}" / "suite.json"
         if not suite_json.is_file():
-            print(f"ERROR: {suite_json} missing", file=sys.stderr)
+            print(
+                f"ERROR: coder-eval exited with code {result.returncode} "
+                f"and {suite_json} was not produced",
+                file=sys.stderr,
+            )
             return 2
 
         data = json.loads(suite_json.read_text(encoding="utf-8"))


### PR DESCRIPTION
**Jira:** [PILOT-5233](https://uipath.atlassian.net/browse/PILOT-5233)

## Summary

`tests/scripts/activation_gate.py` aborts the moment `coder-eval` returns a non-zero exit — which happens for any individual prompt that misses its criterion (wrong-skill activation, `MAX_TURNS_EXHAUSTED`, …). The gate was never reading `suite.json` to compute recall, so the `DROP_PP=15` tolerance has never actually been exercised in CI. On any 100+ prompt dataset, the probability of zero failures is ~0, so the gate fails regardless of actual recall.

## Fix

Drop the early-abort. Always read `suite.json` when it exists. Only treat the run as an infra failure when no `suite.json` was produced (coder-eval crashed before writing it).

## Repro / context

Observed on [PILOT-5232](https://uipath.atlassian.net/browse/PILOT-5232) / #795, which expanded `uipath-rpa` from 52 to 103 activation prompts after merging `uipath-rpa-legacy`:

- 96–98% recall measured across runs (well above the 55% threshold).
- Gate failed every time because 2–4 prompts hit `MAX_TURNS_EXHAUSTED` and coder-eval exited 1.
- The last successful `uipath-rpa` gate run (commit `dd5c0e4`) had 0 failures across 52 prompts; that's what masked the bug until now.

## Test plan

- [ ] Manual: re-run the gate against the merged 103-prompt `uipath-rpa.jsonl` (cherry-pick from #795). Expect PASS with recall ~95–98% against the 55% threshold.
- [ ] Regression: confirm recall below threshold still emits `::error::` and exits 1.
- [ ] Infra failure: confirm a crashed coder-eval (no `suite.json`) still exits 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PILOT-5233]: https://uipath.atlassian.net/browse/PILOT-5233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PILOT-5232]: https://uipath.atlassian.net/browse/PILOT-5232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ