### PR TITLE
fix(uipath-solution): default Level 2 authoring mode to XAML silently

### DIFF
--- a/skills/uipath-solution/assets/templates/rpa-sdd-template.md
+++ b/skills/uipath-solution/assets/templates/rpa-sdd-template.md
@@ -459,7 +459,7 @@ Sub-type reference:
 
 > **For Master Project:** specify the mode per sub-project if they differ. A Dispatcher may be XAML while a Performer with heavy data logic is Hybrid.
 >
-> **Before recommending Coded C#:** verify at least two checklist items from the [RPA Product Guide § Selection checklist before recommending Coded C#](../../references/design/rpa-product-guide.md#selection-checklist-before-recommending-coded-c) are true. "Cleaner control flow over a UI loop" is **not** a sufficient justification — XAML already has Try/Catch + Retry Scope + For Each over UIA activities. If the process body is >70% UI automation with minimal data shaping, recommend **XAML** or **Hybrid**.
+> **Before recommending Coded C#:** verify at least two checklist items from the [RPA Product Guide § Selection checklist before recommending Coded C#](../../references/design/rpa-product-guide.md#selection-checklist-before-recommending-coded-c) are true. "Cleaner control flow over a UI loop" is **not** a sufficient justification — XAML already has Try/Catch + Retry Scope + For Each over UIA activities. If the process body is >49% UI automation with minimal data shaping, recommend **XAML** or **Hybrid**.
 
 **Recommendation:** <XAML / Coded C# / Hybrid>
 

--- a/skills/uipath-solution/references/design/rpa-product-guide.md
+++ b/skills/uipath-solution/references/design/rpa-product-guide.md
@@ -110,7 +110,7 @@ The skill that builds the workflows owns the final, detailed decision — this i
 
 ### Anti-pattern: picking Coded C# for UI-heavy automation
 
-**Trigger:** the process body is **>70% UI automation** against a browser, desktop app, or SaaS UI, with **minimal HTTP / parsing / DTO / data-shaping work**. The PDD describes "log in, navigate to a list, click each row, read fields, compute a derived value, write it back, close" — i.e. UI driving is the bulk of the work.
+**Trigger:** the process body is **>49% UI automation** against a browser, desktop app, or SaaS UI, with **minimal HTTP / parsing / DTO / data-shaping work**. The PDD describes "log in, navigate to a list, click each row, read fields, compute a derived value, write it back, close" — i.e. UI driving is the bulk of the work.
 
 **Decision:** **XAML** (or **Hybrid** if a discrete piece of non-trivial data logic exists). Do **NOT** pick Coded C# on a "cleaner control flow" argument.
 
@@ -146,7 +146,7 @@ Before §13 Implementation Mode commits to Coded C#, confirm at least **two** of
 - [ ] Process has algorithmically non-trivial logic (LINQ aggregation, sorting, dedup, custom comparison).
 - [ ] Process has unit-testable pure functions (exercised by Coded Test Cases on inputs the live system cannot easily reproduce).
 
-If **fewer than two** are true and the body is >70% UI, recommend XAML. The "cleaner control flow" line of reasoning is explicitly insufficient — strike it from the §13 justification.
+If **fewer than two** are true and the body is >49% UI, **default to XAML silently — do not call `AskUserQuestion`.** Only ask when ≥2 are true (recommend Coded C#, or Hybrid if a strong UI body signal is also present) or when signals are ambiguous. When asking, option labels are exactly `Coded C#`, `XAML`, `Hybrid` — never invent brand names like "Studio Classic"; `targetFramework` (Windows / Portable / Legacy) is a separate axis. The "cleaner control flow" line of reasoning is explicitly insufficient — strike it from the §13 justification.
 
 ## Level 2.5 Part A — RPA Decomposition Signals
 


### PR DESCRIPTION
## Summary

- During Phase 2 Step 2, the model fired `AskUserQuestion` for every RPA project and freelanced option labels like **"XAML (Studio Classic)"** — a brand name that appears nowhere in the repo and conflicts with the `targetFramework` axis (`Windows` / `Portable` / `Legacy`).
- Update the existing "Selection checklist" closing rule in `references/design/rpa-product-guide.md` so XAML is the **silent default** when fewer than 2 Coded C# signals match. The question now fires only when ≥2 signals match (Coded C# / Hybrid) or when signals are ambiguous. When it does fire, option labels are locked to `Coded C#` / `XAML` / `Hybrid` — no invented brand names.
- Lower the UI-share threshold from `>70%` to `>49%` so any majority-UI process biases toward XAML. Apply the new threshold consistently in both the canonical guide (Anti-pattern Trigger + Selection checklist) and `assets/templates/rpa-sdd-template.md` §13 callout.

Net diff: 2 files, +3 / -3.

## Test plan

- [ ] Run Phase 2 Step 2 against a UI-heavy PDD → no `AskUserQuestion` fires; §13 in the generated SDD recommends **XAML** with the silent-default justification.
- [ ] Run Phase 2 Step 2 against a REST-heavy PDD (≥2 Coded C# signals) → `AskUserQuestion` fires; options read exactly `Coded C#` / `XAML` / `Hybrid` with no parentheticals.
- [ ] Run against a Solution PDD with one UI-heavy RPA project and one data-heavy RPA project → one silent default, one question; never combined.
- [ ] `grep -rn "Studio Classic" skills/` returns only the new ban line in `rpa-product-guide.md` (the rule forbidding the term).
- [ ] `grep -rn ">70%" skills/` returns no results.
- [ ] `hooks/validate-skill-descriptions.sh` passes.