### PR TITLE
test(uipath-agents): align inline lowcode tests with real tenant resources

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/check_inline_context_index.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/check_inline_context_index.py
@@ -2,18 +2,29 @@
 """Inline agent + context (semantic index) check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node and a
-     `uipath.agent.resource.context.index` node.
-  2. Edge wires agent.context -> context.input.
-  3. Inline agent dir has at least one resource.json under
-     `resources/**/` (UUID-named per inline-in-flow.md) with:
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     matches the sub-folder UUID of the inline agent under the flow
+     project.
+  2. Flow has a `uipath.agent.resource.context.index.<name>.<uuid>`
+     node whose `model.source` matches the sub-folder UUID of the
+     inline agent's resource (under `<inline-agent-uuid>/resources/`).
+  3. Edge wires agent.context -> context.input.
+  4. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for the
+     "UiPathAgentsProductKnowledge" external semantic index with:
        - $resourceType == "context"
        - contextType == "index"
-       - indexName == "ProductKnowledge"
+       - name == "UiPathAgentsProductKnowledge"
+       - indexName == "UiPathAgentsProductKnowledge"
+       - folderPath == "Shared/uipath-agents"
        - settings.retrievalMode in {semantic, structured, deepRAG, batchTransform}
+  5. Inline agent's agent.json declares a required `question:string`
+     input and an `answer:string` output (matching the standalone
+     context_index schema).
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -28,15 +39,69 @@ from _shared.inline_wiring import (  # noqa: E402
 )
 
 FLOW_PATH = Path(os.getcwd()) / "KnowledgeFlowSol" / "KnowledgeFlow" / "KnowledgeFlow.flow"
-CONTEXT_INDEX_NODE_TYPE = "uipath.agent.resource.context.index"
+CONTEXT_INDEX_NODE_TYPE_PREFIX = "uipath.agent.resource.context.index."
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+EXPECTED_INDEX_NAME = "UiPathAgentsProductKnowledge"
+EXPECTED_FOLDER_PATH = "Shared/uipath-agents"
 VALID_RETRIEVAL_MODES = {"semantic", "structured", "deepRAG", "batchTransform"}
+
+
+def assert_input_shape(schema: dict) -> None:
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(props, dict) or "question" not in props:
+        sys.exit(
+            f"FAIL: agent.json inputSchema.properties missing 'question'; "
+            f"got {list(props) if isinstance(props, dict) else props!r}"
+        )
+    q = props["question"]
+    if not isinstance(q, dict) or q.get("type") != "string":
+        sys.exit(f"FAIL: agent.json inputSchema.properties.question.type should be 'string', got {q!r}")
+    required = schema.get("required")
+    if not isinstance(required, list) or "question" not in required:
+        sys.exit(f"FAIL: agent.json inputSchema.required must contain 'question', got {required!r}")
+    print("OK: agent.json inputSchema declares required question:string")
+
+
+def assert_output_shape(schema: dict) -> None:
+    props = schema.get("properties") if isinstance(schema, dict) else None
+    if not isinstance(props, dict) or "answer" not in props:
+        sys.exit(
+            f"FAIL: agent.json outputSchema.properties missing 'answer'; "
+            f"got {list(props) if isinstance(props, dict) else props!r}"
+        )
+    a = props["answer"]
+    if not isinstance(a, dict) or a.get("type") != "string":
+        sys.exit(f"FAIL: agent.json outputSchema.properties.answer.type should be 'string', got {a!r}")
+    print("OK: agent.json outputSchema declares answer:string")
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    context_node = find_resource_node(flow, node_type=CONTEXT_INDEX_NODE_TYPE)
+    context_node = find_resource_node(flow, node_type_prefix=CONTEXT_INDEX_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {context_node['type']} nodes")
+
+    agent_source = (agent_node.get("inputs") or {}).get("source")
+    if not isinstance(agent_source, str) or not UUID_RE.match(agent_source):
+        sys.exit(
+            f"FAIL: {agent_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent's sub-folder name, got {agent_source!r}"
+        )
+    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
+    if agent_dir.name != agent_source:
+        sys.exit(
+            f"FAIL: inputs.source UUID {agent_source!r} does not match "
+            f"the inline agent sub-folder name {agent_dir.name!r}"
+        )
+    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+
+    context_source = (context_node.get("model") or {}).get("source")
+    if not isinstance(context_source, str) or not UUID_RE.match(context_source):
+        sys.exit(
+            f"FAIL: {context_node['type']} model.source must be a UUID matching "
+            f"the inline agent resource's sub-folder name, got {context_source!r}"
+        )
 
     assert_edge(
         flow,
@@ -47,19 +112,40 @@ def main() -> None:
     )
     print("OK: agent 'context' handle is wired to context.index node's 'input' handle")
 
-    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path, resource = find_inline_resource(
         agent_dir,
         lambda d: (
             d.get("$resourceType") == "context"
             and d.get("contextType") == "index"
-            and d.get("indexName") == "ProductKnowledge"
+            and d.get("indexName") == EXPECTED_INDEX_NAME
         ),
-        description='context index "ProductKnowledge"',
+        description=f'context index "{EXPECTED_INDEX_NAME}"',
     )
+    if resource_path.parent.name != context_source:
+        sys.exit(
+            f"FAIL: context node model.source UUID {context_source!r} does not match "
+            f"the resource sub-folder name {resource_path.parent.name!r}"
+        )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
-        f'$resourceType="context", contextType="index", indexName="ProductKnowledge"'
+        f"OK: context node model.source={context_source!r} matches resource sub-folder "
+        f"({resource_path.relative_to(Path(os.getcwd()))})"
+    )
+
+    name = resource.get("name")
+    if name != EXPECTED_INDEX_NAME:
+        sys.exit(
+            f"FAIL: resource.json name should be {EXPECTED_INDEX_NAME!r} "
+            f"(matching the deployed index), got {name!r}"
+        )
+    folder_path = resource.get("folderPath")
+    if folder_path != EXPECTED_FOLDER_PATH:
+        sys.exit(
+            f"FAIL: resource.json folderPath should be {EXPECTED_FOLDER_PATH!r} "
+            f"(the deployed Orchestrator folder of the index), got {folder_path!r}"
+        )
+    print(
+        f'OK: resource.json is $resourceType="context", contextType="index", '
+        f"name=indexName={EXPECTED_INDEX_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}"
     )
 
     settings = resource.get("settings") or {}
@@ -70,6 +156,10 @@ def main() -> None:
             f"got {mode!r}"
         )
     print(f"OK: settings.retrievalMode is {mode!r}")
+
+    agent_json = load_json(agent_dir / "agent.json")
+    assert_input_shape(agent_json.get("inputSchema") or {})
+    assert_output_shape(agent_json.get("outputSchema") or {})
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
@@ -24,11 +24,15 @@ sandbox:
 
 initial_prompt: |
   Create a UiPath solution "KnowledgeFlowSol" containing a flow project
-  "KnowledgeFlow". The flow should use an inline low-code agent that
-  grounds its answers in an EXTERNAL semantic index named
-  "ProductKnowledge" deployed to the Orchestrator "Shared" folder
-  (indexes always live outside the solution). Wire the index as a
-  context resource on the inline agent.
+  "KnowledgeFlow" with an inline low-code agent. The agent accepts a
+  required `question` (string) and returns a string `answer`. It must
+  ground its answers in the existing semantic index named
+  "UiPathAgentsProductKnowledge" that is already deployed in the
+  tenant (indexes always live outside the solution).
+
+  Use the real folder and index name from the tenant — do not
+  hard-code or guess these values. Name the agent's context resource
+  `UiPathAgentsProductKnowledge` (matching the index).
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -40,7 +44,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+init'
     min_count: 1
-    weight: 1.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -48,7 +52,47 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+init\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered the index identity with uip solution resource list --kind Index"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+list\b.*--kind\s+Index'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the index configuration with uip solution resource get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+get\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the flow registry for the context index manifest"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the context index node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.resource\.context\.index\.'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the inline autonomous agent node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.autonomous'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
@@ -64,19 +108,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -91,12 +127,6 @@ success_criteria:
     description: "Flow file was created"
     path: "KnowledgeFlowSol/KnowledgeFlow/KnowledgeFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "KnowledgeFlowSol/KnowledgeFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/check_inline_external_agent_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/check_inline_external_agent_tool.py
@@ -2,20 +2,27 @@
 """Inline agent + external agent-as-tool check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node and a
