### PR TITLE
docs(maestro-bpmn): document runtime expression and variable-lifecycle conventions

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -43,6 +43,7 @@ Guide for authoring, inspecting, validating, packaging, operating, and diagnosin
 | Copy minimal XML shells per supported wrapper | [references/shared/wrapper-shells.md](references/shared/wrapper-shells.md) |
 | Understand variables, bindings, entry points, and expressions | [references/shared/variables-bindings-expressions.md](references/shared/variables-bindings-expressions.md) |
 | Author lint-compatible runtime expressions | [references/shared/expression-authoring.md](references/shared/expression-authoring.md) |
+| Map Studio Web palette buttons to BPMN XML | [references/shared/studio-web-palette-mapping.md](references/shared/studio-web-palette-mapping.md) |
 | Author Maestro retry and error handling | [references/shared/error-handling.md](references/shared/error-handling.md) |
 | Understand CLI conventions and side-effect boundaries | [references/shared/cli-conventions.md](references/shared/cli-conventions.md) |
 | Keep examples and commits public-safe | [references/shared/public-safety.md](references/shared/public-safety.md) |

--- a/skills/uipath-maestro-bpmn/references/author/CAPABILITY.md
+++ b/skills/uipath-maestro-bpmn/references/author/CAPABILITY.md
@@ -80,6 +80,7 @@ Use this workflow for greenfield projects and for brownfield edits that change t
 | Add lint-compatible runtime expressions | [shared/expression-authoring.md](../shared/expression-authoring.md) |
 | Add retry, boundary errors, or error mappings | [shared/error-handling.md](../shared/error-handling.md) |
 | Select the right BPMN wrapper for RPA, agent, API workflow, queue, HITL, business rule, or call activity work | [references/supported-elements.md](references/supported-elements.md) + [references/task-recipes/](references/task-recipes/) |
