### PR TITLE
refactor(tests): split smoke experiment configs and remove driver hardcoding

### DIFF
--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -270,7 +270,7 @@ jobs:
             for attempt in 1 2 3; do
               echo "--- $task attempt $attempt ---"
               if coder-eval run "$task" \
-                  -e experiments/default.yaml --tags smoke -j 1 -v; then
+                  -e experiments/default_smoke_rpa.yaml --tags smoke -j 1 -v; then
                 break
               fi
               # Only retry on Bedrock content-filter ERRORs (not on real

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -56,12 +56,12 @@ jobs:
           # If test infrastructure changed, run all smoke tests except
           # the Windows-only ones and opt-in benchmarks.
           #
-          # We only fan out for the smoke config (default.yaml) — other
+          # We only fan out for the smoke config (default_smoke.yaml) — other
           # experiment files (integration.yaml, e2e.yaml, activation.yaml,
           # ...) drive their own jobs/dashboards and don't change smoke
           # behavior, so editing them shouldn't trigger a 30-min full-suite
           # run on every PR.
-          if echo "$CHANGED" | grep -qE '^tests/experiments/default\.yaml$|^tests/_shared/|^tests/[^/]+\.(py|yaml|toml)$|^\.github/workflows/smoke-skills\.yml$'; then
+          if echo "$CHANGED" | grep -qE '^tests/experiments/default_smoke\.yaml$|^tests/_shared/|^tests/[^/]+\.(py|yaml|toml)$|^\.github/workflows/smoke-skills\.yml$'; then
             shopt -s globstar nullglob
             GLOBS=""
             for f in tests/tasks/**/*.yaml; do
@@ -296,7 +296,7 @@ jobs:
         run: |
           echo "Running: coder-eval run ${{ needs.detect.outputs.task_globs }} --tags smoke -j $TASK_PARALLELISM"
           coder-eval run ${{ needs.detect.outputs.task_globs }} \
-            -e experiments/default.yaml \
+            -e experiments/default_smoke.yaml \
             -j "$TASK_PARALLELISM" -v \
             --run-dir /tmp/runs \
             --tags smoke

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,7 +28,10 @@ all:  ## Run all tests (smoke + integration + e2e) in a single run
 	$(CODER_EVAL) run $(TASKS) -e experiments/e2e.yaml -j $(TASK_PARALLELISM) -v
 
 smoke:  ## Run all smoke tests
-	$(CODER_EVAL) run $(TASKS) -e experiments/default.yaml --tags smoke -j $(TASK_PARALLELISM) -v
+	$(CODER_EVAL) run $(TASKS) -e experiments/default_smoke.yaml --tags smoke -j $(TASK_PARALLELISM) -v
+
+smoke_rpa:  ## Run all RPA smoke tests
+	$(CODER_EVAL) run $(TASKS) -e experiments/default_smoke_rpa.yaml --tags smoke -j $(TASK_PARALLELISM) -v
 
 integration:  ## Run all integration tests
 	$(CODER_EVAL) run $(TASKS) -e experiments/integration.yaml --tags integration -j $(TASK_PARALLELISM) -v

--- a/tests/experiments/default_smoke.yaml
+++ b/tests/experiments/default_smoke.yaml
@@ -14,7 +14,9 @@ defaults:
     turn_timeout: 900
 
   sandbox:
-    driver: tempdir
+    driver: docker
+    python: {}
+    node: {}
     docker:
       env_passthrough_extra:
         - SKILLS_REPO_PATH

--- a/tests/experiments/default_smoke_rpa.yaml
+++ b/tests/experiments/default_smoke_rpa.yaml
@@ -15,20 +15,8 @@ defaults:
 
   sandbox:
     driver: tempdir
-    docker:
-      env_passthrough_extra:
-        - SKILLS_REPO_PATH
-        - BEDROCK_MODEL
-        - TASK_PARALLELISM
-        - UIPATH_CLI_ENABLE_ENV_AUTH
-        - UIPATH_CLI_AUTH_TOKEN
-        - UIPATH_CLI_ORGANIZATION_NAME
-        - UIPATH_CLI_ORGANIZATION_ID
-        - UIPATH_CLI_TENANT_NAME
-        - UIPATH_CLI_TENANT_ID
-        - TRACES_SMOKE_PROCESS_KEY
-      extra_mounts:
-        - ~/.uipath:/.uipath:rw
+    python: {}
+    node: {}
 
   agent:
     type: claude-code

