### PR TITLE
fix(uipath-maestro-flow): fix inline agent prompt wiring contract

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
@@ -71,8 +71,8 @@ Generate a unique UUID (e.g., `5029c8a8-799b-426a-803f-c4ec75255439`). Create a 
 
 Same schema as a standalone agent (see [../../agent-definition.md](../../agent-definition.md)), with these conventions:
 - `projectId` matches the folder name UUID
-- `inputSchema.properties` starts empty, but **must declare one slot per `{{input.<id>}}` token used in `messages[].content`**. Each slot's `<id>` and `type` must match the corresponding `agentInputVariables[]` entry on the flow node. See the `uipath-maestro-flow` skill's [inline-agent prompt-wiring guide](../../../../../uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md#wiring-flow-variables-into-agent-prompts) for the full four-place contract.
-- `messages` have empty `content` and `contentTokens` initially (edit agent.json to set prompts with `type: "simpleText"` and `rawString`)
+- `inputSchema.properties` stays empty `{}` for prompt-only flow-data references. Prompts reference upstream flow nodes directly via `{{ $vars.<flowNodeId>.output[.<field>] }}` in `messages[].content`, mirrored in `contentTokens[]` as `{ "type": "variable", "rawString": " $vars.<flowNodeId>.output[.<field>] " }` (leading and trailing space inside `rawString`). See the `uipath-maestro-flow` skill's [inline-agent prompt-wiring guide](../../../../../uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md#wiring-flow-variables-into-agent-prompts).
+- `messages` have empty `content` and `contentTokens` initially. Set prompts in `messages[].content`, then build `messages[].contentTokens[]` as a parallel list: one `{ "type": "simpleText", "rawString": "..." }` per literal text segment, one `{ "type": "variable", "rawString": " $vars.<flowNodeId>.output[.<field>] " }` per `{{ ... }}` reference.
 - `guardrails: []` at root level — can be populated with guardrail objects. See [../guardrails/guardrails.md](../guardrails/guardrails.md)
 - No `metadata.targetRuntime` field
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
@@ -46,18 +46,16 @@ For detailed agent configuration (contentTokens format, model settings, resource
 
 ## Wiring Flow Variables into Agent Prompts
 
-The agent runtime cannot read `$vars.*` directly. Every flow value the prompt needs (trigger output, upstream node output, flow variable) must travel through the **agent input bridge**, and every prompt token must use the runtime form `{{input.<id>}}`. Bare `{{emailSubject}}` (no `input.` prefix) and raw `{{$vars.X}}` inside `agent.json` resolve to literal text — the prompt looks plausible but the agent receives no data.
-
-The bridge is one binding plus three matching declarations. Author all four whenever the prompt references a flow value:
+Inline-agent prompts reference upstream flow nodes **directly** via `{{ $vars.<flowNodeId>.output[.<field>] }}` tokens in `agent.json messages[].content`. No agent-side input bridge, no `inputSchema` slot, no `agentInputVariables[]` binding.
 
 | Where | What | Example |
 | --- | --- | --- |
-| Flow node `inputs.agentInputVariables[]` | Binding from `$vars` source to a flat slot id | `{ "id": "emailSubject", "type": "string", "binding": "=js:$vars.emailReceived1.output.subject" }` |
-| `agent.json` `inputSchema.properties.<id>` | Slot declaration matching the binding `id` and `type` | `"emailSubject": { "type": "string" }` |
-| `agent.json` `messages[].content` | Runtime token referencing the slot | `"Email subject: {{input.emailSubject}}"` |
-| `agent.json` `messages[].contentTokens[]` | Mirror of `content` with one `{ "type": "variable", "rawString": "input.<id>" }` per `{{input.X}}` token | `{ "type": "variable", "rawString": "input.emailSubject" }` |
+| `agent.json` `messages[].content` | Token referencing an upstream flow node's output | `"Email subject: {{ $vars.emailReceived1.output.subject }}"` |
+| `agent.json` `messages[].contentTokens[]` | One `{ "type": "variable", "rawString": " $vars.<flowNodeId>.output[.<field>] " }` per `{{ ... }}` token in `content`. **`rawString` must include leading and trailing space** to match the spaced-brace form. | `{ "type": "variable", "rawString": " $vars.emailReceived1.output.subject " }` |
+| Flow node `inputs.agentInputVariables` | `[]` for prompt-only flow-data references. | `"agentInputVariables": []` |
+| `agent.json` `inputSchema.properties` | `{}` for prompt-only flow-data references. | `"inputSchema": { "type": "object", "properties": {} }` |
 
-The `id` is a flat identifier you choose (alphanumeric + `_`, no dots). Use it consistently in all four places. The binding `=js:$vars.<sourceNodeId>.output.<field>` follows the standard `=js:` rule — see [../../../../shared/node-output-wiring.md](../../../../shared/node-output-wiring.md) for the full expression contract.
+`<flowNodeId>` must exactly match a node `id` in the `.flow` file, with an edge path reaching the inline-agent node. See [../../../../shared/node-output-wiring.md](../../../../shared/node-output-wiring.md) for the full expression contract.
 
 ### Worked example — wire an email-trigger payload into the agent prompt
 
@@ -71,11 +69,7 @@ Flow node (excerpt):
     "systemPrompt": "Triage the inbound email.",
     "userPrompt": "Process the inbound email payload.",
     "source": "<projectId-uuid>",
-    "agentInputVariables": [
-      { "id": "emailSubject", "type": "string", "binding": "=js:$vars.emailReceived1.output.subject" },
-      { "id": "emailFrom",    "type": "string", "binding": "=js:$vars.emailReceived1.output.from" },
-      { "id": "emailBody",    "type": "string", "binding": "=js:$vars.emailReceived1.output.body" }
-    ],
+    "agentInputVariables": [],
     "agentOutputVariables": [{ "id": "content", "type": "string" }]
   }
 }