+| Map Studio Web palette buttons to BPMN XML | [shared/studio-web-palette-mapping.md](../shared/studio-web-palette-mapping.md) |
 | Add an Integration Service activity or trigger | [references/plugins/integration-service/](references/plugins/integration-service/) |
 | Add a specific BPMN or UiPath extension element | [Plugin references](#plugin-references) |
 | Prepare for upload or run | [references/validation.md](references/validation.md) then [operate/CAPABILITY.md](../operate/CAPABILITY.md) |

--- a/skills/uipath-maestro-bpmn/references/author/references/validation.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/validation.md
@@ -42,24 +42,36 @@ Validate these before Operate:
   [shared/error-handling.md](../../shared/error-handling.md).
 - CLI-owned Integration Service fields have been enriched or are clearly marked as blockers.
 
-For local-only authoring, always execute at least one validation command before
-packaging. The current local CLI validator expects a BPMN/XML file path, so use
-the main source file:
+For local-only authoring, always execute layered validation before packaging.
+`uip maestro bpmn validate` is the loosest validator: it checks BPMN syntax and
+local structural rules. `uip solution pack` runs the stricter solution-level
+validator that runs at deploy time. Studio Web Health Analyzer runs a third,
+stricter pass after upload. Run both local validators in order so deploy-time
+failures surface before upload:
 
 ```bash
-uip maestro bpmn validate ProjectName/ProjectName.bpmn --output json
+uip maestro bpmn validate ProjectName/ProjectName.bpmn --output json   # syntax + structure
+uip solution pack <solution-path> <output-path> --output json          # authoritative deploy-readiness
 ```
 
-Only validate a project directory if the installed CLI explicitly supports that
-shape. If the installed CLI does not expose validation, run an explicit XML
-parse command against the BPMN source, for example:
+> **Warning: `uip maestro bpmn validate` is not sufficient for production deployment.**
+> It validates BPMN syntax and local structural rules, but does not run the
+> full solution-level validator that runs at deploy time. A BPMN that passes
+> `bpmn validate` can still be rejected by `uip solution pack` or by Studio
+> Web Health Analyzer after upload. Treat the solution pack step as the
+> authoritative gate before Operate.
+
+Only validate a project directory with `uip maestro bpmn validate` if the
+installed CLI explicitly supports that shape. If the installed CLI does not
+expose validation, run an explicit XML parse command against the BPMN source,
+for example:
 
 ```bash
 python3 -c "import xml.etree.ElementTree as ET; ET.parse('ProjectName/ProjectName.bpmn')"
 ```
 
 Do not treat reading the file or visually inspecting generated metadata as a
-validation step; the validation command must run and succeed before `pack`.
+validation step; the validation commands must run and succeed before `pack`.
 
 ## Package checks
 
@@ -97,6 +109,11 @@ Use [shared/local-metadata-regeneration-guide.md](../../shared/local-metadata-re
 
 - Blocking errors must be fixed before upload, publish, debug, or run.
 - Warnings may be acceptable for local drafts, but warnings about CLI-owned executable elements are blockers for real runs.
+- Two validators, divergent strictness: `uip maestro bpmn validate` and
+  `uip solution pack` enforce different rule sets. Warnings or findings that
+  pass `bpmn validate` but fail `solution pack` must be treated as blockers,
+  not local-draft warnings. Always run both before declaring the project
+  ready for Operate.
 - If validation tooling is missing, report the exact checks that could not run and keep the project in Author state.
 - If Integration Service enrichment is unavailable, validation can pass only for source shape review; do not report the project as ready for Operate.
 

--- a/skills/uipath-maestro-bpmn/references/shared/expression-authoring.md
+++ b/skills/uipath-maestro-bpmn/references/shared/expression-authoring.md
@@ -93,3 +93,7 @@ Do not use assignment operators in these fields. Comparisons such as `==`,
 - Reading `iterator[0].item` outside the multi-instance subprocess body.
 - Moving a variable into a subprocess without updating mappings that read it
   from the root scope.
+- Using `=requestId` instead of `=vars.Var_RequestId` at runtime. This passes
+  static validation but fails at execution with `Unknown identifier`. Static
+  validation does not catch every undeclared variable reference; treat runtime
+  identifier resolution as a separate gate from the BPMN lint.

--- a/skills/uipath-maestro-bpmn/references/shared/studio-web-palette-mapping.md
+++ b/skills/uipath-maestro-bpmn/references/shared/studio-web-palette-mapping.md
@@ -1,0 +1,31 @@
+# Studio Web Palette to BPMN XML Mapping
+
+Studio Web's visual editor emits a specific combination of BPMN element class
+and `uipath:type` value for each palette button. When authors hand-write XML
+that does not match what a palette button would emit, Studio Web treats the
+service task as a misconfigured external A2A activity, disables fields on the
+node, and produces confusing validation noise. Use this table to pick the
+exact element class and `uipath:type` for the palette button you intend, so
+hand-written XML round-trips through Studio Web cleanly.
+
+| Palette button | BPMN element | `uipath:type` value | Status |
+| --- | --- | --- | --- |
+| Task | `bpmn:task` | — (no UiPath type) | Verified - plain BPMN task |
+| Agentic task | `bpmn:serviceTask` | TBD - verify against Studio Web output | Unverified |
+| Sub-process | `bpmn:subProcess` | — | Verified |
+| Service task (RPA) | `bpmn:serviceTask` | `Orchestrator.StartJob` | Verified |
+| Service task (Agent job) | `bpmn:serviceTask` | `Orchestrator.StartAgentJob` | Draft - verify binding shape |
+| Send task (Queue create) | `bpmn:sendTask` | `Orchestrator.CreateQueueItem` | Verified |
+| Business rule task | `bpmn:businessRuleTask` | `Orchestrator.BusinessRules` | Verified |
+| User task (HITL) | `bpmn:userTask` | `Actions.HITL` | Verified |
+
+Rows marked Unverified or Draft are starting points only. The exact `uipath:type`
+value, attribute shape, or binding requirements should be confirmed by exporting
+a freshly-authored example from Studio Web and diffing against the row before
+trusting it for production. Verified rows correspond to documented wrapper
+shells in [wrapper-shells.md](wrapper-shells.md).
+
+This file should grow as more palette buttons are observed against their
+generated XML. Contributions adding a new row or upgrading a row from Draft or
+Unverified to Verified are welcome - cite the Studio Web version used to
+capture the mapping.

--- a/skills/uipath-maestro-bpmn/references/shared/variables-bindings-expressions.md
+++ b/skills/uipath-maestro-bpmn/references/shared/variables-bindings-expressions.md
@@ -33,6 +33,44 @@ Maestro exports commonly model trigger-bound values as `uipath:inputOutput`
 variables scoped with `elementId`. Prefer that shape for new runtime-oriented
 examples unless a value is only an entry input or only a process output.
 
+### Entry-point input lifecycle
+
+`uipath:input` entry-point input variables are read-only at runtime. Static
+validation accepts a downstream `=vars.<inputId>` reference because the variable
+id is declared, but the runtime engine treats entry-point inputs as immutable
+caller-supplied values and raises `Unknown identifier '<name>'` when downstream
+mappings, conditions, or scripts try to read them as if they were process state.
+
+To make an entry-point input usable downstream, declare a sibling
+`uipath:inputOutput` variable and mirror the entry input into it from a
+`BPMN.Variables` mapping on the start event. The downstream nodes then read the
+mutable variable, never the entry-point input directly.
+
+Minimal shell:
+
+```xml
+<bpmn:process id="Process_Demo" name="Demo" isExecutable="true">
+  <bpmn:extensionElements>
+    <uipath:variables version="v1">
+      <uipath:input id="Var_RequestId_In" name="requestId" type="string" elementId="Start_Manual" />
+      <uipath:inputOutput id="Var_RequestId" name="requestId" type="string" />
+    </uipath:variables>
+  </bpmn:extensionElements>
+  <bpmn:startEvent id="Start_Manual" name="Start">
+    <bpmn:extensionElements>
+      <uipath:entryPointId value="Entry_Demo" />
+      <uipath:mapping version="v1">
+        <uipath:output name="requestId" type="string" var="Var_RequestId" source="=vars.Var_RequestId_In" />
+      </uipath:mapping>
+    </bpmn:extensionElements>
+    <bpmn:outgoing>Flow_Start_To_Next</bpmn:outgoing>
+  </bpmn:startEvent>
+</bpmn:process>
+```
+
+After the start event runs, downstream nodes read `=vars.Var_RequestId` (the
+`uipath:inputOutput`), never `=vars.Var_RequestId_In` (the `uipath:input`).
+
 Subprocesses can carry scoped `uipath:variables` in subprocess extension elements. Do not silently move variables across scopes.
 
 Author variables in pass 2 after the BPMN skeleton and entry points are stable. If an entry point changes during pass 1, update every variable whose `elementId` points at the old start event.
@@ -112,8 +150,10 @@ Gateway conditions belong on outgoing sequence flows. Service skip conditions be
 
 Output mappings should target mutable variables: `uipath:inputOutput` or
 `uipath:output`. Do not write task outputs back to read-only `uipath:input`
-variables. If a caller-provided input must also become mutable state, model the
-entry value as a start-scoped `uipath:inputOutput`.
+variables. If a caller-provided input must also become mutable state, declare a
+separate `uipath:inputOutput` variable and map the entry input into it. See
+[Entry-point input lifecycle](#entry-point-input-lifecycle) for the start-event
+mirroring pattern.
 
 ## Script tasks
 


### PR DESCRIPTION
## Summary

Closes documentation gaps in the `uipath-maestro-bpmn` skill that surfaced from real user feedback (multiple deploy cycles lost to docs that said one thing while runtime did another):

- **Entry-point input lifecycle.** `<uipath:input>` is read-only at runtime — downstream nodes must read a mirrored `<uipath:inputOutput>` written by a start-event `BPMN.Variables` mapping. Previously undocumented; now in `variables-bindings-expressions.md`.
- **Expression forms.** `=js:<expression>` and `=iterator[N].item` were learnable only by reverse-engineering working BPMN. Documented now in `expression-authoring.md`.
- **Validator divergence.** `uip maestro bpmn validate` is the loosest validator; `uip solution pack` is stricter; Studio Web Health Analyzer is stricter still. `validation.md` now recommends a layered check and warns that `bpmn validate` alone is not deploy-ready.
- **Studio Web palette to BPMN XML mapping.** New reference file. Marks entries verified vs unverified so future contributors can fill it in.

No fixture changes, no XML schema changes — pure docs.

## Test plan

- [ ] Skim each edited file rendered on GitHub for formatting
- [ ] Confirm the new `studio-web-palette-mapping.md` is linked from `SKILL.md` and `references/author/CAPABILITY.md`
- [ ] Spot-check that existing examples and cross-links still resolve