### PR TITLE
docs(skills): give agents the http-request superpower for Managed HTTP Request authoring [ENGCE-57998]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
@@ -50,6 +50,8 @@ Record the `Id` and `FolderKey` from the connection.
 
 ### Step 3 — Configure the node
 
+> **Find missing values first.** Before composing `url` / `query` / `body`, resolve any values the agent doesn't have (IDs from names, required body fields, response shape, …). See [/uipath:uipath-platform — http-request.md](../../../../../../uipath-platform/references/integration-service/http-request.md).
+
 **Connector mode** (IS connection auth):
 
 ```bash

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
@@ -8,7 +8,7 @@
 
 > **Always use `core.action.http.v2`** for all HTTP requests — both connector-authenticated and manual. The older `core.action.http` (v1) is deprecated and does not pass IS credentials at runtime.
 
-## When to Use a Managed HTTP Request Node in a Flow
+## When to Use a Managed HTTP Request Node
 
 | Situation | Use Managed HTTP? |
 | --- | --- |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
@@ -1,16 +1,14 @@
 # HTTP Request Node — Planning
 
+> **MUST READ FIRST:** [/uipath:uipath-platform — http-request.md](../../../../../../uipath-platform/references/integration-service/http-request.md). This file is the flow-specific authoring layer on top.
+
 ## Node Type
 
 `core.action.http.v2` (Managed HTTP Request)
 
 > **Always use `core.action.http.v2`** for all HTTP requests — both connector-authenticated and manual. The older `core.action.http` (v1) is deprecated and does not pass IS credentials at runtime.
 
-## When to Use
-
-Use a managed HTTP node to call a REST API — either with IS connector-managed authentication or with manual auth (raw URL).
-
-### Selection Heuristics
+## When to Use a Managed HTTP Request Node in a Flow
 
 | Situation | Use Managed HTTP? |
 | --- | --- |
@@ -20,12 +18,7 @@ Use a managed HTTP node to call a REST API — either with IS connector-managed 
 | Connector exists and covers the use case | No — use [Connector Activity](../connector/planning.md) |
 | Target system has no API (desktop app) | No — use [RPA Workflow](../rpa/planning.md) |
 
-### Two Authentication Modes
-
-| Mode | When to use | Key `--detail` fields |
-| --- | --- | --- |
-| **Connector** | A connector exists for the service — uses IS connection for OAuth/API key auth | `authentication: "connector"`, `targetConnector`, `connectionId`, `folderKey`, `url` |
-| **Manual** | No connector, or public API with no auth needed | `authentication: "manual"`, `url` |
+For the two-mode concept (connector vs. manual) and the `url` / auth rules per mode, see the platform doc linked at the top.
 
 ## Ports
 

--- a/skills/uipath-platform/references/integration-service/connections.md
+++ b/skills/uipath-platform/references/integration-service/connections.md
@@ -138,6 +138,28 @@ Used by the [connectors.md — JDBC Gateway](connectors.md#jdbc-gateway--databas
 
 ---
 
+## Getting a Connection's Vendor Base URL
+
+`uip is connections base-url <connection-id>` returns the exact vendor base URL the connection uses for proxied calls (e.g., raw `http-request` calls, Managed HTTP Request in connector mode). Manual-mode invocations don't use it. The connection must be Enabled.
+
+```bash
+uip is connections base-url "<connection-id>" --output json
+# → { "Result": "Success", "Code": "ConnectionBaseUrl",
+#     "Data": { "ConnectionId": "<id>", "BaseUrl": "https://..." } }
+```
+
+Examples across connectors:
+
+| Connector | Returned `BaseUrl` |
+|---|---|
+| `uipath-atlassian-jira` | `https://api.atlassian.com/ex/jira/<site-id>/rest/api/2` |
+| `uipath-microsoft-outlook365` | `https://graph.microsoft.com/v1.0` |
+| `uipath-uipath-marketo` | `https://<account>.mktorest.com/rest` |
+
+Use this whenever you need to compose a relative `url` for `http-request` or Managed HTTP Request in connector mode. See [http-request.md](http-request.md).
+
+---
+
 ## Scope-Related Errors
 
 A connection can be `Enabled` but lack optional OAuth scopes needed for specific activities. This typically surfaces as a **403 Forbidden** error during execute.

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -32,9 +32,9 @@ uip is connections base-url "<connection-id>" --output json
 - `url` is the **fully qualified URL**.
 - No connection is bound - you supply everything needed to make the call: URL, headers (including auth if needed), query params, and body.
 
-## Filling In Values with `http-request` command
+## Authoring Helper: `http-request` command
 
