### PR TITLE
docs(uipath-agents): rewrite Python Coded Functions guide

### DIFF
--- a/skills/uipath-agents/references/coded/frameworks/coded-function-agents.md
+++ b/skills/uipath-agents/references/coded/frameworks/coded-function-agents.md
@@ -1,151 +1,240 @@
-# Creating UiPath Agents
+# UiPath Python Coded Functions
 
-Guide to creating new UiPath agents with AI-powered business logic implementation.
+## What Python Coded Functions Are
 
-## Initial Setup
+Python Coded Functions are **atomic, bespoke units of business logic** — deterministic Python code packaged as a first-class UiPath artifact. Use them when generic activities don't cover the required logic: calling a third-party API with custom auth, processing documents with domain-specific rules, querying ERP systems via Integration Service connections, or transforming data in ways that no out-of-the-box activity handles.
 
-Follow the [Project Setup Guide](../lifecycle/setup.md) to create your project directory, scaffold with `uip codedagent new`, and install dependencies. Setup/build/init are unauthenticated; check authentication before cloud-backed run/eval/deploy/push. All subsequent commands use the `uip codedagent` CLI wrapper.
+A Coded Function is **not an agent**. It does not reason, route, or call LLMs. It takes typed input, executes deterministic code, and returns typed output.
+
+### Invocation surfaces
+
+A Python Coded Function can be invoked from any UiPath surface:
+
+| Surface | How |
+|---|---|
+| Maestro BPMN | Service Task node |
+| Maestro Flow | Coded Agent node or Service Task |
+| Coded Agents (LangGraph / LlamaIndex / OpenAI Agents) | Called as a tool or step |
+| Other Coded Functions | Direct Python call or Orchestrator job |
+| Orchestrator API | `POST /Jobs/StartJobs` |
+| CLI | `uip functions pack` → `uip functions publish` |
+
+### Python Functions vs JS Functions
+
+| | Python Coded Function | JS/TS Function |
+|---|---|---|
+| **Job semantics** | Yes — Orchestrator job ID, audit trail, retry, scheduling | No — inline HTTP only, no job lifecycle |
+| **Invocation** | Maestro, Flow, Agents, Orchestrator API | HTTP endpoint (BFF for Coded Apps) |
+| **Runtime** | Serverless or Local Unattended Robot | Serverless HTTP shared tier |
+| **SDK access** | Full UiPath Python SDK (assets, buckets, queues, connections) | Workload token forwarding only |
+| **Scaffold** | `uip functions new <name> --language py` | `uip functions new <name> --language ts` (default) |
+| **Init** | `uip functions init` (generates entry-points.json) | Not needed |
+| **Local dev** | `uip functions run` | `uip functions serve` + `uip functions run` |
+| **Best for** | Agentic process steps, ERP integration, document AI, data pipelines | Backend-for-Frontend for Coded Apps |
+
+Use Python when the logic needs job semantics, platform SDK access, or is invoked from Maestro/agents. Use JS when the caller is a Coded App frontend and low HTTP latency matters.
+
+---
+
+## CLI Reference
+
+All Python Coded Function lifecycle commands use `uip functions`:
+
+```bash
+uip functions new <name> -l py     # scaffold a new Python Functions project (--language py required)
+uip functions init                 # Python only — generate entry-points.json, bindings.json, project.uiproj
+uip functions pack                 # pack to .nupkg for deployment
+uip functions publish              # upload .nupkg to Orchestrator (prompts for feed, or use --feed-id)
+uip functions push                 # sync project to Studio Web
+```
+
+> `uip functions run` works for both Python and JS/TS. `uip functions serve` is **JS/TS only** — it starts the local HTTP server that `run` invokes against.
+
+---
 
 ## Workflow
 
-### Step 1: Define Agent Schema
+### Step 1: Scaffold
 
