### PR TITLE
fix(tests): align uipath-agents tasks with `uip solution init`

### DIFF
--- a/tests/tasks/uipath-agents/builtin_tool/builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/builtin_tool/builtin_tool.yaml
@@ -33,9 +33,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -8,7 +8,7 @@ description: >
   `uipath.core.agent.<resourceKey>` node with a matching top-level
   `bindings[]` entry — no duplicates per
   `(resourceKey, propertyAttribute)` pair.
-tags: [uipath-agents, e2e, mode:build, lifecycle:generate, shape:single-node, resource]
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, shape:single-node, resource]
 
 agent:
   type: claude-code
@@ -41,9 +41,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/coded_in_flow_register/coded_in_flow_register.yaml
+++ b/tests/tasks/uipath-agents/coded_in_flow_register/coded_in_flow_register.yaml
@@ -6,7 +6,7 @@ description: >
   registers the project and writes a process resource file with a `resource.key`
   UUID under `resources/solution_folder/process/`, and that
   `uip solution resource list` surfaces it as a Local resource.
-tags: [uipath-agents, smoke, mode:build, lifecycle:generate, resource, feature:registry]
+tags: [uipath-agents, smoke, coded, mode:build, lifecycle:generate, resource, feature:registry]
 
 agent:
   type: claude-code
@@ -39,9 +39,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new or uip solution init"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+(new|init)'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/context_index/context_index.yaml
@@ -33,9 +33,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/dispute_analyst_agent/dispute_analyst_agent.yaml
+++ b/tests/tasks/uipath-agents/dispute_analyst_agent/dispute_analyst_agent.yaml
@@ -64,9 +64,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/external_agent_tool/external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/external_agent_tool/external_agent_tool.yaml
@@ -38,9 +38,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/external_apiworkflow_tool/external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/external_apiworkflow_tool/external_apiworkflow_tool.yaml
@@ -38,9 +38,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/external_escalation/external_escalation.yaml
@@ -42,9 +42,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/external_maestro_tool/external_maestro_tool.yaml
@@ -38,9 +38,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/external_rpa_tool/external_rpa_tool.yaml
@@ -40,9 +40,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/guardrail_custom_word/guardrail_custom_word.yaml
+++ b/tests/tasks/uipath-agents/guardrail_custom_word/guardrail_custom_word.yaml
@@ -32,9 +32,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/guardrail_discovery/guardrail_discovery.yaml
+++ b/tests/tasks/uipath-agents/guardrail_discovery/guardrail_discovery.yaml
@@ -35,9 +35,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app/guardrail_escalation_app.yaml
@@ -47,9 +47,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/guardrail_escalation_app_validation/guardrail_escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/guardrail_escalation_app_validation/guardrail_escalation_app_validation.yaml
@@ -36,7 +36,7 @@ initial_prompt: |
   - Recipient email: reviewer@example.com (type 3)
 
   Use path-based commands from the working directory (no cd required):
-    uip solution new "ValidationSol" --output json
+    uip solution init "ValidationSol" --output json
     uip agent init "ValidationSol/ReviewAgent" --output json
     uip solution project add "ValidationSol/ReviewAgent" --output json
     uip agent guardrails list --output json
@@ -55,7 +55,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created the solution"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/guardrail_pii_detection/guardrail_pii_detection.yaml
+++ b/tests/tasks/uipath-agents/guardrail_pii_detection/guardrail_pii_detection.yaml
@@ -35,9 +35,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/guardrail_prompt_injection/guardrail_prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/guardrail_prompt_injection/guardrail_prompt_injection.yaml
@@ -31,9 +31,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/init_validate.yaml
+++ b/tests/tasks/uipath-agents/init_validate.yaml
@@ -28,9 +28,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_builtin_tool/inline_builtin_tool.yaml
@@ -35,9 +35,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/inline_context_index/inline_context_index.yaml
@@ -36,9 +36,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -36,9 +36,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -34,9 +34,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/inline_external_escalation/inline_external_escalation.yaml
@@ -35,9 +35,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -35,9 +35,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -34,9 +34,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_in_flow/inline_in_flow.yaml
+++ b/tests/tasks/uipath-agents/inline_in_flow/inline_in_flow.yaml
@@ -32,9 +32,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -52,9 +52,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -34,9 +34,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -34,9 +34,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -34,9 +34,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_escalation/inline_solution_escalation.yaml
@@ -34,9 +34,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -34,9 +34,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -35,9 +35,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/is_connector_tool/is_connector_tool.yaml
@@ -50,9 +50,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/mcp_server_tool/mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/mcp_server_tool/mcp_server_tool.yaml
@@ -31,9 +31,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/resolution_drafter_agent/resolution_drafter_agent.yaml
+++ b/tests/tasks/uipath-agents/resolution_drafter_agent/resolution_drafter_agent.yaml
@@ -57,9 +57,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/solution_agent_tool/solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_agent_tool/solution_agent_tool.yaml
@@ -32,9 +32,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
@@ -31,9 +31,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/solution_escalation/solution_escalation.yaml
@@ -39,9 +39,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_maestro_tool/solution_maestro_tool.yaml
@@ -31,9 +31,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/solution_rpa_tool/solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/solution_rpa_tool/solution_rpa_tool.yaml
@@ -31,9 +31,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the solution with uip solution new"
+    description: "Agent created the solution with uip solution init"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+new'
+    command_pattern: 'uip\s+solution\s+init'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- `uip solution new` was renamed to `uip solution init`; 38 low-code uipath-agents task YAMLs had stale `command_pattern` / description text. Updated all of them, plus the embedded shell snippet in `guardrail_escalation_app_validation.yaml`.
- The two coded-agent tasks (`coded_in_flow_e2e`, `coded_in_flow_register`) were also updated to `init` and tagged `coded` (they previously had no type tag).
- 40 files changed; pure string/tag updates — no logic or behavioral changes.

## Verification
- Re-ran `tasks/uipath-agents/init_validate.yaml` after the rename: pattern matches now (score 0.714 → 0.786).
- Ran `tasks/uipath-agents/builtin_tool/builtin_tool.yaml` end-to-end: **8/8 criteria, score 1.000**.

## Out of scope (noted, not fixed in this PR)
`uip agent validate` is now strictly read-only — `.agent-builder/agent.json|bindings.json|entry-points.json` are emitted by `uip agent migrate` instead. 23 low-code tasks still attribute these files to validate. The `builtin_tool` run shows the skill already teaches `migrate` (those criteria passed), so this is a description/assertion cleanup that can land separately.

## Test plan
- [ ] `make -C tests test-uipath-agents` (or smoke subset) passes for low-code tasks
- [ ] `coded_in_flow_e2e` / `coded_in_flow_register` still pass with the new `coded` tag and tightened pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)