### PR TITLE
docs(uipath-maestro-case): strip abbreviated binding tables

### DIFF
--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -281,14 +281,13 @@ The expression is duplicated in two non-config sinks because both have load-bear
 
 ## Root-level bindings
 
-Create 2 entries in the bindings array — destination path per [bindings/impl-json.md § Schema-dependent destination](plugins/variables/bindings/impl-json.md) (v19: `root.data.uipath.bindings[]`; v20: top-level `bindings[]`):
+Read [bindings/impl-json.md § Full binding shape — connector tasks](plugins/variables/bindings/impl-json.md) for the canonical 7-field shape on each entry (all required — omitting any causes Studio Web render failure). Per-trigger value sources:
 
-| Binding | `id` | `name` | `propertyAttribute` | `default` |
-|---|---|---|---|---|
-| ConnectionBinding | `<connBindingId>` (Step 3) | `` `${connectorKey} connection` `` (templated) | `"ConnectionId"` | `connection-id` (tasks.md) |
-| FolderKey | `<folderBindingId>` (Step 3) | `"FolderKey"` (PascalCase) | `"folderKey"` (camelCase — deliberately different from `name`) | `spec.connection.folderKey` (Step 2) |
+- `<connection-id>` (drives `resourceKey` on both bindings + ConnectionBinding `default`): from this trigger's `tasks.md` entry
+- `<connectorKey>` (drives ConnectionBinding templated `name`): from `tasks.md`
+- `<folderKey>` (FolderKey binding `default`): from `spec.connection.folderKey` in Step 2 response. **Omit the FolderKey binding entirely when this value is null** (matches `binding-builder.ts:73-83`).
 
-Both share `resourceKey` = `connection-id`. Deduplicate against existing root bindings. Source of truth for binding shape: `binding-builder.ts` in `uipcli-case-validate/packages/case-tool/src/utils/`.
+Dedup per [§ Deduplication](plugins/variables/bindings/impl-json.md). Source-of-truth code: `binding-builder.ts` in `uipcli-case-validate/packages/case-tool/src/utils/`.
 
 After writing root bindings, populate IS connection cache per [bindings-v2-sync.md § Populate IS connection cache](bindings-v2-sync.md). Skip if `case spec` failed.
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -53,14 +53,13 @@ Fallback: planning-captured schema from tasks.md. If unavailable, placeholder pe
 
 **Step 1 — Root-level bindings:**
 
-Create 2 entries in the bindings array per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
+Read [bindings/impl-json.md § Full binding shape — non-connector tasks](../../variables/bindings/impl-json.md) for the canonical 7-field shape (all required — omitting any causes Studio Web render failure). Per-task overrides:
 
-| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
-|---|---|---|---|
-| `"name"` | `"app"` | — | `name` from tasks.md |
-| `"folderPath"` | `"app"` | — | `folder-path` from tasks.md |
+- `resource`: `"app"`
+- `resourceSubType`: omit (no resourceSubType for action tasks)
+- `name` / `folderPath` defaults: from `tasks.md` `name` / `folder-path` fields
 
-Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 
 **Step 2 — Write task:**
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/agent/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/agent/impl-json.md
@@ -38,14 +38,13 @@ Fallback: planning-captured schema from tasks.md. If unavailable, placeholder pe
 
 **Step 1 — Root-level bindings:**
 
-Create 2 entries in the bindings array per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
+Read [bindings/impl-json.md § Full binding shape — non-connector tasks](../../variables/bindings/impl-json.md) for the canonical 7-field shape (all required — omitting any causes Studio Web render failure). Per-task overrides:
 
-| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
-|---|---|---|---|
-| `"name"` | `"process"` | `"Agent"` | `name` from tasks.md |
-| `"folderPath"` | `"process"` | `"Agent"` | `folder-path` from tasks.md |
+- `resource`: `"process"`
+- `resourceSubType`: `"Agent"`
+- `name` / `folderPath` defaults: from `tasks.md` `name` / `folder-path` fields
 
-Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 
 **Step 2 — Write task:**
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/impl-json.md
@@ -36,14 +36,13 @@ Fallback: planning-captured schema from tasks.md. If unavailable, placeholder pe
 
 **Step 1 — Root-level bindings:**
 