-Specify:
-- **Agent Description**: What does this agent do?
-- **Input Fields**: Name, type, description for each input parameter
-- **Output Fields**: Name, type, description for each output
-
-The schemas should be written as pydantic types.
-
-### Step 2: Choose Agent Type
-
-#### Coded Function Agent (no LLM framework)
-
-For agents with deterministic logic, SDK calls, or simple processing — use `main.py` with a traced function:
-
-```python
-from pydantic import BaseModel, Field
-from uipath.tracing import traced
-
-class Input(BaseModel):
-    # Generated fields based on your inputs
-    pass
-
-class Output(BaseModel):
-    # Generated fields based on your outputs
-    pass
-
-@traced()
-async def main(input: Input) -> Output:
-    """Your agent's business logic implementation."""
-    # AI-implemented logic will go here
-    pass
+```bash
+uip functions new <name> --language py       # Python Coded Function
+uip functions new <name> --language ts       # TypeScript Function (JS/TS, no job semantics)
+uip functions new <name> --language js       # JavaScript Function (JS/TS, no job semantics)
 ```
 
-#### LangGraph Agent
+**`--language py` is required for Python.** The default language is TypeScript — omitting `--language` scaffolds a JS/TS project. Always pass `-l py` or `--language py` when building a Python Coded Function.
 
-For multi-step LLM reasoning, conditional routing, or tool-calling with LangChain — use `graph.py` + `langgraph.json`. See `langgraph-integration.md`.
+`--empty` skips the hello-world function (JS/TS only).
 
-#### LlamaIndex Agent
+### Step 2: Define Function Schema
 
-For LlamaIndex-based workflows using `StartEvent`/`StopEvent` events and the `@step` decorator — use `main.py` + `llama_index.json`. See `llamaindex-integration.md`.
-
-#### OpenAI Agents Agent
-
-For lightweight agents using the OpenAI Agents SDK with tool calling and handoffs — use `main.py` + `openai_agents.json`. See `openai-agents-integration.md`.
-
-## LLM Usage
-
-The **UiPath LLM Gateway** provides access to Large Language Model capabilities for conversational AI, structured data extraction, and semantic search. It supports both OpenAI-compatible and UiPath's normalized API formats.
-
-### Service Options
-
-**UiPathOpenAIService** — For direct OpenAI API compatibility:
-```python
-from uipath.llm_gateway import UiPathOpenAIService
-
-service = UiPathOpenAIService()
-response = await service.chat_completions(messages=[
-    {"role": "system", "content": "You are helpful."},
-    {"role": "user", "content": "What is AI?"}
-])
-```
-
-**UiPathLlmChatService** — For advanced enterprise features (tool calling, function calling):
-```python
-from uipath.llm_gateway import UiPathLlmChatService
-
-service = UiPathLlmChatService()
-response = await service.chat_completions(messages=messages)
-```
-
-### Structured Output with Pydantic
-
-Extract structured data using Pydantic models:
+Schemas are Python `@dataclass` types (not Pydantic BaseModel):
 
 ```python
-from pydantic import BaseModel
+from dataclasses import dataclass, field
+from typing import Any
 
-class Country(BaseModel):
-    name: str
-    capital: str
+@dataclass
+class Input:
+    document_id: str = ""
 
-response = await service.chat_completions(
-    messages=messages,
-    response_format=Country
-)
+@dataclass
+class Output:
+    vendor_name: str = ""
+    total_amount: float = 0.0
+    error_type: str = ""     # populated on failure, empty on success
+    error_message: str = ""  # human-readable error detail
 ```
-
-### Text Embeddings
-
-Generate embeddings for semantic search:
-
-```python
-embedding = await service.embeddings("Hello, world!")
-```
-
-### Configuration
-
-Control LLM behavior with these parameters:
-- `temperature` (0-1): Controls randomness vs. determinism
-- `max_tokens`: Response length limit (default: 4096)
-- `top_p` and `top_k`: Diversity controls
-- `frequency_penalty` and `presence_penalty`: Token repetition management
-
-For detailed information, see the [UiPath LLM Gateway documentation](https://uipath.github.io/uipath-python/core/llm_gateway/).
 
 ### Step 3: Implement Business Logic
 
-Describe your agent's functionality, then implement the main function (or graph nodes) with:
-- Proper error handling
-- UiPath SDK method calls (see [SDK Services](../capabilities/sdk-services.md))
-- Input validation
-- Output formatting
+**Do NOT make LLM calls inside a Coded Function.** LLM calls introduce non-determinism and latency that break the function contract. If the step requires LLM reasoning or multi-step AI decisions, use a framework-based agent (LangGraph, LlamaIndex, OpenAI Agents) instead.
 
-### Step 4: Generate Entry Points
+#### Minimal template
 
-Run `uip codedagent init` to generate `entry-points.json`, `uipath.json`, `bindings.json`, and documentation files. See the [Workflow](../lifecycle/setup.md#workflow) section in Project Setup for details on entrypoint registration, auto-detection, and troubleshooting.
+```python
+from __future__ import annotations
 
