### PR TITLE
docs(uipath-maestro-flow): add shared connection-binding workflow doc

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
@@ -17,7 +17,7 @@ Extract the connector key from the node type (`uipath.connector.trigger.<connect
 uip is connections list "<connector-key>" --output json
 ```
 
-If empty, follow the recovery in [/uipath:uipath-platform — connections.md — For Native Connectors](../../../../../../uipath-platform/references/integration-service/connections.md#for-native-connectors) (`--refresh` retry, then create-or-prompt).
+If the list is empty, follow the standard refresh-retry + STOP-and-ask flow in [Connection Binding — Shared Workflow](../../../../shared/connection-binding.md). Triggers must use a real connection here — `triggers objects` cannot run without one.
 
 **1b. Query trigger objects** — **mandatory** for every trigger node. Do NOT skip:
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -56,21 +56,11 @@ Follow these steps for every connector node.
 
 ### Step 1 — Fetch and bind a connection
 
-For each connector, extract the connector key from the node type (`uipath.connector.<connector-key>.<activity-name>`) and fetch a connection.
-
-```bash
-# 1. List available connections
-uip is connections list "<connector-key>" --folder-key "<folder-key>" --output json
-
-# 2. Pick the default enabled connection (IsDefault: Yes, State: Enabled)
-
-# 3. Verify the connection is healthy
-uip is connections ping "<connection-id>" --output json
-```
+Extract the connector key from the node type (`uipath.connector.<connector-key>.<activity-name>`). Follow the standard list + ping + refresh-retry + STOP-and-ask flow in [Connection Binding — Shared Workflow](../../../../shared/connection-binding.md), passing `--folder-key "<folder-key>"` to `connections list` so the activity binds in the right folder.
 
 **If a connector key fails**, list all available connectors to find the correct key: `uip is connectors list --output json`. Connector keys are often prefixed (e.g., `uipath-<service>`).
 
-**Read [/uipath:uipath-platform — Integration Service — connections.md](../../../../../../uipath-platform/references/integration-service/connections.md) for connection selection rules** (default preference, `--refresh` retry on empty results, HTTP fallback, multi-connection disambiguation, no-connection recovery, ping verification).
+**Read [/uipath:uipath-platform — Integration Service — connections.md](../../../../../../uipath-platform/references/integration-service/connections.md) for full connection selection rules** (default preference, HTTP fallback, multi-connection disambiguation, ping verification).
 
 ### Step 2 — Get enriched node definitions with connection
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
@@ -54,23 +54,7 @@ Minimum node instance shape:
 
 Skip this step for manual mode.
 
-```bash
-# List connections for the target connector (e.g., Slack)
-uip is connections list "<target-connector-key>" --output json
-
-# Verify the connection is healthy
-uip is connections ping "<connection-id>" --output json
-```
-
-If the list is empty, retry once with `--refresh` to bypass the CLI cache:
-
-```bash
-uip is connections list "<target-connector-key>" --refresh --output json
-```
-
-Record the `Id` and `FolderKey` from the connection.
-
-> **A healthy connection is required for connector mode.** If `uip is connections list` returns empty, retry once with `--refresh`. If still empty, **STOP** — the node cannot be configured without a real connection ID. Use `AskUserQuestion` to present the path forward: **Create a new connection now** (`uip is connections create "<target-connector-key>"` starts the OAuth flow — user completes browser auth themselves, then re-run `uip is connections list` to pick up the new connection) / **Switch this node to manual mode** / **Skip this node** / **Something else**. Do not fall back to manual mode silently, do not invent a placeholder ID, do not skip the node without explicit user selection. See [/uipath:uipath-platform — connections.md — For Native Connectors](../../../../../../uipath-platform/references/integration-service/connections.md#for-native-connectors) and the AskUserQuestion dropdown rule in [SKILL.md](../../../../../SKILL.md).
+Follow the standard list + ping + refresh-retry + STOP-and-ask flow in [Connection Binding — Shared Workflow](../../../../shared/connection-binding.md). Record `Id` and `FolderKey` from the chosen connection — Step 3 below passes them as `connectionId` and `folderKey` to `node configure --detail`. HTTP nodes are the one place where the STOP fallback offers "Switch this node to manual mode" as a valid option.
 
 ### Step 3 — Configure the node
 

--- a/skills/uipath-maestro-flow/references/shared/connection-binding.md
+++ b/skills/uipath-maestro-flow/references/shared/connection-binding.md
@@ -1,0 +1,55 @@
+# Connection Binding — Shared Workflow
+
+Reference for the common connection-fetch workflow used by connector activity, connector trigger, and managed HTTP nodes in connector mode. Plugin `impl.md` files link here for the standard list + ping + refresh recovery and the no-healthy-connection STOP block; each plugin documents its own divergences on top.
+
+## Standard list + ping
+
+```bash
+# 1. List connections for the connector
+uip is connections list "<connector-key>" --output json
+
+# 2. Pick the default enabled connection (IsDefault: Yes, State: Enabled)
+
+# 3. Verify health
+uip is connections ping "<connection-id>" --output json
+```
+
+Add `--folder-key "<folder-key>"` to `connections list` when authoring a connector activity that must bind in a specific folder.
+
+## Empty-list recovery
+
+If `connections list` returns an empty array, retry once with `--refresh` to bypass the CLI cache:
+
+```bash
+uip is connections list "<connector-key>" --refresh --output json
+```
+
+## No-healthy-connection STOP
+
+If `--refresh` still returns nothing, **STOP**. The node cannot be configured without a real connection ID. Present the path forward via `AskUserQuestion` (see the dropdown rule in [SKILL.md](../../SKILL.md)):
+
+- **Create a new connection** — `uip is connections create "<connector-key>"` starts the OAuth flow; user completes browser auth, then re-run `connections list` to pick up the new connection.
+- **Switch this node to manual mode** — applies to HTTP nodes only.
+- **Skip this node** — leave it in the flow with empty `inputs`; document it as an open question for the user.
+- **Something else** — free-form input.
+
+Do not fall back silently, invent a placeholder ID, or skip the node without explicit user selection.
+
+## Records to carry forward
+
+From the chosen connection, capture:
+
+- `Id` → `connectionId` in `--detail` and `inputs.detail`.
+- `FolderKey` → `folderKey` in `--detail` (the CLI writes it back as `connectionFolderKey`).
+
+These feed every subsequent `node configure --detail` call.
+
+## Where plugins diverge
+
+| Plugin | Extra steps |
+|---|---|
+| connector activity | Add `--folder-key` to `connections list`; the activity also needs `--connection-id` on `registry get` for enriched field metadata. |
+| connector trigger | Two-stage flow — get any enabled connection first, query `triggers objects` to read the `byoaConnection` flag, then pick a final connection (BYOA if the flag is `true`). |
+| HTTP (v2) | Connector mode only. Manual mode skips this entire workflow. |
+
+For upstream Integration Service rules (default-connection preference, BYOA selection, multi-connection disambiguation, OAuth flow details), see the `uipath-platform` skill's `integration-service/connections.md`.


### PR DESCRIPTION
> ⚠️ For discussion — do not merge until ready. PR #4 of six from the same `uipath-maestro-flow` review. Independent of #798, #799, #800.

## The problem

Three plugins author the same connection-fetch workflow (list → ping → refresh-retry → STOP-and-ask) with cosmetic variation:

- `plugins/connector/impl.md` Step 1 — connector activities (adds `--folder-key`).
- `plugins/connector-trigger/impl.md` Step 1a/1c — triggers (two-stage; reads `byoaConnection`).
- `plugins/http/impl.md` Step 2 — managed HTTP in connector mode (the longest restatement, full STOP block inline).

The HTTP file alone restates the STOP-and-ask block in 16 lines that duplicate guidance the connector plugins reach via cross-references. There is no canonical home inside the skill for the common kernel — each plugin tells its own version and points downstream to the `uipath-platform` skill for IS-side rules.

## Why this fix

Create `references/shared/connection-binding.md` as the canonical home for the kernel — list + ping + refresh-retry + STOP block + records to carry forward. Each plugin links to it for the common parts and keeps only its plugin-specific divergences (BYOA flow on triggers, `--folder-key` on activities, manual-mode escape on HTTP).

Establishing the canonical home matters more than the immediate line savings — future action-node plugins that need connections (queue, etc. when authenticated) can link rather than re-author.

## What changes

- **New `references/shared/connection-binding.md` (~50 lines):** standard list + ping, refresh-retry, STOP-and-ask, records to carry forward, plus a "where plugins diverge" table.
- **`plugins/http/impl.md` Step 2:** the largest migration — replace the inline list/ping/refresh/STOP block with a link to the shared doc. HTTP-specific note retained: it's the only plugin where "Switch this node to manual mode" is a valid STOP fallback.
- **`plugins/connector/impl.md` Step 1:** trim the inline bash block; link to the shared doc; keep the activity-specific `--folder-key` requirement and the "If a connector key fails" recovery hint inline.
- **`plugins/connector-trigger/impl.md` Step 1a:** redirect the empty-list recovery to the shared doc; keep the trigger-specific framing ("triggers must use a real connection here").

Connector-trigger's Steps 1b/1c (the BYOA flow and trigger-objects detour) stay untouched — they're trigger-specific, not shared.

## Expected impact

| File | Before | After | Δ |
|---|---|---|---|
| `shared/connection-binding.md` (new) | — | 50 | +50 |
| `plugins/http/impl.md` (Step 2 section) | 21 lines | 5 lines | −16 |
| `plugins/connector/impl.md` (Step 1 section) | 17 lines | 7 lines | −10 |
| `plugins/connector-trigger/impl.md` (Step 1a section) | 2 lines | 2 lines | 0 (text reworded) |
| **Total** | 40 | 64 | **+24** |

Like PR #798, the immediate diff is mildly positive (new doc costs more than the migrations save). The intent is the canonical home — a future PR migrating other connector-aware plugins (e.g., when queue or rpa nodes pick up connection-binding) lands on this doc for free.

For an agent reading just one plugin (e.g., HTTP), the load drops by ~16 lines because the STOP block is no longer inline.

## Validation

- `.maintenance/check-links.sh`: no new failures. The 11 pre-existing broken links (summarize, agent, batch-transform impl files) are unchanged and unrelated.
- `.maintenance/check-anchors.sh`: clean.
- All inline rules (BYOA filter, `--folder-key`, manual-mode option) preserved on their plugin pages; only the duplicated kernel moved out.

## Out of scope

Same out-of-scope list as #798, #799, #800. A broader connection-binding consolidation across other plugins (e.g., when more action-node plugins gain connector support) deferred to follow-up PRs.