### PR TITLE
chore: bump plugin version to 0.0.29 and rename diagnostics to troubleshoot

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,8 +8,8 @@
     {
       "name": "uipath",
       "source": "./",
-      "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath diagnostics",
-      "version": "0.0.28",
+      "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath troubleshoot",
+      "version": "0.0.29",
       "author": {
         "name": "UiPath"
       },
@@ -26,7 +26,7 @@
         "ui-testing",
         "desktop",
         "browser",
-        "diagnostics"
+        "troubleshoot"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uipath",
-  "version": "0.0.28",
-  "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath RPA workflows, UI automation, UI testing, Python coded agents and UiPath diagnostics",
+  "version": "0.0.29",
+  "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath RPA workflows, UI automation, UI testing, Python coded agents and UiPath troubleshoot",
   "author": {
     "name": "UiPath"
   },
@@ -28,7 +28,7 @@
     "langgraph",
     "llamaindex",
     "openai-agents",
-    "diagnostics"
+    "troubleshoot"
   ],
   "skills": "./skills/"
 }


### PR DESCRIPTION
Needed because we renamed 'diagnostics' to 'troubleshoot'. 
Fresh installs will pick the rename without a version bump however 'auto-update' will not pick up the latest version and rename.