### PR TITLE
docs: align project path argument references

### DIFF
--- a/skills/uipath-maestro-bpmn/references/operate/references/run.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/run.md
@@ -20,19 +20,19 @@ Use debug when the user wants to upload a local BPMN project to Studio Web and r
 visibility.
 
 ```bash
-uip maestro bpmn debug <ProjectDir> --output json
+uip maestro bpmn debug [project-path] --output json
 ```
 
 Pass input arguments only after confirming the values and redacting secrets from summaries:
 
 ```bash
-uip maestro bpmn debug <ProjectDir> --inputs @inputs.json --output json
+uip maestro bpmn debug [project-path] --inputs @inputs.json --output json
 ```
 
 If a target folder is needed, provide the folder ID exposed by the CLI:
 
 ```bash
-uip maestro bpmn debug <ProjectDir> --folder-id <FOLDER_ID> --output json
+uip maestro bpmn debug [project-path] --folder-id <FOLDER_ID> --output json
 ```
 
 Parse and report returned identifiers such as `Data.jobKey`, `Data.instanceId`, `Data.runId`, `Data.solutionId`,

--- a/skills/uipath-maestro-bpmn/references/operate/references/ship.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/ship.md
@@ -35,7 +35,7 @@ Before upload, publish, deploy, or debug:
 Package when the user wants a local `.nupkg`, pre-deploy artifact, or package-shape verification:
 
 ```bash
-uip maestro bpmn pack <ProjectDir> <OutputDir> --output json
+uip maestro bpmn pack <project-path> <OutputDir> --output json
 ```
 
 Use `--name` and `--version` only when the user provides a public-safe package identity.
@@ -66,7 +66,7 @@ Confirm package identity, target folder/context, feed/package expectations, and 
 Typical path:
 
 ```bash
-uip maestro bpmn pack <ProjectDir> <OutputDir> --output json
+uip maestro bpmn pack <project-path> <OutputDir> --output json
 uip solution pack <SolutionDir> <OutputDir> --output json
 uip solution publish <PackageZip> --output json
 ```

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -35,7 +35,7 @@ Do not derive metadata from stale package files first. Use existing generated fi
    output when parsing command results:
 
    ```bash
-   uip maestro bpmn pack <ProjectDir> <OutputDir> --output json
+   uip maestro bpmn pack <project-path> <OutputDir> --output json
    ```
 
 5. Inspect the package or generated content for:

--- a/skills/uipath-maestro-bpmn/references/shared/project-layout.md
+++ b/skills/uipath-maestro-bpmn/references/shared/project-layout.md
@@ -31,7 +31,7 @@ ProjectName/
 Treat these JSON files as derived unless a CLI contract explicitly identifies a field as user-authored. For source fixes, edit BPMN or rerun CLI enrichment rather than patching generated output by hand.
 
 Local packaging requires the generated metadata set to exist. In particular,
-`uip maestro bpmn pack <ProjectDir> <OutputDir> --output json` consumes
+`uip maestro bpmn pack <project-path> <OutputDir> --output json` consumes
 `package-descriptor.json`; it does not create a missing descriptor from only
 the BPMN and `project.uiproj`.
 

--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -105,13 +105,13 @@ uip solution upload <SolutionDir> --output json
 Pack a Case project directory into a `.nupkg` file. Only used when the user explicitly requests Orchestrator deployment via `uip solution publish` — not the default publish path.
 
 ```bash
-uip maestro case pack <projectPath> <outputPath>
+uip maestro case pack <project-path> <outputPath>
 uip maestro case pack ./my-case-project ./dist --name MyCase --version 2.0.0
 ```
 
 | Flag | Description |
 |------|-------------|
-| `<projectPath>` | **(required)** Path to the Case project directory |
+| `<project-path>` | **(required)** Path to the Case project directory |
 | `<outputPath>` | **(required)** Output directory for the `.nupkg` |
 | `-n, --name <name>` | Package name (default: project folder name) |
 | `-v, --version <version>` | Package version (default: `1.0.0`) |
