### PR TITLE
docs(uipath-maestro-case): document bounded repeat for wait-for-timer…

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/impl-json.md
@@ -60,6 +60,14 @@ Write the timer task directly to `caseplan.json`. No CLI command needed.
 
 ISO 8601 duration format (e.g., `PT3M`, `PT1H30M`, `P2D`). Time units use `PT` prefix, date units use `P` (no `T`). Weeks → `P7D` (Luxon doesn't output `W`).
 
+**Bounded repetition** — when tasks.md specifies `repeat: N`, add `data.repeat` as an integer alongside `timeDuration`. Omit `data.repeat` entirely for a single fire.
+
+```json
+"data": { "timerType": "timeDuration", "timeDuration": "PT1H", "repeat": 5 }
+```
+
+Pairs with `timeDuration` only. For bounded repetition with a start datetime, use `timeCycle` instead.
+
 ### timeDate — specific datetime
 
 ```json


### PR DESCRIPTION
docs(uipath-maestro-case): document bounded repeat for wait-for-timer timeDuration

Add `data.repeat` integer field to the timeDuration variant so authors can
express `repeat: N` from tasks.md. Notes the timeDuration-only pairing and
points at timeCycle for repetition with a start datetime.