### PR TITLE
fix(ci): enable globstar so nested smoke tasks are discovered

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -282,6 +282,7 @@ jobs:
         working-directory: tests
         id: smoke
         run: |
+          shopt -s globstar nullglob
           echo "Running: coder-eval run ${{ needs.detect.outputs.task_globs }} --tags smoke -j $TASK_PARALLELISM"
           coder-eval run ${{ needs.detect.outputs.task_globs }} \
             -e experiments/smoke.yaml \


### PR DESCRIPTION
## Summary

- Add `shopt -s globstar` to the `Run smoke tests` step in `smoke-skills.yml`

## Root cause

Without `globstar`, bash treats `**` as `*`. The detect job outputs `tasks/uipath-agents/**/*.yaml` as the glob pattern, but when the `e2e` job runs it without globstar enabled, the shell only expands one level — matching files 2 levels deep (e.g. `lowcode/init_validate.yaml`) and silently skipping anything 3 levels deep (e.g. `lowcode/schema_update/schema_update.yaml`).

Two lowcode smoke tasks — `schema_update` and `edit_roundtrip` — have never run in CI.

This also unblocks PR #902 (`test/organize-coded-agent-tests`), which moves coded tasks into a `coded/` subdirectory — without this fix, that PR would break all coded smoke test coverage.

## Test plan

- [x] CI smoke run picks up `schema_update`, `edit_roundtrip`, and all coded smoke tasks (not just the flat `init_validate.yaml` and `bindings_sync.yaml`)
<img width="1535" height="553" alt="image" src="https://github.com/user-attachments/assets/3471cc20-1e48-40bd-9d68-a384572433f9" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)