### PR TITLE
fix(uipath-agents): align inline-in-flow resource folders on the UUID convention

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
@@ -132,6 +132,7 @@ Escalations hand off agent control to a human via a channel. Generate fresh UUID
   "storageBucketName": null,                        // only used when escalationType = 1
   "properties": {},
   "governanceProperties": { "isEscalatedAtRuntime": false },
+  "isEnabled": true,
   "channels": [
     {
       "id": "<uuid-v4>",                            // channel id — generate a new one per channel

--- a/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/inline-in-flow/inline-in-flow.md
@@ -154,15 +154,22 @@ After creating the inline agent, the flow needs a `uipath.agent.autonomous` node
 
 The node JSON shape that the flow skill must produce is documented in § Flow Node Structure below — keep it as a reference, not as a CLI walkthrough.
 
-## Inline-in-Flow Tool resource.json
+## Inline-in-Flow Resource Paths
 
-Inline tools support four subtypes — `process` (RPA), `agent`, `api`, `processOrchestration`. The `resource.json` shape is identical to standalone agents — follow [../process/process.md](../process/process.md) § Subtypes and § Tool resource.json Shape. Discovery is identical (`uip solution resource list` + `uip solution resource get`) and populates `referenceKey`, `folderPath`, `inputSchema`, and `outputSchema` with real values. The subtype is selected by the `type` field (`process` | `agent` | `api` | `processOrchestration`).
+All inline-agent resources — `tool`, `context`, `escalation`, `memory` — share one path convention:
 
 **Path:** `<FlowProjectDir>/<projectId>/resources/<RES_UUID>/resource.json`
 
-Additional notes for inline-in-flow:
+`<RES_UUID>` is a fresh UUID. It MUST match (a) the resource node's `model.source` in the flow and (b) the `id` field inside `resource.json`. The resource directory name is the UUID — never the human-readable resource name. Human-readable folder names are the standalone-agent convention; inline agents always use UUIDs.
+
+Resource body shape is identical to the standalone-agent docs — only the folder name differs:
+- Tools (`process` / `agent` / `api` / `processOrchestration`): [../process/process.md](../process/process.md) § Subtypes and § Tool resource.json Shape. Discovery is identical (`uip solution resource list` + `uip solution resource get`); subtype is selected by the `type` field.
+- Context index: [../context/index.md](../context/index.md) § Agent-Level Resource Shape.
+- Escalation: [../escalation/escalation.md](../escalation/escalation.md) § Agent-Level Resource.
+
+### Tool-specific notes
+
 - **`location`**: Follows the same rule as standalone agents — set `"solution"` when the row from `uip solution resource list` has `Source: "Local"`, set `"external"` when `Source: "Remote"`. See [../process/process.md](../process/process.md) and [../../critical-rules.md](../../critical-rules.md) Rule 12.
-- **`id`**: Must match the `<RES_UUID>` used as the tool node's `model.source` in the flow and the resource directory name.
 - **`properties.folderPath`**: Must be the **literal folder path from discovery** (e.g., `"Shared/Sales"`) — do **not** leave it empty. An empty `folderPath` prevents `uip solution resource refresh` from resolving the tool at runtime.
 - **`inputSchema.properties`**: Must include `"guardrails": { "type": "array" }` alongside the tool arguments — the runtime expects it.
 - **All fields from the template in [../process/process.md](../process/process.md) are required** — especially `$resourceType: "tool"`, `guardrail`, `properties.processName`, `properties.exampleCalls`, `isEnabled`, and `argumentProperties`. A `resource.json` missing `$resourceType` will not be recognized by `uip agent validate` (the tool reports `"resources": 0`); `uip agent migrate` will then write an empty `bindings_v2.json`.
@@ -280,7 +287,7 @@ uip agent init "<FlowProjectDir>" --inline-in-flow --output json
 # - Configure outputSchema if needed
 
 # 4. Add tools to <FlowProjectDir>/<projectId>/resources/ (optional)
-# See § Inline-in-Flow Tool resource.json above for the exact format
+# See § Inline-in-Flow Resource Paths above for the exact format
 
 # 5. Hand off to the uipath-maestro-flow skill to add the
 #    uipath.agent.autonomous node (inputs.source = <projectId>),

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -5,8 +5,8 @@ description: >
   EXTERNAL RPA process deployed to Orchestrator (not inside this
   solution). Verifies the tool resource.json under the inline agent's
   UUID subdirectory uses `type: "process"`, `location: "external"`,
-  real `folderPath`, and that a `uipath.agent.resource.tool.rpa` flow
-  node is wired to the autonomous agent node's `tool` handle.
+  real `folderPath`, and that a `uipath.agent.resource.tool.process.<uuid>`
+  flow node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
 agent:

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/check_inline_solution_rpa_tool.py
@@ -5,7 +5,7 @@ Validates:
   1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
      (falling back to `model.source` for legacy fixtures) resolves to
      an existing UUID subdirectory.
-  2. Flow has a `uipath.agent.resource.tool.rpa` node.
+  2. Flow has a `uipath.agent.resource.tool.process.<uuid>` node.
   3. Edge wires the autonomous node's `tool` handle (source) to the
      RPA tool node's `input` handle (target).
   4. Inside the inline agent dir, at least one resource.json under
@@ -33,13 +33,13 @@ from _shared.inline_wiring import (  # noqa: E402
 )
 
 FLOW_PATH = Path(os.getcwd()) / "PayrollFlowSol" / "PayrollFlow" / "PayrollFlow.flow"
-RPA_TOOL_NODE_TYPE = "uipath.agent.resource.tool.rpa"
+RPA_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.process."
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    tool_node = find_resource_node(flow, node_type=RPA_TOOL_NODE_TYPE)
+    tool_node = find_resource_node(flow, node_type_prefix=RPA_TOOL_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {tool_node['type']} nodes")
 
     assert_edge(

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -6,7 +6,7 @@ description: >
   Verifies the tool resource.json under the inline agent's UUID
   subdirectory uses `type: "process"`, `location: "solution"`,
   `folderPath: "solution_folder"`, and that a
-  `uipath.agent.resource.tool.rpa` flow node is wired to the
+  `uipath.agent.resource.tool.process.<uuid>` flow node is wired to the
   autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 


### PR DESCRIPTION
## Summary

- Generalize the `uipath-agents` inline-in-flow doc so the UUID resource-folder convention covers **all** inline resource kinds (tool / context / escalation / memory). Previously only documented under "Inline-in-Flow Tool resource.json", which caused agents scaffolding context-grounding or escalation resources to fall back to human-readable folder names and break `model.source` matching.
- Align the sibling `inline_external_rpa_tool` and `inline_solution_rpa_tool` checks/yaml on the `uipath.agent.resource.tool.process.<release-key>` prefix (was the legacy `uipath.agent.resource.tool.rpa`).
- Add `isEnabled: true` to the escalation `resource.json` example.

## Why

The `skill-agent-inline-context-index` eval failed with:
```
FAIL: context node model.source UUID '…' does not match the resource sub-folder name 'UiPathAgentsProductKnowledge'
```
because the docs only carried the UUID-folder rule under a tool-specific section. The fix front-loads the rule for all resource kinds and keeps tool-specific bullets under a subsection. Body shapes still live in the per-capability docs.

## Test plan

- [x] `./hooks/validate-skill-descriptions.sh` exits 0
- [x] Re-ran `skill-agent-inline-context-index` e2e: the previously-failing assertion now passes (`OK: context node model.source='62d02fa4-…' matches resource sub-folder (KnowledgeFlowSol/KnowledgeFlow/<projectId-uuid>/resources/62d02fa4-…/resource.json)`).
- [x] Spot-check sibling tests `inline_external_rpa_tool` / `inline_solution_rpa_tool` still pass with the updated prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)