--- a/tests/tasks/uipath-admin/audit_events_basic_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_events_basic_smoke.yaml
@@ -11,9 +11,7 @@ description: >
   command invocation with correct flags.
 tags: [uipath-admin, smoke, mode:diagnose, audit]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A reviewer wants the most recent 25 tenant audit events from the

--- a/tests/tasks/uipath-admin/audit_events_pagination_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_events_pagination_smoke.yaml
@@ -10,9 +10,7 @@ description: >
   what matters is the agent's CLI invocation pattern.
 tags: [uipath-admin, smoke, mode:diagnose, audit, pagination]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A compliance reviewer wants the 500 most recent tenant audit events

--- a/tests/tasks/uipath-admin/audit_export_basic_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_export_basic_smoke.yaml
@@ -11,9 +11,7 @@ description: >
   command invocation with correct flags.
 tags: [uipath-admin, smoke, mode:operate, audit, export]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   An admin needs a ZIP of all tenant audit events from yesterday for

--- a/tests/tasks/uipath-admin/audit_org_events_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_org_events_smoke.yaml
@@ -13,9 +13,7 @@ description: >
   command invocation with correct flags.
 tags: [uipath-admin, smoke, mode:diagnose, audit, scope-org]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   An admin wants the 50 most recent organization-level audit events

--- a/tests/tasks/uipath-admin/audit_org_export_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_smoke.yaml
@@ -11,9 +11,7 @@ description: >
   command invocation with correct flags.
 tags: [uipath-admin, smoke, mode:operate, audit, export, scope-org]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   An admin needs a ZIP of all ORGANIZATION-level audit events

--- a/tests/tasks/uipath-admin/audit_sources_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_sources_smoke.yaml
@@ -11,9 +11,7 @@ description: >
   command invocation with correct flags.
 tags: [uipath-admin, smoke, mode:diagnose, audit]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   An admin wants to discover what kinds of audit events are visible at

--- a/tests/tasks/uipath-admin/audit_status_filter_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_status_filter_smoke.yaml
@@ -10,9 +10,7 @@ description: >
   command invocation with correct flags.
 tags: [uipath-admin, smoke, mode:diagnose, audit, status]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Show me all FAILED audit events on the active tenant from the last

