### PR TITLE
docs(uipath-maestro-case): canonical form per sink for expression syntax

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -258,7 +258,7 @@ If neither holds, the io-binding validator surfaces the misalignment.
 | Error            | -> sendError                              | ← top-level Error sibling → vars.sendError
 | Action           | -> userDecision                           | ← action task top-level output → vars.userDecision
 | —                | caseStatus = "InReview"                   | ← set caseStatus literally
-| —                | reviewCount = =js:(vars.reviewCount + 1)  | ← increment counter
+| —                | reviewCount = =js:vars.reviewCount + 1    | ← increment counter
 | —                | summary = =vars.response.message.text     | ← copy another variable's sub-field
 ```
 

--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -34,6 +34,44 @@ When using the literal/expression mode, the `--value` string can start with one 
 
 > Plain strings (no prefix) are literal values. `"hello"` is literally the string `hello`, not an expression.
 
+> The prefix tells you WHAT the value refers to. The **sink** tells you HOW to wrap it — see [§ Canonical form per sink](#canonical-form-per-sink) below.
+
+## Canonical form per sink
+
+Every `=`-prefixed value in `caseplan.json` is dispatched to one of two runtime evaluators based on the sink it lands in. **The wrap form must match the sink** — wrong wrap is a silent runtime fault (the literal string arrives at the consumer instead of the resolved value).
+
+### Two evaluator paths
+
+| Path | Trigger | Capabilities |
+|---|---|---|
+| **Lookup** | Value starts with `=vars.<id>` or `=bindings.<id>` | Strip prefix, look up by id, return value. NO operators, NO dotted access, NO `=metadata.` |
+| **JS eval** | Value starts with `=js:<expr>` | Full JS evaluation. `vars`, `metadata`, `bindings`, `response` in scope. Operators, function calls, dotted access all work |
+
+`data.inputs[].value` on non-connector tasks runs **lookup** when the value matches `^=vars\.\w+$` or `^=bindings\.\w+$`; **JS eval** otherwise. Connector body fields, filter expressions, and condition expressions ALL run **JS eval** — they require `=js:` wrap regardless of value shape.
+
+### Canonical form per sink
+
+| Sink | Plain-ref form (when applicable) | Expression form |
+|---|---|---|
+| **Non-connector task `data.inputs[].value`** | `=vars.<id>` / `=bindings.<id>` (single identifier — no dots, no operators) | `=js:<expr>` (everything else: `=metadata.*`, dotted access, operators, function calls) |
+| **Connector body field — dot-notation** (curated connectors) | (no plain branch) | `=js:(<expr>)` — uniform wrap, parens always |
+| **Connector trigger filter expression** (`body.filters.expression`) with variable refs | n/a | `` =js:`<JMESPath with ${vars.X} interpolations>` `` |
+| **Connector trigger filter expression** plain literal (no variables) | Unwrapped CEQL/JMESPath text | n/a |
+| **`conditionExpression`** (stage entry/exit, task entry, case exit, trigger rules, edge transitions) | (no plain branch) | `=js:<expr>` — no outer parens; sub-clauses get manual parens when combining via `&&` / `\|\|` |
+| **SLA rule `expression`** | (no plain branch) | `=js:<expr>` (default: `=js:true`) |
+| **Task output `source` / `target`** | `=vars.<varId>` / `=<rawFieldName>` | n/a (always plain) |
+| **Binding refs in `data.context`, `caseShape.context`** | `=bindings.<id>` | n/a |
+
+> **JIT object mode (out of scope for this version).** When an activity's `inputMetadata.inputMode === "jitObject"` (synthetic HTTP request bodies, generic body-passthrough activities), the whole connector body becomes one `=js:({...})` expression with bare JS variable references inline. The skill currently routes synthetic HTTP through `queryParameters` instead. JIT-mode authoring is not documented in this version.
+
+### Conservative rule for `=metadata.X`
+
+The lookup-path resolver has NO `=metadata.` branch — plain `=metadata.X` is NOT resolved at runtime. **Always wrap as `=js:metadata.X`** (or `=js:(metadata.X)` if the sink requires parens). The FE design-time picker may classify `=metadata.X` as "variable" type, but that's a UI hint, not a runtime contract.
+
+### Planner-emit form
+
+The planner emits `tasks.md` using SDD-natural references — `=vars.X`, `=metadata.X`, `=bindings.X`, cross-task `<- "Stage"."Task".out` (verbatim, unresolved). The implementation step rewrites to the canonical sink form when constructing `caseplan.json`. Detail: [plugins/variables/io-binding/planning.md](plugins/variables/io-binding/planning.md) and each plugin's `impl-json.md`.
+
 ## Cross-Task References
 
 Cross-task references wire the output of an earlier task into an input of a later task. The planning syntax uses **names** (human-readable), which the implementation phase resolves to variable IDs via direct JSON lookup.
@@ -126,3 +164,8 @@ See [plugins/variables/io-binding/impl-json.md](plugins/variables/io-binding/imp
 - **Fabricating output names.** Always discover via `tasks describe`. A typo becomes a runtime null, not a validation error.
 - **Plain-string where expression was intended.** `"metadata.amount"` (no `=`) is the literal string `metadata.amount`, not a reference. Always include the `=` prefix for dynamic values.
 - **Nesting expressions inside literals.** `"$metadata.amount"` or `"{{ amount }}"` do not work. Use `=metadata.amount` directly as the full value.
+- **Plain `=vars.X` inside connector body JSON.** The runtime does NOT evaluate plain prefix refs in connector body sinks — they arrive at the API as literal strings. Wrap as `=js:(vars.X)`. See [§ Canonical form per sink](#canonical-form-per-sink).
+- **Plain `=metadata.X` anywhere.** The lookup-path resolver has no `=metadata.` branch. Always wrap as `=js:metadata.X` (or `=js:(metadata.X)` for connector body / parens-required sinks).
+- **Dotted access via plain prefix.** `=vars.user.email` looks up a variable with id literally `user.email` and fails. Use `=js:vars.user.email`.
+- **`=js:(...)` outer parens on `conditionExpression`.** Conditions use bare `=js:<expr>` per FE convention. Sub-clause parens go inside when combining: `=js:(vars.X) && (vars.Y)` — outer wrap stays bare.
+- **Manually building filter-expression strings.** For filter sinks, author a structured FilterTree with `isLiteral: true` values when possible. Variable-bearing filters use `` =js:`<template>` `` with `${vars.X}` interpolations — see [connector-trigger-common.md](connector-trigger-common.md).

--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -45,7 +45,7 @@ Every `=`-prefixed value in `caseplan.json` is dispatched to one of two runtime 
 | Path | Trigger | Capabilities |
 |---|---|---|
 | **Lookup** | Value starts with `=vars.<id>` or `=bindings.<id>` | Strip prefix, look up by id, return value. NO operators, NO dotted access, NO `=metadata.` |
-| **JS eval** | Value starts with `=js:<expr>` | Full JS evaluation. `vars`, `metadata`, `bindings`, `response` in scope. Operators, function calls, dotted access all work |
+| **JS eval** | Value starts with `=js:<expr>` | Full JS evaluation. Scope: `vars`, `metadata`, `bindings`, `response`, `event`, `Error`, `datafabric`, `orchestrator`. Operators, function calls, dotted access all work. (`event` available only on `wait-for-connector` rules — bound to the incoming event payload.) |
 
 `data.inputs[].value` on non-connector tasks runs **lookup** when the value matches `^=vars\.\w+$` or `^=bindings\.\w+$`; **JS eval** otherwise. Connector body fields, filter expressions, and condition expressions ALL run **JS eval** — they require `=js:` wrap regardless of value shape.
 
@@ -70,7 +70,7 @@ The lookup-path resolver has NO `=metadata.` branch — plain `=metadata.X` is N
 
 ### Planner-emit form
 
-The planner emits `tasks.md` using SDD-natural references — `=vars.X`, `=metadata.X`, `=bindings.X`, cross-task `<- "Stage"."Task".out` (verbatim, unresolved). The implementation step rewrites to the canonical sink form when constructing `caseplan.json`. Detail: [plugins/variables/io-binding/planning.md](plugins/variables/io-binding/planning.md) and each plugin's `impl-json.md`.
+The planner emits `tasks.md` using SDD-natural references — `=vars.X`, `=metadata.X`, `=bindings.X`, cross-task `<- "Stage"."Task".out` (verbatim, unresolved). Other `=`-prefixed forms (`=response.X`, `=Error.X`, `=datafabric.X`, `=orchestrator.JobAttachments`) also pass through to impl for per-sink wrap; see [Expression Prefixes](#expression-prefixes) for the full set. The implementation step rewrites to the canonical sink form when constructing `caseplan.json`. Detail: [plugins/variables/io-binding/planning.md](plugins/variables/io-binding/planning.md) and each plugin's `impl-json.md`.
 
 ## Cross-Task References
 

--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -49,7 +49,7 @@ Every `=`-prefixed value in `caseplan.json` is dispatched to one of two runtime 
 
 `data.inputs[].value` on non-connector tasks runs **lookup** when the value matches `^=vars\.\w+$` or `^=bindings\.\w+$`; **JS eval** otherwise. Connector body fields, filter expressions, and condition expressions ALL run **JS eval** — they require `=js:` wrap regardless of value shape.
 
-### Canonical form per sink
+### Form by sink (the table)
 
 | Sink | Plain-ref form (when applicable) | Expression form |
 |---|---|---|

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -165,6 +165,7 @@ The CLI's filter compiler only accepts `isLiteral: true` clauses in the FilterTr
 |---|---|
 | Literal (`"urgent"`, `42`, `true`) | `{ "isLiteral": true, "rawString": "\"urgent\"", "value": "urgent" }` — JSON-encoded `rawString`, unwrapped `value` |
 | Variable reference (`=vars.X`, `=metadata.X`, `=bindings.X`) | `{ "isLiteral": false, "rawString": "=vars.X", "value": "=vars.X" }` — both fields carry the `=`-prefixed reference verbatim |
+| Pre-wrapped expression (`=js:<expr>` on a filter clause value, e.g. `=js:vars.amount > 5000`) | `{ "isLiteral": false, "rawString": "=js:<expr>", "value": "=js:<expr>" }` — same impl treatment as plain refs (stripped from CLI payload; composed into the post-CLI template literal) |
 
 The planner emits a single unified FilterTree containing both clause types. The impl then:
 
@@ -197,7 +198,7 @@ Planner emits to `tasks.md`:
 Impl composes (after CLI processes the literal-only subset):
 
 ```
