### PR TITLE
docs(uipath-maestro-flow): extract shared action-node structure

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
@@ -6,13 +6,13 @@
 
 > **Always use `core.action.http.v2`** for all HTTP requests. The older `core.action.http` (v1) is deprecated.
 
-## Registry Validation
+## Registry validation
 
 ```bash
 uip maestro flow registry get core.action.http.v2 --output json
 ```
 
-Confirm in `Data.Node.handleConfiguration`: target port `input`, source ports `branch-{item.id}` (dynamic, `repeat: inputs.branches`) and `default`. Also confirm `Data.Node.supportsErrorHandling: true` — HTTP v2 participates in the shared implicit `error` port pattern used by all action nodes. See [Implicit error port on action nodes](../../../../shared/file-format.md#implicit-error-port-on-action-nodes). Model serviceType is `Intsvc.UnifiedHttpRequest`.
+Confirm in `Data.Node.handleConfiguration`: target port `input`, source ports `branch-{item.id}` (dynamic, `repeat: inputs.branches`) and `default`. Also confirm `Data.Node.supportsErrorHandling: true` — HTTP v2 participates in the implicit `error` port pattern shared by every action node (see [Action Node Structure](../../../../shared/action-nodes.md)). Model `serviceType` is `Intsvc.UnifiedHttpRequest`.
 
 ## Critical: Use `node configure`
 
@@ -24,31 +24,7 @@ Confirm in `Data.Node.handleConfiguration`: target port `input`, source ports `b
 
 Use `Edit` / `Write` to add the `core.action.http.v2` node directly to the `.flow` file. Follow [Edit/Write: Add a node](../../editing-operations-json.md#add-a-node): copy the registry definition into `definitions[]`, add the node instance to `nodes[]`, add `variables.nodes`, and add a placeholder `layout.nodes` entry. Save the node ID for Step 3.
 
-Minimum node instance shape:
-
-```json
-{
-  "id": "<nodeId>",
-  "type": "core.action.http.v2",
-  "typeVersion": "2.0",
-  "display": { "label": "<Label>" },
-  "inputs": {},
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the HTTP request.",
-      "source": "=result.response",
-      "var": "output"
-    },
-    "error": {
-      "type": "object",
-      "description": "Error information if the HTTP request fails.",
-      "source": "=result.Error",
-      "var": "error"
-    }
-  }
-}
-```
+For the node instance shape, follow the [Action Node Structure — Standard JSON skeleton](../../../../shared/action-nodes.md#standard-json-skeleton) with `type: "core.action.http.v2"` and `typeVersion: "2.0"`. Leave `inputs` empty at this stage — Step 3 populates `inputs.detail` via `uip maestro flow node configure`.
 
 ### Step 2 — Identify target connector and connection (connector mode only)
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
@@ -4,56 +4,40 @@
 
 `core.action.script`
 
-## Registry Validation
+## Registry validation
 
 ```bash
 uip maestro flow registry get core.action.script --output json
 ```
 
-Confirm: input port `input`, output port `success`, required input `script` (string, non-empty).
+Confirm: input port `input`, output port `success`, required input `script` (string, non-empty). See [Action Node Structure — Registry validation](../../../../shared/action-nodes.md#registry-validation) for the shared pattern.
 
-## JSON Structure
+## JSON structure
+
+Follow the [Action Node Structure — Standard JSON skeleton](../../../../shared/action-nodes.md#standard-json-skeleton). The script-specific input is a single `script` string:
 
 ```json
 {
-  "id": "processData",
-  "type": "core.action.script",
-  "typeVersion": "1.0",
-  "display": { "label": "Process Data" },
   "inputs": {
     "script": "const items = $vars.fetchData.output.body.items;\nconst total = items.reduce((sum, i) => sum + i.amount, 0);\nreturn { total, count: items.length };"
-  },
-  "outputs": {
-    "output": {
-      "type": "object",
-      "description": "The return value of the script",
-      "source": "=result.response",
-      "var": "output"
-    },
-    "error": {
-      "type": "object",
-      "description": "Error information if the script fails",
-      "source": "=result.Error",
-      "var": "error"
-    }
   }
 }
 ```
 
-## Adding / Editing
+## Adding and editing
 
-For step-by-step add, delete, and wiring procedures, see [editing-operations.md](../../editing-operations.md). Use the JSON structure above for the node-specific `inputs`.
+See [Action Node Structure — Adding and editing procedures](../../../../shared/action-nodes.md#adding-and-editing-procedures). The script node uses the standard input port `input` and output port `success`; no plugin-specific wiring.
 
-## Script Rules
+## Script rules
 
 1. **Must `return` an object** — `return { key: value }`, not a bare scalar. The return value becomes `$vars.{nodeId}.output`.
 2. **`$vars` is a global** — use it directly: `return { upper: $vars.input1.toUpperCase() }`
-3. **JavaScript ES2020 (Jint engine)** — see [variables-and-expressions.md](../../../../shared/variables-and-expressions.md) for supported features and Jint constraints
+3. **JavaScript ES2020 (Jint engine)** — see [variables-and-expressions.md](../../../../shared/variables-and-expressions.md) for supported features and Jint constraints.
 4. **No `console.log`** — `console` is not available. Use `return { debug: value }` to inspect values.
-5. **No external calls** — use HTTP node or connector nodes for API calls
-6. **30-second timeout** — long-running computations will be killed
+5. **No external calls** — use the HTTP node or a connector node for API calls.
+6. **30-second timeout** — long-running computations will be killed.
 
-## Common Patterns
+## Common patterns
 
 ### Transform and return
 

--- a/skills/uipath-maestro-flow/references/shared/action-nodes.md
+++ b/skills/uipath-maestro-flow/references/shared/action-nodes.md
@@ -1,0 +1,64 @@
+# Action Node Structure
+
+Reference for the boilerplate shared by every action-node `impl.md` in this skill. Plugin docs should link here for the standard parts and only spell out what is plugin-specific: the registry type string, plugin-specific input fields, plugin-specific rules, debug entries, and node-type configuration workflows.
+
+## Registry validation
+
+Every action node should validate its registry contract before authoring:
+
+```bash
+uip maestro flow registry get <node-type> --output json
+```
+
+Inspect `Data.Node.handleConfiguration` for the input port name, output port name(s), required inputs, and (where applicable) the model `serviceType`. Plugin `impl.md` records what to confirm for that specific node type.
+
+## Standard JSON skeleton
+
+All action nodes share this base shape on the node instance:
+
+```json
+{
+  "id": "<nodeId>",
+  "type": "<node-type>",
+  "typeVersion": "<version>",
+  "display": { "label": "<Label>" },
+  "inputs": { /* plugin-specific — see plugin impl.md */ },
+  "outputs": {
+    "output": {
+      "type": "object",
+      "description": "<plugin-specific description>",
+      "source": "=result.response",
+      "var": "output"
+    },
+    "error": {
+      "type": "object",
+      "description": "Error information if the action fails.",
+      "source": "=result.Error",
+      "var": "error"
+    }
+  }
+}
+```
+
+`outputs.output` carries the success payload, referenced downstream as `=js:$vars.{nodeId}.output`. `outputs.error` carries failure info; the runtime routes to the implicit `error` port when the action faults. See [Implicit error port on action nodes](file-format.md#implicit-error-port-on-action-nodes).
+
+## Standard ports
+
+| Direction | Common name(s) | Notes |
+| --- | --- | --- |
+| Input (target) | `input` | Every action node accepts a single input edge on `input`. |
+| Output (success, source) | `output`, `default`, or `success` | Name varies by plugin — `registry get` is authoritative. |
+| Output (error, source) | `error` | Implicit on every action node via `outputs.error`. |
+
+Some plugins add dynamic source ports (e.g., HTTP `branch-{id}` from `inputs.branches`); those are documented in the plugin's own `impl.md`.
+
+## Adding and editing procedures
+
+For step-by-step add, delete, and wiring instructions, see [editing-operations.md](../author/references/editing-operations.md) and the JSON recipes in [editing-operations-json.md](../author/references/editing-operations-json.md). Plugin `impl.md` files describe only the inputs and wiring patterns that are specific to the node type.
+
+## Migrating a plugin to reference this template
+
+When converting an existing plugin `impl.md` to use this template:
+
+- **Keep in the plugin:** registry type string, `typeVersion`, plugin-specific input fields, plugin-specific configuration workflow (e.g., `node configure` for HTTP/connector nodes), plugin-specific rules, common patterns, debug table.
+- **Replace with a link here:** generic JSON skeleton, generic `outputs` block (`=result.response` / `=result.Error`), generic registry-validation prose, generic "Adding / Editing" cross-reference.


### PR DESCRIPTION
> ⚠️ For discussion — do not merge until ready. This is the first of six proposed PRs from a review of `uipath-maestro-flow`. Each is small and independent. Critique scope, framing, and content before merge.

## The problem

Coding agents using `uipath-maestro-flow` load more context than any single task requires, and a measurable share of that load is content the agent has already read upstream. Measured against `main`:

- 78 markdown files, 12,376 lines in the skill.
- A typical "build a flow with a trigger and an action node" task loads ~2,400 cumulative lines across ~10 files before the agent can act.
- The 24 plugin folders each pair a `planning.md` with an `impl.md`. The ~15 action-node `impl.md` files repeat the same boilerplate per node:
  - The standard node JSON skeleton (`id` / `type` / `typeVersion` / `display` / `inputs` / `outputs`).
  - The standard `outputs` block with `"source": "=result.response"` and `"source": "=result.Error"` — identical across all action nodes.
  - The Registry-Validation pattern (`uip maestro flow registry get <type>`).
  - The Adding / Editing cross-reference to `editing-operations.md`.

Across the action-node `impl.md` files, that boilerplate accounts for roughly 200–300 lines of repetition. The agent re-reads it for every plugin it touches.

## Why this fix

1. One canonical doc — `references/shared/action-nodes.md` — owns the standard JSON skeleton, the standard `outputs` block, the registry-validation pattern, and the Adding/Editing cross-reference.
2. Demonstrated on two plugins of different sizes. `script/impl.md` is small (96 lines) and `http/impl.md` is the largest action-node impl (221 lines). Migrating both shows the template works at both ends.
3. Other action-node plugins (rpa, connector, queue, transform, loop, delay, summarize, batch-transform, hitl, etc.) deliberately left out so this PR stays a reviewable proof-of-concept. If the template shape is agreed, the remaining migrations are mechanical and ship as follow-up PRs.

## Files changed

| File | Before | After | Δ |
|---|---|---|---|
| `references/shared/action-nodes.md` (new) | — | 64 | +64 |
| `plugins/script/impl.md` | 96 | 79 | −17 |
| `plugins/http/impl.md` | 221 | 196 | −25 |
| Total | 317 | 339 | +22 |

This PR alone is net +22 lines — the new template adds 64 lines but the two migrations only save 42 lines combined. The real reduction lands once the pattern is applied to the remaining ~13 action-node plugins; each subsequent migration is expected to save ~20–40 lines with no new template overhead.

## Validation

- `.maintenance/check-orphans.sh`: clean. The new template is reachable from both migrated plugins.
- `.maintenance/check-links.sh` and `check-anchors.sh`: no new failures introduced. Existing failures in `summarize/impl.md`, `agent/{planning,impl}.md`, `batch-transform/impl.md`, `editing-operations-json.md`, and `evaluate/CAPABILITY.md` are pre-existing on `main` and unrelated to this change.
- Both migrated plugins retain every node-specific rule, pattern, and debug entry from the originals.

## Out of scope for this PR

- Migration of the remaining ~13 action-node plugins (follow-up PRs).
- ToCs on `variables-and-expressions.md` and `file-format.md` (separate PR).
- Compression of `author/CAPABILITY.md` (separate PR).
- `=js:` rule consolidation (separate PR).
- Shared connection-binding doc for connector/connector-trigger/http (separate PR).
- A "Common tasks" master index (separate PR).