### PR TITLE
docs(uipath-maestro-case): preserve schema extras + document action outputs

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
@@ -38,6 +38,15 @@ Pick this plugin when the sdd.md describes a `HITL` task, or any task requiring 
 
 See [registry-discovery.md](../../../registry-discovery.md#cli-search-gaps) for the fallback rationale.
 
+## Always-Emitted Outputs
+
+`tasks describe --type action` returns two synthetic outputs on every action task in addition to the action-app's declared outputs:
+
+- **`Action`** — outcome dropdown. Carries `options: [{value, label}, ...]` with the action-app's outcome names (e.g., `Approve`, `Reject`). Downstream tasks can bind `=vars.<actionVar>.Action` and the SDD can validate the value against the enum.
+- **`hitlTask`** — full Orchestrator task record. Type `object` with PascalCase sub-fields: `Id`, `Key`, `Title`, `Status`, `Priority`, `AssignedToUser.{UserName,EmailAddress,...}`, `CompletedByUser.{...}`, `CreationTime`, `CompletionTime`, plus SLA / source / metadata. Bind sub-fields directly via `=vars.<hitlVar>.AssignedToUser.UserName`.
+
+Both are discoverable in the Step 0 schema — no special SDD declaration needed.
+
 ## Unresolved Fallback
 
 Mark `<UNRESOLVED: action-app "<deploymentTitle>" in folder "<folder>" not found in action-apps-index.json>`. Emit only structural fields — drop every action-specific line (`task-title`, `priority`, `recipient`, `inputs`, `outputs`). See [placeholder-tasks.md](../../../placeholder-tasks.md) for the full placeholder entry shape and wiring-block convention.

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -41,6 +41,8 @@ For each entry in the Step 0 schema, check whether the SDD's `outputs:` row in t
 - **`<sdd-name> = <expression>`** (set / compute / copy) → Scenario E shape: `{name: "<sdd-name>", custom: true, var: "<sdd-name>", value: "<expression>", source: "<same as value>", target: "", body: "", type: <case var's type>, elementId: "root"}`. **No `id`**, no `originalVar`. NO root mirror — FE's `isUpdateExistingOutput` filter at `VariableMutationUtils.ts:49-64` skips it.
 - **Schema fields with no SDD reference** → fall back to auto-mint shape (`var` = camelCased schema name). Connector plugins additionally apply the [uniqueness rule](../global-vars/impl-json.md#uniqueness-rule) dedup-suffix on collision (e.g., `response` → `response2`).
 
+> **Preserve schema-provided extras.** Step 0 schema entries may carry fields beyond the shape rules above (e.g., `_jsonSchema` on complex outputs, `options` on `Action`, `body`, `displayName`). Round-trip them verbatim onto the emitted output — the field list in each plugin's task-write template is a minimum, not a maximum. Skill never strips schema-provided fields.
+
 Cross-cutting rules:
 
 - Expression values for `=`: literal (`"InReview"`, `5`, `true`), computed (`=js:vars.x + 1`), or variable reference (`=vars.X.Y.Z`).


### PR DESCRIPTION
## Summary

- **io-binding/impl-json.md** — adds a blockquote in § Output Binding Shapes stating that schema-provided extras (`_jsonSchema`, `options`, `body`, `displayName`) round-trip verbatim onto the emitted output. Per-plugin field lists are a minimum, not a maximum.
- **plugins/tasks/action/planning.md** — adds an "Always-Emitted Outputs" subsection naming the two synthetic outputs surfaced on every action task: `Action` (with `options` enum from outcomes) and `hitlTask` (with PascalCase sub-fields like `AssignedToUser.UserName`).
- Companion to upcoming CLI change `fix/case-tasks-describe-non-connector-divergences` (UiPath/cli), which makes `_jsonSchema`, `Action.options`, and `hitlTask` available in `case tasks describe` output. Until that CLI change lands, this skill doc accurately describes the FE-canonical contract — but the schema-provided extras won't actually flow through.

## Test plan

- [ ] Read both edits end-to-end for clarity and consistency with surrounding docs
- [ ] Confirm the "preserve schema extras" rule is discoverable from the per-plugin task-write steps (linked from agent/action/rpa/process/case-management/api-workflow impl-json `Output binding` references to `io-binding/impl-json.md § Output Binding Shapes`)
- [ ] After CLI prerequisite lands, smoke an action task in the case skill and verify `Action.options` + `hitlTask` appear in the emitted caseplan.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)