### PR TITLE
test(experiments): mirror docker sandbox block from default.yaml into e2e.yaml

### DIFF
--- a/tests/experiments/e2e.yaml
+++ b/tests/experiments/e2e.yaml
@@ -7,6 +7,28 @@ defaults:
     task_timeout: 1200
     turn_timeout: 300
 
+  # Smoke-tagged tasks under tests/tasks/**/*.yaml use `driver: docker`
+  # (set per-task by skills#856). The daily runner's `--suite skills`
+  # invokes those tasks under this experiment, so the docker mounts +
+  # env passthrough must be configured here too — otherwise the
+  # in-container uip CLI has no auth (host's ~/.uipath isn't bound).
+  # Keep this block in sync with tests/experiments/default.yaml.
+  sandbox:
+    docker:
+      env_passthrough_extra:
+        - SKILLS_REPO_PATH
+        - BEDROCK_MODEL
+        - TASK_PARALLELISM
+        - UIPATH_CLI_ENABLE_ENV_AUTH
+        - UIPATH_CLI_AUTH_TOKEN
+        - UIPATH_CLI_ORGANIZATION_NAME
+        - UIPATH_CLI_ORGANIZATION_ID
+        - UIPATH_CLI_TENANT_NAME
+        - UIPATH_CLI_TENANT_ID
+        - TRACES_SMOKE_PROCESS_KEY
+      extra_mounts:
+        - ~/.uipath:/.uipath:rw
+
   agent:
     type: claude-code
     permission_mode: acceptEdits

--- a/tests/experiments/e2e.yaml
+++ b/tests/experiments/e2e.yaml
@@ -7,12 +7,6 @@ defaults:
     task_timeout: 1200
     turn_timeout: 300
 
-  # Smoke-tagged tasks under tests/tasks/**/*.yaml use `driver: docker`
-  # (set per-task by skills#856). The daily runner's `--suite skills`
-  # invokes those tasks under this experiment, so the docker mounts +
-  # env passthrough must be configured here too — otherwise the
-  # in-container uip CLI has no auth (host's ~/.uipath isn't bound).
-  # Keep this block in sync with tests/experiments/default.yaml.
   sandbox:
     docker:
       env_passthrough_extra:


### PR DESCRIPTION
## Why

The daily runner's `--suite skills` (in `coder_eval`) executes all 312 task files under `tests/tasks/**` against `e2e.yaml`. Of those, 115 smoke-tagged tasks were flipped to `driver: docker` in #856 — but #856 only added the matching `sandbox.docker.{env_passthrough_extra,extra_mounts}` block to `default.yaml`.

Without the same block in `e2e.yaml`, those 115 tasks spin containers with no `~/.uipath` bind-mount, so the in-container `uip` CLI is unauthenticated and every tenant-touching call fails.

## What

Mirror the `sandbox.docker:` block from `default.yaml` into `e2e.yaml`. No other changes — the 197 `driver: tempdir` tasks ignore this block and continue to run on the host sandbox.

Keep this in sync with `default.yaml` going forward; longer-term we should factor the shared block out (YAML anchors or a `_base.yaml`).

## What we tested

Ran a mixed batch of 19 tasks (9 docker + 10 tempdir, randomly sampled) against this `e2e.yaml` on the runner VM, max_parallel=20:

- **Docker tasks (9):** 8 SUCCESS, 1 flaky failure (`processes_list_smoke` — not a docker-path issue). Container init + agent + `post_run` + reap clean; env passthrough (Bedrock + `UIPATH_CLI_*` + `SKILLS_REPO_PATH`) works; `~/.uipath:/.uipath:rw` mount works; bridge network reaches Bedrock + Orchestrator + DocsAI.
- **Tempdir tasks (10):** all SUCCESS, and three that had failed in the 2026-05-19 baseline now pass.
- **Compared to baseline:** 0 net regressions for the shared subset.

Tempdir tasks bypass the docker block as expected (no `docker_runner` log prefix on their lines).