-Authoring a Managed HTTP Request payload requires concrete vendor values - IDs, field names, response shape. Use `http-request` command to call any vendor API directly through the connection - same auth, same base URL the Managed HTTP Request will use at runtime.
+Authoring a Managed HTTP Request payload requires concrete vendor values - IDs, field names, endpoint paths. Use `http-request` command to call any vendor API directly through the connection - same auth, same base URL the Managed HTTP Request will use at runtime.
 
 ### When the Agent Needs `http-request` command
 
@@ -42,7 +42,6 @@ Use `http-request` command to resolve any of the following before authoring the 
 
 - **Identifier lookups.** Resolve a human-friendly name to the vendor's internal ID. Examples: project key from a project name, channel ID from a channel name, user ID from email/name, custom-field IDs.
 - **Required and optional fields** the vendor expects in the request body
-- **Response shape** so downstream steps can reference `output.<field>` correctly
 - **Endpoint paths, query params, pagination tokens** before committing to a payload
 - **Vendor error responses** for unsupported parameters or permissions
 

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -110,7 +110,7 @@ All steps 1-2 are GETs because we are in the authoring phase. The POST to `/issu
 
 ## Critical Rules - Do NOT
 
-- **Setting `Authorization` header manually in connector mode.** Auth is applied automatically by the connection. Setting it yourself can leak or override the token.
-- **Absolute URL in connector-mode `url`.** Wrong: `"url": "https://example.atlassian.net/rest/api/2/project"`. Right: `"url": "/project"`.
-- **Writing via CLI during authoring.** See "Read-Only During Authoring" above.
-- **Guessing the base URL.** Use `uip is connections base-url <connection-id>`.
+1. **Do NOT set the `Authorization` header manually in connector mode.** Auth is applied automatically by the connection. Setting it yourself can leak or override the token.
+2. **Do NOT use an absolute URL in connector-mode `url`.** Wrong: `"url": "https://example.atlassian.net/rest/api/2/project"`. Right: `"url": "/project"`.
+3. **Do NOT issue writes via CLI during authoring.** See "Read-Only During Authoring" above.
+4. **Do NOT guess the base URL.** Use `uip is connections base-url <connection-id>`.

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -1,0 +1,116 @@
+# Managed HTTP Request - Concept + `http-request` Authoring Helper
+
+This doc covers two things every agent authoring a Managed HTTP Request needs to know:
+1. What Managed HTTP Request is, and the two modes it runs in.
+2. How to use the `http-request` CLI command to fill in the values Managed HTTP Request needs.
+
+Consumers: Maestro Flow, Maestro BPMN, Case Management, Coded Agents, RPA workflows, API Workflows, and any other UiPath automation surface that supports HTTP calls. Each consumer surfaces Managed HTTP Request differently (as a node, an activity, a tool call, …) and uses its own type identifier and configuration schema - the concept and the rules below are the same. For the exact node/activity type identifier and how to configure it, see your consumer's own authoring docs.
+
+## What is Managed HTTP Request?
+
+A built-in way to make an HTTP call from a UiPath automation when there's no curated activity for it. Runs in two modes - **connector mode** and **manual mode**:
+
+| Mode | When | `url` | Auth |
+|---|---|---|---|
+| **Connector** | Connector exists for the vendor but the specific operation is not curated | **Relative** to the connection's vendor base URL | Applied automatically from the bound connection |
+| **Manual** | No connector exists, or public API with no auth needed | **Full URL** | You supply all headers, including auth |
+
+## Connector-Mode Rules
+
+- `url` must be **relative**. Wrong: `"url": "https://example.atlassian.net/rest/api/2/issue"`. Right: `"url": "/issue"`.
+- The connection's base URL is prepended automatically.
+- The auth header is applied automatically - do not set `Authorization` yourself.
+- To get the exact vendor base URL for a connection (so you can compose the relative `url` correctly):
+
+```bash
+uip is connections base-url "<connection-id>" --output json
+# → { "Data": { "BaseUrl": "https://api.atlassian.com/ex/jira/<site>/rest/api/2" } }
+```
+
+## Manual-Mode Rules
+
+- `url` is the **full URL**.
+- No connection is bound - you supply all headers, including auth.
+- Nothing is prepended or injected automatically.
+
+## Filling In Values with `http-request`
+
+Use `http-request` to call any vendor API directly through the connection - same auth, same base URL Managed HTTP Request will use at runtime. Use it during authoring to find anything missing from the Managed HTTP Request payload (IDs, schemas, response shapes, …).
+
+### When the Agent Needs This
+
+- **Name → ID values** the body needs (project key from a project name, channel ID from a channel name, user ID from email, custom-field IDs, …)
+- **Required / optional fields** the vendor expects in the request body
+- **Response shape** so downstream steps can reference `output.<field>` correctly
+- **Endpoint paths, query params, pagination tokens** before committing to a payload
+- **Vendor error responses** for unsupported parameters or permissions
+
+### Command
+
+```bash
+uip is resources run create <target-connector> http-request \
+  --connection-id "<id>" \
+  --body '{"method":"GET","url":"/relative/path"}' --output json
+```
+
+| `body` field | Required | Notes |
+|---|---|---|
+| `method` | Yes | Uppercase HTTP verb |
+| `url` | Yes | **Relative** to the connection's vendor base URL (same convention as Managed HTTP Request connector mode) |
+| `headers` | No | Extra headers. Do NOT set `Authorization`. |
+| `body` | For POST/PUT/PATCH | **Stringified** JSON for JSON APIs |
+
+`http-request` uses the same connection that Managed HTTP Request will use at runtime, so auth + base URL are applied automatically - same convention as Managed HTTP Request itself.
+
+### Read-Only During Authoring
+
+Use **`GET` only** while authoring Managed HTTP Request. The runtime invocation performs the actual write (`POST` / `PATCH` / `PUT` / `DELETE`) when the automation runs - running the write now via CLI would call the vendor twice (once now, once at runtime). Irreversible for most vendor systems.
+
+CLI writes are allowed only when the user explicitly invokes the CLI as the execution surface ("use `http-request` to create this Jira issue right now"), not during authoring.
+
+## Worked Example: Jira Create Issue
+
+User wants to create a Jira issue. Before composing the Managed HTTP Request payload, the agent needs the project key, issue type ID, and required custom fields. All resolved via `http-request` GETs.
+
+```bash
+# 1. Resolve project key (user said "Engineering project").
+uip is resources run create uipath-atlassian-jira http-request \
+  --connection-id "<id>" \
+  --body '{"method":"GET","url":"/project/search?query=Engineering"}' --output json
+# → key "ENG"
+
+# 2. For project ENG, get available issue types + required custom fields.
+uip is resources run create uipath-atlassian-jira http-request \
+  --connection-id "<id>" \
+  --body '{"method":"GET","url":"/issue/createmeta?projectKeys=ENG&expand=projects.issuetypes.fields"}' \
+  --output json
+# → match "Task" → id "10001"; required custom field: customfield_10010 (Story Points)
+```
+
+3. (Optional) Confirm resolved values with the user.
+
+4. Compose the Managed HTTP Request payload. The actual configuration command and schema are consumer-specific — the request body Managed HTTP Request will send to Jira at runtime looks like:
+
+```json
+{
+  "method": "POST",
+  "url": "/issue",
+  "body": {
+    "fields": {
+      "project": { "key": "ENG" },
+      "issuetype": { "id": "10001" },
+      "summary": "Fix coder evals",
+      "customfield_10010": 3
+    }
+  }
+}
+```
+
+All steps 1-2 are GETs because we are in the authoring phase. The POST to `/issue` happens at runtime, performed by Managed HTTP Request - never by CLI during authoring.
+
+## Critical Rules - Do NOT
+
+- **Setting `Authorization` header manually in connector mode.** Auth is applied automatically by the connection. Setting it yourself can leak or override the token.
+- **Absolute URL in connector-mode `url`.** Wrong: `"url": "https://example.atlassian.net/rest/api/2/project"`. Right: `"url": "/project"`.
+- **Writing via CLI during authoring.** See "Read-Only During Authoring" above.
+- **Guessing the base URL.** Use `uip is connections base-url <connection-id>`.

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -4,7 +4,7 @@ This doc covers two things every agent authoring a Managed HTTP Request needs to
 1. What Managed HTTP Request is, and the two modes it runs in.
 2. How to use the `http-request` CLI command to fill in the values Managed HTTP Request needs.
 
-Consumers: Maestro Flow, Maestro BPMN, Case Management, Coded Agents, RPA workflows, API Workflows, and any other UiPath automation surface that supports HTTP calls. Each consumer surfaces Managed HTTP Request differently (as a node, an activity, a tool call, …) and uses its own type identifier and configuration schema - the concept and the rules below are the same. For the exact node/activity type identifier and how to configure it, see your consumer's own authoring docs.
+Consumers: Maestro Flow, Maestro BPMN, API Workflows, Case Management, etc. Each consumer surfaces Managed HTTP Request differently (as a node, an activity, a tool call, …) and uses its own type identifier and configuration schema - the concept and the rules below are the same. For the exact node/activity type identifier and how to configure it, see your consumer's own authoring docs.
 
 ## What is Managed HTTP Request?
 

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -19,8 +19,8 @@ A built-in way to make an HTTP call from a UiPath automation when there's no cur
 
 - `url` must be **relative**. Wrong: `"url": "https://example.atlassian.net/rest/api/2/issue"`. Right: `"url": "/issue"`.
 - The connection's base URL is prepended automatically.
-- The auth header is applied automatically - do not set `Authorization` yourself.
-- To get the exact vendor base URL for a connection (so you can compose the relative `url` correctly):
+- The auth header is applied automatically - do not set `Authorization`.
+- Get the exact vendor base URL for a connection via (so you can compose the relative `url` correctly):
 
 ```bash
 uip is connections base-url "<connection-id>" --output json
