### PR TITLE
docs(uipath-rpa): cut redundant build calls + add Studio pre-warm

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -120,6 +120,16 @@ When the request is "automate this dialog/form" or "build a UI test from these m
 
 Skip this path when the task has no UI surface (data transforms, IS connector calls, headless file/email automation).
 
+## Session Pre-warm
+
+First heavy `uip rpa` call pays a ~22s Studio host cold-start (shared across `validate`/`build`/`run`/`activities get-default-xaml`/`analyzer-rules list`). When more than one is expected this session, background a cheap warm-up at session start so the tax hides behind planning:
+
+```bash
+uip rpa activities find --query log --output json > /dev/null 2>&1 &
+```
+
+**Skip** when 0 or 1 heavy `uip rpa` calls are expected (read-only Q&A, single-file inspection) — the warm-up doesn't reclaim its cost.
+
 ## Critical Rules
 
 ### Common Rules (Both Modes)
@@ -134,14 +144,13 @@ Skip this path when the task has no UI surface (data transforms, IS connector ca
    - Built-in `--template-id` keywords map without a search: `library` → `LibraryProcessTemplate`, `test automation` / `test project` → `TestAutomationProjectTemplate`, otherwise `BlankTemplate`. When `--template-package-id` is set, `--template-id` is ignored. Full decision flow: [environment-setup.md § Template selection](references/environment-setup.md#template-selection).
 3. **Phase-gated validation: analyzer rules run at AUTHORING-phase start, not session start.** Three-phase validation:
    - **Authoring-phase start** (immediately before creating or editing any workflow file — `.cs` with `[Workflow]`/`[TestCase]`, or `.xaml`): `uip rpa analyzer-rules list --project-dir "<PROJECT_DIR>" --output json` to list the enabled Workflow Analyzer rules. Apply every `error` and `warning` rule during authoring so generated code passes `analyze` and `build` on the first attempt. Run once at this point; re-run only when project dependencies change. **DO NOT run at session start** — the call can take a minute or more (use `--scope <Activity|Workflow|Coded Workflow|Project>` to narrow if it times out, see [cli-reference.md § analyzer-rules list](references/cli-reference.md)). For capture-first tasks (target capture from manual test steps, dialog automation), this prerequisite is deferred until capture is complete — see § Capture-First Fast Path below.
-   - **Per-file** (after every create or edit): run **both** validators in sequence — they catch disjoint error classes, neither alone is sufficient.
-     1. `uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json` until 0 errors. Catches: structural XAML, missing references, analyzer rules, schema violations.
-     2. Then `uip rpa build "<PROJECT_DIR>" --output json` until clean. Catches what `validate` misses: **unknown member names** (`NGetText.Value` when the property is `Text`), **invalid enum values** (`Operator="StartsWith"` when the enum has no such member), **member resolution / CacheMetadata failures**, attribute-form C# expression JIT failures. `validate` returns "no diagnostics found" for these; `build` reports them at compile time.
-     3. Cap the combined loop at 5 fix attempts. Fix one thing per iteration; re-run both validators.
-   - **Project-level end-goal** (before reporting done): the per-file step's project-level `build` already establishes compilability. A successful `uip rpa run` smoke test covers this too. Skip the standalone end-goal `build` only if the per-file `build` already passed clean on the project's current state.
+   - **Per-file** (after every create or edit): `uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json` until 0 errors. Catches structural XAML, missing references, analyzer rules, schema violations. Fix one thing per iteration.
+   - **Project-level build** (after per-file `validate` is clean across all files in the edit session, and before declaring done): `uip rpa build "<PROJECT_DIR>" --output json` until clean. Catches what `validate` misses (unknown members, invalid enums, CacheMetadata / member resolution, attribute-form C# JIT) — full list at [validation-guide.md § Errors `build` catches that `validate` misses](references/validation-guide.md#errors-build-catches-that-validate-misses). If `build` errors, identify the offending file from the output and re-run `validate --file-path` on it.
+   - **5-attempt cap per loop** — 5 attempts for each file's per-file `validate` loop; a separate 5 attempts for the project-level `build` loop. Fix one root cause per iteration.
+   - **Smoke-test shortcut:** A successful `uip rpa run` substitutes for the standalone end-of-session `build` — `run` compiles internally. Prefer `run --skip-build` when `build` has just passed; see [validation-guide.md § Smoke Test](references/validation-guide.md#smoke-test).
 
    See [references/validation-guide.md](references/validation-guide.md).
-4. **ALWAYS validate files as you go AND verify the project builds before declaring done.** After every create or edit: per-file `validate` to clean **and** project-level `build` to clean — both, in that order. `validate` clean alone is not "validated"; it cannot see member or enum errors. See [references/validation-guide.md](references/validation-guide.md).
+4. **ALWAYS validate files as you go AND verify the project builds before declaring done.** After every create or edit: per-file `validate` to clean. Project-level `build` runs once at the end of the edit session (or at any compile-verification gate) — not after every Edit, because `build` is project-scoped and rebuilds the entire project regardless of which file changed. `validate` clean alone is not "validated"; it cannot see member or enum errors — the project-level `build` is mandatory before declaring done. See [references/validation-guide.md](references/validation-guide.md).
 5. **Prefer UiPath built-in activities** for Orchestrator integration, UI automation, and document handling. Prefer plain .NET / third-party packages for pure data transforms, HTTP calls, parsing.
 6. **ALWAYS ensure required package dependencies are in `project.json`** before using their activities or services.
 6a. **Pre-edit verification gate.** Two authoring actions are hard to roll back once `build` fails — verify before serialization, not after.

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -32,22 +32,30 @@ When an error occurs, identify the root cause, fix **only** that one thing, and 
 
 ## Validation Iteration Loop
 
-After every file create or edit, validate with **both** `validate` and `build`. They catch disjoint error classes — neither alone is sufficient. Run them in sequence on every iteration; do not stop at "`validate` is clean".
+Phase 1 — per-file `validate` after every edit. Phase 2 — one project-level `build` per edit session.
 
 ```
-REPEAT:
-  1. uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json
-  2. IF validate has errors -> fix one thing, GOTO 1
-  3. uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
-  4. IF build has errors -> fix one thing, GOTO 1
-  5. EXIT to Smoke Test
+PHASE 1 — validate-clean (per-file):
+  FOR each file created or edited in this session:
+    REPEAT:
+      1. uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json
+      2. IF validate has errors -> fix one root cause, GOTO 1
+      3. EXIT inner loop when validate is clean
+
+PHASE 2 — build-clean (per-project, once per edit session):
+  REPEAT:
+    1. uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
+    2. IF build has errors -> identify offending file from build output
+       a. uip rpa validate --file-path "<OFFENDER>" --project-dir "<PROJECT_DIR>" --output json   # cheap targeted re-check
+       b. fix one root cause, GOTO 1
+    3. EXIT to Smoke Test
 ```
 
-**Why both.** `validate` is static analysis: it catches structural XAML, missing references, analyzer rules, and schema violations. `build` is the compiler: it catches **unknown member names** (e.g. `NGetText.Value` when the property is `Text`), **invalid enum values** (e.g. `Operator="StartsWith"` when the enum has no such member), **member resolution / CacheMetadata failures**, and attribute-form C# expression JIT failures. `validate` returns "no diagnostics found" for these classes; `build` flags them at compile time. Trusting only `validate` ships broken workflows.
+**Why both phases.** `validate` is static analysis: catches structural XAML, missing references, analyzer rules, schema violations. `build` is the compiler: catches **unknown member names** (e.g. `NGetText.Value` when the property is `Text`), **invalid enum values** (e.g. `Operator="StartsWith"` when the enum has no such member), **member resolution / CacheMetadata failures**, and attribute-form C# expression JIT failures. `validate` returns "no diagnostics found" for these; `build` flags them at compile time. Per-file `validate` plus one end-of-session `build` covers both error classes — trusting only `validate` ships broken workflows.
 
-**Target the specific file:** Use `--file-path` on `validate` to validate only the file you changed -- faster than validating the whole project. `build` is project-scoped (no `--file-path`); when it errors, identify the offending file from the build output and re-run `validate --file-path` on that file as part of the fix loop.
+**Target the specific file:** `validate --file-path` validates only the file you changed (faster than whole-project). `build` is project-scoped (no `--file-path`); when it errors, the output names the offending file — re-run `validate --file-path` on it as part of Phase 2's fix loop.
 
-**Cap at 5 fix attempts** across the combined `validate` + `build` loop. After 5 failed iterations, present the remaining errors to the user. They may require domain knowledge or environment-specific fixes.
+**5-attempt cap per loop** — 5 attempts for each file's Phase 1 `validate` loop; a separate 5 attempts for the Phase 2 `build` loop. After a loop exhausts its budget, present the remaining errors to the user. They may require domain knowledge or environment-specific fixes.
 
 ### Rules
 
@@ -61,13 +69,13 @@ See [cli-reference.md](cli-reference.md) for full `validate` and `run` command d
 
 ## Project Build Verification (Required Before Returning a Project)
 
-Every project returned to the user must compile. The per-file iteration loop above already includes `build` after `validate` is clean — if that loop completed cleanly on the project's current state, this gate is already satisfied. Otherwise, run:
+Every project returned to the user must compile. Phase 2 of the iteration loop above is this gate — when Phase 2 exits clean, the gate is satisfied. The standalone command below also satisfies it (for example, when re-verifying after a small fix outside an iteration loop):
 
 ```bash
 uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
 ```
 
-`validate` is static analysis and misses compile-time failures: unknown member names, invalid enum values, member resolution / CacheMetadata failures, and JIT failures like `JIT compilation is disabled for non-Legacy projects` — see [xaml/csharp-expression-pitfalls.md](xaml/csharp-expression-pitfalls.md). If `build` fails, apply the same fix loop as above (fix one thing, re-run, cap at 5). A successful `run` smoke test substitutes for `build` — `run` compiles internally.
+`validate` is static analysis and misses compile-time failures: unknown member names, invalid enum values, member resolution / CacheMetadata failures, and JIT failures like `JIT compilation is disabled for non-Legacy projects` — see [xaml/csharp-expression-pitfalls.md](xaml/csharp-expression-pitfalls.md). If `build` fails, apply the Phase 2 fix loop (fix one root cause, re-run, cap at 5 attempts). A successful `run` smoke test substitutes for `build` — `run` compiles internally. Prefer the `run --skip-build` form when `build` has just passed (see Smoke Test below).
 
 ### Errors `build` catches that `validate` misses
 
@@ -84,16 +92,18 @@ When you see "no diagnostics found" from `validate`, you have not validated the 
 
 `validate` (static analysis) and `run` (runtime compilation) use different validation paths. Some errors -- such as invalid enum values on activity properties -- pass static validation but fail at runtime. Always treat the smoke test as a critical validation step, not just an optional extra.
 
-After reaching 0 validation errors, run the workflow to catch runtime errors (wrong credentials, missing files, logic bugs) that static validation cannot detect:
+After reaching 0 validation errors AND a clean project-level build (Phase 2), run the workflow to catch runtime errors (wrong credentials, missing files, logic bugs) that static validation cannot detect. Use `--skip-build` because the project has just been built clean — default `run` re-validates and re-builds internally, repeating ~10s of compilation:
 
 ```bash
-# Run with default arguments:
-uip rpa run --file-path "<FILE>" --output json
+# Run with default arguments (post-build, skip the redundant rebuild):
+uip rpa run --file-path "<FILE>" --skip-build --output json
 # Run with input arguments:
-uip rpa run --file-path "<FILE>" --input-arguments '{"key": "value"}' --output json
+uip rpa run --file-path "<FILE>" --skip-build --input-arguments '{"key": "value"}' --output json
 # Run with verbose logging for debugging:
-uip rpa run --file-path "<FILE>" --log-level Verbose --output json
+uip rpa run --file-path "<FILE>" --skip-build --log-level Verbose --output json
 ```
+
+Use bare `run` (without `--skip-build`) whenever the build artifact may be stale: **(a)** no recent project-level `build` has been performed, OR **(b)** any file has been edited between the last successful `build` and this `run`. `--skip-build` executes the existing compiled artifact, so any post-build edit is silently ignored until a fresh `build` runs.
 
 **When to run:**
 1. Workflow has no compilation errors but you want to verify runtime behavior


### PR DESCRIPTION
## Summary

- **Defer project-level `build` from per-Edit to once-per-edit-session.** Per-file `validate` cadence unchanged. `build` is project-scoped, so N sequential edits used to trigger N full-project rebuilds — now a single end-of-session build. Saves ~55s on a 5-workflow project, ~475s on a 20-workflow project.
- **Restructure the validation iteration loop into two phases.** Phase 1 loops `validate` to clean per-file; Phase 2 loops `build` to clean per-project. Same fix-one-thing discipline, same 5-attempt cap — only the loop topology changes.
- **Smoke-test `run` uses `--skip-build` after a clean build.** Default `run` re-validates and re-builds internally (~10s of duplicate compilation per run). The `--skip-build` flag short-circuits that work when the project has just been built clean.
- **New `## Session Pre-warm` mini-section.** Background a cheap `uip rpa activities find` call at session start to hide Studio's ~22s host cold-start tax behind planning work. Output redirected to `/dev/null` so the warm-up doesn't pollute the foreground stream.

Improvement #4 from the source research (a curated common-activity property card) is **intentionally not adopted** — it conflicts with Rule 21a's explicit non-exemption for `LogMessage` / `Delay` / `GetText`.

Expected wall-clock saving on a 20-workflow project: ~735s (~85%) of CLI cost.

## Test plan

- [x] `bash hooks/validate-skill-descriptions.sh` passes (exit 0) — frontmatter intact
- [ ] Visual diff confirms heading hierarchy preserved in both files (no skipped levels)
- [ ] All internal links resolve (`#smoke-test` anchor, `references/validation-guide.md`, etc.)
- [ ] Rule numbering preserved (Critical Rules still 1–24 with sub-rules 6a, 7a, 7b, 8a, 21a)
- [ ] Manual: drive a 2-workflow create flow through the updated skill and confirm the agent (a) backgrounds the pre-warm call, (b) does not invoke `build` after every Edit, (c) reaches a single end-of-session `build`, (d) passes `--skip-build` to the smoke `run`

🤖 Generated with [Claude Code](https://claude.com/claude-code)