### PR TITLE
fix(hitl): natural test prompts, contextual link text, CI link checker

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -145,9 +145,9 @@ Present the user with three options. Do not choose on their behalf or perform an
 
 | User selects | Next step |
 |---|---|
-| QuickForm | Read [references/hitl-node-quickform.md](references/hitl-node-quickform.md) for Steps 1–2, then continue with Step 4 |
-| New Coded Action App | Read [references/hitl-node-coded-action-app.md](references/hitl-node-coded-action-app.md) for Step 4c details, then continue with Step 4 |
-| Existing Deployed App → ask: "What is the name of the deployed action app?" | Read [references/hitl-node-apptask.md](references/hitl-node-apptask.md) for Step 4b details, then continue with Step 4 |
+| QuickForm | Read [How to write a QuickForm HITL node](references/hitl-node-quickform.md) for Steps 1–2, then continue with Step 4 |
+| New Coded Action App | Read [How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md) for Step 4c details, then continue with Step 4 |
+| Existing Deployed App → ask: "What is the name of the deployed action app?" | Read [How to wire an existing deployed Action App](references/hitl-node-apptask.md) for Step 4b details, then continue with Step 4 |
 
 **Fallback rules — what to do when the chosen path hits a blocker:**
 
@@ -201,7 +201,7 @@ If the user says "yes but change X" or gives conditional approval, apply the cha
 
 Write the node JSON directly into `workflow.nodes`, add the definition to `workflow.definitions` (once), wire edges into `workflow.edges`, and regenerate `workflow.variables.nodes`. **Direct JSON is the default.**
 
-Full reference: **[references/hitl-node-quickform.md](references/hitl-node-quickform.md)** — complete node JSON, definition entry, edge format, `variables.nodes` regeneration algorithm, and four worked schema conversion examples.
+Node JSON, definition entry, edge format, `variables.nodes` algorithm, and four worked examples: **[How to write a QuickForm HITL node](references/hitl-node-quickform.md)**
 
 **CLI (opt-in):** When the user explicitly requests a CLI command:
 
@@ -228,7 +228,7 @@ Step 4c must be completed first — app name confirmed, solution directory locat
 
 Scaffold the project directory and all source files, add the project to the solution, write the solution resource files, then write the HITL node with `inputs.type = "custom"` and `inputs.app` referencing the new app (`appSystemName: null` since the app has not been deployed yet).
 
-Full reference: **[references/hitl-node-coded-action-app.md](references/hitl-node-coded-action-app.md)** — complete project structure, all file templates, UUID generation, solution CLI commands, resource file templates (`resources/solution_folder/app/codedAction/` and `resources/solution_folder/package/`), node JSON with `inputs.app` field mapping, and post-creation build instructions.
+Full project template, UUID generation, solution CLI commands, resource file templates, node JSON, and post-creation build steps: **[How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md)**
 
 After writing, validate:
 
@@ -242,7 +242,7 @@ Step 4b must be completed first — app resolved, configuration retrieved. Then:
 
 Resolve the solution context (`.uipx` file), write solution resource files, register the app reference, merge `debug_overwrites.json`, then write the node JSON with `inputs.type = "custom"` and `inputs.app` populated from the Step 3b configuration.
 
-Full reference: **[references/hitl-node-apptask.md](references/hitl-node-apptask.md)** — credential sourcing from `~/.uipath/.auth`, solution context resolution, app search/selection (with multi-match list), retrieve-configuration, resource file writing, reference registration, debug overwrites, complete node JSON, `inputs.app` field mapping.
+App search/selection, retrieve-configuration, resource file writing, complete node JSON with `appInputBindings`: **[How to wire an existing deployed Action App](references/hitl-node-apptask.md)**
 
 After writing, validate:
 
@@ -303,8 +303,8 @@ After completing the wiring:
 
 ## References
 