@@ -29,18 +29,19 @@ uip is connections base-url "<connection-id>" --output json
 
 ## Manual-Mode Rules
 
-- `url` is the **full URL**.
-- No connection is bound - you supply all headers, including auth.
-- Nothing is prepended or injected automatically.
+- `url` is the **fully qualified URL**.
+- No connection is bound - you supply everything needed to make the call: URL, headers (including auth if needed), query params, and body.
 
-## Filling In Values with `http-request`
+## Filling In Values with `http-request` command
 
-Use `http-request` to call any vendor API directly through the connection - same auth, same base URL Managed HTTP Request will use at runtime. Use it during authoring to find anything missing from the Managed HTTP Request payload (IDs, schemas, response shapes, …).
+Authoring a Managed HTTP Request payload requires concrete vendor values - IDs, field names, response shape. Use `http-request` command to call any vendor API directly through the connection - same auth, same base URL the Managed HTTP Request will use at runtime.
 
-### When the Agent Needs This
+### When the Agent Needs `http-request` command
 
-- **Name → ID values** the body needs (project key from a project name, channel ID from a channel name, user ID from email, custom-field IDs, …)
-- **Required / optional fields** the vendor expects in the request body
+Use `http-request` command to resolve any of the following before authoring the Managed HTTP Request payload:
+
+- **Identifier lookups.** Resolve a human-friendly name to the vendor's internal ID. Examples: project key from a project name, channel ID from a channel name, user ID from email/name, custom-field IDs.
+- **Required and optional fields** the vendor expects in the request body
 - **Response shape** so downstream steps can reference `output.<field>` correctly
 - **Endpoint paths, query params, pagination tokens** before committing to a payload
 - **Vendor error responses** for unsupported parameters or permissions
