### PR TITLE
docs(skills): document all inline-in-flow tool subtypes (process, agent, api, processOrchestration)

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
@@ -154,17 +154,17 @@ After creating the inline agent, the flow needs a `uipath.agent.autonomous` node
 
 The node JSON shape that the flow skill must produce is documented in § Flow Node Structure below — keep it as a reference, not as a CLI walkthrough.
 
-## Inline-in-Flow Process Tool resource.json
+## Inline-in-Flow Tool resource.json
 
-The `resource.json` for process tools inside an inline-in-flow agent uses the **same format** as external process tools in standalone agents. Follow the discovery workflow and resource.json shape in [../process/process.md](../process/process.md) — run `uip solution resource list` + `uip solution resource get` to populate `referenceKey`, `folderPath`, `inputSchema`, and `outputSchema` with real values.
+Inline tools support four subtypes — `process` (RPA), `agent`, `api`, `processOrchestration`. The `resource.json` shape is identical to standalone agents — follow [../process/process.md](../process/process.md) § Subtypes and § Tool resource.json Shape. Discovery is identical (`uip solution resource list` + `uip solution resource get`) and populates `referenceKey`, `folderPath`, `inputSchema`, and `outputSchema` with real values. The subtype is selected by the `type` field (`process` | `agent` | `api` | `processOrchestration`).
 
 **Path:** `<FlowProjectDir>/<projectId>/resources/<RES_UUID>/resource.json`
 
 Additional notes for inline-in-flow:
 - **`location`**: Follows the same rule as standalone agents — set `"solution"` when the row from `uip solution resource list` has `Source: "Local"`, set `"external"` when `Source: "Remote"`. See [../process/process.md](../process/process.md) and [../../critical-rules.md](../../critical-rules.md) Rule 12.
 - **`id`**: Must match the `<RES_UUID>` used as the tool node's `model.source` in the flow and the resource directory name.
-- **`properties.folderPath`**: Must be the **literal folder path from discovery** (e.g., `"Shared/TestRPA"`) — do **not** leave it empty. An empty `folderPath` prevents `uip solution resource refresh` from resolving the process at runtime.
-- **`inputSchema.properties`**: Must include `"guardrails": { "type": "array" }` alongside the process arguments — the runtime expects it.
+- **`properties.folderPath`**: Must be the **literal folder path from discovery** (e.g., `"Shared/Sales"`) — do **not** leave it empty. An empty `folderPath` prevents `uip solution resource refresh` from resolving the tool at runtime.
+- **`inputSchema.properties`**: Must include `"guardrails": { "type": "array" }` alongside the tool arguments — the runtime expects it.
 - **All fields from the template in [../process/process.md](../process/process.md) are required** — especially `$resourceType: "tool"`, `guardrail`, `properties.processName`, `properties.exampleCalls`, `isEnabled`, and `argumentProperties`. A `resource.json` missing `$resourceType` will not be recognized by `uip agent validate` (the tool reports `"resources": 0`); `uip agent migrate` will then write an empty `bindings_v2.json`.
 
 ## Flow Node Structure
@@ -215,12 +215,12 @@ Additional notes for inline-in-flow:
 - `definitions[]` — The `uipath.agent.autonomous` definition copied from the flow registry supplies `model.serviceType: "Orchestrator.StartInlineAgentJob"`, BPMN type, version, and context. Do not copy those fields into the node instance.
 - No node instance `model` block — the inline-agent source lives at `inputs.source`.
 
-Resource nodes use the same minimal `model.source` pattern:
+Resource nodes use the same minimal `model.source` pattern. The `type` follows the per-kind patterns in § Resource nodes below — `uipath.agent.resource.tool.{process|agent|api|processorchestration}.<release-key>`, where `<release-key>` is the resource's release-key GUID returned by `uip solution resource list`:
 
 ```jsonc
 {
   "id": "agentTool1",
-  "type": "uipath.agent.resource.tool.rpa",
+  "type": "uipath.agent.resource.tool.<kind>.<release-key>",
   "typeVersion": "<DEFINITION_VERSION>",
   "display": { "label": "<ToolName>" },
   "inputs": {},
@@ -253,12 +253,16 @@ Resources are separate canvas nodes wired to the agent via artifact handle edges
 
 | Resource type | Node type pattern |
 |--------------|-------------------|
-| RPA process | `uipath.agent.resource.tool.rpa` |
-| Agent-as-tool | `uipath.agent.resource.tool.agent.<process-key>` |
+| RPA process | `uipath.agent.resource.tool.process.<release-key>` |
+| Agent-as-tool | `uipath.agent.resource.tool.agent.<release-key>` |
+| API workflow | `uipath.agent.resource.tool.api.<release-key>` |
+| Process Orchestration | `uipath.agent.resource.tool.processorchestration.<release-key>` |
 | IS connector | `uipath.agent.resource.tool.connector` |
 | Semantic index | `uipath.agent.resource.context.index` |
 | Escalation | `uipath.agent.resource.escalation` |
 | Memory space | `uipath.agent.resource.memory.*` |
+
+`<release-key>` is the resource's release-key GUID from `uip solution resource list` (the row's `Key` field). The four process-tool kinds share the same registry-discovery flow and the same `resource.json` shape — only the prefix in front of `<release-key>` and the `type` field in `resource.json` differ. See [../process/process.md](../process/process.md) § Subtypes.
 
 ## Walkthrough — End-to-End
 
@@ -276,7 +280,7 @@ uip agent init "<FlowProjectDir>" --inline-in-flow --output json
 # - Configure outputSchema if needed
 
 # 4. Add tools to <FlowProjectDir>/<projectId>/resources/ (optional)
-# See § Inline-in-Flow Process Tool resource.json above for the exact format
+# See § Inline-in-Flow Tool resource.json above for the exact format
 
 # 5. Hand off to the uipath-maestro-flow skill to add the
 #    uipath.agent.autonomous node (inputs.source = <projectId>),
@@ -324,16 +328,17 @@ content/
 ## Node Type Quick Reference
 
 ```
