### PR TITLE
Clean tests Ruff debt

### DIFF
--- a/tests/scripts/activation_gate.py
+++ b/tests/scripts/activation_gate.py
@@ -92,7 +92,9 @@ def main() -> int:
     threshold = threshold_pct / 100.0
 
     repo_root = Path(__file__).resolve().parents[2]
-    dataset = (repo_root / "tests" / "tasks" / "activation" / f"{skill}.jsonl").resolve()
+    dataset = (
+        repo_root / "tests" / "tasks" / "activation" / f"{skill}.jsonl"
+    ).resolve()
     if not dataset.is_file():
         print(f"ERROR: dataset {dataset} missing", file=sys.stderr)
         return 1
@@ -105,12 +107,18 @@ def main() -> int:
 
         result = subprocess.run(
             [
-                "coder-eval", "run", str(task_yaml),
-                "-e", "tests/experiments/activation.yaml",
-                "-j", "4",
-                "--run-dir", str(run_dir),
+                "coder-eval",
+                "run",
+                str(task_yaml),
+                "-e",
+                "tests/experiments/activation.yaml",
+                "-j",
+                "4",
+                "--run-dir",
+                str(run_dir),
             ],
-            cwd=repo_root, check=False,
+            cwd=repo_root,
+            check=False,
         )
         # coder-eval exits non-zero whenever any individual task fails its
         # criteria. That's exactly the case DROP_PP is designed to absorb —
@@ -123,16 +131,20 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-        suite_json = run_dir / "default" / f"skill-activation-gate-{skill}" / "suite.json"
+        suite_json = (
+            run_dir / "default" / f"skill-activation-gate-{skill}" / "suite.json"
+        )
         if not suite_json.is_file():
             print(f"ERROR: {suite_json} missing", file=sys.stderr)
             return 2
 
         data = json.loads(suite_json.read_text(encoding="utf-8"))
         recall = next(
-            (agg["metrics"]["recall.yes"]
-             for agg in data.get("criterion_aggregates", [])
-             if agg.get("criterion_type") == "skill_triggered"),
+            (
+                agg["metrics"]["recall.yes"]
+                for agg in data.get("criterion_aggregates", [])
+                if agg.get("criterion_type") == "skill_triggered"
+            ),
             None,
         )
         if recall is None:

--- a/tests/scripts/token_usage.py
+++ b/tests/scripts/token_usage.py
@@ -39,7 +39,9 @@ def main(run_dir_arg: str) -> int:
     #               billed at ~0.1x fresh rate -- effectively "free" relative to NEW.
     #   "out"     — model-generated output (parent + sub-agents).
     # The bill is dominated by NEW + Output. REUSED is the cheap leg of the cost.
-    print(f"{'rep':>3} {'sc':>4} {'sec':>6} | {'NEW':>7} {'(uncached/cached)':>19} {'REUSED':>10} {'out':>6} | {'$cost':>6}")
+    print(
+        f"{'rep':>3} {'sc':>4} {'sec':>6} | {'NEW':>7} {'(uncached/cached)':>19} {'REUSED':>10} {'out':>6} | {'$cost':>6}"
+    )
     print("-" * 80)
     sums = {"fresh": 0, "cache_c": 0, "cache_r": 0, "out": 0, "cost": 0.0, "dur": 0.0}
     for r in results:
@@ -74,48 +76,72 @@ def main(run_dir_arg: str) -> int:
     )
     if n:
         avg_new = new_total // n
-        avg_fresh = sums['fresh'] // n
-        avg_cc = sums['cache_c'] // n
+        avg_fresh = sums["fresh"] // n
+        avg_cc = sums["cache_c"] // n
         print(
-            f"{'avg':>3} {'':>4} {sums['dur']/n:>6.1f} | "
+            f"{'avg':>3} {'':>4} {sums['dur'] / n:>6.1f} | "
             f"{avg_new:>7,} ({avg_fresh:>3,}/{avg_cc:>7,}) "
-            f"{sums['cache_r']//n:>10,} {sums['out']//n:>6,} | "
-            f"{sums['cost']/n:>5.3f}"
+            f"{sums['cache_r'] // n:>10,} {sums['out'] // n:>6,} | "
+            f"{sums['cost'] / n:>5.3f}"
         )
 
     if not in_total_all:
         return 0
 
     print("\n=== Cost-driving tokens (NEW input + Output) ===")
-    print(f"  NEW input (full price)   : {new_total:>10,}  -- this is what you actually pay full rate for")
-    print(f"      uncached fresh tail  : {sums['fresh']:>10,}  ({100*sums['fresh']/new_total:>5.2f}% of NEW)  -- 1.0x fresh rate")
-    print(f"      new->cache write     : {sums['cache_c']:>10,}  ({100*sums['cache_c']/new_total:>5.2f}% of NEW)  -- 1.25x fresh rate")
-    print(f"  Output                   : {sums['out']:>10,}  -- billed at output rate (5x fresh)")
+    print(
+        f"  NEW input (full price)   : {new_total:>10,}  -- this is what you actually pay full rate for"
+    )
+    print(
+        f"      uncached fresh tail  : {sums['fresh']:>10,}  ({100 * sums['fresh'] / new_total:>5.2f}% of NEW)  -- 1.0x fresh rate"
+    )
+    print(
+        f"      new->cache write     : {sums['cache_c']:>10,}  ({100 * sums['cache_c'] / new_total:>5.2f}% of NEW)  -- 1.25x fresh rate"
+    )
+    print(
+        f"  Output                   : {sums['out']:>10,}  -- billed at output rate (5x fresh)"
+    )
     print()
-    print(f"  REUSED input (discounted): {sums['cache_r']:>10,}  -- 0.1x fresh rate; effectively the 'free' leg")
+    print(
+        f"  REUSED input (discounted): {sums['cache_r']:>10,}  -- 0.1x fresh rate; effectively the 'free' leg"
+    )
     print()
-    print(f"Per-replicate avg of cost-driving content (NEW + Output):")
-    print(f"  NEW input  : {new_total//n:>6,} tokens/rep")
-    print(f"  Output     : {sums['out']//n:>6,} tokens/rep")
-    print(f"  Sum        : {(new_total + sums['out'])//n:>6,} tokens/rep at full-or-output rate")
+    print("Per-replicate avg of cost-driving content (NEW + Output):")
+    print(f"  NEW input  : {new_total // n:>6,} tokens/rep")
+    print(f"  Output     : {sums['out'] // n:>6,} tokens/rep")
+    print(
+        f"  Sum        : {(new_total + sums['out']) // n:>6,} tokens/rep at full-or-output rate"
+    )
 
     print("\nDerived ratios:")
     if sums["out"]:
         print(f"  input  / output (in:out) : {in_total_all // sums['out']}:1")
     if sums["cache_c"]:
-        print(f"  reads-per-cache-write    : {sums['cache_r'] / sums['cache_c']:.1f}x   (how many turns reuse each cache entry)")
+        print(
+            f"  reads-per-cache-write    : {sums['cache_r'] / sums['cache_c']:.1f}x   (how many turns reuse each cache entry)"
+        )
 
-    print(f"\nSDK-reported cost: ${sums['cost']:.2f} for {n} replicate(s)  =  ${sums['cost']/n:.3f}/rep")
-    print("  These figures come straight from total_token_usage.total_cost_usd written by the Anthropic SDK")
-    print("  and account for parent + all sub-agent inference. They are the authoritative cost.")
+    print(
+        f"\nSDK-reported cost: ${sums['cost']:.2f} for {n} replicate(s)  =  ${sums['cost'] / n:.3f}/rep"
+    )
+    print(
+        "  These figures come straight from total_token_usage.total_cost_usd written by the Anthropic SDK"
+    )
+    print(
+        "  and account for parent + all sub-agent inference. They are the authoritative cost."
+    )
 
     # Per-rep variance
     if n > 1:
         costs = [r["cost"] for r in results]
         in_tot = [r["fresh"] + r["cache_c"] + r["cache_r"] for r in results]
-        print(f"\nPer-rep variance:")
-        print(f"  cost      min={min(costs):.3f}  max={max(costs):.3f}  range={max(costs)-min(costs):.3f}")
-        print(f"  cache_r   min={min(r['cache_r'] for r in results):,}  max={max(r['cache_r'] for r in results):,}")
+        print("\nPer-rep variance:")
+        print(
+            f"  cost      min={min(costs):.3f}  max={max(costs):.3f}  range={max(costs) - min(costs):.3f}"
+        )
+        print(
+            f"  cache_r   min={min(r['cache_r'] for r in results):,}  max={max(r['cache_r'] for r in results):,}"
+        )
         print(f"  in_total  min={min(in_tot):,}  max={max(in_tot):,}")
 
     return 0
@@ -123,6 +149,9 @@ def main(run_dir_arg: str) -> int:
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python tmp/token_usage.py <run_dir>/default/<task_id>", file=sys.stderr)
+        print(
+            "Usage: python tmp/token_usage.py <run_dir>/default/<task_id>",
+            file=sys.stderr,
+        )
         sys.exit(2)
     sys.exit(main(sys.argv[1]))

--- a/tests/tasks/uipath-admin/_shared/admin_helpers.py
+++ b/tests/tasks/uipath-admin/_shared/admin_helpers.py
@@ -5,7 +5,6 @@ import json
 import logging
 import subprocess
 import sys
-import time
 
 logger = logging.getLogger(__name__)
 
@@ -15,12 +14,15 @@ def run_cli(args: list[str], timeout: int = 30) -> dict | None:
     try:
         result = subprocess.run(
             ["uip", *args, "--output", "json"],
-            capture_output=True, text=True, timeout=timeout,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
         )
         if result.returncode != 0:
             logger.warning(
                 "CLI returned exit code %d: %s",
-                result.returncode, result.stderr.strip() or result.stdout.strip(),
+                result.returncode,
+                result.stderr.strip() or result.stdout.strip(),
             )
             return None
         return json.loads(result.stdout)

--- a/tests/tasks/uipath-admin/check_group_membership.py
+++ b/tests/tasks/uipath-admin/check_group_membership.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_shared"))
 from admin_helpers import run_cli, find_one, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_group: %(message)s")

--- a/tests/tasks/uipath-admin/check_robot_account.py
+++ b/tests/tasks/uipath-admin/check_robot_account.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_shared"))
 from admin_helpers import run_cli, find_one, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_robot: %(message)s")

--- a/tests/tasks/uipath-admin/check_user_invited.py
+++ b/tests/tasks/uipath-admin/check_user_invited.py
@@ -5,7 +5,7 @@ import logging
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_shared"))
 from admin_helpers import run_cli, find_one, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_user: %(message)s")

--- a/tests/tasks/uipath-admin/cleanup_group.py
+++ b/tests/tasks/uipath-admin/cleanup_group.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_shared"))
 from admin_helpers import run_cli, find_all
 
 logging.basicConfig(level=logging.INFO, format="cleanup_group: %(message)s")
@@ -33,7 +33,11 @@ def main():
         logger.info("Deleting group (id=%s)", group_id)
         result = run_cli(["admin", "groups", "delete", group_id])
         if result:
-            logger.info("Delete result: %s — %s", result.get("Result"), result.get("Message", ""))
+            logger.info(
+                "Delete result: %s — %s",
+                result.get("Result"),
+                result.get("Message", ""),
+            )
         else:
             logger.warning("Delete call returned no result for id=%s", group_id)
 

--- a/tests/tasks/uipath-admin/cleanup_invited_user.py
+++ b/tests/tasks/uipath-admin/cleanup_invited_user.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_shared"))
 from admin_helpers import run_cli, find_all
 
 logging.basicConfig(level=logging.INFO, format="cleanup_user: %(message)s")
@@ -33,7 +33,11 @@ def main():
         logger.info("Deleting user (id=%s)", user_id)
         result = run_cli(["admin", "users", "delete", user_id])
         if result:
-            logger.info("Delete result: %s — %s", result.get("Result"), result.get("Message", ""))
+            logger.info(
+                "Delete result: %s — %s",
+                result.get("Result"),
+                result.get("Message", ""),
+            )
         else:
             logger.warning("Delete call returned no result for id=%s", user_id)
 

--- a/tests/tasks/uipath-admin/cleanup_robot_account.py
+++ b/tests/tasks/uipath-admin/cleanup_robot_account.py
@@ -8,7 +8,7 @@ import logging
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "_shared"))
 from admin_helpers import run_cli, find_all
 
 logging.basicConfig(level=logging.INFO, format="cleanup_robot: %(message)s")
@@ -33,7 +33,11 @@ def main():
         logger.info("Deleting robot account (id=%s)", robot_id)
         result = run_cli(["admin", "robot-accounts", "delete", robot_id])
         if result:
-            logger.info("Delete result: %s — %s", result.get("Result"), result.get("Message", ""))
+            logger.info(
+                "Delete result: %s — %s",
+                result.get("Result"),
+                result.get("Message", ""),
+            )
         else:
             logger.warning("Delete call returned no result for id=%s", robot_id)
 

--- a/tests/tasks/uipath-agents/_shared/ast_lazy_init_check.py
+++ b/tests/tasks/uipath-agents/_shared/ast_lazy_init_check.py
@@ -35,14 +35,16 @@ import ast
 import sys
 from pathlib import Path
 
-DEFAULT_LLM_CLASS_NAMES = frozenset({
-    "UiPath",
-    "UiPathAzureChatOpenAI",
-    "UiPathChat",
-    "UiPathChatOpenAI",
-    "UiPathOpenAIEmbeddings",
-    "UiPathAzureOpenAIEmbeddings",
-})
+DEFAULT_LLM_CLASS_NAMES = frozenset(
+    {
+        "UiPath",
+        "UiPathAzureChatOpenAI",
+        "UiPathChat",
+        "UiPathChatOpenAI",
+        "UiPathOpenAIEmbeddings",
+        "UiPathAzureOpenAIEmbeddings",
+    }
+)
 
 
 def _called_class_name(node: ast.Call) -> str | None:

--- a/tests/tasks/uipath-agents/_shared/bindings_assertions.py
+++ b/tests/tasks/uipath-agents/_shared/bindings_assertions.py
@@ -36,8 +36,12 @@ def load_bindings(path: Path | str = "bindings.json") -> dict:
         sys.exit(f'FAIL: bindings.json version should be "2.0", got {version!r}')
     resources = doc.get("resources")
     if not isinstance(resources, list):
-        sys.exit(f"FAIL: bindings.json resources must be a list, got {type(resources).__name__}")
-    print(f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)')
+        sys.exit(
+            f"FAIL: bindings.json resources must be a list, got {type(resources).__name__}"
+        )
+    print(
+        f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)'
+    )
     return doc
 
 
