### PR TITLE
feat(hitl): add uipath-hitl-from-formtask skill

### DIFF
--- a/skills/uipath-hitl-from-formtask/SKILL.md
+++ b/skills/uipath-hitl-from-formtask/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: uipath-hitl-from-formtask
+description: "Convert existing Action Center FormTask FormLayouts (Formio JSON) to HITL QuickForm nodes in a UiPath Flow. Migrates legacy form-based human review steps to the modern uipath.human-in-the-loop node. Use when user mentions FormTask, form layout, action center form, or wants to migrate an existing form."
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep
+---
+
+# UiPath HITL from FormTask Skill
+
+Converts an existing Action Center **FormTask FormLayout** (Formio JSON) into a HITL QuickForm node in a UiPath Flow. Use this skill when migrating legacy FormTask-based review steps to the modern `uipath.human-in-the-loop` node.
+
+## When to Use This Skill
+
+- User mentions "FormTask", "Form task", "form layout", "action center form", or "old form"
+- User wants to **migrate** a FormTask to a Flow HITL node
+- User has a FormLayout JSON (Formio format) and wants to convert it to QuickForm
+- User is modernizing an existing Orchestrator process that uses FormTasks
+- User says "I have an existing task/form, can I use it in my flow?"
+
+---
+
+## Step 0 — Obtain the FormLayout JSON
+
+Ask the user for the FormLayout. One of three ways:
+
+**Option A — User pastes the JSON directly.** Proceed to Step 1.
+
+**Option B — Fetch from Orchestrator API:**
+```bash
+uip login status --output json   # confirm logged in
+```
+Then look up the FormTask by name in the task catalog. The API returns `formLayout` (Formio JSON) and `buttonNamesList`. See [references/formtask-api.md](references/formtask-api.md) for the exact endpoint and response shape.
+
+**Option C — User provides only a task type name.** Ask: "Can you paste the FormLayout JSON, or should I look it up by name from your tenant?"
+
+---
+
+## Step 1 — Parse the FormLayout
+
+A FormLayout is a Formio configuration. Its root structure is:
+```json
+{ "components": [ ...field definitions... ] }
+```
+
+Read all components recursively:
+- **Containers** (`panel`, `well`, `fieldset`, `columns`) — recurse into `components[]`
+- **Repeating rows** (`datagrid`, `editgrid`) — mark as **unsupported**, note to user
+- **Leaf fields** — convert using the type map in Step 2
+
+The `buttonNamesList` from the API (or a `submit`-type button inside `components`) provides the outcome names.
+
+---
+
+## Step 2 — Map Field Types
+
+| Formio `type` | QuickForm `type` | Notes |
+|---|---|---|
+| `textfield`, `textarea`, `email`, `phoneNumber`, `url` | `text` | |
+| `number`, `currency` | `number` | |
+| `checkbox`, `radio` (boolean true/false) | `boolean` | |
+| `datetime`, `day` | `date` | |
+| `select` | `text` | Options become a hint in the field label; no enum support in QuickForm |
+| `button` | — | Becomes an `outcome` (see Step 3) |
+| `panel`, `well`, `fieldset`, `columns` | — | Container — recurse, do not emit a field |
+| `datagrid`, `editgrid` | **unsupported** | Inform user; suggest flattening into individual output fields |
+| `hidden` | `text` / `input` direction | Hidden fields are pre-populated read-only values; map to `input` direction |
+| `content`, `htmlelement` | — | Display-only, skip |
+| `signature` | `text` | Best-effort; note to user that signature capture is not supported in QuickForm |
+
+---
+
+## Step 3 — Determine Field Direction
+
+For each leaf field, set `direction` based on Formio properties:
+
+| Condition | Direction | Meaning |
+|---|---|---|
+| `disabled: true` OR `hidden: true` | `input` | Pre-filled, read-only; human sees it |
+| `calculateValue` is set (computed) | `input` | Computed from other values |
+| Standard input field, user edits it | `output` | Human fills it in |
+| Pre-populated AND user can edit | `inOut` | Use when the field has both a binding and `required` or is always shown |
+
+When in doubt for a migration, default to `inOut` — it preserves both pre-fill and editability.
+
+---
+
+## Step 4 — Map Outcomes
+
+Formio outcomes come from `buttonNamesList` or `button`-type components:
+
+- First button (typically "Submit") → `isPrimary: true`, `action: "Continue"`
+- All other buttons → `isPrimary: false`, `action: "End"`
+- Rename generic "Submit" → "Approve" if context implies an approval flow
+- If `buttonNamesList` is empty / unavailable, default to `[{name: "Submit", isPrimary: true}]`
+
+---
+
+## Step 5 — Build the QuickForm Schema
+
+Assemble the `--schema` JSON for `uip maestro flow hitl add`, or write the node JSON directly.
+
+**Schema format** (for `--schema` option):
+```json
+{
+  "title": "<derived from FormTask name or user>",
+  "inputs":  [{"name": "<label>", "binding": "=js:$vars.<upstream>.<field>"}],
+  "outputs": [{"name": "<label>", "variable": "<varName>", "required": true}],
+  "inOuts":  [{"name": "<label>", "binding": "=js:$vars.<upstream>.<field>", "variable": "<varName>"}],
+  "outcomes":[{"name": "Approve"}, {"name": "Reject"}]
+}
+```
+
+For each field:
+- `direction: input` → put in `inputs[]`, add `binding` if upstream variable is known
+- `direction: output` → put in `outputs[]`, add `required: true` for mandatory fields
+- `direction: inOut` → put in `inOuts[]`, add both `binding` and `variable`
+- `name` = Formio `label` (human-readable, preserves capitalisation and spaces)
+
+---
+
+## Step 6 — Write the Node
+
+### Via CLI (recommended for brownfield inserts):
+```bash
+uip maestro flow hitl add <path/to/file.flow> \
+  --label "<task name>" \
+  --priority <Low|Medium|High> \
+  --schema '<schema-json>' \
+  --output json
+```
+
+### Via direct JSON edit:
+Read [uipath-human-in-the-loop references/hitl-node-quickform.md](../uipath-human-in-the-loop/references/hitl-node-quickform.md) for the full node JSON format, definition entry, edge wiring, and `variables.nodes` regeneration.
+
+After writing, validate:
+```bash
+uip maestro flow validate <file.flow> --output json
+```
+
+---
+
+## Step 7 — Report Conversion Summary
+
+After writing the node, tell the user:
+
+1. **Fields converted** — list each Formio field → QuickForm field (type, direction)
+2. **Fields skipped** — any `datagrid`, `content`, `htmlelement`, `signature` fields and why
+3. **Outcomes mapped** — list original button names → outcome names
+4. **Bindings to wire** — `input` and `inOut` fields have placeholders; list the `$vars` paths the user must fill in from their flow context
+5. **Validation result** — pass or errors
+
+---
+
+## Conversion Example
+
+**Input FormLayout:**
+```json
+{
+  "components": [
+    {"label": "Invoice ID",   "key": "invoiceId",  "type": "textfield", "input": true, "disabled": true},
+    {"label": "Amount",       "key": "amount",     "type": "number",    "input": true, "disabled": true},
+    {"label": "Approved",     "key": "approved",   "type": "checkbox",  "input": true},
+    {"label": "Notes",        "key": "notes",      "type": "textarea",  "input": true},
+    {"label": "Submit",       "key": "submit",     "type": "button",    "action": "submit"}
+  ]
+}
+```
+`buttonNamesList: ["Approve", "Reject"]`
+
+**Generated schema:**
+```json
+{
+  "title": "Invoice Review",
+  "inputs": [
+    {"name": "Invoice ID", "binding": "=js:$vars.<upstream>.output.invoiceId"},
+    {"name": "Amount",     "binding": "=js:$vars.<upstream>.output.amount"}
+  ],
+  "outputs": [
+    {"name": "Approved", "variable": "approved", "required": true},
+    {"name": "Notes",    "variable": "notes"}
+  ],
+  "outcomes": [
+    {"name": "Approve"},
+    {"name": "Reject"}
+  ]
+}
+```
+
+**CLI command:**
+```bash
+uip maestro flow hitl add InvoiceApproval/InvoiceApproval/InvoiceApproval.flow \
+  --label "Invoice Review" \
+  --schema '{"title":"Invoice Review","inputs":[{"name":"Invoice ID","binding":"=js:$vars.<upstream>.output.invoiceId"},{"name":"Amount","binding":"=js:$vars.<upstream>.output.amount"}],"outputs":[{"name":"Approved","variable":"approved","required":true},{"name":"Notes","variable":"notes"}],"outcomes":[{"name":"Approve"},{"name":"Reject"}]}' \
+  --output json
+```
+
+---
+
+## References
+
+- **[Formio → QuickForm type map](references/formio-to-quickform.md)** — Full type table with edge cases
+- **[FormTask API endpoints](references/formtask-api.md)** — How to fetch FormLayout from Orchestrator
+- **[HITL QuickForm node JSON](../uipath-human-in-the-loop/references/hitl-node-quickform.md)** — Full node format for direct JSON editing