-uipath.agent.autonomous                               ← Inline agent node
+uipath.agent.autonomous                                        ← Inline agent node
 
-uipath.agent.resource.tool.rpa                        ← Tool: RPA process
-uipath.agent.resource.tool.agent.<process-key>        ← Tool: another agent
-uipath.agent.resource.tool.connector                  ← Tool: IS connector
-uipath.agent.resource.tool.api                        ← Tool: API
-uipath.agent.resource.tool.builtin                    ← Tool: built-in
-uipath.agent.resource.context.index                   ← Context: semantic index
-uipath.agent.resource.escalation                      ← Escalation: HITL
-uipath.agent.resource.memory.*                        ← Memory space
+uipath.agent.resource.tool.process.<release-key>               ← Tool: RPA process
+uipath.agent.resource.tool.agent.<release-key>                 ← Tool: agent
+uipath.agent.resource.tool.api.<release-key>                   ← Tool: API workflow
+uipath.agent.resource.tool.processorchestration.<release-key>  ← Tool: process orchestration
+uipath.agent.resource.tool.connector                           ← Tool: IS connector
+uipath.agent.resource.tool.builtin                             ← Tool: built-in
+uipath.agent.resource.context.index                            ← Context: semantic index
+uipath.agent.resource.escalation                               ← Escalation: HITL
+uipath.agent.resource.memory.*                                 ← Memory space
 ```
 
 ## BPMN Execution Engine Notes

--- a/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
@@ -235,13 +235,22 @@ For tool/resource nodes, wire the inline agent's bottom artifact port:
 
 `tool` is the inline agent's bottom artifact port. The target node's `input` port is a target-typed artifact handle.
 
-## Adding an External RPA Process Tool Node
+## Adding an External Tool Node
+
+Inline tool nodes come in four kinds. Discovery, node-add, edge-wire, and `resource.json` authoring are identical across kinds — only the registry-search prefix on the flow side and the `type` field in `resource.json` differ.
+
+| Kind | Registry-search prefix | `resource.json.type` | What it calls |
+|------|------------------------|----------------------|---------------|
+| RPA process | `uipath.agent.resource.tool.process` | `process` | RPA workflow (XAML / coded) |
+| Agent | `uipath.agent.resource.tool.agent` | `agent` | Low-code or coded agent |
+| API workflow | `uipath.agent.resource.tool.api` | `api` | Coded API workflow |
+| Process Orchestration | `uipath.agent.resource.tool.processorchestration` | `processOrchestration` | Agentic / orchestrated process |
 
 Discover the tool via the flow registry, then add the tool resource node directly in the `.flow` JSON. Generate a resource UUID and use it as both the tool node's `model.source` and the `resource.json` directory/id.
 
 ```bash
-# 1. Search for the process tool
-uip maestro flow registry search "uipath.agent.resource.tool.process" --output json
+# 1. Search the registry, picking the prefix from the matrix above
+uip maestro flow registry search "<prefix>" --output json
 
 # 2. Generate a resource UUID
 RES=$(uuidgen)
@@ -273,7 +282,7 @@ Also add:
 
 After adding the tool node, you must also:
 