-=js:`(parentFolderId == '<inbox-id>') && (contains(subject, ${vars.urgentKeyword})) && (contains(from, 'VIP'))`
+=js:`(parentFolderId == '<inbox-id>') && (contains(subject, '${vars.urgentKeyword}')) && (contains(from, 'VIP'))`
 ```
 
 **Canonical filter-expression form with variables** (matches FE `buildFiltersExpression` output at `IntsvcActivityConfigurationUtils.ts:358-371`):
@@ -211,10 +212,18 @@ Impl composes (after CLI processes the literal-only subset):
 - References appear as `${vars.X}` / `${metadata.X}` / `${bindings.X}` template-literal interpolations — NOT as `=vars.X` / `=metadata.X` (plain prefix doesn't get evaluated inside the body sink). All `=js:<ref>` forms get the same transformation via FE's `wrapJsVariablesInTemplateLiteral` (`IntsvcCommonUtils.ts:251-258`).
 - For each `=<prefix>.X` reference in the SDD/tasks.md filter, the impl emits `${<prefix>.X}` inside the appropriate JMESPath clause.
 
+> **String-operand quoting (mandatory).** FE's `wrapJsVariablesInTemplateLiteral` does pure substitution — `=js:vars.X` → `${vars.X}` with NO surrounding quotes added (regex at `IntsvcCommonUtils.ts:257`; behavior confirmed by `IntsvcActivityConfigurationUtils.test.ts:986` → `:996`, which asserts the substituted output is unquoted). For JMESPath string operands (`contains(field, <string>)`, `field == '<string>'`), the impl MUST emit single quotes around the `${vars.X}` substitution. For numeric / boolean / JMESPath-literal-backtick operands, no surrounding quotes. Examples:
+>
+> - String operand: `contains(subject, '${vars.urgentKeyword}')` ✓
+> - Numeric operand: `amount > ${vars.minAmount}` ✓
+> - JMESPath array literal: `` contains(`["Open","Closed"]`, Status) `` ✓ (literal, no substitution)
+>
+> Forgetting quotes on a string operand evaluates at runtime to invalid JMESPath (e.g. `contains(subject, Quarterly Review)` — identifier, not string).
+
 **Worked example.** SDD filter: `subject contains =vars.calendarTitle`. Required event-param `parentFolderId` resolved to an Outlook folder id. The impl writes:
 
 ```js
