### PR TITLE
docs(uipath-troubleshoot): codify task.yaml authoring rules + apply product tags

### DIFF
--- a/tests/tasks/uipath-troubleshoot/CLAUDE.md
+++ b/tests/tasks/uipath-troubleshoot/CLAUDE.md
@@ -127,6 +127,113 @@ When no rule matches:
 
 Test runs require valid `uip` auth on the host (set via `.env` or environment) for any rule with `passthrough: true` to succeed.
 
+## Task YAML requirements
+
+Every new scenario's `task.yaml` MUST satisfy the following.
+
+### `run_limits`
+
+```yaml
+run_limits:
+  task_timeout: 2400
+  max_turns: 60
+  turn_timeout: 1800
+```
+
+Troubleshooting investigations span many turns and produce large intermediate outputs. Lower limits cause spurious timeouts in CI and mask real regressions.
+
+### `tags`
+
+Tags MUST be lowercase kebab-case — the coder-eval schema rejects PascalCase or spaced names (e.g., `RPA` and `Integration Service` are invalid; use `rpa` and `integration-service`).
+
+Must include `uipath-troubleshoot` AND at least one product/domain tag from this list:
+
+| Tag | When to apply |
+|-----|---------------|
+| `rpa` | Anything touching an activity package or `.xaml` workflow. **Default for any activity-package-related failure.** Apply alongside other tags when the failure spans domains (e.g., a preflight that hits both System.Activities and IS connectors gets both `rpa` and `integration-service`). |
+| `flow` | Maestro Flow / flow-graph artifacts |
+| `bpmn`, `maestro` | BPMN-modelled processes (Maestro). Apply both. |
+| `case-management` | Case Management product |
+| `integration-service` | IS connectors, connections, connector activities |
+| `hitl` | Human-in-the-loop / Action Center / Tasks |
+| `agents` | Agent runtime, agent definitions |
+| `ixp` | Intelligent Xtraction and Processing |
+| `document-understanding` | Document Understanding (extraction models, classification, validation, projects) |
+| `llm-gateway` | LLM Gateway (model routing, BYO connections, product LLM configurations) |
+| `data-fabric` | Data Fabric tables, entities |
+| `api-workflow` | API workflow artifacts |
+| `orchestrator` | Orchestrator-only failures with no workflow execution involved (e.g., licensing, machine state, asset/queue admin) |
+
+### Investigation output location
+
+The skill writes investigation artifacts to `.local/investigations/` — NOT `.investigations/`. Every `file_exists` criterion path and every post-run script path MUST use `.local/investigations/...`.
+
+### `docsai` mocking
+
+Any rule matching `uip docsai ask ...` in `manifest.json` MUST be `passthrough: true`. Query strings vary between runs and canned responses go stale immediately; the dispatcher caches passthrough responses per query for in-run reuse.
+
+```json
+{
+  "match": "docsai ask",
+  "passthrough": true
+}
+```
+
+### `success_criteria`
+
+Every scenario MUST include exactly TWO required criteria:
+
+1. **`skill_triggered`** — verify `uipath-troubleshoot` activated. Without this, the agent can fake an answer by reading fixture files directly and bypassing the skill entirely (we have seen this happen).
+2. **`llm_judge`** — grade whether the agent reached the correct conclusion against `RESOLUTION.md`.
+
+Do NOT add `file_exists` or `command_executed` criteria as standard practice — they encode one specific path through the investigation and turn legitimate alternative solutions into false failures.
+
+Concrete failure mode this rule prevents: an agent that reaches the correct root cause via `jobs logs` (skipping `jobs get`) is graded `FAILURE` solely because a `command_executed` rule required `jobs get d5fed611`. The conclusion was right; the path was different. Brittle.
+
+#### Judge prompts grade on PRESENTATION, not internal state
+
+The `llm_judge` prompt MUST grade only:
+
+- The agent's **final response** to the user.
+- The agent's **conclusion vs. `RESOLUTION.md`** (correct root cause, fix, evidence-citation).
+- Optionally: whether the agent **avoided fabrication** (no invented assets/configs/policies).
+
+The judge MUST NOT grade on internal-state fields in `.local/investigations/`:
+
+- ❌ Require a specific path in `state.json.matched_playbooks`.
+- ❌ Require `hypotheses.json` entries to carry a particular `status` (`eliminated`, `confirmed`) or `is_root_cause` value.
+- ❌ Require a specific `evidence_refs` or `evidence_summary` shape.
+
+Reason: `hypotheses.json` legitimately contains `pending` hypotheses after early-stop. The orchestrator stops testing as soon as a high-confidence root cause is confirmed (see `SKILL.md` "When to stop testing"); remaining hypotheses correctly stay `pending` so the user can choose to investigate them later. Grading on those internal fields punishes correct skill behavior.
+
+What the agent presents IS the contract. What it writes into `.local/investigations/` is bookkeeping for the next conversation, not a deliverable.
+
+Permissible exceptions — add a non-required criterion ONLY when:
+
+- **`file_exists`** — only when the scenario specifically tests artifact production (e.g., a deliverable file the skill is contracted to write). Do not use it to verify intermediate investigation state — the judge reads the agent's output directly.
+- **`command_executed`** — only when the scenario specifically tests that a particular dangerous/required action ran (e.g., a destructive cleanup that MUST be invoked). Never use it to enforce investigation paths.
+
+Lean default for a new scenario:
+
+```yaml
+success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-troubleshoot skill"
+    skill_name: "uipath-troubleshoot"
+    expected_skill: "uipath-troubleshoot"
+    weight: 1.0
+
+  - type: llm_judge
+    description: "Agent reached the same root cause as RESOLUTION.md"
+    weight: 3.0
+    pass_threshold: 0.7
+    include_reference: true
+    include_agent_output: true
+    include_tool_calls: true
+    prompt: |
+      ...grading rubric tied to RESOLUTION.md...
+```
+
 ## Anti-patterns
 
 - **Do not** hand-edit a generated scenario's `manifest.json` to "make tests pass." If the agent calls a command not in the manifest, that's a coverage gap — add a rule with the verbatim recorded response.

