### PR TITLE
fix(tests): align uipath-agents check scripts with low-code skill conventions

### DIFF
--- a/tests/tasks/uipath-agents/_shared/inline_wiring.py
+++ b/tests/tasks/uipath-agents/_shared/inline_wiring.py
@@ -7,7 +7,7 @@ Used by inline-agent tests that verify the combined shape of:
     handle (source) to the resource node's `input` handle (target), per
     `agent-flow-integration.md`,
   - a `resource.json` inside the inline agent's UUID subdirectory (pointed
-    to by `model.source` on the autonomous node).
+    to by `inputs.source` on the autonomous node).
 
 Import pattern in a check script:
 
@@ -19,6 +19,7 @@ Import pattern in a check script:
         find_autonomous_agent_node,
         find_resource_node,
         resolve_inline_agent_dir,
+        find_inline_resource,
         assert_edge,
     )
 """
@@ -90,17 +91,60 @@ def find_resource_node(
 
 
 def resolve_inline_agent_dir(flow_path: Path, agent_node: dict) -> Path:
-    """Return the inline agent's UUID subdirectory (from `model.source`)."""
-    source = (agent_node.get("model") or {}).get("source")
-    if not source:
-        sys.exit(f"FAIL: {AUTONOMOUS_NODE_TYPE} node has no model.source")
+    """Return the inline agent's UUID subdirectory.
+
+    Reads the projectId from `inputs.source` on the node instance. Falls
+    back to `model.source` for back-compat with older fixtures.
+    """
+    inputs = agent_node.get("inputs") or {}
+    model = agent_node.get("model") or {}
+    source = inputs.get("source") or model.get("source")
+    if not source or not isinstance(source, str):
+        sys.exit(
+            f"FAIL: {AUTONOMOUS_NODE_TYPE} node has no inputs.source "
+            f"(checked model.source fallback too)"
+        )
     agent_dir = flow_path.parent / source
     if not agent_dir.is_dir():
         sys.exit(
-            f"FAIL: model.source {source!r} does not point to an existing "
+            f"FAIL: inputs.source {source!r} does not point to an existing "
             f"directory ({agent_dir})"
         )
     return agent_dir
+
+
+def find_inline_resource(
+    agent_dir: Path,
+    predicate,
+    *,
+    description: str,
+) -> tuple[Path, dict]:
+    """Locate a resource.json inside an inline agent's resources/ tree by content.
+
+    Inline agents use UUID-named resource subdirectories
+    (`resources/<RES_UUID>/resource.json` per inline-in-flow.md), so checks
+    cannot hardcode a directory name. This helper iterates every
+    `resources/**/resource.json` under `agent_dir` and returns the first one
+    whose loaded JSON satisfies `predicate(data) -> bool`.
+
+    On miss it exits with FAIL referencing the `description` (e.g.
+    "context index 'ProductKnowledge'").
+    """
+    resources_dir = agent_dir / "resources"
+    if not resources_dir.is_dir():
+        sys.exit(f"FAIL: {resources_dir} does not exist — no resources/ directory")
+    for path in sorted(resources_dir.rglob("resource.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if predicate(data):
+            return path, data
+    sys.exit(
+        f"FAIL: no resource.json matching {description} under {resources_dir} — "
+        "inline agents use UUID-named resource subdirectories, so the test "
+        "matches on content (not directory name)"
+    )
 
 
 def assert_edge(

--- a/tests/tasks/uipath-agents/external_escalation/check_external_escalation.py
+++ b/tests/tasks/uipath-agents/external_escalation/check_external_escalation.py
@@ -9,8 +9,8 @@ Validates:
        - isEnabled is truthy
   2. The escalation has at least one channel wired to ActionCenter:
        - channels is a non-empty list
-       - at least one channel has name == "ActionCenter"
-         and type == "ActionCenter"
+       - at least one channel has type == "actionCenter" and
+         a non-empty name.
 
 Note: The escalation resource.json format as documented in
 agent-json-format.md does not show a `location` field on escalation
@@ -61,15 +61,16 @@ def assert_actioncenter_channel(resource: dict) -> None:
     ac_channels = [
         c for c in channels
         if isinstance(c, dict)
-        and c.get("name") == "ActionCenter"
-        and c.get("type") == "ActionCenter"
+        and c.get("type") == "actionCenter"
+        and isinstance(c.get("name"), str)
+        and c["name"].strip()
     ]
     if not ac_channels:
         sys.exit(
-            "FAIL: no channel with name=='ActionCenter' and type=='ActionCenter' "
+            'FAIL: no channel with type=="actionCenter" and non-empty name '
             f"in channels: {json.dumps(channels, indent=2)}"
         )
-    print(f"OK: found {len(ac_channels)} ActionCenter channel(s)")
+    print(f"OK: found {len(ac_channels)} actionCenter channel(s)")
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/inline_context_index/check_inline_context_index.py
+++ b/tests/tasks/uipath-agents/inline_context_index/check_inline_context_index.py
@@ -5,8 +5,8 @@ Validates:
   1. Flow has a `uipath.agent.autonomous` node and a
      `uipath.agent.resource.context.index` node.
   2. Edge wires agent.context -> context.input.
-  3. Inline agent dir has `resources/ProductKnowledge/resource.json`
-     with:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) with:
        - $resourceType == "context"
        - contextType == "index"
        - indexName == "ProductKnowledge"
@@ -21,6 +21,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -47,15 +48,15 @@ def main() -> None:
     print("OK: agent 'context' handle is wired to context.index node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "ProductKnowledge" / "resource.json"
-    resource = load_json(resource_path)
-
-    if resource.get("$resourceType") != "context":
-        sys.exit(f'FAIL: {resource_path} $resourceType should be "context", got {resource.get("$resourceType")!r}')
-    if resource.get("contextType") != "index":
-        sys.exit(f'FAIL: {resource_path} contextType should be "index", got {resource.get("contextType")!r}')
-    if resource.get("indexName") != "ProductKnowledge":
-        sys.exit(f'FAIL: {resource_path} indexName should be "ProductKnowledge", got {resource.get("indexName")!r}')
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "context"
+            and d.get("contextType") == "index"
+            and d.get("indexName") == "ProductKnowledge"
+        ),
+        description='context index "ProductKnowledge"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="context", contextType="index", indexName="ProductKnowledge"'

--- a/tests/tasks/uipath-agents/inline_external_agent_tool/check_inline_external_agent_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_agent_tool/check_inline_external_agent_tool.py
@@ -5,7 +5,9 @@ Validates:
   1. Flow has a `uipath.agent.autonomous` node and a
      `uipath.agent.resource.tool.agent.*` node (per-agent suffix).
   2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has `resources/SupportExpert/resource.json` with:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for a
+     "SupportExpert" external agent-as-tool with:
        - $resourceType == "tool"
        - type == "agent"
        - location == "external"
@@ -21,6 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -46,25 +49,22 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to external agent-as-tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "SupportExpert" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "agent",
-        "location": "external",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "agent"
+            and d.get("location") == "external"
+            and (d.get("properties") or {}).get("processName") == "SupportExpert"
+        ),
+        description='external agent-as-tool "SupportExpert"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="agent", location="external"'
     )
 
     props = resource.get("properties") or {}