-- Hand-write the per-tool `resource.json` at `<FlowProjectDir>/<inlineAgentProjectId>/resources/<RES_UUID>/resource.json`. **Use the exact `resource.json` shape documented in the `uipath-agents` skill: `lowcode/capabilities/process/process.md` § Tool resource.json Shape.** Read that section before writing the file — it defines all required fields. Run `uip solution resource list` + `uip solution resource get` to populate `referenceKey`, `folderPath`, `inputSchema`, and `outputSchema` with real values. Key inline-in-flow notes:
+- Hand-write the per-tool `resource.json` at `<FlowProjectDir>/<inlineAgentProjectId>/resources/<RES_UUID>/resource.json`. **Use the exact `resource.json` shape documented in the `uipath-agents` skill: `lowcode/capabilities/process/process.md` § Tool resource.json Shape.** Read that section before writing the file — it defines all required fields. The subtype is selected by the `type` field (`process` | `agent` | `api` | `processOrchestration`) — see § Subtypes in `process.md`. For RPA the schema uses raw .NET arrays (Template A in `solution-files.md`); for Agent / API / Process Orchestration it uses JSON Schema V2 (Template B). Run `uip solution resource list` + `uip solution resource get` to populate `referenceKey`, `folderPath`, `inputSchema`, and `outputSchema` with real values. Key inline-in-flow notes:
   - Set `id` to `<RES_UUID>` (same value used as the tool node's `model.source` and as the resource directory name).
   - Set `location` based on the discovery `Source` field: `"solution"` when `Source: "Local"`, `"external"` when `Source: "Remote"` (same rule as standalone agents).
   - Set `properties.folderPath` to the **literal folder path from discovery** (e.g., `"Shared/TestRPA"`) — do **not** leave it empty.
@@ -376,7 +385,7 @@ uip maestro flow validate <FlowName>.flow --output json
 | Studio Web reports "System prompt is required" | Inline agent's `agent.json.messages[]` has empty `content`, OR `.agent-builder/agent.json` is stale | Set prompts in `agent.json`, re-run `uip agent validate --inline-in-flow` — see `uipath-agents` skill |
 | Studio Web debug: "Could not find process for tool" | Flow project's `bindings_v2.json` is missing the tool's process binding, so `uip solution resource refresh` never created the solution-level resource | If the installed CLI supports it, re-run `uip agent validate --inline-in-flow --bindings-target <FlowProjectDir>/bindings_v2.json`, then `uip solution resource refresh`, then re-upload; if unsupported, report the CLI capability blocker |
 | `bindings_v2.json` is empty or missing tool bindings | Tool bindings were not propagated to the flow project level, or a later tool overwrote the file | Re-run validation with `--bindings-target <FlowProjectDir>/bindings_v2.json` after all flow node and edge edits are complete when supported; otherwise do not hand-edit the generated file |
-| Agent tool process cannot resolve at runtime | Missing top-level `bindings[]` entries, mismatched tool-node `model.source` / `resource.json` id, stale solution resources, or missing project-level `bindings_v2.json` | Add the resource bindings from the tool definition, keep the tool node's `model.source` equal to the resource UUID, run `uip agent validate --inline-in-flow` with `--bindings-target` when supported, and run `uip solution resource refresh` |
+| Agent tool (process / agent / api / processOrchestration) cannot resolve at runtime | Missing top-level `bindings[]` entries, mismatched tool-node `model.source` / `resource.json` id, stale solution resources, or missing project-level `bindings_v2.json` | Add the resource bindings from the tool definition, keep the tool node's `model.source` equal to the resource UUID, run `uip agent validate --inline-in-flow` with `--bindings-target` when supported, and run `uip solution resource refresh` |
 | `inputs.agentProjectId` unrecognized | Wrong field name | Use `inputs.source` — `agentProjectId` is not valid for inline agents |
 | Inline agent rejected by `uip agent validate` | `entry-points.json` or `project.uiproj` present inside the inline agent dir | Delete those files — they belong only to standalone agent projects |
 | Folder name is human-readable instead of UUID | Folder renamed after scaffolding | Rename to the original `projectId` UUID — the folder name must match `inputs.source` and the `projectId` field inside `agent.json` |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/planning.md
@@ -67,19 +67,26 @@ For agent.json configuration (prompts, model, schemas) and resource file authori
 
 ## Tools — Flow Registry Discovery
 
-The autonomous agent's `tool` artifact port accepts inline tool resource nodes. **External RPA process tools** are the primary supported case. Discovery uses the flow registry:
+The autonomous agent's `tool` artifact port accepts inline tool resource nodes in four kinds: RPA process, agent, API workflow, and process orchestration. Discovery uses the flow registry; pick the prefix per kind from the matrix below.
+
+| Kind | Registry-search prefix | `resource.json.type` | What it calls |
+|------|------------------------|----------------------|---------------|
+| RPA process | `uipath.agent.resource.tool.process` | `process` | RPA workflow (XAML / coded) |
+| Agent | `uipath.agent.resource.tool.agent` | `agent` | Low-code or coded agent |
+| API workflow | `uipath.agent.resource.tool.api` | `api` | Coded API workflow |
+| Process Orchestration | `uipath.agent.resource.tool.processorchestration` | `processOrchestration` | Agentic / orchestrated process |
 
 ```bash
-uip maestro flow registry search "uipath.agent.resource.tool.process" --output json
+uip maestro flow registry search "<prefix>" --output json
 ```
 
-Filter rows where `NodeType` starts with `uipath.agent.resource.tool.process.` and `DisplayName` matches. The `Description` field disambiguates same-named processes by folder. Fetch the full manifest:
+Filter rows where `NodeType` starts with `<prefix>.` and `DisplayName` matches. The `Description` field disambiguates same-named resources by folder. Fetch the full manifest:
 
 ```bash
 uip maestro flow registry get "<NodeType>" --output json
 ```
 
-For the tool's `resource.json` format and solution-level resource setup, see the `uipath-agents` skill (`lowcode/capabilities/process/`). Set `location` based on the discovery `Source` field: `"solution"` when `Source: "Local"`, `"external"` when `Source: "Remote"` (same rule as standalone agents — see `critical-rules.md` Rule 12). Set `properties.folderPath` to the **literal folder path from discovery** — parse it from the registry `Description` field (e.g., `(Shared/TestRPA)` → `"Shared/TestRPA"`) or from `uip solution resource get`. Do **not** leave `folderPath` empty — an empty `folderPath` prevents `uip solution resource refresh` from resolving the process at runtime.
+For the tool's `resource.json` format and solution-level resource setup, see the `uipath-agents` skill (`lowcode/capabilities/process/`). All four subtypes share discovery, `resource.json` shape, and refresh — only the `type` field and the schema flavor differ (see § Subtypes in `process.md`). Set `location` based on the discovery `Source` field: `"solution"` when `Source: "Local"`, `"external"` when `Source: "Remote"` (same rule as standalone agents — see `critical-rules.md` Rule 12). Set `properties.folderPath` to the **literal folder path from discovery** — parse it from the registry `Description` field (e.g., `(Shared/Sales)` → `"Shared/Sales"`) or from `uip solution resource get`. Do **not** leave `folderPath` empty — an empty `folderPath` prevents `uip solution resource refresh` from resolving the tool at runtime.
 
 ### Anti-pattern
 
@@ -90,5 +97,5 @@ Do not use `uip agent tool add` to attach the tool to an inline-in-flow agent. T
 In the architectural plan:
 
 - `inline-agent: <description>` with a `<projectId-placeholder>` — the UUID is assigned during Phase 2 when `uip agent init --inline-in-flow` runs
-- `inline-agent-tool: <ToolName> (rpa, external) → <process-name> in <folder-path>` — one line per tool
+- `inline-agent-tool: <ToolName> (<kind>, solution|external) → <name> in <folder-path>` — one line per tool. `<kind>` is one of `process` | `agent` | `api` | `processOrchestration`.
 - If an existing published agent already covers the use case, prefer the [published agent](../agent/planning.md) annotation instead


### PR DESCRIPTION
## Summary

- Inline-in-flow tool docs previously assumed RPA-only. Expand to cover all four supported subtypes — `process` (RPA), `agent`, `api` (API workflow), `processOrchestration` — across the `uipath-agents` and `uipath-maestro-flow` skills.
- Add the registry-search prefix / `resource.json.type` matrix in `uipath-maestro-flow/.../inline-agent/{impl,planning}.md` so agents pick the correct discovery prefix per kind.
- Update the node-type quick reference in `uipath-agents/.../inline-in-flow.md` to include `<release-key>` suffixes for all four kinds and clarify that the `resource.json` shape is shared across subtypes.

## Verification

E2E coder-eval runs against the four updated subtypes:

| Test | Status | Score | Duration |
|---|---|---|---|
| `inline_external_rpa_tool` | ERROR (turn_timeout after idle; artifacts on disk are correct, including `folderPath: \"Shared/uipath-agents/FibonacciRPA\"`) | n/a | 1361s |
| `inline_external_agent_tool` | SUCCESS | 1.000 | 1097s |
| `inline_external_apiworkflow_tool` | SUCCESS | 1.000 | 405s |
| `inline_external_maestro_tool` | SUCCESS | 1.000 | 579s |

Per-test agent timelines were captured offline (not committed).

## Test plan

- [ ] Re-run \`tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool\` once more (or bump \`turn_timeout\`) to confirm the run scores 1.000 and that the previous \`folderPath: \"Shared\"\` regression does not return
- [ ] Spot-check that \`uip maestro flow registry search\` and \`uip solution resource list --source remote --kind Process --search\` produce the expected manifests for each of the four subtypes

🤖 Generated with [Claude Code](https://claude.com/claude-code)