--- a/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
@@ -10,7 +10,7 @@ description: >
   populate its outputs, then connect that to the documented package-
   version bug.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, activity-bug-silent-failure]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, activity-bug-silent-failure, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
@@ -9,7 +9,7 @@ description: >
   'CyberArk'. Error code: 2304." The agent must recognize that the
   failure layer is the external vault, not the asset itself.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, external-vault-failure, credential-stores]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, external-vault-failure, credential-stores, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
@@ -8,7 +8,7 @@ description: >
   get-asset-folder-scope-mismatch playbook AND identifies the
   FolderPath value in Main.xaml against the actual list of folders.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, folder-scope-mismatch]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, folder-scope-mismatch, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
@@ -6,7 +6,7 @@ description: >
   Success = agent matches the get-asset-not-found playbook AND
   identifies the typo against the correctly-spelled asset
   ("myHiddenAsset") that exists in the target folder.
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, asset-not-found]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, asset-not-found, rpa]
 
 # Inherits from experiments/default.yaml: model, permission_mode, plugins
 # ($SKILLS_REPO_PATH), ignore_patterns. Only the fields below are overrides

--- a/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
@@ -10,7 +10,7 @@ description: >
   playbook with multiple sub-causes — the agent's job is to identify
   the family, not pinpoint the exact sub-cause).
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, network-connectivity]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, network-connectivity, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
@@ -9,7 +9,7 @@ description: >
   folder-scope-mismatch, permission-denied, and wrong-activity-type —
   and converge on the per-robot value gap.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, per-robot-no-value]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, per-robot-no-value, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
@@ -7,7 +7,7 @@ description: >
   agent must rule out asset-not-found (1002) and folder-scope-mismatch
   (1100) and converge on the permission-denied root cause.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, permission-denied]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, permission-denied, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
@@ -10,7 +10,7 @@ description: >
   NOT "not authenticated"), wrong-activity-type, and per-robot-no-value
   before converging on the missing robot license.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, robot-not-authenticated]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, robot-not-authenticated, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
@@ -10,7 +10,7 @@ description: >
   (different error signature) — and converge on the activity-vs-asset
   type mismatch.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, wrong-activity-type]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, wrong-activity-type, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/maestro-stuck-rpa-job/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/maestro-stuck-rpa-job/task.yaml
@@ -4,7 +4,7 @@ description: >
   runs the uipath-troubleshoot skill against a uip CLI mock whose
   responses are the verbatim sub-agent outputs from the real session.
   Success = the agent reaches the same root cause as RESOLUTION.md.
-tags: [uipath-troubleshoot, e2e, faithful-replay, maestro]
+tags: [uipath-troubleshoot, e2e, faithful-replay, maestro, bpmn]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/null-reference-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/null-reference-exception/task.yaml
@@ -1,10 +1,10 @@
 ﻿task_id: skill-troubleshoot-null-reference-exception
 description: >
-  Faithful replay of a real UiPath diagnostic investigation. The agent
+  Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose
   responses are the verbatim sub-agent outputs from the real session.
   Success = the agent reaches the same root cause as RESOLUTION.md.
-tags: [uipath-troubleshoot, e2e, faithful-replay]
+tags: [uipath-troubleshoot, e2e, faithful-replay, rpa]
 
 agent:
   type: claude-code
@@ -41,23 +41,15 @@ success_criteria:
     expected_skill: "uipath-troubleshoot"
     weight: 1.0
 