-=js:`(parentFolderId == 'AAMkAD...') && (contains(subject, ${vars.calendarTitle}))`
+=js:`(parentFolderId == 'AAMkAD...') && (contains(subject, '${vars.calendarTitle}'))`
 ```
 
 Both `body.filters.expression` and `activityPropertyConfiguration.filterExpression` carry this same combined form.

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -93,7 +93,7 @@ If a reference cannot be resolved, **AskUserQuestion** with the candidates (drop
 This is a hard gate — do NOT proceed to writing tasks.md until every required event parameter has a value.
 
 1. Collect every `inputs.eventParameters[?required]` entry from the spec output.
-2. For each, check whether sdd.md names a value (literal, resolved reference id, or — in `filter:` only — a `=vars.X` runtime reference).
+2. For each, check whether sdd.md names a value (literal, resolved reference id, or — in `filter:` only — a `=vars.X` runtime reference; impl compiles this to `` =js:`...${vars.X}...` `` template-literal form when writing `body.filters.expression`, see § Dynamic variable limitation).
 3. If missing and no `defaultValue`, **AskUserQuestion** — list the missing parameters with their `displayName` and what kind of value is expected.
 4. Free-form input is appropriate when the value space is open-ended (folder names, channel names, IDs); when a finite set of sensible values exists (e.g. an `enum`), present them via AskUserQuestion per the dropdown rule in [SKILL.md](../SKILL.md).
 5. Only after all required event parameters have values, proceed.
@@ -105,7 +105,7 @@ This is a hard gate — do NOT proceed to writing tasks.md until every required 
 SDD input fields don't map 1:1 to the connector's schema. Cross-reference each SDD input against `spec.inputs.eventParameters[]` and `spec.filter.fields[]` from Step 3 to decide where it goes:
 
 - **eventParameters** → configure *what* the trigger monitors. Values must be **static** — resolved to IDs at planning time. Go into `input-values`.
-- **filter fields** → narrow *which* events fire the trigger. Values can be **static** literals or **dynamic** `=vars.X` references resolved at runtime. Go into `filter`.
+- **filter fields** → narrow *which* events fire the trigger. Values can be **static** literals (filter tree `isLiteral: true`) or **dynamic** `=vars.X` references compiled into `` =js:`...${vars.X}...` `` at impl time (see § Dynamic variable limitation). Go into `filter`.
 
 If an SDD input matches an `eventParameters` field name, it's an event parameter. If it matches a `filter.fields[].name`, it's a filter. If it matches neither, **AskUserQuestion** — the SDD may use different naming than the connector.
 
@@ -157,11 +157,32 @@ After the Phase 3 `case spec --input-details` call, both filter sinks contain th
 
 #### Dynamic variable limitation
 
-The filter tree only supports `isLiteral: true` values. When a filter requires runtime case variable references (`=vars.X`), write the `body.filters.expression` JMESPath string directly post-CLI and leave `essentialConfiguration.filter` as `null`. This is a known SDK limitation shared with flow-tool. Practically: pass the literal-only filter to `case spec`, then patch the `=vars.X` reference into the relevant sink afterwards (rare path).
+The filter tree only supports `isLiteral: true` values. When a filter requires runtime case variable references, the impl step writes the canonical FE template-literal form into `body.filters.expression` (and `activityPropertyConfiguration.filterExpression`) directly post-CLI, and leaves `essentialConfiguration.filter` as `null`. This is a known SDK limitation shared with flow-tool.
 
-> **Mandatory-filter clauses survive the patch.** The CLI's mandatory-filter expression (derived from required event-param values, see § Mandatory-filter contract above) is computed at `case spec` time and AND-prefixed onto `body.filters.expression` and `activityPropertyConfiguration.filterExpression`. When you hand-patch a `=vars.X` clause into either sink afterwards, preserve the existing mandatory prefix (`(<mandatory>) && (<your-patched-clause>)`) — overwriting the whole expression strips the required event-param matching and the trigger fires on a wider event set than intended.
+**Canonical filter-expression form with variables** (matches FE `buildFiltersExpression` output at `IntsvcActivityConfigurationUtils.ts:358-371`):
+
+```
+=js:`(<JMESPath clause 1>) && (<JMESPath clause 2 with ${vars.X} interpolation>)`
+```
+
+- Outer wrap: `` =js:`...` `` — JS prefix + template-literal backticks. The template literal evaluates at runtime to a JMESPath string.
+- Sub-clauses each wrapped in parens for operator-precedence grouping.
+- Variable references appear as `${vars.X}` template-literal interpolations — NOT as `=vars.X` (plain prefix doesn't get evaluated inside the body sink).
+- For each `=vars.X` reference in the SDD/tasks.md filter, the impl emits `${vars.X}` inside the appropriate JMESPath clause.
+
+**Worked example.** SDD filter: `subject contains =vars.calendarTitle`. Required event-param `parentFolderId` resolved to an Outlook folder id. The impl writes:
+
+```js
+=js:`(parentFolderId == 'AAMkAD...') && (contains(subject, ${vars.calendarTitle}))`
+```
+
+Both `body.filters.expression` and `activityPropertyConfiguration.filterExpression` carry this same combined form.
+
+> **Mandatory-filter clauses survive the rewrite.** The CLI's mandatory-filter expression (derived from required event-param values, see § Mandatory-filter contract above) is computed at `case spec` time. When impl writes the canonical template-literal form, it preserves the mandatory prefix: `` =js:`(<mandatory>) && (<your-vars-clause>)` ``. Overwriting the whole expression strips the required event-param matching and the trigger fires on a wider event set than intended.
 
 Only use field names that appear in `spec.filter.fields[]`. If a filter cannot be translated unambiguously, **AskUserQuestion**.
+
+Full per-sink rule and FE source-of-truth: [bindings-and-expressions.md § Canonical form per sink](bindings-and-expressions.md#canonical-form-per-sink).
 
 ---
 

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -167,8 +167,8 @@ The filter tree only supports `isLiteral: true` values. When a filter requires r
 
 - Outer wrap: `` =js:`...` `` — JS prefix + template-literal backticks. The template literal evaluates at runtime to a JMESPath string.
 - Sub-clauses each wrapped in parens for operator-precedence grouping.
-- Variable references appear as `${vars.X}` template-literal interpolations — NOT as `=vars.X` (plain prefix doesn't get evaluated inside the body sink).
-- For each `=vars.X` reference in the SDD/tasks.md filter, the impl emits `${vars.X}` inside the appropriate JMESPath clause.
+- References appear as `${vars.X}` / `${metadata.X}` / `${bindings.X}` template-literal interpolations — NOT as `=vars.X` / `=metadata.X` (plain prefix doesn't get evaluated inside the body sink). All `=js:<ref>` forms get the same transformation via FE's `wrapJsVariablesInTemplateLiteral` (`IntsvcCommonUtils.ts:251-258`).
+- For each `=<prefix>.X` reference in the SDD/tasks.md filter, the impl emits `${<prefix>.X}` inside the appropriate JMESPath clause.
 
 **Worked example.** SDD filter: `subject contains =vars.calendarTitle`. Required event-param `parentFolderId` resolved to an Outlook folder id. The impl writes:
 

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -157,7 +157,48 @@ After the Phase 3 `case spec --input-details` call, both filter sinks contain th
 
 #### Dynamic variable limitation
 
-The filter tree only supports `isLiteral: true` values. When a filter requires runtime case variable references, the impl step writes the canonical FE template-literal form into `body.filters.expression` (and `activityPropertyConfiguration.filterExpression`) directly post-CLI, and leaves `essentialConfiguration.filter` as `null`. This is a known SDK limitation shared with flow-tool.
+The CLI's filter compiler only accepts `isLiteral: true` clauses in the FilterTree (`case-spec-input-details.md § WorkflowValue`). When a filter requires runtime case variable references, the impl step writes the canonical FE template-literal form into `body.filters.expression` (and `activityPropertyConfiguration.filterExpression`) directly post-CLI, and leaves `essentialConfiguration.filter` as `null`. This is a known SDK limitation shared with flow-tool.
+
+**Planner-side authoring contract.** When translating an SDD filter clause to the `tasks.md` FilterTree, the planner classifies each clause by value shape:
+
+| SDD clause value | Encoded as `WorkflowValue` |
+|---|---|
+| Literal (`"urgent"`, `42`, `true`) | `{ "isLiteral": true, "rawString": "\"urgent\"", "value": "urgent" }` — JSON-encoded `rawString`, unwrapped `value` |
+| Variable reference (`=vars.X`, `=metadata.X`, `=bindings.X`) | `{ "isLiteral": false, "rawString": "=vars.X", "value": "=vars.X" }` — both fields carry the `=`-prefixed reference verbatim |
+
+The planner emits a single unified FilterTree containing both clause types. The impl then:
+
+1. Strips `isLiteral: false` entries from the CLI `--input-details.filter` payload (CLI rejects them).
+2. Runs `case spec --input-details` with the literal-only subset.
+3. Composes the canonical `` =js:`...${vars.X}...` `` template-literal form into `body.filters.expression` post-CLI by joining the CLI-compiled literal clauses with each var-bearing clause's translated JMESPath sub-clause (using `${<ref>}` for the `=vars.X` reference). Mandatory-filter prefix from required event-params is preserved.
+
+Example (SDD with mixed literal + var-bearing clauses):
+
+```
+filter: subject contains =vars.urgentKeyword AND from contains "VIP"
+```
+
+Planner emits to `tasks.md`:
+
+```json
+{
+  "filter": {
+    "groupOperator": "And",
+    "filters": [
+      { "id": "subject", "operator": "Contains",
+        "value": { "isLiteral": false, "rawString": "=vars.urgentKeyword", "value": "=vars.urgentKeyword" } },
+      { "id": "from", "operator": "Contains",
+        "value": { "isLiteral": true, "rawString": "\"VIP\"", "value": "VIP" } }
+    ]
+  }
+}
+```
+
+Impl composes (after CLI processes the literal-only subset):
+
+```
+=js:`(parentFolderId == '<inbox-id>') && (contains(subject, ${vars.urgentKeyword})) && (contains(from, 'VIP'))`
+```
 
 **Canonical filter-expression form with variables** (matches FE `buildFiltersExpression` output at `IntsvcActivityConfigurationUtils.ts:358-371`):
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -72,7 +72,7 @@ Requires `marksCaseComplete: false`. Swap `rule` to `selected-stage-exited` for 
   {
     "id": "Rule_xxxxxx",
     "rule": "wait-for-connector",
-    "conditionExpression": "event.type = 'case_closed'"
+    "conditionExpression": "=js:event.type === 'case_closed'"
   }
 ]]
 ```