-- **[QuickForm Node JSON](references/hitl-node-quickform.md)** — Full node JSON, definition entry, edge format, `variables.nodes` regeneration, four schema conversion examples.
-- **[AppTask Node JSON](references/hitl-node-apptask.md)** — App lookup via direct API, node JSON with `inputs.type = "custom"`, app field mapping.
-- **[Coded Action App (inline)](references/hitl-node-coded-action-app.md)** — Scaffold a new React coded action app inside the solution; full project template, resource files, HITL node JSON.
-- **[HITL Business Pattern Recognition](references/hitl-patterns.md)** — Signal tables for detecting when a process needs a human checkpoint. Includes proactive recommendation language and when NOT to recommend HITL.
-- **[Action Center URL patterns](../uipath-tasks/references/action-center-urls.md)** (in `uipath-tasks` skill) — Canonical task deep-link forms. Read before surfacing any task URL to the user; covers the missing-tenant-slug anti-pattern (which the portal-UI misclassifies as "Orchestrator not enabled") and the API-host vs UI-host mapping.
+- **[How to write a QuickForm HITL node](references/hitl-node-quickform.md)** — Read this after the user confirms QuickForm in Step 3. Covers the complete node JSON, definition entry, edge wiring, `variables.nodes` regeneration algorithm, and four worked schema examples.
+- **[How to wire an existing deployed Action App](references/hitl-node-apptask.md)** — Read this when the user selects an existing deployed app in Step 3. Covers app lookup via the Orchestrator API, `inputs.app` field mapping, `appInputBindings`, and solution resource files.
+- **[How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md)** — Read this when the user wants to build a new React app inside the solution. Covers full project template, UUID generation, solution CLI commands, and post-creation build steps.
+- **[HITL business pattern recognition](references/hitl-patterns.md)** — Read this during Step 2 / Step 2b to identify whether a process needs a human checkpoint and which pattern applies. Includes proactive recommendation language and when NOT to recommend HITL.
+- **[Action Center URL patterns](../uipath-tasks/references/action-center-urls.md)** (in `uipath-tasks` skill) — Read this before surfacing any Action Center task URL to the user. Covers the missing-tenant-slug anti-pattern and the API-host vs UI-host mapping.

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -1,6 +1,6 @@
 # HITL QuickForm Node — Direct JSON Reference
 