--- a/skills/uipath-hitl-from-formtask/references/formio-to-quickform.md
+++ b/skills/uipath-hitl-from-formtask/references/formio-to-quickform.md
@@ -1,0 +1,111 @@
+# Formio Component → QuickForm Field Type Map
+
+Complete reference for converting every Formio component type to a HITL QuickForm field.
+
+## Core Type Mappings
+
+| Formio `type` | Formio usage | QuickForm `type` | Notes |
+|---|---|---|---|
+| `textfield` | Single-line text | `text` | |
+| `textarea` | Multi-line text | `text` | QuickForm has no multiline distinction |
+| `email` | Email address | `text` | No email-specific validation in QuickForm |
+| `phoneNumber` | Phone number | `text` | |
+| `url` | URL string | `text` | |
+| `number` | Numeric value | `number` | |
+| `currency` | Money amount | `number` | Strip currency symbol/formatting |
+| `checkbox` | True/false toggle | `boolean` | |
+| `radio` | Two-option select | `boolean` | Only if options map to true/false; otherwise use `text` |
+| `datetime` | Date and time | `date` | QuickForm `date` accepts ISO strings |
+| `day` | Date only | `date` | |
+| `select` | Dropdown | `text` | No enum support; append options to label as hint: "Status (Open/Closed/Pending)" |
+| `selectboxes` | Multi-select checkboxes | `text` | No multi-value type; note limitation to user |
+| `signature` | Signature pad | `text` | Not supported; collect as text note instead; warn user |
+| `file` | File upload | **skip** | File upload not supported in QuickForm; inform user |
+| `password` | Password input | `text` | Caution: stored as plain text in flow variables |
+
+## Container Types (Never Emit a Field)
+
+| Formio `type` | Action |
+|---|---|
+| `panel` | Recurse into `components[]` |
+| `well` | Recurse into `components[]` |
+| `fieldset` | Recurse into `components[]` |
+| `columns` | Recurse into each column's `components[]` |
+| `tabs` | Recurse into each tab's `components[]` |
+| `form` | Recurse into `components[]` |
+
+## Unsupported / Complex Types
+
+| Formio `type` | Action |
+|---|---|
+| `datagrid` | **Unsupported** — Inform user; suggest flattening into individual fields or collecting as a text summary field |
+| `editgrid` | **Unsupported** — Same as datagrid |
+| `tree` | **Unsupported** — Skip; note to user |
+| `button` | → Outcome (see outcome table below) |
+| `content` | Display-only HTML — Skip |
+| `htmlelement` | Display-only HTML — Skip |
+| `hidden` | Hidden value → `text`, direction `input` (pre-populated, not shown) |
+| `survey` | Multi-question survey — Skip; note to user |
+
+## Direction Rules
+
+Apply in order — first matching rule wins:
+
+1. `type === "hidden"` → `input`
+2. `disabled === true` → `input`
+3. `calculateValue` is set (non-empty string/object) → `input`
+4. `readonly === true` → `input`
+5. Has a known upstream binding (from Orchestrator process variable) → `inOut`
+6. Default → `output`
+
+When migrating without knowing the upstream flow context, use `inOut` for all non-disabled fields so the human can see the current value AND edit it.
+
+## Outcome Mapping
+
+| Formio button `action` / label | QuickForm outcome |
+|---|---|
+| `action: "submit"` or label "Submit" | Primary outcome; `isPrimary: true`, `action: "Continue"` |
+| `action: "reset"` | Skip — no equivalent |
+| `action: "event"` | Secondary outcome; `isPrimary: false`, `action: "End"` |
+| Any other button | Secondary outcome |
+
+**Button label normalization:**
+- "Submit" → keep as "Submit" (or rename to "Approve" if user confirms)
+- "Approve" / "Reject" → keep as-is
+- "Yes" / "No" → keep as-is
+- Buttons with empty label → skip
+
+**`buttonNamesList` takes precedence** over `button`-type components when both are present. Always check `buttonNamesList` first.
+
+## Field Name / Key Normalization
+
+Formio `key` is a camelCase or snake_case identifier used internally. QuickForm uses:
+- `name` (for schema input) = human-readable label from Formio `label`
+- `id` (generated internally) = slugified, lowercase version of `name` (spaces → empty, special chars stripped)
+
+Do NOT use the Formio `key` as the QuickForm `name` — use `label` for readability.
+
+## Required Fields
+
+- If Formio `validate.required === true` → set `required: true` on the QuickForm output/inOut field
+- If no `validate` object → omit `required` (defaults to false)
+
+## Edge Cases
+
+### select with boolean values
+```json
+{"type":"select","label":"Approved","key":"approved","data":{"values":[{"label":"Yes","value":true},{"label":"No","value":false}]}}
+```
+→ Map to `boolean` since values are true/false. Name field "Approved".
+
+### radio with exactly two options
+If options map to a yes/no or true/false semantic → `boolean`. Otherwise → `text`.
+
+### Nested panel with a label
+The panel's `label` becomes a comment, not a field. If the panel contains fields, emit them at the top level with their own labels intact.
+
+### datagrid migration strategy
+If the user must preserve datagrid structure, suggest one of:
+1. Add one `text` output field per column (flatten the grid)
+2. Add a single `text` output field for the whole grid (user types a JSON or CSV summary)
+3. Keep the FormTask for this step and use an AppTask node instead of QuickForm

