### PR TITLE
test(uipath-test): add integration tests and fix folder discovery command

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -83,8 +83,8 @@
 /skills/uipath-llm-configuration-byo-connections/ @denispetre @vstoleru-uipath @dragosvelcea
 
 # Test skill (reports, manual test automation, manual test execution)
-/skills/uipath-test/ @vaishalisharma-uipath @amoluipath
-/tests/tasks/uipath-test/ @vaishalisharma-uipath @amoluipath
+/skills/uipath-test/ @vaishalisharma-uipath @amoluipath @ganeshborle
+/tests/tasks/uipath-test/ @vaishalisharma-uipath @amoluipath @ganeshborle
 
 # Data Fabric skill (CLI entity/record management)
 /skills/uipath-data-fabric/ @aditi-goyal-uipath

--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -24,15 +24,15 @@ Manage UiPath Test Manager resources (projects, test cases, test sets, execution
 
 UiPath Test Manager is a web application that manages the testing lifecycle of projects, enabling requirements traceability, test planning, and reporting. Its key business objects are:
 
-- **Requirements** — Defines what needs to be tested.
-- **Test cases** — Defines the scenarios to be tested.
-- **Test sets** — Groups of test cases for execution.
-- **Test executions** — Defining triggers and schedules for unattended execution.
-- **Test case logs** — Logs of a test case in an execution.
-- **Test step logs** — Step-level logs within a test case log.
-- **Test case log assertions** — Assertion steps of a test case log in an execution.
+- **Requirements** - Defines what needs to be tested.
+- **Test cases** - Defines the scenarios to be tested. A testcase can have **teststeps**..
+- **Test sets** - Groups of test cases for execution..
+- **Test executions** - When a test set is run, a test execution is created..
+- **Test case logs** - Logs of a **test case** in an execution. A **testcase** can be navigated from **testcaselogs**.
+- **Test step logs** — Step-level logs within a **test case log**.
+- **Test case log assertions** - Assertion steps of a test case log in an execution.
 
-CLI tool for UiPath Test Manager (`uip tm`). Use `uip tm --help` and `uip tm <command> <subcommand> --help` to discover commands and options. **Always pass `--output json`** on every `uip` command (see Critical Rule #2).
+CLI tool for UiPath Test Manager (`uip tm`). Use `uip tm --help` and `uip tm <command> <subcommand> --help` to discover commands and options. **Always pass `--output json`** on every `uip` command.
 
 ## Commands
 
@@ -49,7 +49,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm project set-default-folder --project-key <PROJECT_KEY> --folder-key <FOLDER_KEY>` | Set the default Orchestrator folder for a project. |
 | `uip tm project clear-default-folder --project-key <PROJECT_KEY>` | Clear the default Orchestrator folder from a project. |
 
-> Get folder keys with `uip or folders list-current-user --output json` — returns all folders visible to the current user. Prefer it over `uip or folders list`, which is a narrower view and may miss folders the user can access.
+> Get folder keys with `uip or folders list -n <name> --all --output json` — returns all folders visible to the current user.
 
 ### Test Cases Commands
 
@@ -152,12 +152,14 @@ Common `uip tm` commands organized by resource type.
 1. **Always check login first** — run `uip login status --output json` before any Test Manager operation. If not authenticated, run `uip login` to sign in.
 2. **Probe the CLI surface once per session, before the first `uip tm` command.** Run `uip tm testcases --help --output json` (any flags accepted). Result `Success` → post-rename CLI; use the command tables above as-is. `unknown command` / non-zero exit → pre-rename CLI; translate via the [Pre-rename fallbacks](#pre-rename-fallbacks) table before each call. Re-probe on any later `unknown command` error.
 3. **Always pass `--output json`** to every `uip` command — no exceptions. Structured JSON output is what you need to reason about results reliably, even when you only plan to summarize them back to the user.
-4. **Cap retries at 3** for any failing API call. After 3 failures, stop and report the error to the user.
+4. **Cap retries at 3** for any failing `uip` CLI command. After 3 failures, stop and report the error to the user (see Rule — never fall back to direct REST APIs).
 5. **Handle empty results** — if a list command returns an empty array, stop and inform the user rather than proceeding with a null key.
 6. **Confirm before delete** — always confirm the target resource key with the user before running any `delete` command.
-7. **For operations requiring folder key** — use `uip or folders list-current-user --output json` (run `/uipath-platform` for folder management details).
-8. **Discover before assuming** — never guess automation names, folder keys, project IDs, or test case keys. Always run the matching `list` command first (e.g., `uip tm testcases list-automations`, `uip or folders list-current-user`).
+7. **For operations requiring folder key** — use `uip or folders list -n <folder-name> --all --output json` (run `/uipath-platform` for folder management details).
+8. **Discover before assuming** — never guess automation names, folder keys, project IDs, or test case keys. Always run the matching `list` command first (e.g., `uip tm testcases list-automations`, `uip or folders list -n <folder-name> --all`).
 9. **Narrow `list` calls server-side when the user names an entity.** When the user provides a name, key, label, or tag, check `uip tm <resource> list --help` (or `uip or <resource> list --help`) for the narrowing flag the command exposes and pass it on the `list` call. Never list all results and filter client-side — it wastes tokens and misses paginated entries. Applies to every entity across `uip tm` and `uip or`.
+10. **Set default folder before any `run` command** — `uip tm testcases run` and `uip tm testsets run` both require a default Orchestrator folder on the project. Run `uip tm project set-default-folder --project-key <PROJECT_KEY> --folder-key <FOLDER_KEY> --output json` first. Get folder keys with `uip or folders list -n <folder-name> --all --output json`.
+11. **On any `uip` command failure or ambiguity, STOP and ask the user — do NOT fall back to direct REST API calls.** When a `uip` command errors, returns malformed output, or the right flag/value is unclear (e.g., multiple matching entities, missing identifier, unexpected schema), interrupt and ask the user before proceeding. This overrides any instinct to "try the underlying API instead."
 
 ### Pre-rename fallbacks
 
@@ -189,6 +191,13 @@ If the probe in Rule #2 shows singular subjects, the CLI predates the closed-ver
    uip login tenant set <TENANT_NAME> --output json
    ```
   For more authentication details, run `/uipath-platform`.
+
+### Confirm project scope
+  Ask the user for the project name or key before any Test Manager call. For multi-project scenarios, collect ALL names or keys in one prompt. Resolve each to a `PROJECT_KEY`:
+  ```bash
+  uip tm project list --filter <NAME_OR_KEY> --output json
+  ```
+  Zero matches → stop and ask the user. Multiple matches → list candidates and ask the user to pick. Reuse the confirmed `PROJECT_KEY` for every downstream command.
 
 ```bash
   # Get project

--- a/skills/uipath-test/references/publish-and-link-guide.md
+++ b/skills/uipath-test/references/publish-and-link-guide.md
@@ -7,7 +7,7 @@ End-to-end pipeline: take a UiPath project's coded `[TestCase]` (or any test ent
 ```
 uip rpa pack            → .nupkg
 uip or packages upload  → package on Orchestrator feed
-uip or folders list-current-user   → folder UUID (the --folder-key value)
+uip or folders list -n <folder-name> --all  → folder UUID (the 'Key' value)
 uip tm testcases list-automations  → test entry point name (the --test-name value)
 uip tm testcases link-automation   → test case is bound
 uip tm testcases run  / testsets run  → run
@@ -42,12 +42,12 @@ Capture the returned `Id` (the package name) and `Version` from the JSON output.
 `link-automation` requires `--folder-key <UUID>` (NOT `--folder-path`). Discover it:
 
 ```bash
-uip or folders list-current-user --output json
+uip or folders list -n <folder-name> --all --output json
 ```
 
 Filter for the folder that owns the package. The `Key` field is the UUID.
 
-> **Use `list-current-user`, not `list`.** `list` may omit personal workspaces and solution folders. `list-current-user` returns every folder the authenticated user can target.
+> Use `--type <folder type> ` option to include folders of type personal, solution or standard.
 
 ## Step 4 — Find the test entry point name
 

--- a/tests/tasks/uipath-test/flaky_tests_analysis.yaml
+++ b/tests/tasks/uipath-test/flaky_tests_analysis.yaml
@@ -15,7 +15,7 @@ agent:
   type: claude-code
 
 run_limits:
-  max_turns: 3
+  max_turns: 35
 
 sandbox:
   driver: docker

--- a/tests/tasks/uipath-test/flaky_tests_analysis.yaml
+++ b/tests/tasks/uipath-test/flaky_tests_analysis.yaml
@@ -1,0 +1,65 @@
+task_id: skill-test-flaky-tests-analysis
+description: >
+  Integration test: agent uses the uipath-test skill to identify flaky testcases
+  in a test set by analysing multiple executions. Asserts that the agent (a)
+  checks login status with --output json, (b) lists multiple executions for
+  a test set with --test-set-id + --output json, (c) retrieves testcase
+  logs for at least one execution with --execution-id + --output json and (d) fetches
+  assertions for at least one failing testcase log with --test-case-log-id +
+  --output json. The
+  skill — not the prompt — must teach the multi-execution analysis pattern
+  and the --output json flag.
+tags: [uipath-test, integration, mode:operate, lifecycle:triage, feature:execution]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 3
+
+sandbox:
+  driver: docker
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/test-manager-tool"
+
+initial_prompt: |
+  Before starting, load the uipath-test skill and follow its workflow.
+
+  Analyse the top 3 executions with a finished executionStatus of a test
+  set 'UAT Smoke Suite' in my UiPath Test Manager project CLAIM. List testcases that pass and
+  fail intermittently, ranked by flakiness. Also, list the assertions for such testcases.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent checked login status with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed executions for a test set with --test-set-id + --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+executions?\s+list\s+.*--test-set-id.*--output\s+json|uip\s+tm\s+executions?\s+list\s+.*--output\s+json.*--test-set-id'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent retrieved testcase logs for at least one execution (--execution-id + --output json)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+(executions?\s+testcaselogs\s+list|execution\s+list-testcaselogs)\s+.*--execution-id.*--output\s+json|uip\s+tm\s+(executions?\s+testcaselogs\s+list|execution\s+list-testcaselogs)\s+.*--output\s+json.*--execution-id'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched assertions for a failing testcase log (--test-case-log-id + --output json)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcaselog\s+list-assertions\s+.*--test-case-log-id.*--output\s+json|uip\s+tm\s+testcaselog\s+list-assertions\s+.*--output\s+json.*--test-case-log-id'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-test/link_automation_and_run.yaml
+++ b/tests/tasks/uipath-test/link_automation_and_run.yaml
@@ -1,0 +1,74 @@
+task_id: skill-test-link-automation-and-run
+description: >
+  Integration test: agent uses the uipath-testcloud skill to link a published
+  automation to a Test Manager testcase and trigger an automated execution.
+  Asserts that the agent (a) checks login status with --output json, (b) discovers
+  the folder key via `uip or folders list -n <folder-name> --all`,
+  (c) probes available test entry points with `uip tm testcases list-automations`
+  before linking, (d) links via `uip tm testcases link-automation` with the required
+  flags, and (e) runs the testcase with `uip tm testcases run` using --test-case-id
+  (UUID, not --test-case-key) and --execution-type automated. The skill -- not the
+  prompt -- must teach the discover-before-link pattern, the `folders list -n <folder-name> --all`
+  folder lookup, and the UUID vs ObjKey distinction for the run command.
+tags: [uipath-test, integration, mode:operate, lifecycle:manage, feature:link-automation]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 35
+
+sandbox:
+  driver: docker
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/test-manager-tool"
+
+initial_prompt: |
+  Before starting, load the uipath-test skill and follow its workflow.
+
+  Link the testcase "TestCase1" from the orchestrator package "Testcases.with.parameters" published to the Orchestrator folder "uipath-test-folder-feed" to the Test Manager testcase
+  "Claim Approval - Manager Escalation" in the project CLAIM. Then trigger an automated execution of
+  that testcase.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent checked login status with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered folder key with `folders list -n <folder-name> --all`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+or\s+folders\s+list\s+-n\s+\S+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent probed available test entry points via list-automations before linking (Critical Rule #8)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+list-automations\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent linked automation using link-automation with --project-key + --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+link-automation\s+.*--project-key.*--output\s+json|uip\s+tm\s+testcases?\s+link-automation\s+.*--output\s+json.*--project-key'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran testcase with --test-case-id (UUID) and --execution-type automated (not --test-case-key)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+run\s+.*--test-case-id.*--execution-type\s+automated.*--output\s+json|uip\s+tm\s+testcases?\s+run\s+.*--execution-type\s+automated.*--test-case-id.*--output\s+json|uip\s+tm\s+testcase\s+execute\s+.*--test-case-id.*--execution-type\s+automated.*--output\s+json'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
+++ b/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
@@ -13,7 +13,7 @@ agent:
   type: claude-code
 
 run_limits:
-  max_turns: 3
+  max_turns: 35
 
 sandbox:
   driver: docker

--- a/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
+++ b/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
@@ -1,0 +1,64 @@
+task_id: skill-test-organize-testcases-into-testsets
+description: >
+  Integration test: agent uses the uipath-test skill to organise testcases into
+  logical test sets for a named feature. Asserts that the agent (a) checks
+  login status with --output json, (b) lists
+  testcases with --project-key + --filter , and
+  (c) creates at least one test set with --project-key + --output json.
+  The skill — not the prompt — must teach the --filter narrowing rule and
+  the testcases add command for assigning testcases to a set.
+tags: [uipath-test, integration, mode:operate, lifecycle:manage, feature:test-set]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 3
+
+sandbox:
+  driver: docker
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/test-manager-tool"
+
+initial_prompt: |
+  Before starting, load the uipath-test skill and follow its workflow.
+
+  I have a project called CLAIM. Organise testcases for the "disbursement"
+  feature into logical test sets (e.g. happy path, edge cases, regression).
+  List the testcases filtered by "disbursement", group them, and create the
+  test sets in Test Manager with appropriate names and descriptions.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent checked login status with --output json (Critical Rules #1 + #2)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed testcases with --project-key and --filter flag (Critical Rules #2 + #8)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+list\s+.*--filter.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created a test set with --project-key and --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testsets?\s+create\s+.*--project-key.*--output\s+json|uip\s+tm\s+testsets?\s+create\s+.*--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added testcases to the new test set with --test-set-key + --test-case-keys + --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+add\s+.*--test-set-key.*--test-case-keys.*--output\s+json|uip\s+tm\s+testsets?\s+add-testcases\s+.*--test-set-key.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-test/test_report_junit_export.yaml
+++ b/tests/tasks/uipath-test/test_report_junit_export.yaml
@@ -1,0 +1,54 @@
+task_id: skill-test-junit-export
+description: >
+  Integration test: agent uses the uipath-test skill to export test execution
+  results as a JUnit XML report. Asserts that the agent (a) checks login
+  status with --output json, (b) lists executions with --project-key +
+  --output json to resolve the execution ID, and (c) downloads results via
+  `uip tm result download` with --execution-id + --output json. The skill
+  — not the prompt — must teach the result download command and distinguish
+  it from the attachment download command.
+tags: [uipath-test, integration, mode:operate, lifecycle:report, feature:execution]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 3
+
+sandbox:
+  driver: docker
+  python: {}
+  node:
+    env_packages:
+      - "@uipath/test-manager-tool"
+
+initial_prompt: |
+  Before starting, load the uipath-test skill and follow its workflow.
+
+  Export the results of the latest execution of my test set 'UAT Smoke Suite' in UiPath Test
+  Manager project CLAIM as a JUnit report XML.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent checked login status with --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed executions with --project-key + --output json to resolve execution ID"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+executions?\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+executions?\s+list\s+.*--output\s+json.*--project-key'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent downloaded JUnit results with --execution-id + --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+result\s+download\s+.*--execution-id.*--output\s+json|uip\s+tm\s+result\s+download\s+.*--output\s+json.*--execution-id'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-test/test_report_junit_export.yaml
+++ b/tests/tasks/uipath-test/test_report_junit_export.yaml
@@ -13,7 +13,7 @@ agent:
   type: claude-code
 
 run_limits:
-  max_turns: 3
+  max_turns: 35
 
 sandbox:
   driver: docker


### PR DESCRIPTION
## Summary

- Add new coder-eval integration tests for the `uipath-test` skill: flaky-test analysis, testcase-to-testset organization, and JUnit export
- Fix `uip or folders list-current-user` (non-existing command) → `uip or folders list -n <name> --all` in `SKILL.md` (Critical Rules #7 & #8) and `publish-and-link-guide.md` (Step 3 and pipeline overview)

## Test plan

- [ ] Verify the new YAML task files parse correctly with the lint-task skill
- [ ] Confirm `uip or folders list -n <name> --all --output json` is the correct CLI form on a live tenant
- [ ] Run smoke eval against `uipath-test` skill to confirm success criteria patterns match real agent behaviour

Generated with Claude Code