--- a/tests/tasks/uipath-admin/identity_create_external_app_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_create_external_app_smoke.yaml
@@ -5,9 +5,7 @@ description: >
   (Critical Rule #6) and positional name argument.
 tags: [uipath-admin, smoke, create]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a new external app named "Smoke Test App" with application

--- a/tests/tasks/uipath-admin/identity_create_robot_account_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_create_robot_account_smoke.yaml
@@ -5,9 +5,7 @@ description: >
   correct positional arg for name, and --display-name flag.
 tags: [uipath-admin, smoke, create]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a new robot account named "smoke-test-bot" with display name

--- a/tests/tasks/uipath-admin/identity_list_groups_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_list_groups_smoke.yaml
@@ -4,9 +4,7 @@ description: >
   Tests correct CLI namespace and --output json convention.
 tags: [uipath-admin, smoke, list]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Show me all groups in my UiPath organization.

--- a/tests/tasks/uipath-admin/identity_list_robot_accounts_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_list_robot_accounts_smoke.yaml
@@ -4,9 +4,7 @@ description: >
   Tests correct CLI namespace and flag usage.
 tags: [uipath-admin, smoke, list]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List all robot accounts in my UiPath organization.

--- a/tests/tasks/uipath-admin/identity_list_users_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_list_users_smoke.yaml
@@ -4,9 +4,7 @@ description: >
   Tests correct CLI namespace and --output json convention.
 tags: [uipath-admin, smoke, list]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List all users in my UiPath organization.

--- a/tests/tasks/uipath-agents/antipattern_build_system/antipattern_build_system.yaml
+++ b/tests/tasks/uipath-agents/antipattern_build_system/antipattern_build_system.yaml
@@ -15,9 +15,7 @@ agent:
 run_limits:
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I have an existing UiPath coded agent project under `legacy-port`

--- a/tests/tasks/uipath-agents/antipattern_module_level_llm/antipattern_module_level_llm.yaml
+++ b/tests/tasks/uipath-agents/antipattern_module_level_llm/antipattern_module_level_llm.yaml
@@ -15,9 +15,7 @@ agent:
 run_limits:
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I'm porting an existing LangGraph agent into UiPath. Recreate the

--- a/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/antipattern_openai_agents_hitl.yaml
+++ b/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/antipattern_openai_agents_hitl.yaml
@@ -18,9 +18,7 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   turn_timeout: 1200
 
-sandbox:
-  driver: tempdir
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Recreate the UiPath coded agent project under `triage-broken/`

--- a/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
+++ b/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
@@ -14,9 +14,7 @@ agent:
 run_limits:
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I have an existing UiPath coded agent that I'm trying to run.

--- a/tests/tasks/uipath-agents/bindings_sync.yaml
+++ b/tests/tasks/uipath-agents/bindings_sync.yaml
@@ -6,9 +6,7 @@ description: >
   scanning beyond main.py and constant resolution.
 tags: [uipath-agents, smoke, coded, bindings]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I have a UiPath coded agent project. Please set up these files, then sync

--- a/tests/tasks/uipath-agents/coded_in_flow_register/coded_in_flow_register.yaml
+++ b/tests/tasks/uipath-agents/coded_in_flow_register/coded_in_flow_register.yaml
@@ -17,9 +17,7 @@ agent:
 
 task_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a UiPath solution "ClaimsSol" containing a Flow project

--- a/tests/tasks/uipath-agents/file_attachment_input/file_attachment_input.yaml
+++ b/tests/tasks/uipath-agents/file_attachment_input/file_attachment_input.yaml
@@ -7,9 +7,7 @@ description: >
   Orchestrator use to render a file picker at runtime.
 tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:framework-simple]
 
-sandbox:
-  driver: tempdir
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   1. Create a 'test.txt' file at cwd with 'This is the file content' as content.

--- a/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
@@ -16,9 +16,7 @@ agent:
   max_turns: 30
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a UiPath solution "GreetSol" containing a low-code agent

--- a/tests/tasks/uipath-agents/lowcode/guardrail_discovery/guardrail_discovery.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_discovery/guardrail_discovery.yaml
@@ -17,9 +17,7 @@ agent:
   max_turns: 30
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a UiPath solution "DiscoverSol" containing a low-code agent

--- a/tests/tasks/uipath-agents/lowcode/init_validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/init_validate.yaml
@@ -14,9 +14,7 @@ run_limits:
   max_turns: 30
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a UiPath solution "EchoSol" containing a low-code agent

--- a/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
+++ b/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
@@ -17,9 +17,7 @@ run_limits:
   max_turns: 30
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a UiPath solution "QuerySol" containing a low-code agent

--- a/tests/tasks/uipath-agents/simple_echo/simple_echo.yaml
+++ b/tests/tasks/uipath-agents/simple_echo/simple_echo.yaml
@@ -21,9 +21,7 @@ run_limits:
   max_turns: 40
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Build a Simple Function UiPath coded agent named `echo-agent` whose

--- a/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
@@ -12,9 +12,7 @@ agent:
 run_limits:
   max_turns: 30
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.

--- a/tests/tasks/uipath-data-fabric/smoke_entities.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_entities.yaml
@@ -15,9 +15,7 @@ agent:
 run_limits:
   max_turns: 30
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.

--- a/tests/tasks/uipath-data-fabric/smoke_files.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_files.yaml
@@ -14,9 +14,7 @@ agent:
 run_limits:
   max_turns: 30
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.

--- a/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
@@ -14,9 +14,7 @@ agent:
 run_limits:
   max_turns: 30
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-data-fabric skill and follow its workflow.

--- a/tests/tasks/uipath-data-fabric/smoke_records.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_records.yaml
@@ -15,9 +15,7 @@ agent:
 run_limits:
   max_turns: 30
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.

