### PR TITLE
ci: validate refreshed UIPATH_* secrets via smoke run

### DIFF
--- a/tests/tasks/uipath-review/review_rpa_project.yaml
+++ b/tests/tasks/uipath-review/review_rpa_project.yaml
@@ -1,3 +1,4 @@
+# ci: validate refreshed UIPATH_* secrets (draft PR — do not merge)
 task_id: skill-review-rpa-project
 description: >
   Skill-guided evaluation: agent uses the uipath-review skill to perform


### PR DESCRIPTION
## Summary

- Throwaway PR to exercise `smoke-skills.yml` against the rotated `UIPATH_CLIENT_SECRET` and freshly-set `UIPATH_ORG_ID` / `UIPATH_TENANT_ID` secrets.
- Single change is a no-op YAML comment on `tests/tasks/uipath-review/review_rpa_project.yaml`, just enough to make `detect` schedule the `uipath-review` smoke tasks (2 tasks, cheapest non-Windows skill).
- **Not for merge** — close once CI is green.

## Test plan

- [ ] `smoke-skills.yml` *Mint UiPath service-account token + enable env-auth* step succeeds (token mint + `uip login status` returns `Logged in`).
- [ ] `uipath-review` smoke tasks run to completion (pass/fail of the tasks themselves is secondary — auth success is what we're validating).
- [ ] Close PR and delete branch afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)