@@ -89,7 +89,7 @@ Valid for both `marksCaseComplete: true` and `false`.
 | `false` | `selected-stage-exited` | `selectedStageId` |
 | `false` | `wait-for-connector` | — |
 
-`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
+`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
 ## Post-Write Verification
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -73,12 +73,14 @@ Fires when an upstream stage exits via a `wait-for-user` exit condition and the 
   {
     "id": "Rule_xxxxxx",
     "rule": "wait-for-connector",
-    "conditionExpression": "event.fraudScore > 0.8"
+    "conditionExpression": "=js:event.fraudScore > 0.8"
   }
 ]]
 ```
 
 Set `isInterrupting: true` for exception/fraud/escalation flows.
+
+`conditionExpression` uses bare `=js:<expr>` (no outer parens). For combined boolean expressions, wrap each sub-clause in parens before joining: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
 ## Rule-Type Catalog
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -76,7 +76,7 @@ Rules use DNF — outer array is OR, inner array is AND.
   {
     "id": "Rule_xxxxxx",
     "rule": "wait-for-connector",
-    "conditionExpression": "event.type = 'approved'"
+    "conditionExpression": "=js:event.type === 'approved'"
   }
 ]]
 ```
@@ -110,7 +110,7 @@ Routes the case back to the originating stage.
 | `false` | `selected-tasks-completed` | `selectedTasksIds` (array) |
 | `false` | `wait-for-connector` | — |
 