-### Step 5: Create Smoke Evaluation Set
+from dataclasses import dataclass
+from uipath.core.tracing import traced
+from uipath.platform import UiPath
 
-**Required.** Create `evaluations/eval-sets/smoke-test.json` with 2-3 basic test cases, then run `uip codedagent eval`. Use `ExactMatchEvaluator` for deterministic agents or `LLMJudgeOutputEvaluator` for LLM agents.
+@dataclass
+class Input:
+    document_id: str = ""
 
-### Step 6: Deploy
+@dataclass
+class Output:
+    result: str = ""
+    error_type: str = ""
+    error_message: str = ""
 
-When deploying: add author to `pyproject.toml`, bump version if re-deploying, then run `uip codedagent deploy --my-workspace`.
+# Lazy SDK singleton — never instantiate UiPath() at module level
+_sdk: UiPath | None = None
 
-## Generated Template Details
+def sdk() -> UiPath:
+    global _sdk
+    if _sdk is None:
+        _sdk = UiPath()
+    return _sdk
 
-The created agent will include:
-- Pydantic models for Input and Output based on your schema
-- UiPath SDK initialization
-- `@traced()` decorator for monitoring
-- Function signature with type hints
+@traced(name="my_function", run_type="uipath")
+def my_function(input: Input) -> Output:
+    out = Output()
+    try:
+        # SDK calls, data processing, rule-based logic only
+        asset = sdk().assets.retrieve("MY_ASSET", folder_path="Shared")
+        out.result = str(asset.value)
+    except Exception as exc:
+        out.error_type = "FAILED"
+        out.error_message = str(exc)
+    return out
+```
+
+Key rules:
+- **`@dataclass`** for Input/Output — not `BaseModel`
+- **Sync function** — `def`, not `async def`; the function name is arbitrary
+- **Lazy SDK init** — instantiate `UiPath()` inside a getter, never at module level
+- **Errors returned, not raised** — populate `error_type`/`error_message` output fields and return; never let exceptions bubble out of the entrypoint
+- **`@traced(name=..., run_type="uipath")`** — apply to the entrypoint and any sub-functions you want visible in LLM Ops Traces
+
+### Step 4: Register in `uipath.json`
+
+```json
+{
+  "runtimeOptions": { "isConversational": false },
+  "functions": {
+    "main": "main.py:my_function"
+  }
+}
+```
+
+The key is the entrypoint name — it can be any string and marks this as the callable entrypoint. The value is `"<file>:<function_name>"`. Both the key and the function name are arbitrary.
+
+### Step 5: Mark project type in `pyproject.toml`
+
+```toml
+[project]
+name = "my-function"
+version = "0.1.0"
+description = "..."
+authors = [{ name = "..." }]
+requires-python = ">=3.11"
+dependencies = [
+    "uipath>=2.10",
+    "httpx>=0.28",          # if making HTTP calls
+    "pydantic-settings>=2", # if using Settings for env/asset config
+]
+
+[tool.uipath]
+type = "function"           # required — identifies this as a Python Coded Function
+```
+
+**`[tool.uipath] type = "function"` is required.** Without it the project is treated as a coded agent. No `[build-system]` section.
+
+### Step 6: Generate Entry Points
+
+```bash
+uip functions init
+```
+
+Python only. Discovers entrypoints and generates `entry-points.json`, `bindings.json`, and `project.uiproj`. Must run before `pack` or `push`. Re-run whenever Input/Output schemas or the entrypoint registration in `uipath.json` changes.
+
+### Step 7: SDK Capabilities
+
+Full SDK reference: https://uipath.github.io/uipath-python/
+
+Access UiPath platform resources via `sdk()`:
+
+```python
+from uipath.platform import UiPath
+from uipath.platform.connections.connections import ActivityMetadata, ActivityParameterLocationInfo
+
+# Assets — retrieve named credentials or config values
+asset = sdk().assets.retrieve("ASSET_NAME", folder_path="Shared")
+value = asset.string_value          # or credential_username / credential_password
+
+# Buckets — download files for processing
+sdk().buckets.download(
+    name="BucketName",
+    blob_file_path="relative/path/file.pdf",
+    destination_path="/tmp/local.pdf",
+    folder_path="Shared",
+)
+
+# Integration Service connections — invoke connector activities (ERP, CRM, etc.)
+result = sdk().connections.invoke_activity(
+    activity_metadata=ActivityMetadata(
+        object_path="/executeSuiteQL",
+        method_name="POST",
+        content_type="application/json",
+        parameter_location_info=ActivityParameterLocationInfo(body_fields=["q"]),
+    ),
+    connection_id="<connection-uuid>",
+    activity_input={"q": "SELECT id FROM vendor WHERE ..."},
+)
+```
+
+### Step 8: Pack and Publish
+
+```bash
+uip functions pack                            # creates .nupkg
+uip functions publish                         # upload to Orchestrator (interactive feed picker)
+uip functions publish --feed-id <FEED_ID>     # CI/non-interactive
+```
+
+To sync to Studio Web instead of publishing to Orchestrator:
+
+```bash
+uip functions push
+```
 
 ## Important Notes
 
-- All agents are automatically traced for monitoring and debugging
-- Input/output fields are strongly typed with Pydantic
-- The agent works globally and can call any UiPath SDK services
-- Generated `entry-points.json` enables integration with UiPath Cloud
+- `UiPath()` must never be instantiated at module level — always inside a function body
+- `[tool.uipath] type = "function"` in `pyproject.toml` is required
+- `uip functions init` must run before `pack` or `push` — it generates `entry-points.json`
+- Python Functions have full job semantics: Orchestrator job ID, audit trail, retry, scheduling
+- JS Functions have no job semantics and cannot be started as Orchestrator jobs — use Python when the caller is Maestro, a Flow, or an agent
+- `uip functions run` works for both Python and JS/TS local execution; `uip functions serve` is JS/TS only (starts the local HTTP server that `run` invokes against)
 - If cloud-backed work requires authentication, run `uip login --organization "<ORG>" --tenant "<TENANT>" --output json`.


### PR DESCRIPTION
## Summary

- Repositions `coded-function-agents.md` as a **Python Coded Functions** guide — not agents. Adds clear positioning: atomic, bespoke logic not covered by generic activities, invocable from Maestro, Flow, Coded Agents, and Orchestrator
- Updates all CLI references from `uip codedagent` to **`uip functions`** (`new`, `init`, `pack`, `publish`, `push`, `run`)
- Adds **`-l py` / `--language py` requirement** on `uip functions new` — TypeScript is the default; omitting the flag scaffolds the wrong runtime
- Replaces Pydantic `BaseModel` schema pattern with **`@dataclass`** (confirmed from real production project)
- Adds **`[tool.uipath] type = "function"`** in `pyproject.toml` — required to declare Python Coded Function project type
- Adds **lazy SDK singleton pattern** (`_sdk: UiPath | None = None`), sync entrypoint, errors-returned-not-raised pattern — all derived from real OCR Extraction project
- Adds **Python vs JS Functions comparison table** with job semantics, invocation surfaces, and CLI differences
- Documents `uipath.core.tracing.traced`, `assets.retrieve()`, `buckets.download()`, `connections.invoke_activity()` SDK examples

## Test plan

- [ ] Review `coded-function-agents.md` content for accuracy against `uip functions --help` and `uip functions new --help`
- [ ] Verify `[tool.uipath] type = "function"` pattern against a real Python Functions project

🤖 Generated with [Claude Code](https://claude.com/claude-code)