@@ -48,9 +49,9 @@ Use `http-request` to call any vendor API directly through the connection - same
 ### Command
 
 ```bash
-uip is resources run create <target-connector> http-request \
+uip is resources run create "<connector-key>" http-request \
   --connection-id "<id>" \
-  --body '{"method":"GET","url":"/relative/path"}' --output json
+  --body '{"method":"<method>","url":"<relative-path>"}' --output json
 ```
 
 | `body` field | Required | Notes |
@@ -58,19 +59,19 @@ uip is resources run create <target-connector> http-request \
 | `method` | Yes | Uppercase HTTP verb |
 | `url` | Yes | **Relative** to the connection's vendor base URL (same convention as Managed HTTP Request connector mode) |
 | `headers` | No | Extra headers. Do NOT set `Authorization`. |
-| `body` | For POST/PUT/PATCH | **Stringified** JSON for JSON APIs |
+| `body` | For POST/PUT/PATCH | **Stringified** JSON. Only `application/json` is supported today - non-JSON content types (form-urlencoded, XML, multipart, plain text) are not. |
 
-`http-request` uses the same connection that Managed HTTP Request will use at runtime, so auth + base URL are applied automatically - same convention as Managed HTTP Request itself.
+`http-request` command uses the same connection that Managed HTTP Request will use at runtime, so auth + base URL are applied automatically - same convention as Managed HTTP Request itself.
 
 ### Read-Only During Authoring
 
-Use **`GET` only** while authoring Managed HTTP Request. The runtime invocation performs the actual write (`POST` / `PATCH` / `PUT` / `DELETE`) when the automation runs - running the write now via CLI would call the vendor twice (once now, once at runtime). Irreversible for most vendor systems.
+When using the `http-request` command, use `GET` method only, as `POST` / `PATCH` / `PUT` / `DELETE` mutate vendor state, often irreversibly.
 
