### PR TITLE
docs(uipath-maestro-flow): add common-tasks.md master index

### DIFF
--- a/skills/uipath-maestro-flow/SKILL.md
+++ b/skills/uipath-maestro-flow/SKILL.md
@@ -44,6 +44,8 @@ Comprehensive guide for creating, editing, validating, debugging, publishing, di
 
 ## Capability router
 
+> **For frequent named tasks** (add a script node, validate, diagnose a failure, run an eval, etc.) jump straight to [references/common-tasks.md](references/common-tasks.md) — direct file routing for the most-common journeys. The table below is for tradeoff decisions and exploratory work.
+
 | I want to...                                                 | Read                                                                                             |
 | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
 | Create a new flow or edit an existing one                    | [references/author/CAPABILITY.md](references/author/CAPABILITY.md)                               |

--- a/skills/uipath-maestro-flow/references/common-tasks.md
+++ b/skills/uipath-maestro-flow/references/common-tasks.md
@@ -1,0 +1,56 @@
+# Common tasks — direct routing
+
+For the most-frequent named journeys, this index points straight at the file that handles the task. Use it to skip the four `CAPABILITY.md` indexes when you already know what you want to do. For navigation that explores tradeoffs, start from [SKILL.md](../SKILL.md) → the relevant `CAPABILITY.md`.
+
+## Index
+
+| I want to... | Go to |
+|---|---|
+| **Create a brand-new flow project** | [author/references/greenfield.md](author/references/greenfield.md) |
+| **Edit an existing flow** | [author/references/brownfield.md](author/references/brownfield.md) |
+| **Add a script node** | [author/references/plugins/script/impl.md](author/references/plugins/script/impl.md) |
+| **Add an HTTP node (Managed HTTP Request)** | [author/references/plugins/http/impl.md](author/references/plugins/http/impl.md) |
+| **Add a connector activity** | [author/references/plugins/connector/impl.md](author/references/plugins/connector/impl.md) |
+| **Add a connector trigger** | [author/references/plugins/connector-trigger/impl.md](author/references/plugins/connector-trigger/impl.md) |
+| **Add a decision (if/else)** | [author/references/plugins/decision/impl.md](author/references/plugins/decision/impl.md) |
+| **Add a switch (multi-way branch)** | [author/references/plugins/switch/impl.md](author/references/plugins/switch/impl.md) |
+| **Add a loop over a collection** | [author/references/plugins/loop/impl.md](author/references/plugins/loop/impl.md) |
+| **Add an end node** | [author/references/plugins/end/impl.md](author/references/plugins/end/impl.md) |
+| **Add a terminate node (abort on error)** | [author/references/plugins/terminate/impl.md](author/references/plugins/terminate/impl.md) |
+| **Add a subflow** | [author/references/plugins/subflow/impl.md](author/references/plugins/subflow/impl.md) |
+| **Call a published RPA process** | [author/references/plugins/rpa/impl.md](author/references/plugins/rpa/impl.md) |
+| **Call a published AI agent** | [author/references/plugins/agent/impl.md](author/references/plugins/agent/impl.md) |
+| **Embed an inline AI agent** | [author/references/plugins/inline-agent/impl.md](author/references/plugins/inline-agent/impl.md) |
+| **Pause for human input (HITL)** | [author/references/plugins/hitl/impl.md](author/references/plugins/hitl/impl.md) |
+| **Add a data transform** | [author/references/plugins/transform/impl.md](author/references/plugins/transform/impl.md) |
+| **Add an LLM batch transform over CSV rows** | [author/references/plugins/batch-transform/impl.md](author/references/plugins/batch-transform/impl.md) |
+| **Summarize a document with citations** | [author/references/plugins/summarize/impl.md](author/references/plugins/summarize/impl.md) |
+| **Add a queue node** | [author/references/plugins/queue/impl.md](author/references/plugins/queue/impl.md) |
+| **Add a scheduled trigger** | [author/references/plugins/scheduled-trigger/impl.md](author/references/plugins/scheduled-trigger/impl.md) |
+| **Add or update a variable** | [shared/variables-and-expressions.md](shared/variables-and-expressions.md) |
+| **Write an `=js:` expression** | [shared/node-output-wiring.md](shared/node-output-wiring.md) + [shared/variables-and-expressions.md](shared/variables-and-expressions.md) |
+| **Wire one node's output into another's input** | [shared/node-output-wiring.md](shared/node-output-wiring.md) |
+| **Fetch and bind an IS connection** | [author/references/plugins/connector/impl.md](author/references/plugins/connector/impl.md) Step 1 |
+| **Look up the `.flow` JSON shape** | [shared/file-format.md](shared/file-format.md) |
+| **Look up a `uip` CLI command** | [shared/cli-commands.md](shared/cli-commands.md) |
+| **Validate the flow** | `uip maestro flow validate <ProjectName>.flow` — see [author/CAPABILITY.md](author/CAPABILITY.md) rule #9 |
+| **Format / normalize layout** | `uip maestro flow format <ProjectName>.flow` — see [author/CAPABILITY.md](author/CAPABILITY.md) rule #13 |
+| **Publish to Studio Web** | [operate/references/ship.md](operate/references/ship.md) (Path 1) |
+| **Deploy to Orchestrator** | [operate/references/ship.md](operate/references/ship.md) (Path 2) |
+| **Run a flow via `flow debug`** | [operate/references/run.md](operate/references/run.md) |
+| **Check job status / stream traces** | [operate/references/run.md](operate/references/run.md) |
+| **Pause / resume / cancel / retry an instance** | [operate/references/manage.md](operate/references/manage.md) |
+| **Diagnose a failed run** | [diagnose/references/troubleshooting-guide.md](diagnose/references/troubleshooting-guide.md) |
+| **Look up MST-9107 / MST-9061 / HITL-stuck / etc.** | [diagnose/references/failure-modes.md](diagnose/references/failure-modes.md) |
+| **Create an evaluator** | [evaluate/references/evaluators-guide.md](evaluate/references/evaluators-guide.md) |
+| **Create an eval set / add data points** | [evaluate/references/eval-sets-guide.md](evaluate/references/eval-sets-guide.md) |
+| **Run a Studio Web eval** | [evaluate/references/running-guide.md](evaluate/references/running-guide.md) |
+
+## When to use a `CAPABILITY.md` instead
+
+If the task isn't in the table above, or you need to make a tradeoff decision (e.g., "Studio Web vs Orchestrator publish", "inline agent vs published agent", "decision vs switch"), start from the relevant capability:
+
+- [author/CAPABILITY.md](author/CAPABILITY.md) — create or edit a `.flow` file
+- [operate/CAPABILITY.md](operate/CAPABILITY.md) — publish, run, manage runs
+- [diagnose/CAPABILITY.md](diagnose/CAPABILITY.md) — investigate failures
+- [evaluate/CAPABILITY.md](evaluate/CAPABILITY.md) — design and run evaluations


