### PR TITLE
docs(bpmn): state script-task body rule explicitly

### DIFF
--- a/skills/uipath-maestro-bpmn/references/shared/bpmn-xml-contract.md
+++ b/skills/uipath-maestro-bpmn/references/shared/bpmn-xml-contract.md
@@ -139,13 +139,20 @@ before authoring a task wrapper.
 
 ### Script-task body rule
 
-A `<bpmn:script>` body on `bpmn:scriptTask` is only valid when the task also carries UiPath script metadata. `uip maestro bpmn validate` accepts the body when **at least one** of these extension elements is present inside `<bpmn:extensionElements>`:
+A `<bpmn:script>` body on `bpmn:scriptTask` is only valid when the task also
+carries UiPath script metadata. `uip maestro bpmn validate` accepts the body
+when **at least one** of these extension elements is present inside
+`<bpmn:extensionElements>`:
 
-- `<uipath:scriptVersion value="v3" />` (preferred for new tasks; `v2` is preserve-only on imports)
-- `<uipath:mapping>` containing `<uipath:type value="BPMN.ScriptTask" />`
-- `<uipath:mapping>` containing `<uipath:type value="BPMN.Variables" />`
+- `<uipath:scriptVersion value="v3" />` (preferred for new tasks; `v2` is
+  preserve-only on imports)
+- `<uipath:mapping>` containing `<uipath:type value="BPMN.ScriptTask" version="v1" />`
+- `<uipath:mapping>` containing `<uipath:type value="BPMN.Variables" version="v1" />`
 
-Without one of those, the validator rejects the body. If the task does not need to execute JavaScript, drop the `<bpmn:script>` and express the logic as a `BPMN.Variables` output mapping on a generic `bpmn:task`, or as a condition on a downstream gateway.
+Without one of those, the validator rejects the body. If the task does not
+need to execute JavaScript, drop the `<bpmn:script>` and express the logic as
+a `BPMN.Variables` output mapping on a generic `bpmn:task`, or as a condition
+on a downstream gateway.
 
 ## CLI-owned or CLI-enriched areas
 

--- a/skills/uipath-maestro-bpmn/references/shared/bpmn-xml-contract.md
+++ b/skills/uipath-maestro-bpmn/references/shared/bpmn-xml-contract.md
@@ -137,6 +137,16 @@ Keep resource identity fields synthetic or placeholder-based until CLI or user-p
 For copyable minimal XML shells, read [wrapper-shells.md](wrapper-shells.md)
 before authoring a task wrapper.
 
+### Script-task body rule
+
+A `<bpmn:script>` body on `bpmn:scriptTask` is only valid when the task also carries UiPath script metadata. `uip maestro bpmn validate` accepts the body when **at least one** of these extension elements is present inside `<bpmn:extensionElements>`:
+
+- `<uipath:scriptVersion value="v3" />` (preferred for new tasks; `v2` is preserve-only on imports)
+- `<uipath:mapping>` containing `<uipath:type value="BPMN.ScriptTask" />`
+- `<uipath:mapping>` containing `<uipath:type value="BPMN.Variables" />`
+
+Without one of those, the validator rejects the body. If the task does not need to execute JavaScript, drop the `<bpmn:script>` and express the logic as a `BPMN.Variables` output mapping on a generic `bpmn:task`, or as a condition on a downstream gateway.
+
 ## CLI-owned or CLI-enriched areas
 
 The CLI must generate, enrich, or validate these before upload, debug, publish, or deploy:

--- a/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
+++ b/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
@@ -469,6 +469,7 @@ return { result: "preserved" };
 
 Rules:
 
+- `<bpmn:script>` bodies on `bpmn:scriptTask` require either `<uipath:scriptVersion>` or a `<uipath:mapping>` containing `<uipath:type value="BPMN.ScriptTask" />` or `<uipath:type value="BPMN.Variables" />`. Without one of those extensions, `uip maestro bpmn validate` rejects the body.
 - `uipath:migrationVersion` is preserve-only. Numeric values such as `5`,
   `11`, and `11.5` carry import migration history; do not delete them.
 - `uipath:scriptVersion value="v2"` is preserve-only on imported scripts.

--- a/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
+++ b/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
@@ -469,7 +469,11 @@ return { result: "preserved" };
 
 Rules:
 
-- `<bpmn:script>` bodies on `bpmn:scriptTask` require either `<uipath:scriptVersion>` or a `<uipath:mapping>` containing `<uipath:type value="BPMN.ScriptTask" />` or `<uipath:type value="BPMN.Variables" />`. Without one of those extensions, `uip maestro bpmn validate` rejects the body.
+- `<bpmn:script>` bodies on `bpmn:scriptTask` require either
+  `<uipath:scriptVersion>` or a `<uipath:mapping>` containing
+  `<uipath:type value="BPMN.ScriptTask" version="v1" />` or
+  `<uipath:type value="BPMN.Variables" version="v1" />`. Without one of those
+  extensions, `uip maestro bpmn validate` rejects the body.
 - `uipath:migrationVersion` is preserve-only. Numeric values such as `5`,
   `11`, and `11.5` carry import migration history; do not delete them.
 - `uipath:scriptVersion value="v2"` is preserve-only on imported scripts.


### PR DESCRIPTION
## Summary

State the BPMN script-task body rule explicitly in the skill docs. A `<bpmn:script>` body on `bpmn:scriptTask` is only valid when the task carries UiPath script metadata — either `<uipath:scriptVersion>` or a `<uipath:mapping>` of type `BPMN.ScriptTask` / `BPMN.Variables`. The existing docs implied this through an example but did not call out the rule.

Two surgical doc edits:

- `skills/uipath-maestro-bpmn/references/shared/bpmn-xml-contract.md` — new `### Script-task body rule` subsection under "Non-Integration-Service task shells".
- `skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md` — one new bullet at the top of the rules list following the `Task_LegacyScript` example.

## Why

An LLM-authoring latency experiment ran the BPMN skill across 9 scenarios. Every BPMN agent (9/9) hit the script-task validator and spent 30-90 s working out the required extension shape from examples. Naming the rule directly turns a trial-and-error recovery into a single read.

Pairs with:
- UiPath/cli#2138 — validator now accepts the documented pattern (merged).
- UiPath/cli#2141 — rejection message names the required extensions (open).

## Test plan

- [ ] `markdownlint` / repo doc checks pass via CI (no changes to schemas, manifests, or fixtures).
- [ ] Manually re-render both files; confirm the new subsection / bullet appear at the intended positions and use the right heading levels.
- [ ] Spot-check: an agent reading `bpmn-xml-contract.md` without prior context can answer "when is `<bpmn:script>` valid?" from a single section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)