### PR TITLE
fix (test): Pin WikiPageviews daily route

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/test_wiki_pageviews_task_contract.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/test_wiki_pageviews_task_contract.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+TASK_YAML = Path(__file__).with_name("wiki_pageviews.yaml")
+
+
+def test_prompt_pins_wikimedia_daily_route_and_debug_check() -> None:
+    text = TASK_YAML.read_text()
+
+    assert "/daily/{date1}/{date2}" in text
+    assert "Do not omit the literal `/daily/` path segment" in text
+    assert "Run a debug check with article=UiPath, date1=20240101, date2=20240115" in text

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -26,6 +26,8 @@ initial_prompt: |
   once to fetch the daily view counts in the range, use a Transform node to
   filter the returned items down to days whose `views` exceed 500, then sum
   the `views` across those matching days and return the total as an integer.
+  Do not omit the literal `/daily/` path segment between `{article}` and
+  `{date1}`; without it Wikimedia returns HTTP 404 "invalid route".
   When the article does not exist and the HTTP call fails, wire the HTTP
   node's `error` output port to an End node that returns the literal string
   `Article not found` instead.
@@ -36,6 +38,7 @@ initial_prompt: |
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+  Run a debug check with article=UiPath, date1=20240101, date2=20240115 before finishing; if the success path returns 404, inspect the HTTP URL and restore the required `/daily/` segment.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Tighten the WikiPageviews task prompt around Wikimedia's required `/daily/` route segment.
- Require an agent-side debug check with the success-path inputs so a malformed URL is caught before the task finishes.
- Add a contract test for the route/debug prompt requirements.

## Root Cause
`skill-flow-wiki-pageviews` authored a valid Flow with a malformed Wikimedia pageviews URL missing `/daily/`. The success-path HTTP call then deterministically returned HTTP 404 `invalid route`, while the invalid-article error branch still passed.

## Validation
- `uvx pytest tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/test_wiki_pageviews_task_contract.py` -> 1 passed
- `uvx ruff check tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/test_wiki_pageviews_task_contract.py` -> passed
- Wikimedia route probe with `/daily/20240101/20240115` -> HTTP 200, sum over days >500 = 4130
- Wikimedia route probe without `/daily/` -> HTTP 404, `invalid route`

🤖 Generated with Claude Code
Co-Authored-By: Claude noreply@anthropic.com