### PR TITLE
docs(uipath-admin): tenants-create wizard + correct services body shape

### DIFF
--- a/skills/uipath-admin/SKILL.md
+++ b/skills/uipath-admin/SKILL.md
@@ -147,7 +147,7 @@ One row per common goal. Per-area workflows are in the reference files.
 | **Grant permission(s) to a principal** ("grant me X", "give alice Y, Z") | [grant-permissions.md](references/authorization/grant-permissions.md) — intersection-and-menu flow |
 | **Assign a role to a principal** | (1) Resolve principal per Rule 5. (2) `roles get <ROLE_ID>` → echo `ownerServiceName` + verify scope-path service segment matches (Rule 17). (3) `roles assignments create --role-id <ROLE_ID> --identity-id <ID> --identity-type <User\|Group\|Robot\|ExternalApplication> --output json` |
 | **See what a principal can do** | `uip admin authorization check-access <USER_GUID_OR_EMAIL> --scope <Tenant\|Folder> --output json` (Rule 15) |
-| **Create a tenant** | `organizations regions list` → `tenants create --name <N> --region <R>` → poll `organizations operation get <OP_ID>` (Rule 18) |
+| **Create a tenant** | [tenant-management.md](references/tenant-management.md) — region + default-services resolution, file-body shape, operation polling (Rule 18) |
 | **Add a tenant service** | `tenants services list-available --region <R>` → `tenants services add --tenant-id <TID> --service <SVC>` (verify post-state per Rule 22) |
 | **Enable IP allowlist enforcement** | `ip-restriction my-ip` → verify covered by `ip-ranges list` → `ip-restriction enforcement enable --confirm` (Rule 31) |
 | **Query audit events / export** | [audit-workflow-guide.md](references/audit-workflow-guide.md) — scope disambiguation + 4 investigation playbooks (who-did-X, login history, date-range dump, overview) |

--- a/skills/uipath-admin/references/tenant-management.md
+++ b/skills/uipath-admin/references/tenant-management.md
@@ -74,7 +74,7 @@ Surface to the user as **"Available service catalog for region `<REGION>`"**. Do
 
 If the user says "show services on this tenant" without specifying, run both `services list` and `services list-available --region <TENANT_REGION>` and present them in two clearly labeled sections.
 
-## Before Mutating a Tenant or Tenant Service — Name the Target
+## Mutation Echo Rules
 
 Before any tenant lifecycle or tenant-service mutation, echo the resolved target back so the user knows exactly which resource will change:
 
