### PR TITLE
test(uipath-agents): fix inline-agent node-add drift in lowcode tests

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
@@ -29,7 +29,7 @@ initial_prompt: |
   Create a UiPath solution "ProcurementSol" containing a single
   low-code agent "ProcurementAgent". The agent accepts a required
   `productId` (number) and returns a boolean `status`. It must
-  determine the status by delegating to a Maestro / agentic process
+  determine the status by delegating to an Agentic process
   named "ProcurementProcess" that is already deployed in the
   tenant — not by reasoning about the answer itself.
 

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
@@ -63,14 +63,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -90,12 +82,6 @@ success_criteria:
     description: "Flow file was created"
     path: "DocsFlowSol/DocsFlow/DocsFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "DocsFlowSol/DocsFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -63,14 +63,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -90,12 +82,6 @@ success_criteria:
     description: "Flow file was created"
     path: "FraudFlowSol/FraudFlow/FraudFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "FraudFlowSol/FraudFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -26,9 +26,9 @@ initial_prompt: |
   Create a UiPath solution "ProcurementFlowSol" containing a flow
   project "ProcurementFlow" with an inline low-code agent. The agent
   accepts a required `productId` (number) and returns a boolean
-  `status`. It must determine the status by delegating to a Maestro /
-  agentic process named "ProcurementProcess" that is already deployed
-  in the tenant — not by reasoning about the answer itself.
+  `status`. It must determine the status by delegating to an Agentic
+  process named "ProcurementProcess" that is already deployed in the
+  tenant — not by reasoning about the answer itself.
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/check_inline_is_connector_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/check_inline_is_connector_tool.py
@@ -30,7 +30,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.inline_wiring import find_inline_resource  # noqa: E402
 
 INLINE_AGENT_NODE_TYPE = "uipath.agent.autonomous"

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -80,14 +80,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node (expected: uipath.agent.resource.tool.connector)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent refreshed solution resources"
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+resource\s+refresh'
@@ -115,12 +107,6 @@ success_criteria:
     description: "Flow file was created"
     path: "ResearchFlowSol/ResearchFlow/ResearchFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "ResearchFlowSol/ResearchFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -62,14 +62,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -89,12 +81,6 @@ success_criteria:
     description: "Flow file was created"
     path: "DevToolsFlowSol/DevToolsFlow/DevToolsFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "DevToolsFlowSol/DevToolsFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -62,14 +62,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -89,12 +81,6 @@ success_criteria:
     description: "Flow file was created"
     path: "OrchestratorFlowSol/OrchestratorFlow/OrchestratorFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "OrchestratorFlowSol/OrchestratorFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -62,14 +62,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -89,12 +81,6 @@ success_criteria:
     description: "Flow file was created"
     path: "ShippingFlowSol/ShippingFlow/ShippingFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "ShippingFlowSol/ShippingFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
@@ -62,14 +62,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -89,12 +81,6 @@ success_criteria:
     description: "Flow file was created"
     path: "ReviewFlowSol/ReviewFlow/ReviewFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "ReviewFlowSol/ReviewFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -25,8 +25,8 @@ initial_prompt: |
   Create a UiPath solution "OnboardingFlowSol" containing a flow
   project "OnboardingFlow". The flow should use an inline low-code
   agent that calls an Agentic process called "EmployeeOnboarding" living
-  inside this same solution as a separate project. Wire the Maestro
-  flow as a tool on the inline agent.
+  inside this same solution as a separate project. Wire the Agentic
+  process as a tool on the inline agent.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -24,7 +24,7 @@ sandbox:
 initial_prompt: |
   Create a UiPath solution "OnboardingFlowSol" containing a flow
   project "OnboardingFlow". The flow should use an inline low-code
-  agent that calls a Maestro flow called "EmployeeOnboarding" living
+  agent that calls an Agentic process called "EmployeeOnboarding" living
   inside this same solution as a separate project. Wire the Maestro
   flow as a tool on the inline agent.
 
@@ -62,14 +62,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -89,12 +81,6 @@ success_criteria:
     description: "Flow file was created"
     path: "OnboardingFlowSol/OnboardingFlow/OnboardingFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "OnboardingFlowSol/OnboardingFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -63,14 +63,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a flow node"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+node\s+add'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent validated the inline agent with --inline-in-flow"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
@@ -90,12 +82,6 @@ success_criteria:
     description: "Flow file was created"
     path: "PayrollFlowSol/PayrollFlow/PayrollFlow.flow"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "Flow project descriptor was created"
-    path: "PayrollFlowSol/PayrollFlow/project.uiproj"
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
@@ -21,7 +21,7 @@ sandbox:
 
 initial_prompt: |
   Create a UiPath solution "OnboardingSol" containing a low-code agent
-  "OnboardingAgent". The agent should call a Maestro flow called
+  "OnboardingAgent". The agent should call an Agentic process called
   "EmployeeOnboarding" that lives INSIDE this same solution as a
   separate project. Expose it to the agent as a tool resource.
 


### PR DESCRIPTION
## Summary
- Drop `uip flow node add` `command_executed` rule from 9 lowcode inline-agent tasks — the command is deprecated in favor of manual flow-file authoring, so asserting the agent invoked it no longer reflects expected behavior.
- Drop the `<Sol>/<Flow>/project.uiproj` `file_exists` rule from the same tasks so each scores the inline-agent wiring rather than flow-project scaffolding.
- Replace stale "Maestro flow" / "Maestro / agentic process" wording with "Agentic process" in the four `*_maestro_tool` prompts.
- Fix `inline_is_connector_tool/check_inline_is_connector_tool.py` `sys.path` so `_shared.inline_wiring` resolves from `tests/tasks/uipath-agents/lowcode/`.

## Test plan
- [ ] CI smoke runs on the changed lowcode tasks pass against the updated success criteria
- [ ] `python3 tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/check_inline_is_connector_tool.py` imports `_shared.inline_wiring` without `ModuleNotFoundError`
- [ ] Spot-check one `*_maestro_tool` task end-to-end to confirm the "Agentic process" prompt still drives the expected resource wiring

🤖 Generated with [Claude Code](https://claude.com/claude-code)