@@ -54,10 +58,9 @@ def find_resource(
     """
     resources = doc.get("resources") or []
     matches = [
-        r for r in resources
-        if isinstance(r, dict)
-        and r.get("resource") == resource
-        and r.get("key") == key
+        r
+        for r in resources
+        if isinstance(r, dict) and r.get("resource") == resource and r.get("key") == key
     ]
     if not matches:
         sys.exit(
@@ -91,13 +94,11 @@ def assert_value_field(
         sys.exit(f"FAIL: entry value must be an object, got {value!r}")
     block = value.get(field)
     if not isinstance(block, dict):
-        sys.exit(f'FAIL: entry value.{field} must be an object, got {block!r}')
+        sys.exit(f"FAIL: entry value.{field} must be an object, got {block!r}")
     actual = block.get(inner)
     if actual != expected:
-        sys.exit(
-            f'FAIL: value.{field}.{inner} should be {expected!r}, got {actual!r}'
-        )
-    print(f'OK: value.{field}.{inner} == {expected!r}')
+        sys.exit(f"FAIL: value.{field}.{inner} should be {expected!r}, got {actual!r}")
+    print(f"OK: value.{field}.{inner} == {expected!r}")
 
 
 def assert_metadata_field(entry: dict, *, field: str, expected: Any) -> None:
@@ -107,10 +108,8 @@ def assert_metadata_field(entry: dict, *, field: str, expected: Any) -> None:
         sys.exit(f"FAIL: entry metadata must be an object, got {metadata!r}")
     actual = metadata.get(field)
     if actual != expected:
-        sys.exit(
-            f'FAIL: metadata.{field} should be {expected!r}, got {actual!r}'
-        )
-    print(f'OK: metadata.{field} == {expected!r}')
+        sys.exit(f"FAIL: metadata.{field} should be {expected!r}, got {actual!r}")
+    print(f"OK: metadata.{field} == {expected!r}")
 
 
 def assert_entrypoint_link(
@@ -131,31 +130,31 @@ def assert_entrypoint_link(
     if isinstance(uid_block, dict):
         if uid_block.get("defaultValue") != unique_id:
             sys.exit(
-                f'FAIL: EntryPointUniqueId.defaultValue should be {unique_id!r}, '
-                f'got {uid_block.get("defaultValue")!r}'
+                f"FAIL: EntryPointUniqueId.defaultValue should be {unique_id!r}, "
+                f"got {uid_block.get('defaultValue')!r}"
             )
         if uid_block.get("displayName") != file_path:
             sys.exit(
-                f'FAIL: EntryPointUniqueId.displayName must equal the entrypoint '
-                f'filePath ({file_path!r}), got {uid_block.get("displayName")!r}'
+                f"FAIL: EntryPointUniqueId.displayName must equal the entrypoint "
+                f"filePath ({file_path!r}), got {uid_block.get('displayName')!r}"
             )
         print(
-            f'OK: entry bound to entrypoint uniqueId={unique_id!r} '
-            f'(displayName={file_path!r})'
+            f"OK: entry bound to entrypoint uniqueId={unique_id!r} "
+            f"(displayName={file_path!r})"
         )
         return
     path_block = value.get("EntryPointPath")
     if isinstance(path_block, dict):
         if path_block.get("defaultValue") != file_path:
             sys.exit(
-                f'FAIL: EntryPointPath.defaultValue should be {file_path!r}, '
-                f'got {path_block.get("defaultValue")!r}'
+                f"FAIL: EntryPointPath.defaultValue should be {file_path!r}, "
+                f"got {path_block.get('defaultValue')!r}"
             )
-        print(f'OK: entry bound to entrypoint filePath={file_path!r} (fallback)')
+        print(f"OK: entry bound to entrypoint filePath={file_path!r} (fallback)")
         return
     sys.exit(
-        f'FAIL: entry has neither EntryPointUniqueId nor EntryPointPath; expected '
-        f'a binding to entrypoint uniqueId={unique_id!r} (filePath={file_path!r})'
+        f"FAIL: entry has neither EntryPointUniqueId nor EntryPointPath; expected "
+        f"a binding to entrypoint uniqueId={unique_id!r} (filePath={file_path!r})"
     )
 
 
@@ -163,6 +162,7 @@ def count_resources_by_type(doc: dict, resource_type: str) -> int:
     """Return the number of entries with `resource == resource_type`."""
     resources = doc.get("resources") or []
     return sum(
-        1 for r in resources
+        1
+        for r in resources
         if isinstance(r, dict) and r.get("resource") == resource_type
     )

--- a/tests/tasks/uipath-agents/_shared/inline_wiring.py
+++ b/tests/tasks/uipath-agents/_shared/inline_wiring.py
@@ -75,9 +75,9 @@ def find_resource_node(
         descriptor = f"type {node_type!r}"
     elif node_type_prefix is not None:
         matches = [
-            n for n in nodes
-            if isinstance(n.get("type"), str)
-            and n["type"].startswith(node_type_prefix)
+            n
+            for n in nodes
+            if isinstance(n.get("type"), str) and n["type"].startswith(node_type_prefix)
         ]
         descriptor = f"type starting with {node_type_prefix!r}"
     else:
@@ -158,7 +158,8 @@ def assert_edge(
     """Assert that an edge wires source_id:source_port -> target_id:target_port."""
     edges = flow.get("edges") or []
     matches = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("sourceNodeId") == source_id
         and e.get("sourcePort") == source_port
         and e.get("targetNodeId") == target_id

--- a/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/check_antipattern_openai_agents_hitl.py
+++ b/tests/tasks/uipath-agents/antipattern_openai_agents_hitl/check_antipattern_openai_agents_hitl.py
@@ -19,7 +19,6 @@ import json
 import os
 import re
 import sys
-from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.project_root import find_project_root  # noqa: E402

--- a/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/check_antipattern_wrong_sdk_import.py
+++ b/tests/tasks/uipath-agents/antipattern_wrong_sdk_import/check_antipattern_wrong_sdk_import.py
@@ -18,8 +18,12 @@ from pathlib import Path
 ROOT = Path(os.getcwd()) / "bad-import"
 MAIN = ROOT / "main.py"
 
-WRONG = re.compile(r"^\s*from\s+uipath\s+import\s+(?:[^,\n]*,\s*)*UiPath(?:\s*,|$)", re.M)
-RIGHT = re.compile(r"^\s*from\s+uipath\.platform\s+import\s+(?:[^,\n]*,\s*)*UiPath\b", re.M)
+WRONG = re.compile(
+    r"^\s*from\s+uipath\s+import\s+(?:[^,\n]*,\s*)*UiPath(?:\s*,|$)", re.M
+)
+RIGHT = re.compile(
+    r"^\s*from\s+uipath\.platform\s+import\s+(?:[^,\n]*,\s*)*UiPath\b", re.M
+)
 
 
 def main() -> None:
@@ -37,7 +41,9 @@ def main() -> None:
             "FAIL: main.py does not import UiPath from `uipath.platform`. "
             "Add `from uipath.platform import UiPath`."
         )
-    print("OK: main.py imports UiPath from `uipath.platform` (no `from uipath import UiPath`)")
+    print(
+        "OK: main.py imports UiPath from `uipath.platform` (no `from uipath import UiPath`)"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/bindings_asset_subtypes/check_bindings_asset_subtypes.py
+++ b/tests/tasks/uipath-agents/bindings_asset_subtypes/check_bindings_asset_subtypes.py
@@ -52,16 +52,18 @@ def main() -> None:
         metadata = entry.get("metadata") or {}
         actual = metadata.get("SubType")
         if actual is None:
-            print(f'OK: {name} asset binding has no SubType (acceptable fallback)')
+            print(f"OK: {name} asset binding has no SubType (acceptable fallback)")
             continue
         if actual == expected_subtype:
-            print(f'OK: {name} asset binding has SubType={actual!r} (high-confidence inference)')
+            print(
+                f"OK: {name} asset binding has SubType={actual!r} (high-confidence inference)"
+            )
             continue
         sys.exit(
-            f'FAIL: {name} asset binding has SubType={actual!r}, expected '
-            f'either {expected_subtype!r} (from annotation) or omitted. '
-            f'Wrong SubType is worse than no SubType — `uipath push` would '
-            f'create the wrong placeholder kind.'
+            f"FAIL: {name} asset binding has SubType={actual!r}, expected "
+            f"either {expected_subtype!r} (from annotation) or omitted. "
+            f"Wrong SubType is worse than no SubType — `uipath push` would "
+            f"create the wrong placeholder kind."
         )
 
 

--- a/tests/tasks/uipath-agents/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
+++ b/tests/tasks/uipath-agents/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
@@ -62,14 +62,16 @@ def main() -> None:
         value = entry.get("value") or {}
         ep = value.get("EntryPointUniqueId")
         if not isinstance(ep, dict):
-            print(f"OK: {entry.get('resource')} binding has no EntryPointUniqueId (acceptable)")
+            print(
+                f"OK: {entry.get('resource')} binding has no EntryPointUniqueId (acceptable)"
+            )
             continue
         uid = ep.get("defaultValue")
         if uid not in real:
             sys.exit(
-                f'FAIL: {entry.get("resource")} binding references '
-                f'EntryPointUniqueId={uid!r}, which is not one of the real '
-                f'entrypoints {sorted(real)}.'
+                f"FAIL: {entry.get('resource')} binding references "
+                f"EntryPointUniqueId={uid!r}, which is not one of the real "
+                f"entrypoints {sorted(real)}."
             )
         print(
             f"OK: {entry.get('resource')} binding's EntryPointUniqueId "

--- a/tests/tasks/uipath-agents/bindings_queue_app_index/check_bindings_queue_app_index.py
+++ b/tests/tasks/uipath-agents/bindings_queue_app_index/check_bindings_queue_app_index.py
@@ -49,7 +49,9 @@ def main() -> None:
     assert_metadata_field(index, field="ActivityName", expected="retrieve_async")
     # connection
     connection = find_resource(doc, resource="connection", key="salesforce-prod-conn")
-    assert_value_field(connection, field="ConnectionId", expected="salesforce-prod-conn")
+    assert_value_field(
+        connection, field="ConnectionId", expected="salesforce-prod-conn"
+    )
     assert_metadata_field(connection, field="UseConnectionService", expected="True")
     # mcpServer
     mcp = find_resource(doc, resource="mcpServer", key="weather-mcp.Tools")
@@ -61,7 +63,9 @@ def main() -> None:
         n = count_resources_by_type(doc, kind)
         if n != 1:
             sys.exit(f"FAIL: expected exactly 1 `{kind}` binding entry, got {n}")
-    print("OK: each of queue/app/index/connection/mcpServer has exactly one binding entry")
+    print(
+        "OK: each of queue/app/index/connection/mcpServer has exactly one binding entry"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded_in_flow_e2e/check_coded_in_flow_e2e.py
+++ b/tests/tasks/uipath-agents/coded_in_flow_e2e/check_coded_in_flow_e2e.py
@@ -31,7 +31,9 @@ from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E
 CWD = Path(os.getcwd())
 SOL = CWD / "GreeterSol"
 FLOW = SOL / "GreeterFlow" / "GreeterFlow.flow"
-CODED_RESOURCE = SOL / "resources" / "solution_folder" / "process" / "agent" / "InputProcessor.json"
+CODED_RESOURCE = (
+    SOL / "resources" / "solution_folder" / "process" / "agent" / "InputProcessor.json"
+)
 CODED_MAIN = SOL / "InputProcessor" / "main.py"
 
 AGENT_NODE_TYPE_PREFIX = "uipath.core.agent."
@@ -62,9 +64,13 @@ def main() -> None:
     nodes = flow.get("nodes") or []
     bindings = flow.get("bindings") or []
 
-    agent_nodes = [n for n in nodes if isinstance(n, dict)
-                   and isinstance(n.get("type"), str)
-                   and n["type"].startswith(AGENT_NODE_TYPE_PREFIX)]
+    agent_nodes = [
+        n
+        for n in nodes
+        if isinstance(n, dict)
+        and isinstance(n.get("type"), str)
+        and n["type"].startswith(AGENT_NODE_TYPE_PREFIX)
+    ]
     if len(agent_nodes) != 1:
         sys.exit(
             f"FAIL: expected exactly one `{AGENT_NODE_TYPE_PREFIX}<key>` node "
@@ -73,7 +79,7 @@ def main() -> None:
         )
     print(f"OK: flow has {len(agent_nodes)} agent node")
 
-    suffixes = {n["type"][len(AGENT_NODE_TYPE_PREFIX):] for n in agent_nodes}
+    suffixes = {n["type"][len(AGENT_NODE_TYPE_PREFIX) :] for n in agent_nodes}
     if coded_key not in suffixes:
         sys.exit(
             f"FAIL: no flow node with type `{AGENT_NODE_TYPE_PREFIX}{coded_key}` "
@@ -81,12 +87,12 @@ def main() -> None:
         )
     print(f"OK: flow node binds the coded agent via type suffix {coded_key}")
 
-    agent_bindings = [b for b in bindings
-                      if isinstance(b, dict) and b.get("resourceKey") == coded_key]
+    agent_bindings = [
+        b for b in bindings if isinstance(b, dict) and b.get("resourceKey") == coded_key
+    ]
     if not agent_bindings:
         sys.exit(
-            f"FAIL: top-level bindings[] has no entry with "
-            f"resourceKey=={coded_key!r}"
+            f"FAIL: top-level bindings[] has no entry with resourceKey=={coded_key!r}"
         )
     print(f"OK: bindings[] has {len(agent_bindings)} entry/entries for the coded agent")
 
@@ -107,7 +113,9 @@ def main() -> None:
             "node instances referencing the same agent must reuse the same "
             "bindings[].id."
         )
-    print(f"OK: bindings[] has no duplicate (resourceKey, propertyAttribute) pairs ({len(seen)} unique)")
+    print(
+        f"OK: bindings[] has no duplicate (resourceKey, propertyAttribute) pairs ({len(seen)} unique)"
+    )
 
     violations = find_module_level_llm_clients(CODED_MAIN)
     if violations:

--- a/tests/tasks/uipath-agents/coded_in_flow_published/check_coded_in_flow_published.py
+++ b/tests/tasks/uipath-agents/coded_in_flow_published/check_coded_in_flow_published.py
@@ -54,21 +54,23 @@ def assert_pattern_2_not_pattern_1(flow_path: Path) -> dict:
             f"{flow_path} contains no `uipath.core.agent.<resourceKey>` node — "
             "the flow must reference the published agent"
         )
-    print(f"OK: flow references a uipath.core.agent.<key> node ({len(agent_nodes)} occurrence(s))")
+    print(
+        f"OK: flow references a uipath.core.agent.<key> node ({len(agent_nodes)} occurrence(s))"
+    )
 
     if '"In this solution"' in text:
         fail(
-            f"{flow_path} references the agent with `section: \"In this solution\"` — "
+            f'{flow_path} references the agent with `section: "In this solution"` — '
             "that is Pattern 1 (in-solution). This test verifies Pattern 2 (Published). "
             "The agent must be referenced as a Published resource."
         )
 
     if '"Published"' not in text:
         fail(
-            f"{flow_path} does not contain `section: \"Published\"` for the agent node. "
+            f'{flow_path} does not contain `section: "Published"` for the agent node. '
             "Pattern 2 requires the agent node's model.section to be 'Published'."
         )
-    print("OK: agent node carries `section: \"Published\"` (Pattern 2)")
+    print('OK: agent node carries `section: "Published"` (Pattern 2)')
 
     return doc
 
@@ -86,7 +88,9 @@ def assert_not_in_solution_sibling() -> None:
             + " — these indicate Pattern 1 (in-solution), not Pattern 2 (published). "
             "The coded agent must NOT be registered as a sibling of the flow."
         )
-    print("OK: no in-solution resource manifest exists (correctly publishes as Pattern 2)")
+    print(
+        "OK: no in-solution resource manifest exists (correctly publishes as Pattern 2)"
+    )
 
 
 def main() -> None:
@@ -101,7 +105,9 @@ def main() -> None:
             f"coded agent project `{AGENT_PROJECT_HINT}` is missing its langgraph.json "
             "— the agent must be a LangGraph project before it can be deployed and referenced"
         )
-    print(f"OK: coded agent LangGraph marker present at {agent_marker.relative_to(CWD)}")
+    print(
+        f"OK: coded agent LangGraph marker present at {agent_marker.relative_to(CWD)}"
+    )
 
     print("OK: Pattern 2 (Published coded agent) wiring verified")
 

--- a/tests/tasks/uipath-agents/deploy_folder_and_rebump/check_deploy_folder_and_rebump.py
+++ b/tests/tasks/uipath-agents/deploy_folder_and_rebump/check_deploy_folder_and_rebump.py
@@ -80,7 +80,9 @@ def main() -> None:
             "patch was bumped — bump the version in pyproject.toml between the "
             "two deploys."
         )
-    print(f"OK: version {version} is greater than the scaffold default 0.0.1 — re-deploy bump happened")
+    print(
+        f"OK: version {version} is greater than the scaffold default 0.0.1 — re-deploy bump happened"
+    )
 
     if not MAIN.is_file():
         fail(f"missing {MAIN}")

--- a/tests/tasks/uipath-agents/deploy_my_workspace/check_deploy_my_workspace.py
+++ b/tests/tasks/uipath-agents/deploy_my_workspace/check_deploy_my_workspace.py
@@ -53,8 +53,7 @@ def check_pack_artifacts() -> None:
     uipath_dir = ROOT / ".uipath"
     if not uipath_dir.is_dir():
         sys.exit(
-            f"FAIL: {uipath_dir} does not exist — `uip codedagent pack` "
-            "did not run."
+            f"FAIL: {uipath_dir} does not exist — `uip codedagent pack` did not run."
         )
     nupkgs = sorted(uipath_dir.glob("*.nupkg"))
     if not nupkgs:
@@ -62,17 +61,25 @@ def check_pack_artifacts() -> None:
             f"FAIL: no .nupkg file in {uipath_dir} — pack did not produce "
             "the expected package artifact."
         )
-    print(f"OK: {uipath_dir.name}/{nupkgs[0].name} exists ({len(nupkgs)} package(s) total)")
+    print(
+        f"OK: {uipath_dir.name}/{nupkgs[0].name} exists ({len(nupkgs)} package(s) total)"
+    )
 
 
 def check_invoke_output() -> None:
     path = ROOT / "invoke-output.txt"
     text = _read_text(path)
     if not text.strip():
-        sys.exit(f"FAIL: {path.name} is empty — `uip codedagent invoke` produced no output")
+        sys.exit(
+            f"FAIL: {path.name} is empty — `uip codedagent invoke` produced no output"
+        )
     if "https://" not in text:
-        sys.exit(f"FAIL: {path.name} does not contain a monitoring URL (no `https://` substring)")
-    print(f"OK: {path.name} captured {len(text)} bytes of invoke stdout (with monitoring URL)")
+        sys.exit(
+            f"FAIL: {path.name} does not contain a monitoring URL (no `https://` substring)"
+        )
+    print(
+        f"OK: {path.name} captured {len(text)} bytes of invoke stdout (with monitoring URL)"
+    )
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/diagnose_deploy_failure/check_diagnose_deploy_failure.py
+++ b/tests/tasks/uipath-agents/diagnose_deploy_failure/check_diagnose_deploy_failure.py
@@ -48,7 +48,9 @@ def check_pyproject() -> None:
     if "[project]" not in text:
         sys.exit("FAIL: pyproject.toml has no [project] section")
 
-    authors_match = re.search(r"^\s*authors\s*=\s*\[(.*?)\]", text, re.DOTALL | re.MULTILINE)
+    authors_match = re.search(
+        r"^\s*authors\s*=\s*\[(.*?)\]", text, re.DOTALL | re.MULTILINE
+    )
     if not authors_match:
         sys.exit(
             "FAIL: pyproject.toml has no `authors = [...]` entry — "
@@ -63,9 +65,9 @@ def check_pyproject() -> None:
         )
     if "name" not in inner:
         sys.exit(
-            f'FAIL: pyproject.toml `authors` entry does not contain a '
+            f"FAIL: pyproject.toml `authors` entry does not contain a "
             f'`name` field. Expected something like `[{{ name = "..." }}]`. '
-            f'Got: {inner!r}'
+            f"Got: {inner!r}"
         )
 
     for needle in ("name", "version", "description", "dependencies"):

--- a/tests/tasks/uipath-agents/eval_exact_match/check_eval_exact_match.py
+++ b/tests/tasks/uipath-agents/eval_exact_match/check_eval_exact_match.py
@@ -53,7 +53,9 @@ def find_single_json(directory: Path) -> Path:
     if not files:
         sys.exit(f"FAIL: {directory} contains no .json files")
     if len(files) > 1:
-        sys.exit(f"FAIL: {directory} should contain exactly one .json file, got {len(files)}")
+        sys.exit(
+            f"FAIL: {directory} should contain exactly one .json file, got {len(files)}"
+        )
     return files[0]
 
 
@@ -64,12 +66,14 @@ def check_evaluator() -> str:
     if type_id != "uipath-exact-match":
         sys.exit(
             f'FAIL: {path.name} evaluatorTypeId should be "uipath-exact-match", '
-            f'got {type_id!r}'
+            f"got {type_id!r}"
         )
     eval_id = doc.get("id")
     if not eval_id:
         sys.exit(f"FAIL: {path.name} is missing required `id` field")
-    print(f'OK: evaluator config {path.name} has evaluatorTypeId={type_id!r} id={eval_id!r}')
+    print(
+        f"OK: evaluator config {path.name} has evaluatorTypeId={type_id!r} id={eval_id!r}"
+    )
     return eval_id
 
 
@@ -81,8 +85,8 @@ def check_eval_set(evaluator_id: str) -> int:
     refs = doc.get("evaluatorRefs") or []
     if evaluator_id not in refs:
         sys.exit(
-            f'FAIL: eval set `evaluatorRefs` does not include the evaluator '
-            f'id {evaluator_id!r}. Got: {refs}'
+            f"FAIL: eval set `evaluatorRefs` does not include the evaluator "
+            f"id {evaluator_id!r}. Got: {refs}"
         )
     cases = doc.get("evaluations") or []
     if len(cases) < 2:
@@ -91,11 +95,13 @@ def check_eval_set(evaluator_id: str) -> int:
         crit = case.get("evaluationCriterias") or {}
         if evaluator_id not in crit:
             sys.exit(
-                f'FAIL: eval set test case {i} (`{case.get("id", "?")}`) does '
-                f'not key its evaluationCriterias on the evaluator id '
-                f'{evaluator_id!r}. Got keys: {list(crit.keys())}'
+                f"FAIL: eval set test case {i} (`{case.get('id', '?')}`) does "
+                f"not key its evaluationCriterias on the evaluator id "
+                f"{evaluator_id!r}. Got keys: {list(crit.keys())}"
             )
-    print(f'OK: eval set {path.name} references {evaluator_id!r} across {len(cases)} test cases')
+    print(
+        f"OK: eval set {path.name} references {evaluator_id!r} across {len(cases)} test cases"
+    )
     return len(cases)
 
 
@@ -103,7 +109,9 @@ def check_results(evaluator_id: str, expected_case_count: int) -> None:
     path = ROOT / "eval-results.json"
     doc = _load_json(path)
     if not isinstance(doc, dict):
-        sys.exit(f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}")
+        sys.exit(
+            f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}"
+        )
     cases = doc.get("evaluationSetResults")
     if not isinstance(cases, list) or not cases:
         sys.exit(
@@ -115,7 +123,7 @@ def check_results(evaluator_id: str, expected_case_count: int) -> None:
             f"FAIL: expected {expected_case_count} entries in "
             f"`evaluationSetResults` (one per eval-set test case), got {len(cases)}"
         )
-    print(f'OK: eval-results.json carries {len(cases)} entries in evaluationSetResults')
+    print(f"OK: eval-results.json carries {len(cases)} entries in evaluationSetResults")
     bad_cases = []
     matching_run_count = 0
     for case in cases:
@@ -124,29 +132,30 @@ def check_results(evaluator_id: str, expected_case_count: int) -> None:
         case_name = case.get("evaluationName") or "?"
         runs = case.get("evaluationRunResults") or []
         matching = [
-            r for r in runs
+            r
+            for r in runs
             if isinstance(r, dict) and r.get("evaluatorId") == evaluator_id
         ]
         if not matching:
             bad_cases.append(
-                f'{case_name!r}: no evaluationRunResults entry references '
-                f'evaluatorId={evaluator_id!r}'
+                f"{case_name!r}: no evaluationRunResults entry references "
+                f"evaluatorId={evaluator_id!r}"
             )
             continue
         for r in matching:
             score = (r.get("result") or {}).get("score")
             if score != 1.0:
                 bad_cases.append(
-                    f'{case_name!r}: evaluator {evaluator_id!r} scored '
-                    f'{score!r}, expected 1.0 (deterministic agent + '
-                    f'deterministic evaluator)'
+                    f"{case_name!r}: evaluator {evaluator_id!r} scored "
+                    f"{score!r}, expected 1.0 (deterministic agent + "
+                    f"deterministic evaluator)"
                 )
         matching_run_count += len(matching)
     if bad_cases:
         sys.exit("FAIL: " + " | ".join(bad_cases))
     print(
-        f'OK: every test case has an ExactMatchEvaluator run scoring 1.0 '
-        f'({matching_run_count} run(s) across {len(cases)} case(s))'
+        f"OK: every test case has an ExactMatchEvaluator run scoring 1.0 "
+        f"({matching_run_count} run(s) across {len(cases)} case(s))"
     )
 
 

--- a/tests/tasks/uipath-agents/eval_llm_judges/check_eval_llm_judges.py
+++ b/tests/tasks/uipath-agents/eval_llm_judges/check_eval_llm_judges.py
@@ -56,16 +56,18 @@ def check_evaluator_configs() -> None:
             expected_type = EXPECTED_EVALUATORS[eval_id]
             if type_id != expected_type:
                 sys.exit(
-                    f'FAIL: evaluator {eval_id!r} should have evaluatorTypeId='
-                    f'{expected_type!r}, got {type_id!r}'
+                    f"FAIL: evaluator {eval_id!r} should have evaluatorTypeId="
+                    f"{expected_type!r}, got {type_id!r}"
                 )
             found_by_id[eval_id] = json_file
-            print(f'OK: evaluator config {json_file.name} has id={eval_id!r} typeId={type_id!r}')
+            print(
+                f"OK: evaluator config {json_file.name} has id={eval_id!r} typeId={type_id!r}"
+            )
     missing = set(EXPECTED_EVALUATORS) - set(found_by_id)
     if missing:
         sys.exit(
-            f'FAIL: missing evaluator configs for ids {sorted(missing)}. '
-            f'Found ids: {sorted(found_by_id)}'
+            f"FAIL: missing evaluator configs for ids {sorted(missing)}. "
+            f"Found ids: {sorted(found_by_id)}"
         )
 
 
@@ -86,8 +88,8 @@ def check_eval_set() -> None:
     missing_refs = set(EXPECTED_EVALUATORS) - set(refs)
     if missing_refs:
         sys.exit(
-            f'FAIL: eval set `evaluatorRefs` is missing {sorted(missing_refs)}. '
-            f'Got: {refs}'
+            f"FAIL: eval set `evaluatorRefs` is missing {sorted(missing_refs)}. "
+            f"Got: {refs}"
         )
     cases = doc.get("evaluations") or []
     if len(cases) < 2:
@@ -97,23 +99,23 @@ def check_eval_set() -> None:
         for evaluator_id in EXPECTED_EVALUATORS:
             if evaluator_id not in crit:
                 sys.exit(
-                    f'FAIL: test case {i} (`{case.get("id", "?")}`) does not '
-                    f'key evaluationCriterias on {evaluator_id!r}. Got keys: '
-                    f'{list(crit.keys())}'
+                    f"FAIL: test case {i} (`{case.get('id', '?')}`) does not "
+                    f"key evaluationCriterias on {evaluator_id!r}. Got keys: "
+                    f"{list(crit.keys())}"
                 )
         # Trajectory judge requires `expectedAgentBehavior`.
         traj = crit.get("LLMJudgeTrajectoryEvaluator") or {}
         if not traj.get("expectedAgentBehavior"):
             sys.exit(
-                f'FAIL: test case {i} LLMJudgeTrajectoryEvaluator entry is '
-                f'missing the required `expectedAgentBehavior` field. Got: {traj}'
+                f"FAIL: test case {i} LLMJudgeTrajectoryEvaluator entry is "
+                f"missing the required `expectedAgentBehavior` field. Got: {traj}"
             )
         # Output judge requires `expectedOutput`.
         out = crit.get("LLMJudgeOutputEvaluator") or {}
         if "expectedOutput" not in out:
             sys.exit(
-                f'FAIL: test case {i} LLMJudgeOutputEvaluator entry is '
-                f'missing the required `expectedOutput` field. Got: {out}'
+                f"FAIL: test case {i} LLMJudgeOutputEvaluator entry is "
+                f"missing the required `expectedOutput` field. Got: {out}"
             )
     print(
         f"OK: eval set {path.name} references both judges across {len(cases)} "
@@ -125,7 +127,9 @@ def check_results() -> None:
     path = ROOT / "eval-results.json"
     doc = _load_json(path)
     if not isinstance(doc, dict):
-        sys.exit(f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}")
+        sys.exit(
+            f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}"
+        )
     cases = doc.get("evaluationSetResults")
     if not isinstance(cases, list) or not cases:
         sys.exit(
@@ -144,9 +148,9 @@ def check_results() -> None:
     missing = set(EXPECTED_EVALUATORS) - seen_ids
     if missing:
         sys.exit(
-            f'FAIL: results file does not surface evaluatorId entries for '
-            f'{sorted(missing)} (seen: {sorted(seen_ids)}). Both judges '
-            f'should run on every test case.'
+            f"FAIL: results file does not surface evaluatorId entries for "
+            f"{sorted(missing)} (seen: {sorted(seen_ids)}). Both judges "
+            f"should run on every test case."
         )
     print(
         f"OK: results file references both evaluator ids ({sorted(seen_ids)}) "

--- a/tests/tasks/uipath-agents/eval_mocking_mockito/check_eval_mocking_mockito.py
+++ b/tests/tasks/uipath-agents/eval_mocking_mockito/check_eval_mocking_mockito.py
@@ -117,8 +117,8 @@ def check_json_similarity_evaluator() -> str:
             matched_ids.append(doc.get("id") or path.stem)
     if not matched_ids:
         sys.exit(
-            "FAIL: no evaluator with `evaluatorTypeId == \"uipath-json-"
-            "similarity\"` found. The agent emits structured JSON output; "
+            'FAIL: no evaluator with `evaluatorTypeId == "uipath-json-'
+            'similarity"` found. The agent emits structured JSON output; '
             "JsonSimilarityEvaluator is the documented fit for this shape."
         )
     print(f"OK: JsonSimilarityEvaluator wired (ids: {matched_ids})")
@@ -133,7 +133,11 @@ def _has_mockito_with_return(case: dict) -> bool:
         if not isinstance(b, dict):
             continue
         for step in b.get("then") or []:
-            if isinstance(step, dict) and step.get("type") == "return" and step.get("value") is not None:
+            if (
+                isinstance(step, dict)
+                and step.get("type") == "return"
+                and step.get("value") is not None
+            ):
                 return True
     return False
 
@@ -144,8 +148,7 @@ def check_eval_set() -> int:
     doc = _load_json(path)
     if doc.get("version") != "1.0":
         sys.exit(
-            f'FAIL: {path.name} version should be "1.0", '
-            f'got {doc.get("version")!r}'
+            f'FAIL: {path.name} version should be "1.0", got {doc.get("version")!r}'
         )
     cases = doc.get("evaluations") or []
     if not cases:
@@ -153,10 +156,10 @@ def check_eval_set() -> int:
     cases_with_mocks = [c for c in cases if _has_mockito_with_return(c)]
     if not cases_with_mocks:
         sys.exit(
-            f'FAIL: no test case in {path.name} carries a '
+            f"FAIL: no test case in {path.name} carries a "
             f'`mockingStrategy.type == "mockito"` with a non-empty return. '
-            f'The asset retrieval must be mocked declaratively for offline '
-            f'evals to pass.'
+            f"The asset retrieval must be mocked declaratively for offline "
+            f"evals to pass."
         )
     print(
         f"OK: {path.name} carries declarative mockito mocks on "
@@ -170,8 +173,7 @@ def check_results(expected_case_count: int) -> None:
     doc = _load_json(path)
     if not isinstance(doc, dict):
         sys.exit(
-            f"FAIL: {path.name} top-level should be an object, "
-            f"got {type(doc).__name__}"
+            f"FAIL: {path.name} top-level should be an object, got {type(doc).__name__}"
         )
     cases = doc.get("evaluationSetResults")
     if not isinstance(cases, list) or not cases:

--- a/tests/tasks/uipath-agents/eval_trajectory_empty_history/check_eval_trajectory_empty_history.py
+++ b/tests/tasks/uipath-agents/eval_trajectory_empty_history/check_eval_trajectory_empty_history.py
@@ -117,9 +117,9 @@ def detect_fix_a() -> bool:
                 keys = set((case.get("evaluationCriterias") or {}).keys())
                 if not (keys & set(contains_ids)):
                     sys.exit(
-                        f'FAIL: eval-set case `{case.get("id")}` does not key '
-                        f'its evaluationCriterias on the ContainsEvaluator '
-                        f'id(s) {contains_ids}. Got keys: {sorted(keys)}'
+                        f"FAIL: eval-set case `{case.get('id')}` does not key "
+                        f"its evaluationCriterias on the ContainsEvaluator "
+                        f"id(s) {contains_ids}. Got keys: {sorted(keys)}"
                     )
     if not refs_match:
         sys.exit(
@@ -138,7 +138,9 @@ def detect_fix_b() -> bool:
     has_traced = any(hint in text for hint in UIPATH_TRACING_HINTS)
     if not has_traced:
         return False
-    print("OK: Fix B detected — @traced() decorator from uipath.tracing wired into main.py")
+    print(
+        "OK: Fix B detected — @traced() decorator from uipath.tracing wired into main.py"
+    )
     return True
 
 

--- a/tests/tasks/uipath-agents/existing_project_resume/check_existing_project_resume.py
+++ b/tests/tasks/uipath-agents/existing_project_resume/check_existing_project_resume.py
@@ -64,7 +64,9 @@ def main() -> None:
         fail(f"entry-points.json is not valid JSON: {exc}")
     serialized = json.dumps(ep_payload)
     if "mood" not in serialized:
-        fail("entry-points.json does not advertise the original `mood` field — schema may have been clobbered")
+        fail(
+            "entry-points.json does not advertise the original `mood` field — schema may have been clobbered"
+        )
     if "confidence" not in serialized:
         fail(
             "entry-points.json does not advertise the new `confidence` field. "
@@ -84,17 +86,23 @@ def main() -> None:
     print("OK: main.py preserves the original `mood` field")
 
     if "confidence" not in main_text:
-        fail("main.py does not contain the new `confidence` field — the feature was not added")
+        fail(
+            "main.py does not contain the new `confidence` field — the feature was not added"
+        )
     print("OK: main.py adds the new `confidence` field")
 
     if not re.search(r"^\s*graph\s*=\s*", main_text, re.M):
-        fail("main.py no longer exports a top-level `graph =` variable — LangGraph entrypoint broken")
+        fail(
+            "main.py no longer exports a top-level `graph =` variable — LangGraph entrypoint broken"
+        )
     print("OK: top-level `graph` variable still exported")
 
     if not PYPROJECT.is_file():
         fail(f"missing {PYPROJECT}")
     if re.search(r"^\s*\[build-system\]", PYPROJECT.read_text(encoding="utf-8"), re.M):
-        fail("pyproject.toml gained a [build-system] section — Critical Rule C1 violation")
+        fail(
+            "pyproject.toml gained a [build-system] section — Critical Rule C1 violation"
+        )
     print("OK: pyproject.toml still has no [build-system] section")
 
     print("OK: existing-coded resume completed without clobbering")

--- a/tests/tasks/uipath-agents/file_attachment_input/check_file_attachment_input.py
+++ b/tests/tasks/uipath-agents/file_attachment_input/check_file_attachment_input.py
@@ -118,9 +118,7 @@ def check_entry_points() -> None:
             "`x-uipath-resource-kind: JobAttachment` — `uip codedagent init` "
             "did not emit the job-attachment schema."
         )
-    print(
-        "OK: entry-points.json carries x-uipath-resource-kind=JobAttachment"
-    )
+    print("OK: entry-points.json carries x-uipath-resource-kind=JobAttachment")
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/hitl_create_task/check_hitl_create_task.py
+++ b/tests/tasks/uipath-agents/hitl_create_task/check_hitl_create_task.py
@@ -21,7 +21,6 @@ Also runs the lazy-LLM-init AST scan as a hygiene check.
 from __future__ import annotations
 
 import ast
-import json
 import os
 import re
 import sys
@@ -102,7 +101,9 @@ def check_imports_and_calls(text: str, tree: ast.Module) -> None:
     if not re.search(r"from\s+langgraph\.types\s+import\s+[^\n]*\binterrupt\b", text):
         sys.exit("FAIL: missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateEscalation\b", text):
+    if not re.search(
+        r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateEscalation\b", text
+    ):
         sys.exit(
             "FAIL: missing `from uipath.platform.common import CreateEscalation`. "
             "The prompt describes an explicit escalation — the skill prescribes "
@@ -118,11 +119,11 @@ def check_imports_and_calls(text: str, tree: ast.Module) -> None:
     expected = {"app_name": "ExpenseReview", "app_folder_path": "Finance"}
     for kw, want in expected.items():
         if kw not in kwargs:
-            sys.exit(f'FAIL: `CreateEscalation(...)` is missing `{kw}=`')
+            sys.exit(f"FAIL: `CreateEscalation(...)` is missing `{kw}=`")
         got = _resolve_kwarg(kwargs[kw], consts)
         if got != want:
             sys.exit(
-                f'FAIL: `CreateEscalation({kw}=...)` resolves to {got!r}, expected {want!r}.'
+                f"FAIL: `CreateEscalation({kw}=...)` resolves to {got!r}, expected {want!r}."
             )
     print('OK: escalation targets app_name="ExpenseReview" / app_folder_path="Finance"')
 

--- a/tests/tasks/uipath-agents/hitl_create_task_with_app/check_hitl_create_task_with_app.py
+++ b/tests/tasks/uipath-agents/hitl_create_task_with_app/check_hitl_create_task_with_app.py
@@ -77,7 +77,11 @@ def find_create_task_call(tree: ast.Module) -> ast.Call | None:
         if not node.args:
             continue
         inner = node.args[0]
-        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id == "CreateTask":
+        if (
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == "CreateTask"
+        ):
             return inner
     return None
 
@@ -97,7 +101,9 @@ def main() -> None:
         fail("missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
 
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateTask\b", text):
+    if not re.search(
+        r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bCreateTask\b", text
+    ):
         fail(
             "missing `from uipath.platform.common import CreateTask`. "
             "The scenario opens a new Action Center task — use `CreateTask`."
@@ -124,7 +130,9 @@ def main() -> None:
         got = resolve_kwarg(kwargs[kw], consts)
         if got != want:
             fail(f"`CreateTask({kw}=...)` resolves to {got!r}, expected {want!r}")
-    print('OK: CreateTask targets app_name="RefundReview" / app_folder_path="Compliance"')
+    print(
+        'OK: CreateTask targets app_name="RefundReview" / app_folder_path="Compliance"'
+    )
 
     if not re.search(r"^\s*graph\s*=\s*", text, re.M):
         fail("main.py does not export a top-level `graph =` variable")

--- a/tests/tasks/uipath-agents/hitl_wait_task/check_hitl_wait_task.py
+++ b/tests/tasks/uipath-agents/hitl_wait_task/check_hitl_wait_task.py
@@ -51,7 +51,11 @@ def has_interrupt_wait_task(tree: ast.Module) -> bool:
         if not node.args:
             continue
         inner = node.args[0]
-        if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name) and inner.func.id == "WaitTask":
+        if (
+            isinstance(inner, ast.Call)
+            and isinstance(inner.func, ast.Name)
+            and inner.func.id == "WaitTask"
+        ):
             return True
     return False
 
@@ -71,7 +75,9 @@ def main() -> None:
         fail("missing `from langgraph.types import interrupt`")
     print("OK: imports `interrupt` from langgraph.types")
 
-    if not re.search(r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bWaitTask\b", text):
+    if not re.search(
+        r"from\s+uipath\.platform\.common\s+import\s+[^\n]*\bWaitTask\b", text
+    ):
         fail(
             "missing `from uipath.platform.common import WaitTask`. "
             "The scenario is `WaitTask` (wait on an existing Action Center task), "
@@ -86,13 +92,17 @@ def main() -> None:
         )
     print("OK: graph node calls interrupt(WaitTask(...))")
 
-    if re.search(r"\bCreateTask\s*\(", text) or re.search(r"\bCreateEscalation\s*\(", text):
+    if re.search(r"\bCreateTask\s*\(", text) or re.search(
+        r"\bCreateEscalation\s*\(", text
+    ):
         fail(
             "main.py invokes `CreateTask(...)` or `CreateEscalation(...)`. "
             "Those open a NEW Action Center task — the scenario is monitoring an "
             "ALREADY-CREATED task via `WaitTask`. Use `WaitTask` only."
         )
-    print("OK: no CreateTask / CreateEscalation usage (scenario is monitor-existing-task)")
+    print(
+        "OK: no CreateTask / CreateEscalation usage (scenario is monitor-existing-task)"
+    )
 
     if not re.search(r"^\s*graph\s*=\s*", text, re.M):
         fail("main.py does not export a top-level `graph =` variable")

--- a/tests/tasks/uipath-agents/langgraph_classifier/check_langgraph_classifier.py
+++ b/tests/tasks/uipath-agents/langgraph_classifier/check_langgraph_classifier.py
@@ -89,7 +89,9 @@ def check_graph_module(path: Path) -> None:
         if needle not in text:
             sys.exit(f"FAIL: {path.name} is missing `{needle}`")
     if "StateGraph" not in text and "CompiledStateGraph" not in text:
-        sys.exit(f"FAIL: {path.name} does not reference StateGraph / CompiledStateGraph")
+        sys.exit(
+            f"FAIL: {path.name} does not reference StateGraph / CompiledStateGraph"
+        )
     print(f"OK: {path.name} defines GraphInput, GraphOutput, and a graph variable")
     violations = find_module_level_llm_clients(path)
     if violations:
@@ -111,8 +113,8 @@ def check_runtime_config() -> None:
         target = next(iter(graphs.values()))
         if not isinstance(target, str) or ":graph" not in target:
             sys.exit(
-                f'FAIL: langgraph.json graphs entry should map to a `<file>:graph` '
-                f'reference, got {target!r}'
+                f"FAIL: langgraph.json graphs entry should map to a `<file>:graph` "
+                f"reference, got {target!r}"
             )
         print(f"OK: langgraph.json registers a graph -> {target!r}")
         return
@@ -125,7 +127,7 @@ def check_runtime_config() -> None:
                 "FAIL: neither langgraph.json nor uipath.json `functions.graph` "
                 "is present — the runtime cannot find the compiled graph."
             )
-        print(f'OK: uipath.json registers functions.graph -> {graph_entry!r}')
+        print(f"OK: uipath.json registers functions.graph -> {graph_entry!r}")
         return
     sys.exit(
         "FAIL: project has neither langgraph.json nor uipath.json — at "
@@ -137,15 +139,17 @@ def check_entry_points() -> None:
     doc = _load_json(ROOT / "entry-points.json")
     entrypoints = doc.get("entryPoints") or []
     if not entrypoints:
-        sys.exit("FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully")
+        sys.exit(
+            "FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully"
+        )
     raw = json.dumps(entrypoints)
     for field in ("text", "category"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entry-points.json schemas do not mention `{field}`. '
-                f'Either `uip codedagent init` ran before the Pydantic models '
-                f'were written, or the models did not declare the expected '
-                f'fields. Got: {raw}'
+                f"FAIL: entry-points.json schemas do not mention `{field}`. "
+                f"Either `uip codedagent init` ran before the Pydantic models "
+                f"were written, or the models did not declare the expected "
+                f"fields. Got: {raw}"
             )
     print(
         "OK: entry-points.json schemas reflect the GraphInput/GraphOutput "
@@ -168,7 +172,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/llamaindex_rag/check_llamaindex_rag.py
+++ b/tests/tasks/uipath-agents/llamaindex_rag/check_llamaindex_rag.py
@@ -23,7 +23,6 @@ import json
 import os
 import re
 import sys
-from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
@@ -41,7 +40,11 @@ def fail(msg: str) -> None:
 
 def find_call(tree: ast.Module, func_name: str) -> ast.Call | None:
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == func_name:
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == func_name
+        ):
             return node
     return None
 
@@ -71,28 +74,41 @@ def main() -> None:
     except SyntaxError as exc:
         fail(f"main.py has a syntax error: {exc}")
 
-    if not re.search(r"from\s+llama_index\.core\.workflow\s+import\s+[^\n]*\bWorkflow\b", text):
+    if not re.search(
+        r"from\s+llama_index\.core\.workflow\s+import\s+[^\n]*\bWorkflow\b", text
+    ):
         fail("main.py does not import `Workflow` from `llama_index.core.workflow`")
-    if not re.search(r"from\s+llama_index\.core\.workflow\s+import\s+[^\n]*\bstep\b", text):
+    if not re.search(
+        r"from\s+llama_index\.core\.workflow\s+import\s+[^\n]*\bstep\b", text
+    ):
         fail("main.py does not import `step` from `llama_index.core.workflow`")
     if not re.search(r"@step\b", text):
-        fail("main.py has no `@step` decorator — the workflow nodes must be marked with @step")
+        fail(
+            "main.py has no `@step` decorator — the workflow nodes must be marked with @step"
+        )
     print("OK: LlamaIndex Workflow shape (Workflow import + @step decorator) present")
 
-    if not re.search(r"from\s+uipath_llamaindex\.query_engines\s+import\s+[^\n]*\bContextGroundingQueryEngine\b", text):
+    if not re.search(
+        r"from\s+uipath_llamaindex\.query_engines\s+import\s+[^\n]*\bContextGroundingQueryEngine\b",
+        text,
+    ):
         fail(
             "main.py does not import `ContextGroundingQueryEngine` from "
             "`uipath_llamaindex.query_engines`. That is the UiPath RAG primitive "
             "for LlamaIndex — use it to ground answers in the index."
         )
-    print("OK: imports ContextGroundingQueryEngine from uipath_llamaindex.query_engines")
+    print(
+        "OK: imports ContextGroundingQueryEngine from uipath_llamaindex.query_engines"
+    )
 
     call = find_call(tree, "ContextGroundingQueryEngine")
     if call is None:
         fail("no `ContextGroundingQueryEngine(...)` call site found")
     kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
     name_node = kwargs.get("index_name")
-    if name_node is None or not (isinstance(name_node, ast.Constant) and name_node.value == "hr-policy"):
+    if name_node is None or not (
+        isinstance(name_node, ast.Constant) and name_node.value == "hr-policy"
+    ):
         got = getattr(name_node, "value", name_node)
         fail(
             f"`ContextGroundingQueryEngine(index_name=...)` resolves to {got!r}, "

--- a/tests/tasks/uipath-agents/llamaindex_workflow/check_llamaindex_workflow.py
+++ b/tests/tasks/uipath-agents/llamaindex_workflow/check_llamaindex_workflow.py
@@ -73,8 +73,8 @@ def check_llama_index_json() -> None:
     target = next(iter(workflows.values()))
     if not isinstance(target, str) or ":" not in target:
         sys.exit(
-            f'FAIL: llama_index.json workflows entry should map to a '
-            f'`<file>:<variable>` reference, got {target!r}'
+            f"FAIL: llama_index.json workflows entry should map to a "
+            f"`<file>:<variable>` reference, got {target!r}"
         )
     print(f"OK: llama_index.json registers a workflow -> {target!r}")
 
@@ -107,9 +107,9 @@ def check_entry_points() -> None:
     for field in ("question", "answer", "word_count"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entry-points.json schemas do not mention `{field}`. '
-                f'StartEvent/StopEvent fields were not picked up by '
-                f'`uip codedagent init`. Got: {raw}'
+                f"FAIL: entry-points.json schemas do not mention `{field}`. "
+                f"StartEvent/StopEvent fields were not picked up by "
+                f"`uip codedagent init`. Got: {raw}"
             )
     print(
         "OK: entry-points.json reflects StartEvent/StopEvent fields "
@@ -131,7 +131,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/local_workspace_iterate/check_local_workspace_iterate.py
+++ b/tests/tasks/uipath-agents/local_workspace_iterate/check_local_workspace_iterate.py
@@ -37,11 +37,17 @@ def fail(msg: str) -> None:
 def main() -> None:
     # --- Studio Web ownership preserved ---
     if not SW_MARKER.is_file():
-        fail(f"missing Studio Web detection marker {SW_MARKER} — Local Workspace identity lost")
+        fail(
+            f"missing Studio Web detection marker {SW_MARKER} — Local Workspace identity lost"
+        )
     if not FOLDER_LOCK.is_file():
-        fail(f"missing Studio Web folder lock {FOLDER_LOCK} — Local Workspace identity lost")
+        fail(
+            f"missing Studio Web folder lock {FOLDER_LOCK} — Local Workspace identity lost"
+        )
     if not PROJECT_UIPROJ.is_file():
-        fail(f"{PROJECT_UIPROJ} missing — Local Workspace anti-pattern: do not delete project.uiproj")
+        fail(
+            f"{PROJECT_UIPROJ} missing — Local Workspace anti-pattern: do not delete project.uiproj"
+        )
     print("OK: Studio Web markers and project.uiproj are intact")
 
     # --- UIPATH_PROJECT_ID sentinel untouched ---
@@ -60,7 +66,9 @@ def main() -> None:
         fail(f"missing {MAIN}")
     main_text = MAIN.read_text(encoding="utf-8")
     if "category" not in main_text:
-        fail("main.py does not mention a `category` field — the requested behavior is missing")
+        fail(
+            "main.py does not mention a `category` field — the requested behavior is missing"
+        )
     print("OK: main.py declares the `category` field")
 
     # --- entry-points.json regenerated to advertise the new output ---
@@ -87,12 +95,18 @@ def main() -> None:
         fail(f"outputs.json is not valid JSON: {exc}")
     flat = json.dumps(outs).lower()
     if "tiny" not in flat:
-        fail("outputs.json does not mention a `tiny` result — value=2 run not captured or wrong branch")
+        fail(
+            "outputs.json does not mention a `tiny` result — value=2 run not captured or wrong branch"
+        )
     if "huge" not in flat:
-        fail("outputs.json does not mention a `huge` result — value=150 run not captured or wrong branch")
+        fail(
+            "outputs.json does not mention a `huge` result — value=150 run not captured or wrong branch"
+        )
     print("OK: outputs.json captured both `tiny` and `huge` branches")
 
-    print("OK: Local Workspace iteration completed without violating ownership invariants")
+    print(
+        "OK: Local Workspace iteration completed without violating ownership invariants"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/builtin_tool/check_builtin_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/builtin_tool/check_builtin_tool.py
@@ -51,16 +51,19 @@ def find_resource_jsons() -> list:
 
 def is_builtin_tool(resource: dict) -> bool:
     return (
-        resource.get("$resourceType") == "tool"
-        and resource.get("type") == "internal"
+        resource.get("$resourceType") == "tool" and resource.get("type") == "internal"
     )
 
 
 def assert_builtin_shape(path: Path, resource: dict) -> str:
     if resource.get("$resourceType") != "tool":
-        sys.exit(f'FAIL: {path} $resourceType should be "tool", got {resource.get("$resourceType")!r}')
+        sys.exit(
+            f'FAIL: {path} $resourceType should be "tool", got {resource.get("$resourceType")!r}'
+        )
     if resource.get("type") != "internal":
-        sys.exit(f'FAIL: {path} type should be "internal" for a built-in tool, got {resource.get("type")!r}')
+        sys.exit(
+            f'FAIL: {path} type should be "internal" for a built-in tool, got {resource.get("type")!r}'
+        )
     if resource.get("referenceKey") is not None:
         sys.exit(
             f"FAIL: {path} referenceKey should be null for a built-in tool "
@@ -101,7 +104,7 @@ def assert_builtin_tool_enabled() -> None:
         sys.exit(
             f'FAIL: prompt asked for the "Analyze Files" built-in tool '
             f'(toolType "analyze-attachments"), but none was enabled. '
-            f'Got toolTypes: {builtin_tool_types_seen}'
+            f"Got toolTypes: {builtin_tool_types_seen}"
         )
     print('OK: "Analyze Files" (toolType="analyze-attachments") is enabled')
 
@@ -120,7 +123,7 @@ def assert_job_attachment_input(agent: dict) -> None:
     if ja_def.get("type") != "object":
         sys.exit(
             'FAIL: inputSchema.definitions["job-attachment"] must be an object '
-            f'schema, got type={ja_def.get("type")!r}'
+            f"schema, got type={ja_def.get('type')!r}"
         )
     print('OK: inputSchema.definitions["job-attachment"] is defined')
 
@@ -143,9 +146,7 @@ def assert_job_attachment_input(agent: dict) -> None:
     missing = []
     for name in refs:
         # Match {{ input.<name> }} with any internal whitespace.
-        pattern = re.compile(
-            r"\{\{\s*input\." + re.escape(name) + r"\s*\}\}"
-        )
+        pattern = re.compile(r"\{\{\s*input\." + re.escape(name) + r"\s*\}\}")
         if not any(pattern.search(body) for body in bodies):
             missing.append(name)
     if missing:

--- a/tests/tasks/uipath-agents/lowcode/context_index/check_context_index.py
+++ b/tests/tasks/uipath-agents/lowcode/context_index/check_context_index.py
@@ -49,14 +49,16 @@ def load(path: Path) -> dict:
 def assert_context_resource(resource: dict) -> None:
     rtype = resource.get("$resourceType")
     if rtype != "context":
-        sys.exit(f'FAIL: resource.json $resourceType should be "context", got {rtype!r}')
+        sys.exit(
+            f'FAIL: resource.json $resourceType should be "context", got {rtype!r}'
+        )
     ctype = resource.get("contextType")
     if ctype != "index":
         sys.exit(f'FAIL: resource.json contextType should be "index", got {ctype!r}')
     name = resource.get("name")
     if name != EXPECTED_INDEX_NAME:
         sys.exit(
-            f'FAIL: resource.json name should be {EXPECTED_INDEX_NAME!r} '
+            f"FAIL: resource.json name should be {EXPECTED_INDEX_NAME!r} "
             f"(matching the deployed index), got {name!r}"
         )
     index_name = resource.get("indexName")
@@ -119,10 +121,14 @@ def assert_input_shape(schema: dict) -> None:
         )
     q = props["question"]
     if not isinstance(q, dict) or q.get("type") != "string":
-        sys.exit(f"FAIL: inputSchema.properties.question.type should be 'string', got {q!r}")
+        sys.exit(
+            f"FAIL: inputSchema.properties.question.type should be 'string', got {q!r}"
+        )
     required = schema.get("required")
     if not isinstance(required, list) or "question" not in required:
-        sys.exit(f"FAIL: inputSchema.required must contain 'question', got {required!r}")
+        sys.exit(
+            f"FAIL: inputSchema.required must contain 'question', got {required!r}"
+        )
     print("OK: inputSchema declares required question:string")
 
 
@@ -134,7 +140,9 @@ def assert_output_shape(schema: dict) -> None:
         )
     a = props["answer"]
     if not isinstance(a, dict) or a.get("type") != "string":
-        sys.exit(f"FAIL: outputSchema.properties.answer.type should be 'string', got {a!r}")
+        sys.exit(
+            f"FAIL: outputSchema.properties.answer.type should be 'string', got {a!r}"
+        )
     print("OK: outputSchema declares answer:string")
 
 
@@ -143,7 +151,9 @@ def assert_bindings_index(bindings: dict) -> None:
     if not isinstance(resources, list):
         sys.exit(f"FAIL: bindings_v2.json resources must be a list, got {resources!r}")
 
-    index_bindings = [r for r in resources if isinstance(r, dict) and r.get("resource") == "index"]
+    index_bindings = [
+        r for r in resources if isinstance(r, dict) and r.get("resource") == "index"
+    ]
     if not index_bindings:
         sys.exit(
             'FAIL: bindings_v2.json has no resource entry with resource="index". '
@@ -164,10 +174,14 @@ def assert_bindings_index(bindings: dict) -> None:
 
     value = binding.get("value")
     if not isinstance(value, dict):
-        sys.exit(f"FAIL: bindings_v2.json index binding value must be an object, got {value!r}")
+        sys.exit(
+            f"FAIL: bindings_v2.json index binding value must be an object, got {value!r}"
+        )
 
     name_field = value.get("name") or {}
-    name_default = name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    name_default = (
+        name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    )
     if name_default != EXPECTED_INDEX_NAME:
         sys.exit(
             f"FAIL: bindings_v2.json index binding value.name.defaultValue should be "
@@ -175,7 +189,9 @@ def assert_bindings_index(bindings: dict) -> None:
         )
 
     folder_field = value.get("folderPath") or {}
-    folder_default = folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    folder_default = (
+        folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    )
     if folder_default != EXPECTED_FOLDER_PATH:
         sys.exit(
             f"FAIL: bindings_v2.json index binding value.folderPath.defaultValue should be "

--- a/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/check_dispute_analyst_agent.py
+++ b/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/check_dispute_analyst_agent.py
@@ -45,6 +45,7 @@ OUTPUT_FIELDS = [
     "flags",
 ]
 
+
 def load(path: Path) -> dict:
     if not path.is_file():
         sys.exit(f"FAIL: Missing {path}")
@@ -129,9 +130,7 @@ def resolve_analysis_properties(out_schema: dict) -> dict:
             )
         inner = nested.get("properties")
         if not isinstance(inner, dict):
-            sys.exit(
-                "FAIL: outputSchema.properties.disputeAnalysis.properties missing"
-            )
+            sys.exit("FAIL: outputSchema.properties.disputeAnalysis.properties missing")
         print("OK: outputSchema uses nested disputeAnalysis object")
         return inner
 
@@ -144,8 +143,7 @@ def assert_output_shape(out_schema: dict) -> None:
     missing = [f for f in OUTPUT_FIELDS if f not in props]
     if missing:
         sys.exit(
-            f"FAIL: outputSchema missing fields {missing!r}; "
-            f"got {sorted(props)!r}"
+            f"FAIL: outputSchema missing fields {missing!r}; got {sorted(props)!r}"
         )
     print(f"OK: outputSchema declares all {len(OUTPUT_FIELDS)} fields")
 
@@ -154,7 +152,9 @@ def get_user_message(agent: dict) -> dict:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     return user_messages[0]
@@ -181,7 +181,7 @@ def assert_user_message_inlines(agent: dict) -> None:
                 f"input.{field}\n  expected: {expected}\n"
                 f"  got tokens: {json.dumps(tokens, indent=2)}"
             )
-    print(f"OK: user message inlines all 5 inputs with matching contentTokens")
+    print("OK: user message inlines all 5 inputs with matching contentTokens")
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/lowcode/edit_roundtrip/check_edit_roundtrip.py
+++ b/tests/tasks/uipath-agents/lowcode/edit_roundtrip/check_edit_roundtrip.py
@@ -71,7 +71,9 @@ def assert_input_fields(in_schema: dict) -> None:
     for f in INPUT_FIELDS:
         ftype = props[f].get("type") if isinstance(props[f], dict) else None
         if ftype != "string":
-            sys.exit(f"FAIL: inputSchema.properties.{f}.type should be 'string', got {ftype!r}")
+            sys.exit(
+                f"FAIL: inputSchema.properties.{f}.type should be 'string', got {ftype!r}"
+            )
     required = in_schema.get("required")
     if not isinstance(required, list):
         sys.exit(f"FAIL: inputSchema.required must be a list, got {required!r}")
@@ -92,7 +94,9 @@ def assert_output_field(out_schema: dict) -> None:
         )
     g = props["greeting"]
     if not isinstance(g, dict) or g.get("type") != "string":
-        sys.exit(f"FAIL: outputSchema.properties.greeting.type should be 'string', got {g!r}")
+        sys.exit(
+            f"FAIL: outputSchema.properties.greeting.type should be 'string', got {g!r}"
+        )
     print("OK: outputSchema declares greeting:string")
 
 
@@ -100,7 +104,9 @@ def assert_user_message_inlines_both(agent: dict) -> None:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     user = user_messages[0]

--- a/tests/tasks/uipath-agents/lowcode/external_agent_tool/check_external_agent_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/external_agent_tool/check_external_agent_tool.py
@@ -58,7 +58,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="agent", location="external"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="agent", location="external"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -94,12 +96,16 @@ def assert_identity_and_schemas(resource: dict) -> None:
             f"from `uip solution resource list`'s `Key`, got {rkey!r}"
         )
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):
         sys.exit("FAIL: resource.outputSchema must be an object")
-    print(f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas")
+    print(
+        f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas"
+    )
 
 
 def assert_bindings_process(bindings: dict) -> None:
@@ -110,12 +116,14 @@ def assert_bindings_process(bindings: dict) -> None:
     process_bindings = [
         r
         for r in resources
-        if isinstance(r, dict) and r.get("resource") == "process" and r.get("key") == EXPECTED_PROCESS_NAME
+        if isinstance(r, dict)
+        and r.get("resource") == "process"
+        and r.get("key") == EXPECTED_PROCESS_NAME
     ]
     if not process_bindings:
         sys.exit(
             f'FAIL: bindings_v2.json has no resource entry with resource="process" '
-            f'and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit '
+            f"and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit "
             "one for the external agent tool."
         )
     if len(process_bindings) > 1:
@@ -127,10 +135,14 @@ def assert_bindings_process(bindings: dict) -> None:
 
     value = binding.get("value")
     if not isinstance(value, dict):
-        sys.exit(f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}")
+        sys.exit(
+            f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}"
+        )
 
     name_field = value.get("name") or {}
-    name_default = name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    name_default = (
+        name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    )
     if name_default != EXPECTED_PROCESS_NAME:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.name.defaultValue should be "
@@ -138,7 +150,9 @@ def assert_bindings_process(bindings: dict) -> None:
         )
 
     folder_field = value.get("folderPath") or {}
-    folder_default = folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    folder_default = (
+        folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    )
     if folder_default != EXPECTED_FOLDER_PATH:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.folderPath.defaultValue should be "

--- a/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/check_external_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/check_external_apiworkflow_tool.py
@@ -94,12 +94,16 @@ def assert_identity_and_schemas(resource: dict) -> None:
             f"from `uip solution resource list`'s `Key`, got {rkey!r}"
         )
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):
         sys.exit("FAIL: resource.outputSchema must be an object")
-    print(f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas")
+    print(
+        f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas"
+    )
 
 
 def assert_bindings_process(bindings: dict) -> None:
@@ -110,12 +114,14 @@ def assert_bindings_process(bindings: dict) -> None:
     process_bindings = [
         r
         for r in resources
-        if isinstance(r, dict) and r.get("resource") == "process" and r.get("key") == EXPECTED_PROCESS_NAME
+        if isinstance(r, dict)
+        and r.get("resource") == "process"
+        and r.get("key") == EXPECTED_PROCESS_NAME
     ]
     if not process_bindings:
         sys.exit(
             f'FAIL: bindings_v2.json has no resource entry with resource="process" '
-            f'and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit '
+            f"and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit "
             "one for the external API workflow tool."
         )
     if len(process_bindings) > 1:
@@ -127,10 +133,14 @@ def assert_bindings_process(bindings: dict) -> None:
 
     value = binding.get("value")
     if not isinstance(value, dict):
-        sys.exit(f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}")
+        sys.exit(
+            f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}"
+        )
 
     name_field = value.get("name") or {}
-    name_default = name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    name_default = (
+        name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    )
     if name_default != EXPECTED_PROCESS_NAME:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.name.defaultValue should be "
@@ -138,7 +148,9 @@ def assert_bindings_process(bindings: dict) -> None:
         )
 
     folder_field = value.get("folderPath") or {}
-    folder_default = folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    folder_default = (
+        folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    )
     if folder_default != EXPECTED_FOLDER_PATH:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.folderPath.defaultValue should be "

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/check_external_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/check_external_escalation.py
@@ -50,16 +50,23 @@ def assert_escalation_header(resource: dict) -> None:
     if not isinstance(name, str) or not name.strip():
         sys.exit(f"FAIL: escalation name missing or empty: {name!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}")
-    print(f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)')
+        sys.exit(
+            f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
+    print(
+        f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)'
+    )
 
 
 def assert_actioncenter_channel(resource: dict) -> None:
     channels = resource.get("channels")
     if not isinstance(channels, list) or not channels:
-        sys.exit(f"FAIL: escalation.channels must be a non-empty list, got {channels!r}")
+        sys.exit(
+            f"FAIL: escalation.channels must be a non-empty list, got {channels!r}"
+        )
     ac_channels = [
-        c for c in channels
+        c
+        for c in channels
         if isinstance(c, dict)
         and c.get("type") == "actionCenter"
         and isinstance(c.get("name"), str)

--- a/tests/tasks/uipath-agents/lowcode/external_maestro_tool/check_external_maestro_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/external_maestro_tool/check_external_maestro_tool.py
@@ -58,7 +58,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="processOrchestration", location="external"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="processOrchestration", location="external"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -94,12 +96,16 @@ def assert_identity_and_schemas(resource: dict) -> None:
             f"from `uip solution resource list`'s `Key`, got {rkey!r}"
         )
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):
         sys.exit("FAIL: resource.outputSchema must be an object")
-    print(f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas")
+    print(
+        f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas"
+    )
 
 
 def assert_bindings_process(bindings: dict) -> None:
@@ -110,12 +116,14 @@ def assert_bindings_process(bindings: dict) -> None:
     process_bindings = [
         r
         for r in resources
-        if isinstance(r, dict) and r.get("resource") == "process" and r.get("key") == EXPECTED_PROCESS_NAME
+        if isinstance(r, dict)
+        and r.get("resource") == "process"
+        and r.get("key") == EXPECTED_PROCESS_NAME
     ]
     if not process_bindings:
         sys.exit(
             f'FAIL: bindings_v2.json has no resource entry with resource="process" '
-            f'and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit '
+            f"and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit "
             "one for the external Maestro tool."
         )
     if len(process_bindings) > 1:
@@ -127,10 +135,14 @@ def assert_bindings_process(bindings: dict) -> None:
 
     value = binding.get("value")
     if not isinstance(value, dict):
-        sys.exit(f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}")
+        sys.exit(
+            f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}"
+        )
 
     name_field = value.get("name") or {}
-    name_default = name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    name_default = (
+        name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    )
     if name_default != EXPECTED_PROCESS_NAME:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.name.defaultValue should be "
@@ -138,7 +150,9 @@ def assert_bindings_process(bindings: dict) -> None:
         )
 
     folder_field = value.get("folderPath") or {}
-    folder_default = folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    folder_default = (
+        folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    )
     if folder_default != EXPECTED_FOLDER_PATH:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.folderPath.defaultValue should be "

--- a/tests/tasks/uipath-agents/lowcode/external_rpa_tool/check_external_rpa_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/external_rpa_tool/check_external_rpa_tool.py
@@ -55,7 +55,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="process", location="external"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="process", location="external"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -91,12 +93,16 @@ def assert_identity_and_schemas(resource: dict) -> None:
             f"from `uip solution resource list`'s `Key`, got {rkey!r}"
         )
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):
         sys.exit("FAIL: resource.outputSchema must be an object")
-    print(f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas")
+    print(
+        f"OK: resource has id={rid}, referenceKey={rkey}, isEnabled=true, and input/output schemas"
+    )
 
 
 def assert_bindings_process(bindings: dict) -> None:
@@ -107,12 +113,14 @@ def assert_bindings_process(bindings: dict) -> None:
     process_bindings = [
         r
         for r in resources
-        if isinstance(r, dict) and r.get("resource") == "process" and r.get("key") == EXPECTED_PROCESS_NAME
+        if isinstance(r, dict)
+        and r.get("resource") == "process"
+        and r.get("key") == EXPECTED_PROCESS_NAME
     ]
     if not process_bindings:
         sys.exit(
             f'FAIL: bindings_v2.json has no resource entry with resource="process" '
-            f'and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit '
+            f"and key={EXPECTED_PROCESS_NAME!r}. `uip agent validate` should emit "
             "one for the external RPA tool."
         )
     if len(process_bindings) > 1:
@@ -124,10 +132,14 @@ def assert_bindings_process(bindings: dict) -> None:
 
     value = binding.get("value")
     if not isinstance(value, dict):
-        sys.exit(f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}")
+        sys.exit(
+            f"FAIL: bindings_v2.json process binding value must be an object, got {value!r}"
+        )
 
     name_field = value.get("name") or {}
-    name_default = name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    name_default = (
+        name_field.get("defaultValue") if isinstance(name_field, dict) else None
+    )
     if name_default != EXPECTED_PROCESS_NAME:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.name.defaultValue should be "
@@ -135,7 +147,9 @@ def assert_bindings_process(bindings: dict) -> None:
         )
 
     folder_field = value.get("folderPath") or {}
-    folder_default = folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    folder_default = (
+        folder_field.get("defaultValue") if isinstance(folder_field, dict) else None
+    )
     if folder_default != EXPECTED_FOLDER_PATH:
         sys.exit(
             f"FAIL: bindings_v2.json process binding value.folderPath.defaultValue should be "

--- a/tests/tasks/uipath-agents/lowcode/guardrail_custom_word/check_guardrail_custom_word.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_custom_word/check_guardrail_custom_word.py
@@ -82,12 +82,14 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(
             f"FAIL: guardrail.selector.scopes contains invalid values {invalid}. "
-            f'Valid PascalCase values: {sorted(VALID_SCOPES)}'
+            f"Valid PascalCase values: {sorted(VALID_SCOPES)}"
         )
     print(f"OK: selector.scopes = {scopes} (all PascalCase)")
 
@@ -100,8 +102,7 @@ def main() -> None:
     rule = rules[0]
     if rule.get("$ruleType") != "word":
         sys.exit(
-            f'FAIL: rules[0].$ruleType must be "word", '
-            f"got {rule.get('$ruleType')!r}"
+            f'FAIL: rules[0].$ruleType must be "word", got {rule.get("$ruleType")!r}'
         )
     print('OK: rules[0].$ruleType == "word"')
 
@@ -120,16 +121,14 @@ def main() -> None:
     # --- operator == "contains" ---
     if rule.get("operator") != "contains":
         sys.exit(
-            f'FAIL: rules[0].operator must be "contains", '
-            f"got {rule.get('operator')!r}"
+            f'FAIL: rules[0].operator must be "contains", got {rule.get("operator")!r}'
         )
     print('OK: rules[0].operator == "contains"')
 
     # --- value == "CONFIDENTIAL" ---
     if rule.get("value") != "CONFIDENTIAL":
         sys.exit(
-            f'FAIL: rules[0].value must be "CONFIDENTIAL", '
-            f"got {rule.get('value')!r}"
+            f'FAIL: rules[0].value must be "CONFIDENTIAL", got {rule.get("value")!r}'
         )
     print('OK: rules[0].value == "CONFIDENTIAL"')
 

--- a/tests/tasks/uipath-agents/lowcode/guardrail_discovery/check_guardrail_discovery.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_discovery/check_guardrail_discovery.py
@@ -49,8 +49,7 @@ def main() -> None:
 
     # --- find builtInValidator ---
     validators = [
-        g for g in guardrails
-        if g.get("$guardrailType") == "builtInValidator"
+        g for g in guardrails if g.get("$guardrailType") == "builtInValidator"
     ]
     if not validators:
         types = [g.get("$guardrailType") for g in guardrails]
@@ -64,7 +63,9 @@ def main() -> None:
     # --- validatorType is a non-empty string ---
     vt = g.get("validatorType")
     if not isinstance(vt, str) or not vt:
-        sys.exit(f"FAIL: guardrail.validatorType must be a non-empty string, got {vt!r}")
+        sys.exit(
+            f"FAIL: guardrail.validatorType must be a non-empty string, got {vt!r}"
+        )
     print(f"OK: validatorType = {vt!r}")
 
     # --- id is UUID-shaped ---
@@ -90,7 +91,9 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(

--- a/tests/tasks/uipath-agents/lowcode/guardrail_escalation_app/check_guardrail_escalation_app.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_escalation_app/check_guardrail_escalation_app.py
@@ -63,7 +63,8 @@ def main() -> None:
 
     # --- find builtInValidator with pii_detection and escalate action ---
     escalation_candidates = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and g.get("validatorType") == "pii_detection"
         and isinstance(g.get("action"), dict)
@@ -71,8 +72,11 @@ def main() -> None:
     ]
     if not escalation_candidates:
         found = [
-            (g.get("$guardrailType"), g.get("validatorType"),
-             (g.get("action") or {}).get("$actionType"))
+            (
+                g.get("$guardrailType"),
+                g.get("validatorType"),
+                (g.get("action") or {}).get("$actionType"),
+            )
             for g in guardrails
         ]
         sys.exit(
@@ -124,7 +128,9 @@ def main() -> None:
     if folder_id:
         print(f"OK: action.app.folderId = {folder_id!r}")
     if app.get("id"):
-        print(f"OK: action.app.id = {app['id']!r} (optional, populated from resource lookup)")
+        print(
+            f"OK: action.app.id = {app['id']!r} (optional, populated from resource lookup)"
+        )
 
     # --- action.recipient ---
     recipient = action.get("recipient")
@@ -154,7 +160,9 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(
@@ -183,7 +191,9 @@ def main() -> None:
         )
     entities_value = entities_param.get("value")
     if not isinstance(entities_value, list):
-        sys.exit(f"FAIL: entities parameter.value must be an array, got {entities_value!r}")
+        sys.exit(
+            f"FAIL: entities parameter.value must be an array, got {entities_value!r}"
+        )
     entities_set = set(entities_value)
     missing = REQUIRED_ENTITIES - entities_set
     if missing:
@@ -191,7 +201,9 @@ def main() -> None:
             f"FAIL: entities parameter.value must include {sorted(REQUIRED_ENTITIES)}, "
             f"missing: {sorted(missing)}. Got: {entities_value}"
         )
-    snake = [e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())]
+    snake = [
+        e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())
+    ]
     if snake:
         sys.exit(
             f"FAIL: entity names must be PascalCase (not snake_case). "

--- a/tests/tasks/uipath-agents/lowcode/guardrail_escalation_app_validation/check_guardrail_escalation_app_validation.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_escalation_app_validation/check_guardrail_escalation_app_validation.py
@@ -35,7 +35,9 @@ def main() -> None:
 
     guardrails = agent.get("guardrails")
     if not isinstance(guardrails, list) or len(guardrails) == 0:
-        print("OK: no guardrails array (or empty) — agent did not write the escalate guardrail")
+        print(
+            "OK: no guardrails array (or empty) — agent did not write the escalate guardrail"
+        )
         return
 
     # Check that no guardrail uses EscalationWorksApp in an escalate action
@@ -51,13 +53,13 @@ def main() -> None:
         app_name = app.get("name", "")
         if "EscalationWorksApp" in app_name:
             sys.exit(
-                f"FAIL: agent wrote an escalate guardrail using EscalationWorksApp "
-                f"without validating the action schema. The app is incompatible — "
-                f"it has inputs=[input], outputs=[output], outcomes=[Submit,Reject] "
-                f"instead of the required 8 inputs, 3 outputs, and Approve/Reject outcomes. "
-                f"The agent should have reported: "
-                f"'EscalationWorksApp does not have the required action schema "
-                f"configuration for tool guardrails.'"
+                "FAIL: agent wrote an escalate guardrail using EscalationWorksApp "
+                "without validating the action schema. The app is incompatible — "
+                "it has inputs=[input], outputs=[output], outcomes=[Submit,Reject] "
+                "instead of the required 8 inputs, 3 outputs, and Approve/Reject outcomes. "
+                "The agent should have reported: "
+                "'EscalationWorksApp does not have the required action schema "
+                "configuration for tool guardrails.'"
             )
 
     print("OK: no escalate guardrail references EscalationWorksApp")

--- a/tests/tasks/uipath-agents/lowcode/guardrail_pii_detection/check_guardrail_pii_detection.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_pii_detection/check_guardrail_pii_detection.py
@@ -58,18 +58,16 @@ def main() -> None:
 
     # --- find builtInValidator with pii_detection ---
     pii = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and g.get("validatorType") == "pii_detection"
     ]
     if not pii:
-        types = [
-            (g.get("$guardrailType"), g.get("validatorType"))
-            for g in guardrails
-        ]
+        types = [(g.get("$guardrailType"), g.get("validatorType")) for g in guardrails]
         sys.exit(
-            f"FAIL: no guardrail with $guardrailType == \"builtInValidator\" "
-            f"and validatorType == \"pii_detection\". Got: {types}"
+            f'FAIL: no guardrail with $guardrailType == "builtInValidator" '
+            f'and validatorType == "pii_detection". Got: {types}'
         )
     g = pii[0]
     print('OK: found builtInValidator guardrail with validatorType == "pii_detection"')
@@ -97,7 +95,9 @@ def main() -> None:
         sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
     scopes = selector.get("scopes")
     if not isinstance(scopes, list) or len(scopes) == 0:
-        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}"
+        )
     invalid = [s for s in scopes if s not in VALID_SCOPES]
     if invalid:
         sys.exit(
@@ -126,7 +126,9 @@ def main() -> None:
         )
     entities_value = entities_param.get("value")
     if not isinstance(entities_value, list):
-        sys.exit(f"FAIL: entities parameter.value must be an array, got {entities_value!r}")
+        sys.exit(
+            f"FAIL: entities parameter.value must be an array, got {entities_value!r}"
+        )
     entities_set = set(entities_value)
     missing = REQUIRED_ENTITIES - entities_set
     if missing:
@@ -135,7 +137,9 @@ def main() -> None:
             f"missing: {sorted(missing)}. Got: {entities_value}"
         )
     # Check PascalCase (first letter uppercase, no underscores)
-    snake = [e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())]
+    snake = [
+        e for e in entities_value if "_" in e or (isinstance(e, str) and e[0].islower())
+    ]
     if snake:
         sys.exit(
             f"FAIL: entity names must be PascalCase (not snake_case). "

--- a/tests/tasks/uipath-agents/lowcode/guardrail_prompt_injection/check_guardrail_prompt_injection.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_prompt_injection/check_guardrail_prompt_injection.py
@@ -49,21 +49,21 @@ def main() -> None:
 
     # --- find prompt_injection validator ---
     pi = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and g.get("validatorType") == "prompt_injection"
     ]
     if not pi:
-        types = [
-            (g.get("$guardrailType"), g.get("validatorType"))
-            for g in guardrails
-        ]
+        types = [(g.get("$guardrailType"), g.get("validatorType")) for g in guardrails]
         sys.exit(
-            f"FAIL: no guardrail with $guardrailType == \"builtInValidator\" "
-            f"and validatorType == \"prompt_injection\". Got: {types}"
+            f'FAIL: no guardrail with $guardrailType == "builtInValidator" '
+            f'and validatorType == "prompt_injection". Got: {types}'
         )
     g = pi[0]
-    print('OK: found builtInValidator guardrail with validatorType == "prompt_injection"')
+    print(
+        'OK: found builtInValidator guardrail with validatorType == "prompt_injection"'
+    )
 
     # --- id is UUID-shaped ---
     gid = g.get("id")
@@ -85,7 +85,7 @@ def main() -> None:
     if bad:
         sys.exit(
             f"FAIL: prompt_injection guardrail must NOT include {bad} in scopes. "
-            f"Only \"Llm\" is supported. Got scopes: {scopes}"
+            f'Only "Llm" is supported. Got scopes: {scopes}'
         )
     if "Llm" not in scopes:
         sys.exit(
@@ -95,8 +95,7 @@ def main() -> None:
     # Check PascalCase
     if scopes != ["Llm"]:
         sys.exit(
-            f'FAIL: prompt_injection scopes should be exactly ["Llm"]. '
-            f"Got: {scopes}"
+            f'FAIL: prompt_injection scopes should be exactly ["Llm"]. Got: {scopes}'
         )
     print('OK: selector.scopes == ["Llm"] (correct Llm-only constraint)')
 
@@ -138,8 +137,7 @@ def main() -> None:
         sys.exit(f"FAIL: threshold parameter.value must be a number, got {val!r}")
     if not (0.0 <= val <= 1.0):
         sys.exit(
-            f"FAIL: threshold parameter.value must be between 0.0 and 1.0, "
-            f"got {val}"
+            f"FAIL: threshold parameter.value must be between 0.0 and 1.0, got {val}"
         )
     print(f"OK: threshold parameter = {val} (number, in range)")
 

--- a/tests/tasks/uipath-agents/lowcode/guardrail_recommend_all/check_guardrail_recommend_all.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_recommend_all/check_guardrail_recommend_all.py
@@ -101,12 +101,15 @@ def main() -> None:
 
     # Check for Llm-scoped protection
     llm_guards = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and "Llm" in ((g.get("selector") or {}).get("scopes") or [])
     ]
     if not llm_guards:
-        validators_found = [get_validator_type(g) for g in guardrails if get_validator_type(g)]
+        validators_found = [
+            get_validator_type(g) for g in guardrails if get_validator_type(g)
+        ]
         sys.exit(
             f"FAIL: no Llm-scoped builtInValidator guardrail found. "
             f"Expected a builtInValidator with scope 'Llm' "
@@ -118,8 +121,7 @@ def main() -> None:
 
     # Check for content-safety guardrail
     content_guards = [
-        g for g in guardrails
-        if get_validator_type(g) in CONTENT_SAFETY_VALIDATORS
+        g for g in guardrails if get_validator_type(g) in CONTENT_SAFETY_VALIDATORS
     ]
     if not content_guards:
         sys.exit(

--- a/tests/tasks/uipath-agents/lowcode/guardrail_recommend_scoped/check_guardrail_recommend_scoped.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_recommend_scoped/check_guardrail_recommend_scoped.py
@@ -86,22 +86,16 @@ def main() -> None:
     # selector.scopes contains "Tool"
     scopes = (g.get("selector") or {}).get("scopes") or []
     if "Tool" not in scopes:
-        sys.exit(
-            f'FAIL: guardrail selector.scopes must contain "Tool", got {scopes!r}'
-        )
+        sys.exit(f'FAIL: guardrail selector.scopes must contain "Tool", got {scopes!r}')
     print(f"OK: selector.scopes includes 'Tool': {scopes}")
 
     # rules array
     rules = g.get("rules")
     if not isinstance(rules, list) or len(rules) == 0:
-        sys.exit(
-            f"FAIL: guardrail.rules must be a non-empty array, got {rules!r}"
-        )
+        sys.exit(f"FAIL: guardrail.rules must be a non-empty array, got {rules!r}")
     for i, rule in enumerate(rules):
         if not rule.get("$ruleType"):
-            sys.exit(
-                f"FAIL: rules[{i}] missing $ruleType discriminator. rule={rule!r}"
-            )
+            sys.exit(f"FAIL: rules[{i}] missing $ruleType discriminator. rule={rule!r}")
     print(f"OK: rules array has {len(rules)} rule(s), all have $ruleType")
 
     print("OK: custom tool-scoped guardrail check passed")

--- a/tests/tasks/uipath-agents/lowcode/guardrail_validate/check_guardrail_validate.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_validate/check_guardrail_validate.py
@@ -46,21 +46,21 @@ def main() -> None:
 
     # Find harmful_content guardrail
     harmful = [
-        g for g in guardrails
+        g
+        for g in guardrails
         if g.get("$guardrailType") == "builtInValidator"
         and g.get("validatorType") == "harmful_content"
     ]
     if not harmful:
-        types = [
-            (g.get("$guardrailType"), g.get("validatorType"))
-            for g in guardrails
-        ]
+        types = [(g.get("$guardrailType"), g.get("validatorType")) for g in guardrails]
         sys.exit(
-            f"FAIL: no guardrail with validatorType == \"harmful_content\" found. "
+            f'FAIL: no guardrail with validatorType == "harmful_content" found. '
             f"Got: {types}"
         )
     g = harmful[0]
-    print('OK: found builtInValidator guardrail with validatorType == "harmful_content"')
+    print(
+        'OK: found builtInValidator guardrail with validatorType == "harmful_content"'
+    )
 
     params = g.get("validatorParameters")
     if not isinstance(params, list):

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/check_inline_builtin_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/check_inline_builtin_tool.py
@@ -21,7 +21,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -66,7 +68,9 @@ def main() -> None:
         if data.get("$resourceType") != "tool" or data.get("type") != "internal":
             continue
         if data.get("referenceKey") is not None:
-            sys.exit(f"FAIL: {path} referenceKey should be null for a built-in tool, got {data.get('referenceKey')!r}")
+            sys.exit(
+                f"FAIL: {path} referenceKey should be null for a built-in tool, got {data.get('referenceKey')!r}"
+            )
         props = data.get("properties") or {}
         tool_type = props.get("toolType")
         if tool_type not in BUILTIN_TOOL_TYPES:
@@ -87,9 +91,11 @@ def main() -> None:
         sys.exit(
             f'FAIL: prompt asked for "Analyze Files" (toolType '
             f'"analyze-attachments"), but it was not enabled. '
-            f'Got toolTypes: {seen_tool_types}'
+            f"Got toolTypes: {seen_tool_types}"
         )
-    print('OK: "Analyze Files" (toolType="analyze-attachments") is enabled on the inline agent')
+    print(
+        'OK: "Analyze Files" (toolType="analyze-attachments") is enabled on the inline agent'
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/check_inline_context_index.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/check_inline_context_index.py
@@ -28,7 +28,9 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -38,9 +40,13 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "KnowledgeFlowSol" / "KnowledgeFlow" / "KnowledgeFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd()) / "KnowledgeFlowSol" / "KnowledgeFlow" / "KnowledgeFlow.flow"
+)
 CONTEXT_INDEX_NODE_TYPE_PREFIX = "uipath.agent.resource.context.index."
-UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 EXPECTED_INDEX_NAME = "UiPathAgentsProductKnowledge"
 EXPECTED_FOLDER_PATH = "Shared/uipath-agents"
@@ -56,10 +62,14 @@ def assert_input_shape(schema: dict) -> None:
         )
     q = props["question"]
     if not isinstance(q, dict) or q.get("type") != "string":
-        sys.exit(f"FAIL: agent.json inputSchema.properties.question.type should be 'string', got {q!r}")
+        sys.exit(
+            f"FAIL: agent.json inputSchema.properties.question.type should be 'string', got {q!r}"
+        )
     required = schema.get("required")
     if not isinstance(required, list) or "question" not in required:
-        sys.exit(f"FAIL: agent.json inputSchema.required must contain 'question', got {required!r}")
+        sys.exit(
+            f"FAIL: agent.json inputSchema.required must contain 'question', got {required!r}"
+        )
     print("OK: agent.json inputSchema declares required question:string")
 
 
@@ -72,14 +82,18 @@ def assert_output_shape(schema: dict) -> None:
         )
     a = props["answer"]
     if not isinstance(a, dict) or a.get("type") != "string":
-        sys.exit(f"FAIL: agent.json outputSchema.properties.answer.type should be 'string', got {a!r}")
+        sys.exit(
+            f"FAIL: agent.json outputSchema.properties.answer.type should be 'string', got {a!r}"
+        )
     print("OK: agent.json outputSchema declares answer:string")
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    context_node = find_resource_node(flow, node_type_prefix=CONTEXT_INDEX_NODE_TYPE_PREFIX)
+    context_node = find_resource_node(
+        flow, node_type_prefix=CONTEXT_INDEX_NODE_TYPE_PREFIX
+    )
     print(f"OK: flow has {agent_node['type']} and {context_node['type']} nodes")
 
     agent_source = (agent_node.get("inputs") or {}).get("source")
@@ -94,7 +108,9 @@ def main() -> None:
             f"FAIL: inputs.source UUID {agent_source!r} does not match "
             f"the inline agent sub-folder name {agent_dir.name!r}"
         )
-    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+    print(
+        f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder"
+    )
 
     context_source = (context_node.get("model") or {}).get("source")
     if not isinstance(context_source, str) or not UUID_RE.match(context_source):

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/check_inline_external_agent_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/check_inline_external_agent_tool.py
@@ -26,7 +26,9 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -38,7 +40,9 @@ from _shared.inline_wiring import (  # noqa: E402
 
 FLOW_PATH = Path(os.getcwd()) / "OutreachFlowSol" / "OutreachFlow" / "OutreachFlow.flow"
 AGENT_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.agent."
-UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 EXPECTED_PROCESS_NAME = "EmailDrafter"
 EXPECTED_FOLDER_PATH = "Shared/uipath-agents/EmailDrafter"
@@ -62,7 +66,9 @@ def main() -> None:
             f"FAIL: inputs.source UUID {agent_source!r} does not match "
             f"the inline agent sub-folder name {agent_dir.name!r}"
         )
-    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+    print(
+        f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder"
+    )
 
     tool_source = (tool_node.get("model") or {}).get("source")
     if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
@@ -78,7 +84,9 @@ def main() -> None:
         target_id=tool_node["id"],
         target_port="input",
     )
-    print("OK: agent 'tool' handle is wired to external agent-as-tool node's 'input' handle")
+    print(
+        "OK: agent 'tool' handle is wired to external agent-as-tool node's 'input' handle"
+    )
 
     resource_path, resource = find_inline_resource(
         agent_dir,
@@ -100,7 +108,7 @@ def main() -> None:
         f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="agent", location="external"'
     )
 
@@ -111,7 +119,9 @@ def main() -> None:
             f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
             f"(the deployed Orchestrator folder of {EXPECTED_PROCESS_NAME}), got {fpath!r}"
         )
-    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+    print(
+        f"OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}"
+    )
 
     rkey = resource.get("referenceKey")
     if not isinstance(rkey, str) or "-" not in rkey:

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/check_inline_external_apiworkflow_tool.py
@@ -26,7 +26,9 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -38,7 +40,9 @@ from _shared.inline_wiring import (  # noqa: E402
 
 FLOW_PATH = Path(os.getcwd()) / "WeatherFlowSol" / "WeatherFlow" / "WeatherFlow.flow"
 API_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.api."
-UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 EXPECTED_PROCESS_NAME = "WeatherAPI"
 EXPECTED_FOLDER_PATH = "Shared/uipath-agents/WeatherAPI"
@@ -62,7 +66,9 @@ def main() -> None:
             f"FAIL: inputs.source UUID {agent_source!r} does not match "
             f"the inline agent sub-folder name {agent_dir.name!r}"
         )
-    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+    print(
+        f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder"
+    )
 
     tool_source = (tool_node.get("model") or {}).get("source")
     if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
@@ -78,7 +84,9 @@ def main() -> None:
         target_id=tool_node["id"],
         target_port="input",
     )
-    print("OK: agent 'tool' handle is wired to external API workflow tool node's 'input' handle")
+    print(
+        "OK: agent 'tool' handle is wired to external API workflow tool node's 'input' handle"
+    )
 
     resource_path, resource = find_inline_resource(
         agent_dir,
@@ -100,7 +108,7 @@ def main() -> None:
         f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="api", location="external"'
     )
 
@@ -111,7 +119,9 @@ def main() -> None:
             f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
             f"(the deployed Orchestrator folder of {EXPECTED_PROCESS_NAME}), got {fpath!r}"
         )
-    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+    print(
+        f"OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}"
+    )
 
     rkey = resource.get("referenceKey")
     if not isinstance(rkey, str) or "-" not in rkey:

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
@@ -23,7 +23,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -65,7 +67,8 @@ def main() -> None:
         sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
     channels = data.get("channels") or []
     ac = [
-        c for c in channels
+        c
+        for c in channels
         if isinstance(c, dict)
         and c.get("type") == "actionCenter"
         and isinstance(c.get("name"), str)
@@ -76,7 +79,9 @@ def main() -> None:
             f'FAIL: {path} has no channel with type=="actionCenter" '
             f"and a non-empty name"
         )
-    print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} actionCenter channel(s))")
+    print(
+        f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} actionCenter channel(s))"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/check_inline_external_maestro_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/check_inline_external_maestro_tool.py
@@ -26,7 +26,9 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -36,9 +38,16 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "ProcurementFlowSol" / "ProcurementFlow" / "ProcurementFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd())
+    / "ProcurementFlowSol"
+    / "ProcurementFlow"
+    / "ProcurementFlow.flow"
+)
 MAESTRO_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.processorchestration."
-UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 EXPECTED_PROCESS_NAME = "ProcurementProcess"
 EXPECTED_FOLDER_PATH = "Shared/uipath-agents/ProcurementProcess"
@@ -62,7 +71,9 @@ def main() -> None:
             f"FAIL: inputs.source UUID {agent_source!r} does not match "
             f"the inline agent sub-folder name {agent_dir.name!r}"
         )
-    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+    print(
+        f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder"
+    )
 
     tool_source = (tool_node.get("model") or {}).get("source")
     if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
@@ -78,7 +89,9 @@ def main() -> None:
         target_id=tool_node["id"],
         target_port="input",
     )
-    print("OK: agent 'tool' handle is wired to external Maestro tool node's 'input' handle")
+    print(
+        "OK: agent 'tool' handle is wired to external Maestro tool node's 'input' handle"
+    )
 
     resource_path, resource = find_inline_resource(
         agent_dir,
@@ -100,7 +113,7 @@ def main() -> None:
         f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="processOrchestration", location="external"'
     )
 
@@ -111,7 +124,9 @@ def main() -> None:
             f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
             f"(the deployed Orchestrator folder of {EXPECTED_PROCESS_NAME}), got {fpath!r}"
         )
-    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+    print(
+        f"OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}"
+    )
 
     rkey = resource.get("referenceKey")
     if not isinstance(rkey, str) or "-" not in rkey:

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/check_inline_external_rpa_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/check_inline_external_rpa_tool.py
@@ -26,7 +26,9 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -36,9 +38,13 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "FibonacciFlowSol" / "FibonacciFlow" / "FibonacciFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd()) / "FibonacciFlowSol" / "FibonacciFlow" / "FibonacciFlow.flow"
+)
 RPA_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.process."
-UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 
 EXPECTED_PROCESS_NAME = "FibonacciRPA"
 EXPECTED_FOLDER_PATH = "Shared/uipath-agents/FibonacciRPA"
@@ -62,7 +68,9 @@ def main() -> None:
             f"FAIL: inputs.source UUID {agent_source!r} does not match "
             f"the inline agent sub-folder name {agent_dir.name!r}"
         )
-    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+    print(
+        f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder"
+    )
 
     tool_source = (tool_node.get("model") or {}).get("source")
     if not isinstance(tool_source, str) or not UUID_RE.match(tool_source):
@@ -100,7 +108,7 @@ def main() -> None:
         f"({resource_path.relative_to(Path(os.getcwd()))})"
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="process", location="external"'
     )
 
@@ -111,7 +119,9 @@ def main() -> None:
             f"FAIL: properties.folderPath should be {EXPECTED_FOLDER_PATH!r} "
             f"(the deployed Orchestrator folder of FibonacciRPA), got {fpath!r}"
         )
-    print(f'OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}')
+    print(
+        f"OK: properties.processName={EXPECTED_PROCESS_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}"
+    )
 
     rkey = resource.get("referenceKey")
     if not isinstance(rkey, str) or "-" not in rkey:

--- a/tests/tasks/uipath-agents/lowcode/inline_in_flow/check_inline_in_flow.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_in_flow/check_inline_in_flow.py
@@ -46,8 +46,7 @@ def main() -> None:
     agent_nodes = [n for n in nodes if n.get("type") == INLINE_AGENT_NODE_TYPE]
     if not agent_nodes:
         sys.exit(
-            f"FAIL: {FLOW_PATH.name} has no node of type "
-            f"{INLINE_AGENT_NODE_TYPE!r}"
+            f"FAIL: {FLOW_PATH.name} has no node of type {INLINE_AGENT_NODE_TYPE!r}"
         )
 
     agent_node = agent_nodes[0]
@@ -93,11 +92,13 @@ def main() -> None:
 
     edges = flow.get("edges") or []
     incoming_input = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("targetNodeId") == agent_id and e.get("targetPort") == "input"
     ]
     outgoing_success = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("sourceNodeId") == agent_id and e.get("sourcePort") == "success"
     ]
     if not incoming_input:

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/check_inline_is_connector_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/check_inline_is_connector_tool.py
@@ -58,13 +58,12 @@ def assert_agent_and_connector_nodes(flow: dict) -> tuple:
     nodes = flow.get("nodes") or []
     agent_nodes = [n for n in nodes if n.get("type") == INLINE_AGENT_NODE_TYPE]
     if not agent_nodes:
-        sys.exit(
-            f"FAIL: flow has no node of type {INLINE_AGENT_NODE_TYPE!r}"
-        )
+        sys.exit(f"FAIL: flow has no node of type {INLINE_AGENT_NODE_TYPE!r}")
     agent_node = agent_nodes[0]
 
     connector_nodes = [
-        n for n in nodes
+        n
+        for n in nodes
         if isinstance(n.get("type"), str)
         and n["type"].startswith(CONNECTOR_TOOL_NODE_TYPE_PREFIX)
     ]
@@ -79,7 +78,7 @@ def assert_agent_and_connector_nodes(flow: dict) -> tuple:
     if not agent_node.get("id"):
         sys.exit(f"FAIL: {INLINE_AGENT_NODE_TYPE} node has no id")
     if not connector_node.get("id"):
-        sys.exit(f"FAIL: connector tool node has no id")
+        sys.exit("FAIL: connector tool node has no id")
 
     print(
         f"OK: flow has {INLINE_AGENT_NODE_TYPE!r} and connector tool node "
@@ -111,7 +110,8 @@ def assert_agent_source_dir(agent_node: dict) -> Path:
 def assert_tool_edge(flow: dict, agent_id: str, connector_id: str) -> None:
     edges = flow.get("edges") or []
     matching = [
-        e for e in edges
+        e
+        for e in edges
         if e.get("sourceNodeId") == agent_id
         and e.get("sourcePort") == "tool"
         and e.get("targetNodeId") == connector_id
@@ -159,7 +159,9 @@ def assert_bindings_v2_authored() -> None:
     except json.JSONDecodeError as e:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
     if not isinstance(data, (dict, list)):
-        sys.exit(f"FAIL: {path} root is neither object nor array: {type(data).__name__}")
+        sys.exit(
+            f"FAIL: {path} root is neither object nor array: {type(data).__name__}"
+        )
     print(f"OK: bindings_v2.json authored at {path.relative_to(SOLUTION.parent)}")
 
 

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/check_inline_mcp_server_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/check_inline_mcp_server_tool.py
@@ -23,7 +23,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -62,7 +64,9 @@ def main() -> None:
     if not isinstance(description, str) or not description.strip():
         sys.exit(f"FAIL: MCP resource description missing or empty: {description!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     rid = resource.get("id")
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: MCP resource id missing or malformed: {rid!r}")
@@ -70,9 +74,9 @@ def main() -> None:
     if not isinstance(tools, list):
         sys.exit(f"FAIL: MCP resource tools must be a list, got {tools!r}")
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="mcp", name="GitHubMcp", id={rid}, isEnabled=true, '
-        f'tools list present ({len(tools)} entries)'
+        f"tools list present ({len(tools)} entries)"
     )
 
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/check_inline_solution_agent_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/check_inline_solution_agent_tool.py
@@ -19,7 +19,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -29,7 +31,12 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "OrchestratorFlowSol" / "OrchestratorFlow" / "OrchestratorFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd())
+    / "OrchestratorFlowSol"
+    / "OrchestratorFlow"
+    / "OrchestratorFlow.flow"
+)
 AGENT_TOOL_NODE_PREFIX = "uipath.agent.resource.tool.agent."
 
 
@@ -60,13 +67,15 @@ def main() -> None:
         description='solution agent-as-tool "ToolAgent"',
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="agent", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.processName="ToolAgent", folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/check_inline_solution_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/check_inline_solution_apiworkflow_tool.py
@@ -22,7 +22,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -63,13 +65,15 @@ def main() -> None:
         description='solution API workflow tool "CalculateShippingRate"',
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="api", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/check_inline_solution_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/check_inline_solution_escalation.py
@@ -24,7 +24,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -66,7 +68,8 @@ def main() -> None:
         sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
     channels = data.get("channels") or []
     ac = [
-        c for c in channels
+        c
+        for c in channels
         if isinstance(c, dict)
         and c.get("type") == "actionCenter"
         and isinstance(c.get("name"), str)
@@ -77,7 +80,9 @@ def main() -> None:
             f'FAIL: {path} has no channel with type=="actionCenter" '
             f"and a non-empty name"
         )
-    print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} actionCenter channel(s))")
+    print(
+        f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} actionCenter channel(s))"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/check_inline_solution_maestro_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/check_inline_solution_maestro_tool.py
@@ -19,7 +19,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -29,7 +31,9 @@ from _shared.inline_wiring import (  # noqa: E402
     resolve_inline_agent_dir,
 )
 
-FLOW_PATH = Path(os.getcwd()) / "OnboardingFlowSol" / "OnboardingFlow" / "OnboardingFlow.flow"
+FLOW_PATH = (
+    Path(os.getcwd()) / "OnboardingFlowSol" / "OnboardingFlow" / "OnboardingFlow.flow"
+)
 TOOL_NODE_PREFIX = "uipath.agent.resource.tool."
 
 
@@ -60,13 +64,15 @@ def main() -> None:
         description='solution Maestro tool "EmployeeOnboarding"',
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="processOrchestration", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
@@ -22,7 +22,9 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
@@ -63,13 +65,15 @@ def main() -> None:
         description='solution RPA tool "CalculatePay"',
     )
     print(
-        f'OK: {resource_path.relative_to(Path(os.getcwd()))} is '
+        f"OK: {resource_path.relative_to(Path(os.getcwd()))} is "
         f'$resourceType="tool", type="process", location="solution"'
     )
 
     props = resource.get("properties") or {}
     if props.get("folderPath") != "solution_folder":
-        sys.exit(f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}')
+        sys.exit(
+            f'FAIL: properties.folderPath should be "solution_folder", got {props.get("folderPath")!r}'
+        )
     print('OK: properties.processName="CalculatePay", folderPath="solution_folder"')
 
 

--- a/tests/tasks/uipath-agents/lowcode/is_connector_tool/check_is_connector_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/is_connector_tool/check_is_connector_tool.py
@@ -80,7 +80,9 @@ def assert_bindings_v2_authored() -> Path:
     except json.JSONDecodeError as e:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
     if not isinstance(data, dict) and not isinstance(data, list):
-        sys.exit(f"FAIL: {path} root is neither object nor array: {type(data).__name__}")
+        sys.exit(
+            f"FAIL: {path} root is neither object nor array: {type(data).__name__}"
+        )
     print(f"OK: bindings_v2.json authored at {path.relative_to(SOLUTION.parent)}")
     return path
 
@@ -119,7 +121,9 @@ def main() -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: IS tool id missing or malformed: {rid!r}")
     if not tool.get("isEnabled"):
-        sys.exit(f"FAIL: IS tool isEnabled must be truthy, got {tool.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: IS tool isEnabled must be truthy, got {tool.get('isEnabled')!r}"
+        )
     print(f"OK: IS tool has id={rid}, isEnabled=true")
 
     assert_bindings_v2_authored()

--- a/tests/tasks/uipath-agents/lowcode/mcp_server_tool/check_mcp_server_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/mcp_server_tool/check_mcp_server_tool.py
@@ -43,7 +43,9 @@ def assert_mcp_resource(resource: dict) -> None:
     if not isinstance(description, str) or not description.strip():
         sys.exit(f"FAIL: MCP resource description missing or empty: {description!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: MCP resource isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     rid = resource.get("id")
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: MCP resource id missing or malformed: {rid!r}")
@@ -52,7 +54,7 @@ def assert_mcp_resource(resource: dict) -> None:
         sys.exit(f"FAIL: MCP resource tools must be a list, got {tools!r}")
     print(
         f'OK: resource.json is $resourceType="mcp", name="GitHubMcp", '
-        f'id={rid}, isEnabled=true, tools list present ({len(tools)} entries)'
+        f"id={rid}, isEnabled=true, tools list present ({len(tools)} entries)"
     )
 
 

--- a/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/check_resolution_drafter_agent.py
+++ b/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/check_resolution_drafter_agent.py
@@ -112,7 +112,9 @@ def get_user_message(agent: dict) -> dict:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     return user_messages[0]
@@ -139,7 +141,7 @@ def assert_user_message_inlines(agent: dict) -> None:
                 f"input.{field}\n  expected: {expected}\n"
                 f"  got tokens: {json.dumps(tokens, indent=2)}"
             )
-    print(f"OK: user message inlines all 4 inputs with matching contentTokens")
+    print("OK: user message inlines all 4 inputs with matching contentTokens")
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/lowcode/schema_update/check_schema_update.py
+++ b/tests/tasks/uipath-agents/lowcode/schema_update/check_schema_update.py
@@ -41,10 +41,14 @@ def assert_input_shape(schema: dict, label: str) -> None:
         sys.exit(f"FAIL: {label}.type should be 'object', got {schema.get('type')!r}")
     props = schema.get("properties")
     if not isinstance(props, dict) or "userQuery" not in props:
-        sys.exit(f"FAIL: {label}.properties missing 'userQuery': got {list(props) if isinstance(props, dict) else props!r}")
+        sys.exit(
+            f"FAIL: {label}.properties missing 'userQuery': got {list(props) if isinstance(props, dict) else props!r}"
+        )
     uq = props["userQuery"]
     if not isinstance(uq, dict) or uq.get("type") != "string":
-        sys.exit(f"FAIL: {label}.properties.userQuery.type should be 'string', got {uq!r}")
+        sys.exit(
+            f"FAIL: {label}.properties.userQuery.type should be 'string', got {uq!r}"
+        )
     required = schema.get("required")
     if not isinstance(required, list) or "userQuery" not in required:
         sys.exit(f"FAIL: {label}.required must contain 'userQuery', got {required!r}")
@@ -58,10 +62,14 @@ def assert_output_shape(schema: dict, label: str) -> None:
         sys.exit(f"FAIL: {label}.type should be 'object', got {schema.get('type')!r}")
     props = schema.get("properties")
     if not isinstance(props, dict) or "reply" not in props:
-        sys.exit(f"FAIL: {label}.properties missing 'reply': got {list(props) if isinstance(props, dict) else props!r}")
+        sys.exit(
+            f"FAIL: {label}.properties missing 'reply': got {list(props) if isinstance(props, dict) else props!r}"
+        )
     reply = props["reply"]
     if not isinstance(reply, dict) or reply.get("type") != "string":
-        sys.exit(f"FAIL: {label}.properties.reply.type should be 'string', got {reply!r}")
+        sys.exit(
+            f"FAIL: {label}.properties.reply.type should be 'string', got {reply!r}"
+        )
     print(f"OK: {label} declares reply:string (matches prompt)")
 
 
@@ -69,7 +77,9 @@ def assert_user_message_inlines_variable(agent: dict, field: str) -> None:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [m for m in messages if isinstance(m, dict) and m.get("role") == "user"]
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
     if not user_messages:
         sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
     user = user_messages[0]
@@ -77,7 +87,9 @@ def assert_user_message_inlines_variable(agent: dict, field: str) -> None:
     placeholder = "{{input." + field + "}}"
     content = user.get("content", "")
     if placeholder not in content:
-        sys.exit(f"FAIL: user message content does not inline {placeholder}: content={content!r}")
+        sys.exit(
+            f"FAIL: user message content does not inline {placeholder}: content={content!r}"
+        )
 
     tokens = user.get("contentTokens")
     if not isinstance(tokens, list):
@@ -89,7 +101,9 @@ def assert_user_message_inlines_variable(agent: dict, field: str) -> None:
             f"  expected token: {expected}\n"
             f"  got tokens:     {json.dumps(tokens, indent=2)}"
         )
-    print(f"OK: user message inlines {placeholder} with a matching variable contentToken")
+    print(
+        f"OK: user message inlines {placeholder} with a matching variable contentToken"
+    )
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/lowcode/solution_agent_tool/check_solution_agent_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/solution_agent_tool/check_solution_agent_tool.py
@@ -25,9 +25,7 @@ import sys
 from pathlib import Path
 
 SOLUTION_DIR = Path(os.getcwd()) / "OrchestratorSol"
-RESOURCE = (
-    SOLUTION_DIR / "ParentAgent" / "resources" / "ToolAgent" / "resource.json"
-)
+RESOURCE = SOLUTION_DIR / "ParentAgent" / "resources" / "ToolAgent" / "resource.json"
 TOOL_AGENT = SOLUTION_DIR / "ToolAgent" / "agent.json"
 PARENT_AGENT = SOLUTION_DIR / "ParentAgent" / "agent.json"
 
@@ -67,7 +65,9 @@ def assert_resource_fields(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json has $resourceType="tool", type="agent", location="solution"')
+    print(
+        'OK: resource.json has $resourceType="tool", type="agent", location="solution"'
+    )
 
     props = resource.get("properties")
     if not isinstance(props, dict):
@@ -118,7 +118,9 @@ def assert_schemas_match_tool_agent(resource: dict, tool: dict) -> None:
                 f"  resource.{label}:\n{json.dumps(r_shape, sort_keys=True, indent=2)}\n"
                 f"  tool.{label}:\n{json.dumps(t_shape, sort_keys=True, indent=2)}"
             )
-        print(f"OK: resource.json.{label} is shape-equivalent to ToolAgent/agent.json.{label}")
+        print(
+            f"OK: resource.json.{label} is shape-equivalent to ToolAgent/agent.json.{label}"
+        )
 
 
 def main() -> None:

--- a/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/check_solution_apiworkflow_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/check_solution_apiworkflow_tool.py
@@ -51,7 +51,7 @@ def assert_properties(resource: dict) -> None:
     if props.get("folderPath") != "solution_folder":
         sys.exit(
             f'FAIL: properties.folderPath should be "solution_folder" for a '
-            f'solution-internal API workflow tool, got {props.get("folderPath")!r}'
+            f"solution-internal API workflow tool, got {props.get('folderPath')!r}"
         )
     print('OK: properties.folderPath="solution_folder"')
 
@@ -61,7 +61,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/check_solution_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/check_solution_escalation.py
@@ -48,16 +48,23 @@ def assert_escalation_header(resource: dict) -> None:
     if not isinstance(name, str) or not name.strip():
         sys.exit(f"FAIL: escalation name missing or empty: {name!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}")
-    print(f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)')
+        sys.exit(
+            f"FAIL: escalation isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
+    print(
+        f'OK: resource.json is $resourceType="escalation" (id={eid}, name={name!r}, isEnabled=true)'
+    )
 
 
 def assert_actioncenter_channel(resource: dict) -> None:
     channels = resource.get("channels")
     if not isinstance(channels, list) or not channels:
-        sys.exit(f"FAIL: escalation.channels must be a non-empty list, got {channels!r}")
+        sys.exit(
+            f"FAIL: escalation.channels must be a non-empty list, got {channels!r}"
+        )
     ac_channels = [
-        c for c in channels
+        c
+        for c in channels
         if isinstance(c, dict)
         and c.get("type") == "actionCenter"
         and isinstance(c.get("name"), str)
@@ -77,9 +84,13 @@ def assert_schema_sync(agent: dict, entry: dict) -> None:
         sys.exit("FAIL: entry-points.json has no entryPoints[0]")
     ep = entry_points[0]
     if agent.get("inputSchema") != ep.get("input"):
-        sys.exit("FAIL: agent.json.inputSchema != entry-points.json entryPoints[0].input")
+        sys.exit(
+            "FAIL: agent.json.inputSchema != entry-points.json entryPoints[0].input"
+        )
     if agent.get("outputSchema") != ep.get("output"):
-        sys.exit("FAIL: agent.json.outputSchema != entry-points.json entryPoints[0].output")
+        sys.exit(
+            "FAIL: agent.json.outputSchema != entry-points.json entryPoints[0].output"
+        )
     print("OK: inputSchema and outputSchema are in sync with entry-points.json")
 
 

--- a/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/check_solution_maestro_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/check_solution_maestro_tool.py
@@ -41,7 +41,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="processOrchestration", location="solution"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="processOrchestration", location="solution"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -51,7 +53,7 @@ def assert_properties(resource: dict) -> None:
     if props.get("folderPath") != "solution_folder":
         sys.exit(
             f'FAIL: properties.folderPath should be "solution_folder" for a '
-            f'solution-internal Maestro tool, got {props.get("folderPath")!r}'
+            f"solution-internal Maestro tool, got {props.get('folderPath')!r}"
         )
     print('OK: properties.folderPath="solution_folder"')
 
@@ -61,7 +63,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/check_solution_rpa_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/check_solution_rpa_tool.py
@@ -42,7 +42,9 @@ def assert_tool_header(resource: dict) -> None:
         got = resource.get(key)
         if got != want:
             sys.exit(f"FAIL: resource.json {key!r} should be {want!r}, got {got!r}")
-    print('OK: resource.json is $resourceType="tool", type="process", location="solution"')
+    print(
+        'OK: resource.json is $resourceType="tool", type="process", location="solution"'
+    )
 
 
 def assert_properties(resource: dict) -> None:
@@ -56,7 +58,7 @@ def assert_properties(resource: dict) -> None:
     if props.get("folderPath") != "solution_folder":
         sys.exit(
             f'FAIL: properties.folderPath should be "solution_folder" for a '
-            f'solution-internal tool, got {props.get("folderPath")!r}'
+            f"solution-internal tool, got {props.get('folderPath')!r}"
         )
     print('OK: properties.processName="CalculatePay", folderPath="solution_folder"')
 
@@ -66,7 +68,9 @@ def assert_identity_and_schemas(resource: dict) -> None:
     if not isinstance(rid, str) or "-" not in rid:
         sys.exit(f"FAIL: resource id missing or malformed: {rid!r}")
     if not resource.get("isEnabled"):
-        sys.exit(f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}")
+        sys.exit(
+            f"FAIL: resource.isEnabled must be truthy, got {resource.get('isEnabled')!r}"
+        )
     if not isinstance(resource.get("inputSchema"), dict):
         sys.exit("FAIL: resource.inputSchema must be an object")
     if not isinstance(resource.get("outputSchema"), dict):

--- a/tests/tasks/uipath-agents/openai_agents_handoff/check_openai_agents_handoff.py
+++ b/tests/tasks/uipath-agents/openai_agents_handoff/check_openai_agents_handoff.py
@@ -86,9 +86,9 @@ def check_openai_agents_json() -> None:
     target = next(iter(agents.values()))
     if not isinstance(target, str) or ":main" not in target:
         sys.exit(
-            f'FAIL: openai_agents.json should point at the factory function '
-            f'(`<file>:main`), got {target!r}. Pointing at a top-level '
-            f'variable would break the lazy-LLM-init invariant.'
+            f"FAIL: openai_agents.json should point at the factory function "
+            f"(`<file>:main`), got {target!r}. Pointing at a top-level "
+            f"variable would break the lazy-LLM-init invariant."
         )
     print(f"OK: openai_agents.json registers an agent -> {target!r} (factory pattern)")
 
@@ -129,7 +129,10 @@ def check_main_py() -> None:
     for node in tree.body:
         if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
             func = node.value.func
-            if isinstance(func, ast.Attribute) and func.attr == "set_default_openai_client":
+            if (
+                isinstance(func, ast.Attribute)
+                and func.attr == "set_default_openai_client"
+            ):
                 sys.exit(
                     f"FAIL: main.py:{node.lineno} `set_default_openai_client(...)` "
                     "is at module level — it must run inside the factory "
@@ -148,9 +151,9 @@ def check_entry_points() -> None:
     for field in ("customer_id", "messages"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entry-points.json schemas do not mention `{field}`. '
-                f'`uip codedagent init` did not pick up the Agent[CustomerInput] '
-                f'context type. Got: {raw}'
+                f"FAIL: entry-points.json schemas do not mention `{field}`. "
+                f"`uip codedagent init` did not pick up the Agent[CustomerInput] "
+                f"context type. Got: {raw}"
             )
     print(
         "OK: entry-points.json reflects the Agent[CustomerInput] context "
@@ -172,7 +175,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/push_pull_roundtrip/check_push_pull_roundtrip.py
+++ b/tests/tasks/uipath-agents/push_pull_roundtrip/check_push_pull_roundtrip.py
@@ -57,7 +57,9 @@ def main() -> None:
     print(f"OK: .env still pins UIPATH_PROJECT_ID={EXPECTED_PROJECT_ID}")
 
     if not PULLED.is_dir():
-        fail(f"missing pulled sibling directory {PULLED} — agent did not pull a fresh copy")
+        fail(
+            f"missing pulled sibling directory {PULLED} — agent did not pull a fresh copy"
+        )
     if not PULLED_MAIN.is_file():
         fail(f"missing {PULLED_MAIN} — pulled copy is incomplete")
     pulled_text = PULLED_MAIN.read_text(encoding="utf-8")

--- a/tests/tasks/uipath-agents/rag_langgraph/check_rag_langgraph.py
+++ b/tests/tasks/uipath-agents/rag_langgraph/check_rag_langgraph.py
@@ -61,12 +61,20 @@ def check_imports_and_calls(text: str) -> None:
             "FAIL: ContextGroundingRetriever must be imported from "
             "`uipath_langchain.retrievers` — the canonical path the skill teaches."
         )
-    print("OK: main.py imports ContextGroundingRetriever from uipath_langchain.retrievers")
+    print(
+        "OK: main.py imports ContextGroundingRetriever from uipath_langchain.retrievers"
+    )
     if not re.search(r'index_name\s*=\s*["\']company_docs["\']', text):
-        sys.exit('FAIL: ContextGroundingRetriever call does not pass index_name="company_docs"')
+        sys.exit(
+            'FAIL: ContextGroundingRetriever call does not pass index_name="company_docs"'
+        )
     if not re.search(r'folder_path\s*=\s*["\']Shared["\']', text):
-        sys.exit('FAIL: ContextGroundingRetriever call does not pass folder_path="Shared"')
-    print('OK: retriever is constructed with index_name="company_docs" / folder_path="Shared"')
+        sys.exit(
+            'FAIL: ContextGroundingRetriever call does not pass folder_path="Shared"'
+        )
+    print(
+        'OK: retriever is constructed with index_name="company_docs" / folder_path="Shared"'
+    )
 
 
 def check_index_binding() -> None:

--- a/tests/tasks/uipath-agents/simple_echo/check_simple_echo.py
+++ b/tests/tasks/uipath-agents/simple_echo/check_simple_echo.py
@@ -90,33 +90,34 @@ def check_uipath_json() -> None:
     if main_entry not in ("main.py:main", "./main.py:main"):
         sys.exit(
             f'FAIL: uipath.json functions.main should be "main.py:main", '
-            f'got {main_entry!r}'
+            f"got {main_entry!r}"
         )
-    print(f'OK: uipath.json registers functions.main -> {main_entry!r}')
+    print(f"OK: uipath.json registers functions.main -> {main_entry!r}")
 
 
 def check_entry_points() -> None:
     doc = _load_json(ROOT / "entry-points.json")
     entrypoints = doc.get("entryPoints") or []
     if not entrypoints:
-        sys.exit("FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully")
-    matches = [
-        ep for ep in entrypoints
-        if ep.get("filePath") in ("main", "main.py")
-    ]
+        sys.exit(
+            "FAIL: entry-points.json has no entryPoints — `uip codedagent init` did not run successfully"
+        )
+    matches = [ep for ep in entrypoints if ep.get("filePath") in ("main", "main.py")]
     if not matches:
         paths = [ep.get("filePath") for ep in entrypoints]
         sys.exit(f'FAIL: no entrypoint with filePath "main" or "main.py"; got {paths}')
     ep = matches[0]
     if not ep.get("uniqueId"):
-        sys.exit("FAIL: entrypoint is missing `uniqueId` — `uip codedagent init` did not generate it")
+        sys.exit(
+            "FAIL: entrypoint is missing `uniqueId` — `uip codedagent init` did not generate it"
+        )
     raw = json.dumps(ep)
     for field in ("message", "repeat", "echoed", "length"):
         if field not in raw:
             sys.exit(
-                f'FAIL: entrypoint schema does not mention `{field}` — '
-                f'agent.json ↔ entry-points.json schema sync failed. '
-                f'Got: {raw}'
+                f"FAIL: entrypoint schema does not mention `{field}` — "
+                f"agent.json ↔ entry-points.json schema sync failed. "
+                f"Got: {raw}"
             )
     print(
         "OK: entry-points.json has one `main` entrypoint with all four "
@@ -128,7 +129,16 @@ def check_bindings() -> None:
     doc = load_bindings(ROOT / "bindings.json")
     total = sum(
         count_resources_by_type(doc, t)
-        for t in ("asset", "queue", "process", "bucket", "app", "index", "connection", "mcpServer")
+        for t in (
+            "asset",
+            "queue",
+            "process",
+            "bucket",
+            "app",
+            "index",
+            "connection",
+            "mcpServer",
+        )
     )
     if total != 0:
         sys.exit(
@@ -147,7 +157,9 @@ def main() -> None:
     check_entry_points()
     check_bindings()
     if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
+        sys.exit(
+            f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished"
+        )
     print("OK: run_marker.txt exists (run completed cleanly)")
 
 

--- a/tests/tasks/uipath-agents/subtype_credential_asset/check_subtype_credential_asset.py
+++ b/tests/tasks/uipath-agents/subtype_credential_asset/check_subtype_credential_asset.py
@@ -48,14 +48,19 @@ def assert_envelope(bindings: dict) -> list:
         sys.exit(f'FAIL: bindings.json version should be "2.0", got {version!r}')
     resources = bindings.get("resources")
     if not isinstance(resources, list) or not resources:
-        sys.exit(f"FAIL: bindings.json resources must be a non-empty list, got {resources!r}")
-    print(f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)')
+        sys.exit(
+            f"FAIL: bindings.json resources must be a non-empty list, got {resources!r}"
+        )
+    print(
+        f'OK: bindings.json envelope is version="2.0" with {len(resources)} resource(s)'
+    )
     return resources
 
 
 def find_asset_entry(resources: list) -> dict:
     matches = [
-        r for r in resources
+        r
+        for r in resources
         if isinstance(r, dict)
         and r.get("resource") == "asset"
         and r.get("key") == EXPECTED_KEY
@@ -87,9 +92,7 @@ def assert_value_shape(entry: dict) -> None:
             f'FAIL: value.folderPath.defaultValue should be "{EXPECTED_FOLDER}", '
             f"got {folder_block.get('defaultValue')!r}"
         )
-    print(
-        f'OK: value.name="{EXPECTED_NAME}", value.folderPath="{EXPECTED_FOLDER}"'
-    )
+    print(f'OK: value.name="{EXPECTED_NAME}", value.folderPath="{EXPECTED_FOLDER}"')
 
 
 def assert_subtype(entry: dict) -> None:

--- a/tests/tasks/uipath-agents/tracing_redaction/check_tracing_redaction.py
+++ b/tests/tasks/uipath-agents/tracing_redaction/check_tracing_redaction.py
@@ -50,12 +50,17 @@ def main() -> None:
     main_py = ROOT / "main.py"
     text = _read_text(main_py)
     if "from uipath.tracing import traced" not in text:
-        sys.exit("FAIL: main.py must import `traced` via `from uipath.tracing import traced`")
+        sys.exit(
+            "FAIL: main.py must import `traced` via `from uipath.tracing import traced`"
+        )
     print("OK: main.py imports `traced` from uipath.tracing")
     tree = ast.parse(text, filename=str(main_py))
     main_func: ast.AsyncFunctionDef | ast.FunctionDef | None = None
     for node in ast.walk(tree):
-        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)) and node.name == "main":
+        if (
+            isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+            and node.name == "main"
+        ):
             main_func = node
             break
     if main_func is None:
@@ -71,7 +76,9 @@ def main() -> None:
             "*call form* — `@traced` without parentheses cannot pass kwargs)."
         )
     if len(decorated_calls) > 1:
-        sys.exit(f"FAIL: `main` has {len(decorated_calls)} `@traced(...)` decorators; expected 1")
+        sys.exit(
+            f"FAIL: `main` has {len(decorated_calls)} `@traced(...)` decorators; expected 1"
+        )
     call = decorated_calls[0]
     kwargs = {kw.arg: kw for kw in call.keywords if kw.arg is not None}
     for required in ("name", "input_processor", "output_processor"):
@@ -80,7 +87,9 @@ def main() -> None:
                 f"FAIL: `@traced(...)` on `main` is missing required kwarg "
                 f"`{required}=`. Got kwargs: {sorted(kwargs)}"
             )
-    print("OK: `@traced(...)` on `main` carries name + input_processor + output_processor")
+    print(
+        "OK: `@traced(...)` on `main` carries name + input_processor + output_processor"
+    )
     for forbidden in ("hide_input", "hide_output"):
         if forbidden in kwargs:
             kw = kwargs[forbidden]
@@ -91,7 +100,9 @@ def main() -> None:
                     "input/output processors. The skill recommends processors "
                     "over `hide_*` so partial visibility is preserved — pick one."
                 )
-    print("OK: no conflicting `hide_input=True` / `hide_output=True` on the same decorator")
+    print(
+        "OK: no conflicting `hide_input=True` / `hide_output=True` on the same decorator"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py
+++ b/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py
@@ -57,12 +57,18 @@ def get_auth_token() -> tuple[str, str]:
         try:
             result = subprocess.run(
                 ["uip", "login", "status", "--output", "json"],
-                capture_output=True, text=True, timeout=30,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if result.returncode != 0:
-                raise RuntimeError(f"uip login status failed (exit {result.returncode}): {result.stderr}")
+                raise RuntimeError(
+                    f"uip login status failed (exit {result.returncode}): {result.stderr}"
+                )
             if not result.stdout.strip():
-                raise RuntimeError(f"uip login status returned empty output; stderr: {result.stderr}")
+                raise RuntimeError(
+                    f"uip login status returned empty output; stderr: {result.stderr}"
+                )
             data = json.loads(result.stdout)
             inner = data.get("Data") or data
             org = inner.get("Organization") or ""
@@ -97,9 +103,13 @@ def delete_entity(tenant_url: str, token: str, entity_id: str) -> None:
             print(f"OK: deleted entity {entity_id} — HTTP {resp.status}")
     except urllib.error.HTTPError as e:
         if e.code == 404:
-            print(f"SKIP: entity {entity_id} not found (already deleted or never created)")
+            print(
+                f"SKIP: entity {entity_id} not found (already deleted or never created)"
+            )
         else:
-            raise RuntimeError(f"DELETE {url} returned HTTP {e.code}: {e.read().decode()}") from e
+            raise RuntimeError(
+                f"DELETE {url} returned HTTP {e.code}: {e.read().decode()}"
+            ) from e
 
 
 def resolve_entity_ids(args) -> list[str]:
@@ -134,7 +144,9 @@ def resolve_entity_ids(args) -> list[str]:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Delete test-created Data Fabric entities")
+    parser = argparse.ArgumentParser(
+        description="Delete test-created Data Fabric entities"
+    )
     parser.add_argument("--entity-id", help="Entity ID to delete directly")
     args = parser.parse_args()
 

--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_assertions.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_assertions.py
@@ -120,6 +120,7 @@ def assert_package_lifecycle(project_dir: Path, bpmn_name: str, start_id: str) -
 
     expected_file_path = f"/content/{bpmn_name}#{start_id}"
     if not any(
-        ep.get("filePath") == expected_file_path for ep in entry_points.get("entryPoints", [])
+        ep.get("filePath") == expected_file_path
+        for ep in entry_points.get("entryPoints", [])
     ):
         fail(f"entry-points.json missing filePath {expected_file_path}")

--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
@@ -74,8 +74,14 @@ def has_uipath_extension(element: ET.Element, token: str) -> bool:
 
 
 def require_di_for_visible_elements(root: ET.Element) -> None:
-    shaped = {shape.attrib.get("bpmnElement") for shape in root.findall(".//bpmndi:BPMNShape", NS)}
-    edged = {edge.attrib.get("bpmnElement") for edge in root.findall(".//bpmndi:BPMNEdge", NS)}
+    shaped = {
+        shape.attrib.get("bpmnElement")
+        for shape in root.findall(".//bpmndi:BPMNShape", NS)
+    }
+    edged = {
+        edge.attrib.get("bpmnElement")
+        for edge in root.findall(".//bpmndi:BPMNEdge", NS)
+    }
     nodes = [
         *elements(root, "startEvent"),
         *elements(root, "endEvent"),
@@ -91,11 +97,15 @@ def require_di_for_visible_elements(root: ET.Element) -> None:
         *elements(root, "parallelGateway"),
         *elements(root, "inclusiveGateway"),
     ]
-    missing_shapes = [attr(node, "id") for node in nodes if attr(node, "id") not in shaped]
+    missing_shapes = [
+        attr(node, "id") for node in nodes if attr(node, "id") not in shaped
+    ]
     if missing_shapes:
         fail(f"visible BPMN elements missing BPMNShape: {missing_shapes}")
     missing_edges = [
-        attr(flow, "id") for flow in elements(root, "sequenceFlow") if attr(flow, "id") not in edged
+        attr(flow, "id")
+        for flow in elements(root, "sequenceFlow")
+        if attr(flow, "id") not in edged
     ]
     if missing_edges:
         fail(f"sequence flows missing BPMNEdge: {missing_edges}")
@@ -107,7 +117,9 @@ def require_sequence_integrity(root: ET.Element) -> None:
         source = attr(flow, "sourceRef")
         target = attr(flow, "targetRef")
         if source not in ids or target not in ids:
-            fail(f"sequence flow {attr(flow, 'id')} has unresolved refs {source!r}->{target!r}")
+            fail(
+                f"sequence flow {attr(flow, 'id')} has unresolved refs {source!r}->{target!r}"
+            )
 
 
 def require_no_private_connector_values(root: ET.Element) -> None:

--- a/tests/tasks/uipath-maestro-bpmn/author/check_gateway_sequence_flows.py
+++ b/tests/tasks/uipath-maestro-bpmn/author/check_gateway_sequence_flows.py
@@ -24,7 +24,9 @@ def main() -> None:
         fail(f"expected at least 8 sequence flows in {path}, found {len(flows)}")
     if not any(attr(gateway, "default") for gateway in exclusive):
         fail("exclusive gateway is missing a default sequence-flow reference")
-    conditioned = [flow for flow in flows if flow.find("bpmn:conditionExpression", NS) is not None]
+    conditioned = [
+        flow for flow in flows if flow.find("bpmn:conditionExpression", NS) is not None
+    ]
     if not conditioned:
         fail("missing conditional sequence flow")
     require_sequence_integrity(root)

--- a/tests/tasks/uipath-maestro-bpmn/author/check_simple_approval_bpmn.py
+++ b/tests/tasks/uipath-maestro-bpmn/author/check_simple_approval_bpmn.py
@@ -27,7 +27,9 @@ def main() -> None:
         if has_uipath_extension(task, "Orchestrator.StartAgentJob")
     ]
     if not agent_jobs:
-        fail("missing bpmn:serviceTask with Orchestrator.StartAgentJob uipath:activity shell")
+        fail(
+            "missing bpmn:serviceTask with Orchestrator.StartAgentJob uipath:activity shell"
+        )
 
     queue_sends = [
         task
@@ -35,7 +37,9 @@ def main() -> None:
         if has_uipath_extension(task, "Orchestrator.CreateQueueItem")
     ]
     if not queue_sends:
-        fail("missing bpmn:sendTask with Orchestrator.CreateQueueItem uipath:activity shell")
+        fail(
+            "missing bpmn:sendTask with Orchestrator.CreateQueueItem uipath:activity shell"
+        )
 
     exclusive = one_or_more(root, "exclusiveGateway")
     if not any(attr(gateway, "default") for gateway in exclusive):
@@ -67,9 +71,12 @@ def main() -> None:
             fail(f"missing root variable named {required!r}")
 
     migration_versions = {
-        elem.attrib.get("version") for elem in root.findall(".//uipath:migrationVersion", NS)
+        elem.attrib.get("version")
+        for elem in root.findall(".//uipath:migrationVersion", NS)
     }
-    numeric_versions = {v for v in migration_versions if v and any(ch.isdigit() for ch in v)}
+    numeric_versions = {
+        v for v in migration_versions if v and any(ch.isdigit() for ch in v)
+    }
     if not numeric_versions:
         fail('missing numeric uipath:migrationVersion (e.g. version="11" or "11.5")')
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_api_workflow_task.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_api_workflow_task.py
@@ -29,10 +29,14 @@ EXPECTED_TYPE = "Orchestrator.ExecuteApiWorkflowAsync"
 def main() -> None:
     root = load_bpmn(str(PROJECT / BPMN_NAME))
     service_tasks = [
-        task for task in elements(root, "serviceTask") if activity_type(task) == EXPECTED_TYPE
+        task
+        for task in elements(root, "serviceTask")
+        if activity_type(task) == EXPECTED_TYPE
     ]
     if len(service_tasks) != 1:
-        fail(f"expected exactly one serviceTask with {EXPECTED_TYPE}, found {len(service_tasks)}")
+        fail(
+            f"expected exactly one serviceTask with {EXPECTED_TYPE}, found {len(service_tasks)}"
+        )
     task = service_tasks[0]
 
     wrong_wrappers = []
@@ -52,13 +56,20 @@ def main() -> None:
         fail("API workflow task should map invocation/status/result outputs")
 
     declared = variable_ids(root)
-    output_targets = {out.attrib.get("var") or out.attrib.get("target") for out in outputs}
-    missing = sorted(target for target in output_targets if target and target not in declared)
+    output_targets = {
+        out.attrib.get("var") or out.attrib.get("target") for out in outputs
+    }
+    missing = sorted(
+        target for target in output_targets if target and target not in declared
+    )
     if missing:
         fail(f"API workflow outputs target undeclared variables: {missing}")
 
     boundary_events = elements(root, "boundaryEvent")
-    if not any(event.attrib.get("attachedToRef") == task.attrib["id"] for event in boundary_events):
+    if not any(
+        event.attrib.get("attachedToRef") == task.attrib["id"]
+        for event in boundary_events
+    ):
         fail("API workflow serviceTask should have an attached boundary error path")
     assert_has_shape(root, task.attrib["id"])
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_business_rule_task.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_business_rule_task.py
@@ -30,7 +30,9 @@ def main() -> None:
     task = one_element(root, "businessRuleTask")
 
     if activity_type(task) != "Orchestrator.BusinessRules":
-        fail("businessRuleTask must contain uipath:activity type Orchestrator.BusinessRules")
+        fail(
+            "businessRuleTask must contain uipath:activity type Orchestrator.BusinessRules"
+        )
     for service_task in elements(root, "serviceTask"):
         if activity_type(service_task) == "Orchestrator.BusinessRules":
             fail("Orchestrator.BusinessRules must not be modeled as bpmn:serviceTask")
@@ -42,8 +44,12 @@ def main() -> None:
         fail("businessRuleTask should map rule outputs")
 
     declared = variable_ids(root)
-    output_targets = {out.attrib.get("var") or out.attrib.get("target") for out in outputs}
-    missing = sorted(target for target in output_targets if target and target not in declared)
+    output_targets = {
+        out.attrib.get("var") or out.attrib.get("target") for out in outputs
+    }
+    missing = sorted(
+        target for target in output_targets if target and target not in declared
+    )
     if missing:
         fail(f"rule outputs target undeclared variables: {missing}")
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_script_jint_lifecycle.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_script_jint_lifecycle.py
@@ -23,7 +23,15 @@ from _shared.bpmn_assertions import (  # noqa: E402
 
 PROJECT = Path("ScriptNormalizer/ScriptNormalizer")
 BPMN_NAME = "ScriptNormalizer.bpmn"
-FORBIDDEN_JS = ("require(", "fetch(", "XMLHttpRequest", "window.", "document.", "process.", "fs.")
+FORBIDDEN_JS = (
+    "require(",
+    "fetch(",
+    "XMLHttpRequest",
+    "window.",
+    "document.",
+    "process.",
+    "fs.",
+)
 
 
 def main() -> None:
@@ -43,7 +51,9 @@ def main() -> None:
     if "return" not in source and "response" not in source:
         fail("script source should return or produce an explicit response value")
 
-    version = task.find(f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}scriptVersion")
+    version = task.find(
+        f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}scriptVersion"
+    )
     if version is None or version.attrib.get("value") != "v3":
         fail('scriptTask must include uipath:scriptVersion value="v3"')
 
@@ -54,15 +64,21 @@ def main() -> None:
         fail("scriptTask should map a response/output variable")
 
     declared = variable_ids(root)
-    output_targets = {out.attrib.get("var") or out.attrib.get("target") for out in outputs}
-    missing = sorted(target for target in output_targets if target and target not in declared)
+    output_targets = {
+        out.attrib.get("var") or out.attrib.get("target") for out in outputs
+    }
+    missing = sorted(
+        target for target in output_targets if target and target not in declared
+    )
     if missing:
         fail(f"script outputs target undeclared variables: {missing}")
 
     assert_has_shape(root, task.attrib["id"])
     start = one_element(root, "startEvent")
     assert_package_lifecycle(PROJECT, BPMN_NAME, start.attrib["id"])
-    print("OK: scriptTask uses JavaScript/v3 Jint-safe source and package lifecycle files")
+    print(
+        "OK: scriptTask uses JavaScript/v3 Jint-safe source and package lifecycle files"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-bpmn/connector/check_integration_service_boundary.py
+++ b/tests/tasks/uipath-maestro-bpmn/connector/check_integration_service_boundary.py
@@ -34,12 +34,19 @@ def main() -> None:
         if glob.glob(f"**/{name}", recursive=True)
     ]
     if generated:
-        fail(f"draft boundary should not hand-author generated package files: {generated}")
+        fail(
+            f"draft boundary should not hand-author generated package files: {generated}"
+        )
     notes = "\n".join(
         Path(p).read_text(encoding="utf-8")
         for p in glob.glob("SlackDigestBoundaryBpmn/**/*.md", recursive=True)
     )
-    required = ["connection binding", "dynamic schemas", "bindings_v2.json", "package metadata"]
+    required = [
+        "connection binding",
+        "dynamic schemas",
+        "bindings_v2.json",
+        "package metadata",
+    ]
     missing = [token for token in required if token.lower() not in notes.lower()]
     if missing:
         fail(f"boundary notes missing CLI-owned blockers: {missing}")

--- a/tests/tasks/uipath-maestro-bpmn/connector/check_registry_discovery.py
+++ b/tests/tasks/uipath-maestro-bpmn/connector/check_registry_discovery.py
@@ -61,7 +61,9 @@ def main() -> None:
     if leaks:
         sys.exit(f"FAIL: registry evidence contains concrete private values: {leaks}")
 
-    print(f"OK: registry-evidence covers agent/queue/connector wrappers across {len(files)} files")
+    print(
+        f"OK: registry-evidence covers agent/queue/connector wrappers across {len(files)} files"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-bpmn/e2e/check_invoice_exception_triage.py
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/check_invoice_exception_triage.py
@@ -62,7 +62,13 @@ def main() -> int:
 
     elements = list(process)
     element_types = {local(elem.tag) for elem in elements}
-    for expected in ["startEvent", "scriptTask", "exclusiveGateway", "userTask", "endEvent"]:
+    for expected in [
+        "startEvent",
+        "scriptTask",
+        "exclusiveGateway",
+        "userTask",
+        "endEvent",
+    ]:
         if expected not in element_types:
             fail(f"missing BPMN element type {expected}")
 
@@ -76,7 +82,8 @@ def main() -> int:
     if len(sequence_flows) < 4:
         fail("expected at least four sequence flows")
     if not any(
-        flow.attrib.get("sourceRef", "").lower().find("route") >= 0 for flow in sequence_flows
+        flow.attrib.get("sourceRef", "").lower().find("route") >= 0
+        for flow in sequence_flows
     ):
         fail("gateway outgoing sequence flows should use a readable routeByRisk id")
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_contract_variant_wrappers.py
@@ -16,7 +16,9 @@ from _shared.bpmn_check import (  # noqa: E402
 )
 
 
-def has_typed_extension(element: ET.Element, extension_name: str, type_value: str) -> bool:
+def has_typed_extension(
+    element: ET.Element, extension_name: str, type_value: str
+) -> bool:
     ext = element.find("bpmn:extensionElements", NS)
     if ext is None:
         return False
@@ -27,7 +29,9 @@ def has_typed_extension(element: ET.Element, extension_name: str, type_value: st
     return False
 
 
-def require_wrapper(root: ET.Element, wrapper: str, extension_name: str, type_value: str) -> None:
+def require_wrapper(
+    root: ET.Element, wrapper: str, extension_name: str, type_value: str
+) -> None:
     matches = [
         elem
         for elem in elements(root, wrapper)
@@ -43,9 +47,16 @@ def require_uipath_element(root: ET.Element, local_name: str, description: str) 
 
 
 def require_uipath_attr_value(
-    root: ET.Element, local_name: str, attr_name: str, expected_value: str, description: str
+    root: ET.Element,
+    local_name: str,
+    attr_name: str,
+    expected_value: str,
+    description: str,
 ) -> None:
-    values = {elem.attrib.get(attr_name) for elem in root.findall(f".//uipath:{local_name}", NS)}
+    values = {
+        elem.attrib.get(attr_name)
+        for elem in root.findall(f".//uipath:{local_name}", NS)
+    }
     if expected_value not in values:
         fail(f"missing {description}: {expected_value}")
 
@@ -79,13 +90,19 @@ def main() -> None:
         require_wrapper(root, wrapper, extension_name, type_value)
 
     for version in {"5", "11", "11.5"}:
-        require_uipath_attr_value(root, "migrationVersion", "version", version, "migration version")
+        require_uipath_attr_value(
+            root, "migrationVersion", "version", version, "migration version"
+        )
 
     require_uipath_attr_value(
         root, "scriptVersion", "value", "v2", "preserved legacy scriptVersion"
     )
-    require_uipath_element(root, "caseManagement", "preserve-only uipath:caseManagement payload")
-    require_uipath_element(root, "Activity", "preserve-only generic uipath:Activity payload")
+    require_uipath_element(
+        root, "caseManagement", "preserve-only uipath:caseManagement payload"
+    )
+    require_uipath_element(
+        root, "Activity", "preserve-only generic uipath:Activity payload"
+    )
 
     require_no_private_connector_values(root)
     require_sequence_integrity(root)

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_hitl_rpa_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_hitl_rpa_wrappers.py
@@ -18,7 +18,9 @@ from _shared.bpmn_check import (  # noqa: E402
 def main() -> None:
     path, root = parse_bpmn("EmployeeAccessBpmn")
     hitl = [
-        task for task in elements(root, "userTask") if has_uipath_extension(task, "Actions.HITL")
+        task
+        for task in elements(root, "userTask")
+        if has_uipath_extension(task, "Actions.HITL")
     ]
     rpa = [
         task
@@ -28,7 +30,9 @@ def main() -> None:
     if not hitl:
         fail("missing bpmn:userTask with Actions.HITL uipath:activity shell")
     if not rpa:
-        fail("missing bpmn:serviceTask with Orchestrator.StartJob uipath:activity shell")
+        fail(
+            "missing bpmn:serviceTask with Orchestrator.StartJob uipath:activity shell"
+        )
     require_no_private_connector_values(root)
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
@@ -118,7 +118,9 @@ def main() -> None:
     if present:
         fail(f"script uses APIs outside the Jint boundary: {present}")
     if "args." in body:
-        fail("script body should read mapped fields as top-level identifiers, not args.*")
+        fail(
+            "script body should read mapped fields as top-level identifiers, not args.*"
+        )
     for identifier in ("amount", "daysOverdue"):
         if identifier not in body:
             fail(f"script body should reference mapped input identifier {identifier!r}")
@@ -137,14 +139,20 @@ def main() -> None:
         if expected not in args_body:
             fail(f"script args should map {variable_name!r} through {expected!r}")
         if f"={variable_name}" in args_body:
-            fail(f"script args should not use bare variable expression ={variable_name}")
+            fail(
+                f"script args should not use bare variable expression ={variable_name}"
+            )
 
     output_var = variables["riskScore"]
     outputs = uipath_outputs(task)
     if not any(out.attrib.get("var") == output_var for out in outputs):
         fail("script output must map to the declared riskScore variable id")
-    if not any((out.attrib.get("source") or "").startswith("=result.") for out in outputs):
-        fail("script output should map from a result expression such as =result.response")
+    if not any(
+        (out.attrib.get("source") or "").startswith("=result.") for out in outputs
+    ):
+        fail(
+            "script output should map from a result expression such as =result.response"
+        )
 
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)

--- a/tests/tasks/uipath-maestro-bpmn/smoke/check_imported_xml_inspect.py
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/check_imported_xml_inspect.py
@@ -50,7 +50,9 @@ def main() -> None:
         root = tree.getroot()
         process = root.find("bpmn:process", NS)
         if process is None or process.attrib.get("id") != signature["process_id"]:
-            failures.append(f"{rel}: process id changed; expected {signature['process_id']!r}")
+            failures.append(
+                f"{rel}: process id changed; expected {signature['process_id']!r}"
+            )
             continue
         for kind in signature["elements"]:
             if not root.findall(f".//bpmn:{kind}", NS):
@@ -58,13 +60,18 @@ def main() -> None:
         body = ET.tostring(root, encoding="unicode")
         for token in signature["uipath_tokens"]:
             if token not in body:
-                failures.append(f"{rel}: expected uipath token {token!r} no longer present")
+                failures.append(
+                    f"{rel}: expected uipath token {token!r} no longer present"
+                )
 
     if failures:
         sys.exit(
-            "FAIL: imported fixture inspection drift detected:\n  - " + "\n  - ".join(failures)
+            "FAIL: imported fixture inspection drift detected:\n  - "
+            + "\n  - ".join(failures)
         )
-    print(f"OK: {len(EXPECTED_SIGNATURES)} imported fixtures retain expected structural signatures")
+    print(
+        f"OK: {len(EXPECTED_SIGNATURES)} imported fixtures retain expected structural signatures"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-bpmn/smoke/check_validation_fixtures_pack.py
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/check_validation_fixtures_pack.py
@@ -57,7 +57,9 @@ def main() -> None:
             f"FAIL: package artifacts were written under fixture folders: {fixture_package_paths}"
         )
 
-    print(f"OK: {len(EXPECTED)} fixture BPMN files parse and {len(packages)} packages exist")
+    print(
+        f"OK: {len(EXPECTED)} fixture BPMN files parse and {len(packages)} packages exist"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -69,7 +69,9 @@ def assert_validate_passes(caseplan_path: str, *, timeout: int = 60) -> None:
         )
 
 
-def assert_task_type_present(task_type: str, *, caseplan_path: str | None = None) -> dict:
+def assert_task_type_present(
+    task_type: str, *, caseplan_path: str | None = None
+) -> dict:
     plan = read_caseplan(caseplan_path)
     matches = find_tasks_of_type(plan, task_type)
     if not matches:
@@ -127,7 +129,7 @@ def find_project_dir(pattern: str = "**/project.uiproj") -> str:
         joined = "\n  - ".join(candidates)
         _fail(
             f"No Case project.uiproj found matching {pattern} — "
-            f"candidates exist but none declare ProjectType=\"CaseManagement\":"
+            f'candidates exist but none declare ProjectType="CaseManagement":'
             f"\n  - {joined}"
         )
     if len(case_projects) > 1:
@@ -174,11 +176,18 @@ def run_debug(
     solution_dir = find_solution_dir(solution_glob)
 
     refresh_cmd = [
-        "uip", "solution", "resource", "refresh",
-        "--solution-folder", solution_dir,
-        "--output", "json",
+        "uip",
+        "solution",
+        "resource",
+        "refresh",
+        "--solution-folder",
+        solution_dir,
+        "--output",
+        "json",
     ]
-    r = subprocess.run(refresh_cmd, capture_output=True, text=True, timeout=refresh_timeout)
+    r = subprocess.run(
+        refresh_cmd, capture_output=True, text=True, timeout=refresh_timeout
+    )
     if r.returncode != 0:
         _fail(
             f"solution resource refresh exit {r.returncode}\n"
@@ -186,14 +195,19 @@ def run_debug(
         )
 
     debug_cmd = [
-        "uip", "maestro", "case", "debug", project_dir,
-        "--log-level", "debug", "--output", "json",
+        "uip",
+        "maestro",
+        "case",
+        "debug",
+        project_dir,
+        "--log-level",
+        "debug",
+        "--output",
+        "json",
     ]
     r = subprocess.run(debug_cmd, capture_output=True, text=True, timeout=timeout)
     if r.returncode != 0:
-        _fail(
-            f"case debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}"
-        )
+        _fail(f"case debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}")
     data = _parse_json(r.stdout)
     if data is None:
         _fail(f"Could not parse JSON from case debug\n{r.stdout}")
@@ -208,13 +222,31 @@ def run_debug(
 # output extraction so GUID / timestamp / status digits do not falsely
 # match small expected values (e.g. an integer in [0, 120] would match
 # any 1-3 digit chunk of an instanceId UUID).
-_METADATA_KEYS = frozenset({
-    "jobKey", "instanceId", "runId", "solutionId", "finalStatus",
-    "status", "studioWebUrl", "createdAt", "startedAt", "endedAt",
-    "elementId", "id", "uniqueId", "projectId", "tenantId", "folderId",
-    "uipathActivityTypeId", "taskTypeId", "elementInstanceId",
-    "timestamp", "occurredAt",
-})
+_METADATA_KEYS = frozenset(
+    {
+        "jobKey",
+        "instanceId",
+        "runId",
+        "solutionId",
+        "finalStatus",
+        "status",
+        "studioWebUrl",
+        "createdAt",
+        "startedAt",
+        "endedAt",
+        "elementId",
+        "id",
+        "uniqueId",
+        "projectId",
+        "tenantId",
+        "folderId",
+        "uipathActivityTypeId",
+        "taskTypeId",
+        "elementInstanceId",
+        "timestamp",
+        "occurredAt",
+    }
+)
 
 
 def collect_outputs(payload: dict) -> list[Any]:
@@ -311,8 +343,7 @@ def assert_output_int_in_range(payload: dict, lo: int, hi: int) -> int:
     hits = [int(m) for m in re.findall(r"-?\d+", haystack) if lo <= int(m) <= hi]
     if not hits:
         _fail(
-            f"No integer in [{lo}, {hi}] found in outputs\n"
-            f"Outputs: {haystack[:1000]}"
+            f"No integer in [{lo}, {hi}] found in outputs\nOutputs: {haystack[:1000]}"
         )
     return hits[0]
 

--- a/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/check_agent_case.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.case_check import (  # noqa: E402
     assert_task_type_present,
     run_debug,

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/check_api_workflow_case.py
@@ -5,7 +5,9 @@ successfully."""
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.case_check import (  # noqa: E402
     assert_task_type_present,
     run_debug,

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
 
 

--- a/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/process/check_process_case.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.case_check import (  # noqa: E402
     assert_task_type_present,
     run_debug,

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/check_rpa_case.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.case_check import (  # noqa: E402
     assert_task_type_present,
     run_debug,

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -265,7 +265,9 @@ def _iter_flow_nodes(project_glob: str):
 
 
 def _non_empty_binding_value(value: Any) -> bool:
-    return isinstance(value, str) and bool(value.strip()) and value != "ImplicitConnection"
+    return (
+        isinstance(value, str) and bool(value.strip()) and value != "ImplicitConnection"
+    )
 
 
 def _find_project(pattern: str) -> str:
@@ -288,7 +290,7 @@ def _find_project(pattern: str) -> str:
         joined = "\n  - ".join(candidates)
         _fail(
             f"No Flow project.uiproj found matching {pattern} — "
-            f"candidates exist but none declare ProjectType=\"Flow\":\n  - {joined}"
+            f'candidates exist but none declare ProjectType="Flow":\n  - {joined}'
         )
     if len(flow_projects) > 1:
         joined = "\n  - ".join(flow_projects)

--- a/tests/tasks/uipath-maestro-flow/canary/canary.py
+++ b/tests/tasks/uipath-maestro-flow/canary/canary.py
@@ -241,7 +241,7 @@ def main() -> int:
 
         errors: list[str] = []
         if payload.get("finalStatus") != "Completed":
-            errors.append(f"finalStatus != Completed")
+            errors.append("finalStatus != Completed")
 
         print()
         for eid, path, matcher, fmt in LEGS:

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
@@ -83,7 +83,9 @@ def _assert_filter_tree_shape(tree, *, source: str) -> None:
         )
 
     values = [_leaf_value(n) for n in leaves]
-    if not any(isinstance(v, str) and v.strip().lower() == EXPECTED_VALUE for v in values):
+    if not any(
+        isinstance(v, str) and v.strip().lower() == EXPECTED_VALUE for v in values
+    ):
         sys.exit(
             f"FAIL: {source} has no leaf with value '{EXPECTED_VALUE}' "
             f"(found values: {[v for v in values if v is not None]})"

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_connection_available.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_connection_available.py
@@ -43,7 +43,17 @@ def main() -> None:
 
     try:
         proc = subprocess.run(
-            [uip, "is", "connections", "list", connector_key, "--all-folders", "--refresh", "--output", "json"],
+            [
+                uip,
+                "is",
+                "connections",
+                "list",
+                connector_key,
+                "--all-folders",
+                "--refresh",
+                "--output",
+                "json",
+            ],
             capture_output=True,
             text=True,
             timeout=30,

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_drive_to_slack.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_drive_to_slack.py
@@ -22,7 +22,6 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-from _shared.flow_check import run_debug  # noqa: E402
 
 FLOW_GLOB = "**/DriveToSlackTest*.flow"
 DRIVE_KEY = "uipath-google-drive"

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
@@ -48,7 +48,7 @@ _JSONSTRING_PREFIX = "=jsonString:"
 
 _EXPECTED_BODY = {
     "to": "baishali13@gmail.com",
-    "importance": "medium", # this is the enum field under test
+    "importance": "medium",  # this is the enum field under test
 }
 
 
@@ -121,10 +121,7 @@ def _check_control(flow_path: str, flow: dict[str, Any]) -> None:
 
 def main() -> None:
     if len(sys.argv) != 3:
-        _fail(
-            "usage: check_enum_flow.py <flow_glob> "
-            "<structure|body_params|control>"
-        )
+        _fail("usage: check_enum_flow.py <flow_glob> <structure|body_params|control>")
 
     flow_path, flow = _load_flow(sys.argv[1])
     check_name = sys.argv[2]

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_generate_schema.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_generate_schema.py
@@ -64,12 +64,7 @@ def main() -> None:
         )
 
     jira_nodes = [n for n in flow["nodes"] if n.get("type") == JIRA_NODE_TYPE]
-    body = (
-        jira_nodes[0]
-        .get("inputs", {})
-        .get("detail", {})
-        .get("bodyParameters", {})
-    )
+    body = jira_nodes[0].get("inputs", {}).get("detail", {}).get("bodyParameters", {})
     summary = body.get("fields.summary")
     if not summary:
         _fail(f"fields.summary missing or empty in bodyParameters: {body}")

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/check_trigger_filter.py
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/check_trigger_filter.py
@@ -47,7 +47,9 @@ def main():
         )
 
     # 2. At least one leaf must use the PascalCase `Contains` operator.
-    operators = {n.get("operator") for n in leaves if isinstance(n.get("operator"), str)}
+    operators = {
+        n.get("operator") for n in leaves if isinstance(n.get("operator"), str)
+    }
     if "Contains" not in operators:
         sys.exit(
             f"FAIL: expected PascalCase `Contains` operator in filter tree, "

--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -53,7 +53,9 @@ def main() -> None:
 
     hitl_nodes = [n for n in nodes if n.get("type") == "uipath.human-in-the-loop"]
     if len(hitl_nodes) != 1:
-        fail(f"Expected exactly one uipath.human-in-the-loop node, found {len(hitl_nodes)}")
+        fail(
+            f"Expected exactly one uipath.human-in-the-loop node, found {len(hitl_nodes)}"
+        )
     hitl = hitl_nodes[0]
     hitl_id = hitl.get("id")
     if not hitl_id:
@@ -72,7 +74,8 @@ def main() -> None:
         fail("HITL schema must define at least two outcomes")
 
     if not any(
-        (field_text(f, "id") == "amount" or "amount" in field_text(f, "label")) and f.get("type") == "number"
+        (field_text(f, "id") == "amount" or "amount" in field_text(f, "label"))
+        and f.get("type") == "number"
         for f in fields
     ):
         fail("Amount field must use type number")
@@ -81,7 +84,11 @@ def main() -> None:
         f
         for f in fields
         if f.get("direction") in {"output", "inOut"}
-        and ("approval" in field_text(f, "id") or "approved" in field_text(f, "id") or "decision" in field_text(f, "id"))
+        and (
+            "approval" in field_text(f, "id")
+            or "approved" in field_text(f, "id")
+            or "decision" in field_text(f, "id")
+        )
     ]
     has_boolean_decision = any(f.get("type") == "boolean" for f in decision_fields)
     outcome_names = {str(o.get("name") or o.get("id") or "").lower() for o in outcomes}
@@ -89,21 +96,29 @@ def main() -> None:
         "reject" in name for name in outcome_names
     )
     if not (has_boolean_decision or has_approval_outcomes):
-        fail("HITL must capture the manager decision as a boolean output or approve/reject outcomes")
+        fail(
+            "HITL must capture the manager decision as a boolean output or approve/reject outcomes"
+        )
 
     reason_keywords = ("reason", "comment", "explanation", "justification", "note")
     if not any(
         f.get("direction") in {"output", "inOut"}
         and f.get("type") in {"text", "string", "textarea"}
-        and any(kw in field_text(f, "id") or kw in field_text(f, "label") for kw in reason_keywords)
+        and any(
+            kw in field_text(f, "id") or kw in field_text(f, "label")
+            for kw in reason_keywords
+        )
         for f in fields
     ):
-        fail("HITL must expose a text output field for the rejection reason (e.g., reason, comment)")
+        fail(
+            "HITL must expose a text output field for the rejection reason (e.g., reason, comment)"
+        )
 
     input_bindings = [
         f.get("binding", "")
         for f in fields
-        if f.get("direction") in {"input", "inOut"} and isinstance(f.get("binding"), str)
+        if f.get("direction") in {"input", "inOut"}
+        and isinstance(f.get("binding"), str)
     ]
     if not input_bindings:
         fail("HITL input fields must be bound to upstream script output")
@@ -113,7 +128,10 @@ def main() -> None:
             "or =js:$vars.<node>.output.<field>"
         )
 
-    if not any(e.get("sourceNodeId") == hitl_id and e.get("sourcePort") == "completed" for e in edges):
+    if not any(
+        e.get("sourceNodeId") == hitl_id and e.get("sourcePort") == "completed"
+        for e in edges
+    ):
         fail("HITL completed handle must be wired")
 
     scripts = [
@@ -125,7 +143,9 @@ def main() -> None:
     if not any(expected_output_path in script for script in scripts):
         fail(f"Downstream script must read HITL output via {expected_output_path}")
 
-    print(f"OK: HITL node {hitl_id} uses v1.0 schema, captures approval + reason, wires completed, and uses .output paths")
+    print(
+        f"OK: HITL node {hitl_id} uses v1.0 schema, captures approval + reason, wires completed, and uses .output paths"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/check_add_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/check_add_node.py
@@ -39,7 +39,10 @@ def _assert_edge_exists(source_id: str, target_id: str) -> None:
         with open(path) as f:
             flow = json.load(f)
         for edge in flow.get("edges") or []:
-            if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+            if (
+                edge.get("sourceNodeId") == source_id
+                and edge.get("targetNodeId") == target_id
+            ):
                 return
     sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
 

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/check_group_to_subflow.py
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/check_group_to_subflow.py
@@ -45,7 +45,9 @@ def _assert_main_flow_nodes_removed(flow: dict) -> None:
     main_ids = {n.get("id") for n in flow.get("nodes") or []}
     for removed in ("getWeather", "formatSummary"):
         if removed in main_ids:
-            sys.exit(f"FAIL: '{removed}' should have been moved to subflow but is still in main flow nodes")
+            sys.exit(
+                f"FAIL: '{removed}' should have been moved to subflow but is still in main flow nodes"
+            )
 
 
 def main():

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/check_move_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/check_move_node.py
@@ -28,7 +28,10 @@ def _load_flow() -> dict:
 
 def _assert_edge_exists(flow: dict, source_id: str, target_id: str) -> None:
     for edge in flow.get("edges") or []:
-        if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+        if (
+            edge.get("sourceNodeId") == source_id
+            and edge.get("targetNodeId") == target_id
+        ):
             return
     sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
 
@@ -42,7 +45,11 @@ def main():
 
     # Decision must come before formatSummary: getWeather → decision node
     # Find the decision node id
-    decision_ids = [n["id"] for n in flow.get("nodes") or [] if n.get("type") == "core.logic.decision"]
+    decision_ids = [
+        n["id"]
+        for n in flow.get("nodes") or []
+        if n.get("type") == "core.logic.decision"
+    ]
     if not decision_ids:
         sys.exit("FAIL: no decision node found")
     decision_id = decision_ids[0]
@@ -50,7 +57,11 @@ def main():
     _assert_edge_exists(flow, "getWeather", decision_id)
 
     # formatSummary must exist and be downstream of decision
-    fmt_ids = [n["id"] for n in flow.get("nodes") or [] if n.get("type") == "core.action.script"]
+    fmt_ids = [
+        n["id"]
+        for n in flow.get("nodes") or []
+        if n.get("type") == "core.action.script"
+    ]
     if not fmt_ids:
         sys.exit("FAIL: no script node (formatSummary) found")
 
@@ -64,7 +75,9 @@ def main():
     # Runtime check
     payload = run_debug(timeout=240)
     assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
-    print("OK: decision before formatSummary, branches merged, single end node, debug valid")
+    print(
+        "OK: decision before formatSummary, branches merged, single end node, debug valid"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/check_remove_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/check_remove_node.py
@@ -26,7 +26,9 @@ def _assert_node_absent(node_id: str) -> None:
             flow = json.load(f)
         for node in flow.get("nodes") or []:
             if node.get("id") == node_id:
-                sys.exit(f"FAIL: node '{node_id}' should have been removed but still exists")
+                sys.exit(
+                    f"FAIL: node '{node_id}' should have been removed but still exists"
+                )
 
 
 def _assert_edge_exists(source_id: str, target_id: str) -> None:
@@ -38,7 +40,10 @@ def _assert_edge_exists(source_id: str, target_id: str) -> None:
         with open(path) as f:
             flow = json.load(f)
         for edge in flow.get("edges") or []:
-            if edge.get("sourceNodeId") == source_id and edge.get("targetNodeId") == target_id:
+            if (
+                edge.get("sourceNodeId") == source_id
+                and edge.get("targetNodeId") == target_id
+            ):
                 return
     sys.exit(f"FAIL: no edge from '{source_id}' to '{target_id}'")
 

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/check_update_node.py
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/check_update_node.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,
@@ -17,9 +19,7 @@ def main():
     # branch message in a Script node without calling the weather API.
     assert_flow_has_node_type(["core.action.http"])
     payload = run_debug(timeout=240)
-    assert_outputs_contain(
-        payload, ["amazing day", "go home"], require_all=False
-    )
+    assert_outputs_contain(payload, ["amazing day", "go home"], require_all=False)
     print("OK: HTTP node present; output contains a weather branch message")
 
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
@@ -13,6 +13,7 @@ ran the right shell command):
 These checks fail if the agent ran the commands but they errored, or if
 the agent fabricated stdout without producing real files.
 """
+
 from __future__ import annotations
 
 import json
@@ -84,7 +85,9 @@ def main() -> None:
         sys.exit('FAIL: data point "hello" has empty inputs')
     if not (hello.get("expectedOutput") or hello.get("expected")):
         sys.exit('FAIL: data point "hello" has no expectedOutput / expected field')
-    print(f"OK: eval set {set_match[0]} contains data point 'hello' with inputs + expected")
+    print(
+        f"OK: eval set {set_match[0]} contains data point 'hello' with inputs + expected"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py
@@ -8,6 +8,7 @@ Reads `report.json` and asserts:
   - action               is one of {"refused", "asked-user"}
   - reason               mentions "Studio Web" (the rule's framing)
 """
+
 from __future__ import annotations
 
 import json
@@ -44,9 +45,7 @@ def main() -> None:
         )
     reason = doc.get("reason") or ""
     if "Studio Web" not in reason:
-        failures.append(
-            f"reason does not reference 'Studio Web': {reason!r}"
-        )
+        failures.append(f"reason does not reference 'Studio Web': {reason!r}")
 
     if failures:
         sys.exit("FAIL: " + " | ".join(failures))

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py
@@ -9,6 +9,7 @@ Reads `report.json` written by the agent and asserts:
 
 Each goal must use the kebab-case spelling exactly as the CLI accepts it.
 """
+
 from __future__ import annotations
 
 import json
@@ -39,7 +40,9 @@ def main() -> None:
 
     if failures:
         sys.exit("FAIL: " + " | ".join(failures))
-    print(f"OK: all 3 evaluator-type choices match expected ({list(EXPECTED.values())})")
+    print(
+        f"OK: all 3 evaluator-type choices match expected ({list(EXPECTED.values())})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
@@ -17,6 +17,7 @@ The CLI's exact field names may evolve; we tolerate both `EvaluatorScores`
 (list/dict of evaluator entries) and a flat per-row `Score` field. Anything
 that surfaces a numeric score gets checked.
 """
+
 from __future__ import annotations
 
 import json
@@ -48,7 +49,7 @@ def _extract_rows(doc: dict) -> list[dict]:
     if code != "MaestroFlowEvalRunResults":
         _fail(
             f'eval-results.json `Code` should be "MaestroFlowEvalRunResults", '
-            f'got {code!r}'
+            f"got {code!r}"
         )
     data = doc.get("Data") or {}
     for key in ("Results", "DataPoints", "Rows"):
@@ -56,8 +57,8 @@ def _extract_rows(doc: dict) -> list[dict]:
         if isinstance(rows, list) and rows:
             return rows
     _fail(
-        f'eval-results.json has no Results/DataPoints/Rows list under Data. '
-        f'Top-level keys: {list(doc.keys())}, Data keys: {list(data.keys())}'
+        f"eval-results.json has no Results/DataPoints/Rows list under Data. "
+        f"Top-level keys: {list(doc.keys())}, Data keys: {list(data.keys())}"
     )
     return []  # unreachable
 
@@ -118,9 +119,7 @@ def main() -> None:
             continue
         bad = [s for s in scores if s != 1.0]
         if bad:
-            failures.append(
-                f"{name!r}: scored {bad!r} (expected 1.0 from exact-match)"
-            )
+            failures.append(f"{name!r}: scored {bad!r} (expected 1.0 from exact-match)")
 
     if failures:
         _fail(" | ".join(failures))

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/check_weather_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/check_weather_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,
@@ -17,9 +19,7 @@ def main():
     # branch message in a Script node without calling the weather API.
     assert_flow_has_node_type(["core.action.http"])
     payload = run_debug(timeout=240)
-    assert_outputs_contain(
-        payload, ["nice day", "bring a jacket"], require_all=False
-    )
+    assert_outputs_contain(payload, ["nice day", "bring a jacket"], require_all=False)
     print("OK: HTTP node present; output contains a weather branch message")
 
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/check_calculator_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/check_calculator_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
@@ -79,7 +79,9 @@ def main() -> None:
         fail("Flow must contain nodes[] and edges[]")
 
     if len(nodes) < 5:
-        fail(f"Expected >=5 nodes (trigger + 2 scripts + decision + branch action(s)), found {len(nodes)}")
+        fail(
+            f"Expected >=5 nodes (trigger + 2 scripts + decision + branch action(s)), found {len(nodes)}"
+        )
 
     triggers = [n for n in nodes if is_trigger(n)]
     if not triggers:
@@ -89,7 +91,9 @@ def main() -> None:
 
     scripts = [n for n in nodes if node_type(n) == "core.action.script"]
     if len(scripts) < 2:
-        fail(f"Expected >=2 core.action.script nodes (urgency + VIP classifier), found {len(scripts)}")
+        fail(
+            f"Expected >=2 core.action.script nodes (urgency + VIP classifier), found {len(scripts)}"
+        )
 
     decisions = [n for n in nodes if node_type(n) == "core.logic.decision"]
     if len(decisions) != 1:
@@ -99,19 +103,27 @@ def main() -> None:
         fail("Decision node missing id")
 
     out_edges = [
-        e for e in edges
-        if decision_id in (e.get("sourceNodeId"), e.get("source"), e.get("from"), e.get("sourceId"))
+        e
+        for e in edges
+        if decision_id
+        in (e.get("sourceNodeId"), e.get("source"), e.get("from"), e.get("sourceId"))
     ]
     if len(out_edges) < 2:
-        fail(f"Decision node must have >=2 outgoing edges (VIP + standard), found {len(out_edges)}")
+        fail(
+            f"Decision node must have >=2 outgoing edges (VIP + standard), found {len(out_edges)}"
+        )
 
     if not any(references(n, "slack") for n in nodes):
-        fail("No Slack connector reference found anywhere in flow (VIP branch should DM via Slack)")
+        fail(
+            "No Slack connector reference found anywhere in flow (VIP branch should DM via Slack)"
+        )
 
     outlook_needles = ("outlook", "office365", "graph.microsoft.com")
     non_trigger_outlook = [
-        n for n in nodes
-        if not is_trigger(n) and any(references(n, needle) for needle in outlook_needles)
+        n
+        for n in nodes
+        if not is_trigger(n)
+        and any(references(n, needle) for needle in outlook_needles)
     ]
     if not non_trigger_outlook:
         fail(

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
@@ -56,17 +56,29 @@ def _manual_trigger_with_graph_replies() -> tuple[list[Node], list[Edge]]:
         {
             "id": "reply_vip",
             "type": "core.action.http.v2",
-            "inputs": {"detail": {"url": "https://graph.microsoft.com/v1.0/me/messages/{id}/reply"}},
+            "inputs": {
+                "detail": {
+                    "url": "https://graph.microsoft.com/v1.0/me/messages/{id}/reply"
+                }
+            },
         },
         {
             "id": "reply_standard",
             "type": "core.action.http.v2",
-            "inputs": {"detail": {"url": "https://graph.microsoft.com/v1.0/me/messages/{id}/reply"}},
+            "inputs": {
+                "detail": {
+                    "url": "https://graph.microsoft.com/v1.0/me/messages/{id}/reply"
+                }
+            },
         },
         {
             "id": "slack",
             "type": "core.action.http.v2",
-            "inputs": {"detail": {"bodyParameters": {"targetConnector": "uipath-salesforce-slack"}}},
+            "inputs": {
+                "detail": {
+                    "bodyParameters": {"targetConnector": "uipath-salesforce-slack"}
+                }
+            },
         },
         {"id": "end", "type": "core.control.end"},
     ]
@@ -79,12 +91,21 @@ def _manual_trigger_with_graph_replies() -> tuple[list[Node], list[Edge]]:
 
 def _outlook_connector_shape() -> tuple[list[Node], list[Edge]]:
     nodes = [
-        {"id": "start", "type": "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"},
+        {
+            "id": "start",
+            "type": "uipath.connector.trigger.uipath-microsoft-outlook365.email-received",
+        },
         {"id": "urgency", "type": "core.action.script"},
         {"id": "vip", "type": "core.action.script"},
         {"id": "decide", "type": "core.logic.decision"},
-        {"id": "reply", "type": "uipath.connector.uipath-microsoft-outlook365.send-reply"},
-        {"id": "slack", "type": "uipath.connector.uipath-salesforce-slack.send-direct-message"},
+        {
+            "id": "reply",
+            "type": "uipath.connector.uipath-microsoft-outlook365.send-reply",
+        },
+        {
+            "id": "slack",
+            "type": "uipath.connector.uipath-salesforce-slack.send-direct-message",
+        },
         {"id": "end", "type": "core.control.end"},
     ]
     edges = [
@@ -121,7 +142,10 @@ def test_missing_outlook_reference_fails(tmp_path: Path) -> None:
     _write_flow(tmp_path, nodes, edges)
     result = _run(tmp_path)
     assert result.returncode != 0
-    assert "non-trigger Outlook reply reference" in result.stderr or "non-trigger Outlook reply reference" in result.stdout
+    assert (
+        "non-trigger Outlook reply reference" in result.stderr
+        or "non-trigger Outlook reply reference" in result.stdout
+    )
 
 
 def test_no_trigger_fails(tmp_path: Path) -> None:

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/check_dice_runs.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/check_dice_runs.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_int_in_range,

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/check_feet_inches_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/check_feet_inches_flow.py
@@ -7,7 +7,9 @@ Usage: check_feet_inches_flow.py {f2i|i2f|y2f}
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/check_loop_multiply.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/check_loop_multiply.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/check_multi_city_weather.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/check_multi_city_weather.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,
@@ -22,9 +24,7 @@ def main():
     assert_outputs_contain(payload, ["Seattle", "Phoenix", "New York"])
 
     # At least one verdict must appear — proves the script classified the temp
-    assert_outputs_contain(
-        payload, ["warm", "cold"], require_all=False
-    )
+    assert_outputs_contain(payload, ["warm", "cold"], require_all=False)
     print("OK: loop + HTTP + script all executed, all 3 cities with verdicts present")
 
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/check_reading_list.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/check_reading_list.py
@@ -9,7 +9,9 @@ Information Theory (MacKay) — with titles uppercased.
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/check_channel_description.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/check_channel_description.py
@@ -5,7 +5,9 @@ the Bellevue office address fragments."""
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_uses_connector_target,
     assert_outputs_contain,

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/check_slack_weather_pipeline.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/check_slack_weather_pipeline.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_flow_uses_connector_target,

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
@@ -36,7 +36,9 @@ exits 1.
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,
@@ -85,11 +87,15 @@ def main():
 
     if case == "uipath_success":
         lo, hi = SUCCESS_RANGE
-        print(f"[{case}] Injecting inputs: {inputs} (expect numeric leaf in [{lo}, {hi}])")
+        print(
+            f"[{case}] Injecting inputs: {inputs} (expect numeric leaf in [{lo}, {hi}])"
+        )
         payload = run_debug(inputs=inputs, timeout=300)
         match = _find_numeric_leaf_in_range(payload, lo, hi)
         if match is None:
-            sys.exit(f"FAIL: No numeric output in [{lo}, {hi}]\nOutputs: {list(collect_outputs(payload))}")
+            sys.exit(
+                f"FAIL: No numeric output in [{lo}, {hi}]\nOutputs: {list(collect_outputs(payload))}"
+            )
         print(f"OK: [{case}] output {match} in [{lo}, {hi}]")
     else:
         print(f"[{case}] Injecting inputs: {inputs} (expect {ERROR_STRING!r})")

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/check_api_workflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/check_api_workflow_flow.py
@@ -37,7 +37,9 @@ import sys
 from pathlib import Path
 from typing import Any, NoReturn
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import assert_flow_has_node_type  # noqa: E402
 
 
@@ -63,9 +65,12 @@ def load_flow() -> dict[str, Any]:
 def assert_api_workflow_binding(flow: dict[str, Any]) -> None:
     bindings = flow.get("bindings")
     if not isinstance(bindings, list) or not bindings:
-        fail("Flow has no top-level bindings[] — API workflow resource is not wired up.")
+        fail(
+            "Flow has no top-level bindings[] — API workflow resource is not wired up."
+        )
     api_bindings = [
-        b for b in bindings
+        b
+        for b in bindings
         if isinstance(b, dict)
         and b.get("resource") == "process"
         and b.get("resourceSubType") == "Api"
@@ -84,19 +89,24 @@ def assert_name_input(flow: dict[str, Any]) -> None:
     if not isinstance(nodes, list):
         fail("Flow has no nodes[] array.")
     api_nodes = [
-        n for n in nodes
+        n
+        for n in nodes
         if isinstance(n, dict)
         and isinstance(n.get("type"), str)
         and n["type"].lower().startswith(API_WORKFLOW_NODE_PREFIX)
     ]
     if not api_nodes:
-        fail(f"No api-workflow node (type starts with '{API_WORKFLOW_NODE_PREFIX}') found.")
+        fail(
+            f"No api-workflow node (type starts with '{API_WORKFLOW_NODE_PREFIX}') found."
+        )
     for node in api_nodes:
         inputs = node.get("inputs") or {}
         name = inputs.get("name")
         if isinstance(name, str) and name.strip().lower() == "tomasz":
             return
-    fail("API workflow node does not set inputs.name = 'tomasz' as the prompt requires.")
+    fail(
+        "API workflow node does not set inputs.name = 'tomasz' as the prompt requires."
+    )
 
 
 def main() -> None:
@@ -104,7 +114,9 @@ def main() -> None:
     flow = load_flow()
     assert_api_workflow_binding(flow)
     assert_name_input(flow)
-    print("OK: API workflow node present, published binding wired, inputs.name='tomasz'")
+    print(
+        "OK: API workflow node present, published binding wired, inputs.name='tomasz'"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/test_check_api_workflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/test_check_api_workflow_flow.py
@@ -99,7 +99,12 @@ def test_missing_binding_fails(tmp_path: Path) -> None:
 def test_binding_without_resource_key_fails(tmp_path: Path) -> None:
     payload = _well_formed()
     payload["bindings"] = [
-        {"id": "b1", "resource": "process", "resourceSubType": "Api", "resourceKey": ""},
+        {
+            "id": "b1",
+            "resource": "process",
+            "resourceSubType": "Api",
+            "resourceKey": "",
+        },
     ]
     _write_flow(tmp_path, payload)
     result = _run(tmp_path)

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/check_batch_transform_flow.py
@@ -86,7 +86,9 @@ def _check_outputColumns(value) -> None:
 
 def _check_attachment_canonical(flow: dict, attachment) -> None:
     if not isinstance(attachment, str) or not attachment.strip():
-        _fail("inputs.attachment missing or empty — wire it to the trigger output binding")
+        _fail(
+            "inputs.attachment missing or empty — wire it to the trigger output binding"
+        )
     m = _ATTACHMENT_REF.match(attachment.strip())
     if not m:
         _fail(
@@ -107,7 +109,10 @@ def _check_attachment_canonical(flow: dict, attachment) -> None:
             f"inputs.attachment references `$vars.{trigger_id}.output...` but no node with "
             f"id={trigger_id!r} exists in the flow."
         )
-    if not isinstance(trigger_node.get("type"), str) or "trigger" not in trigger_node["type"]:
+    if (
+        not isinstance(trigger_node.get("type"), str)
+        or "trigger" not in trigger_node["type"]
+    ):
         _fail(
             f"node id={trigger_id!r} has type={trigger_node.get('type')!r}; expected a trigger "
             "(file-typed input variables must be trigger-bound)."
@@ -169,7 +174,11 @@ def _check_output_source(node: dict) -> None:
 def _check_result_output_mapping(flow: dict, bt_node_id: str) -> None:
     globals_ = (flow.get("variables") or {}).get("globals") or []
     result_var = next(
-        (v for v in globals_ if v.get("id") == "result" and v.get("direction") == "out"),
+        (
+            v
+            for v in globals_
+            if v.get("id") == "result" and v.get("direction") == "out"
+        ),
         None,
     )
     if result_var is None:
@@ -178,7 +187,9 @@ def _check_result_output_mapping(flow: dict, bt_node_id: str) -> None:
             "Batch Transform result file handle to be surfaced as a flow output named `result`."
         )
 
-    end_nodes = [n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"]
+    end_nodes = [
+        n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"
+    ]
     if not end_nodes:
         _fail("flow has no End node — required to terminate the path and map outputs")
 

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -18,12 +18,13 @@ Privacy: never logs folder display names. Only counts + truncated IDs.
 
 import glob
 import json
-import os
 import subprocess
 import sys
 
 CONNECTOR_KEY = "uipath-microsoft-outlook365"
-TRIGGER_TYPE_MARKER = "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"
+TRIGGER_TYPE_MARKER = (
+    "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"
+)
 TEST_FOLDER_PATH = "Shared/uipath-maestro-flow"
 
 
@@ -47,7 +48,9 @@ def _parse_uip_stdout(args: list[str], result: subprocess.CompletedProcess) -> d
 def _uip_json(args: list[str]) -> dict:
     """Run a uip CLI command and return parsed JSON. Fails the test on
     non-zero exit or invalid JSON."""
-    return _parse_uip_stdout(args, subprocess.run(args, capture_output=True, text=True, timeout=120))
+    return _parse_uip_stdout(
+        args, subprocess.run(args, capture_output=True, text=True, timeout=120)
+    )
 
 
 def _uip_resources_run(tail_args: list[str]) -> dict:
@@ -63,9 +66,8 @@ def _uip_resources_run(tail_args: list[str]) -> dict:
     """
     primary = ["uip", "is", "resources", "run", *tail_args]
     result = subprocess.run(primary, capture_output=True, text=True, timeout=120)
-    needs_fallback = (
-        result.returncode != 0
-        and "unknown command 'run'" in (result.stdout + result.stderr)
+    needs_fallback = result.returncode != 0 and "unknown command 'run'" in (
+        result.stdout + result.stderr
     )
     if needs_fallback:
         legacy = ["uip", "is", "resources", "execute", *tail_args]
@@ -83,7 +85,9 @@ def _read_flow() -> tuple[dict, str]:
 
 
 def _find_test_folder_key() -> str:
-    resp = _uip_json(["uip", "or", "folders", "get", TEST_FOLDER_PATH, "--output", "json"])
+    resp = _uip_json(
+        ["uip", "or", "folders", "get", TEST_FOLDER_PATH, "--output", "json"]
+    )
     key = resp.get("Data", {}).get("Key")
     if not key:
         sys.exit(f"FAIL: no '{TEST_FOLDER_PATH}' folder in Orchestrator")
@@ -96,8 +100,15 @@ def _find_default_outlook_connection() -> tuple[str, str, str]:
     folder_key = _find_test_folder_key()
     conns_raw = _uip_json(
         [
-            "uip", "is", "connections", "list", CONNECTOR_KEY,
-            "--folder-key", folder_key, "--output", "json",
+            "uip",
+            "is",
+            "connections",
+            "list",
+            CONNECTOR_KEY,
+            "--folder-key",
+            folder_key,
+            "--output",
+            "json",
         ]
     ).get("Data", [])
     if not isinstance(conns_raw, list) or not conns_raw:
@@ -105,7 +116,11 @@ def _find_default_outlook_connection() -> tuple[str, str, str]:
             f"FAIL: no {CONNECTOR_KEY} connection in folder {TEST_FOLDER_PATH}. "
             f"Provision an Outlook connection in the test tenant first."
         )
-    defaults = [c for c in conns_raw if c.get("IsDefault") == "Yes" and c.get("State") == "Enabled"]
+    defaults = [
+        c
+        for c in conns_raw
+        if c.get("IsDefault") == "Yes" and c.get("State") == "Enabled"
+    ]
     chosen = defaults[0] if defaults else conns_raw[0]
     return chosen["Id"], folder_key, chosen.get("Name", "")
 
@@ -127,7 +142,11 @@ def _extract_list_items(resp: dict) -> list[dict]:
     if isinstance(data, list):
         return [x for x in data if isinstance(x, dict)]
     if isinstance(data, dict):
-        return [x for x in (data.get("items") or data.get("Items") or []) if isinstance(x, dict)]
+        return [
+            x
+            for x in (data.get("items") or data.get("Items") or [])
+            if isinstance(x, dict)
+        ]
     return []
 
 
@@ -152,7 +171,15 @@ def check_folder_id_fresh():
 
     conn_id, _folder_key, _conn_name = _find_default_outlook_connection()
     live = _uip_resources_run(
-        ["list", CONNECTOR_KEY, "MailFolder", "--connection-id", conn_id, "--output", "json"]
+        [
+            "list",
+            CONNECTOR_KEY,
+            "MailFolder",
+            "--connection-id",
+            conn_id,
+            "--output",
+            "json",
+        ]
     )
     live_ids = {f.get("id") for f in _extract_list_items(live)}
     if not live_ids:
@@ -168,7 +195,9 @@ def check_folder_id_fresh():
             f"the {len(live_ids)} MailFolder IDs on the current connection. The agent "
             f"reused a reference ID from another connection or session."
         )
-    print(f"OK: parentFolderId resolves on current connection ({len(live_ids)} folders checked)")
+    print(
+        f"OK: parentFolderId resolves on current connection ({len(live_ids)} folders checked)"
+    )
 
 
 DISPATCH = {

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
@@ -19,7 +19,9 @@ CHECKER = Path(__file__).with_name("check_outlook_trigger_inbox.py")
 
 
 def _load_checker():
-    spec = importlib.util.spec_from_file_location("check_outlook_trigger_inbox", CHECKER)
+    spec = importlib.util.spec_from_file_location(
+        "check_outlook_trigger_inbox", CHECKER
+    )
     assert spec is not None
     assert spec.loader is not None
     module = importlib.util.module_from_spec(spec)
@@ -44,8 +46,12 @@ def _patch_static(monkeypatch, checker, folder_id: str = "mail-folder-1") -> Non
     )
 
 
-def _fake_proc(returncode: int, stdout: str = "", stderr: str = "") -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+def _fake_proc(
+    returncode: int, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=stderr
+    )
 
 
 def _success_payload(folder_id: str = "mail-folder-1") -> str:
@@ -81,7 +87,10 @@ def test_falls_back_to_execute_on_unknown_command_run(monkeypatch) -> None:
             return _fake_proc(
                 1,
                 stdout=json.dumps(
-                    {"Result": "ValidationError", "Message": "error: unknown command 'run'"}
+                    {
+                        "Result": "ValidationError",
+                        "Message": "error: unknown command 'run'",
+                    }
                 ),
             )
         return _fake_proc(0, stdout=_success_payload())

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/check_rpa_flow.py
@@ -4,7 +4,9 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_outputs_contain,

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/check_subflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/check_subflow_flow.py
@@ -34,7 +34,9 @@ def _check_subflow_structure(project_dir):
         (n for n in flow.get("nodes", []) if n.get("type") == "core.subflow"), None
     )
     if not subflow_node:
-        _fail(f"No Subflow node found. Types: {[n.get('type') for n in flow.get('nodes', [])]}")
+        _fail(
+            f"No Subflow node found. Types: {[n.get('type') for n in flow.get('nodes', [])]}"
+        )
 
     sid = subflow_node["id"]
     if not subflow_node.get("inputs"):
@@ -43,12 +45,16 @@ def _check_subflow_structure(project_dir):
     # Verify the subflows section
     sf = flow.get("subflows", {}).get(sid)
     if not sf:
-        _fail(f"No subflows.{sid} section found. Keys: {list(flow.get('subflows', {}).keys())}")
+        _fail(
+            f"No subflows.{sid} section found. Keys: {list(flow.get('subflows', {}).keys())}"
+        )
 
     sf_nodes = sf.get("nodes", [])
     sf_edges = sf.get("edges", [])
     if len(sf_nodes) < 3:
-        _fail(f"Subflow needs at least 3 nodes (start, logic, end), found {len(sf_nodes)}")
+        _fail(
+            f"Subflow needs at least 3 nodes (start, logic, end), found {len(sf_nodes)}"
+        )
     if len(sf_edges) < 2:
         _fail(f"Subflow needs at least 2 edges, found {len(sf_edges)}")
 
@@ -75,7 +81,9 @@ def _check_subflow_structure(project_dir):
         if n.get("type") == "core.control.end" and not n.get("outputs"):
             _fail(f"Subflow End node '{n['id']}' has no output mappings")
 
-    print(f"OK: Subflow '{sid}' structure valid ({len(sf_nodes)} nodes, {len(in_vars)} in, {len(out_vars)} out)")
+    print(
+        f"OK: Subflow '{sid}' structure valid ({len(sf_nodes)} nodes, {len(in_vars)} in, {len(out_vars)} out)"
+    )
 
 
 def main():

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/check_summarize_flow.py
@@ -35,7 +35,9 @@ EXPECTED_OUTPUT_SOURCE = "=response"
 _ATTACHMENT_REF = re.compile(
     r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\.([A-Za-z_][A-Za-z0-9_]*)\s*$"
 )
-_OUTPUT_MAPPING_BASE = re.compile(r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\.content\.")
+_OUTPUT_MAPPING_BASE = re.compile(
+    r"^=js:\s*\$vars\.([A-Za-z_][A-Za-z0-9_]*)\.output\.content\."
+)
 
 
 def _fail(msg: str) -> NoReturn:
@@ -65,7 +67,9 @@ def _find_node(flow: dict) -> dict:
 
 def _check_attachment_canonical(flow: dict, attachment) -> None:
     if not isinstance(attachment, str) or not attachment.strip():
-        _fail("inputs.attachment missing or empty — wire it to the trigger output binding")
+        _fail(
+            "inputs.attachment missing or empty — wire it to the trigger output binding"
+        )
     m = _ATTACHMENT_REF.match(attachment.strip())
     if not m:
         _fail(
@@ -85,7 +89,10 @@ def _check_attachment_canonical(flow: dict, attachment) -> None:
             f"inputs.attachment references `$vars.{trigger_id}.output...` but no node with "
             f"id={trigger_id!r} exists in the flow."
         )
-    if not isinstance(trigger_node.get("type"), str) or "trigger" not in trigger_node["type"]:
+    if (
+        not isinstance(trigger_node.get("type"), str)
+        or "trigger" not in trigger_node["type"]
+    ):
         _fail(
             f"node id={trigger_id!r} has type={trigger_node.get('type')!r}; expected a trigger."
         )
@@ -147,13 +154,17 @@ def _check_pascal_output_mappings(flow: dict, dr_node_id: str) -> None:
     """
     globals_ = (flow.get("variables") or {}).get("globals") or []
     for var_id in ("summary", "citations"):
-        if not any(v.get("id") == var_id and v.get("direction") == "out" for v in globals_):
+        if not any(
+            v.get("id") == var_id and v.get("direction") == "out" for v in globals_
+        ):
             _fail(
                 f"flow has no `out` variable with id={var_id!r}. The task prompt asks for "
                 f"`{var_id}` to be surfaced as a flow output."
             )
 
-    end_nodes = [n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"]
+    end_nodes = [
+        n for n in flow.get("nodes", []) if n.get("type") == "core.control.end"
+    ]
     if not end_nodes:
         _fail("flow has no End node — required to terminate the path and map outputs")
 

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
@@ -24,10 +24,14 @@ def _check_parallel_branches(project_dir):
         flow = json.load(f)
 
     edges = flow.get("edges", [])
-    trigger_ids = {n["id"] for n in flow.get("nodes", []) if "trigger" in n.get("type", "")}
+    trigger_ids = {
+        n["id"] for n in flow.get("nodes", []) if "trigger" in n.get("type", "")
+    }
     outgoing = [e for e in edges if e.get("sourceNodeId") in trigger_ids]
     if len(outgoing) < 2:
-        sys.exit(f"FAIL: Expected 2+ edges from trigger for parallel branches, found {len(outgoing)}")
+        sys.exit(
+            f"FAIL: Expected 2+ edges from trigger for parallel branches, found {len(outgoing)}"
+        )
 
     print("OK: Parallel branches from trigger verified")
 
@@ -45,9 +49,13 @@ def main():
     terminated = [e for e in executions if e.get("status") == "Terminated"]
     if not terminated:
         statuses = [(e.get("elementId"), e.get("status")) for e in executions]
-        sys.exit(f"FAIL: No element was Terminated — terminate node didn't kill the delay branch. Statuses: {statuses}")
+        sys.exit(
+            f"FAIL: No element was Terminated — terminate node didn't kill the delay branch. Statuses: {statuses}"
+        )
 
-    print(f"OK: Terminate + Delay nodes present; {len(terminated)} element(s) terminated")
+    print(
+        f"OK: Terminate + Delay nodes present; {len(terminated)} element(s) terminated"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-platform/integration-service/_shared/is_check.py
+++ b/tests/tasks/uipath-platform/integration-service/_shared/is_check.py
@@ -26,6 +26,7 @@ import sys
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _find(pattern: str) -> str:
     """Find a single file matching the glob pattern, or exit."""
     matches = glob.glob(pattern, recursive=True)
@@ -52,8 +53,10 @@ def _assert_key(data: dict, key: str, label: str):
 
 def _assert_type(value, expected_type, label: str):
     if not isinstance(value, expected_type):
-        sys.exit(f"FAIL: {label} should be {expected_type.__name__}, "
-                 f"got {type(value).__name__}: {value!r}")
+        sys.exit(
+            f"FAIL: {label} should be {expected_type.__name__}, "
+            f"got {type(value).__name__}: {value!r}"
+        )
     return value
 
 
@@ -76,6 +79,7 @@ def _assert_commands(cmds: list, patterns: list[str], label: str) -> None:
 # ---------------------------------------------------------------------------
 # Per-test checks
 # ---------------------------------------------------------------------------
+
 
 def check_connector_discovery() -> None:
     """Validate connector_discovery: correct search commands, HTTP fallback.
@@ -101,14 +105,20 @@ def check_connector_discovery() -> None:
 
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+connectors\s+list",   # used connectors list
-        r"--filter",                         # used --filter flag
-        r"--output\s+json",                  # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+connectors\s+list",  # used connectors list
+            r"--filter",  # used --filter flag
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: connector_discovery — {len(cmds)} commands logged, "
-          f"HTTP fallback documented")
+    print(
+        f"OK: connector_discovery — {len(cmds)} commands logged, "
+        f"HTTP fallback documented"
+    )
 
 
 def check_connection_lifecycle() -> None:
@@ -161,14 +171,20 @@ def check_connection_lifecycle() -> None:
     # Validate commands_used — only list and ping were actually run
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+connections\s+list",   # listed connections
-        r"uip\s+is\s+connections\s+ping",    # pinged a connection
-        r"--output\s+json",                  # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+connections\s+list",  # listed connections
+            r"uip\s+is\s+connections\s+ping",  # pinged a connection
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: connection_lifecycle — {len(cmds)} commands executed, "
-          f"connections_found={found}, create/edit commands documented correctly")
+    print(
+        f"OK: connection_lifecycle — {len(cmds)} commands executed, "
+        f"connections_found={found}, create/edit commands documented correctly"
+    )
 
 
 def check_activity_discovery() -> None:
