### PR TITLE
ci(smoke): skip pass-rate gate when 0 tasks match smoke filter

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -439,7 +439,10 @@ jobs:
           results = [json.loads(p.read_text(encoding='utf-8')) for p in tasks]
           passed = sum(1 for d in results if d.get('final_status') == 'SUCCESS')
           n = len(results)
-          rate = passed / n if n else 0.0
+          if n == 0:
+              print('No smoke-tagged tasks matched — skipping rate check')
+              sys.exit(0)
+          rate = passed / n
           for d in results:
               s = d.get('final_status')
               if s != 'SUCCESS':


### PR DESCRIPTION
## Summary
- Smoke pass-rate gate currently treats `0/0` as 0% and fails the required check when a changed skill has no `smoke`-tagged tasks (the case for `uipath-maestro-case` since 37e74121 disabled smoke "until login issue solved").
- Gate now exits 0 with a notice when no tasks match — the detect step decides *whether* to run smoke; the gate enforces quality only *if* tasks ran.

## Test plan
- [ ] Verify a PR touching a skill with no `smoke`-tagged tasks (e.g. `uipath-maestro-case`) passes the "Smoke Skill Tests" check
- [ ] Verify a PR touching a skill *with* `smoke` tasks still enforces the 95% threshold (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)