--- a/tests/tasks/uipath-governance/access-policy/get_policy_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/get_policy_smoke.yaml
@@ -13,9 +13,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, get]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A tenant admin wants to inspect the full PolicyDefinition (selectors,

--- a/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
@@ -15,9 +15,7 @@ description: >
   correct commands with the correct flags.
 tags: [uipath-governance, smoke, access-policy, identity-lookup]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I am authoring a UiPath access policy and need three UUIDs for the

--- a/tests/tasks/uipath-governance/access-policy/list_policies_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/list_policies_smoke.yaml
@@ -13,9 +13,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, list]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A tenant admin wants to see every Active access policy for the tenant,

--- a/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
@@ -12,9 +12,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, deployed-policy]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Determine which AOps governance policy is currently in effect for the

--- a/tests/tasks/uipath-governance/aops-policy/deployment_configure_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployment_configure_smoke.yaml
@@ -18,9 +18,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, aops-policy, deployment, configure]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Apply AOps governance policy assignments to two subjects. Save every

--- a/tests/tasks/uipath-governance/aops-policy/deployment_discovery_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployment_discovery_smoke.yaml
@@ -12,9 +12,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, deployment, discovery]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A tenant admin wants to audit AOps governance deployment state. List

--- a/tests/tasks/uipath-governance/aops-policy/discover_catalog_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/discover_catalog_smoke.yaml
@@ -13,9 +13,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, catalog]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A tenant admin wants a catalog snapshot of AOps governance before

--- a/tests/tasks/uipath-governance/aops-policy/list_policies_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/list_policies_smoke.yaml
@@ -12,9 +12,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, list]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A tenant admin wants to see every AOps governance policy registered for

--- a/tests/tasks/uipath-governance/aops-policy/template_bootstrap_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/template_bootstrap_smoke.yaml
@@ -14,9 +14,7 @@ description: >
   the correct commands with the correct flags.
 tags: [uipath-governance, smoke, template, bootstrap]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I am starting a new AOps governance policy authoring session. Bootstrap

--- a/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_01_explicit.yaml
@@ -5,9 +5,7 @@ description: >
   direct HITL language and that the agent identifies the correct pattern.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I have a UiPath Flow. Add a Human-in-the-Loop node before the final data

--- a/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_02_approval_gate.yaml
@@ -5,9 +5,7 @@ description: >
   proactive business-language-based triggering.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Build a UiPath Flow that extracts expense report data and emails it to

--- a/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_03_escalation.yaml
@@ -5,9 +5,7 @@ description: >
   signals without explicit HITL mention.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   My UiPath Flow has an AI agent that classifies customer complaints.

--- a/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_04_writeback.yaml
@@ -5,9 +5,7 @@ description: >
   WITHOUT explicitly asking for HITL. Verifies proactive recommendation.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Build a UiPath Flow where an AI agent reads incomplete SAP purchase orders,

--- a/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_05_compliance.yaml
@@ -4,9 +4,7 @@ description: >
   regulatory language. Verifies the skill fires on audit/sign-off signals.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Automate GDPR data deletion requests. These are subject to regulatory

--- a/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
@@ -4,9 +4,7 @@ description: >
   human must fill in incomplete extracted data before the flow continues.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   OCR extracted invoice data from a PDF but several fields are blank —

--- a/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_07_neg_automated.yaml
@@ -5,9 +5,7 @@ description: >
   the skill does not produce false positives.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Our automated invoice pipeline handles all invoices from a single verified

