### PR TITLE
docs(uipath-maestro-case): close send_as drop regression via reinforced required-input gate

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/planning.md
@@ -187,7 +187,7 @@ Planner emits to `tasks.md input-values.bodyParameters`:
 - runOnlyOnce: false
 - order: after T<m>
 - lane: <n>
-- verify: Confirm task created with correct inputs
+- verify: tasks.md `input-values` covers every `inputs.*[?required]` from the lean spec across `bodyFields`, `queryParameters`, `pathParameters` — see Step 5 above.
 ```
 
 `filter:` is optional and present only when the operation supports CEQL (i.e. `spec.filter` was non-null in step 7).


### PR DESCRIPTION
## Summary

Tighten the connector-activity `tasks.md` verify line so it references planning Step 5's existing required-field gate as a checkable artifact, instead of the vague "Confirm task created with correct inputs".

```diff
- verify: Confirm task created with correct inputs
+ verify: tasks.md `input-values` covers every `inputs.*[?required]` from the lean spec across `bodyFields`, `queryParameters`, `pathParameters` — see Step 5 above.
```

## Why

Surfaced by case-vars v1 test-plan T4 follow-up (and previously T1) — Slack `send_message_to_channel_v2` queryParameter `send_as` was occasionally omitted from `caseplan.json` even though the SDD declared it. `validate` passed; runtime returned HTTP 400.

The root cause was on the authoring side: planning Step 5 (the required-field HARD GATE that already enumerates `bodyFields`/`queryParameters`/`pathParameters`) was bypassed, so `tasks.md` was written without `send_as`. Impl phase is mechanical transport — once `tasks.md` `input-values` covers every required field, `case spec --input-details` produces a populated `caseShape` with all required keys.

So the load-bearing fix is making the planning-phase gate visible at the tasks.md entry level. The new verify line gives every entry a per-task assertion to check.

## What's NOT in this PR

- Earlier draft also added an impl-phase Step 3 rewording + Post-Write item 12. Dropped after review — they restated planning Step 5 in a place that can only catch CLI/transport bugs (out of scope for a doc PR). Single load-bearing change wins.

## Test plan

- [ ] Re-run T1 (`case-vars-v1-tests/t01-trigger-sourced/`) — SDD intentionally omitting `send_as` should trigger AskUserQuestion at planning Step 5; tasks.md must NOT be written until `send_as` has a value
- [ ] Re-run T4 (`case-vars-v1-tests/t04-task-operators/`) — same check on the Slack send-message task
- [ ] Positive-path smoke: connector task where every required input is already provided — confirm no regression in tasks.md generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)