### PR TITLE
Additional E2E tests for Audit and fixed smoke tests

### DIFF
--- a/skills/uipath-admin/SKILL.md
+++ b/skills/uipath-admin/SKILL.md
@@ -113,8 +113,8 @@ The `org` vs `tenant` choice matters — they hit different basePaths and surfac
 
 | User says... | Likely scope | Why |
 |---|---|---|
-| "who joined / left the organization", "who was made an admin", "license changes", "cross-tenant audit" | **org** | Org-level admin events (memberships, license, tenant lifecycle) live under `/orgaudit_`. |
-| "what happened on tenant X", "logins on this tenant", "policy changes within a tenant", "asset/queue/folder edits" | **tenant** | Tenant-scoped events (Orchestrator, AOps, AI Trust, etc.) live under `/{tenantId}/tenantaudit_`. |
+| "who joined / left the organization", "who was made an admin", "license changes", "cross-tenant audit", **"failed/successful logins"**, **"login history for user X"**, **"who's been signing in"** | **org** | Org-level events (memberships, license, tenant lifecycle, **Identity Server / IdP authentication including User Login**) live under `/orgaudit_`. |
+| "what happened on tenant X", "asset/queue/folder edits", "queue items processed", "job failures", "Action Center task changes", "Apps / AgentHub / Document Understanding / Integration Service / Test Manager activity" | **tenant** | Tenant-scoped events (Orchestrator, Action Center, Apps, AgentHub, Document Understanding, Integration Service, Test Manager, Data Fabric, Process Mining, Relay, Hypervisor, tenant-side Admin) live under `/{tenantId}/tenantaudit_`. Note: governance/AOps policies, source control, and pipelines are **org**-scoped despite the AOps name. |
 | "everything everywhere" | **both** — run the same flow once per scope and present combined results. |
 
 If the prompt is **vague about scope** AND no prior turn has established it, **stop and ask** (one yes/no question, two clarifications max). Don't assume `tenant` just because it's the more common case.

--- a/skills/uipath-admin/references/audit-workflow-guide.md
+++ b/skills/uipath-admin/references/audit-workflow-guide.md
@@ -8,13 +8,13 @@ Four canonical investigations the `uipath-audit` skill should drive. Each starts
 
 ## Investigation 1 — "Who did X to resource Y?"
 
-**User asks:** "Who deleted the `Sales-Reports` folder last Tuesday?" / "Who edited the AI Trust Layer policy this week?" / "Who turned off MFA for the org admin group?"
+**User asks:** "Who deleted the `Sales-Reports` folder last Tuesday?" / "Who edited the production governance policy this week?" / "Who removed jane.doe from the organization yesterday?"
 
 **Approach:** Discover the source/target IDs that match the resource, narrow `events` by source + target + time window, then format actor + timestamp.
 
 ### Step 1 — Discover sources at the right scope
 