-    if props.get("processName") != "SupportExpert":
-        sys.exit(f'FAIL: properties.processName should be "SupportExpert", got {props.get("processName")!r}')
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
         sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")

--- a/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
@@ -6,8 +6,9 @@ Validates:
      `uipath.agent.resource.tool.*` node (exact API suffix
      under-asserted — use prefix match).
   2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has `resources/GetLatestQuote/resource.json`
-     with:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for a
+     "GetLatestQuote" external API workflow tool with:
        - $resourceType == "tool"
        - type == "api"
        - location == "external"
@@ -22,6 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -47,17 +49,16 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to external API workflow tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "GetLatestQuote" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "api",
-        "location": "external",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "api"
+            and d.get("location") == "external"
+            and d.get("name") == "GetLatestQuote"
+        ),
+        description='external API workflow tool "GetLatestQuote"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="api", location="external"'

--- a/tests/tasks/uipath-agents/inline_external_escalation/check_inline_external_escalation.py
+++ b/tests/tasks/uipath-agents/inline_external_escalation/check_inline_external_escalation.py
@@ -11,7 +11,7 @@ Validates:
        - id is a UUID-shaped string
        - isEnabled is truthy
        - channels contains at least one entry with
-         name == type == "ActionCenter"
+         type == "actionCenter" (lowercase) and a non-empty name
 
   Note: the escalation resource.json format does not expose a
   `location` field — the solution-vs-external distinction is captured