-  - type: file_exists
-    description: "Agent wrote investigation state under .local/investigations/"
-    path: .local/investigations/state.json
-    weight: 0.5
-
   - type: llm_judge
-    description: "Agent matched the null-reference-exception playbook AND identified the explicit Assign-to-null of myVar dereferenced by CopyFile.Path"
+    description: "Agent reached the same root cause as RESOLUTION.md"
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
     include_agent_output: true
     include_tool_calls: true
-    files:
-      - .local/investigations/state.json
-      - .local/investigations/hypotheses.json
     prompt: |
-      You are grading a UiPath diagnostic agent against a known-correct
+      You are grading a UiPath troubleshooting agent against a known-correct
       reference outcome. The Reference solution attached to this prompt
       is the RESOLUTION.md for this scenario. Treat it as the
       authoritative ground truth.
@@ -66,105 +58,66 @@ success_criteria:
         "why did my job 77dc53dd-5c45-4a77-b39f-a52e9e7ef163 from Shared
          folder has failed?"
 
-      You must grade BOTH dimensions in a single score:
+      Grade ONLY on what the agent presented to the user (its final
+      response) and the tool-call summary. Do NOT grade on the shape or
+      content of files under `.local/investigations/` — those are
+      bookkeeping for the next conversation, not the deliverable.
 
-      DIMENSION A -- Correct playbook
-        The matching playbook is
-          references/runtime-exceptions/playbooks/null-reference-exception.md
-        because the runtime error
-          "System.NullReferenceException: Object reference not set to an
-           instance of an object."
-        with the location chain
-          "in ERN.xaml at CopyFile 'Copy File' at Sequence 'ERN'"
-        is the verbatim signature of that playbook.
+      The reference root cause is:
+        - In Main entry point ERN.xaml, a top-level Sequence does two
+          things in order:
+            1. Assign activity: `myVar = null` (variable `myVar` is
+               declared as x:Object with no default, then explicitly
+               overwritten with the literal null).
+            2. CopyFile activity: `Path = myVar.ToString()`.
+        - When CopyFile evaluates Path, `myVar.ToString()` is called on
+          a null reference and throws System.NullReferenceException.
+        - No If/Switch/While gates the CopyFile activity, so the
+          failure is deterministic.
+      The reference fix:
+        - Delete or correct the `Assign myVar = null` activity, OR
+        - Give `myVar` a meaningful default in the Variables panel, OR
+        - Add a null guard before the CopyFile activity.
 
-        Within that playbook, the correct branch is the
-        "uninitialized variable" branch (variable declared with no
-        default, or explicitly set to null upstream, then dereferenced).
+      SCORING RUBRIC (grade the presented conclusion):
 
-        Evidence sources (in priority order):
-          1. state.json's `matched_playbooks` -- the
-             null-reference-exception playbook should appear (absolute or
-             relative path).
-          2. The agent's tool-call summary -- a Read on a file under
-             references/runtime-exceptions/playbooks/.
-          3. state.json's `scope.domain` -- should include the
-             runtime-exceptions domain.
-
-        Acceptable / non-penalized: the agent may also Read neighboring
-        runtime-exception playbooks while ruling them out. Exploration
-        is normal.
-
-      DIMENSION B -- Same conclusion as RESOLUTION.md
-        The reference root cause is:
-          - In Main entry point ERN.xaml, a top-level Sequence does two
-            things in order:
-              1. Assign activity: `myVar = null` (variable `myVar` is
-                 declared as x:Object with no default, then explicitly
-                 overwritten with the literal null).
-              2. CopyFile activity: `Path = myVar.ToString()`.
-          - When CopyFile evaluates Path, `myVar.ToString()` (compiled
-            as `__Expr2Get` in `ERN_Expressions`) is called on a null
-            reference and throws System.NullReferenceException.
-          - No If/Switch/While gates the CopyFile activity, so the
-            failure is deterministic.
-        The reference fix:
-          - Delete or correct the `Assign myVar = null` activity, OR
-          - Give `myVar` a meaningful default in the Variables panel, OR
-          - Add a null guard before the CopyFile activity.
-
-        Evidence sources (in priority order):
-          1. hypotheses.json -- the hypothesis flagged
-             `is_root_cause: true` should explicitly name BOTH:
-               (a) the `myVar` variable being null / set to null by the
-                   upstream Assign, AND
-               (b) the CopyFile activity dereferencing it via
-                   `myVar.ToString()` (or the `__Expr2Get` /
-                   `ERN_Expressions` stack frame).
-          2. state.json -- `requirements.error_message`,
-             `triage_summary`, scope/domain.
-          3. The agent's last text response.
-
-      SCORING RUBRIC (single score reflecting both dimensions):
-
-        1.0  Agent matched null-reference-exception (uninitialized-
-             variable branch) AND named BOTH the explicit `Assign myVar
-             = null` upstream AND the CopyFile.Path = myVar.ToString()
-             dereference.
-        0.8  Both partial: correct playbook but conclusion says
+        1.0  The agent's response names BOTH the explicit upstream
+             `Assign myVar = null` AND the CopyFile dereference of
+             myVar (`myVar.ToString()` / `.Path = myVar`). Fix
+             recommendation aligns with one of the three reference
+             fixes.
+        0.8  Conclusion identifies BOTH the Assign-null and the
+             CopyFile dereference but is missing a meaningful fix
+             recommendation, OR identifies them with minor wording
+             differences from the reference.
+        0.5  Conclusion identifies ONE of (a) the upstream Assign-null
+             or (b) the CopyFile dereference, but not both. E.g.,
              "myVar was null at CopyFile" without identifying the