-The "what changed" determines scope. Folder/queue/asset edits are **tenant** scope. Membership/license/tenant-lifecycle is **org** scope. Most resource-touching investigations are tenant.
+The "what changed" determines scope. Orchestrator-managed entities (folders, queues, assets, processes) and tenant-service activity (Action Center, Apps, Document Understanding, Integration Service, Test Manager, Data Fabric) are **tenant** scope. Identity / authentication, org membership, license, governance policies, and tenant lifecycle are **org** scope.
 
 ```bash
 uip admin audit tenant sources --output json > /tmp/sources.json
@@ -22,30 +22,39 @@ uip admin audit tenant sources --output json > /tmp/sources.json
 
 ### Step 2 — Locate the matching source/target
 
-Find a source whose `name` matches the resource type, then drill into its `eventTargets[]` for the specific entity type, and `eventTypes[]` for the verb.
+Find a source whose `Name` matches the broad product area, then drill into its `EventTargets[]` for the specific entity type, and `EventTypes[]` for the verb. Names come straight from the `event-metadata/definitions/{org,tenant}/*.json` set published by the Audit Service.
 
-For "deleted folder":
+For "deleted folder" (tenant scope):
 
-- Source: `Folders` (or similar)
-- Target: `Folder`
-- Type: `Deleted folder`
+- Source: `Orchestrator`
+- Target: `Folders`
+- Type: `Delete folder`
+
+Other realistic mappings to keep in mind:
+
+- "edited a governance policy" → **org** scope, Source `Governance`, Target `Policy management`, Type `Edited policy`
+- "removed a user from the org" → **org** scope, Source `Organization Management`, Target `Org Membership`, Type `User Manually Removed From An Org`
+- "created an Orchestrator queue/asset/process" → **tenant** scope, Source `Orchestrator`, with the matching `EventTarget`
 
 The agent should grep the JSON for these names to extract the GUIDs:
 
 ```bash
-jq -r '.Data[] | select(.name == "Folders") | .id' /tmp/sources.json
-jq -r '.Data[] | select(.name == "Folders") | .eventTargets[] | select(.name == "Folder") | .id' /tmp/sources.json
+jq -r '.Data[] | select(.name == "Orchestrator") | .id' /tmp/sources.json
+jq -r '.Data[] | select(.name == "Orchestrator") | .eventTargets[] | select(.name == "Folders") | .id' /tmp/sources.json
+jq -r '.Data[] | select(.name == "Orchestrator") | .eventTargets[] | select(.name == "Folders") | .eventTypes[] | select(.name == "Delete folder") | .id' /tmp/sources.json
 ```
+
+> The CLI returns lowerCamelCase keys (`name`, `id`, `eventTargets`, `eventTypes`) over the `Name`/`Id`/`EventTargets`/`EventTypes` shape in the metadata JSON. Use lowerCamelCase in `jq` selectors against the CLI response.
 
 ### Step 3 — Query events with filters
 
 ```bash
 uip admin audit tenant events \
-  --source <FOLDERS_SOURCE_GUID> \
-  --target <FOLDER_TARGET_GUID> \
-  --type   <DELETED_FOLDER_TYPE_GUID> \
-  --from-date   2026-04-22T00:00:00Z \
-  --to-date     2026-04-29T00:00:00Z \
+  --source <ORCHESTRATOR_SOURCE_GUID> \
+  --target <FOLDERS_TARGET_GUID> \
+  --type   <DELETE_FOLDER_TYPE_GUID> \
+  --from-date   2026-05-11T00:00:00Z \
+  --to-date     2026-05-18T00:00:00Z \
   --limit  50 \
   --output json
 ```
@@ -69,7 +78,18 @@ If `Data.previous` is non-null, mention "older results available — extend the 
 
 **User asks:** "Show me failed logins for jane.doe@example.com this month." / "When did Bob last log in?" / "Was anyone logging in from outside the US last week?"
 
-**Approach:** Filter events by user ID + the `User Login` event type, optionally with `--status Failure`. Present chronologically with `ipAddress`/`ipCountry` from `clientInfo`.
+**Scope: `org`.** Org-level audit events are everything that's not scoped to a single tenant — anything emitted by services that operate at the organization or cross-tenant level. The broad categories live under `/orgaudit_`:
+
+- **Identity Server / IdP authentication** — `User Login`, password changes, MFA setup, federation events, SSO bindings
+- **Membership** — users joining/leaving the org, role assignments, invitations, group changes at org scope
+- **License & billing** — license assignments, plan changes, seat allocation, billing events
+- **Tenant lifecycle** — tenant create/suspend/delete/restore, region moves
+- **Org settings** — admin role changes, branding/identity provider settings, org-wide policy changes
+- **Robot accounts & external apps** — when managed at org level (vs tenant-bound)
+
+If the user's question maps to anything in those categories — and `User Login` does — query `org` scope. Anything scoped to a single tenant (Orchestrator runs, asset/queue/folder edits, Action Center task changes, Apps / AgentHub / Document Understanding / Integration Service / Test Manager activity) is `tenant` scope instead. Querying `tenant events` for org-level events returns nothing useful because the events don't live under `/{tenantId}/tenantaudit_`. Note that **AOps governance policies, pipelines, and source control are org-scoped** despite the AOps naming — `Governance`, `Pipelines`, and `Source Control` are sources in `org sources`, not tenant.
+
+**Approach:** Filter `org` events by user ID + the `User Login` event type, optionally with `--status Failure`. Present chronologically with `ipAddress`/`ipCountry` from `clientInfo`.
 
 ### Step 1 — Find the user's GUID
 
@@ -79,25 +99,28 @@ The user's `actorId` GUID is required by `--user-id`. It's not visible from emai
 2. Otherwise, run a search-only query (no `--user-id`) for `--search jane.doe` and take `actorId` from the first match.
 
 ```bash
-uip admin audit tenant events \
+uip admin audit org events \
   --search "jane.doe@example.com" \
   --limit 5 --output json --output-filter "Data.auditEvents[0].actorId"
 ```
 
 ### Step 2 — Find the User Login type GUID
 
+Discover from `org sources` (not tenant — login event metadata lives org-side):
+
 ```bash
+uip admin audit org sources --output json > /tmp/sources.json
 jq -r '.Data[] | select(.name == "Identity") | .eventTargets[] | select(.name == "Authentication") | .eventTypes[] | select(.name == "User Login") | .id' /tmp/sources.json
 ```
 
-Names like `Identity`, `Authentication`, `User Login` are illustrative — confirm against your actual `sources.json` output before committing the selector. They can vary across UiPath cloud versions and regions; if the `jq` returns empty, list the candidate names with `jq -r '.Data[].name'` and `.eventTargets[].name` and pick the closest match.
+The `Identity` → `Authentication` → `User Login` path matches the Audit Service event metadata (`event-metadata/definitions/org/identity.json`). Adjacent types under the same target — `Robot Login`, `External App Login`, `User Logout` — work the same way and are useful when the question is about non-user sign-ins. If `jq` returns empty, list the candidate names with `jq -r '.Data[].name'` and `.eventTargets[].name` and pick the closest match (names can drift across cloud regions/versions).
 
 ### Step 3 — Query
 
 For "all logins this month":
 
 ```bash
-uip admin audit tenant events \
+uip admin audit org events \
   --user-id <USER_GUID> \
   --type    <USER_LOGIN_TYPE_GUID> \
   --from-date    2026-04-01T00:00:00Z \
@@ -109,7 +132,7 @@ uip admin audit tenant events \
 For "failed logins only":
 
 ```bash
-uip admin audit tenant events \
+uip admin audit org events \
   --user-id <USER_GUID> \
   --type    <USER_LOGIN_TYPE_GUID> \
   --status  Failure \

--- a/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
@@ -1,0 +1,124 @@
+task_id: skill-admin-audit-export-verify-e2e
+description: >
+  End-to-end test (artifact verification tier): agent drives
+  `uip admin audit tenant export` to produce a real ZIP, then verifies
+  (a) the ZIP exists, (b) it contains at least one daily .txt file,
+  (c) the event IDs inside the export are a subset of what the live
+  `events` API returns for the same whole-day window.
+
+  Unlike the command-construction e2e (`audit_export_e2e.yaml`), this
+  task asserts real artifact correctness against the test tenant
+  authenticated via the workflow's env-var auth (UIPATH_CLI_AUTH_TOKEN
+  + UIPATH_CLI_ORG/TENANT_*).
+
+  Whole-day granularity note: `uip admin audit ... export` issues one
+  HTTP call per UTC day inside [--from-date, --to-date] and produces
+  one .txt per day. The `events` API takes timestamp-precise bounds,
+  so to compare the same window the events query must use
+  `T00:00:00Z` / `T23:59:59.999Z` boundaries that bracket the export's
+  per-day files.
+
+  LTS lag note: the export reads from the long-term store, which lags
+  the live `events` endpoint. We pin the comparison window to dates at
+  least 48h in the past so LTS has caught up. Assertion direction is
+  "export IDs ⊆ events IDs" — events is the more complete set.
+
+  Blocker: this task requires `uip admin audit` to exist in the
+  published `@uipath/cli` (UiPath/cli#1372 must ship + publish first).
+  Until then it will fail at the export step with `unknown command
+  'audit'`.
+tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  max_turns: 40
+  turn_timeout: 600
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Export tenant audit events for the 3-day window from 5 days ago
+  through 2 days ago (UTC, whole days) to ./audit-window.zip in the
+  current working directory. Resolve the dates with
+  `date -u -d '5 days ago' +%Y-%m-%d` and `date -u -d '2 days ago' +%Y-%m-%d`
+  so the window slides with the run date.
+
+  Important:
+  - The `uip` CLI is available and connected via env-var auth to a
+    real tenant. The export should produce a real ZIP file at the
+    requested path.
+  - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
+    bounds (no inline `T00:00:00Z` for these flags — the CLI treats
+    them as whole-day boundaries).
+  - The 2-days-ago upper bound preserves the >48h LTS-lag buffer so
+    the export is comparable against the live events endpoint.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked tenant export with bounded window + --output-file"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--output-file\s+\S+)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Export produced ./audit-window.zip"
+    path: "./audit-window.zip"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "ZIP contains at least one daily .txt file"
+    command: |
+      set -euo pipefail
+      test -f ./audit-window.zip
+      unzip -l ./audit-window.zip | grep -qE '\.txt$'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Export event IDs are a subset of the events API for the same window (whole-day boundaries)"
+    command: |
+      set -euo pipefail
+      mkdir -p /tmp/audit-export
+      unzip -o ./audit-window.zip -d /tmp/audit-export >/dev/null
+
+      # Export shape uses PascalCase keys (Id, CreatedOn, ...).
+      # `.[]?.Id` covers per-day files that are JSON arrays.
+      EXPORTED=$(jq -r '.[]?.Id' /tmp/audit-export/*.txt 2>/dev/null | sort -u)
+      EXPORTED_COUNT=$(echo "$EXPORTED" | grep -c . || true)
+
+      # Live events API — must use whole-day boundaries to bracket the
+      # export's per-day captures. Dates slide with the run date and match
+      # the relative window in the prompt (5 days ago through 2 days ago).
+      FROM=$(date -u -d '5 days ago' +%Y-%m-%d)
+      TO=$(date -u -d '2 days ago' +%Y-%m-%d)
+      LIVE_JSON=$(uip admin audit tenant events \
+        --from-date "${FROM}T00:00:00Z" \
+        --to-date   "${TO}T23:59:59.999Z" \
+        --limit 50000 --output json)
+      LIVE=$(echo "$LIVE_JSON" | jq -r '.Data.auditEvents[].id' | sort -u)
+      LIVE_COUNT=$(echo "$LIVE" | grep -c . || true)
+
+      # Export ⊆ Live (LTS lag means events can have *more* than export,
+      # but every export ID must appear in events).
+      MISSING=$(comm -23 <(echo "$EXPORTED") <(echo "$LIVE") | grep -c . || true)
+
+      echo "exported=$EXPORTED_COUNT  live=$LIVE_COUNT  missing_from_live=$MISSING"
+      if [ "$MISSING" -gt 0 ]; then
+        echo "FAIL: $MISSING export IDs not found in events API" >&2
+        comm -23 <(echo "$EXPORTED") <(echo "$LIVE") | head -5 >&2
+        exit 1
+      fi
+    timeout: 60
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_login_history_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_login_history_e2e.yaml
@@ -1,16 +1,17 @@
 task_id: skill-admin-audit-login-history-e2e
 description: >
   End-to-end test: agent runs Investigation 2 from
-  audit-workflow-guide.md ("login history for user X, failed attempts
-  only"). Sequence is: list `sources` to find the User Login type GUID
-  (Identity → Authentication → User Login), then query `events` with
-  `--user-id`, `--type`, and `--status Failure` inside a bounded
-  window. Validates the agent uses server-side filters instead of
-  pulling everything and post-filtering.
+  audit-workflow-guide.md ("login history for user X") at ORG scope —
+  cross-tenant / IdP-level login activity. Sequence is: list `org
+  sources` to find the User Login type GUID (Identity →
+  Authentication → User Login), then query `org events` scoped to
+  that user inside a bounded window. Validates the agent goes through
+  the sources-discovery → user-filtered-events chain at org scope
+  rather than blanket scanning all events.
 
   Command-construction only — no live tenant available for
   side-effect verification.
-tags: [uipath-admin, e2e, mode:diagnose, audit, investigation, login-history]
+tags: [uipath-admin, e2e, mode:diagnose, audit, investigation, login-history, scope-org]
 max_iterations: 2
 
 agent:
@@ -25,8 +26,7 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Show me failed login attempts for jane.doe@example.com on the
-  active tenant during April 2026.
+  Show me login attempts for jane.doe@example.com over the last month.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be
@@ -39,33 +39,25 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip admin audit tenant sources` to discover the User Login type GUID"
+    description: "Agent invoked `uip admin audit org sources` to discover the User Login type GUID"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+sources\b'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip admin audit tenant events` with --status Failure"
+    description: "Agent passed --user-id (or --search to resolve the user) on the org events call"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b.*--status\s+(?i:Failure|1)'
-    min_count: 1
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent passed --user-id (or --search to resolve the user) on the events call"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b.*(?:--user-id\s+\S+|--search\s+\S+)'
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+events\b(?=.*(?:--user-id\s+\S+|--search\s+\S+))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent kept a bounded time window via --from-date/--to-date covering April 2026"
+    description: "Agent kept a bounded time window via --from-date/--to-date on the org events call"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b.*--from-date\s+\S+.*--to-date\s+\S+'
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+events\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
@@ -1,0 +1,147 @@
+task_id: skill-admin-audit-org-export-verify-e2e
+description: >
+  End-to-end test (artifact verification tier): agent drives
+  `uip admin audit org export` to produce a real ZIP, then verifies
+  (a) the ZIP exists, (b) it contains at least one daily .txt file,
+  (c) the event IDs inside the export are a subset of what the live
+  `events` API returns for the same whole-day window.
+
+  Sibling to `audit_export_verify_e2e.yaml` — same verification logic,
+  but exercises the `org` scope (admin events: memberships, license,
+  tenant lifecycle, Identity Server logins) rather than `tenant` scope.
+  Org-scope hits a different basePath (`/orgaudit_` vs `/tenantaudit_`)
+  and surfaces a different event set, so this isn't redundant with the
+  tenant artifact-verify task — it catches regressions on the org code
+  path specifically.
+
+  Whole-day granularity note: `uip admin audit ... export` issues one
+  HTTP call per UTC day inside [--from-date, --to-date] and produces
+  one .txt per day. The `events` API takes timestamp-precise bounds,
+  so to compare the same window the events query must use
+  `T00:00:00Z` / `T23:59:59.999Z` boundaries that bracket the export's
+  per-day files.
+
+  LTS lag note: the export reads from the long-term store, which lags
+  the live `events` endpoint. We pin the comparison window to dates at
+  least 48h in the past so LTS has caught up. Assertion direction is
+  "export IDs ⊆ events IDs" — events is the more complete set.
+
+  Org-scope volume note: organization-level audit events (memberships,
+  license, tenant lifecycle) are typically sparser than tenant events.
+  An empty or near-empty result on a quiet test org is a real outcome
+  and should not fail the test — the assertion is *correctness* of the
+  subset relationship, not a minimum event count.
+
+  Blocker: this task requires `uip admin audit` to exist in the
+  published `@uipath/cli` (UiPath/cli#1372 must ship + publish first).
+  Until then it will fail at the export step with `unknown command
+  'audit'`.
+tags: [uipath-admin, e2e, mode:operate, audit, export, scope-org, real-artifact]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  max_turns: 40
+  turn_timeout: 600
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Export ORGANIZATION-level audit events (memberships, license changes,
+  tenant lifecycle) for the 3-day window from 5 days ago through
+  2 days ago (UTC, whole days) to ./audit-org-window.zip in the
+  current working directory. Resolve the dates with
+  `date -u -d '5 days ago' +%Y-%m-%d` and `date -u -d '2 days ago' +%Y-%m-%d`
+  so the window slides with the run date.
+
+  Important:
+  - The `uip` CLI is available and connected via env-var auth to a
+    real tenant. The export should produce a real ZIP file at the
+    requested path.
+  - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
+    bounds (no inline `T00:00:00Z` for these flags — the CLI treats
+    them as whole-day boundaries).
+  - The 2-days-ago upper bound preserves the >48h LTS-lag buffer so
+    the export is comparable against the live events endpoint.
+  - This is ORG scope, not tenant. Do NOT pass `--tenant-id` (org
+    silently ignores it).
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip admin audit org export` (org scope) with bounded window + --output-file"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+export\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--output-file\s+\S+)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Export produced ./audit-org-window.zip"
+    path: "./audit-org-window.zip"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "ZIP is a valid archive (zero or more .txt entries — an empty zip is acceptable for a quiet org)"
+    command: |
+      set -euo pipefail
+      test -f ./audit-org-window.zip
+      # `unzip -l` should succeed on a valid archive; we don't require entries
+      # since a quiet org over a 3-day window can legitimately produce no events.
+      unzip -l ./audit-org-window.zip >/dev/null
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Org export event IDs are a subset of org events API for the same window (whole-day boundaries)"
+    command: |
+      set -euo pipefail
+      mkdir -p /tmp/audit-org-export
+      unzip -o ./audit-org-window.zip -d /tmp/audit-org-export >/dev/null
+
+      # If the ZIP has no .txt files (quiet org), the export-subset assertion
+      # trivially holds and we exit cleanly.
+      shopt -s nullglob
+      TXT_FILES=(/tmp/audit-org-export/*.txt)
+      if [ ${#TXT_FILES[@]} -eq 0 ]; then
+        echo "OK: org export window is empty — subset assertion trivially holds"
+        exit 0
+      fi
+
+      # Export shape uses PascalCase keys (Id, CreatedOn, ...).
+      EXPORTED=$(jq -r '.[]?.Id' "${TXT_FILES[@]}" 2>/dev/null | sort -u)
+      EXPORTED_COUNT=$(echo "$EXPORTED" | grep -c . || true)
+
+      # Live ORG events API — whole-day boundaries to bracket the
+      # export's per-day captures. NOTE: `org events`, not `tenant events`.
+      # Dates slide with the run date and match the relative window in
+      # the prompt (5 days ago through 2 days ago).
+      FROM=$(date -u -d '5 days ago' +%Y-%m-%d)
+      TO=$(date -u -d '2 days ago' +%Y-%m-%d)
+      LIVE_JSON=$(uip admin audit org events \
+        --from-date "${FROM}T00:00:00Z" \
+        --to-date   "${TO}T23:59:59.999Z" \
+        --limit 50000 --output json)
+      LIVE=$(echo "$LIVE_JSON" | jq -r '.Data.auditEvents[].id' | sort -u)
+      LIVE_COUNT=$(echo "$LIVE" | grep -c . || true)
+
+      # Export ⊆ Live (LTS lag means events can have *more* than export,
+      # but every export ID must appear in events).
+      MISSING=$(comm -23 <(echo "$EXPORTED") <(echo "$LIVE") | grep -c . || true)
+
+      echo "exported=$EXPORTED_COUNT  live=$LIVE_COUNT  missing_from_live=$MISSING"
+      if [ "$MISSING" -gt 0 ]; then
+        echo "FAIL: $MISSING org export IDs not found in events API" >&2
+        comm -23 <(echo "$EXPORTED") <(echo "$LIVE") | head -5 >&2
+        exit 1
+      fi
+    timeout: 60
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_sources_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_sources_smoke.yaml
@@ -31,17 +31,17 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip admin audit org sources` with --output json"
+    description: "Agent invoked `uip admin audit org sources`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+org\s+sources\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+sources\b'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip admin audit tenant sources` with --output json"
+    description: "Agent invoked `uip admin audit tenant sources`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources\b'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
@@ -55,7 +55,7 @@ success_criteria:
   - type: command_executed
     description: "Agent invoked `uip admin audit tenant events` with a bounded window AND at least one of --source/--target/--type"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b.*--from-date\s+\S+.*--to-date\s+\S+.*--(?:source|target|type)\s+'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--(?:source|target|type)\s+)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Follow-up to UiPath/skills#527 (merged). Four buckets of change to the `uipath-admin` audit content:

1. **Scope correction for login events** — login events live at **org** scope (Identity Server / IdP), not per-tenant. Fixed in `SKILL.md` disambiguation table, Investigation 2 in `audit-workflow-guide.md`, and `audit_login_history_e2e.yaml`.
2. **Two new e2e artifact-verify tests** — `audit_export_verify_e2e.yaml` (tenant) and `audit_org_export_verify_e2e.yaml` (org). Both run real exports, unzip them, and assert that the per-day event IDs are a subset of the live `events` API for the same whole-day window. Window slides with the run date (`5 days ago` → `2 days ago` UTC) to keep the >48h LTS-lag buffer.
3. **Event examples cross-checked against the Audit Service metadata** — walked `AuditService/event-metadata/definitions/{org,tenant}/*.json` and fixed every made-up source/target/type name in the workflow guide:
   - Investigation 1 example: Source `Orchestrator` (not `Folders`), Target `Folders` (not `Folder`), Type `Delete folder` (not `Deleted folder`).
   - Replaced fictional "AI Trust Layer policy" / "MFA" prompts with real events: `Governance` → `Policy management` → `Edited policy`, and `Organization Management` → `Org Membership` → `User Manually Removed From An Org`.
   - Corrected the SKILL.md disambiguation row: AOps Governance/Pipelines/Source Control are **org**-scoped despite the AOps naming; tenant scope is Orchestrator, Action Center, Apps, AgentHub, Document Understanding, Integration Service, Test Manager, Data Fabric, Process Mining, Relay, Hypervisor, tenant-side Admin.
   - Added a callout that CLI responses use lowerCamelCase (`name`, `id`, `eventTargets`, `eventTypes`) over the metadata JSON's PascalCase.
4. **Fixes from the May 15 evalboard run**:
   - `audit_sources_smoke.yaml` — drop `--output json` requirement (test grades user-intent, not flag-compliance).
   - `audit_who_did_x_e2e.yaml` — convert sequential `.*` regex to order-independent lookaheads.
   - `audit_login_history_e2e.yaml` — drop the over-specific `--status Failure` criterion; broaden prompt to "login attempts" generally.

### Tyler's review on this PR (all addressed)

- ✅ **#1 Broaden org-scope guideline** beyond identity events — Investigation 2's `**Scope: org**` callout now lists Identity Server / Membership / License & billing / Tenant lifecycle / Org settings / Robot accounts.
- ✅ **#2 Dynamic dates in export tests** — replaced the pinned `2026-05-10..12` window with a sliding `date -u -d '5 days ago'` → `date -u -d '2 days ago'` window resolved in both the prompt and the verifier `run_command`.
- ✅ **#3 Drop the org-scope hint from the login prompt** — prompt is now just `"Show me login attempts for jane.doe@example.com over the last month."` (also makes the window evergreen).

## Files

```
skills/uipath-admin/
├── SKILL.md                                            # disambiguation: logins → org; tenant-scope source list corrected
└── references/audit-workflow-guide.md                  # Investigation 1 & 2: real source/target/type names; broader org-scope callout

tests/tasks/uipath-admin/
├── audit_login_history_e2e.yaml                        # tenant → org; "last month" prompt; drop --status criterion
├── audit_sources_smoke.yaml                            # drop --output json requirement
├── audit_who_did_x_e2e.yaml                            # lookahead regex
├── audit_export_verify_e2e.yaml                        # NEW — tenant artifact verify, sliding window
└── audit_org_export_verify_e2e.yaml                    # NEW — org artifact verify, sliding window
```

## Verification

| Test | Status |
|---|---|
| 7 existing audit smokes | ✅ Passed in parent-PR's last green CI run ([UiPath/skills#527 run #25831810376](https://github.com/UiPath/skills/actions/runs/25831810376) — all at score 1.00). This PR only loosens regex in 2 of them; new patterns are `⊇` previously-passing patterns. |
| `audit_who_did_x_e2e` (modified) | ✅ Regex change addresses the May 15 evalboard failure where the agent put `--source/--target/--type` before date flags; lookaheads are order-agnostic. |
| `audit_login_history_e2e` (modified) | ⏳ Will be re-verified via evalboard daily e2e against the org scope; scope correction matches the May 15 evalboard's actual agent behavior (the agent was already trying org-style queries). |
| `audit_export_verify_e2e` (new) | ⏳ Blocked on UiPath/cli#1372 — published `@uipath/cli` doesn't include `uip admin audit` yet. Will auto-pass on first daily e2e run after CLI republishes. Documented in the task description. |
| `audit_org_export_verify_e2e` (new) | ⏳ Same blocker — auto-passes after CLI republish. |

**Local validation**:
- [x] All 5 changed/new YAML task files parse cleanly via `python -c "import yaml; yaml.safe_load(open('...'))"`
- [x] Every source/target/event-type name referenced in workflow guide and tests exists in `AuditService/event-metadata/definitions/{org,tenant}/*.json` (verified by reading the JSON)
- [x] No `tenant`-scope login references remain in any audit content (verified via `grep`)
- [x] Disambiguation table change matches Investigation 2 workflow guide
- [x] Sliding-window math in both verify tests uses identical `date -u -d` invocations in prompt and verifier (so the agent's query and the comparison query target the same window)
- [ ] Smoke CI on this branch — pending the latest push

## Sequencing

The two new artifact-verify e2e tasks depend on `uip admin audit` existing in the **published** `@uipath/cli`. Until UiPath/cli#1372 lands and republishes, those tasks fail at the export step with `unknown command 'audit'`. The scope-correction, metadata-alignment, and existing-test fixes all work today against the published CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)