### PR TITLE
docs(platform): document audit logs destination export

### DIFF
--- a/skills/uipath-platform/references/orchestrator/tenant-admin.md
+++ b/skills/uipath-platform/references/orchestrator/tenant-admin.md
@@ -96,7 +96,7 @@ Audit logs record who did what and when across the tenant. Filter by component, 
 | Command | What it does |
 |---------|--------------|
 | `uip or audit-logs list` | List audit entries with filters (see below). |
-| `uip or audit-logs list --export` | Export logs to CSV instead of terminal output. Use `-o <path>` to set the file path. |
+| `uip or audit-logs list --export --destination <path>` | Export logs to CSV instead of terminal output. Use `--destination` (or `-d`) to set the file path. |
 
 **Filter options for `audit-logs list`:**
 
@@ -115,7 +115,7 @@ uip or audit-logs list --component "Jobs" --output json
 # Export last week's audit logs to CSV
 uip or audit-logs list \
   --created-after "2026-04-14" --created-before "2026-04-22" \
-  --export -o audit-week.csv
+  --export --destination audit-week.csv
 ```
 
 ---
@@ -192,7 +192,7 @@ Export last week's audit logs for user-related actions, then download attachment
 uip or audit-logs list \
   --component "Users" \
   --created-after "2026-04-14" --created-before "2026-04-22" \
-  --export -o user-audit-week.csv
+  --export --destination user-audit-week.csv
 
 # 2. Find the failed job (inspect audit logs or list jobs directly)
 uip or jobs list --state Faulted \


### PR DESCRIPTION
Summary:
- update `uip or audit-logs list --export` examples to use `--destination <path>`
- document `-d` as the shorthand for CSV export file paths

Validation:
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh`

Related:
- CLI PR: https://github.com/UiPath/cli/pull/2118