-             upstream Assign that set it; OR identifies both Assign and
-             CopyFile but matched a generic runtime-exceptions
-             investigation_guide rather than the specific
-             null-reference-exception playbook.
-        0.5  Only one dimension correct (e.g., right playbook but
-             generic "something was null" conclusion; or correct
-             Assign+CopyFile naming but wrong playbook match).
-        0.2  Recognized the surface (NullReferenceException at CopyFile)
-             but neither matched the playbook nor named the upstream
-             Assign-to-null on myVar.
-        0.0  Misdiagnosed (e.g., blamed selector, asset, connection,
+             explicit Assign that set it.
+        0.2  Recognized the surface (NullReferenceException at
+             CopyFile) but neither named the upstream Assign-to-null
+             nor proposed a credible fix.
+        0.0  Misdiagnosed (blamed selector, asset, connection,
              permissions) or got blocked.
 
-      Be substance-focused, not schema-focused. Intermediate file shapes
-      may vary between runs — look at the meaning of what the agent
-      recorded.
+      Penalize fabrication: invented assets, configs, or upstream
+      activity outputs that do not appear in the evidence.
 
-      Return JSON: {"score": <float>, "rationale": "<one sentence covering both playbook and conclusion>"}
+      Return JSON: {"score": <float>, "rationale": "<one sentence>"}
 
-# Auto-answer the diagnostic skill's AskUserQuestion calls so the test runs
+# Auto-answer the troubleshooting skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /
-# affirmative option, and never invents data — keeps the diagnostic flow
+# affirmative option, and never invents data — keeps the troubleshooting flow
 # faithful to the original session.
 simulation:
   enabled: true
   persona: |
     You are the UiPath user who originally reported the failing process.
-    You are waiting for the diagnostic agent to finish its investigation
+    You are waiting for the troubleshooting agent to finish its investigation
     and trust its expertise. You only have the information you wrote in
     your initial report — no extra data.
   goal: |
-    Let the agent complete its diagnostic flow without imposing
+    Let the agent complete its troubleshooting flow without imposing
     constraints. Approve every scope expansion or clarification the
     agent requests so the investigation reaches the final resolution.
   constraints:

--- a/tests/tasks/uipath-troubleshoot/rpa-foreground-already-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-foreground-already-running/task.yaml
@@ -9,7 +9,7 @@ description: >
   maestro/foreground-unattended-robot playbook for HTTP 409 #1230) and
   identify concurrent foreground jobs as the cause.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, foreground-already-running, concurrency]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, foreground-already-running, concurrency, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/rpa-foreground-misconfigured/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-foreground-misconfigured/task.yaml
@@ -14,7 +14,7 @@ description: >
   need UI interaction. Trigger-sequencing or "Run only one job at a
   time" would mask the misconfiguration.
 
-tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, foreground-already-running, misconfigured-foreground]
+tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, foreground-already-running, misconfigured-foreground, rpa]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/task.yaml
@@ -4,7 +4,7 @@ description: >
   runs the uipath-troubleshoot skill against a uip CLI mock whose
   responses are the verbatim sub-agent outputs from the real session.
   Success = the agent reaches the same root cause as RESOLUTION.md.
-tags: [uipath-troubleshoot, e2e, faithful-replay, faulted-jobs, integration-service, orchestrator]
+tags: [uipath-troubleshoot, e2e, faithful-replay, faulted-jobs, integration-service, orchestrator, rpa]
 
 agent:
   type: claude-code


### PR DESCRIPTION
Adds 'Task YAML requirements' section to tests/tasks/uipath-troubleshoot/CLAUDE.md covering run_limits floors, mandatory product/domain tag from the canonical list, .local/investigations path, and passthrough for docsai mocks. Applies the new tag to all 16 existing scenarios.

**Local verification:** Ran the modified task (`null-reference-exception`) locally on commit `419222e3` — judge score **1.000** (skill_triggered 1.00, llm_judge 1.00), status SUCCESS, run dir `runs/2026-05-18_23-04-39`.