-The agent writes the `uipath.human-in-the-loop` node directly into the `.flow` file as JSON. **Direct JSON is the default.** A CLI opt-in is also available when the user explicitly requests it — see [cli-commands.md — uip maestro flow hitl add](../../../../uipath-maestro-flow/references/shared/cli-commands.md#uip-maestro-flow-hitl-add).
+The agent writes the `uipath.human-in-the-loop` node directly into the `.flow` file as JSON. **Direct JSON is the default.** A CLI opt-in is also available when the user explicitly requests it — see [CLI reference: uip maestro flow hitl add](../../uipath-maestro-flow/references/shared/cli-commands.md#uip-maestro-flow-hitl-add).
 
 ---
 
@@ -67,7 +67,7 @@ Also read `workflow.variables.globals`. Each entry has an `id` that maps directl
 | Node output | `vars.<nodeId>.output.<field>` | `=js:$vars.<nodeId>.output.<field>` |
 | Flow global (`direction: "in"`) | `vars.<globalId>` | `=js:$vars.<globalId>` |
 
-For the full variable system, see → [uipath-maestro-flow — variables-and-expressions.md](../../../../uipath-maestro-flow/references/shared/variables-and-expressions.md)
+For the full variable system, see → [How $vars paths are constructed in Flow](../../uipath-maestro-flow/references/shared/variables-and-expressions.md)
 
 ---
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -52,4 +52,7 @@ sys.exit(0 if matches else 3)'
 test-%:  ## Run all tests for a specific skill
 	$(CODER_EVAL) run $(shell find tasks/$* -name '*.yaml' -type f) -e experiments/default.yaml -j $(TASK_PARALLELISM) -v
 
+check-links:  ## Validate all relative Markdown links in skills/ resolve to existing files
+	python3 scripts/check_skill_links.py --root ..
+
 .DEFAULT_GOAL := help

--- a/tests/scripts/check_skill_links.py
+++ b/tests/scripts/check_skill_links.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Validate that every Markdown link in skill files resolves to an existing file.
+
+Usage:
+    python3 tests/scripts/check_skill_links.py [--root <repo-root>]
+
+Exit codes:
+    0  All links valid
+    1  One or more broken links found
+    2  Usage error
+
+Scope:
+    Walks all *.md files under skills/ (relative to the repo root).
+    Checks only relative links that look like file paths.
+    Skips:
+      - Absolute URLs (http://, https://)
+      - Anchor-only links (#section)
+      - Skill namespace refs (/uipath:...)
+      - Absolute filesystem paths (/tmp/, /Users/, /private/, /)
+      - Links containing template placeholders (<...>)
+      - Multi-line link targets (code false-positives)
+      - mailto: links
+
+Section anchors (#fragment) in the link target are stripped before
+checking file existence — they are not validated individually.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Only match single-line [text](href) — avoids false-positives from
+# multiline Python constructor calls like Agent(\n    name="x",\n...)
+_LINK_RE = re.compile(r"\[(?:[^\]\n]*)\]\(([^)\n]+)\)")
+
+
+def _should_skip(href: str) -> bool:
+    """Return True for hrefs that are not local file references."""
+    # URL schemes
+    if href.startswith(("http://", "https://", "mailto:")):
+        return True
+    # Anchor-only
+    if href.startswith("#"):
+        return True
+    # Skill namespace cross-references (/uipath:skill-name)
+    if href.startswith("/uipath:"):
+        return True
+    # Absolute filesystem paths — these appear in docs as examples, not real links
+    if href.startswith("/"):
+        return True
+    # Template placeholders like <ABSOLUTE_PATH> or <slug>
+    if "<" in href or ">" in href:
+        return True
+    # Paths that are clearly code/example content (contain spaces or newlines)
+    if " " in href or "\n" in href:
+        return True
+    # Regex-style hrefs used as illustrative examples (e.g. "error|errorCode")
+    if "|" in href:
+        return True
+    # Generic placeholder segments used in template READMEs (e.g. "path", "...")
+    path_part = href.split("#")[0]
+    if path_part in ("path", "..."):
+        return True
+    return False
+
+
+def _resolve(href: str, source_file: Path) -> Path:
+    """Resolve href relative to the source file's directory, stripping fragments."""
+    path_part = href.split("#")[0]
+    return (source_file.parent / path_part).resolve()
+
+
+def check(root: Path) -> list[tuple[Path, str, Path]]:
+    """Return list of (source_file, raw_href, resolved_path) for broken links."""
+    broken: list[tuple[Path, str, Path]] = []
+    for md_file in sorted(root.glob("skills/**/*.md")):
+        if ".maintenance" in md_file.parts:
+            continue
+        text = md_file.read_text(encoding="utf-8")
+        for match in _LINK_RE.finditer(text):
+            href = match.group(1).strip()
+            if _should_skip(href):
+                continue
+            resolved = _resolve(href, md_file)
+            if not resolved.exists():
+                broken.append((md_file, href, resolved))
+    return broken
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="Repo root (default: current directory)",
+    )
+    args = parser.parse_args()
+    root = Path(args.root).resolve()
+
+    if not (root / "skills").is_dir():
+        print(f"ERROR: skills/ directory not found under {root}", file=sys.stderr)
+        sys.exit(2)
+
+    broken = check(root)
+    if not broken:
+        md_count = sum(1 for _ in root.glob("skills/**/*.md"))
+        print(f"OK: all relative links valid across {md_count} skill .md files")
+        sys.exit(0)
+
+    print(f"BROKEN LINKS ({len(broken)} found):", file=sys.stderr)
+    for source, href, resolved in broken:
+        rel_source = source.relative_to(root)
+        print(f"  {rel_source}  →  {href!r}", file=sys.stderr)
+        print(f"         resolved to: {resolved}", file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
@@ -37,8 +37,7 @@ initial_prompt: |
 
   Wire: Trigger → Script → HITL →|completed| Script (log) → End
 
-  Use the inline quickform node (uipath.human-in-the-loop).
-  Do NOT run flow debug. Validate after building.
+  Validate the flow after building.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
@@ -34,8 +34,7 @@ initial_prompt: |
 
   Wire: Trigger → Script → HITL →|completed| Script (log) → End
 
-  Use the inline quickform node (uipath.human-in-the-loop).
-  Do NOT run flow debug. Validate after building.
+  Validate the flow after building.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
@@ -41,11 +41,10 @@ initial_prompt: |
 
   Wire: Trigger → Script → HITL →|completed| Decision → both branches → End
 
-  Use the inline quickform node (uipath.human-in-the-loop).
   Read variables.nodes before writing input field bindings — use the exact
   $vars path from the node's outputId entry.
   Output fields must NOT have a binding property.
-  Do NOT run flow debug. Validate after building.
+  Validate the flow after building.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
@@ -42,8 +42,7 @@ initial_prompt: |
 
   Wire: Trigger → Script → HITL →|completed| Script (log) → End
 
-  Use the inline quickform node (uipath.human-in-the-loop).
-  Do NOT run flow debug. Validate after building.
+  Validate the flow after building.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
@@ -10,34 +10,20 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  I have a UiPath Flow. Add a Human-in-the-Loop node before the final data
-  write step so a manager can review and approve the data before it is posted.
+  I have a UiPath Flow. Before the final data write step, a manager
+  needs to review and approve the data before it is posted.
 
-  Recommend whether HITL is needed and identify which canonical HITL
-  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
-  `references/hitl-patterns.md` enumerates six canonical patterns; pick
-  exactly one and emit its machine name verbatim.
-
-  Write a `recommendation.json` file with this exact shape:
+  Analyze whether a human checkpoint is needed and what kind of approval
+  pattern applies. Write your analysis to `recommendation.json`:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<one of the canonical pattern names listed below>",
+    "pattern": "<type of human checkpoint pattern>",
     "proposed_schema": {
       "inputs": ["<field names the human will see>"],
       "outputs": ["<field names the human fills in>"],
       "outcomes": ["<action button names>"]
     }
   }
-
-  Use EXACTLY one of these machine names for `pattern` (lowercase,
-  hyphenated, no extra adjectives or prefixes — names mirror the
-  section titles in `references/hitl-patterns.md`):
-    - approval-gate
-    - exception-escalation
-    - data-enrichment
-    - compliance-checkpoint
-    - write-back-validation
-    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -65,7 +51,7 @@ success_criteria:
     assertions:
       - expression: "pattern"
         operator: regex
-        expected: "^(approval-gate|write-back-validation)$"
+        expected: "(?i)(approval.gate|write.back)"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
@@ -14,31 +14,17 @@ initial_prompt: |
   finance — but a manager must approve each expense report before the email
   is sent.
 
-  Recommend whether HITL is needed and identify which canonical HITL
-  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
-  `references/hitl-patterns.md` enumerates six canonical patterns; pick
-  exactly one and emit its machine name verbatim.
-
-  Write a `recommendation.json` file with this exact shape:
+  Analyze whether a human checkpoint is needed and identify what type of
+  approval pattern applies. Write your analysis to `recommendation.json`:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<one of the canonical pattern names listed below>",
+    "pattern": "<type of human checkpoint pattern>",
     "proposed_schema": {
       "inputs": ["<field names>"],
       "outputs": ["<field names>"],
       "outcomes": ["<button names>"]
     }
   }
-
-  Use EXACTLY one of these machine names for `pattern` (lowercase,
-  hyphenated, no extra adjectives or prefixes — names mirror the
-  section titles in `references/hitl-patterns.md`):
-    - approval-gate
-    - exception-escalation
-    - data-enrichment
-    - compliance-checkpoint
-    - write-back-validation
-    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -60,7 +46,7 @@ success_criteria:
     path: "recommendation.json"
     assertions:
       - expression: "pattern"
-        operator: equals
-        expected: "approval-gate"
+        operator: regex
+        expected: "(?i)approval.gate"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
@@ -16,31 +16,19 @@ initial_prompt: |
   cases the agent cannot resolve autonomously — they need to escalate
   to a human supervisor who makes the final routing call.
 
-  Recommend whether HITL is needed and identify which canonical HITL
-  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
-  `references/hitl-patterns.md` enumerates six canonical patterns; pick
-  exactly one and emit its machine name verbatim.
+  Analyze whether a human checkpoint is needed, identify what type of pattern
+  this is, and describe where in the flow it should go.
 
-  Write a `recommendation.json` file with this exact shape:
+  Write your analysis to `recommendation.json`:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<one of the canonical pattern names listed below>",
+    "pattern": "<type of human checkpoint pattern>",
     "insertion_point": "<short phrase describing where in the flow>",
     "proposed_schema": {
       "inputs": ["<field names>"],
       "outcomes": ["<button names>"]
     }
   }
-
-  Use EXACTLY one of these machine names for `pattern` (lowercase,
-  hyphenated, no extra adjectives or prefixes — names mirror the
-  section titles in `references/hitl-patterns.md`):
-    - approval-gate
-    - exception-escalation
-    - data-enrichment
-    - compliance-checkpoint
-    - write-back-validation
-    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -67,7 +55,7 @@ success_criteria:
     assertions:
       - expression: "pattern"
         operator: regex
-        expected: "^(exception-escalation|agentic-output-review)$"
+        expected: "(?i)(escalat|agentic.output)"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
@@ -10,32 +10,21 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Build a UiPath Flow where an AI agent reads incomplete SAP purchase orders,
+  I'm designing a UiPath Flow where an AI agent reads incomplete SAP purchase orders,
   enriches the missing vendor and cost-center fields using company data, and
   writes the corrected records back to SAP.
 
-  Analyze whether this flow needs any human checkpoints. If yes, identify
-  which canonical HITL pattern from the `uipath-human-in-the-loop` skill
-  applies. The skill's `references/hitl-patterns.md` enumerates six
-  canonical patterns; pick exactly one and emit its machine name verbatim.
+  Analyze whether this flow needs any human checkpoints, explain why,
+  and identify where one should go if needed.
 
-  Write a `recommendation.json` file with this exact shape:
+  Do not build or scaffold a project. Write only your analysis to
+  `recommendation.json`:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<one of the canonical pattern names listed below>",
+    "pattern": "<type of human checkpoint pattern, if applicable>",
     "reason": "<why HITL is or is not needed>",
     "proposed_insertion_point": "<where in the flow>"
   }
-
-  Use EXACTLY one of these machine names for `pattern` (lowercase,
-  hyphenated, no extra adjectives or prefixes — names mirror the
-  section titles in `references/hitl-patterns.md`):
-    - approval-gate
-    - exception-escalation
-    - data-enrichment
-    - compliance-checkpoint
-    - write-back-validation
-    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -64,6 +53,6 @@ success_criteria:
     assertions:
       - expression: "pattern"
         operator: regex
-        expected: "^(write-back-validation|data-enrichment|agentic-output-review)$"
+        expected: "(?i)(write.back|enrich|agentic.output|approval.gate)"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
@@ -15,31 +15,17 @@ initial_prompt: |
   an audit trail for every decision (required for compliance with GDPR
   Article 17 — Right to Erasure).
 
-  Recommend whether HITL is needed and identify which canonical HITL
-  pattern from the `uipath-human-in-the-loop` skill applies. The skill's
-  `references/hitl-patterns.md` enumerates six canonical patterns; pick
-  exactly one and emit its machine name verbatim.
-
-  Write a `recommendation.json` file with this exact shape:
+  Analyze whether a human checkpoint is needed and what kind of sign-off
+  pattern this is. Write your analysis to `recommendation.json`:
   {
     "hitl_needed": <true or false>,
-    "pattern": "<one of the canonical pattern names listed below>",
+    "pattern": "<type of human checkpoint pattern>",
     "proposed_schema": {
       "inputs": ["<what the privacy officer will see>"],
       "outputs": ["<what they fill in>"],
       "outcomes": ["<their decision options>"]
     }
   }
-
-  Use EXACTLY one of these machine names for `pattern` (lowercase,
-  hyphenated, no extra adjectives or prefixes — names mirror the
-  section titles in `references/hitl-patterns.md`):
-    - approval-gate
-    - exception-escalation
-    - data-enrichment
-    - compliance-checkpoint
-    - write-back-validation
-    - agentic-output-review
 
 success_criteria:
   - type: file_exists
@@ -67,6 +53,6 @@ success_criteria:
     assertions:
       - expression: "pattern"
         operator: regex
-        expected: "^(compliance-checkpoint|approval-gate)$"
+        expected: "(?i)(compliance|gdpr|regulatory|sign.off|approval.gate)"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -23,8 +23,8 @@ initial_prompt: |
   2. Pauses for a finance manager to review and approve an invoice (human-in-the-loop)
   3. Ends after the review is complete
 
-  The HITL node must use the inline quickform style (uipath.human-in-the-loop),
-  not an external app. The node must show the reviewer: invoice ID and amount.
+  The reviewer's form should be rendered inline by Action Center — no external app.
+  The node must show the reviewer: invoice ID and amount.
   The reviewer clicks Approve or Reject.
 
   Wire the completed handle to an End node.

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -21,11 +21,11 @@ initial_prompt: |
   Build a UiPath Flow named "PurchaseApproval" with this structure:
     Manual Trigger -> HITL (manager approves purchase) -> Script (log approval) -> End
 
-  Use the inline quickform HITL node (uipath.human-in-the-loop).
+  The reviewer's form should be inline — rendered by Action Center.
   The HITL node shows the reviewer: purchase amount and vendor name.
   Outcomes: Approve and Reject.
 
-  Wire the HITL node's completed handle to the Script node.
+  Wire the output of the HITL step to the Script node.
   The Script node logs: "Approval recorded."
 
   Validate the flow after building.


### PR DESCRIPTION
## Why

A code review surfaced three categories of problems with the HITL skill and its tests:

1. **Test prompts contained insider vocabulary** — canonical pattern names (`approval-gate`, `write-back-validation`), node type literals (`uipath.human-in-the-loop`), and test-harness instructions (`Do NOT run flow debug`) that no real customer would write. Tests were measuring vocabulary recall, not signal detection.

2. **Link text was context-free** — `Full reference: references/hitl-node-quickform.md` tells the agent nothing about *when* to follow the link or *what* it will find. Same for bare file paths in the task-type selection table.

3. **Two links in hitl-node-quickform.md were broken** — `../../../../` paths resolved outside the skills repo root.

A follow-up ask added: **CI enforcement** so broken links are caught automatically going forward.

---

## What changed

### 1. Test prompt vocabulary (11 YAML files)

We've seen human users describe "someone needs to approve this before it goes to SAP" — they don't say "write-back-validation approval gate". So:

- **Smoke prompts**: Removed all canonical name lists. Replaced with plain-English questions. Widened `success_criteria` regex to accept natural synonyms (`approval.gate`, `write.back`, `escalat`, etc.) instead of exact machine names.
- **Quality prompts**: Removed `Use the inline quickform node (uipath.human-in-the-loop)` and `Do NOT run flow debug` — the skill should make those choices autonomously based on context.

### 2. Contextual link text in SKILL.md

We've seen agents skip reading reference docs because the link text gave no signal about relevance. So:

- Step 3 task-type table: bare file paths → readable titles ("How to write a QuickForm HITL node")
- Step 5 "Full reference:" lines → content description first, then the link
- References section: all five entries rewritten with "Read this when: [trigger condition]" structure

### 3. Broken link fixes

`hitl-node-quickform.md` had two links using `../../../../` that resolved to a path outside the skills repo. Fixed to `../../` (correct relative path within `skills/uipath-human-in-the-loop/references/`).

### 4. CI link checker (`tests/scripts/check_skill_links.py`)

We've seen broken links sit undetected for months because there was no automated check. So:

- New script walks `skills/**/*.md`, resolves all relative links, reports broken ones
- Skips: absolute URLs, anchor-only links, skill namespace refs (`/uipath:`), absolute filesystem paths, template placeholders (`<...>`), `.maintenance/` template dirs, regex-style hrefs (`|`)
- `make check-links` target added to `tests/Makefile`
- **16 pre-existing broken links remain** in skills owned by other teams (`uipath-agents`, `uipath-rpa`, `uipath-platform`, `uipath-solution`, `uipath-maestro-case`) — logged here for respective owners to fix

---

## Test plan

- [ ] `python3 tests/scripts/check_skill_links.py --root .` — exits 1 with only the 16 pre-existing non-HITL broken links (no HITL links in the list)
- [ ] `make check-links` from `tests/` runs the same check
- [ ] Smoke tests pass with rewritten prompts (covered by existing CI runs on PR #837 baseline)
- [ ] Quality tests pass: no change to success criteria, only prompt cleanup

## Related PRs

- #837 — smoke criteria regex widening (prerequisite, pending merge)
- #861 — FormTask skill
- #871 — E2E round-trip test

🤖 Generated with [Claude Code](https://claude.com/claude-code)