@@ -202,15 +218,21 @@ def check_activity_discovery() -> None:
 
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+activities\s+list",    # listed activities
-        r"--triggers",                        # used --triggers flag
-        r"--output\s+json",                  # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+activities\s+list",  # listed activities
+            r"--triggers",  # used --triggers flag
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: activity_discovery — {len(cmds)} commands logged, "
-          f"activity_count={act}, trigger_count={trig}, "
-          f"explanation={len(explanation)} chars")
+    print(
+        f"OK: activity_discovery — {len(cmds)} commands logged, "
+        f"activity_count={act}, trigger_count={trig}, "
+        f"explanation={len(explanation)} chars"
+    )
 
 
 def check_resource_describe() -> None:
@@ -240,15 +262,21 @@ def check_resource_describe() -> None:
 
     cmds = _assert_key(data, "commands_used", "report")
     _assert_type(cmds, list, "report.commands_used")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+resources\s+list",      # listed resources
-        r"uip\s+is\s+resources\s+describe",   # described resource
-        r"--operation",                        # used --operation flag
-        r"--output\s+json",                    # used --output json
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+resources\s+list",  # listed resources
+            r"uip\s+is\s+resources\s+describe",  # described resource
+            r"--operation",  # used --operation flag
+            r"--output\s+json",  # used --output json
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: resource_describe — {len(cmds)} commands logged, "
-          f"{len(fields)} contact_fields, {len(req)} required_fields")
+    print(
+        f"OK: resource_describe — {len(cmds)} commands logged, "
+        f"{len(fields)} contact_fields, {len(req)} required_fields"
+    )
 
 
 def check_resource_execute() -> None:
@@ -276,8 +304,12 @@ def check_resource_execute() -> None:
 
     # Validate all 6 workflow actions are present
     expected_actions = [
-        "find_connector", "find_connection", "ping_connection",
-        "discover_resources", "describe_resource", "execute_create",
+        "find_connector",
+        "find_connection",
+        "ping_connection",
+        "discover_resources",
+        "describe_resource",
+        "execute_create",
     ]
     actual_actions = [s.get("action", "") for s in steps]
     for expected in expected_actions:
@@ -307,15 +339,21 @@ def check_resource_execute() -> None:
     _assert_type(cmds, list, "report.commands_used")
     if len(cmds) < 5:
         sys.exit(f"FAIL: commands_used has {len(cmds)} entries, expected >= 5")
-    _assert_commands(cmds, [
-        r"uip\s+is\s+connectors\s+list",         # step 1
-        r"uip\s+is\s+connections\s+(list|ping)",   # step 2-3
-        r"uip\s+is\s+resources\s+execute",         # step 6
-        r"--output\s+json",                        # universal flag
-    ], "report.commands_used")
+    _assert_commands(
+        cmds,
+        [
+            r"uip\s+is\s+connectors\s+list",  # step 1
+            r"uip\s+is\s+connections\s+(list|ping)",  # step 2-3
+            r"uip\s+is\s+resources\s+execute",  # step 6
+            r"--output\s+json",  # universal flag
+        ],
+        "report.commands_used",
+    )
 