--- a/skills/uipath-hitl-from-formtask/references/formtask-api.md
+++ b/skills/uipath-hitl-from-formtask/references/formtask-api.md
@@ -1,0 +1,89 @@
+# Fetching FormTask Layouts from Orchestrator
+
+## Login requirement
+
+All API calls require an active `uip` session:
+```bash
+uip login status --output json
+# Expect: "Status": "Logged in"
+```
+
+## Get the list of FormTask types
+
+FormTask types live in the Orchestrator task catalog. Fetch them by querying the Forms endpoint:
+
+```bash
+uip login status --output json | python3 -c "
+import json,sys,subprocess,os
+d=json.load(sys.stdin)
+base=d['Data']['CloudUrl']          # e.g. https://cloud.uipath.com
+org=d['Data']['Organization']
+tenant=d['Data']['Tenant']
+print(f'{base}/{org}/{tenant}/orchestrator_/api/TaskForms/GetTaskForms')
+"
+```
+
+Then call the endpoint with the bearer token from `uip`:
+```bash
+TOKEN=$(cat ~/.uipath/.auth | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['access_token'])")
+curl -s -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  "<URL_from_above>" | python3 -m json.tool
+```
+
+## GetTaskForms response shape
+
+```json
+{
+  "value": [
+    {
+      "Id": 123,
+      "Name": "Invoice Approval Form",
+      "Key": "invoice-approval-form",
+      "formLayout": "{\"components\":[...]}",   // JSON string — parse it
+      "buttonNamesList": ["Approve", "Reject"],
+      "tenantId": 1
+    }
+  ]
+}
+```
+
+Note: `formLayout` is a **JSON string** (double-serialized) — you must `JSON.parse()` it to get the Formio components array.
+
+## Extract specific FormLayout by name
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  "<URL>?$filter=Name eq 'Invoice Approval Form'" | \
+  python3 -c "
+import json,sys
+d=json.load(sys.stdin)
+item=d['value'][0]
+layout=json.loads(item['formLayout'])
+print(json.dumps(layout, indent=2))
+print('---BUTTONS---')
+print(item.get('buttonNamesList', []))
+"
+```
+
+## Alternative: User pastes the FormLayout JSON
+
+If the user has access to Studio or Studio Web, they can export the FormLayout by:
+1. Opening Action Center → Task Catalog
+2. Finding the FormTask
+3. Clicking "View JSON" or copying from the form designer
+
+The pasted JSON is the Formio object: `{ "components": [...] }`.
+
+## Auth token location
+
+The `uip` CLI stores credentials at `~/.uipath/.auth`. The relevant fields:
+- `access_token` — bearer token for Orchestrator API calls
+- `base_url` — cloud URL (e.g. `https://cloud.uipath.com`)
+- `organization_name` — slug for the org
+- `tenant_name` — slug for the tenant
+
+Full orchestrator base URL pattern:
+```
+{base_url}/{organization_name}/{tenant_name}/orchestrator_
+```


### PR DESCRIPTION
## Summary

- New skill `uipath-hitl-from-formtask` — converts Action Center **FormTask FormLayouts** (Formio JSON) into HITL QuickForm nodes in a UiPath Flow
- Covers the full migration path: obtain FormLayout → parse Formio components → map field types and directions → map outcomes → write HITL node

## Files

- `skills/uipath-hitl-from-formtask/SKILL.md` — step-by-step conversion guide (obtain → parse → map → write → report)
- `skills/uipath-hitl-from-formtask/references/formio-to-quickform.md` — complete Formio component → QuickForm type table, direction rules, edge cases
- `skills/uipath-hitl-from-formtask/references/formtask-api.md` — how to fetch FormLayouts from the Orchestrator API

## Test plan

- [ ] Verify skill is auto-discovered via `"skills": "./skills/"` in plugin.json
- [ ] Walk through the worked example in SKILL.md with a real FormLayout

🤖 Generated with [Claude Code](https://claude.com/claude-code)