@@ -27,6 +27,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -52,38 +53,30 @@ def main() -> None:
     print("OK: agent 'escalation' handle is wired to escalation node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resources_dir = agent_dir / "resources"
-    if not resources_dir.is_dir():
-        sys.exit(f"FAIL: {resources_dir} does not exist — no resources/ directory")
-
-    for path in sorted(resources_dir.rglob("resource.json")):
-        data = load_json(path)
-        if data.get("$resourceType") != "escalation":
-            continue
-        rid = data.get("id")
-        if not isinstance(rid, str) or "-" not in rid:
-            sys.exit(f"FAIL: escalation id missing or malformed at {path}: {rid!r}")
-        if not data.get("isEnabled"):
-            sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
-        channels = data.get("channels") or []
-        ac = [
-            c for c in channels
-            if isinstance(c, dict)
-            and c.get("name") == "ActionCenter"
-            and c.get("type") == "ActionCenter"
-        ]
-        if not ac:
-            sys.exit(
-                f"FAIL: {path} has no channel with name=='ActionCenter' "
-                f"and type=='ActionCenter'"
-            )
-        print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} ActionCenter channel(s))")
-        return
-
-    sys.exit(
-        f'FAIL: no escalation resource found under {resources_dir} — '
-        'expected at least one resource.json with $resourceType="escalation"'
+    path, data = find_inline_resource(
+        agent_dir,
+        lambda d: d.get("$resourceType") == "escalation",
+        description='escalation resource ($resourceType=="escalation")',
     )
+    rid = data.get("id")
+    if not isinstance(rid, str) or "-" not in rid:
+        sys.exit(f"FAIL: escalation id missing or malformed at {path}: {rid!r}")
+    if not data.get("isEnabled"):
+        sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
+    channels = data.get("channels") or []
+    ac = [
+        c for c in channels
+        if isinstance(c, dict)
+        and c.get("type") == "actionCenter"
+        and isinstance(c.get("name"), str)
+        and c["name"].strip()
+    ]
+    if not ac:
+        sys.exit(
+            f'FAIL: {path} has no channel with type=="actionCenter" '
+            f"and a non-empty name"
+        )
+    print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} actionCenter channel(s))")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/inline_external_maestro_tool/check_inline_external_maestro_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_maestro_tool/check_inline_external_maestro_tool.py
@@ -6,7 +6,9 @@ Validates:
      `uipath.agent.resource.tool.*` node (exact Maestro suffix
      under-asserted — use prefix match).
   2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has `resources/ProcessClaim/resource.json` with:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for a
+     "ProcessClaim" external Maestro tool with:
        - $resourceType == "tool"
        - type == "processOrchestration"
        - location == "external"
@@ -21,6 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -46,17 +49,16 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to external Maestro tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "ProcessClaim" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "processOrchestration",
-        "location": "external",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "processOrchestration"
+            and d.get("location") == "external"
+            and d.get("name") == "ProcessClaim"
+        ),
+        description='external Maestro tool "ProcessClaim"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="processOrchestration", location="external"'

--- a/tests/tasks/uipath-agents/inline_external_rpa_tool/check_inline_external_rpa_tool.py
+++ b/tests/tasks/uipath-agents/inline_external_rpa_tool/check_inline_external_rpa_tool.py
@@ -5,8 +5,9 @@ Validates:
   1. Flow has a `uipath.agent.autonomous` node and a
      `uipath.agent.resource.tool.rpa` node.
   2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has `resources/InvoiceProcessor/resource.json`
-     with:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for an
+     "InvoiceProcessor" external RPA tool with:
        - $resourceType == "tool"
        - type == "process"
        - location == "external"
@@ -22,6 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -47,25 +49,22 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to external RPA tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "InvoiceProcessor" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "process",
-        "location": "external",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "process"
+            and d.get("location") == "external"
+            and (d.get("properties") or {}).get("processName") == "InvoiceProcessor"
+        ),
+        description='external RPA tool "InvoiceProcessor"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="process", location="external"'
     )
 
     props = resource.get("properties") or {}
-    if props.get("processName") != "InvoiceProcessor":
-        sys.exit(f'FAIL: properties.processName should be "InvoiceProcessor", got {props.get("processName")!r}')
     fpath = props.get("folderPath")
     if not isinstance(fpath, str) or not fpath.strip():
         sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")

--- a/tests/tasks/uipath-agents/inline_in_flow/check_inline_agent.py
+++ b/tests/tasks/uipath-agents/inline_in_flow/check_inline_agent.py
@@ -5,11 +5,16 @@ Reads WeatherSol/WeatherFlow/WeatherFlow.flow (existence asserted by
 a file_exists criterion in the task YAML) and verifies:
 
   1. The flow contains a `uipath.agent.autonomous` node.