-     `uipath.agent.resource.tool.agent.*` node (per-agent suffix).
-  2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has at least one resource.json under
-     `resources/**/` (UUID-named per inline-in-flow.md) for a
-     "SupportExpert" external agent-as-tool with:
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     matches the sub-folder UUID of the inline agent under the flow
+     project.
+  2. Flow has a `uipath.agent.resource.tool.agent.<uuid>` node whose
+     `model.source` matches the sub-folder UUID of the inline agent's
+     resource (under `<inline-agent-uuid>/resources/`).
+  3. Edge wires agent.tool -> tool.input.
+  4. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for the
+     "EmailDrafter" external agent-as-tool with:
        - $resourceType == "tool"
        - type == "agent"
        - location == "external"
-       - properties.processName == "SupportExpert"
-       - properties.folderPath is a real path (NOT "solution_folder")
+       - properties.processName == "EmailDrafter"
+       - properties.folderPath == "Shared/uipath-agents/EmailDrafter"
+       - referenceKey is a UUID-shaped non-empty string (copied from
+         `uip solution resource list`'s `Key`)
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -29,15 +36,40 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "RouterFlowSol" / "RouterFlow" / "RouterFlow.flow"
-AGENT_TOOL_NODE_PREFIX = "uipath.agent.resource.tool.agent."
+FLOW_PATH = Path(os.getcwd()) / "OutreachFlowSol" / "OutreachFlow" / "OutreachFlow.flow"
+AGENT_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.agent."
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+EXPECTED_PROCESS_NAME = "EmailDrafter"
+EXPECTED_FOLDER_PATH = "Shared/uipath-agents/EmailDrafter"
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    tool_node = find_resource_node(flow, node_type_prefix=AGENT_TOOL_NODE_PREFIX)
+    tool_node = find_resource_node(flow, node_type_prefix=AGENT_TOOL_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {tool_node['type']} nodes")
+
+    agent_source = (agent_node.get("inputs") or {}).get("source")
+    if not isinstance(agent_source, str) or not UUID_RE.match(agent_source):
+        sys.exit(
+            f"FAIL: {agent_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent's sub-folder name, got {agent_source!r}"
+        )
+    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
+    if agent_dir.name != agent_source:
+        sys.exit(
+            f"FAIL: inputs.source UUID {agent_source!r} does not match "
+            f"the inline agent sub-folder name {agent_dir.name!r}"
+        )
+    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+
+    tool_source = (tool_node.get("model") or {}).get("source")
+    if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
+        sys.exit(
+            f"FAIL: {tool_node['type']} model.source must be a UUID matching "
+            f"the inline agent resource's sub-folder name, got {tool_source!r}"
+        )
 
     assert_edge(
         flow,
@@ -48,16 +80,24 @@ def main() -> None:
     )
     print("OK: agent 'tool' handle is wired to external agent-as-tool node's 'input' handle")
 
-    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path, resource = find_inline_resource(
         agent_dir,
         lambda d: (
             d.get("$resourceType") == "tool"
             and d.get("type") == "agent"
             and d.get("location") == "external"
-            and (d.get("properties") or {}).get("processName") == "SupportExpert"
+            and (d.get("properties") or {}).get("processName") == EXPECTED_PROCESS_NAME
         ),
-        description='external agent-as-tool "SupportExpert"',
+        description=f'external agent-as-tool "{EXPECTED_PROCESS_NAME}"',
+    )
+    if resource_path.parent.name != tool_source:
+        sys.exit(
+            f"FAIL: tool model.source UUID {tool_source!r} does not match "
+            f"the resource sub-folder name {resource_path.parent.name!r}"
+        )
+    print(
+        f"OK: tool node model.source={tool_source!r} matches resource sub-folder "
+        f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
@@ -66,15 +106,20 @@ def main() -> None:
 
     props = resource.get("properties") or {}
     fpath = props.get("folderPath")
-    if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
-    if fpath == "solution_folder":
+    if fpath != EXPECTED_FOLDER_PATH:
         sys.exit(
-            'FAIL: properties.folderPath is "solution_folder", which is only '
-            'valid for location=="solution". External agent tools require a '
-            'real Orchestrator folder path like "Shared".'
+            f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
+            f"(the deployed Orchestrator folder of {EXPECTED_PROCESS_NAME}), got {fpath!r}"
         )
-    print(f'OK: properties.processName="SupportExpert", folderPath={fpath!r} (not "solution_folder")')
+    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+
+    rkey = resource.get("referenceKey")
+    if not isinstance(rkey, str) or "-" not in rkey:
+        sys.exit(
+            f"FAIL: resource.referenceKey must be a UUID-shaped string copied "
+            f"from `uip solution resource list`'s `Key`, got {rkey!r}"
+        )
+    print(f"OK: resource.referenceKey={rkey!r} (UUID-shaped)")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -23,12 +23,16 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Create a UiPath solution "RouterFlowSol" containing a flow project
-  "RouterFlow". The flow should use an inline low-code agent that
-  delegates specialized questions to an EXTERNAL agent called
-  "SupportExpert" already deployed to the Orchestrator "Shared"
-  folder (not inside this solution). Wire the external agent as a
-  tool on the inline agent.
+  Create a UiPath solution "OutreachFlowSol" containing a flow project
+  "OutreachFlow" with an inline low-code agent. The agent accepts a
+  required `subject` (string) and returns a string `content`. It must
+  compose the content by delegating to an agent named "EmailDrafter"
+  that is already deployed in the tenant — not by drafting the email
+  itself.
+
+  Use the real folder and process name from the tenant — do not
+  hard-code or guess these values. Name the agent's tool resource
+  `EmailDrafter` (matching the deployed agent).
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -40,7 +44,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+init'
     min_count: 1
-    weight: 1.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -48,14 +52,54 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+init\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered the EmailDrafter identity with uip solution resource list --kind Process"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+list\b.*--kind\s+Process'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the EmailDrafter configuration with uip solution resource get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+get\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the flow registry for the external agent-as-tool manifest"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the external agent-as-tool node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.resource\.tool\.agent\.'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the inline autonomous agent node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.autonomous'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
   # `uip solution project add` both populate Projects[] in the .uipx).
   - type: json_check
     description: "Project is registered in the parent solution .uipx"
-    path: "RouterFlowSol/RouterFlowSol.uipx"
+    path: "OutreachFlowSol/OutreachFlowSol.uipx"
     assertions:
       - expression: "length(Projects)"
         operator: "gte"
@@ -64,19 +108,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -89,14 +125,8 @@ success_criteria:
 
   - type: file_exists
     description: "Flow file was created"
-    path: "RouterFlowSol/RouterFlow/RouterFlow.flow"
+    path: "OutreachFlowSol/OutreachFlow/OutreachFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "RouterFlowSol/RouterFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
@@ -2,20 +2,27 @@
 """Inline agent + external API workflow tool check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node and a
-     `uipath.agent.resource.tool.*` node (exact API suffix
-     under-asserted — use prefix match).
-  2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has at least one resource.json under
-     `resources/**/` (UUID-named per inline-in-flow.md) for a
-     "GetLatestQuote" external API workflow tool with:
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     matches the sub-folder UUID of the inline agent under the flow
+     project.
+  2. Flow has a `uipath.agent.resource.tool.api.<uuid>` node whose
+     `model.source` matches the sub-folder UUID of the inline agent's
+     resource (under `<inline-agent-uuid>/resources/`).
+  3. Edge wires agent.tool -> tool.input.
+  4. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for the
+     "WeatherAPI" external API workflow tool with:
        - $resourceType == "tool"
        - type == "api"
        - location == "external"
-       - properties.folderPath is a real path (NOT "solution_folder")
+       - properties.processName == "WeatherAPI"
+       - properties.folderPath == "Shared/uipath-agents/WeatherAPI"
+       - referenceKey is a UUID-shaped non-empty string (copied from
+         `uip solution resource list`'s `Key`)
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -29,15 +36,40 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "QuoteFlowSol" / "QuoteFlow" / "QuoteFlow.flow"
-TOOL_NODE_PREFIX = "uipath.agent.resource.tool."
+FLOW_PATH = Path(os.getcwd()) / "WeatherFlowSol" / "WeatherFlow" / "WeatherFlow.flow"
+API_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.api."
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+EXPECTED_PROCESS_NAME = "WeatherAPI"
+EXPECTED_FOLDER_PATH = "Shared/uipath-agents/WeatherAPI"
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    tool_node = find_resource_node(flow, node_type_prefix=TOOL_NODE_PREFIX)
+    tool_node = find_resource_node(flow, node_type_prefix=API_TOOL_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {tool_node['type']} nodes")
+
+    agent_source = (agent_node.get("inputs") or {}).get("source")
+    if not isinstance(agent_source, str) or not UUID_RE.match(agent_source):
+        sys.exit(
+            f"FAIL: {agent_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent's sub-folder name, got {agent_source!r}"
+        )
+    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
+    if agent_dir.name != agent_source:
+        sys.exit(
+            f"FAIL: inputs.source UUID {agent_source!r} does not match "
+            f"the inline agent sub-folder name {agent_dir.name!r}"
+        )
+    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+
+    tool_source = (tool_node.get("model") or {}).get("source")
+    if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
+        sys.exit(
+            f"FAIL: {tool_node['type']} model.source must be a UUID matching "
+            f"the inline agent resource's sub-folder name, got {tool_source!r}"
+        )
 
     assert_edge(
         flow,
@@ -48,16 +80,24 @@ def main() -> None:
     )
     print("OK: agent 'tool' handle is wired to external API workflow tool node's 'input' handle")
 
-    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path, resource = find_inline_resource(
         agent_dir,
         lambda d: (
             d.get("$resourceType") == "tool"
             and d.get("type") == "api"
             and d.get("location") == "external"
-            and d.get("name") == "GetLatestQuote"
+            and (d.get("properties") or {}).get("processName") == EXPECTED_PROCESS_NAME
         ),
-        description='external API workflow tool "GetLatestQuote"',
+        description=f'external API workflow tool "{EXPECTED_PROCESS_NAME}"',
+    )
+    if resource_path.parent.name != tool_source:
+        sys.exit(
+            f"FAIL: tool model.source UUID {tool_source!r} does not match "
+            f"the resource sub-folder name {resource_path.parent.name!r}"
+        )
+    print(
+        f"OK: tool node model.source={tool_source!r} matches resource sub-folder "
+        f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
@@ -66,15 +106,20 @@ def main() -> None:
 
     props = resource.get("properties") or {}
     fpath = props.get("folderPath")
-    if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
-    if fpath == "solution_folder":
+    if fpath != EXPECTED_FOLDER_PATH:
         sys.exit(
-            'FAIL: properties.folderPath is "solution_folder", which is only '
-            'valid for location=="solution". External tools require a real '
-            'Orchestrator folder path like "Shared".'
+            f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
+            f"(the deployed Orchestrator folder of {EXPECTED_PROCESS_NAME}), got {fpath!r}"
         )
-    print(f'OK: properties.folderPath={fpath!r} (not "solution_folder")')
+    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+
+    rkey = resource.get("referenceKey")
+    if not isinstance(rkey, str) or "-" not in rkey:
+        sys.exit(
+            f"FAIL: resource.referenceKey must be a UUID-shaped string copied "
+            f"from `uip solution resource list`'s `Key`, got {rkey!r}"
+        )
+    print(f"OK: resource.referenceKey={rkey!r} (UUID-shaped)")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -22,11 +22,16 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Create a UiPath solution "QuoteFlowSol" containing a flow project
-  "QuoteFlow". The flow should use an inline low-code agent that
-  calls an EXTERNAL API workflow called "GetLatestQuote" deployed to
-  the Orchestrator "Shared" folder (not inside this solution). Wire
-  the API workflow as a tool on the inline agent.
+  Create a UiPath solution "WeatherFlowSol" containing a flow project
+  "WeatherFlow" with an inline low-code agent. The agent accepts a
+  required `location` (string) and returns a number `temperature`. It
+  must compute the temperature using an API workflow named "WeatherAPI"
+  that is already deployed in the tenant — not by reasoning about the
+  answer itself.
+
+  Use the real folder and process name from the tenant — do not
+  hard-code or guess these values. Name the agent's tool resource
+  `WeatherAPI` (matching the process).
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -38,7 +43,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+init'
     min_count: 1
-    weight: 1.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -46,14 +51,54 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+init\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered the API workflow identity with uip solution resource list --kind Process"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+list\b.*--kind\s+Process'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the API workflow configuration with uip solution resource get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+get\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the flow registry for the external API workflow manifest"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the external API workflow tool node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.resource\.tool\.api\.'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the inline autonomous agent node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.autonomous'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
   # `uip solution project add` both populate Projects[] in the .uipx).
   - type: json_check
     description: "Project is registered in the parent solution .uipx"
-    path: "QuoteFlowSol/QuoteFlowSol.uipx"
+    path: "WeatherFlowSol/WeatherFlowSol.uipx"
     assertions:
       - expression: "length(Projects)"
         operator: "gte"
@@ -62,19 +107,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -87,14 +124,8 @@ success_criteria:
 
   - type: file_exists
     description: "Flow file was created"
-    path: "QuoteFlowSol/QuoteFlow/QuoteFlow.flow"
+    path: "WeatherFlowSol/WeatherFlow/WeatherFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "QuoteFlowSol/QuoteFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/check_inline_external_maestro_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/check_inline_external_maestro_tool.py
@@ -2,20 +2,27 @@
 """Inline agent + external Maestro (processOrchestration) tool check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node and a
-     `uipath.agent.resource.tool.*` node (exact Maestro suffix
-     under-asserted — use prefix match).
-  2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has at least one resource.json under
-     `resources/**/` (UUID-named per inline-in-flow.md) for a
-     "ProcessClaim" external Maestro tool with:
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     matches the sub-folder UUID of the inline agent under the flow
+     project.
+  2. Flow has a `uipath.agent.resource.tool.processorchestration.<uuid>`
+     node whose `model.source` matches the sub-folder UUID of the
+     inline agent's resource (under `<inline-agent-uuid>/resources/`).
+  3. Edge wires agent.tool -> tool.input.
+  4. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for the
+     "ProcurementProcess" external Maestro tool with:
        - $resourceType == "tool"
        - type == "processOrchestration"
        - location == "external"
-       - properties.folderPath is a real path (NOT "solution_folder")
+       - properties.processName == "ProcurementProcess"
+       - properties.folderPath == "Shared/uipath-agents/ProcurementProcess"
+       - referenceKey is a UUID-shaped non-empty string (copied from
+         `uip solution resource list`'s `Key`)
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -29,15 +36,40 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "ClaimsFlowSol" / "ClaimsFlow" / "ClaimsFlow.flow"
-TOOL_NODE_PREFIX = "uipath.agent.resource.tool."
+FLOW_PATH = Path(os.getcwd()) / "ProcurementFlowSol" / "ProcurementFlow" / "ProcurementFlow.flow"
+MAESTRO_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.processorchestration."
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+EXPECTED_PROCESS_NAME = "ProcurementProcess"
+EXPECTED_FOLDER_PATH = "Shared/uipath-agents/ProcurementProcess"
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    tool_node = find_resource_node(flow, node_type_prefix=TOOL_NODE_PREFIX)
+    tool_node = find_resource_node(flow, node_type_prefix=MAESTRO_TOOL_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {tool_node['type']} nodes")
+
+    agent_source = (agent_node.get("inputs") or {}).get("source")
+    if not isinstance(agent_source, str) or not UUID_RE.match(agent_source):
+        sys.exit(
+            f"FAIL: {agent_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent's sub-folder name, got {agent_source!r}"
+        )
+    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
+    if agent_dir.name != agent_source:
+        sys.exit(
+            f"FAIL: inputs.source UUID {agent_source!r} does not match "
+            f"the inline agent sub-folder name {agent_dir.name!r}"
+        )
+    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+
+    tool_source = (tool_node.get("model") or {}).get("source")
+    if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
+        sys.exit(
+            f"FAIL: {tool_node['type']} model.source must be a UUID matching "
+            f"the inline agent resource's sub-folder name, got {tool_source!r}"
+        )
 
     assert_edge(
         flow,
@@ -48,16 +80,24 @@ def main() -> None:
     )
     print("OK: agent 'tool' handle is wired to external Maestro tool node's 'input' handle")
 
-    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path, resource = find_inline_resource(
         agent_dir,
         lambda d: (
             d.get("$resourceType") == "tool"
             and d.get("type") == "processOrchestration"
             and d.get("location") == "external"
-            and d.get("name") == "ProcessClaim"
+            and (d.get("properties") or {}).get("processName") == EXPECTED_PROCESS_NAME
         ),
-        description='external Maestro tool "ProcessClaim"',
+        description=f'external Maestro tool "{EXPECTED_PROCESS_NAME}"',
+    )
+    if resource_path.parent.name != tool_source:
+        sys.exit(
+            f"FAIL: tool model.source UUID {tool_source!r} does not match "
+            f"the resource sub-folder name {resource_path.parent.name!r}"
+        )
+    print(
+        f"OK: tool node model.source={tool_source!r} matches resource sub-folder "
+        f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
@@ -66,15 +106,20 @@ def main() -> None:
 
     props = resource.get("properties") or {}
     fpath = props.get("folderPath")
-    if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
-    if fpath == "solution_folder":
+    if fpath != EXPECTED_FOLDER_PATH:
         sys.exit(
-            'FAIL: properties.folderPath is "solution_folder", which is only '
-            'valid for location=="solution". External tools require a real '
-            'Orchestrator folder path like "Shared".'
+            f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
+            f"(the deployed Orchestrator folder of {EXPECTED_PROCESS_NAME}), got {fpath!r}"
         )
-    print(f'OK: properties.folderPath={fpath!r} (not "solution_folder")')
+    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+
+    rkey = resource.get("referenceKey")
+    if not isinstance(rkey, str) or "-" not in rkey:
+        sys.exit(
+            f"FAIL: resource.referenceKey must be a UUID-shaped string copied "
+            f"from `uip solution resource list`'s `Key`, got {rkey!r}"
+        )
+    print(f"OK: resource.referenceKey={rkey!r} (UUID-shaped)")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -23,11 +23,16 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Create a UiPath solution "ClaimsFlowSol" containing a flow project
-  "ClaimsFlow". The flow should use an inline low-code agent that
-  calls an EXTERNAL Maestro flow called "ProcessClaim" deployed to
-  the Orchestrator "Shared" folder (not inside this solution). Wire
-  the Maestro flow as a tool on the inline agent.
+  Create a UiPath solution "ProcurementFlowSol" containing a flow
+  project "ProcurementFlow" with an inline low-code agent. The agent
+  accepts a required `productId` (number) and returns a boolean
+  `status`. It must determine the status by delegating to a Maestro /
+  agentic process named "ProcurementProcess" that is already deployed
+  in the tenant — not by reasoning about the answer itself.
+
+  Use the real folder and process name from the tenant — do not
+  hard-code or guess these values. Name the agent's tool resource
+  `ProcurementProcess` (matching the deployed process).
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -39,7 +44,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+init'
     min_count: 1
-    weight: 1.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -47,14 +52,54 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+init\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered the Maestro process identity with uip solution resource list --kind Process"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+list\b.*--kind\s+Process'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the Maestro process configuration with uip solution resource get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+get\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the flow registry for the external Maestro tool manifest"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the external Maestro tool node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.resource\.tool\.processorchestration\.'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the inline autonomous agent node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.autonomous'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
   # `uip solution project add` both populate Projects[] in the .uipx).
   - type: json_check
     description: "Project is registered in the parent solution .uipx"
-    path: "ClaimsFlowSol/ClaimsFlowSol.uipx"
+    path: "ProcurementFlowSol/ProcurementFlowSol.uipx"
     assertions:
       - expression: "length(Projects)"
         operator: "gte"
@@ -63,19 +108,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -88,14 +125,8 @@ success_criteria:
 
   - type: file_exists
     description: "Flow file was created"
-    path: "ClaimsFlowSol/ClaimsFlow/ClaimsFlow.flow"
+    path: "ProcurementFlowSol/ProcurementFlow/ProcurementFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "ClaimsFlowSol/ClaimsFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/check_inline_external_rpa_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/check_inline_external_rpa_tool.py
@@ -2,20 +2,27 @@
 """Inline agent + external RPA tool check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node and a
-     `uipath.agent.resource.tool.rpa` node.
-  2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has at least one resource.json under
-     `resources/**/` (UUID-named per inline-in-flow.md) for an
-     "InvoiceProcessor" external RPA tool with:
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     matches the sub-folder UUID of the inline agent under the flow
+     project.
+  2. Flow has a `uipath.agent.resource.tool.process.<uuid>` node
+     whose `model.source` matches the sub-folder UUID of the inline
+     agent's resource (under `<inline-agent-uuid>/resources/`).
+  3. Edge wires agent.tool -> tool.input.
+  4. Inline agent dir has at least one resource.json under
+     `resources/**/` (UUID-named per inline-in-flow.md) for the
+     "FibonacciRPA" external RPA tool with:
        - $resourceType == "tool"
        - type == "process"
        - location == "external"
-       - properties.processName == "InvoiceProcessor"
-       - properties.folderPath is a real path (NOT "solution_folder")
+       - properties.processName == "FibonacciRPA"
+       - properties.folderPath == "Shared/uipath-agents/FibonacciRPA"
+       - referenceKey is a UUID-shaped non-empty string (copied from
+         `uip solution resource list`'s `Key`)
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -29,15 +36,40 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "BillingFlowSol" / "BillingFlow" / "BillingFlow.flow"
-RPA_TOOL_NODE_TYPE = "uipath.agent.resource.tool.rpa"
+FLOW_PATH = Path(os.getcwd()) / "FibonacciFlowSol" / "FibonacciFlow" / "FibonacciFlow.flow"
+RPA_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.process."
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+EXPECTED_PROCESS_NAME = "FibonacciRPA"
+EXPECTED_FOLDER_PATH = "Shared/uipath-agents/FibonacciRPA"
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    tool_node = find_resource_node(flow, node_type=RPA_TOOL_NODE_TYPE)
+    tool_node = find_resource_node(flow, node_type_prefix=RPA_TOOL_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {tool_node['type']} nodes")
+
+    agent_source = (agent_node.get("inputs") or {}).get("source")
+    if not isinstance(agent_source, str) or not UUID_RE.match(agent_source):
+        sys.exit(
+            f"FAIL: {agent_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent's sub-folder name, got {agent_source!r}"
+        )
+    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
+    if agent_dir.name != agent_source:
+        sys.exit(
+            f"FAIL: inputs.source UUID {agent_source!r} does not match "
+            f"the inline agent sub-folder name {agent_dir.name!r}"
+        )
+    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+
+    tool_source = (tool_node.get("model") or {}).get("source")
+    if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
+        sys.exit(
+            f"FAIL: {tool_node['type']} model.source must be a UUID matching "
+            f"the inline agent resource's sub-folder name, got {tool_source!r}"
+        )
 
     assert_edge(
         flow,
@@ -48,16 +80,24 @@ def main() -> None:
     )
     print("OK: agent 'tool' handle is wired to external RPA tool node's 'input' handle")
 
-    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resource_path, resource = find_inline_resource(
         agent_dir,
         lambda d: (
             d.get("$resourceType") == "tool"
             and d.get("type") == "process"
             and d.get("location") == "external"
-            and (d.get("properties") or {}).get("processName") == "InvoiceProcessor"
+            and (d.get("properties") or {}).get("processName") == EXPECTED_PROCESS_NAME
         ),
-        description='external RPA tool "InvoiceProcessor"',
+        description=f'external RPA tool "{EXPECTED_PROCESS_NAME}"',
+    )
+    if resource_path.parent.name != tool_source:
+        sys.exit(
+            f"FAIL: tool model.source UUID {tool_source!r} does not match "
+            f"the resource sub-folder name {resource_path.parent.name!r}"
+        )
+    print(
+        f"OK: tool node model.source={tool_source!r} matches resource sub-folder "
+        f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
         f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
@@ -66,15 +106,20 @@ def main() -> None:
 
     props = resource.get("properties") or {}
     fpath = props.get("folderPath")
-    if not isinstance(fpath, str) or not fpath.strip():
-        sys.exit(f"FAIL: properties.folderPath must be a non-empty string, got {fpath!r}")
-    if fpath == "solution_folder":
+    if fpath != EXPECTED_FOLDER_PATH:
         sys.exit(
-            'FAIL: properties.folderPath is "solution_folder", which is only '
-            'valid for location=="solution". External tools require a real '
-            'Orchestrator folder path like "Shared".'
+            f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
+            f"(the deployed Orchestrator folder of FibonacciRPA), got {fpath!r}"
         )
-    print(f'OK: properties.processName="InvoiceProcessor", folderPath={fpath!r} (not "solution_folder")')
+    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+
+    rkey = resource.get("referenceKey")
+    if not isinstance(rkey, str) or "-" not in rkey:
+        sys.exit(
+            f"FAIL: resource.referenceKey must be a UUID-shaped string copied "
+            f"from `uip solution resource list`'s `Key`, got {rkey!r}"
+        )
+    print(f"OK: resource.referenceKey={rkey!r} (UUID-shaped)")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -22,11 +22,16 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Create a UiPath solution "BillingFlowSol" containing a flow project
-  "BillingFlow". The flow should use an inline low-code agent that
-  calls an EXTERNAL RPA process called "InvoiceProcessor" deployed to
-  the Orchestrator "Shared" folder (not inside this solution). Wire
-  the RPA process as a tool on the inline agent.
+  Create a UiPath solution "FibonacciFlowSol" containing a flow project
+  "FibonacciFlow" with an inline low-code agent. The agent accepts a
+  required `index` (number) and returns a number `value`. It must
+  compute the value using an process named "FibonacciRPA" that is
+  already deployed in the tenant — not by reasoning about the answer
+  itself.
+
+  Use the real folder and process name from the tenant — do not
+  hard-code or guess these values. Name the agent's tool resource
+  `FibonacciRPA` (matching the process).
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -38,7 +43,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+init'
     min_count: 1
-    weight: 1.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -46,14 +51,54 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+init\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered the process identity with uip solution resource list --kind Process"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+list\b.*--kind\s+Process'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the process configuration with uip solution resource get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+get\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the flow registry for the external resource manifest"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the external RPA tool node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.resource\.tool\.process\.'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the inline autonomous agent node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.autonomous'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
   # `uip solution project add` both populate Projects[] in the .uipx).
   - type: json_check
     description: "Project is registered in the parent solution .uipx"
-    path: "BillingFlowSol/BillingFlowSol.uipx"
+    path: "FibonacciFlowSol/FibonacciFlowSol.uipx"
     assertions:
       - expression: "length(Projects)"
         operator: "gte"
@@ -62,19 +107,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -87,14 +124,8 @@ success_criteria:
 
   - type: file_exists
     description: "Flow file was created"
-    path: "BillingFlowSol/BillingFlow/BillingFlow.flow"
+    path: "FibonacciFlowSol/FibonacciFlow/FibonacciFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "BillingFlowSol/BillingFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command


### PR DESCRIPTION
## Summary

Aligns five `uipath-agents` lowcode inline-in-flow tests with their standalone counterparts so each pair references the **same real deployed tenant resource** and the inline tests share a consistent shape (prompt + criteria + check):

| Pair | Tenant resource | E2E status |
|---|---|---|
| `inline_external_rpa_tool` | `FibonacciRPA` @ `Shared/uipath-agents/FibonacciRPA` | ✅ 12/12 |
| `inline_external_agent_tool` | `EmailDrafter` @ `Shared/uipath-agents/EmailDrafter` | ✅ 12/12 |
| `inline_context_index` | `UiPathAgentsProductKnowledge` @ `Shared/uipath-agents` | ❌ skill-doc gap |
| `inline_external_apiworkflow_tool` | `WeatherAPI` @ `Shared/uipath-agents/WeatherAPI` | ❌ skill-doc gap |
| `inline_external_maestro_tool` | `ProcurementProcess` @ `Shared/uipath-agents/ProcurementProcess` | ❌ skill-doc gap |

Per-pair changes (each in its own commit):
- Prompt rewritten to reference the real deployed resource, mirror the standalone's I/O schema, and require tenant discovery (`do not hard-code or guess`).
- Solution/flow renamed to mirror the standalone theme (e.g. `OutreachFlowSol/OutreachFlow` for the agent-tool pair).
- Success criteria realigned with the standalone (uniform 1.5 weights, `--output json` at 1.0, run_command at 5.0). Added three new `command_executed` criteria for the flow-registry discovery commands (`registry search`, `registry get <tool-type-prefix>`, `registry get uipath.agent.autonomous`). Dropped obsolete `flow node add` regex and `project.uiproj` file_exists.
- Check script tightened: exact `folderPath`, UUID `referenceKey`, autonomous node `inputs.source` matches inline-agent sub-folder UUID, tool/context node `model.source` matches resource sub-folder UUID. Switched node-type match to the actual registry prefixes (`tool.process.<uuid>`, `tool.agent.<uuid>`, `tool.api.<uuid>`, `tool.processorchestration.<uuid>`, `context.index.<name>.<uuid>`).

### Skill-doc gaps surfaced by the failing pairs

The three failing tests intentionally encode the standalone convention; their failures expose real inline-in-flow skill gaps:

- **`inline_context_index`** — agent writes the resource under a name-named directory (`resources/UiPathAgentsProductKnowledge/`) instead of UUID-named, and uses output key `content` instead of `answer`.
- **`inline_external_apiworkflow_tool`** — agent writes the resource name at top-level `name` only, omits `properties.processName`, and skips `uip solution resource list --kind Process`.
- **`inline_external_maestro_tool`** — agent writes lowercase `type: \"processorchestration\"` instead of camelCase, omits `properties.processName`, populates `referenceKey` with the structured path `<folder>.<process>` instead of a UUID Key, and skips both `resource list` and `resource get`.

Each failing commit message documents the specific gap so it's traceable when the inline-in-flow skill docs get updated.

## Test plan

- [x] \`inline_external_rpa_tool\` — e2e SUCCESS 12/12 (\`runs/inline_external_rpa_tool_20260519_172257\`)
- [x] \`inline_external_agent_tool\` — e2e SUCCESS 12/12 (\`runs/inline_three_pairs_20260519_181028\`)
- [ ] \`inline_context_index\` — pending skill-doc update (UUID-named resource subdir + correct output schema field name)
- [ ] \`inline_external_apiworkflow_tool\` — pending skill-doc update (\`properties.processName\` + discovery flow)
- [ ] \`inline_external_maestro_tool\` — pending skill-doc update (camelCase \`type\`, UUID \`referenceKey\`, \`properties.processName\`, discovery flow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)