@@ -88,32 +88,82 @@ Resolve UUIDs to names — never leave a raw `tenantId` in the echo. `tenants ge
 
 ## Workflow: Create a Tenant
 
-1. Confirm available regions:
-   ```bash
-   uip admin organizations regions list --output json
-   ```
-2. **Validate the tenant name client-side.** OMS rejects display names with `-`, `_`, spaces, or special chars — must start with a letter, be 2–32 chars, alphanumeric only. Reject hyphenated names before sending.
-3. **Propose default services to provision.** Query the regional catalog, then filter to the default-provision set — services with `provisioningMode === "Implicit"` AND `isVisible === true` AND `isAlwaysProvision === false`. Services with `isAlwaysProvision === true` are auto-provisioned by the platform (don't list as a choice); `isVisible === false` are platform-internal (don't surface); `provisioningMode === "Explicit"` are optional opt-ins (offer separately on request).
-   ```bash
-   uip admin tenants services list-available --region "<REGION>" --output json \
-     --output-filter "Data[?provisioningMode=='Implicit' && isVisible==\`true\` && isAlwaysProvision==\`false\`].{id:id,name:name}"
-   ```
-   Render this list to the user; let them remove any they don't want before submitting. Build the `services{}` map in the create body from the confirmed set.
-4. Create from a file (recommended once a services list is involved):
-   ```bash
-   uip admin tenants create --file ./tenant.json --output json
-   ```
-   Where `./tenant.json` is a `CreateTenantRequestDto`:
-   ```json
-   {
-     "name": "<TENANT_NAME>",
-     "region": "<REGION>",
-     "environment": "<ENV>",
-     "services": { "orchestrator": true, "du": true, "actions": true, "automationhub": true, "processes": true, "taskmining": true }
-   }
-   ```
-   For the bare no-services case use inline: `uip admin tenants create --name "<NAME>" --region "<REGION>" --environment "<ENV>"` (the platform still auto-provisions every `isAlwaysProvision === true` service).
-5. Response includes both the new `id` and an `operationId`. `(poll)`
+Run as a **wizard** — never accept a single-shot "create tenant X" and submit. Collect each required field interactively, validate it before moving on, and echo a confirmation summary before calling the API. Skip a step only if the user has already supplied that exact value in their request.
+
+### Step 1 — Tenant name
+
+Ask the user for the display name, then validate **client-side** before doing anything else:
+
+- Alphanumeric only (no `-`, `_`, spaces, or special chars).
+- Must start with a letter.
+- 2–32 chars.
+
+If the name fails, push back and ask for a corrected one. Do not call the API to "see what happens".
+
+### Step 2 — Region
+
+Fetch the available regions for the org and present them as a numbered list:
+
+```bash
+uip admin organizations regions list --output json
+```
+
+Render a numbered Markdown list (`1. Europe`, `2. UnitedStates`, ...) and ask the user to reply with a digit. Do not assume a default region.
+
+### Step 3 — Environment (optional)
+
+Ask the user to pick an environment tag — numbered list of `Production`, `NonProduction`, `Development`, or "skip". If the user skips, omit the field from the body.
+
+### Step 4 — Services
+
+Fetch the region-specific catalog and apply the **default-provision filter** (`provisioningMode === "Implicit"` AND `isVisible === true` AND `isAlwaysProvision === false`):
+
+```bash
+uip admin tenants services list-available --region "<REGION>" --output json \
+  --output-filter "[?provisioningMode=='Implicit' && isVisible==\`true\` && isAlwaysProvision==\`false\`].name"
+```
+
+> Filter root is the `Data` array itself — start the expression with `[?...]`, NOT `Data[?...]`.
+
+Present the resulting service names as a numbered list. Ask the user to confirm the default set, remove unwanted entries, or add Explicit services on request. The catalog is region-aware — never hardcode the default set.
+
+Catalog metadata cheatsheet (for deciding what to surface):
+- `isAlwaysProvision === true` → platform-pinned, auto-provisioned, don't list as a choice.
+- `isVisible === false` → platform-internal, don't surface.
+- `provisioningMode === "Explicit"` → optional opt-in, offer only on request.
+
+### Step 5 — Confirm and submit
+
+Echo the resolved values per the [Mutation echo rules](#mutation-echo-rules) (organization, name, region, plus the resolved environment + services list) and wait for the user's go-ahead.
+
+Then write `./tenant.json` and submit. **Always use `--file`** — the inline path (`--name --region --environment`) does not populate the required `services` field and returns `HTTP 400: The Services field is required.`
+
+```bash
+uip admin tenants create --file ./tenant.json --output json
+```
+
+`./tenant.json` is a `CreateTenantRequestDto`. The `services` field is a **plain string array of catalog `name` values** (e.g. `taskmining`, `du`) — NOT a `{name: true}` map; that's the `services add` shape and OMS rejects it on create with `services.<name>.services: Cannot deserialize ... IList<string>`:
+
+```json
+{
+  "name": "<TENANT_NAME>",
+  "region": "<REGION>",
+  "environment": "<ENV>",
+  "services": ["<SERVICE_NAME>", "<SERVICE_NAME>", "..."]
+}
+```
+
+Platform-pinned services (`isAlwaysProvision === true`) are added automatically regardless of what's in `services[]`; don't list them.
+
+### Step 6 — Poll the operation
+
+Response includes both the new tenant `id` and an `operationId`. Poll the operation until it reaches a terminal status (`Succeeded` / `Failed` / `Cancelled`):
+
+```bash
+uip admin organizations operation get <OPERATION_ID> --output json
+```
+
+Same command applies to every async tenant verb — `create`, `update`, `delete`, `enable`, `disable`. Follow the [shared polling procedure](organization-management.md#polling-procedure-auto-poll-then-hand-off): auto-poll 3 × 5 s, then hand off to the user with a numbered menu if still in-progress. Never indefinite-loop.
 
 ## Workflow: Update a Tenant
 

--- a/skills/uipath-admin/references/tenants-commands.md
+++ b/skills/uipath-admin/references/tenants-commands.md
@@ -86,20 +86,32 @@ uip admin tenants get --output json
 
 Create a new tenant. **Async** — returns both the new `id` and an `operationId`.
 
+> **`--file` is required in practice.** The server marks the `services` field required on `CreateTenantRequestDto`, but the inline path (`--name --region --environment`) does not populate it — a pure inline call returns `HTTP 400: The Services field is required.` Use a JSON file with the full body for any real create.
+
 ```bash