-    print(f"OK: resource_execute — {len(steps)} workflow steps in correct order, "
-          f"{len(cmds)} commands logged")
+    print(
+        f"OK: resource_execute — {len(steps)} workflow steps in correct order, "
+        f"{len(cmds)} commands logged"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tasks/uipath-platform/licensing/_shared/licensing_check.py
+++ b/tests/tasks/uipath-platform/licensing/_shared/licensing_check.py
@@ -32,7 +32,10 @@ def _load(name: str) -> dict | None:
 
 def _check_envelope(name: str, data: dict) -> bool:
     if data.get("Result") != "Success":
-        print(f"FAIL: {name} Result != 'Success' (got {data.get('Result')!r})", file=sys.stderr)
+        print(
+            f"FAIL: {name} Result != 'Success' (got {data.get('Result')!r})",
+            file=sys.stderr,
+        )
         return False
     if "Data" not in data:
         print(f"FAIL: {name} missing 'Data' field", file=sys.stderr)
@@ -50,7 +53,10 @@ def main() -> int:
 
     available = _load("available.json")
     if available is not None and not available.get("Data"):
-        print("FAIL: available.json Data is empty — expected at least one user bundle", file=sys.stderr)
+        print(
+            "FAIL: available.json Data is empty — expected at least one user bundle",
+            file=sys.stderr,
+        )
         errors += 1
 
     rules = _load("rules.json")
@@ -59,7 +65,10 @@ def main() -> int:
         if details is None or not _check_envelope("details.json", details):
             errors += 1
     else:
-        print("INFO: skipping details.json check — rules.json has no groups", file=sys.stderr)
+        print(
+            "INFO: skipping details.json check — rules.json has no groups",
+            file=sys.stderr,
+        )
 
     if errors:
         return 1

--- a/tests/tasks/uipath-platform/traces/check_traces_e2e.py
+++ b/tests/tasks/uipath-platform/traces/check_traces_e2e.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Assert spans.json (raw uip traces spans get output) has Data with >= 1 span."""
+
 import json
 import sys
 from pathlib import Path

--- a/tests/tasks/uipath-platform/traces/check_traces_feedback_e2e.py
+++ b/tests/tasks/uipath-platform/traces/check_traces_feedback_e2e.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Assert feedback round-trip: create → get returns same ID with IsPositive=True, SpanId=agent span."""
+
 import json
 import sys
 from pathlib import Path
@@ -18,12 +19,15 @@ def load(path: str) -> dict:
 def get_id(data: dict) -> str | None:
     return data.get("Id") or data.get("id")
 
+
 def get_span_id(data: dict) -> str | None:
     return data.get("SpanId") or data.get("spanId")
+
 
 def get_is_positive(data: dict) -> bool | None:
     v = data.get("IsPositive")
     return v if v is not None else data.get("isPositive")
+
 
 def normalize_span_id(span_id: str) -> str:
     """Normalize span ID to 32-char hex for comparison.
@@ -34,6 +38,7 @@ def normalize_span_id(span_id: str) -> str:
     Both represent the same span — backend zero-pads hex into GUID form.
     """
     return span_id.replace("-", "").lower().zfill(32)
+
 
 def find_agent_span(span_list: list) -> tuple[dict | None, str]:
     """Return (span, reason) for the best agent-level span to attach feedback to.
@@ -79,7 +84,9 @@ if not agent_span_id:
 
 create = load("feedback_create.json")
 if create.get("Result") != "Success":
-    sys.exit(f"FAIL: feedback create Result={create.get('Result')!r}, Message={create.get('Message')!r}")
+    sys.exit(
+        f"FAIL: feedback create Result={create.get('Result')!r}, Message={create.get('Message')!r}"
+    )
 
 feedback_id = get_id(create.get("Data") or {})
 if not feedback_id:
@@ -93,7 +100,7 @@ got_id = get_id(got_feedback)
 if got_id != feedback_id:
     sys.exit(f"FAIL: ID mismatch — create={feedback_id!r}, get={got_id!r}")
 if get_is_positive(got_feedback) is not True:
-    sys.exit(f"FAIL: IsPositive not True in feedback_get.json")
+    sys.exit("FAIL: IsPositive not True in feedback_get.json")
 
 got_span_id = get_span_id(got_feedback)
 if got_span_id and normalize_span_id(got_span_id) != normalize_span_id(agent_span_id):
@@ -104,5 +111,7 @@ if got_span_id and normalize_span_id(got_span_id) != normalize_span_id(agent_spa
 
 span_note = f"SpanId={got_span_id!r}" if got_span_id else "SpanId not returned by API"
 span_name = agent_span.get("Name", "unknown")
-print(f"OK: round-trip verified (id={feedback_id}, IsPositive=True, {span_note}, "
-      f"agent_span='{span_name}' [{selection_reason}])")
+print(
+    f"OK: round-trip verified (id={feedback_id}, IsPositive=True, {span_note}, "
+    f"agent_span='{span_name}' [{selection_reason}])"
+)

--- a/tests/tasks/uipath-platform/traces/cleanup_traces_feedback_e2e.py
+++ b/tests/tasks/uipath-platform/traces/cleanup_traces_feedback_e2e.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Delete the feedback record created during the e2e run."""
+
 import json
 import subprocess
 import sys
@@ -32,4 +33,6 @@ result = subprocess.run(cmd, capture_output=True, text=True)
 if result.returncode == 0:
     print(f"OK: deleted feedback {feedback_id}")
 else:
-    print(f"WARN: delete returned exit {result.returncode}: {result.stdout.strip() or result.stderr.strip()}")
+    print(
+        f"WARN: delete returned exit {result.returncode}: {result.stdout.strip() or result.stderr.strip()}"
+    )

--- a/tests/tasks/uipath-solution/e2e_rpa_sdd/check_sdd.py
+++ b/tests/tasks/uipath-solution/e2e_rpa_sdd/check_sdd.py
@@ -77,11 +77,11 @@ def check_sections(content: str) -> list[str]:
     failures = []
     for section in REQUIRED_SECTIONS:
         pattern = (
-            rf"^#{{1,4}}\s+"                       # heading marker (h1-h4)
-            rf"\**\s*"                             # optional opening bold
-            rf"(?:§\s*)?"                          # optional § prefix
-            rf"(?:\d+(?:\.\d+)*\s*[.\):—–-]?\s+)?" # optional 1. / 1.1 / 1) / 1 — etc.
-            rf"\**\s*"                             # optional bold before the title
+            rf"^#{{1,4}}\s+"  # heading marker (h1-h4)
+            rf"\**\s*"  # optional opening bold
+            rf"(?:§\s*)?"  # optional § prefix
+            rf"(?:\d+(?:\.\d+)*\s*[.\):—–-]?\s+)?"  # optional 1. / 1.1 / 1) / 1 — etc.
+            rf"\**\s*"  # optional bold before the title
             rf"{re.escape(section)}"
         )
         if not re.search(pattern, content, re.MULTILINE | re.IGNORECASE):
@@ -131,7 +131,9 @@ def check_table_minimums(content: str) -> list[str]:
     """Verify key tables have enough rows."""
     failures = []
 
-    steps = count_table_rows(content, r"^#{1,3}\s+.*(?:Step Summary|Detailed Process Steps)")
+    steps = count_table_rows(
+        content, r"^#{1,3}\s+.*(?:Step Summary|Detailed Process Steps)"
+    )
     if steps < MIN_PROCESS_STEPS:
         failures.append(
             f"Process steps table has {steps} rows (minimum {MIN_PROCESS_STEPS})"
@@ -145,9 +147,7 @@ def check_table_minimums(content: str) -> list[str]:
 
     errors = count_table_rows(content, r"^#{1,3}\s+.*Error Handling")
     if errors < MIN_SYSTEM_ERRORS:
-        failures.append(
-            f"Error table has {errors} rows (minimum {MIN_SYSTEM_ERRORS})"
-        )
+        failures.append(f"Error table has {errors} rows (minimum {MIN_SYSTEM_ERRORS})")
 
     apps = count_table_rows(content, r"^#{1,3}\s+.*Application Inventory")
     if apps < MIN_APPLICATIONS:
@@ -180,7 +180,9 @@ def check_planner_handoff(content: str) -> list[str]:
             failures.append(f"Planner Handoff missing field: {field}")
 
     if "uipath-planner" not in content:
-        failures.append("SDD does not reference uipath-planner (Next Steps handoff missing)")
+        failures.append(
+            "SDD does not reference uipath-planner (Next Steps handoff missing)"
+        )
 
     return failures
 

--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/coverage_report.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/coverage_report.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import json
 import sys
-from collections import Counter, defaultdict
+from collections import Counter
 from pathlib import Path
 
 
@@ -63,13 +63,15 @@ def analyze_replicate(rep_dir: Path) -> dict:
         pat = spec.get("pattern", "")
         minimum = spec.get("min", 1)
         hits = sum(1 for c in calls if pat in c.get("args", ""))
-        expected_status.append({
-            "pattern": pat,
-            "min": minimum,
-            "hits": hits,
-            "satisfied": hits >= minimum,
-            "description": spec.get("description", ""),
-        })
+        expected_status.append(
+            {
+                "pattern": pat,
+                "min": minimum,
+                "hits": hits,
+                "satisfied": hits >= minimum,
+                "description": spec.get("description", ""),
+            }
+        )
 
     # Rule usage
     rule_counts: Counter = Counter()
@@ -87,7 +89,9 @@ def analyze_replicate(rep_dir: Path) -> dict:
     rec["unmocked"] = unmocked
     rec["rule_hits"] = dict(rule_counts.most_common())
     if expected_status:
-        rec["match_rate"] = sum(1 for e in expected_status if e["satisfied"]) / len(expected_status)
+        rec["match_rate"] = sum(1 for e in expected_status if e["satisfied"]) / len(
+            expected_status
+        )
 
     return rec
 
@@ -98,8 +102,10 @@ def write_outputs(rep_dir: Path, rec: dict) -> None:
     lines.append(f"Coverage report for replicate {rec['replicate']}")
     lines.append(f"  total uip calls : {len(rec['calls'])}")
     if rec["match_rate"] is not None:
-        lines.append(f"  expected hit-rate: {rec['match_rate']*100:.0f}% "
-                     f"({len(rec['expected']) - len(rec['missing_expected'])}/{len(rec['expected'])})")
+        lines.append(
+            f"  expected hit-rate: {rec['match_rate'] * 100:.0f}% "
+            f"({len(rec['expected']) - len(rec['missing_expected'])}/{len(rec['expected'])})"
+        )
     if rec["missing_expected"]:
         lines.append("  MISSING expected:")
         for e in rec["missing_expected"]:
@@ -126,7 +132,9 @@ def main(run_dir_arg: str) -> int:
         return 2
 
     print(f"Coverage report for {run_dir}\n")
-    print(f"{'rep':>4}  {'calls':>5}  {'expected':>14}  {'unmocked':>8}  {'top exploration':<60}")
+    print(
+        f"{'rep':>4}  {'calls':>5}  {'expected':>14}  {'unmocked':>8}  {'top exploration':<60}"
+    )
     print("-" * 100)
     for rep_dir in rep_dirs:
         rec = analyze_replicate(rep_dir)
@@ -136,15 +144,20 @@ def main(run_dir_arg: str) -> int:
         write_outputs(rep_dir, rec)
         nm = len(rec["expected"]) - len(rec["missing_expected"])
         tot = len(rec["expected"])
-        rate = f"{nm}/{tot} ({(rec['match_rate'] or 0)*100:.0f}%)"
+        rate = f"{nm}/{tot} ({(rec['match_rate'] or 0) * 100:.0f}%)"
         top_unmocked = rec["unmocked"][0] if rec["unmocked"] else ""
-        print(f"{rep_dir.name:>4}  {len(rec['calls']):>5}  {rate:>14}  {len(rec['unmocked']):>8}  {top_unmocked[:60]}")
+        print(
+            f"{rep_dir.name:>4}  {len(rec['calls']):>5}  {rate:>14}  {len(rec['unmocked']):>8}  {top_unmocked[:60]}"
+        )
 
     return 0
 
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:
-        print("Usage: python tmp/coverage_report.py <run_dir>/default/<task_id>", file=sys.stderr)
+        print(
+            "Usage: python tmp/coverage_report.py <run_dir>/default/<task_id>",
+            file=sys.stderr,
+        )
         sys.exit(2)
     sys.exit(main(sys.argv[1]))

--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/extract_session.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/extract_session.py
@@ -112,7 +112,7 @@ def _extract_uip_args(command: str) -> str:
     after it.
     """
     m = UIP_INVOCATION_RE.search(command)
-    stripped = command[m.end():] if m else command
+    stripped = command[m.end() :] if m else command
     stripped = TRAILING_REDIRECT_RE.sub("", stripped)
     return stripped.strip()
 
@@ -195,7 +195,9 @@ def parse_transcript(path: Path) -> dict:
             user_initial_prompt = result["first_user_text"]
 
     inferred = (
-        _slugify(inferred_release_name) if inferred_release_name else "troubleshooting-scenario"
+        _slugify(inferred_release_name)
+        if inferred_release_name
+        else "troubleshooting-scenario"
     )
 
     return {
@@ -267,7 +269,10 @@ def _parse_one(path: Path) -> dict:
                 for block in content:
                     if not isinstance(block, dict):
                         continue
-                    if block.get("type") == "tool_use" and block.get("name") in ("Bash", "PowerShell"):
+                    if block.get("type") == "tool_use" and block.get("name") in (
+                        "Bash",
+                        "PowerShell",
+                    ):
                         cmd = (block.get("input") or {}).get("command", "")
                         if _is_uip_call(cmd):
                             pending_tool_uses[block["id"]] = {
@@ -309,7 +314,13 @@ def _parse_one(path: Path) -> dict:
                     elif block.get("is_error"):
                         exit_code = 1
                     if project_release_name is None:
-                        for field in ("ReleaseName", "processKey", "ProcessKey", "processName", "ProcessName"):
+                        for field in (
+                            "ReleaseName",
+                            "processKey",
+                            "ProcessKey",
+                            "processName",
+                            "ProcessName",
+                        ):
                             rel = re.search(rf'"{field}"\s*:\s*"([^"]+)"', stdout)
                             if rel:
                                 project_release_name = rel.group(1)

--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
@@ -26,11 +26,11 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import shutil
 import subprocess
 import sys
 from collections import OrderedDict
 from pathlib import Path
+
 
 def _find_repo_root() -> Path:
     """Walk up from this file until we find the repo's `.git` marker."""
@@ -40,6 +40,7 @@ def _find_repo_root() -> Path:
             return p
         p = p.parent
     raise RuntimeError("Could not locate repo root (no .git ancestor found)")
+
 
 REPO_ROOT = _find_repo_root()
 EXTRACT_SCRIPT = Path(__file__).with_name("extract_session.py")
@@ -67,13 +68,13 @@ EMPTY_STDOUT_PATTERNS = (
     r"^\(Bash completed with no output\)\s*$",
     r"^\(PowerShell completed with no output\)\s*$",
     r"^EXIT_CODE=\d+\s*$",
-    r"^[A-Z][A-Z0-9_]*=\d+\s*$",       # generic `EXIT=N`, `TRACES=N`, `RC=N`
+    r"^[A-Z][A-Z0-9_]*=\d+\s*$",  # generic `EXIT=N`, `TRACES=N`, `RC=N`
     r"^Exit:\s*\d+\s*$",
     r"^Exit\s+code\s+\d+\s*$",
     r"^FAILED\s*$",
     r"^OK\s*$",
     r"^exit=(?:True|False)\s*$",
-    r"^[A-Za-z_]+:\d+\s*$",            # PowerShell `get:0`, `logs:0` trailers
+    r"^[A-Za-z_]+:\d+\s*$",  # PowerShell `get:0`, `logs:0` trailers
 )
 EMPTY_STDOUT_RE = re.compile("|".join(EMPTY_STDOUT_PATTERNS), re.IGNORECASE)
 
@@ -250,9 +251,11 @@ PROJECT_SNAPSHOT_IGNORE_SUFFIXES = {".pyc", ".pdb"}
 
 # ---------- helpers ----------
 
+
 def _slugify(text: str) -> str:
     out = re.sub(r"[^A-Za-z0-9]+", "-", text).strip("-").lower()
     return out or "troubleshooting-scenario"
+
 
 def _backfill_redirect_stdouts(uip_calls: list[dict], investigation: Path) -> dict:
     """For calls with empty stdout and a redirect target, load the file.
@@ -297,21 +300,27 @@ def _backfill_redirect_stdouts(uip_calls: list[dict], investigation: Path) -> di
                     loaded = None
         if loaded is not None:
             call["stdout"] = loaded
-            call["_backfilled_from"] = str(target_path) if target_path.is_file() else str(by_basename.get(target_path.name))
+            call["_backfilled_from"] = (
+                str(target_path)
+                if target_path.is_file()
+                else str(by_basename.get(target_path.name))
+            )
             backfilled += 1
         else:
             missing += 1
     return {"backfilled": backfilled, "missing": missing, "skipped": skipped}
+
 
 def _is_empty_stdout(stdout: str) -> bool:
     """True if `stdout` is just bash-trailer noise (no real content)."""
     if not stdout.strip():
         return True
     # If every non-empty line matches a trailer pattern, treat as empty.
-    lines = [l for l in stdout.splitlines() if l.strip()]
+    lines = [line for line in stdout.splitlines() if line.strip()]
     if not lines:
         return True
-    return all(EMPTY_STDOUT_RE.fullmatch(l.strip()) for l in lines)
+    return all(EMPTY_STDOUT_RE.fullmatch(line.strip()) for line in lines)
+
 
 def _run_extract(transcript: Path) -> dict:
     """Invoke extract_session.py as a subprocess and return its parsed JSON."""
@@ -324,6 +333,7 @@ def _run_extract(transcript: Path) -> dict:
     if proc.returncode != 0:
         raise RuntimeError(f"extract_session.py failed: {proc.stderr.strip()}")
     return json.loads(proc.stdout)
+
 
 def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
     """Auto-detect emails and personal Windows paths across all sampled text.
@@ -352,7 +362,9 @@ def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
                 seen_emails.append(full)
             idx = seen_emails.index(full)
             placeholder = (
-                placeholders[idx] if idx < len(placeholders) else f"user{idx + 1}@test.com"
+                placeholders[idx]
+                if idx < len(placeholders)
+                else f"user{idx + 1}@test.com"
             )
             mapping[full] = placeholder
             # Also map the bare local-part if it has structure (looks like a real name).
@@ -391,17 +403,26 @@ def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
                 continue
             if lower not in user_placeholders:
                 idx = len(user_placeholders) + 1
-                placeholder = "replacement_user" if idx == 1 else f"replacement_user{idx}"
+                placeholder = (
+                    "replacement_user" if idx == 1 else f"replacement_user{idx}"
+                )
                 user_placeholders[lower] = placeholder
         for m in WIN_DOMAIN_USER_RE.finditer(text):
-            domain, user = m.group(1), m.group(2)
+            user = m.group(2)
             # Skip well-known service accounts.
-            if user.upper() in {"SYSTEM", "ADMINISTRATOR", "NETWORKSERVICE", "LOCALSERVICE"}:
+            if user.upper() in {
+                "SYSTEM",
+                "ADMINISTRATOR",
+                "NETWORKSERVICE",
+                "LOCALSERVICE",
+            }:
                 continue
             lower = user.lower()
             if lower not in user_placeholders:
                 idx = len(user_placeholders) + 1
-                placeholder = "replacement_user" if idx == 1 else f"replacement_user{idx}"
+                placeholder = (
+                    "replacement_user" if idx == 1 else f"replacement_user{idx}"
+                )
                 user_placeholders[lower] = placeholder
 
     # Add username substitutions in both case forms.
@@ -414,6 +435,7 @@ def _detect_scrub_map(samples: list[str]) -> "OrderedDict[str, str]":
 
     return mapping
 
+
 def _apply_scrub(text: str, mapping: "OrderedDict[str, str]") -> str:
     if not isinstance(text, str):
         return text
@@ -423,11 +445,13 @@ def _apply_scrub(text: str, mapping: "OrderedDict[str, str]") -> str:
         out = out.replace(key, mapping[key])
     return out
 
+
 def _scrub_path(path: Path, mapping: "OrderedDict[str, str]") -> Path:
     """Apply scrub mapping to each path component (filenames containing real emails)."""
     parts = list(path.parts)
     new_parts = [_apply_scrub(p, mapping) for p in parts]
     return Path(*new_parts) if new_parts else path
+
 
 def _build_manifest_rules(uip_calls: list[dict]) -> tuple[list[dict], dict[str, str]]:
     """One rule per unique `args`. Returns (rules, fixture_filename_by_args).
@@ -456,6 +480,7 @@ def _build_manifest_rules(uip_calls: list[dict]) -> tuple[list[dict], dict[str, 
             rule["exit_code"] = call["exit_code"]
         rules.append(rule)
     return rules, fixture_by_args
+
 
 def _snapshot_project(
     src: Path, dst: Path, mapping: "OrderedDict[str, str] | None" = None
@@ -508,6 +533,7 @@ def _snapshot_project(
             plan.append((scrubbed_rel, p.read_bytes()))
     return plan
 
+
 def _format_initial_prompt(extracted: dict, scenario_name: str) -> str:
     """Indented YAML block for task.yaml's initial_prompt field.
 
@@ -521,6 +547,7 @@ def _format_initial_prompt(extracted: dict, scenario_name: str) -> str:
             f"(Generated for scenario {scenario_name} — review and customize.)"
         )
     return "\n".join("  " + line for line in body.splitlines())
+
 
 def _build_resolution_md(extracted: dict, resolution_arg: Path | None) -> str:
     if resolution_arg is not None:
@@ -536,12 +563,15 @@ def _build_resolution_md(extracted: dict, resolution_arg: Path | None) -> str:
         text = "# Final Resolution\n\n" + text.lstrip()
     return text.rstrip() + "\n"
 
+
 def _build_readme_md(scenario_name: str, summary: str) -> str:
     return README_TEMPLATE.format(
         scenario_title=scenario_name.replace("-", " ").title(),
         slug=scenario_name,
-        summary=summary or "_Add a 1–3 sentence summary of the original investigation here._",
+        summary=summary
+        or "_Add a 1–3 sentence summary of the original investigation here._",
     )
+
 
 def _build_task_yaml(
     scenario_name: str, initial_prompt_indented: str, has_project: bool
@@ -555,7 +585,9 @@ def _build_task_yaml(
         process_source_block=process_source_block,
     )
 
+
 # ---------- main pipeline ----------
+
 
 def plan_scenario(args: argparse.Namespace) -> dict:
     """Build the in-memory plan. Pure: no file writes."""
@@ -570,7 +602,11 @@ def plan_scenario(args: argparse.Namespace) -> dict:
         raise FileNotFoundError(f"project not found: {project}")
 
     extracted = _run_extract(transcript)
-    scenario_name = args.scenario_name or extracted.get("inferred_scenario_name") or "troubleshooting-scenario"
+    scenario_name = (
+        args.scenario_name
+        or extracted.get("inferred_scenario_name")
+        or "troubleshooting-scenario"
+    )
     scenario_name = _slugify(scenario_name)
 
     # Backfill empty stdouts from the investigation's saved files. The
@@ -594,9 +630,9 @@ def plan_scenario(args: argparse.Namespace) -> dict:
 
     # Build readme.
     summary = (extracted.get("presenter_output") or "").splitlines()
-    summary_oneline = next((s.strip() for s in summary if s.strip().startswith("**")), "") or (
-        summary[0].strip() if summary else ""
-    )
+    summary_oneline = next(
+        (s.strip() for s in summary if s.strip().startswith("**")), ""
+    ) or (summary[0].strip() if summary else "")
     readme_md = _build_readme_md(scenario_name, summary_oneline)
 
     # Build task.yaml.
@@ -620,7 +656,9 @@ def plan_scenario(args: argparse.Namespace) -> dict:
         project_plan = []
 
     if args.scrub_map:
-        scrub_map = OrderedDict(json.loads(Path(args.scrub_map).read_text(encoding="utf-8")))
+        scrub_map = OrderedDict(
+            json.loads(Path(args.scrub_map).read_text(encoding="utf-8"))
+        )
     else:
         scrub_map = _detect_scrub_map(samples)
 
@@ -634,11 +672,15 @@ def plan_scenario(args: argparse.Namespace) -> dict:
     for rel, content in project_plan:
         rel_scrubbed = _scrub_path(rel, scrub_map)
         if isinstance(content, str):
-            project_plan_scrubbed.append((rel_scrubbed, _apply_scrub(content, scrub_map)))
+            project_plan_scrubbed.append(
+                (rel_scrubbed, _apply_scrub(content, scrub_map))
+            )
         else:
             project_plan_scrubbed.append((rel_scrubbed, content))
 
-    out_base = Path(args.output) if args.output else (DEFAULT_OUTPUT_BASE / scenario_name)
+    out_base = (
+        Path(args.output) if args.output else (DEFAULT_OUTPUT_BASE / scenario_name)
+    )
 
     return {
         "scenario_name": scenario_name,
@@ -662,6 +704,7 @@ def plan_scenario(args: argparse.Namespace) -> dict:
         "task_yaml": task_yaml,
         "project_files": project_plan_scrubbed,
     }
+
 
 def render_dry_run(plan: dict) -> str:
     out: list[str] = []
@@ -696,15 +739,24 @@ def render_dry_run(plan: dict) -> str:
     out.append("")
     out.append("Files that would be written:")
     base = plan["output_dir"]
-    out.append(f"  {base / 'task.yaml'}                             ({len(plan['task_yaml'])} bytes)")
-    out.append(f"  {base / 'README.md'}                             ({len(plan['readme_md'])} bytes)")
-    out.append(f"  {base / 'RESOLUTION.md'}                         ({len(plan['resolution_md'])} bytes)")
+    out.append(
+        f"  {base / 'task.yaml'}                             ({len(plan['task_yaml'])} bytes)"
+    )
+    out.append(
+        f"  {base / 'README.md'}                             ({len(plan['readme_md'])} bytes)"
+    )
+    out.append(
+        f"  {base / 'RESOLUTION.md'}                         ({len(plan['resolution_md'])} bytes)"
+    )
     out.append(f"  {base / 'fixtures' / 'mocks' / 'responses' / 'manifest.json'}")
-    out.append(f"  {base / 'fixtures' / 'mocks' / 'responses' / '<rule>.json'} x {len(plan['fixtures'])}")
+    out.append(
+        f"  {base / 'fixtures' / 'mocks' / 'responses' / '<rule>.json'} x {len(plan['fixtures'])}"
+    )
     out.append(f"  {base / 'process' / '<files>'} x {len(plan['project_files'])}")
     out.append("")
     out.append("(dry-run — no files written. Pass --apply to write.)")
     return "\n".join(out)
+
 
 def apply_plan(plan: dict) -> None:
     base: Path = plan["output_dir"]
@@ -735,11 +787,20 @@ def apply_plan(plan: dict) -> None:
         else:
             target.write_bytes(content)
 
+
 def main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     parser.add_argument("--investigation", required=True)
-    parser.add_argument("--project", default=None, help="Optional. UiPath project dir to snapshot into process/.")
-    parser.add_argument("--transcript", required=True, help="JSONL file or directory containing main + subagent transcripts.")
+    parser.add_argument(
+        "--project",
+        default=None,
+        help="Optional. UiPath project dir to snapshot into process/.",
+    )
+    parser.add_argument(
+        "--transcript",
+        required=True,
+        help="JSONL file or directory containing main + subagent transcripts.",
+    )
     parser.add_argument("--resolution", default=None)
     parser.add_argument("--scenario-name", default=None)
     parser.add_argument("--output", default=None)
@@ -769,6 +830,7 @@ def main(argv: list[str]) -> int:
 
     print(render_dry_run(plan))
     return 0
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/verify_manifest_commands.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/verify_manifest_commands.py
@@ -39,7 +39,9 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Iterable
 
-UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
 HELP_TIMEOUT_S = 30
 
 
@@ -165,15 +167,21 @@ def arg_count(help_payload: dict) -> int:
     return len(data.get("Arguments") or [])
 
 
-GLOBAL_FLAGS = frozenset({
-    # CLI-wide flags accepted by every subcommand, even when leaf help doesn't
-    # relist them. Root `uip --help` doesn't include these either — they're
-    # surfaced only on intermediate command-group help. Hardcoded so we don't
-    # depend on a particular intermediate level being scraped.
-    "--output", "--output-filter",
-    "--log-level", "--log-file",
-    "-h", "--help", "--help-all",
-})
+GLOBAL_FLAGS = frozenset(
+    {
+        # CLI-wide flags accepted by every subcommand, even when leaf help doesn't
+        # relist them. Root `uip --help` doesn't include these either — they're
+        # surfaced only on intermediate command-group help. Hardcoded so we don't
+        # depend on a particular intermediate level being scraped.
+        "--output",
+        "--output-filter",
+        "--log-level",
+        "--log-file",
+        "-h",
+        "--help",
+        "--help-all",
+    }
+)
 
 
 def validate_match(
@@ -195,17 +203,26 @@ def validate_match(
             # dep, etc.). Can't introspect further; treat as plausibly
             # valid so the smoke isn't gated on upstream tool-packaging
             # issues. The runtime e2e tests still exercise the real call.
-            return True, f"WARN: could not fetch help for 'uip {' '.join(parent)}' — skipping deeper validation"
+            return (
+                True,
+                f"WARN: could not fetch help for 'uip {' '.join(parent)}' — skipping deeper validation",
+            )
         result = help_payload.get("Result")
         if result == "ConfigError":
             # Tool failed to load at runtime (e.g., missing peer dep like
             # @uipath/auth on traces-tool). Same tolerance as above.
-            return True, f"WARN: parent 'uip {' '.join(parent)}' returned ConfigError — skipping deeper validation"
+            return (
+                True,
+                f"WARN: parent 'uip {' '.join(parent)}' returned ConfigError — skipping deeper validation",
+            )
         if result != "Success":
             return False, f"parent 'uip {' '.join(parent)}' returned {result}"
         subs = subcommand_names(help_payload)
         if token not in subs:
-            return False, f"'{token}' is not a subcommand of 'uip {' '.join(parent) or '(root)'}'"
+            return (
+                False,
+                f"'{token}' is not a subcommand of 'uip {' '.join(parent) or '(root)'}'",
+            )
 
     # 2. Leaf-level flag validation (per-command flags + inherited global flags)
     leaf_help = fetch_help(uip_bin, tuple(path))
@@ -215,7 +232,10 @@ def validate_match(
     allowed_flags = flag_names(leaf_help) | GLOBAL_FLAGS
     bad_flags = [f for f in set(used_flags) if f not in allowed_flags]
     if bad_flags:
-        return False, f"unknown flag(s) on 'uip {' '.join(path)}': {', '.join(sorted(bad_flags))}"
+        return (
+            False,
+            f"unknown flag(s) on 'uip {' '.join(path)}': {', '.join(sorted(bad_flags))}",
+        )
 
     # 3. Argument count check (informational — many commands accept varargs)
     expected_args = arg_count(leaf_help)
@@ -235,7 +255,11 @@ def walk_manifests(root: Path) -> Iterable[dict]:
         try:
             manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as exc:
-            yield {"scenario": scenario, "manifest": manifest_path, "parse_error": str(exc)}
+            yield {
+                "scenario": scenario,
+                "manifest": manifest_path,
+                "parse_error": str(exc),
+            }
             continue
         for idx, rule in enumerate(manifest.get("rules", [])):
             yield {
@@ -255,7 +279,9 @@ def main(argv: list[str] | None = None) -> int:
         default=Path(__file__).resolve().parents[2],
         help="troubleshoot task root (default: parent of _shared/scripts)",
     )
-    parser.add_argument("--uip", default="uip", help="uip binary (default: uip on PATH)")
+    parser.add_argument(
+        "--uip", default="uip", help="uip binary (default: uip on PATH)"
+    )
     args = parser.parse_args(argv)
 
     if not args.root.exists():
@@ -312,7 +338,9 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     print()
-    print("OK — every mocked command, flag, and positional shape is valid against the installed uip CLI.")
+    print(
+        "OK — every mocked command, flag, and positional shape is valid against the installed uip CLI."
+    )
     return 0
 
 


### PR DESCRIPTION
## Summary

Rescues Rookery task `0fc2c6f6-4ff7-53e5-86f7-ca5bca380df2`, which completed successfully but could not finalize because its original branch was based on stale Maestro BPMN project defaults.

The stale task commit could not be cherry-picked cleanly onto current `main` because the tests tree has moved since that branch. This PR recreates the same intent on current `origin/main`: clean existing Ruff format/lint debt under `tests/` only.

## Scope

- Only files under `tests/` changed.
- Changes are mechanical Ruff formatting/lint cleanup.
- One manual lint fix was needed in `tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py`:
  - renamed ambiguous local variable `l` to `line`
  - removed unused `domain` binding from a regex match

## Validation

- `uvx ruff format tests`
- `uvx ruff check tests`
- `uvx ruff format --check tests`
- `git diff --check`
