### PR TITLE
docs(uipath-maestro-flow): add table of contents to two large shared docs

### DIFF
--- a/skills/uipath-maestro-flow/references/shared/file-format.md
+++ b/skills/uipath-maestro-flow/references/shared/file-format.md
@@ -2,6 +2,22 @@
 
 The `.flow` file is a JSON document at `<ProjectName>.flow` in the project root. It is the **only file you should edit** — other generated files will be overwritten.
 
+## Table of contents
+
+- [Top-level structure](#top-level-structure)
+- [Project structure (from `uip maestro flow init`)](#project-structure-from-uip-maestro-flow-init)
+- [Node instance](#node-instance)
+- [Layout](#layout)
+- [Edge — both ports required](#edge--both-ports-required)
+- [Definition entry](#definition-entry)
+- [Common node types](#common-node-types)
+- [Standard ports by node type](#standard-ports-by-node-type)
+- [Implicit error port on action nodes](#implicit-error-port-on-action-nodes)
+- [Minimal working example — dice roller](#minimal-working-example--dice-roller)
+- [entry-points.json — auto-generated, do not edit](#entry-pointsjson--auto-generated-do-not-edit)
+- [Bindings — Orchestrator resource bindings (top-level `bindings[]`)](#bindings--orchestrator-resource-bindings-top-level-bindings)
+- [Bindings — connector connection binding](#bindings--connector-connection-binding)
+
 ## Top-level structure
 
 ```json

--- a/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
+++ b/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
@@ -15,6 +15,23 @@ Complete reference for declaring variables, writing expressions, and managing da
 
 ---
 
+## Table of contents
+
+- [Variables Overview](#variables-overview)
+- [Workflow Variables (`globals`)](#workflow-variables-globals)
+- [Node Variables (`nodes`)](#node-variables-nodes)
+- [Variable Updates (`variableUpdates`)](#variable-updates-variableupdates)
+- [Output Mapping on End Nodes](#output-mapping-on-end-nodes)
+- [Expression System](#expression-system)
+- [Available Globals](#available-globals)
+- [Expression Contexts](#expression-contexts)
+- [Jint Engine Constraints](#jint-engine-constraints)
+- [Scoping Rules](#scoping-rules)
+- [Variable Management via CLI](#variable-management-via-cli)
+- [Complete Example](#complete-example)
+
+---
+
 ## Variables Overview
 
 Every flow has a `variables` object at the top level of the `.flow` file. It contains three sections:


### PR DESCRIPTION
> ⚠️ For discussion — do not merge until ready. PR #2 of six from the same `uipath-maestro-flow` review. Independent of #798.

## The problem

Two shared docs in `uipath-maestro-flow/references/shared/` are reached by nearly every agent task and read whole because neither has a table of contents:

- `variables-and-expressions.md` — 685 lines.
- `file-format.md` — 493 lines.

Both have well-structured H2 sections (12 and 13 respectively), but the agent has no way to jump to the one it needs — e.g. "JSON shape of the `outputs` block", "what `--inputs` JSON looks like for `flow debug`", "how subflows scope variables". The skill router in `SKILL.md` already references these docs for narrow needs, but the agent loads them in full.

In the two hot-path traces from the earlier review:

- "Greenfield Slack flow" task: `variables-and-expressions.md` alone added 685 lines to the cumulative read.
- "Diagnose MST-9107" task: `variables-and-expressions.md` (685) + `file-format.md` (493) added 1,178 lines.

## Why this fix

A 10–15 line ToC at the top of each file lets an agent (or human) jump straight to the relevant section. Zero content change, no risk to any existing rule or guidance — pure progressive disclosure.

## What changes

- `variables-and-expressions.md`: insert a `## Table of contents` block after the introductory blockquote (line 17), listing the 12 H2 sections with anchor links.
- `file-format.md`: insert a `## Table of contents` block after the introductory paragraph (line 4), listing the 13 H2 sections with anchor links.

## Expected impact

Once the ToC exists, an agent can read the file's intro + ToC (~25 lines) and jump to one or two relevant H2 sections (~50–100 lines each) instead of reading the whole 493- or 685-line file. Estimated savings on a typical task that touches these docs: 300–500 lines of avoided read each time the file is consulted.

No measurable downside — both files still load in full when an agent decides to read top-to-bottom; the ToC just makes targeted access possible.

## Validation

- `.maintenance/check-anchors.sh`: all 25 new ToC anchor links resolve. The 3 pre-existing bad anchors on `main` (in `editing-operations-json.md` and `evaluate/CAPABILITY.md`) are unchanged.
- `.maintenance/check-links.sh`: no new failures.
- All existing inbound links to either file from other docs continue to resolve — existing H2 anchors are unchanged.

## Out of scope

Same out-of-scope list as #798. ToCs on smaller reference files (planning-arch, editing-operations-json, connector/impl, etc.) deferred — they're under or near the 500-line threshold and the value of a ToC on them is lower.