-CLI writes are allowed only when the user explicitly invokes the CLI as the execution surface ("use `http-request` to create this Jira issue right now"), not during authoring.
+Exception: the user asks you to actually run the operation now, not just author it.
 
 ## Worked Example: Jira Create Issue
 
-User wants to create a Jira issue. Before composing the Managed HTTP Request payload, the agent needs the project key, issue type ID, and required custom fields. All resolved via `http-request` GETs.
+User wants to create a Jira issue. Before composing the Managed HTTP Request payload, the agent needs the project key, issue type ID, and required custom fields. All resolved via `http-request` command GETs.
 
 ```bash
 # 1. Resolve project key (user said "Engineering project").
@@ -108,7 +109,7 @@ uip is resources run create uipath-atlassian-jira http-request \
 
 All steps 1-2 are GETs because we are in the authoring phase. The POST to `/issue` happens at runtime, performed by Managed HTTP Request - never by CLI during authoring.
 
-## Critical Rules - Do NOT
+## Critical Rules
 
 1. **Do NOT set the `Authorization` header manually in connector mode.** Auth is applied automatically by the connection. Setting it yourself can leak or override the token.
 2. **Do NOT use an absolute URL in connector-mode `url`.** Wrong: `"url": "https://example.atlassian.net/rest/api/2/project"`. Right: `"url": "/project"`.

--- a/skills/uipath-platform/references/integration-service/integration-service.md
+++ b/skills/uipath-platform/references/integration-service/integration-service.md
@@ -33,6 +33,7 @@ Interact with external services through UiPath Integration Service — discover 
 | Step 4: discover activities | [activities.md](activities.md) | Activity discovery, trigger activities, activities vs resources |
 | Steps 4–6: resources | [resources.md](resources.md) | Describe, execute CRUD, pagination, vendor error recovery |
 | Step 5: resolve references | [reference-resolution.md](reference-resolution.md) | Simple refs, dependency chains, inferring, required field validation |
+| Managed HTTP Request authoring | [http-request.md](http-request.md) | Concept, two modes (connector / manual), `http-request` CLI helper, worked example |
 | Trigger metadata | [triggers.md](triggers.md) | Trigger objects, trigger field metadata, trigger workflow |
 
 ---

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -61,7 +61,7 @@ success_criteria:
   - type: command_executed
     description: "Agent executed a create operation with --body"
     tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+execute\s+create[\s\S]*--body'
+    command_pattern: 'uip\s+is\s+resources\s+run\s+create[\s\S]*--body'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Gives agents the **`http-request` superpower** for authoring a Managed HTTP Request node.

`http-request` is a CLI command that calls any REST endpoint through the same connection the Managed HTTP Request will use at runtime. It is the superpower agents were missing: with it they can look up values on their own - resolve IDs from names, check required fields, see response shapes - before configuring the node.

## Why

Agents can build a Managed HTTP Request node, but they don't know what to put inside it. They guess values, hardcode placeholders, or ask the user for every ID.

`http-request` already exists in the CLI. The problem was that agents didn't know about it. This PR documents it so agents use it by default.

## What changed

- **New canonical doc:** `integration-service/http-request.md` - Managed HTTP Request concept, two modes, `http-request` command, Jira create-issue example. Any skill can link to it.
- **Flow skill:** `http/planning.md` adds MUST READ pointer; `http/impl.md` Step 3 tells agent to resolve values via `http-request` first.
- **Connections doc:** documents `uip is connections base-url <connection-id>` for correct relative URLs in connector mode.

## Validated

Prompt used:

> use uip cli to create a flow to create a jira task in IntegrationService project for me to fix coder evals, use my jira connection and set Needs loc/a11y as false/not needed. NOTE: Use managed http request only - DONOT use any curated nodes of Jira from registry

Agent path: `connector/planning.md` -> curated missing -> `http/planning.md` -> MUST READ -> `http-request.md` -> agent runs `http-request` GETs to find the project key, issue type ID, and custom field IDs -> bakes resolved values into the Managed HTTP Request payload. End-to-end, no user intervention.

### Demo run
<img width="1217" height="932" alt="Screenshot 2026-05-19 at 12 25 15 AM" src="https://github.com/user-attachments/assets/0ec8758a-1888-4a23-bb98-e8fa7c68b276" />

### Session export
[2026-05-19-002531-se-uip-cli-to-create-a-flow-to-create-a-jira-task.txt](https://github.com/user-attachments/files/27972042/2026-05-19-002531-se-uip-cli-to-create-a-flow-to-create-a-jira-task.txt)

## Follow-ups (separate PRs)

- Point BPMN / Case / Agents / RPA skills at the same doc when they add Managed HTTP Request authoring guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