-Create 2 entries in the bindings array per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
+Read [bindings/impl-json.md § Full binding shape — non-connector tasks](../../variables/bindings/impl-json.md) for the canonical 7-field shape (all required — omitting any causes Studio Web render failure). Per-task overrides:
 
-| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
-|---|---|---|---|
-| `"name"` | `"process"` | `"Api"` | `name` from tasks.md |
-| `"folderPath"` | `"process"` | `"Api"` | `folder-path` from tasks.md |
+- `resource`: `"process"`
+- `resourceSubType`: `"Api"`
+- `name` / `folderPath` defaults: from `tasks.md` `name` / `folder-path` fields
 
-Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 
 **Step 2 — Write task:**
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/case-management/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/case-management/impl-json.md
@@ -36,14 +36,13 @@ Fallback: planning-captured schema from tasks.md. If unavailable, placeholder pe
 
 **Step 1 — Root-level bindings:**
 
-Create 2 entries in the bindings array per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
+Read [bindings/impl-json.md § Full binding shape — non-connector tasks](../../variables/bindings/impl-json.md) for the canonical 7-field shape (all required — omitting any causes Studio Web render failure). Per-task overrides:
 
-| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
-|---|---|---|---|
-| `"name"` | `"process"` | `"CaseManagement"` | `name` from tasks.md |
-| `"folderPath"` | `"process"` | `"CaseManagement"` | `folder-path` from tasks.md |
+- `resource`: `"process"`
+- `resourceSubType`: `"CaseManagement"`
+- `name` / `folderPath` defaults: from `tasks.md` `name` / `folder-path` fields
 
-Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 
 **Step 2 — Write task:**
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
@@ -175,14 +175,14 @@ Append the task to the target stage's `tasks[]` array. Default: own task set (on
 
 ### Step 9 — Append root-level bindings
 
-Create 2 entries in the bindings array per [bindings/impl-json.md](../../variables/bindings/impl-json.md). Connector tasks use `resource: "Connection"`:
+Read [bindings/impl-json.md § Full binding shape — connector tasks](../../variables/bindings/impl-json.md) for the canonical 7-field shape on each entry (all required — omitting any causes Studio Web render failure). Per-task value sources:
 
-| Binding | `id` | `name` | `propertyAttribute` | `default` |
-|---|---|---|---|---|
-| ConnectionBinding | `<connBindingId>` (Step 5) | `` `${connectorKey} connection` `` (templated) | `"ConnectionId"` | `connection-id` (tasks.md) |
-| FolderKey | `<folderBindingId>` (Step 5) | `"FolderKey"` (PascalCase) | `"folderKey"` (camelCase — deliberately different from `name`) | `spec.connection.folderKey` (Step 2) |
+- `<connection-id>` (drives `resourceKey` on both bindings + ConnectionBinding `default`): from this task's `tasks.md` entry
+- `<connectorKey>` (drives ConnectionBinding templated `name`): from `tasks.md`
+- `<folderKey>` (FolderKey binding `default`): from `spec.connection.folderKey` in Step 2 response. **Omit the FolderKey binding entirely when this value is null** (matches `binding-builder.ts:73-83`).
+- Binding IDs `<connBindingId>` / `<folderBindingId>` come from Step 5.
 
-Both share `resourceKey` = `connection-id`. Source of truth for binding shape: `binding-builder.ts` in `uipcli-case-validate/packages/case-tool/src/utils/`.
+Dedup per [§ Deduplication](../../variables/bindings/impl-json.md). Source-of-truth code: `binding-builder.ts` in `uipcli-case-validate/packages/case-tool/src/utils/`.
 
 ### Step 10 — Sync IS connection cache
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/process/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/process/impl-json.md
@@ -36,14 +36,13 @@ Fallback: planning-captured schema from tasks.md. If unavailable, placeholder pe
 
 **Step 1 — Root-level bindings:**
 
-Create 2 entries in the bindings array per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
+Read [bindings/impl-json.md § Full binding shape — non-connector tasks](../../variables/bindings/impl-json.md) for the canonical 7-field shape (all required — omitting any causes Studio Web render failure). Per-task overrides:
 
-| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
-|---|---|---|---|
-| `"name"` | `"process"` | `"ProcessOrchestration"` | `name` from tasks.md |
-| `"folderPath"` | `"process"` | `"ProcessOrchestration"` | `folder-path` from tasks.md |
+- `resource`: `"process"`
+- `resourceSubType`: `"ProcessOrchestration"`
+- `name` / `folderPath` defaults: from `tasks.md` `name` / `folder-path` fields
 
-Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 
 **Step 2 — Write task:**
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/rpa/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/rpa/impl-json.md
@@ -37,14 +37,13 @@ Fallback: planning-captured schema from tasks.md. If unavailable, placeholder pe
 
 **Step 1 — Root-level bindings:**
 
-Create 2 entries in the bindings array per [bindings/impl-json.md](../../variables/bindings/impl-json.md):
+Read [bindings/impl-json.md § Full binding shape — non-connector tasks](../../variables/bindings/impl-json.md) for the canonical 7-field shape (all required — omitting any causes Studio Web render failure). Per-task overrides:
 
-| `propertyAttribute` | `resource` | `resourceSubType` | `default` |
-|---|---|---|---|
-| `"name"` | `"process"` | — | `name` from tasks.md |
-| `"folderPath"` | `"process"` | — | `folder-path` from tasks.md |
+- `resource`: `"process"`
+- `resourceSubType`: omit (no resourceSubType for rpa tasks)
+- `name` / `folderPath` defaults: from `tasks.md` `name` / `folder-path` fields
 
-Both share `resourceKey` = `<folderPath>.<name>`. ID: `b` + 8 chars. Deduplicate by `default + resource + resourceKey`.
+Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 
 **Step 2 — Write task:**
 


### PR DESCRIPTION
## Summary

- The 8 affected plugin docs each carried their own abbreviated reference table at "Root-level bindings" listing only a subset of the canonical 7 required binding fields. Different docs dropped different fields (`id`, `name`, `type`, `resource`, `resourceKey` — varying per doc), so an agent treating any table as authoritative produced binding JSON that Studio Web couldn't render. The connector path was empirically broken (observed: Outlook 365 root binding missing `type` + `resource`); the non-connector path was latently broken on the same bug class.
- Every abbreviated table is replaced with an imperative directive to read `bindings/impl-json.md § Full binding shape — (non-)connector tasks` for the canonical 7-field shape, plus only the per-plugin parametrization (`resource` / `resourceSubType` for non-connector; value sources for connector). Single source of truth for the binding shape; per-doc content is strictly the values that differ per plugin.
- `bindings/impl-json.md` itself is unchanged — it was already canonical. Per-plugin docs now point at it cleanly.

**Note:** the same fix exists on branch `audit/case-io-binding-variables` (commit `270db71f`), bundled inside a larger io-binding redesign. This PR carries only the binding-shape portion in isolation so it can land independently. The audit branch will rebase past this PR or vice versa — diffs are byte-identical on the binding-shape lines.

## Files touched

- `skills/uipath-maestro-case/references/connector-trigger-common.md` (shared by `connector-trigger`, `triggers/event`)
- `skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md` Step 9
- `skills/uipath-maestro-case/references/plugins/tasks/agent/impl-json.md` Step 1
- `skills/uipath-maestro-case/references/plugins/tasks/process/impl-json.md` Step 1
- `skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md` Step 1
- `skills/uipath-maestro-case/references/plugins/tasks/rpa/impl-json.md` Step 1
- `skills/uipath-maestro-case/references/plugins/tasks/api-workflow/impl-json.md` Step 1
- `skills/uipath-maestro-case/references/plugins/tasks/case-management/impl-json.md` Step 1

## Test plan

- [ ] Re-run the variable-redesign test case at `case_coding_agent_tests/trigger-varaible-test/outlook-calendar-event-basic/` (sdd.md only; clear `tasks/` + built solution first)
- [ ] Inspect the resulting caseplan's `bindings[]` — every entry must contain all 7 required fields (`id`, `name`, `type`, `resource`, `resourceKey`, `default`, `propertyAttribute`)
- [ ] Confirm the check passes for at least one connector task and one non-connector task (agent or process)
- [ ] Verify Studio Web renders the resulting case without binding-render errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)