@@ -144,14 +144,14 @@ Debug a Case JSON file via a Studio Web debug session. **Requires `uip login`. E
 
 ```bash
 uip solution resource refresh --solution-folder <SolutionDir> --output json
-uip maestro case debug <projectDirectory> --log-level debug --output json
+uip maestro case debug <project-path> --log-level debug --output json
 ```
 
 > **Always run `uip solution resource refresh`** on the solution directory before debug.
 
 | Flag | Description |
 |------|-------------|
-| `<projectDirectory>` | **(required)** Path to the case project directory (must contain `project.uiproj`) |
+| `<project-path>` | **(required)** Path to the case project directory (must contain `project.uiproj`) |
 | `--folder-id <id>` | Orchestrator folder ID (`OrganizationUnitId`). Auto-detected if omitted. |
 | `--poll-interval <ms>` | Polling interval in milliseconds (default: `2000`) |
 | `--output <format>` | Output format: `table`, `json`, `yaml`, `plain` (default: `json`) |

--- a/skills/uipath-maestro-flow/references/operate/references/ship.md
+++ b/skills/uipath-maestro-flow/references/operate/references/ship.md
@@ -41,7 +41,7 @@ Pack the flow project into a `.nupkg` then publish via the platform skill:
 uip solution resource refresh <SolutionDir> --output json
 
 # 2. Pack
-uip maestro flow pack <ProjectDir> <OutputDir>
+uip maestro flow pack <project-path> <OutputDir>
 ```
 
 For `uip solution publish` and the rest of the deployment workflow, see [/uipath:uipath-solution](/uipath:uipath-solution). See [shared/cli-commands.md — uip maestro flow pack](../../shared/cli-commands.md#uip-maestro-flow-pack) for `pack` flags.

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -79,9 +79,9 @@ JSON output (`--output json`) reports counts in `Data`: `NodesTotal`, `EdgesTota
 Pack a Flow project into a `.nupkg` for Orchestrator deployment.
 
 ```bash
-uip maestro flow pack <ProjectDir> <OutputDir>
-uip maestro flow pack <ProjectDir> <OutputDir> --version 2.0.0
-uip maestro flow pack <ProjectDir> <OutputDir> --output json
+uip maestro flow pack <project-path> <OutputDir>
+uip maestro flow pack <project-path> <OutputDir> --version 2.0.0
+uip maestro flow pack <project-path> <OutputDir> --output json
 ```
 
 Requires `content/package-descriptor.json` and `content/operate.json` in the project. Output: `<Name>.flow.Flow.<version>.nupkg`.

--- a/skills/uipath-solution/references/operate/solution-overview.md
+++ b/skills/uipath-solution/references/operate/solution-overview.md
@@ -76,8 +76,8 @@ uip solution
   ├── pack <solution> <output>            Pack into a deployable .zip package
   ├── publish <package>                   Upload packed solution to UiPath
   ├── project
-  │     ├── add <projectPath> [solutionFile]    Register an existing subfolder in .uipx
-  │     ├── remove <projectPath> [solutionFile] Unregister a project from .uipx
+  │     ├── add <project-path> [solutionFile]   Register an existing subfolder in .uipx
+  │     ├── remove <project-path> [solutionFile] Unregister a project from .uipx
   │     ├── import --source <path>              Copy external project into solution and register
   │     └── list                                List projects registered in the local .uipx (no backend call)
   ├── resource


### PR DESCRIPTION
## Summary
- update affected skill command references from `projectPath` / `ProjectDir` style placeholders to `project-path`
- keep skills docs in sync with the CLI argument-name cleanup

## Validation
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh`
- stale placeholder search: `rg -n "<projectPath>|<ProjectDir>|<projectDirectory>|\[projectPath\]|\[ProjectDir\]|\[projectDirectory\]" skills tests commands agents README.md CLAUDE.md`

## Related
- CLI PR: https://github.com/UiPath/cli/pull/2184