-  2. The node's `model.source` property points to an existing
-     directory (the inline agent's UUID-named subdirectory).
-  3. The node's `model.serviceType` is `Orchestrator.StartInlineAgentJob`
-     (inline agents only — `StartAgentJob` is the solution-agent variant
-     and would fail at runtime).
+  2. The node's source (read from `inputs.source`, falling back to
+     `model.source` for legacy fixtures) points to an existing
+     directory (the inline agent's UUID-named subdirectory). Per
+     inline-in-flow.md Critical Rule 15, the registry definition
+     declares `model.source: true` but flow-core hoists the source
+     identity onto `inputs.source` on each node instance.
+  3. If `model.serviceType` is present, it must be
+     `Orchestrator.StartInlineAgentJob` (not the solution-agent variant
+     `StartAgentJob`). The field is optional on the instance — the BPMN
+     `serviceType` is inherited from the node definition at compile time.
   4. The agent node is wired into the flow — at least one incoming edge
      on port `input` and at least one outgoing edge on port `success`.
 """
@@ -39,35 +44,41 @@ def main() -> None:
         )
 
     agent_node = agent_nodes[0]
+    inputs = agent_node.get("inputs") or {}
     model = agent_node.get("model") or {}
 
-    source = model.get("source")
-    if not source:
+    source = inputs.get("source") or model.get("source")
+    if not isinstance(source, str) or not source:
         sys.exit(
-            f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no model.source"
+            f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no inputs.source "
+            f"(checked model.source fallback too)"
         )
+    source_location = "inputs.source" if inputs.get("source") else "model.source"
 
     agent_dir = FLOW_PATH.parent / source
     if not agent_dir.is_dir():
         sys.exit(
-            f"FAIL: model.source {source!r} does not point to an "
+            f"FAIL: {source_location} {source!r} does not point to an "
             f"existing directory ({agent_dir})"
         )
 
     print(
-        f"OK: {INLINE_AGENT_NODE_TYPE} node's model.source points to "
+        f"OK: {INLINE_AGENT_NODE_TYPE} node's {source_location} points to "
         f"inline agent directory {source}"
     )
 
     service_type = model.get("serviceType")
-    if service_type != INLINE_AGENT_SERVICE_TYPE:
+    if service_type is not None and service_type != INLINE_AGENT_SERVICE_TYPE:
         sys.exit(
             f"FAIL: {INLINE_AGENT_NODE_TYPE} node's model.serviceType is "
-            f"{service_type!r}, expected {INLINE_AGENT_SERVICE_TYPE!r}. "
-            f"'Orchestrator.StartAgentJob' is the solution-agent variant "
-            f"and must not be used for inline agents."
+            f"{service_type!r}, expected {INLINE_AGENT_SERVICE_TYPE!r} or "
+            f"omitted. 'Orchestrator.StartAgentJob' is the solution-agent "
+            f"variant and must not be used for inline agents."
         )
-    print(f"OK: model.serviceType is {INLINE_AGENT_SERVICE_TYPE!r}")
+    if service_type == INLINE_AGENT_SERVICE_TYPE:
+        print(f"OK: model.serviceType is {INLINE_AGENT_SERVICE_TYPE!r}")
+    else:
+        print("OK: model.serviceType omitted (inherited from node definition)")
 
     agent_id = agent_node.get("id")
     if not agent_id:

--- a/tests/tasks/uipath-agents/inline_is_connector_tool/check_inline_is_connector_tool.py
+++ b/tests/tasks/uipath-agents/inline_is_connector_tool/check_inline_is_connector_tool.py
@@ -7,7 +7,8 @@ Combines the F8 (standalone IS tool) resource-shape assertions with
 the F2 (inline agent) flow-wiring assertions. Specifically:
 
   1. The flow file contains a `uipath.agent.autonomous` node whose
-     `model.source` points at the inline agent's UUID subdirectory.
+     `inputs.source` (falling back to `model.source` for legacy
+     fixtures) points at the inline agent's UUID subdirectory.
   2. The flow file contains a `uipath.agent.resource.tool.connector`
      node.
   3. An edge wires the agent's `tool` handle (source) to the connector
@@ -29,8 +30,14 @@ import os
 import sys
 from pathlib import Path
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.inline_wiring import find_inline_resource  # noqa: E402
+
 INLINE_AGENT_NODE_TYPE = "uipath.agent.autonomous"
-CONNECTOR_TOOL_NODE_TYPE = "uipath.agent.resource.tool.connector"
+# Connector tool nodes carry the connector-key + activity in the type suffix
+# (e.g. `uipath.agent.resource.tool.connector.uipath-slack.send-message`),
+# so match on the prefix. Trailing "." disambiguates from any future bare type.
+CONNECTOR_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.connector."
 
 SOLUTION = Path(os.getcwd()) / "ResearchFlowSol"
 FLOW_PROJECT = SOLUTION / "ResearchFlow"
@@ -56,31 +63,45 @@ def assert_agent_and_connector_nodes(flow: dict) -> tuple:
         )
     agent_node = agent_nodes[0]
 
-    connector_nodes = [n for n in nodes if n.get("type") == CONNECTOR_TOOL_NODE_TYPE]
+    connector_nodes = [
+        n for n in nodes
+        if isinstance(n.get("type"), str)
+        and n["type"].startswith(CONNECTOR_TOOL_NODE_TYPE_PREFIX)
+    ]
     if not connector_nodes:
         sys.exit(
-            f"FAIL: flow has no node of type {CONNECTOR_TOOL_NODE_TYPE!r} — "
-            "the IS connector tool was not added to the flow canvas"
+            f"FAIL: flow has no node with type starting with "
+            f"{CONNECTOR_TOOL_NODE_TYPE_PREFIX!r} — the IS connector tool was "
+            "not added to the flow canvas"
         )
     connector_node = connector_nodes[0]
 
     if not agent_node.get("id"):
         sys.exit(f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no id")
     if not connector_node.get("id"):
-        sys.exit(f"FAIL: {CONNECTOR_TOOL_NODE_TYPE} node has no id")
+        sys.exit(f"FAIL: connector tool node has no id")
 
-    print(f"OK: flow has both {INLINE_AGENT_NODE_TYPE!r} and {CONNECTOR_TOOL_NODE_TYPE!r} nodes")
+    print(
+        f"OK: flow has {INLINE_AGENT_NODE_TYPE!r} and connector tool node "
+        f"{connector_node['type']!r}"
+    )
     return agent_node, connector_node
 
 
 def assert_agent_source_dir(agent_node: dict) -> Path:
-    source = (agent_node.get("model") or {}).get("source")
-    if not source:
-        sys.exit(f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no model.source")
+    inputs = agent_node.get("inputs") or {}
+    model = agent_node.get("model") or {}
+    source = inputs.get("source") or model.get("source")
+    if not isinstance(source, str) or not source:
+        sys.exit(
+            f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no inputs.source "
+            f"(checked model.source fallback too)"
+        )
     agent_dir = FLOW_PATH.parent / source
     if not agent_dir.is_dir():
+        source_location = "inputs.source" if inputs.get("source") else "model.source"
         sys.exit(
-            f"FAIL: model.source {source!r} does not point to an existing "
+            f"FAIL: {source_location} {source!r} does not point to an existing "
             f"directory ({agent_dir})"
         )
     print(f"OK: inline agent directory resolves to {agent_dir.name}")
@@ -107,29 +128,19 @@ def assert_tool_edge(flow: dict, agent_id: str, connector_id: str) -> None:
 
 
 def assert_integration_tool_resource(agent_dir: Path) -> None:
-    resources_dir = agent_dir / "resources"
-    if not resources_dir.is_dir():
-        sys.exit(
-            f"FAIL: {resources_dir} does not exist — the inline agent has no "
-            "resources/ directory, so no IS tool resource.json was authored"
-        )
-    for path in sorted(resources_dir.rglob("resource.json")):
-        data = load(path)
-        if data.get("$resourceType") == "tool" and data.get("type") == "integration":
-            rid = data.get("id")
-            if not isinstance(rid, str) or "-" not in rid:
-                sys.exit(f"FAIL: IS tool id missing or malformed at {path}: {rid!r}")
-            if not data.get("isEnabled"):
-                sys.exit(f"FAIL: IS tool isEnabled must be truthy at {path}")
-            print(
-                f'OK: {path.relative_to(SOLUTION.parent)} is $resourceType="tool", '
-                f'type="integration" (id={rid})'
-            )
-            return
-    sys.exit(
-        f"FAIL: no IS tool resource found under {resources_dir} — "
-        'expected at least one resource.json with $resourceType="tool" '
-        'and type="integration"'
+    path, data = find_inline_resource(
+        agent_dir,
+        lambda d: d.get("$resourceType") == "tool" and d.get("type") == "integration",
+        description='IS tool ($resourceType=="tool", type=="integration")',
+    )
+    rid = data.get("id")
+    if not isinstance(rid, str) or "-" not in rid:
+        sys.exit(f"FAIL: IS tool id missing or malformed at {path}: {rid!r}")
+    if not data.get("isEnabled"):
+        sys.exit(f"FAIL: IS tool isEnabled must be truthy at {path}")
+    print(
+        f'OK: {path.relative_to(SOLUTION.parent)} is $resourceType="tool", '
+        f'type="integration" (id={rid})'
     )
 
 

--- a/tests/tasks/uipath-agents/inline_mcp_server_tool/check_inline_mcp_server_tool.py
+++ b/tests/tasks/uipath-agents/inline_mcp_server_tool/check_inline_mcp_server_tool.py
@@ -8,8 +8,9 @@ Validates:
   2. Edge wires agent.tool -> mcp.input. (The `tool` handle is the
      only agent-side handle documented for non-context / non-escalation
      resources; MCP uses it per convention.)
-  3. Inline agent dir has `resources/GitHubMcp/resource.json` with the
-     documented sparse shape:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for a
+     "GitHubMcp" MCP server with the documented sparse shape:
        - $resourceType == "mcp"  (not "tool")
        - name == "GitHubMcp"
        - description is non-empty
@@ -26,6 +27,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -51,16 +53,11 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to MCP server node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "GitHubMcp" / "resource.json"
-    resource = load_json(resource_path)
-
-    if resource.get("$resourceType") != "mcp":
-        sys.exit(
-            f'FAIL: {resource_path} $resourceType should be "mcp" '
-            f'(distinct from "tool"), got {resource.get("$resourceType")!r}'
-        )
-    if resource.get("name") != "GitHubMcp":
-        sys.exit(f'FAIL: MCP resource name should be "GitHubMcp", got {resource.get("name")!r}')
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: d.get("$resourceType") == "mcp" and d.get("name") == "GitHubMcp",
+        description='MCP server "GitHubMcp" ($resourceType=="mcp")',
+    )
     description = resource.get("description")
     if not isinstance(description, str) or not description.strip():
         sys.exit(f"FAIL: MCP resource description missing or empty: {description!r}")

--- a/tests/tasks/uipath-agents/inline_solution_agent_tool/check_inline_solution_agent_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_agent_tool/check_inline_solution_agent_tool.py
@@ -5,7 +5,9 @@ Validates:
   1. Flow has a `uipath.agent.autonomous` node and a
      `uipath.agent.resource.tool.agent.*` node (per-agent suffix).
   2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has `resources/ToolAgent/resource.json` with:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for a
+     "ToolAgent" solution agent-as-tool with:
        - $resourceType == "tool"
        - type == "agent"
        - location == "solution"
@@ -21,6 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -46,25 +49,22 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to agent-as-tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "ToolAgent" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "agent",
-        "location": "solution",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "agent"
+            and d.get("location") == "solution"
+            and (d.get("properties") or {}).get("processName") == "ToolAgent"
+        ),
+        description='solution agent-as-tool "ToolAgent"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="agent", location="solution"'
     )
 
     props = resource.get("properties") or {}
-    if props.get("processName") != "ToolAgent":
-        sys.exit(f'FAIL: properties.processName should be "ToolAgent", got {props.get("processName")!r}')
     if props.get("folderPath") != "solution_folder":
         sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
     print('OK: properties.processName="ToolAgent", folderPath="solution_folder"')

--- a/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/check_inline_solution_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_apiworkflow_tool/check_inline_solution_apiworkflow_tool.py
@@ -2,14 +2,16 @@
 """Inline agent + solution API workflow tool check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node whose `model.source`
-     resolves to an existing UUID subdirectory.
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     (falling back to `model.source` for legacy fixtures) resolves to
+     an existing UUID subdirectory.
   2. Flow has a `uipath.agent.resource.tool.*` node for the API workflow
      (exact suffix under-asserted — use prefix match).
   3. Edge wires the autonomous node's `tool` handle (source) to the
      tool node's `input` handle (target).
-  4. Inside the inline agent dir, `resources/CalculateShippingRate/resource.json`
-     declares a solution-internal API workflow tool:
+  4. Inside the inline agent dir, at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) declares a
+     "CalculateShippingRate" solution-internal API workflow tool:
        - $resourceType == "tool"
        - type == "api"
        - location == "solution"