-`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
+`conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); for combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
 ## Post-Write Verification
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -65,12 +65,12 @@ Rules use DNF — outer array is OR, inner array is AND.
   {
     "id": "rxxxxxxxx",
     "rule": "adhoc",
-    "conditionExpression": "in.riskScore > 700"
+    "conditionExpression": "=js:vars.riskScore > 700"
   }
 ]]
 ```
 
-Expression syntax per [`../../../bindings-and-expressions.md`](../../../bindings-and-expressions.md). Use `=js:(...)` for expressions with operators.
+`conditionExpression` uses bare `=js:<expr>` (no outer parens) — per FE convention for conditions. Operators (`>`, `<`, `===`, etc.) and function calls go inline. For combined boolean expressions, wrap each sub-clause in parens before joining: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
 ### wait-for-connector — external event
 
@@ -79,7 +79,7 @@ Expression syntax per [`../../../bindings-and-expressions.md`](../../../bindings
   {
     "id": "rxxxxxxxx",
     "rule": "wait-for-connector",
-    "conditionExpression": "event.type = 'order_received'"
+    "conditionExpression": "=js:event.type === 'order_received'"
   }
 ]]
 ```

--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -152,7 +152,7 @@ List every unresolved recipient in the completion report (per SKILL.md § Comple
 
 ## Expression translation
 
-`tasks.md` entries carry natural-language conditions. Translate at execution using the expression prefixes documented in [`bindings-and-expressions.md`](../../bindings-and-expressions.md). Common patterns: `=js:<javascript>` for arbitrary boolean, `=vars.<id> === "<literal>"` for variable comparison, `=metadata.<field>` for case metadata. If ambiguous, AskUserQuestion with 2–3 candidates + "Something else" per SKILL.md Rule 2.
+`tasks.md` entries carry natural-language conditions. Translate at execution using the expression prefixes documented in [`bindings-and-expressions.md`](../../bindings-and-expressions.md). SLA rule `expression` is a boolean-condition sink — use bare `=js:<expr>` (no outer parens) per [§ Canonical form per sink](../../bindings-and-expressions.md#canonical-form-per-sink). Common patterns: `=js:vars.<id> === "<literal>"` for variable comparison, `=js:metadata.<field> === "<literal>"` for case metadata comparison, `=js:true` for the default rule, `=js:(vars.X === 'foo') && (vars.Y > 5)` for combined boolean (each sub-clause parenthesized for operator precedence). If ambiguous, AskUserQuestion with 2–3 candidates + "Something else" per SKILL.md Rule 2.
 
 ## Post-write validation
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
@@ -25,16 +25,17 @@ The `tasks.md` entry provides:
 
 ### Step 1 — Build `--input-details` JSON from tasks.md
 
-Construct the input-details object literally from `tasks.md`:
+Construct the input-details object from `tasks.md`, rewriting every value containing a reference to its canonical sink form (connector body fields use `=js:(<expr>)`):
 
 ```jsonc
 {
-    // bodyParameters from tasks.md input-values.bodyParameters (dotted keys preserved)
-    "bodyParameters": "<input-values.bodyParameters or omit>",
-    // queryParameters from tasks.md input-values.queryParameters (or omit)
-    "queryParameters": "<input-values.queryParameters or omit>",
-    // pathParameters from tasks.md input-values.pathParameters (or omit)
-    "pathParameters":  "<input-values.pathParameters or omit>",
+    // bodyParameters from tasks.md input-values.bodyParameters (dotted keys preserved;
+    // each value rewritten to canonical form per Step 1.a)
+    "bodyParameters": "<input-values.bodyParameters with values rewritten>",
+    // queryParameters from tasks.md input-values.queryParameters (same rewrite rule)
+    "queryParameters": "<input-values.queryParameters with values rewritten>",
+    // pathParameters from tasks.md input-values.pathParameters (same rewrite rule)
+    "pathParameters":  "<input-values.pathParameters with values rewritten>",
     // filter — FilterTree object from tasks.md (or omit when not authored)
     "filter": "<filter from tasks.md or omit>"
 }
@@ -44,7 +45,22 @@ Synthetic HTTP request activities (`object-name === "httpRequest"` / `"http-requ
 
 Full input-details contract: [`case-spec-input-details.md`](../../../case-spec-input-details.md).
 
-#### Step 1.a — Array-of-object body fields: pre-input scan (MANDATORY)
+#### Step 1.a — Rewrite references to canonical sink form
+
+Connector body sinks (`bodyParameters`, `queryParameters`, `pathParameters`) require `=js:(...)` wrap for every reference. Resolve cross-task refs first, then apply the wrap:
+
+| Value in tasks.md | Value passed to CLI |
+|---|---|
+| `"=vars.X"` | `"=js:(vars.X)"` |
+| `"=metadata.X"` | `"=js:(metadata.X)"` |
+| `"=bindings.X"` | `"=js:(bindings.X)"` |
+| `"<- "Stage"."Task".out"` | resolve to `"=vars.<outputVar>"` → `"=js:(vars.<outputVar>)"` |
+| `"=js:(<expr>)"` (pre-wrapped operator expression) | pass-through unchanged |
+| `"<literal value>"` (no leading `=`) | pass-through unchanged |
+
+Full per-sink rule and FE source-of-truth: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
+
+#### Step 1.b — Array-of-object body fields: pre-input scan (MANDATORY)
 
 Before passing `bodyParameters` to the CLI, scan for keys containing literal `[*]`. Halt if any are present — the binding is malformed.
 
@@ -216,7 +232,7 @@ All issues appended to the shared issue list per [logging/impl-json.md](../../lo
 8. `data.bindings[]` is empty `[]`
 9. Each entry in `data.inputs[]` and `data.outputs[]` has `var` / `id` / `elementId` minted (uniqueness rule applied for outputs)
 10. `bindings_v2.json` `resources` array matches the schema-appropriate bindings array (v19: `root.data.uipath.bindings[]`; v20: top-level `bindings[]`) after the deferred sync
-11. **No literal `[*]` keys in `data.inputs[name="body"].body` (or any input body).** Scan recursively (JSON.stringify + regex `"[^"]*\\[\\*\\][^"]*"\\s*:`). If any key contains literal `[*]`, halt — Step 1.a translation was skipped or incomplete. The body MUST use real arrays under parent names (e.g., `"toRecipients": [{...}]`), never `"toRecipients[*]": {...}`. Validate passes regardless; runtime APIs reject with HTTP 400.
+11. **No literal `[*]` keys in `data.inputs[name="body"].body` (or any input body).** Scan recursively (JSON.stringify + regex `"[^"]*\\[\\*\\][^"]*"\\s*:`). If any key contains literal `[*]`, halt — Step 1.b translation was skipped or incomplete. The body MUST use real arrays under parent names (e.g., `"toRecipients": [{...}]`), never `"toRecipients[*]": {...}`. Validate passes regardless; runtime APIs reject with HTTP 400.
 
 ## What NOT to Do
 
@@ -228,7 +244,7 @@ All issues appended to the shared issue list per [logging/impl-json.md](../../lo
 - **Do NOT pass a raw CEQL string under `queryParameters.where`** (or whichever connector-specific name) when authoring a filter. Pass the structured tree under `filter:` in tasks.md and let the CLI compile both halves.
 - **Do NOT pass `ceqlExpression` directly under `--input-details`.** Derived only.
 - **Do NOT pass `bodyParameters` for synthetic HTTP request activities.** Use `queryParameters` instead, or omit.
-- **Do NOT pass literal `field[*]` keys in `bodyParameters`.** The `[*]` in `inputs.bodyFields[].name` is JSONPath-style schema notation meaning "array of"; it is NOT a valid input key. Express array-of-object body fields as real JSON arrays under the parent name (see [planning.md](planning.md)). Pre-input scan in [Step 1.a](#step-1a--array-of-object-body-fields-pre-input-scan-mandatory) halts on any literal `[*]` key.
+- **Do NOT pass literal `field[*]` keys in `bodyParameters`.** The `[*]` in `inputs.bodyFields[].name` is JSONPath-style schema notation meaning "array of"; it is NOT a valid input key. Express array-of-object body fields as real JSON arrays under the parent name (see [planning.md](planning.md)). Pre-input scan in [Step 1.b](#step-1b--array-of-object-body-fields-pre-input-scan-mandatory) halts on any literal `[*]` key.
 - **Do NOT auto-inject `entryConditions`.** Step 10 in [implementation.md](../../../implementation.md) handles them — injecting here creates duplicates.
 - **Never reuse a reference ID from a prior case or session.** Reference IDs (e.g., Jira project keys, Slack channel IDs) are scoped to the authenticated account behind each connection. Always resolve fresh via `uip is resources run list` against the current `--connection-id`. See [/uipath:uipath-platform — reference-resolution.md § Reference IDs Are Connection-Scoped (CRITICAL)](../../../../../uipath-platform/references/integration-service/reference-resolution.md#reference-ids-are-connection-scoped-critical).
 - **Do NOT call legacy `uip maestro case tasks describe` or `uip is resources describe`.** `case spec --input-details` replaces both. The legacy commands still work but produce a different shape that doesn't include `caseShape` / placeholders.

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
@@ -54,6 +54,7 @@ Connector body sinks (`bodyParameters`, `queryParameters`, `pathParameters`) req
 | `"=vars.X"` | `"=js:(vars.X)"` |
 | `"=metadata.X"` | `"=js:(metadata.X)"` |
 | `"=bindings.X"` | `"=js:(bindings.X)"` |
+| `"=<other-prefix>.X"` (e.g. `=response.X`, `=Error.X`, `=datafabric.X`, `=orchestrator.JobAttachments[0]`) | `"=js:(<other-prefix>.X)"` — strip leading `=`, wrap in `=js:(...)` |
 | `"<- "Stage"."Task".out"` | resolve to `"=vars.<outputVar>"` → `"=js:(vars.<outputVar>)"` |
 | `"=js:(<expr>)"` (pre-wrapped operator expression) | pass-through unchanged |
 | `"<literal value>"` (no leading `=`) | pass-through unchanged |

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/planning.md
@@ -111,8 +111,12 @@ For each required field in spec.inputs.*, there must be a matching SDD input. If
 Values can be:
 - **Static literals** — `"Payment__c"`, `"Text"`, `42`
 - **Resolved reference IDs** — from Step 4
-- **Case variable references** — `=vars.X` for runtime values
-- **Expressions** — `=js:()` only when operators are needed
+- **Case variable references** — `=vars.X` (impl wraps as `=js:(vars.X)` for the connector body sink before passing to the CLI)
+- **Metadata references** — `=metadata.X` (impl wraps as `=js:(metadata.X)`)
+- **Pre-wrapped operator expressions** — `=js:(vars.amount > 5000)` (already canonical — pass-through)
+- **Cross-task refs** — `<- "Stage"."Task".output` (impl resolves to `=vars.<outputVar>` then wraps)
+
+> **tasks.md carries SDD-natural form.** The implementation step (Step 9.7 of connector-activity impl) rewrites every reference to its canonical sink form when constructing `--input-details`. Connector body sinks use `=js:(<expr>)`. Full rule: [bindings-and-expressions.md § Canonical form per sink](../../../../bindings-and-expressions.md#canonical-form-per-sink).
 
 ### 7. Optional — author a server-side filter
 
@@ -167,7 +171,7 @@ Planner emits to `tasks.md input-values.bodyParameters`:
 }
 ```
 
-**Never** emit a key with literal `[*]` in `bodyParameters`. The CLI accepts it (well-formed JSON) and validate passes; runtime APIs (Microsoft Graph, Slack, etc.) reject with HTTP 400 `UnableToDeserializePostBody`. Pre-input scan in [`impl-json.md` § Step 1.a](impl-json.md#step-1a--array-of-object-body-fields-pre-input-scan-mandatory) halts on any literal `[*]` key.
+**Never** emit a key with literal `[*]` in `bodyParameters`. The CLI accepts it (well-formed JSON) and validate passes; runtime APIs (Microsoft Graph, Slack, etc.) reject with HTTP 400 `UnableToDeserializePostBody`. Pre-input scan in [`impl-json.md` § Step 1.b](impl-json.md#step-1b--array-of-object-body-fields-pre-input-scan-mandatory) halts on any literal `[*]` key.
 
 ## tasks.md Entry Format
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/impl-json.md
@@ -6,7 +6,7 @@
 
 Fetch the populated trigger task scaffold via `uip maestro case spec --type trigger --input-details`, then drop it into `caseplan.json` as a `wait-for-connector` task. Field discovery and reference resolution are done during [planning](planning.md) — implementation reads resolved values from `tasks.md` and threads them through the spec call.
 
-For shared CLI invocation, placeholder substitution, and anti-patterns, see [connector-trigger-common.md](../../../connector-trigger-common.md). This doc covers only the **task-specific** parts.
+For shared CLI invocation, placeholder substitution, anti-patterns, and the canonical form for filter expressions with variable references, see [connector-trigger-common.md](../../../connector-trigger-common.md). For the per-sink canonical-form table covering all expression-syntax decisions in this skill, see [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink). This doc covers only the **task-specific** parts.
 
 ## Prerequisites from Planning
 

--- a/skills/uipath-maestro-case/references/plugins/triggers/event/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/triggers/event/impl-json.md
@@ -2,7 +2,7 @@
 
 Configure the case-level event trigger by writing directly into the trigger node in `caseplan.json`. Field discovery and reference resolution are done during [planning](planning.md). Phase 3 calls `uip maestro case spec --type trigger --input-details` once and consumes the populated `caseShape`.
 
-For shared CLI invocation, placeholder substitution, and anti-patterns, see [connector-trigger-common.md](../../../connector-trigger-common.md). This doc covers only the **trigger-node-specific** parts.
+For shared CLI invocation, placeholder substitution, anti-patterns, and the canonical form for filter expressions with variable references, see [connector-trigger-common.md](../../../connector-trigger-common.md). For the per-sink canonical-form table covering all expression-syntax decisions in this skill, see [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink). This doc covers only the **trigger-node-specific** parts.
 
 > **v20 layout-strip (Rule 19).** Read `Schema:` header from `tasks.md`. In **v20 mode**, omit ALL of: `position`, `style`, `measured`, `width`, `height`, `zIndex` from the trigger node. Skip the position-computation step entirely. Keep `data.parentElement`, `data.isInvalidDropTarget`, `data.isPendingParent`, `data.label`, `data.description`, `data.uipath`. Recipe shape below shows v19 fields; v20 strips listed render fields and skips position math. Placeholder-fallback logic and `entry-points.json` shape are identical across schemas.
 

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -52,9 +52,9 @@ Cross-cutting rules:
 
 For each task input in `tasks.md`:
 
-**Literals/expressions** — write the value string directly to `input.value`:
+**Literals/expressions** — write the value string directly to `input.value`. Values shown are POST-rewrite — impl translates `=metadata.X` from `tasks.md` to `=js:metadata.X` per the [canonical-form table](../../../bindings-and-expressions.md#canonical-form-per-sink) (plain `=metadata.X` is not resolved by the lookup-path evaluator):
 ```
-"=vars.amount"  |  "=metadata.ExternalId"  |  "50"  |  "=js:new Date()"
+"=vars.amount"  |  "=js:metadata.ExternalId"  |  "50"  |  "=js:new Date()"
 ```
 
 **Cross-task references** (`input <- "Stage A"."Task X".outputName`) — resolve first:

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -183,13 +183,15 @@ Where a `=vars.X` reference resolves to a declaration with a different `type` th
 
 ## Connector Tasks
 
-Connector task input values are written during Step 9.7 (connector detail), not during this I/O binding step. Resolve cross-task `var` IDs before constructing the `input-values` body from `tasks.md`:
+Connector task input values are written during Step 9.7 (connector detail), not during this I/O binding step. Resolve cross-task `var` IDs before constructing the `input-values` body from `tasks.md`, then apply the canonical wrap per sink:
 
 ```json
-{ "body": { "email": "=vars.employeeEmail", "caseRef": "=metadata.ExternalId" } }
+{ "body": { "email": "=js:(vars.employeeEmail)", "caseRef": "=js:(metadata.ExternalId)" } }
 ```
 
-Use `=js:()` only for expressions with operators (e.g., `=js:(vars.amount > 5000)`). See [connector-activity/impl-json.md](../../../plugins/tasks/connector-activity/impl-json.md).
+**Connector body sinks require `=js:(...)` wrap for ALL references** — `=vars.X`, `=metadata.X`, `=bindings.X`, and operator expressions (e.g. `=js:(vars.amount > 5000)`). The runtime only evaluates `=js:` prefixed strings inside connector body fields; plain prefix forms arrive at the API as literal strings (silent runtime fault). Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
+
+See [connector-activity/impl-json.md](../../../plugins/tasks/connector-activity/impl-json.md) for the connector body write path.
 
 ## End-to-End: Task A Output → Task B Input
 

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/planning.md
@@ -50,11 +50,14 @@ For the full notation and expression prefixes, see [bindings-and-expressions.md]
 | Cross-task output | `input <- "Stage"."Task".output` | `emails <- "Triage"."Fetch Inbox".emails` |
 | Global variable | `input = "=vars.<id>"` | `caseId = "=vars.caseId"` |
 | Metadata | `input = "=metadata.<field>"` | `caseRef = "=metadata.ExternalId"` |
+| Binding | `input = "=bindings.<id>"` | `connectionId = "=bindings.bA1B2C3D4"` |
 | Literal | `input = "<value>"` | `maxResults = "50"` |
 
 > **Note:** task INPUT bindings still use `<-` for cross-task references (`input <- "Stage"."Task".output`) — this is the planner-side notation for "this input value comes from another task's output." Task OUTPUT bindings use `->` for extract (`Field -> caseVar`) and `=` for set/compute/copy. Different directional conventions because inputs read from somewhere; outputs write to somewhere.
 
 Record discovered outputs on each task entry (`outputs: kycResult, riskScore, error`) so downstream cross-task references can be validated during implementation.
+
+> **Planner emits SDD-natural form; impl applies the per-sink canonical wrap.** Values in `tasks.md` use the natural prefix notation shown above — `=vars.X`, `=metadata.X`, `=bindings.X`, cross-task `<-`. The implementation step rewrites each value to its canonical sink form when constructing `caseplan.json` (e.g., `=js:(vars.X)` for connector body fields, `=js:metadata.X` for `=metadata` references in any sink that runs the JS evaluator). Full rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
 ## Outputs table validation rules
 


### PR DESCRIPTION
## Summary

- Agents writing into `caseplan.json` had no consistent rule for wrapping references (`=vars.X`, `=metadata.X`, `=bindings.X`) when those values land in different sinks. Wrong wrap is a silent runtime fault — the literal string arrives at the connector API / JMESPath engine / JS evaluator instead of the resolved value. Empirically observed in `outlook-calendar-event-basic` test: caseplan.json `"messageToSend": "=vars.calendarTitle"` arrived at the Slack API as literal text.
- Adds **§ Canonical form per sink** to `bindings-and-expressions.md` — a single per-sink table grounded in the FE source-of-truth (`EditorUtil.ts`, `IntsvcCommonUtils.ts`, `IntsvcActivityConfigurationUtils.ts`, `case-mgmt-migrations/v11-to-v12/`, `VariablesService.tsx`).
- Aligns all 13 affected docs across the maestro-case skill: io-binding, connector-activity, connector-trigger / event triggers, the 4 conditions plugins, and SLA. Includes a follow-up commit addressing 3 skill-review findings.

## Mental model

Planner emits SDD-natural form (`=vars.X`); impl rewrites to canonical sink form (e.g. `=js:(vars.X)` for connector body, bare `=js:<expr>` for conditions, `` =js:`...${vars.X}...` `` for filter expressions). Single transformation point per sink.

| Sink | Canonical form |
|---|---|
| Non-connector task `data.inputs[].value` (plain ref) | `=vars.<id>` / `=bindings.<id>` |
| Non-connector task `data.inputs[].value` (expression) | `=js:<expr>` |
| Connector body field (dot-notation) | `=js:(<expr>)` |
| Filter expression with variable refs | `` =js:`<JMESPath with ${vars.X} interpolations>` `` |
| `conditionExpression` (entry/exit/SLA/edge/trigger-rule) | `=js:<expr>` (no outer parens; manual sub-clause parens for combined boolean) |
| Output `source` / `target`, binding refs | plain prefix (`=vars.<varId>`, `=bindings.<id>`) |

JIT object mode (synthetic HTTP, generic-body activities) deferred with an explicit out-of-scope note — current skill routes synthetic HTTP via `queryParameters`, no JIT-mode test corpus.

## Doc bugs fixed en route

- `task-entry-conditions/impl-json.md:72`: `"in.riskScore > 700"` → `"=js:vars.riskScore > 700"` (missing `=js:` prefix; `in` identifier doesn't exist in FE evaluator scope — verified in `useStudioJavascriptEditor.tsx:240` and `EditorUtil.ts:292+`)
- `stage-exit-conditions`, `case-exit-conditions`, `task-entry-conditions`: `event.type = 'X'` → `=js:event.type === 'X'` (JS assignment vs comparison bug)
- `stage-entry-conditions`: `event.fraudScore > 0.8` → `=js:event.fraudScore > 0.8` (missing prefix)
- `sla/impl-json.md`: removed `=vars.<id> === "<literal>"` and bare `=metadata.<field>` from Expression translation patterns — both don't resolve at runtime; replaced with canonical `=js:...` forms

## FE source-of-truth references

| Find | Location |
|---|---|
| `addJavascriptPrefixWithParentheses` (the canonical wrap helper) | `~/UiPath/PO.Frontend/src/utils/EditorUtil.ts:60-74` |
| Doc comment: "wrapping is safe for all cases" | `EditorUtil.ts:47-50` |
| `TRANSLATION_CONFIGURATION.expressions.wrap` (IS activity properties write helper) | `IntsvcCommonUtils.ts:89-95` |
| `buildFiltersExpression` (template-literal form for filter sinks) | `IntsvcActivityConfigurationUtils.ts:358-371` |
| `wrapJsVariablesInTemplateLiteral` (`=js:<ref>` → `${<ref>}` transformation) | `IntsvcCommonUtils.ts:251-258` |
| `addJavascriptPrefix` (no-parens — used for condition sinks) | `EditorUtil.ts:30-44` + `case-mgmt-migrations/v11-to-v12/.../*ConditionUtils.ts:119,126,242,276` |
| `VariablesService.resolveVariable` (runtime lookup-path resolver — only handles `=vars.` and `=bindings.`) | `VariablesService.tsx:264-282` |

## Files changed

14 files: 1 new section in `bindings-and-expressions.md` + 12 alignment edits across io-binding, connector-activity / connector-trigger / event-trigger / conditions / SLA plugins.

```
skills/uipath-maestro-case/references/bindings-and-expressions.md
skills/uipath-maestro-case/references/connector-trigger-common.md
skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
skills/uipath-maestro-case/references/plugins/sla/impl-json.md
skills/uipath-maestro-case/references/plugins/tasks/connector-activity/impl-json.md
skills/uipath-maestro-case/references/plugins/tasks/connector-activity/planning.md
skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/impl-json.md
skills/uipath-maestro-case/references/plugins/triggers/event/impl-json.md
skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
skills/uipath-maestro-case/references/plugins/variables/io-binding/planning.md
```

## Out of scope / known follow-ups

- **JIT object mode** — single-line note in the canonical-form table marks it as deferred. Re-open when a JIT-mode activity hits the test corpus.
- **Cross-task ref var-ID resolution at planner time** — currently resolved at impl Step 9.7. Could canonicalize at planner if needed; not justified by current pain.

## Test plan

- [ ] Re-run the variable-redesign test case at `~/Library/CloudStorage/OneDrive-UiPath/case_coding_agent_tests/trigger-varaible-test/outlook-calendar-event-basic/` (clear `tasks/` + built solution first; sdd.md only)
- [ ] Inspect resulting caseplan.json `inputs[name="body"].body.messageToSend` — must be `=js:(vars.calendarTitle)` form, not plain `=vars.calendarTitle`
- [ ] Confirm Studio Web renders the case without expression-resolution errors
- [ ] Test at least one non-connector task input with a simple `=vars.X` binding (should remain plain — no `=js:` wrap)
- [ ] Test one `conditionExpression` (e.g. on a stage entry condition) with the new bare `=js:<expr>` form

## Knowledge dump for reviewers

Full grilling Q&A trail (11 questions covering parens-vs-no-parens, the four sink families, JIT defer rationale, planner-vs-impl transformation point, conservative `=metadata.X` rule, etc.) plus FE code reference index is captured at:

`~/Library/CloudStorage/OneDrive-UiPath/case_knowledge/case-expression-syntax-canonical-form.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)