### PR TITLE
fix(uipath-solution-design): repair smoke_file_reading.yaml

### DIFF
--- a/tests/tasks/uipath-solution-design/smoke_file_reading.yaml
+++ b/tests/tasks/uipath-solution-design/smoke_file_reading.yaml
@@ -1,10 +1,10 @@
-`task_id: skill-sdd-smoke-file-reading
+task_id: skill-sdd-smoke-file-reading
 description: >
   Smoke test: the skill workflow uses the Read tool on a provided PDD file
   rather than relying on inline prompt content. Round-trip verification with
   a unique random sentinel string the LLM cannot know without reading the
   file. No analysis, no SDD generation.
-tags: [uipath-solution-design, smoke, lifecycle:generate]
+tags: [uipath-solution-design, smoke, mode:build]
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
- Remove stray backtick on line 1 (made the file invalid YAML)
- Replace obsolete `lifecycle:generate` tag with `mode:build`, matching the documented taxonomy in tests/README.md

Note: coder-eval's installed tag validator currently rejects any colon-prefixed tag — `mode:build` triggers the same kebab-case error as `lifecycle:generate`. ~148 task YAMLs across the repo already use this pattern, so this file remains consistent with them until the upstream validator is relaxed.