@@ -24,6 +26,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -49,17 +52,16 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to API workflow tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "CalculateShippingRate" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "api",
-        "location": "solution",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "api"
+            and d.get("location") == "solution"
+            and d.get("name") == "CalculateShippingRate"
+        ),
+        description='solution API workflow tool "CalculateShippingRate"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="api", location="solution"'

--- a/tests/tasks/uipath-agents/inline_solution_escalation/check_inline_solution_escalation.py
+++ b/tests/tasks/uipath-agents/inline_solution_escalation/check_inline_solution_escalation.py
@@ -11,7 +11,7 @@ Validates:
        - id is a UUID-shaped string
        - isEnabled is truthy
        - channels contains at least one entry with
-         name == type == "ActionCenter"
+         type == "actionCenter" (lowercase) and a non-empty name
 
   Note: the escalation resource.json format documented in
   agent-json-format.md does not expose a `location` field on escalation
@@ -28,6 +28,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -53,38 +54,30 @@ def main() -> None:
     print("OK: agent 'escalation' handle is wired to escalation node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resources_dir = agent_dir / "resources"
-    if not resources_dir.is_dir():
-        sys.exit(f"FAIL: {resources_dir} does not exist — no resources/ directory")
-
-    for path in sorted(resources_dir.rglob("resource.json")):
-        data = load_json(path)
-        if data.get("$resourceType") != "escalation":
-            continue
-        rid = data.get("id")
-        if not isinstance(rid, str) or "-" not in rid:
-            sys.exit(f"FAIL: escalation id missing or malformed at {path}: {rid!r}")
-        if not data.get("isEnabled"):
-            sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
-        channels = data.get("channels") or []
-        ac = [
-            c for c in channels
-            if isinstance(c, dict)
-            and c.get("name") == "ActionCenter"
-            and c.get("type") == "ActionCenter"
-        ]
-        if not ac:
-            sys.exit(
-                f"FAIL: {path} has no channel with name=='ActionCenter' "
-                f"and type=='ActionCenter'"
-            )
-        print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} ActionCenter channel(s))")
-        return
-
-    sys.exit(
-        f'FAIL: no escalation resource found under {resources_dir} — '
-        'expected at least one resource.json with $resourceType="escalation"'
+    path, data = find_inline_resource(
+        agent_dir,
+        lambda d: d.get("$resourceType") == "escalation",
+        description='escalation resource ($resourceType=="escalation")',
     )
+    rid = data.get("id")
+    if not isinstance(rid, str) or "-" not in rid:
+        sys.exit(f"FAIL: escalation id missing or malformed at {path}: {rid!r}")
+    if not data.get("isEnabled"):
+        sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
+    channels = data.get("channels") or []
+    ac = [
+        c for c in channels
+        if isinstance(c, dict)
+        and c.get("type") == "actionCenter"
+        and isinstance(c.get("name"), str)
+        and c["name"].strip()
+    ]
+    if not ac:
+        sys.exit(
+            f'FAIL: {path} has no channel with type=="actionCenter" '
+            f"and a non-empty name"
+        )
+    print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} actionCenter channel(s))")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/inline_solution_maestro_tool/check_inline_solution_maestro_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_maestro_tool/check_inline_solution_maestro_tool.py
@@ -6,8 +6,9 @@ Validates:
      `uipath.agent.resource.tool.*` node (exact Maestro suffix
      under-asserted — use prefix match).
   2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has `resources/EmployeeOnboarding/resource.json`