### PR DESCRIPTION
> ⚠️ For discussion — do not merge until ready. PR #5 of six from the same `uipath-maestro-flow` review. Independent of #798–#801.

## The problem

When an agent knows what it wants to build (e.g. "add a script node", "diagnose MST-9107", "publish to Studio Web"), it currently still has to load the 143-line `author/CAPABILITY.md` (or one of the other three capability indexes) just to find the right plugin or workflow doc.

The four `CAPABILITY.md` files are valuable for tradeoff decisions (Studio Web vs Orchestrator, inline agent vs published agent, decision vs switch), but they are heavyweight for the case where the agent already knows the journey.

## Why this fix

Add a single top-level `references/common-tasks.md` that maps the ~35 most-common named tasks directly to their target files. An agent that recognises its task in the list can skip the CAPABILITY layer and go straight to the relevant plugin / workflow / shared doc.

The CAPABILITY indexes stay as the home for exploratory navigation and tradeoff content — the new file is purely a shortcut.

## What changes

- **New `references/common-tasks.md` (~57 lines):** a table of named tasks → file paths, plus a short "When to use a `CAPABILITY.md` instead" footer.
- **`SKILL.md` Capability router section:** add a one-paragraph callout above the existing capability table pointing to `references/common-tasks.md`. Existing table left intact — both paths coexist.

## Expected impact

For a task the agent recognises (about 70% of typical journeys based on the audit), the read path shrinks from:

`SKILL.md (88) → author/CAPABILITY.md (143) → plugin doc`

to:

`SKILL.md (88) → common-tasks.md (57) → plugin doc`

A ~86-line saving on the routing layer per task, repeated for every recognized task.

For tasks not in the index, behavior is unchanged — the agent reads SKILL.md → the relevant CAPABILITY.md as before.

## Validation

- `.maintenance/check-links.sh`: no new failures introduced (11 pre-existing broken links unchanged).
- `.maintenance/check-orphans.sh`: clean. The new file is reachable from SKILL.md.
- All 35+ links in the index point at files that exist on `main`.

## Out of scope

Same out-of-scope list as #798–#801. The connection-binding row in this index intentionally points at `connector/impl.md` Step 1 rather than `shared/connection-binding.md` (which lives on #801's branch) to keep this PR independently mergeable. If #801 lands first, a follow-up can update the row.