### PR TITLE
fix: list connections for shared folder (#ENGCE-57790)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -70,7 +70,7 @@ uip is connections ping "<connection-id>" --output json
 
 **If a connector key fails**, list all available connectors to find the correct key: `uip is connectors list --output json`. Connector keys are often prefixed (e.g., `uipath-<service>`).
 
-**Read [/uipath:uipath-platform — Integration Service — connections.md](../../../../../../uipath-platform/references/integration-service/connections.md) for connection selection rules** (default preference, `--refresh` retry on empty results, HTTP fallback, multi-connection disambiguation, no-connection recovery, ping verification).
+**Read [/uipath:uipath-platform — Integration Service — connections.md](../../../../../../uipath-platform/references/integration-service/connections.md) for connection selection rules** (default preference, `--all-folders` and `--refresh` retry on empty results as mentioned in the selection rules, HTTP fallback, multi-connection disambiguation, no-connection recovery, ping verification).
 
 ### Step 2 — Get enriched node definitions with connection
 

--- a/skills/uipath-platform/references/integration-service/connections.md
+++ b/skills/uipath-platform/references/integration-service/connections.md
@@ -28,14 +28,36 @@ Connections are authenticated sessions for a specific connector. They store cred
 
 **Always present connections to the user** — do not auto-select silently, even if there is only one default enabled connection. Recommend the default but let the user confirm.
 
+### Folder Scoping (`--all-folders`)
+
+`uip is connections list` returns connections from the **active folder only** by default. A "no connections found" result there does NOT mean tenant-wide absence — the connection may exist in another folder you can see.
+
+- Default: active folder only.
+- `--all-folders`: span every folder you have access to. Works with or without a `<connector-key>` positional.
+- **Mutually exclusive with `--folder` / `--folder-key`** — passing both fails with `Result: Failure`, `Message: "Conflicting folder flags..."`, exit code 1.
+
 ### For Native Connectors
 
-1. List connections for the connector
+1. List connections for the connector in the active folder:
+
+   ```bash
+   uip is connections list "<connector-key>" --output json
+   ```
+
 2. Present all enabled connections to the user using **Name, Owner, and Folder** (never UUIDs), **recommending** the default (`IsDefault: Yes`, `State: Enabled`):
    - "I found these connections: 1) **Salesforce Prod** by user@example.com (default, enabled, Shared folder) ← recommended 2) **Salesforce Dev** by admin@example.com (enabled, Shared folder). Which should I use?"
 3. If only one enabled connection exists, still confirm: "I found connection **<Name>** by <Owner> in **<Folder>** folder (default, enabled). Should I use this one?"
 4. If not enabled → prompt user to re-authenticate via `is connections edit <id>`
-5. If no connections exist → retry with `--refresh` (`uip is connections list "<connector-key>" --refresh --output json`) to bypass the CLI cache. If still empty, prompt user to create one via `is connections create "<connector-key>"`.
+5. **No connections in step 1 — widen the search before concluding none exist:**
+   1. Retry across all folders:
+      ```bash
+      uip is connections list "<connector-key>" --all-folders --output json
+      ```
+   2. If still empty, retry with `--refresh` to bypass the CLI cache:
+      ```bash
+      uip is connections list "<connector-key>" --all-folders --refresh --output json
+      ```
+   3. If still empty, prompt user to create one via `uip is connections create "<connector-key>"`.
 
 ### For BYOA Connections (Webhook Triggers)
 
@@ -62,10 +84,16 @@ BYOA (Bring Your Own Account) connections use an OAuth app the customer register
    uip is connections list "<connector-key>" --byoa --output json
    ```
 
-   If empty, retry with `--refresh` to bypass the CLI cache:
+   If empty, widen across folders:
 
    ```bash
-   uip is connections list "<connector-key>" --byoa --refresh --output json
+   uip is connections list "<connector-key>" --byoa --all-folders --output json
+   ```
+
+   If still empty, retry with `--refresh` to bypass the CLI cache:
+
+   ```bash
+   uip is connections list "<connector-key>" --byoa --all-folders --refresh --output json
    ```
 
    If still empty, **stop and tell the user**: "This trigger requires a BYOA connection for `<connector-key>`. None found. Create one in the Integration Service portal or with `uip is connections create "<connector-key>"`, then re-run."

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -4,7 +4,7 @@ description: >
   path parameter on the Jira "Get Issue" activity. Project + issue type are
   freely chosen by the agent; the issue key is deterministic so the test can
   verify the path-parameter wiring.
-tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira]
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira, ipe]
 
 agent:
   type: claude-code


### PR DESCRIPTION
## Description

Merging this PR will enable the agent to make `uip is connections list` call with `--all-folders` flag before fallback methods are called for `no connections found` error.

<img width="1512" height="749" alt="image" src="https://github.com/user-attachments/assets/94f30a8e-7e05-41d5-87cc-691b60eacf54" />