-     with:
+  3. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for an
+     "EmployeeOnboarding" solution Maestro tool with:
        - $resourceType == "tool"
        - type == "processOrchestration"
        - location == "solution"
@@ -22,6 +23,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -47,17 +49,16 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to Maestro tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "EmployeeOnboarding" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "processOrchestration",
-        "location": "solution",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "processOrchestration"
+            and d.get("location") == "solution"
+            and d.get("name") == "EmployeeOnboarding"
+        ),
+        description='solution Maestro tool "EmployeeOnboarding"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="processOrchestration", location="solution"'

--- a/tests/tasks/uipath-agents/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
+++ b/tests/tasks/uipath-agents/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
@@ -2,13 +2,15 @@
 """Inline agent + solution RPA tool check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node whose `model.source`
-     resolves to an existing UUID subdirectory.
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     (falling back to `model.source` for legacy fixtures) resolves to
+     an existing UUID subdirectory.
   2. Flow has a `uipath.agent.resource.tool.rpa` node.
   3. Edge wires the autonomous node's `tool` handle (source) to the
      RPA tool node's `input` handle (target).
-  4. Inside the inline agent dir, `resources/CalculatePay/resource.json`
-     declares a solution-internal RPA tool:
+  4. Inside the inline agent dir, at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) declares a
+     "CalculatePay" solution-internal RPA tool:
        - $resourceType == "tool"
        - type == "process"
        - location == "solution"
@@ -24,6 +26,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
@@ -49,25 +52,22 @@ def main() -> None:
     print("OK: agent 'tool' handle is wired to RPA tool node's 'input' handle")
 
     agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
-    resource_path = agent_dir / "resources" / "CalculatePay" / "resource.json"
-    resource = load_json(resource_path)
-
-    expected = {
-        "$resourceType": "tool",
-        "type": "process",
-        "location": "solution",
-    }
-    for key, want in expected.items():
-        if resource.get(key) != want:
-            sys.exit(f"FAIL: {resource_path} {key!r} should be {want!r}, got {resource.get(key)!r}")
+    resource_path, resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "process"
+            and d.get("location") == "solution"
+            and (d.get("properties") or {}).get("processName") == "CalculatePay"
+        ),
+        description='solution RPA tool "CalculatePay"',
+    )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
         f'$resourceType="tool", type="process", location="solution"'
     )
 
     props = resource.get("properties") or {}
-    if props.get("processName") != "CalculatePay":
-        sys.exit(f'FAIL: properties.processName should be "CalculatePay", got {props.get("processName")!r}')
     if props.get("folderPath") != "solution_folder":
         sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
     print('OK: properties.processName="CalculatePay", folderPath="solution_folder"')

--- a/tests/tasks/uipath-agents/solution_escalation/check_solution_escalation.py
+++ b/tests/tasks/uipath-agents/solution_escalation/check_solution_escalation.py
@@ -9,8 +9,9 @@ Validates:
        - isEnabled is truthy
   2. The escalation has at least one channel wired to ActionCenter:
        - channels is a non-empty list
-       - at least one channel has name == "ActionCenter"
-         and type == "ActionCenter"
+       - at least one channel has type == "actionCenter" (lowercase, per
+         the schema documented in the skill's escalation reference) and
+         a non-empty name.
   3. agent.json.inputSchema  == entry-points.json entryPoints[0].input
      agent.json.outputSchema == entry-points.json entryPoints[0].output
      (Critical Rule 4 — schema sync.)
@@ -58,15 +59,16 @@ def assert_actioncenter_channel(resource: dict) -> None:
     ac_channels = [
         c for c in channels
         if isinstance(c, dict)
-        and c.get("name") == "ActionCenter"
-        and c.get("type") == "ActionCenter"
+        and c.get("type") == "actionCenter"
+        and isinstance(c.get("name"), str)
+        and c["name"].strip()
     ]
     if not ac_channels:
         sys.exit(
-            "FAIL: no channel with name=='ActionCenter' and type=='ActionCenter' "
+            'FAIL: no channel with type=="actionCenter" and non-empty name '
             f"in channels: {json.dumps(channels, indent=2)}"
         )
-    print(f"OK: found {len(ac_channels)} ActionCenter channel(s)")
+    print(f"OK: found {len(ac_channels)} actionCenter channel(s)")
 
 
 def assert_schema_sync(agent: dict, entry: dict) -> None:


### PR DESCRIPTION
## Summary

Three test-bug shapes surfaced during a replay of `uipath-agents` low-code coder-eval tasks. All cause the tests to reject output that the lowcode skill actually prescribes — so the agent did the right thing but the check script disagreed.

### 1. ActionCenter channel discriminator was PascalCase

Checks asserted `channels[].name == "ActionCenter" && channels[].type == "ActionCenter"`. The skill's [escalation.md](skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md#L138-L140) prescribes lowercase `type == "actionCenter"` with an author-chosen channel `name`. Fixed in 4 escalation check scripts.

### 2. Inline `uipath.agent.autonomous` source was read from `model.source`

Per [critical-rules.md Rule 15](skills/uipath-agents/references/lowcode/critical-rules.md#L35), the registry definition declares `model.source: true` but flow-core hoists the source identity onto `inputs.source` on each node instance. The shared `resolve_inline_agent_dir` helper now reads `inputs.source` first with `model.source` as legacy fallback; standalone inline checks updated to match. Also relaxed the `model.serviceType` assertion in `check_inline_agent.py` (it's a definition-level field that may be omitted from the instance).

### 3. Inline-agent resource lookups hardcoded human-readable directory names

Tests asserted paths like `resources/InvoiceProcessor/resource.json`. The skill prescribes **UUID-named** resource subdirectories (`resources/<RES_UUID>/resource.json` per [inline-in-flow.md L160-L164](skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md#L160-L164)). Added centralized `find_inline_resource(agent_dir, predicate, description)` helper in `_shared/inline_wiring.py` that iterates `resources/**/resource.json` and matches on JSON content. Migrated 13 inline-* check scripts to it.

### 4. (bonus) Connector tool node type was checked too strictly

Test asserted exact type `uipath.agent.resource.tool.connector`, but the skill prescribes the suffixed form `uipath.agent.resource.tool.connector.<connector-key>.<activity>`. Switched to prefix match in `check_inline_is_connector_tool.py`.

## Replay results

Replayed every `check_*.py` script against the prior failing artifacts (no agent re-runs needed):

| Stage | PASS | FAIL |
|---|---|---|
| Original live run (sonnet-4-6) | 19/37 | 18/37 |
| After these test fixes (replay) | 28/37 | 9/37 |

The 9 remaining failures are pre-existing infrastructure (turn timeouts on `inline-solution-*` e2e tasks) or genuine agent model variance, none related to test↔skill alignment.

## Files changed

- `tests/tasks/uipath-agents/_shared/inline_wiring.py` (centralized helper + `inputs.source` fallback)
- 4 escalation checks (ActionCenter lowercase): `external_escalation`, `inline_external_escalation`, `inline_solution_escalation`, `solution_escalation`
- 13 inline-* checks migrated to `find_inline_resource` helper

## Test plan

- [x] Re-replayed all 37 inline + non-inline check scripts — 28 PASS (up from 19); 9 remaining failures are unrelated.
- [x] Replayed first-batch 5 tasks (`init_validate`, `external_*`) — no regressions.
- [x] Grep confirms no `== "ActionCenter"` (PascalCase) remains in any check.
- [x] Grep confirms no hardcoded `agent_dir / "resources" / "<Name>"` remains in inline-* checks.
- [ ] Live re-run of `inline-*` and `solution-escalation-tool` to confirm end-to-end (optional — replay against same-artifact is deterministic).

## Companion PR

Skill reference updates that motivated this sweep: #fix/agents-validate-migrate-align (separate PR, no overlap with this one — both branch off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)