-uip admin tenants create \
-  --name "<TENANT_NAME>" \
-  --region "<REGION>" \
-  --environment "<ENV>" \
-  --output json
+uip admin tenants create --file ./tenant.json --output json
 ```
 
-| Flag | Required | Description |
-|------|----------|-------------|
-| `--name <name>` | Yes (inline) | Tenant display name |
-| `--region <region>` | Yes (inline) | Provisioning region — resolve via `organizations regions list` |
-| `--environment <env>` | No | Environment tag (e.g., `Production`, `Development`) |
-| `--file <path>` | Alternative | Full `CreateTenantRequestDto` body (required for `services[]`, `customProperties`, `color`, `isDefaultTenant`) |
+`./tenant.json` (`CreateTenantRequestDto`):
+
+```json
+{
+  "name": "<TENANT_NAME>",
+  "region": "<REGION>",
+  "environment": "<ENV>",
+  "services": ["<SERVICE_NAME>", "<SERVICE_NAME>", "..."]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Tenant display name. Alphanumeric, 2–32 chars, starts with a letter. |
+| `region` | Yes | Provisioning region — resolve via `organizations regions list`. |
+| `environment` | No | Environment tag: `Production`, `NonProduction`, or `Development`. |
+| `services` | **Yes** | **Plain string array of service names** to provision (catalog `name` field, e.g. `taskmining`, `du`). NOT a `{name: true}` map — that's the `services add` shape; OMS rejects it on create. Resolve via the **Default-provision filter** in the `services list-available` section below — the catalog is region-aware, never hardcode names. Platform-pinned services (`isAlwaysProvision === true`) are added automatically regardless. |
+| `customProperties` | No | Free-form key/value bag carried with the tenant. |
+| `color` | No | UI color tag. |
+| `isDefaultTenant` | No | Mark as the org's default tenant. |
 
 **Output code:** `OmsTenantCreated`.
 
@@ -220,7 +232,14 @@ Each catalog entry carries provisioning metadata. The agent uses these fields to
 | `isAlwaysProvision` | `true` if the platform automatically provisions this service on every tenant | **Defaults set:** filter to `false`. `true` services are auto-provisioned by the platform — no need to include in the user's choice; they will be there regardless. |
 | `supportedRegions[]`, `defaultRegion`, `entitlement`, `serviceLicenseStatus` | informational | — |
 
-**Default-provision filter** (use for new-tenant proposals): `provisioningMode === "Implicit" && isVisible === true && isAlwaysProvision === false`. From the current US catalog this yields: Task Mining (`taskmining`), Document Understanding (`du`), Actions (`actions`), Processes (`processes`), Automation Hub (`automationhub`). Render those as the default services on `tenants create`; let the user remove unwanted entries and add Explicit services explicitly.
+**Default-provision filter** (use for new-tenant proposals): `provisioningMode === "Implicit" && isVisible === true && isAlwaysProvision === false`. Run the filter command below for the target region to get the current set — the catalog is region-aware, never hardcode names. Render the result as the default services on `tenants create`; let the user remove unwanted entries and add Explicit services explicitly. Pass the confirmed catalog `name` values as a string array in the create body's `services` field (NOT the `id` field).
+
+Filter command (note: filter root is the `Data` array itself — use `[?...]`, NOT `Data[?...]`):
+
+```bash
+uip admin tenants services list-available --region "<REGION>" --output json \
+  --output-filter "[?provisioningMode=='Implicit' && isVisible==\`true\` && isAlwaysProvision==\`false\`].name"
+```
 
 **Output code:** `OmsTenantServicesAvailable`.
 


### PR DESCRIPTION
## Summary

- Rewrite **Workflow: Create a Tenant** in `references/tenant-management.md` as a 6-step wizard (name → region → environment → services → confirm/submit → poll), with client-side name validation, numbered-list menus for region/env/services, and the explicit `organizations operation get` poll command for every async tenant verb (`create`/`update`/`delete`/`enable`/`disable`).
- Correct the `services` body shape across `tenant-management.md` and `tenants-commands.md`: it is a **plain string array of catalog `name` slugs** (e.g. `taskmining`, `du`), NOT the `{name: true}` map used by `services add` (which OMS rejects on create with a misleading deserialization 400). Also document that `--file` is required in practice — the inline path drops `services` and returns `HTTP 400: The Services field is required`.
- Tighten the default-provision filter to project `.name` directly (the only value the create body uses), correct the JMESPath root (`[?...]`, not `Data[?...]`), and stop hardcoding region-specific service lists — the catalog is region-aware and must be resolved at runtime.
- Collapse the SKILL.md "Create a tenant" row to a single reference link (mirrors the pattern used by `Grant permission(s)` and `Query audit events`), and rename the echo-rules H2 to `## Mutation Echo Rules` so the in-file anchor `#mutation-echo-rules` resolves.
- Expand the `tenants create` field table in `tenants-commands.md` to document `services`, `customProperties`, `color`, and `isDefaultTenant`.

## Test plan

- [ ] `hooks/validate-skill-descriptions.sh` passes (SKILL.md description unchanged in length but verify).
- [ ] All in-file anchors in `tenant-management.md` resolve (`#mutation-echo-rules`, `organization-management.md#polling-procedure-auto-poll-then-hand-off`).
- [ ] `uip admin tenants services list-available --region "<R>" --output-filter "[?provisioningMode=='Implicit' && isVisible==\`true\` && isAlwaysProvision==\`false\`].name"` returns a flat array of service `name` slugs against a real org.
- [ ] `uip admin tenants create --file ./tenant.json` succeeds with a body of shape `{name, region, environment, services: ["<name>", ...]}` and returns an `operationId` that `organizations operation get` can poll to `Succeeded`.
- [ ] Manual: ask an agent to "create a tenant" in this skill and confirm it drives the user through the 6 wizard steps rather than single-shotting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)