### PR TITLE
docs(uipath-maestro-flow): add table of contents to two large connector docs

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/data-fabric/impl.md
@@ -7,6 +7,23 @@ Step-by-step guide for building Data Fabric connector nodes in a `.flow` file.
 
 ---
 
+## Table of contents
+
+- [Step 1 — Resolve the Connection](#step-1--resolve-the-connection)
+- [Step 2 — Resolve the Entity Name](#step-2--resolve-the-entity-name)
+- [Step 3 — Set Up the Flow File](#step-3--set-up-the-flow-file)
+- [Step 4 — Create `bindings_v2.json`](#step-4--create-bindings_v2json)
+- [Step 5 — Create the Connection Resource File](#step-5--create-the-connection-resource-file)
+- [Step 6 — Write Connector Nodes](#step-6--write-connector-nodes)
+- [Step 7 — Run `node configure` and Restore Configuration](#step-7--run-node-configure-and-restore-configuration)
+- [`inputs.detail` — Data Fabric Specifics](#inputsdetail--data-fabric-specifics)
+- [Configuration Strings](#configuration-strings)
+- [Definitions Templates](#definitions-templates)
+- [Node JSON Templates](#node-json-templates)
+- [Script Nodes That Consume Query Results](#script-nodes-that-consume-query-results)
+
+---
+
 ## Step 1 — Resolve the Connection
 
 Per [parent impl.md § Step 1](../impl.md#step-1--fetch-and-bind-a-connection), filter by `ConnectorKey = "uipath-uipath-dataservice"`. Capture `Id` (→ `<connectionId>`), `FolderKey` (→ `<folderKey>`), and `Name` (→ `<IS connection Name>`).

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -4,6 +4,17 @@ How to configure connector activity nodes: connection binding, enriched metadata
 
 For generic node/edge add, remove, and wiring procedures, see [editing-operations.md](../../editing-operations.md). This guide covers the connector-specific configuration workflow that must follow the generic node add.
 
+## Table of contents
+
+- [How Connector Nodes Differ from OOTB](#how-connector-nodes-differ-from-ootb)
+- [Generic vs Concrete Activities](#generic-vs-concrete-activities)
+- [Critical: Connector Definition Must Include `form`](#critical-connector-definition-must-include-form)
+- [No-Live-Tenant / Planned Configuration Mode](#no-live-tenant--planned-configuration-mode)
+- [Configuration Workflow](#configuration-workflow)
+- [IS CLI Commands](#is-cli-commands)
+- [Bindings — top-level `.flow` `bindings[]`](#bindings--top-level-flow-bindings)
+- [Debug](#debug)
+
 ## How Connector Nodes Differ from OOTB
 
 1. **Connection binding required** — every connector node needs an IS connection (OAuth, API key, etc.) authored in the flow's top-level `bindings[]` (which the CLI regenerates into `bindings_v2.json` at debug/pack time). Without it, the node cannot authenticate.


### PR DESCRIPTION
> ⚠️ For discussion — do not merge until ready. PR #6 of six from the same `uipath-maestro-flow` review. Independent of #798–#802.

## The problem

The two largest plugin docs in the skill have no table of contents:

- `plugins/connector/impl.md` — **661 lines**, 8 H2 sections.
- `plugins/connector/data-fabric/impl.md` — **683 lines**, 12 H2 sections.

An agent that needs only a narrow piece — e.g., "the `inputs.detail` field reference for connector activities", "the CEQL filter syntax for Data Fabric", "the Debug section's error table" — currently loads the whole file. Both files have well-structured H2 sections; they just have no entry point that lets the agent jump directly.

## Why this fix

Same pattern as #799: a 10–15 line ToC at the top of each file lets the agent (and humans) jump to one section instead of reading top-to-bottom. Zero content change, no risk to any rule or guidance — pure progressive disclosure.

## What changes

- `plugins/connector/impl.md`: insert a `## Table of contents` block after the introductory paragraph (line 5), listing the 8 H2 sections.
- `plugins/connector/data-fabric/impl.md`: insert a `## Table of contents` block after the introductory bullets and `---` divider (line 9), listing the 12 H2 sections.

## Expected impact

Combined, the two files account for **1,344 lines** of agent-loadable plugin content (more than the shared `variables-and-expressions.md` + `file-format.md` combined). After this PR, an agent that needs a specific subsection can jump straight there — typical savings 300–600 lines per consultation.

The connector files are loaded by every connector-related task (and there are many — Salesforce, Slack, Outlook, Jira, Dataservice, etc.), so the cumulative impact is significant.

## Validation

- `.maintenance/check-anchors.sh`: all 20 new ToC anchor links resolve. The 3 pre-existing bad anchors on `main` (in `editing-operations-json.md` and `evaluate/CAPABILITY.md`) are unchanged.
- `.maintenance/check-links.sh`: no new failures.
- Existing H2 anchors in both files are unchanged — inbound links from other docs continue to work.

## Out of scope

Same out-of-scope list as #798–#802. Two other plugin files near the 400-500 line threshold (`connector-trigger/impl.md` 436, `inline-agent/impl.md` 465) would also benefit from ToCs — deferred to follow-up PRs to keep this one focused on the worst offenders.