--- a/tests/tasks/uipath-human-in-the-loop/smoke_08_neg_admin.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_08_neg_admin.yaml
@@ -5,9 +5,7 @@ description: >
   management, not automation authoring.
 tags: [uipath-human-in-the-loop, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   How do I reassign a pending Action Center task that has been sitting for

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -15,9 +15,7 @@ description: >
   command shape with the correct flags.
 tags: [uipath-ixp, smoke, lifecycle:execute]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Review the IXP model's predictions for document `doc-abc-123` on

--- a/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
+++ b/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
@@ -14,9 +14,7 @@ description: >
   command with the correct flags.
 tags: [uipath-ixp, smoke, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A document automation engineer wants to inspect the per-field F1 scores

--- a/tests/tasks/uipath-ixp/smoke/list_projects.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_projects.yaml
@@ -10,9 +10,7 @@ description: >
   command with the correct flags.
 tags: [uipath-ixp, smoke, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A document automation engineer wants to see every IXP project on the

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -18,9 +18,7 @@ agent:
 run_limits:
   max_turns: 30
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   You have three tasks against IXP project `my_invoices-f1afa9ef-ixp`.

--- a/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
@@ -13,9 +13,7 @@ description: >
   command in the documented heredoc shape.
 tags: [uipath-ixp, smoke, lifecycle:edit]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   The InvoiceNumber field on IXP project `my_invoices-f1afa9ef-ixp` is

--- a/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
@@ -12,9 +12,7 @@ run_limits:
   max_turns: 80
   turn_timeout: 900
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.

--- a/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
@@ -12,9 +12,7 @@ run_limits:
   max_turns: 60
   turn_timeout: 900
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.

--- a/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
@@ -16,8 +16,6 @@ run_limits:
   turn_timeout: 900
 
 sandbox:
-  driver: docker
-  python: {}
   template_sources:
     - type: template_dir
       path: ../../../../skills/uipath-maestro-bpmn

--- a/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
@@ -16,8 +16,6 @@ run_limits:
   turn_timeout: 900
 
 sandbox:
-  driver: docker
-  python: {}
   template_sources:
     - type: template_dir
       path: ../../../../skills/uipath-maestro-bpmn

--- a/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
@@ -13,9 +13,7 @@ run_limits:
   max_turns: 60
   turn_timeout: 900
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a UiPath Maestro BPMN Process Orchestration project named

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
@@ -14,8 +14,6 @@ run_limits:
   max_turns: 20
 
 sandbox:
-  driver: docker
-  python: {}
   template_sources:
     - type: template_dir
       path: ../../../../skills/uipath-maestro-bpmn

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
@@ -14,8 +14,6 @@ run_limits:
   turn_timeout: 900
 
 sandbox:
-  driver: docker
-  python: {}
   template_sources:
     - type: template_dir
       path: ../../../../skills/uipath-maestro-bpmn

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
@@ -4,9 +4,7 @@ description: >
   Without this, UI drops the filter silently on first open.
 tags: [uipath-maestro-flow, smoke, lifecycle:discover, connector-trigger, uipath-microsoft-outlook365, filter, ipe]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   You are authoring a UiPath Flow that is triggered by an Outlook email with subject containing "good day" and sent from

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -21,9 +21,7 @@ agent:
 run_limits:
   max_turns: 50
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Use the `uipath-maestro-flow` skill's evaluate capability to scaffold a

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -19,9 +19,7 @@ agent:
 run_limits:
   max_turns: 60
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Scaffold a UiPath Flow project called "SmokeEval" inside a solution of the

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -19,9 +19,7 @@ agent:
 run_limits:
   max_turns: 50
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the `uipath-maestro-flow` skill and read its

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -13,9 +13,7 @@ run_limits:
   max_turns: 80
   turn_timeout: 900
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Build a UiPath Flow named "InvoiceApproval" that:

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -13,9 +13,7 @@ run_limits:
   max_turns: 105
   turn_timeout: 600
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Build a UiPath Flow named "PurchaseApproval" with this structure:

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -13,9 +13,7 @@ run_limits:
   max_turns: 80
   turn_timeout: 600
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Build a UiPath Flow named "LeaveRequest" with this structure:

--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -5,9 +5,7 @@ description: >
   the skill teaches the correct solution-first workflow and CLI usage.
 tags: [uipath-maestro-flow, smoke, lifecycle:generate]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a new UiPath Flow project called "WeatherAlert" and make sure it

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -11,9 +11,7 @@ agent:
 run_limits:
   max_turns: 28
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I want to build a UiPath Flow that makes an HTTP request and processes the

--- a/tests/tasks/uipath-planner/smoke_skill_activation.yaml
+++ b/tests/tasks/uipath-planner/smoke_skill_activation.yaml
@@ -7,9 +7,7 @@ description: >
   loading the skill.
 tags: [uipath-planner, smoke, lifecycle:plan]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Help me plan a UiPath solution from scratch — a multi-step process that

--- a/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
@@ -6,10 +6,7 @@ description: >
   and resources.
 tags: [uipath-platform, smoke, integration-service, activities]
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -7,10 +7,7 @@ description: >
   (both require browser interaction).
 tags: [uipath-platform, smoke, integration-service, connections]
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
@@ -6,10 +6,7 @@ description: >
   fallback strategy when no native connector exists.
 tags: [uipath-platform, smoke, integration-service, connectors]
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
@@ -6,10 +6,7 @@ description: >
   for field-level detail, and always passing --connection-id.
 tags: [uipath-platform, smoke, integration-service, resources, describe]
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -6,10 +6,7 @@ description: >
   complete 6-step workflow and correct execute syntax with --body.
 tags: [uipath-platform, smoke, integration-service, resources, execute]
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
@@ -11,10 +11,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the consumables surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
@@ -10,10 +10,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the consumables surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -10,10 +10,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the consumables surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
@@ -10,10 +10,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the groups surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
@@ -11,10 +11,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the groups surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
@@ -13,10 +13,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the groups surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
@@ -6,10 +6,7 @@ description: >
   failure is expected in this offline environment.
 tags: [uipath-platform, smoke, licensing, tenants]
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
@@ -7,10 +7,7 @@ description: >
   CLI auth failure is expected; this validates command shape only.
 tags: [uipath-platform, smoke, licensing, tenants]
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-platform skill and follow its workflow.

--- a/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
@@ -13,10 +13,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the users surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
@@ -12,10 +12,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the users surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
@@ -13,10 +13,7 @@ skip: true
 # @uipath/platform-tool (v1.0.0 ships only `tenants licenses get|set`).
 # Re-enable when the CLI ships the users surface. See PLT-103133.
 
-sandbox:
-  driver: docker
-  python: {}
-  node: {}
+sandbox: {}
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-platform/orchestrator/folders_get_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_get_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   outcome — the goal is correct command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Fetch the metadata for the Orchestrator folder with key

--- a/tests/tasks/uipath-platform/orchestrator/folders_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List all Orchestrator folders available in the current UiPath tenant.

--- a/tests/tasks/uipath-platform/orchestrator/jobs_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/jobs_list_smoke.yaml
@@ -7,9 +7,7 @@ description: >
   state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the recently faulted jobs in the Orchestrator folder with key

--- a/tests/tasks/uipath-platform/orchestrator/packages_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/packages_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the Orchestrator packages available in the current UiPath tenant.

--- a/tests/tasks/uipath-platform/orchestrator/processes_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/processes_list_smoke.yaml
@@ -7,9 +7,7 @@ description: >
   tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the processes published in the `Finance/Accounting` folder of the

--- a/tests/tasks/uipath-platform/orchestrator/sessions_unattended_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/sessions_unattended_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the unattended robot sessions available in the current UiPath tenant.

--- a/tests/tasks/uipath-platform/resources/assets_get_smoke.yaml
+++ b/tests/tasks/uipath-platform/resources/assets_get_smoke.yaml
@@ -9,9 +9,7 @@ description: >
   the asset actually exists in the tenant.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Fetch the metadata for the Orchestrator asset named `ApiBaseUrl` in

--- a/tests/tasks/uipath-platform/resources/assets_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/resources/assets_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   goal is correct command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the assets defined in the `Shared` folder of the current UiPath

--- a/tests/tasks/uipath-platform/resources/buckets_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/resources/buckets_list_smoke.yaml
@@ -10,9 +10,7 @@ description: >
   In CI the plugin auth is provisioned, so this is environment-transparent.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the storage buckets defined in the `Finance` folder of the current

--- a/tests/tasks/uipath-platform/resources/libraries_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/resources/libraries_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the library packages available in the current UiPath tenant.

--- a/tests/tasks/uipath-platform/resources/queue_items_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/resources/queue_items_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   acceptable; the goal is correct command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the queue items in the Orchestrator folder with key

--- a/tests/tasks/uipath-platform/resources/queues_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/resources/queues_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   goal is correct command shape, not tenant state.
 tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the queues defined in the Orchestrator folder with key

--- a/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   Auth/404 errors are acceptable outcomes — the goal is correct command shape.
 tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I want to annotate a trace with positive feedback and then list all feedback

--- a/tests/tasks/uipath-platform/traces/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_fetch.yaml
@@ -6,9 +6,7 @@ description: >
   A 404 response (no traces for this job key) is an acceptable outcome.
 tags: [uipath-platform, smoke, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Use the `uipath-platform` skill.

--- a/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
+++ b/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
@@ -11,9 +11,7 @@ description: >
   correct command shape.
 tags: [uipath-platform, smoke, mode:build, lifecycle:setup]
 
-sandbox:
-  driver: tempdir
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I created a robot account in Identity Service called "InvoiceRunner"

--- a/tests/tasks/uipath-review/review_rpa_project.yaml
+++ b/tests/tasks/uipath-review/review_rpa_project.yaml
@@ -13,9 +13,7 @@ description: >
   agent to produce, not on CLI runtime success.
 tags: [uipath-review, smoke]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A small UiPath RPA project needs a quality review.

--- a/tests/tasks/uipath-rpa/coded_test_case.yaml
+++ b/tests/tasks/uipath-rpa/coded_test_case.yaml
@@ -12,9 +12,7 @@ run_limits:
   task_timeout: 400
   turn_timeout: 400
 
-sandbox:
-  driver: tempdir
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I have a UiPath coded test project called "LoginTests" that exercises a

--- a/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
@@ -30,9 +30,7 @@ run_limits:
   max_turns: 40
   turn_timeout: 900
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a new legacy UiPath RPA project called "HelloLegacy" with a Main.xaml

--- a/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
+++ b/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
@@ -18,9 +18,7 @@ run_limits:
   max_turns: 40
   turn_timeout: 900
 
-sandbox:
-  driver: tempdir
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   A legacy UiPath RPA project already exists in this directory. Wrap the

--- a/tests/tasks/uipath-rpa/template_aware_create.yaml
+++ b/tests/tasks/uipath-rpa/template_aware_create.yaml
@@ -7,9 +7,7 @@ description: >
   template-detection decision before `init`.
 tags: [uipath-rpa, smoke, lifecycle:generate]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I want to create a new UiPath REFramework project called "InvoiceREF"

--- a/tests/tasks/uipath-rpa/uia_google_search.yaml
+++ b/tests/tasks/uipath-rpa/uia_google_search.yaml
@@ -23,9 +23,8 @@ run_limits:
   max_turns: 80
   turn_timeout: 1200
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
+
 initial_prompt: |
   Build a standard UiPath RPA project named "GoogleSearch" (XAML
   workflow, VisualBasic expression language) under ./GoogleSearch

--- a/tests/tasks/uipath-solution/operate/deploy_list_smoke.yaml
+++ b/tests/tasks/uipath-solution/operate/deploy_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   command shape, not tenant state.
 tags: [uipath-solution, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the active solution deployments in the current UiPath tenant.

--- a/tests/tasks/uipath-solution/operate/new_smoke.yaml
+++ b/tests/tasks/uipath-solution/operate/new_smoke.yaml
@@ -7,9 +7,7 @@ description: >
   entirely in the sandbox tempdir — no tenant interaction.
 tags: [uipath-solution, smoke, mode:build, lifecycle:generate]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a new empty UiPath solution called "MySolution" in the current

--- a/tests/tasks/uipath-solution/operate/packages_list_smoke.yaml
+++ b/tests/tasks/uipath-solution/operate/packages_list_smoke.yaml
@@ -6,9 +6,7 @@ description: >
   command shape, not tenant state.
 tags: [uipath-solution, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   List the published solution packages available in the current UiPath tenant.

--- a/tests/tasks/uipath-solution/operate/project_list_smoke.yaml
+++ b/tests/tasks/uipath-solution/operate/project_list_smoke.yaml
@@ -5,9 +5,7 @@ description: >
   in the sandbox tempdir — no tenant interaction.
 tags: [uipath-solution, smoke, mode:build, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a new UiPath solution called "ProjectListDemo" and then show me the

--- a/tests/tasks/uipath-solution/operate/resource_list_smoke.yaml
+++ b/tests/tasks/uipath-solution/operate/resource_list_smoke.yaml
@@ -5,9 +5,7 @@ description: >
   entirely in the sandbox tempdir — no tenant interaction.
 tags: [uipath-solution, smoke, mode:build, lifecycle:discover]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Create a new UiPath solution called "ResourceListDemo" and then list the

--- a/tests/tasks/uipath-solution/smoke_file_reading.yaml
+++ b/tests/tasks/uipath-solution/smoke_file_reading.yaml
@@ -6,9 +6,7 @@ description: >
   file. No analysis, no SDD generation.
 tags: [uipath-solution, smoke, lifecycle:generate]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Step 1 — Write the following content to `pdd.md` using the Write tool.

--- a/tests/tasks/uipath-solution/smoke_skill_activation.yaml
+++ b/tests/tasks/uipath-solution/smoke_skill_activation.yaml
@@ -6,9 +6,7 @@ description: >
   SKILL.md and cannot be fabricated without loading the skill.
 tags: [uipath-solution, smoke, lifecycle:generate]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   I have a Process Design Document I want to turn into a UiPath solution

--- a/tests/tasks/uipath-tasks/smoke_assignment.yaml
+++ b/tests/tasks/uipath-tasks/smoke_assignment.yaml
@@ -8,9 +8,7 @@ description: >
   retry or login.
 tags: [uipath-tasks, smoke, assignment]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-tasks skill and follow its workflow.

--- a/tests/tasks/uipath-tasks/smoke_completion.yaml
+++ b/tests/tasks/uipath-tasks/smoke_completion.yaml
@@ -8,9 +8,7 @@ description: >
   carry --action and --data. Runs against fake IDs; auth errors expected.
 tags: [uipath-tasks, smoke, completion]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-tasks skill and follow its workflow.

--- a/tests/tasks/uipath-tasks/smoke_discovery.yaml
+++ b/tests/tasks/uipath-tasks/smoke_discovery.yaml
@@ -8,9 +8,7 @@ description: >
   is applied consistently. Runs against fake IDs — auth errors are expected.
 tags: [uipath-tasks, smoke, discovery]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-tasks skill and follow its workflow.

--- a/tests/tasks/uipath-tasks/smoke_negative_guards.yaml
+++ b/tests/tasks/uipath-tasks/smoke_negative_guards.yaml
@@ -9,9 +9,7 @@ description: >
   complete already-completed tasks) without a live tenant.
 tags: [uipath-tasks, smoke, negative]
 
-sandbox:
-  driver: docker
-  python: {}
+sandbox: {}
 
 initial_prompt: |
   Before starting, load the uipath-tasks skill and follow its workflow.

--- a/tests/tasks/uipath-test/auth_project_discovery.yaml
+++ b/tests/tasks/uipath-test/auth_project_discovery.yaml
@@ -9,8 +9,6 @@ description: >
 tags: [uipath-test, smoke, mode:operate, lifecycle:discover]
 
 sandbox:
-  driver: docker
-  python: {}
   node:
     env_packages:
       - "@uipath/test-manager-tool"

--- a/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
@@ -17,8 +17,6 @@ run_limits:
   max_turns: 30
 
 sandbox:
-  driver: docker
-  python: {}
   node:
     env_packages:
       - "@uipath/test-manager-tool"

--- a/tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml
@@ -22,9 +22,7 @@ run_limits:
   turn_timeout: 60
   max_turns: 1
 
-sandbox:
-  driver: tempdir
-  python: {}
+sandbox: {}
 
 # Run the verification script BEFORE the agent. fail_on_error: true (the
 # default) aborts the task with FinalStatus.ERROR if any mocked uip command


### PR DESCRIPTION
- Create default_smoke.yaml and default_smoke_rpa.yaml for non-RPA and RPA smoke tests
- Update smoke-skills.yml and smoke-rpa-skills.yml to use respective experiment configs
- Remove docker driver hardcoding from sandbox sections in 125+ smoke-tagged tasks
- Update detect job to trigger on new experiment files