@@ -87,11 +81,7 @@ Matching `agent.json` (excerpt):
 {
   "inputSchema": {
     "type": "object",
-    "properties": {
-      "emailSubject": { "type": "string" },
-      "emailFrom":    { "type": "string" },
-      "emailBody":    { "type": "string" }
-    }
+    "properties": {}
   },
   "messages": [
     {
@@ -101,38 +91,38 @@ Matching `agent.json` (excerpt):
     },
     {
       "role": "user",
-      "content": "From {{input.emailFrom}}\nSubject: {{input.emailSubject}}\n\n{{input.emailBody}}",
+      "content": "From {{ $vars.emailReceived1.output.from }}\nSubject: {{ $vars.emailReceived1.output.subject }}\n\n{{ $vars.emailReceived1.output.body }}",
       "contentTokens": [
         { "type": "simpleText", "rawString": "From " },
-        { "type": "variable",   "rawString": "input.emailFrom" },
+        { "type": "variable",   "rawString": " $vars.emailReceived1.output.from " },
         { "type": "simpleText", "rawString": "\nSubject: " },
-        { "type": "variable",   "rawString": "input.emailSubject" },
+        { "type": "variable",   "rawString": " $vars.emailReceived1.output.subject " },
         { "type": "simpleText", "rawString": "\n\n" },
-        { "type": "variable",   "rawString": "input.emailBody" }
+        { "type": "variable",   "rawString": " $vars.emailReceived1.output.body " }
       ]
     }
   ]
 }
 ```
 
-The flow-node `inputs.systemPrompt` / `inputs.userPrompt` stay as short, generic validator placeholders — **do not copy the templated agent.json prompt with `{{input.<id>}}` tokens here**. Those runtime tokens only resolve inside `agent.json messages[].content`; in the flow-node they are inert text that just duplicates content and obscures which prompt is canonical. The contract that matters is: every `{{input.<id>}}` token in `agent.json` has a matching `inputSchema.properties.<id>` slot and a matching `agentInputVariables[]` binding on the flow node.
+The flow-node `inputs.systemPrompt` / `inputs.userPrompt` are short, generic validator placeholders — **do not copy the templated `agent.json` prompt with `{{ $vars.X }}` tokens here**. The contract: every `{{ $vars.<flowNodeId>.output[.<field>] }}` token in `agent.json content` has a matching `{ type: "variable", rawString: " $vars.<flowNodeId>.output[.<field>] " }` entry in the same message's `contentTokens[]` (leading and trailing spaces inside `rawString`).
 
 ### When the source field name is unknown at authoring time
 
 Some upstream nodes (notably connector triggers like email-received) only expose their full output shape after a real run — `subject`, `from`, `body` are not knowable from the registry definition alone. In that case:
 
-1. Pick descriptive slot ids (`emailSubject`, `emailFrom`, `emailBody`) and write the prompt + `inputSchema` against them.
-2. Record the `binding` strings as your **best guess** based on the connector's documented output schema (e.g., `=js:$vars.emailReceived1.output.subject`).
-3. Surface the assumption to the user with `AskUserQuestion` — list the bindings and ask the user to correct any source paths before they run or upload the flow. Do not invent field names silently.
-4. After the first real run, the author can verify the actual output paths and update the bindings; the prompt and `inputSchema` do not need to change because the slot ids are stable.
+1. Write the prompt against your **best guess** of the upstream node's output paths based on the connector's documented output schema (e.g., `{{ $vars.emailReceived1.output.subject }}`).
+2. Surface the assumption to the user with `AskUserQuestion` — list the referenced paths and ask the user to correct any wrong fields before they run or upload the flow. Do not invent field names silently.
+3. After the first real run, the author can verify the actual output paths and update the prompt tokens (and matching `contentTokens[].rawString` mirrors).
 
 ### Anti-patterns
 
-- **Never write `{{plainName}}` (no `input.` prefix) in `agent.json` prompts.** It is treated as literal text by the agent runtime.
-- **Never write `{{$vars.X}}` or `{{ $vars.X }}` directly in `agent.json` prompts.** That mustache form is canvas-input syntax, not the runtime token; without the workbench rewrite step, it ships verbatim and resolves to nothing. The runtime form is `{{input.<id>}}`, paired with an `agentInputVariables[]` binding.
-- **Never copy `{{input.<id>}}` tokens into the flow-node `inputs.systemPrompt` / `inputs.userPrompt`.** Those fields are validator placeholders — keep them as short, generic strings. Runtime tokens belong in `agent.json messages[].content` only.
-- **Never leave `agentInputVariables: []` while the prompt references flow data.** Empty bindings means no values reach the agent.
-- **Never declare an `inputSchema.properties.<id>` slot without a matching `agentInputVariables[]` binding** (the slot stays empty at runtime), and never the reverse (the binding has nowhere to land).
+- **Never write `{{input.<id>}}` (or any `input.X` form) in `agent.json` prompts.** Use `{{ $vars.<flowNodeId>.output[.<field>] }}` referencing the upstream flow node directly.
+- **Never write `{{plainName}}` (no prefix) in `agent.json` prompts.** Use the `{{ $vars.<flowNodeId>.output[.<field>] }}` form.
+- **Never omit the leading and trailing space inside `contentTokens[].rawString` for variable tokens.** `rawString` is `" $vars.X "`, matching the `{{ $vars.X }}` spaced-brace form in `content`.
+- **Never copy `{{ $vars.X }}` tokens into the flow-node `inputs.systemPrompt` / `inputs.userPrompt`.** Those fields are validator placeholders — keep them as short, generic strings. Canvas tokens belong in `agent.json messages[].content` only.
+- **Never populate `agentInputVariables[]` on the flow node for prompt-data passing.** Use `{{ $vars.<flowNodeId>.output[.<field>] }}` in `agent.json messages[].content` instead. For prompt-only flow-data references, set `inputs.agentInputVariables: []` on the flow node.
+- **Never declare an `inputSchema.properties.<id>` slot for prompt-data wiring.** For prompt-only flow-data references, leave `inputSchema.properties` as `{}`.
 
 ## Registry Validation
 
@@ -343,7 +333,7 @@ Notes:
 
 - `inputs.source` — the inline agent's `projectId`; must match the subdirectory name and `agent.json.projectId`. The definition still declares `model.source: true`, but flow-core hoists that identity field onto `inputs.source` for the node instance.
 - `inputs.systemPrompt` / `inputs.userPrompt` must be non-empty for current `flow validate`. Treat them as validator placeholders; the canonical inline-agent prompts live in `agent.json`.
-- `inputs.agentInputVariables` is `[]` only for agents whose prompts reference no flow data. Whenever the prompt needs a trigger output, upstream-node output, or flow variable, populate this array per § Wiring Flow Variables into Agent Prompts above — and add matching `inputSchema.properties.<id>` slots in `agent.json`.
+- `inputs.agentInputVariables` is `[]` for prompt-only flow-data references — which covers the common case. The canvas does not read this array when resolving prompt tokens; flow values flow into prompts directly via `{{ $vars.<flowNodeId>.output[.<field>] }}` in `agent.json messages[].content` (see § Wiring Flow Variables into Agent Prompts above). Populate `agentInputVariables[]` only for non-prompt typed-schema uses.
 - **No `model` block on the inline-agent node instance.** The node inherits serviceType/version/context from `definitions[]`; `source` lives at `inputs.source`. Stale instance fields such as `model.serviceType`, `model.version`, or `model.context` override the inherited definition and can cause runtime mismatch.
 
 ## Accessing Output
@@ -394,7 +384,9 @@ uip maestro flow validate <FlowName>.flow --output json
 | Inline agent rejected by `uip agent validate` | `entry-points.json` or `project.uiproj` present inside the inline agent dir | Delete those files — they belong only to standalone agent projects |
 | Folder name is human-readable instead of UUID | Folder renamed after scaffolding | Rename to the original `projectId` UUID — the folder name must match `inputs.source` and the `projectId` field inside `agent.json` |
 | Agent runs but returns empty `output.content` | Missing or malformed `contentTokens` in `agent.json` | Rebuild `messages[].contentTokens` using `{ "type": "simpleText", "rawString": "..." }` entries; see `uipath-agents` for detail |
-| Agent prompt receives literal `{{X}}` text instead of flow data, or one prompt slot resolves to nothing while others work | Bare `{{X}}` placeholders without the `input.` prefix; or `{{input.<id>}}` token written without a matching `inputSchema.properties.<id>` slot in `agent.json` and `agentInputVariables[]` binding on the flow node | Adopt the four-place contract from § Wiring Flow Variables into Agent Prompts: pick a flat slot id, add an `agentInputVariables[]` entry with `{ id, type, binding: "=js:$vars.<sourceNode>.output.<field>" }`, declare `inputSchema.properties.<id>`, write the prompt token as `{{input.<id>}}`, and add a matching `{ "type": "variable", "rawString": "input.<id>" }` to `messages[].contentTokens` |
+| `Prompt references "$vars.<id>" but that variable is not available in this scope` | Token written as `{{input.<id>}}` or `{{<id>}}` | Rewrite to `{{ $vars.<flowNodeId>.output[.<field>] }}` and mirror in `contentTokens[]` as `{ "type": "variable", "rawString": " $vars.<flowNodeId>.output[.<field>] " }`. See § Wiring Flow Variables into Agent Prompts. |
+| `uip agent validate` fails with `Expected " $vars.X " but got "$vars.X"` | Variable `contentToken` `rawString` missing leading/trailing space | Add one leading and one trailing space inside `rawString`. The `content` field is `{{ $vars.X }}` (spaced braces); `rawString` is `" $vars.X "` (spaced). |
+| Agent prompt receives literal `{{X}}` text instead of flow data | Bare `{{plainName}}` (no `$vars.`), or `<flowNodeId>` typo not matching any node `id` | Use `{{ $vars.<flowNodeId>.output[.<field>] }}` with an exact upstream node `id`. |
 
 ## Repair Recipes
 

--- a/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
+++ b/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
@@ -71,7 +71,7 @@ Three failure modes observed in agent-generated `.flow` files:
 | **Loop nodes** (`core.logic.loop`) | `inputs.collection` | **YES** |
 | **Subflow nodes** (`core.subflow`) | `inputs.<inputId>.source` | **YES** |
 | **Script nodes** (`core.action.script`) | `inputs.script` body — `$vars.*` is read inside JS, no `=js:` wrapping | **NO** — the body is already JS |
-| **Inline-agent prompt** (`uipath.agent.autonomous` `agent.json` `messages[].content`) | Tokens reference an `agentInputVariables[]` binding via `{{input.<id>}}` — never raw `{{ $vars.X }}` and never bare `{{name}}` | **NO** — runtime tokens, not `=js:`. See [author/references/plugins/inline-agent/impl.md § Wiring Flow Variables into Agent Prompts](../author/references/plugins/inline-agent/impl.md#wiring-flow-variables-into-agent-prompts) for the four-place contract |
+| **Inline-agent prompt** (`uipath.agent.autonomous` `agent.json` `messages[].content`) | Tokens reference upstream flow nodes directly: `{{ $vars.<flowNodeId>.output[.<field>] }}` (spaced braces). Mirror in `contentTokens[]` as `{ "type": "variable", "rawString": " $vars.<flowNodeId>.output[.<field>] " }` — `rawString` must include leading and trailing space. Never `{{input.<id>}}` and never bare `{{name}}`. | **NO** — `{{ ... }}` tokens, not `=js:`. See [author/references/plugins/inline-agent/impl.md § Wiring Flow Variables into Agent Prompts](../author/references/plugins/inline-agent/impl.md#wiring-flow-variables-into-agent-prompts). |
 
 **Rule of thumb:** If the field is *value-typed* (anything other than a hardcoded condition), `=js:` is required for `$vars`/`$metadata`/`$self` references. The two condition fields (Decision, Switch) and the script body are the only exceptions — they are always parsed as JS regardless.
 


### PR DESCRIPTION
# Fix inline-agent prompt-wiring contract

The `uipath-maestro-flow` skill (and one mirror reference in `uipath-agents`) documents an **agent input bridge** for wiring flow data into inline-agent prompts: `agentInputVariables[]` on the flow node ↔ `inputSchema.properties.<id>` ↔ `{{input.<id>}}` token ↔ `contentTokens[].rawString: "input.<id>"`.

That contract is wrong. Studio Web's canvas does not resolve `input.*` against the agent's `inputSchema` when rendering prompt tokens — it rewrites `{{input.<id>}}` to `{{ $vars.<id> }}` against flow scope, then fails its own lint with:

> `Prompt references "$vars.<id>" but that variable is not available in this scope. Fix or remove the reference before publishing.`

The correct contract — verified end-to-end against `uip agent validate --inline-in-flow` and a published flow in Studio Web — is to reference upstream flow nodes **directly** in `agent.json messages[].content`, with no bridge:

```json
"content": "From {{ $vars.emailReceived1.output.from }}\nSubject: {{ $vars.emailReceived1.output.subject }}",
"contentTokens": [
  { "type": "simpleText", "rawString": "From " },
  { "type": "variable",   "rawString": " $vars.emailReceived1.output.from " },
  { "type": "simpleText", "rawString": "\nSubject: " },
  { "type": "variable",   "rawString": " $vars.emailReceived1.output.subject " }
]
```

Plus a previously-undocumented constraint: `contentTokens[].rawString` for variable tokens **must include leading and trailing spaces** to match the spaced-brace `{{ <expr> }}` form in `content`. Without them, `uip agent validate` fails with:

> `messages[N].contentTokens[M].rawString: Expected " $vars.X " but got "$vars.X"`

## Changes

| File | Change |
| --- | --- |
| `skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md` | Rewrote the **Wiring Flow Variables into Agent Prompts** section: replaced the four-place bridge with the direct `{{ $vars.<flowNodeId>.output[.<field>] }}` form. Updated the worked example (email-trigger) to use empty `agentInputVariables: []` and `inputSchema.properties: {}`. Rewrote the **When the source field name is unknown** subsection. Inverted the anti-patterns list (the old "Never write `{{ $vars.X }}` directly" rule was backwards; now the bans are `{{input.X}}`, bare `{{plainName}}`, omitted `rawString` spaces, and populated `agentInputVariables[]` / `inputSchema.properties` for prompt-data wiring). Updated the JSON Structure note on `inputs.agentInputVariables`. Replaced the literal-`{{X}}` Debug row with three precise rows covering scope-lint, `rawString` spacing, and literal-text symptoms — each citing the exact empirical error string. |
| `skills/uipath-maestro-flow/references/shared/node-output-wiring.md` | Fixed the inline-agent row in the `=js:` field reference table to teach `{{ $vars.<flowNodeId>.output[.<field>] }}` + spaced `rawString` instead of the bridge form. |
| `skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md` | Updated the `inputSchema.properties` and `messages`/`contentTokens` bullets in **Step 3: Create agent.json** to describe the canvas-form contract (no `{{input.X}}` slot declarations; one `simpleText` token per literal segment and one `variable` token per `{{ ... }}` reference). |

## Verification

End-to-end empirical confirmation against `alpha.uipath.com / popoc / DefaultTenant`:

- Built a flow with an upstream HTTP node → Script node → inline-agent → Slack node.
- First attempt used the old four-place bridge as documented — `uip agent validate` passed, but Studio Web showed `Prompt references "$vars.hnHits" but that variable is not available in this scope.`
- Switched the prompt to `{{ $vars.extractHits1.output.hnHits }}` with empty `agentInputVariables: []` / `inputSchema.properties: {}` — `uip agent validate` first failed on unspaced `rawString`, then passed once leading/trailing spaces were added inside `rawString`. Studio Web accepted the flow.
- Grepped the entire skills repo for stale `{{input.<id>}}` / "four-place" / "input bridge" references — all remaining matches are either anti-pattern citations (warning against the bad form) or unrelated JSON skeletons with `agentInputVariables: []`.

## What this PR does NOT change

- The flow-node JSON skeletons under **JSON Structure** and **Adding / Editing** continue to show `agentInputVariables: []` — that's correct under the new contract and unchanged.
- No claims are made about non-prompt typed-schema uses of `agentInputVariables[]` or `inputSchema.properties.<id>`. The new docs constrain themselves to **prompt-only flow-data references**, which is what was verified.
- `uip agent migrate --inline-in-flow` and `uip solution upload` behavior is unchanged — only the authoring contract is corrected.