### PR TITLE
docs(uipath-data-fabric): cover choice-set + relationship fields + CS…

### DIFF
--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -16,12 +16,13 @@ All operations go through `uip df <subject> <verb> --output json`.
 
 ## When to Use
 
-- Creating or modifying entity schemas (add fields, update metadata)
+- Creating or modifying entity schemas (add fields of any supported type, update metadata)
 - Reading, inserting, updating, or deleting records
 - Filtering records with complex predicates
 - Computing aggregate metrics for dashboards / KPIs (counts, sums, averages, group-by) — see [references/records-query.md](references/records-query.md#aggregates-server-side)
 - Importing bulk data from CSV files
 - Uploading or downloading file attachments on records
+- Browsing choice sets (`choice-sets list` / `get`) — choice sets are read-only resources from the CLI
 
 ## When NOT to Use — Hand Off to Another Skill
 
@@ -49,6 +50,7 @@ Respond that the operation is not supported. Do not try to work around it.
 | Change a field's data type | Not supported; type is fixed at creation |
 | Create a federated entity | Not supported via CLI or UiPath portal |
 | Write records to a federated entity | Federated entities are read-only |
+| Create / update / delete a choice set | Choice sets are authored in the Data Fabric web UI; the CLI exposes only `choice-sets list` / `choice-sets get` for browsing |
 
 ---
 
@@ -66,7 +68,7 @@ Respond that the operation is not supported. Do not try to work around it.
 
 6. **File fields are separate from record data.** Use `files upload`/`download`, not `records insert`. Field must be type `FILE`.
 
-7. **CSV headers must match exact field names** (case-sensitive). Use `entities get` to discover field names before importing.
+7. **CSV `records import` is Basic-types only.** Headers must match field names exactly (case-sensitive); `CHOICE_SET_*` / `RELATIONSHIP` / `FILE` / `AUTO_NUMBER` columns are silently dropped. For complex fields, use `records insert --file <json>` — see [`references/bulk-import.md`](references/bulk-import.md).
 
 8. **Never create duplicate entities.** Always `entities list` first; reuse if it already exists.
 
@@ -75,6 +77,12 @@ Respond that the operation is not supported. Do not try to work around it.
 10. **Never attempt entity delete.** No command exists. Respond: *"Deleting entities is not supported via the CLI."*
 
 11. **Never attempt field delete.** Do not pass `removeFields` in `entities update`. Respond: *"Removing fields is not supported via the CLI."*
+
+12. **Complex field types need extra config and lookups, just like `DECIMAL` needs `decimalPrecision`.** `CHOICE_SET_SINGLE` / `CHOICE_SET_MULTIPLE` require `choiceSetId` (from `choice-sets list`); `RELATIONSHIP` requires `referenceEntityName` (target's technical `Name`) + `referenceFieldName` (usually `Id`), and the target entity must exist first. Full shape in [`references/entity-schema.md`](references/entity-schema.md).
+
+13. **`choice-sets` is read-only.** CLI has only `list` / `get` — author choice sets in the Data Fabric web UI. If a needed choice set is missing, stop and ask; do not fall back to `STRING`.
+
+14. **Choice / relationship record values use lookup tokens, not labels.** Choice value → integer `NumberId` (single) or array of `NumberId`s (multi), from `choice-sets get`. Relationship value → target record's UUID `Id` regardless of `referenceFieldName`. Filter / `groupBy` use the same tokens; `CHOICE_SET_MULTIPLE` filtering has special operator semantics — see [`references/records-query.md`](references/records-query.md#filtering-on-choice-set-fields).
 
 ---
 
@@ -115,6 +123,8 @@ uip df records query <entity-id> \
   --output json
 ```
 
+For `CHOICE_SET_SINGLE` / `CHOICE_SET_MULTIPLE` / `RELATIONSHIP` field shapes and value formats, see [`references/entity-schema.md`](references/entity-schema.md#supported-field-types) and [`references/records-query.md`](references/records-query.md#filtering-on-choice-set-fields).
+
 ---
 
 ## Task Navigation
@@ -123,21 +133,23 @@ uip df records query <entity-id> \
 |------|----------------|
 | Explore what entities exist | `entities list` → `entities get <id>` |
 | Explore only native entities | `entities list --native-only` |
-| Create a new entity | `entities create <name> --body '{"fields":[{"fieldName":"Title","type":"STRING"}]}'` |
+| Browse / inspect choice sets (read-only) | `choice-sets list`, `choice-sets get <choice-set-id>` |
+| Create a new entity | `entities create <name> --body '{"fields":[{"fieldName":"Title","type":"STRING"}]}'` — for complex field types (`CHOICE_SET_*`, `RELATIONSHIP`) and their required extras, see [`references/entity-schema.md`](references/entity-schema.md#supported-field-types) |
 | Update entity / add fields | `entities update <id> --body '{"addFields":[{"fieldName":"NewField","type":"STRING"}]}'` |
 | Update existing field metadata | `entities update <id> --body '{"updateFields":[{"id":"<field-uuid>","displayName":"New Label","isRequired":true}]}'` — `id` is the field UUID from `entities get Fields[].ID` |
 | Update entity metadata | `entities update <id> --body '{"displayName":"New Name","description":"desc"}'` |
 | Read records (first page) | `records list <entity-id> --limit 50` |
 | Read records (next page) | `records list <entity-id> --cursor <NextCursor>` |
 | Get one record | `records get <entity-id> <record-id>` |
-| Insert one record | `records insert <entity-id> --body '{...}'` (or `--file`) |
+| Insert one record | `records insert <entity-id> --body '{...}'` (or `--file`). Choice / relationship value formats: see [`references/records-query.md`](references/records-query.md#writing-choice-set-and-relationship-values) |
 | Batch insert | `records insert <entity-id> --body '[{...},{...}]'` |
 | Update one record | `records update <entity-id> --body '{"Id":"<record-id>","field":"val"}'` |
 | Batch update | `records update <entity-id> --body '[{"Id":"<id1>","field":"val"},{"Id":"<id2>","field":"val"}]'` |
 | Delete records | `records delete <entity-id> <id1> <id2>` |
-| Filter/search records | `records query <entity-id> --body '{...}'` |
+| Filter/search records | `records query <entity-id> --body '{...}'`. Choice / relationship filter operators: see [`references/records-query.md`](references/records-query.md#filtering-on-choice-set-fields) |
 | Aggregate / group-by metrics | `records query <entity-id> --body '{"aggregates":[{"function":"COUNT","field":"Id","alias":"total"}],"groupBy":["FieldName"]}'` |
-| Bulk import from CSV | `records import <entity-id> --file data.csv` |
+| Bulk import from CSV (Basic field types only — `CHOICE_SET_*`, `RELATIONSHIP`, `FILE`, `AUTO_NUMBER` are silently dropped) | `records import <entity-id> --file data.csv` |
+| Bulk seed records that include complex fields | `records insert <entity-id> --file records.json` with a JSON array body |
 | Upload file to record | `files upload <entity-id> <record-id> <field-name> --file path` |
 | Download file | `files download <entity-id> <record-id> <field-name> --destination path` |
 | Delete file | `files delete <entity-id> <record-id> <field-name>` |
@@ -146,7 +158,7 @@ uip df records query <entity-id> \
 
 ## Field Types
 
-Pass the exact `EntityFieldDataType` string — the CLI is case-sensitive. Common types: `STRING`, `INTEGER`, `DECIMAL`, `BOOLEAN`, `DATE`, `DATETIME`, `UUID`. For the full type table with SQL backing types, see [`references/entity-schema.md`](references/entity-schema.md).
+Pass the exact `EntityFieldDataType` string — the CLI is case-sensitive. Common types: `STRING`, `INTEGER`, `DECIMAL`, `BOOLEAN`, `DATE`, `DATETIME`, `UUID`, `FILE`. Complex types that require extra config: `CHOICE_SET_SINGLE` / `CHOICE_SET_MULTIPLE` (need `choiceSetId`), `RELATIONSHIP` (needs `referenceEntityName` + `referenceFieldName`), `AUTO_NUMBER`. Full table with SQL backing types, required extras, and value semantics in [`references/entity-schema.md`](references/entity-schema.md).
 
 ### Advanced Field Constraints
 
@@ -213,13 +225,17 @@ Pass via `--body` or `--file`. Use `--limit`, `--cursor`, and `--offset` CLI fla
 | `Each field must include a 'fieldName' string` | Invalid field in `entities create` | Use `{"fieldName":"myfield"}` not `{"name":"myfield"}` |
 | `Entity name resolution failed` | Query/import with bad ID | Verify entity exists with `entities list` |
 | Import errors in CSV | Header mismatch | Run `entities get` and check exact field names (case-sensitive) |
+| `records import` succeeded but choice / relationship / file column is `null` on every row | `records import` silently drops complex field types (Basic only) | Re-seed via `records insert` with a JSON body — see [`references/bulk-import.md`](references/bulk-import.md) |
 | Write to federated entity | Entity is read-only | Use `--native-only`; federated entities cannot be written to |
+| Missing `choiceSetId` / `referenceEntityName` / `referenceFieldName` on a complex field | Required extras omitted on field definition | See [`references/entity-schema.md`](references/entity-schema.md) for the required keys per type |
+| Choice / relationship value rejected on insert / update / query | Passed a display label, UUID for choice, non-UUID for relationship, or wrong operator form for `CHOICE_SET_MULTIPLE` | See [`references/records-query.md`](references/records-query.md#writing-choice-set-and-relationship-values) for the value form per type |
 
 ---
 
 ## References
 
-- `references/entity-schema.md` — Field definitions, supported types, schema update patterns
-- `references/records-query.md` — Query filter syntax, pagination, sorting examples
+- `references/entity-schema.md` — Field definitions, supported types, schema update patterns, choice-set + relationship field shapes
+- `references/choice-sets.md` — Browse choice sets, look up `NumberId`s, add CHOICE_SET fields to entities, write choice values on records
+- `references/records-query.md` — Query filter syntax, pagination, sorting, choice/relationship semantics on read & write
 - `references/file-attachments.md` — File field upload/download/delete file
-- `references/bulk-import.md` — CSV format requirements and bulk import patterns
+- `references/bulk-import.md` — CSV format requirements and the Basic-fields-only limitation (complex types are silently dropped — use `records insert` with a JSON body instead)

--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -16,13 +16,12 @@ All operations go through `uip df <subject> <verb> --output json`.
 
 ## When to Use
 
-- Creating or modifying entity schemas (add fields of any supported type, update metadata)
+- Creating or modifying entity schemas (add fields, update metadata)
 - Reading, inserting, updating, or deleting records
 - Filtering records with complex predicates
 - Computing aggregate metrics for dashboards / KPIs (counts, sums, averages, group-by) — see [references/records-query.md](references/records-query.md#aggregates-server-side)
 - Importing bulk data from CSV files
 - Uploading or downloading file attachments on records
-- Browsing choice sets (`choice-sets list` / `get`) — choice sets are read-only resources from the CLI
 
 ## When NOT to Use — Hand Off to Another Skill
 
@@ -68,7 +67,7 @@ Respond that the operation is not supported. Do not try to work around it.
 
 6. **File fields are separate from record data.** Use `files upload`/`download`, not `records insert`. Field must be type `FILE`.
 
-7. **CSV `records import` is Basic-types only.** Headers must match field names exactly (case-sensitive); `CHOICE_SET_*` / `RELATIONSHIP` / `FILE` / `AUTO_NUMBER` columns are silently dropped. For complex fields, use `records insert --file <json>` — see [`references/bulk-import.md`](references/bulk-import.md).
+7. **CSV headers must match exact field names** (case-sensitive). Use `entities get` to discover field names before importing.
 
 8. **Never create duplicate entities.** Always `entities list` first; reuse if it already exists.
 
@@ -83,6 +82,8 @@ Respond that the operation is not supported. Do not try to work around it.
 13. **`choice-sets` is read-only.** CLI has only `list` / `get` — author choice sets in the Data Fabric web UI. If a needed choice set is missing, stop and ask; do not fall back to `STRING`.
 
 14. **Choice / relationship record values use lookup tokens, not labels.** Choice value → integer `NumberId` (single) or array of `NumberId`s (multi), from `choice-sets get`. Relationship value → target record's UUID `Id` regardless of `referenceFieldName`. Filter / `groupBy` use the same tokens; `CHOICE_SET_MULTIPLE` filtering has special operator semantics — see [`references/records-query.md`](references/records-query.md#filtering-on-choice-set-fields).
+
+15. **Answer with `records query`, not from memory.** Counts, sums, filters, lookups — issue a fresh `records query` (or `records list`) and use the server's response. Do not reuse cached insert responses, IDs you generated earlier, or values from previous tool results. Exception: the `Id` returned by the same `records insert` you just made.
 
 ---
 
@@ -123,7 +124,7 @@ uip df records query <entity-id> \
   --output json
 ```
 
-For `CHOICE_SET_SINGLE` / `CHOICE_SET_MULTIPLE` / `RELATIONSHIP` field shapes and value formats, see [`references/entity-schema.md`](references/entity-schema.md#supported-field-types) and [`references/records-query.md`](references/records-query.md#filtering-on-choice-set-fields).
+For Complex types  field shapes and value formats, see [`references/entity-schema.md`](references/entity-schema.md#supported-field-types) and [`references/records-query.md`](references/records-query.md#filtering-on-choice-set-fields).
 
 ---
 
@@ -227,8 +228,6 @@ Pass via `--body` or `--file`. Use `--limit`, `--cursor`, and `--offset` CLI fla
 | Import errors in CSV | Header mismatch | Run `entities get` and check exact field names (case-sensitive) |
 | `records import` succeeded but choice / relationship / file column is `null` on every row | `records import` silently drops complex field types (Basic only) | Re-seed via `records insert` with a JSON body — see [`references/bulk-import.md`](references/bulk-import.md) |
 | Write to federated entity | Entity is read-only | Use `--native-only`; federated entities cannot be written to |
-| Missing `choiceSetId` / `referenceEntityName` / `referenceFieldName` on a complex field | Required extras omitted on field definition | See [`references/entity-schema.md`](references/entity-schema.md) for the required keys per type |
-| Choice / relationship value rejected on insert / update / query | Passed a display label, UUID for choice, non-UUID for relationship, or wrong operator form for `CHOICE_SET_MULTIPLE` | See [`references/records-query.md`](references/records-query.md#writing-choice-set-and-relationship-values) for the value form per type |
 
 ---
 

--- a/skills/uipath-data-fabric/references/bulk-import.md
+++ b/skills/uipath-data-fabric/references/bulk-import.md
@@ -31,7 +31,9 @@ For an entity with fields: `Name` (STRING), `Score` (INTEGER), `Active` (BOOLEAN
 
 ### Complex Field Types Are Silently Dropped
 
-`records import` only processes Basic types (`STRING`, `INTEGER`, `DECIMAL`, `BOOLEAN`, `DATE`, `DATETIME`, `MULTILINE_TEXT`, `UUID`). Columns for `CHOICE_SET_*`, `RELATIONSHIP`, `FILE`, and `AUTO_NUMBER` are accepted in the header but the row values are discarded — no error, nothing in `ErrorFileLink`, just `null` on every imported row (or row failure if the field is `isRequired` without a `defaultValue`).
+**Complex field types** in Data Fabric are the ones that need extra config or lookup tokens beyond the value itself: `CHOICE_SET_SINGLE`, `CHOICE_SET_MULTIPLE`, `RELATIONSHIP`, `FILE`, and `AUTO_NUMBER`. Everything else is a Basic type.
+
+`records import` only processes Basic types (`STRING`, `INTEGER`, `DECIMAL`, `BOOLEAN`, `DATE`, `DATETIME`, `MULTILINE_TEXT`, `UUID`). Columns for the complex types listed above are accepted in the header but the row values are discarded — no error, nothing in `ErrorFileLink`, just `null` on every imported row (or row failure if the field is `isRequired` without a `defaultValue`).
 
 For entities with any complex field, use `records insert --file <json>` instead — the insert endpoint handles all types. See [`records-query.md`](records-query.md#writing-choice-set-and-relationship-values) for the value form.
 

--- a/skills/uipath-data-fabric/references/bulk-import.md
+++ b/skills/uipath-data-fabric/references/bulk-import.md
@@ -29,6 +29,12 @@ Charlie,74,false,2024-03-05
 
 For an entity with fields: `Name` (STRING), `Score` (INTEGER), `Active` (BOOLEAN), `CreatedDate` (DATE).
 
+### Complex Field Types Are Silently Dropped
+
+`records import` only processes Basic types (`STRING`, `INTEGER`, `DECIMAL`, `BOOLEAN`, `DATE`, `DATETIME`, `MULTILINE_TEXT`, `UUID`). Columns for `CHOICE_SET_*`, `RELATIONSHIP`, `FILE`, and `AUTO_NUMBER` are accepted in the header but the row values are discarded — no error, nothing in `ErrorFileLink`, just `null` on every imported row (or row failure if the field is `isRequired` without a `defaultValue`).
+
+For entities with any complex field, use `records insert --file <json>` instead — the insert endpoint handles all types. See [`records-query.md`](records-query.md#writing-choice-set-and-relationship-values) for the value form.
+
 ## Full Workflow
 
 ```bash

--- a/skills/uipath-data-fabric/references/choice-sets.md
+++ b/skills/uipath-data-fabric/references/choice-sets.md
@@ -1,0 +1,62 @@
+# Choice Sets Reference
+
+Reusable picklists that back `CHOICE_SET_SINGLE` and `CHOICE_SET_MULTIPLE` entity fields. **CLI is read-only — `list` and `get` only**; author / edit / delete in the Data Fabric web UI. If a needed choice set doesn't exist, stop and ask — do not fall back to `STRING`.
+
+## Commands
+
+| Command | Use |
+|---------|-----|
+| `uip df choice-sets list --output json` | Find a choice set's `ID` (pass as `choiceSetId` on the field) |
+| `uip df choice-sets get <choice-set-id> --output json` | Get each value's `NumberId` (pass as record value); `--limit` / `--cursor` / `--offset` for pagination |
+
+## Response shapes
+
+```json
+// list
+{ "Data": [{ "ID": "<choice-set-id>", "Name": "ExpenseTypes", "DisplayName": "Expense Types", ... }] }
+
+// get
+{ "Data": { "Values": [{ "Id": "<value-uuid>", "Name": "travel", "DisplayName": "Travel", "NumberId": 1 }, ...] } }
+```
+
+- `ID` from `list` → `choiceSetId` on the field definition
+- `NumberId` from `get` → record value (integer for `_SINGLE`, integer array for `_MULTIPLE`)
+- `Name` / `DisplayName` → human display only; never write these on a record
+
+## Add a choice-set field to an entity
+
+```bash
+# 1. Discover ID (and confirm values)
+uip df choice-sets list --output json
+uip df choice-sets get <choice-set-id> --output json
+
+# 2a. New entity
+uip df entities create "Expense" --body '{
+  "fields":[
+    {"fieldName":"amount",   "type":"DECIMAL", "isRequired": true},
+    {"fieldName":"category", "type":"CHOICE_SET_SINGLE",   "choiceSetId":"<choice-set-id>"},
+    {"fieldName":"tags",     "type":"CHOICE_SET_MULTIPLE", "choiceSetId":"<choice-set-id>"}
+  ]
+}' --output json
+
+# 2b. Existing entity
+uip df entities update <entity-id> --body '{
+  "addFields":[{"fieldName":"category","type":"CHOICE_SET_SINGLE","choiceSetId":"<choice-set-id>"}]
+}' --output json
+```
+
+## Write / read / filter record values
+
+Record value is the integer `NumberId` (single) or integer array (multi). Records read back in the same shape — resolve to display labels client-side via `choice-sets get` if needed.
+
+```bash
+uip df records insert <entity-id> --body '{"amount":250,"category":1,"tags":[1,2]}' --output json
+```
+
+Passing a display label (`"category":"Travel"`) is rejected. Filter operator semantics — especially `CHOICE_SET_MULTIPLE` (`contains` vs `=`) — are in [`records-query.md`](records-query.md#filtering-on-choice-set-fields).
+
+## Decision: is this field a choice set?
+
+- Finite, reused list of named options → choice set. Single value → `_SINGLE`; multiple → `_MULTIPLE`.
+- Link to a *row* in another entity → `RELATIONSHIP` (see [`entity-schema.md`](entity-schema.md#relationship-fields)), not a choice set.
+- No matching choice set exists → stop and ask the user to author it in the web UI; do not fall back to `STRING`.

--- a/skills/uipath-data-fabric/references/entity-schema.md
+++ b/skills/uipath-data-fabric/references/entity-schema.md
@@ -122,23 +122,54 @@ uip df entities update <entity-id> \
 ### Choice Set Fields
 
 ```json
-{ "fieldName": "Status", "type": "CHOICE_SET_SINGLE", "choiceSetId": "<choice-set-id>" }
+{ "fieldName": "Status", "type": "CHOICE_SET_SINGLE",   "choiceSetId": "<choice-set-id>" }
+{ "fieldName": "Tags",   "type": "CHOICE_SET_MULTIPLE", "choiceSetId": "<choice-set-id>" }
 ```
 
-`CHOICE_SET_SINGLE` and `CHOICE_SET_MULTIPLE` both require `choiceSetId`.
+`choiceSetId` is the UUID from `uip df choice-sets list`. Choice sets are read-only via the CLI — if a needed one doesn't exist, stop and ask the user to author it in the web UI (do not fall back to `STRING`). Record value is the integer `NumberId` (single) or integer array (multi), from `choice-sets get`. Filter semantics — including the `CHOICE_SET_MULTIPLE` `=` vs `contains` distinction — are in [records-query.md](records-query.md#filtering-on-choice-set-fields). Full workflow in [`choice-sets.md`](choice-sets.md).
 
 ### Relationship Fields
 
 ```json
-{
-  "fieldName": "CustomerId",
-  "type": "RELATIONSHIP",
-  "referenceEntityName": "<target-entity-name>",
-  "referenceFieldName": "<field-name-in-target-entity>"
-}
+{ "fieldName": "customerId", "type": "RELATIONSHIP", "referenceEntityName": "Customer", "referenceFieldName": "Id" }
 ```
 
-`RELATIONSHIP` requires `referenceEntityName` (the technical name of the target entity) and `referenceFieldName` (the field in the target entity to link on). Use `entities get <id>` to verify exact entity and field names.
+- `referenceEntityName` — target entity's technical `Name` (not `DisplayName` / `ID`). Target must exist and be native (no federated targets). Verify with `entities list --native-only`.
+- `referenceFieldName` — join field on read; usually `Id`, but any unique field works.
+- The field lives on the *child* (many-side) and points at the *parent* (one-side) — no reverse field on the parent.
+- Record value is **always the target record's UUID `Id`**, regardless of `referenceFieldName` (which configures join-on-read, not the stored value). If the user supplies an email / label, resolve it first via `records query` on the target entity.
+
+```bash
+# Resolve email → Id, then insert
+uip df records query <customer-entity-id> \
+  --body '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"Email","operator":"=","value":"alice@example.com"}]},"selectedFields":["Id"]}' \
+  --output json
+uip df records insert <child-entity-id> --body '{"customerId":"<resolved-uuid>","amount":250}' --output json
+```
+
+### Combined Example — mixing scalar, choice-set, and relationship fields
+
+Complex types accept the same standard field options as scalars — `isRequired`, `isUnique`, `displayName`, `description`, `defaultValue`, `isRbacEnabled`, `isEncrypted`, and the type-specific constraints (`lengthLimit`, `maxValue`/`minValue`, `decimalPrecision`). The only extras unique to complex types are `choiceSetId` (for `CHOICE_SET_*`) and `referenceEntityName` + `referenceFieldName` (for `RELATIONSHIP`).
+
+```bash
+# Prereqs: target entity exists; choice set exists (look up ID)
+uip df entities create "Expense" --body '{
+  "displayName": "Expense",
+  "description": "Reimbursable expenses with category, tags, and submitter",
+  "fields": [
+    {"fieldName":"invoiceNumber", "type":"STRING",  "isRequired": true, "isUnique": true, "lengthLimit": 50,
+     "displayName":"Invoice Number"},
+    {"fieldName":"amount",        "type":"DECIMAL", "isRequired": true, "decimalPrecision": 2, "minValue": 0,
+     "displayName":"Amount (USD)"},
+    {"fieldName":"notes",         "type":"MULTILINE_TEXT", "lengthLimit": 2000},
+    {"fieldName":"category",      "type":"CHOICE_SET_SINGLE",   "choiceSetId":"<choice-set-id>",
+     "isRequired": true, "displayName":"Category"},
+    {"fieldName":"tags",          "type":"CHOICE_SET_MULTIPLE", "choiceSetId":"<choice-set-id>"},
+    {"fieldName":"customerId",    "type":"RELATIONSHIP", "referenceEntityName":"Customer", "referenceFieldName":"Id",
+     "isRequired": true, "displayName":"Customer"}
+  ]
+}' --output json
+```
 
 ## Not Supported
 
@@ -233,9 +264,13 @@ uip df entities get <entity-id> --output json
 | Field | Description |
 |-------|-------------|
 | `Fields[].FieldName` | Exact field name for use in record bodies and CSV headers |
-| `Fields[].Type` | Data type (e.g. `STRING`, `INTEGER`) |
+| `Fields[].Type` | Data type (e.g. `STRING`, `INTEGER`, `CHOICE_SET_SINGLE`, `RELATIONSHIP`) |
 | `Fields[].ID` | Field UUID — required for `updateFields` in `entities update` |
 | `Fields[].IsRequired` | Whether the field must have a value on insert |
+
+**`entities get` does NOT echo back `choiceSetId` / `referenceEntityName` / `referenceFieldName`** — only the basic field metadata. To recover: for `CHOICE_SET_*`, match by `Name` via `choice-sets list`; for `RELATIONSHIP`, ask the user or fetch one record and identify which parent entity the UUID lives in.
+
+Before writing records, identify complex fields by `Type` and resolve lookups: `CHOICE_SET_*` → `choice-sets get <choice-set-id>` for `NumberId`s; `RELATIONSHIP` → `records query` on the referenced entity for target UUIDs.
 
 **Example — discover an entity before writing records:**
 ```bash

--- a/skills/uipath-data-fabric/references/records-query.md
+++ b/skills/uipath-data-fabric/references/records-query.md
@@ -33,6 +33,17 @@ uip df records list <entity-id> --limit 100 --cursor "<NextCursor>" --output jso
 uip df records list <entity-id> --limit 100 --offset 250 --output json
 ```
 
+## Always Query the Server for Answers
+
+Issue a fresh `records query` (or `records list`) — don't filter cached transcript data. Records mutate between turns, and the CLI call is the audit trail.
+
+Common shapes:
+
+- **By relationship:** `--body '{"filterGroup":{"queryFilters":[{"fieldName":"<rel-field>","operator":"=","value":"<target-uuid>"}]}}'`
+- **Resolve unique key before write:** `--body '{"filterGroup":{"queryFilters":[{"fieldName":"Email","operator":"=","value":"alice@example.com"}]},"selectedFields":["Id"]}'`
+- **Set membership over UUIDs:** `--body '{"filterGroup":{"queryFilters":[{"fieldName":"<rel-field>","operator":"in","valueList":["<u1>","<u2>","<u3>"]}]}}'`
+- **Counts / sums / groupings:** `aggregates` + `groupBy` — see [Aggregates (server-side)](#aggregates-server-side).
+
 ## Filtered Query
 
 ```bash

--- a/skills/uipath-data-fabric/references/records-query.md
+++ b/skills/uipath-data-fabric/references/records-query.md
@@ -88,6 +88,8 @@ uip df records query <entity-id> \
 
 > `in` and `not in` use `valueList` (string array), **not** `value`. Using `value` for these operators will be ignored.
 
+> `CHOICE_SET_MULTIPLE` is a special case — `=` means whole-array set equality, `contains` is membership, others are unsupported. See [Filtering on Choice-Set Fields](#filtering-on-choice-set-fields) below.
+
 ### logicalOperator
 
 - `0` = AND (all filters must match)
@@ -116,6 +118,55 @@ uip df records query <entity-id> \
     ]
   }
 }
+```
+
+### Filtering on Choice-Set Fields
+
+Filter on the integer `NumberId` (as a string in `value` / `valueList`), never the display label. Resolve via `choice-sets get <choice-set-id>` first.
+
+```bash
+# CHOICE_SET_SINGLE — category == "travel" (NumberId 1)
+uip df records query <entity-id> --body \
+  '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"category","operator":"=","value":"1"}]}}' \
+  --output json
+```
+
+**`CHOICE_SET_MULTIPLE`** is stored as a JSON-encoded integer array (e.g. `[1,3]`) and has special operator semantics:
+
+| Operator | Value form | Meaning |
+|----------|-----------|---------|
+| `contains` / `not contains` | bare NumberId string (`"1"`) | Membership — the usual case |
+| `=` / `!=` | JSON-array string (`"[1,3]"`) | Whole-set equality, order-insensitive |
+| anything else | — | Not supported |
+
+```bash
+# Membership — records tagged with NumberId 1
+uip df records query <entity-id> --body \
+  '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"tags","operator":"contains","value":"1"}]}}' \
+  --output json
+
+# Set equality — tags == exactly {1,3}
+uip df records query <entity-id> --body \
+  '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"tags","operator":"=","value":"[1,3]"}]}}' \
+  --output json
+```
+
+Failure modes: `=` with a bare value (`"1"`) → HTTP 400. `contains` with brackets (`"[1]"`) → HTTP 400. For per-value reporting, run `contains` per `NumberId`; for distribution of exact combinations, use `groupBy: ["tags"]` with `COUNT`.
+
+### Filtering on Relationship Fields
+
+Filter on the target record's UUID `Id`, regardless of `referenceFieldName`. If the user describes the parent by another field (email, name, etc.), resolve the UUID first on the parent entity, then filter the child.
+
+```bash
+# Direct
+uip df records query <child-entity-id> --body \
+  '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"customerId","operator":"=","value":"<parent-uuid>"}]}}' \
+  --output json
+
+# Resolve-first: email → Id on parent, then filter child
+uip df records query <parent-entity-id> --body \
+  '{"filterGroup":{"logicalOperator":0,"queryFilters":[{"fieldName":"Email","operator":"=","value":"alice@example.com"}]},"selectedFields":["Id"]}' \
+  --output json
 ```
 
 ## Aggregates (server-side)
@@ -223,6 +274,21 @@ Single insert response: `{ Code: "RecordInserted", Data: { ...record with Id } }
 
 Batch insert response: `{ Code: "RecordsBatchInserted", Data: { SuccessCount, FailureCount, SuccessRecords, FailureRecords } }`
 
+### Writing Choice-Set and Relationship Values
+
+| Field type | Value | Resolve via |
+|------------|-------|-------------|
+| `CHOICE_SET_SINGLE` | Integer `NumberId` | `choice-sets get <choice-set-id>` |
+| `CHOICE_SET_MULTIPLE` | Integer `NumberId` array | `choice-sets get <choice-set-id>` |
+| `RELATIONSHIP` | Target record's UUID `Id` (always, even if `referenceFieldName` ≠ `Id`) | `records query <target-entity-id>` on the unique field |
+
+```bash
+uip df records insert <entity-id> \
+  --body '{"amount":250,"category":1,"tags":[1,3],"customerId":"<target-uuid>"}' --output json
+```
+
+Display labels, choice-value UUIDs, and non-UUID relationship values are rejected — resolve first. Reads echo the same shape.
+
 ## Update Records
 
 The CLI routes by body shape: a JSON object (or 1-element array) calls the single-record endpoint; a JSON array with 2+ elements calls the batch endpoint. Both require `Id` in the body.
@@ -236,6 +302,8 @@ uip df records update <entity-id> \
   --body '[{"Id":"<id1>","Score":100},{"Id":"<id2>","Score":90}]' \
   --output json
 ```
+
+Choice / relationship fields use the same value form as insert — see [Writing Choice-Set and Relationship Values](#writing-choice-set-and-relationship-values).
 
 Single update response: `{ Code: "RecordUpdated", Data: { ...updated record } }`
 

--- a/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py
+++ b/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py
@@ -121,8 +121,17 @@ def resolve_entity_ids(args) -> list[str]:
         print(f"SKIP: could not parse {report_path}: {e}")
         return ids
 
-    # Collect all entity IDs from the report
-    for key in ("entity_id", "tenant_entity_id", "folder_entity_id"):
+    # Collect all entity IDs from the report.
+    # Order matters when relationships exist: child entities must be deleted
+    # before their parents to avoid FK constraint errors. List child-side keys
+    # (e.g. child_entity_id) before parent-side keys (e.g. parent_entity_id).
+    for key in (
+        "entity_id",
+        "tenant_entity_id",
+        "folder_entity_id",
+        "child_entity_id",
+        "parent_entity_id",
+    ):
         val = report.get(key)
         if val and val not in ids:
             ids.append(val)

--- a/tests/tasks/uipath-data-fabric/e2e_expense_tracker.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_expense_tracker.yaml
@@ -25,13 +25,11 @@ sandbox:
 initial_prompt: |
   Finance needs an expense tracker in UiPath Data Fabric where each Expense is
   submitted by an Employee, has a category from a fixed picklist (choice set),
-  and can carry one or more tags from a second picklist. The Expense entity
-  combines plain types (`DECIMAL`, `MULTILINE_TEXT`) with complex types
-  (`RELATIONSHIP` to Employee, `CHOICE_SET_SINGLE` for category, optional
-  `CHOICE_SET_MULTIPLE` for tags) — treat them the same way you'd treat any
-  other type, just with the extra config + lookup tokens they require.
+  and can carry one or more tags from a second picklist. Use these field types:
+  `DECIMAL` (amount), `MULTILINE_TEXT` (description), `RELATIONSHIP` (submitter
+  → Employee), `CHOICE_SET_SINGLE` (category), and optionally
+  `CHOICE_SET_MULTIPLE` (tags).
 
-  Load the uipath-data-fabric skill before starting.
   Use --output json on every uip df command.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation.

--- a/tests/tasks/uipath-data-fabric/e2e_expense_tracker.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_expense_tracker.yaml
@@ -1,0 +1,306 @@
+task_id: skill-datafabric-e2e-expense-tracker
+description: >
+  E2E scenario: agent builds an expense tracker in Data Fabric — a parent
+  Employee entity and a child Expense entity whose fields include the complex
+  types (RELATIONSHIP to Employee, CHOICE_SET_SINGLE for category, optional
+  CHOICE_SET_MULTIPLE for tags). Seeds 6 employees and 12 expenses, produces a
+  department summary using filterGroup queries on both the relationship and
+  choice fields, and confirms each field stores its expected value form
+  (UUID for relationship, integer for choice). Choice sets are authored only
+  in the web UI — if none exists in the tenant, the agent records the gap and
+  finishes the relationship workflow.
+tags: [uipath-data-fabric, e2e, expense-tracker, complex-fields]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 60
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Finance needs an expense tracker in UiPath Data Fabric where each Expense is
+  submitted by an Employee, has a category from a fixed picklist (choice set),
+  and can carry one or more tags from a second picklist. The Expense entity
+  combines plain types (`DECIMAL`, `MULTILINE_TEXT`) with complex types
+  (`RELATIONSHIP` to Employee, `CHOICE_SET_SINGLE` for category, optional
+  `CHOICE_SET_MULTIPLE` for tags) — treat them the same way you'd treat any
+  other type, just with the extra config + lookup tokens they require.
+
+  Load the uipath-data-fabric skill before starting.
+  Use --output json on every uip df command.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation.
+
+  Choice sets cannot be created via the CLI — they are authored in the Data
+  Fabric web UI. Discover what is already available before you commit to a
+  schema.
+
+  1. Login check (do not re-login):
+       uip df entities list --native-only --output json
+       uip df choice-sets list --output json
+
+  2. Pick a choice set to use as Expense.category. Strategy:
+       - If the list contains a choice set whose Name looks like a category
+         picklist (e.g. contains "Category", "Expense", or "Type") pick it.
+       - Otherwise pick the first choice set returned.
+       - If the list is empty, set `category_choice_set_id = null` and skip
+         the category field on Expense.
+     Capture the chosen ID as `category_choice_set_id` and call
+     `uip df choice-sets get <id>` to resolve each value's NumberId. Save the
+     full Name → NumberId map under `category_value_map` in report.json.
+
+  3. Optionally pick a second choice set for tags. Same strategy as step 2 —
+     prefer one whose Name suggests tags, fall back to the second-listed
+     choice set, otherwise null. Save as `tags_choice_set_id` (and its value
+     map as `tags_value_map`). If only one choice set exists, OR if you'd
+     rather reuse the category one, you may reuse `category_choice_set_id`
+     for tags — the same choice set can back multiple fields.
+
+  4. Create the PARENT entity "E2EEmployee<RUN_SUFFIX>" where <RUN_SUFFIX> is
+     a unique 6-character suffix using ONLY `[a-zA-Z0-9_]` (entity names
+     must start with a letter and contain only letters / digits / underscores;
+     3–100 chars total). Generate via Python `secrets.token_hex(3)` or similar.
+     Fields:
+       - Name       (STRING, isRequired: true)
+       - Email      (STRING, isUnique: true)
+       - Department (STRING, isRequired: true)
+     Save entity ID as `parent_entity_id` in report.json.
+
+  5. Create the CHILD entity "E2EExpense<SAME_SUFFIX>" with fields:
+       - amount      (DECIMAL, decimalPrecision 2, minValue 0, isRequired: true)
+       - submitter   (RELATIONSHIP — referenceEntityName equals parent's
+                      technical Name from step 4, referenceFieldName "Id",
+                      isRequired: true)
+       - description (MULTILINE_TEXT, lengthLimit 1000)
+       - if category_choice_set_id is not null:
+           category  (CHOICE_SET_SINGLE, choiceSetId = category_choice_set_id,
+                      isRequired: true)
+       - if tags_choice_set_id is not null:
+           tags      (CHOICE_SET_MULTIPLE, choiceSetId = tags_choice_set_id)
+     Save entity ID as `child_entity_id` in report.json.
+
+  6. Seed 6 employees across 2 departments (3 in "Engineering", 3 in "Sales")
+     via batch insert. Use realistic names + emails. Save the 6 returned UUIDs
+     under `employee_ids` (an array) in report.json.
+
+  7. Insert 12 expenses across the 6 employees (2 expenses per employee).
+       - Every expense's `submitter` MUST be an Employee UUID from
+         `employee_ids` — never an email, never a Name.
+       - If `category_choice_set_id` is set, every expense's `category` MUST
+         be a NumberId integer from `category_value_map` — never a display
+         label. Vary categories across expenses.
+       - If `tags_choice_set_id` is set, half of the expenses include `tags`
+         as a JSON array of 1–2 NumberId integers.
+       - amounts: spread between 25 and 1200.
+     Save the 12 returned expense UUIDs under `expense_ids`.
+
+  8. Business questions — answer with filterGroup queries:
+       a. Total expenses for one specific employee.
+          Query Expense where submitter == <one_employee_uuid>.
+          Save the count as `q_per_employee_count`.
+       b. If category_choice_set_id is set: count of expenses per category.
+          For each NumberId in `category_value_map`, query Expense where
+          category == "<NumberId-as-string>" and record the count under
+          `q_per_category` (object keyed by category Name).
+       c. Sum of amounts for the Engineering department's employees:
+          - First resolve the 3 Engineering employee UUIDs via a parent
+            query: filter Employee where Department == "Engineering",
+            selectedFields ["Id"]. Capture Records[].Id as
+            `engineering_employee_ids`.
+          - Then query Expense where submitter IN engineering_employee_ids
+            using operator `in` and `valueList` (array of UUID strings).
+            Sum the `amount` values of returned records and save as
+            `engineering_total_amount`.
+
+  9. Read ONE expense back via `records get` and confirm in report.json:
+       - "stored_submitter_is_uuid": true (the value matches the UUID
+         regex `^[0-9a-fA-F-]{8,}` and was NOT the submitter's email)
+       - if category was used:
+           "stored_category_is_integer": true
+       - if tags were used:
+           "stored_tags_is_integer_array": true
+
+  10. Write a final report.json with every captured field:
+        {
+          "category_choice_set_id": "<id-or-null>",
+          "category_value_map": { "<Name>": <NumberId>, ... } | null,
+          "tags_choice_set_id": "<id-or-null>",
+          "tags_value_map":     { "<Name>": <NumberId>, ... } | null,
+          "parent_entity_id": "<id>",
+          "child_entity_id":  "<id>",
+          "employee_ids": ["<id>", ... 6 ...],
+          "expense_ids":  ["<id>", ... 12 ...],
+          "q_per_employee_count": <int>,
+          "q_per_category": { "<Name>": <int>, ... } | null,
+          "engineering_employee_ids": ["<id>", "<id>", "<id>"],
+          "engineering_total_amount": <number>,
+          "stored_submitter_is_uuid": true,
+          "stored_category_is_integer": <bool|null>,
+          "stored_tags_is_integer_array": <bool|null>
+        }
+
+  Constraints:
+  - NEVER write a choice value as a display label, e.g. "category":"travel".
+    Use the integer NumberId. Multi-select tags use a JSON array of integers.
+  - NEVER write a relationship value as anything but the target record's
+    UUID Id — even though we could declare referenceFieldName: "Id", that
+    only configures join behavior on read, not the stored value shape.
+  - NEVER attempt to create / update / delete a choice set via the CLI.
+  - Do NOT delete any entity or record yourself — cleanup runs post-test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed choice sets to discover available picklists"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+choice-sets\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the parent Employee entity"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+create.*E2EEmployee'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the child Expense entity with a RELATIONSHIP field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+create(?=.*E2EExpense)(?=.*RELATIONSHIP)(?=.*referenceEntityName)(?=.*referenceFieldName)'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted employee records"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\"(Name|Email|Department)\"'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted expense records writing submitter as a UUID"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\"submitter\"\s*:\s*\"[0-9a-fA-F-]{8,}'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT write an email / non-UUID into the submitter relationship"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+(insert|update).*\"submitter\"\s*:\s*\"[^\"]*@'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent filtered expenses by the relationship (submitter UUID)"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*filterGroup)(?=.*\"fieldName\"\s*:\s*\"submitter\")'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent resolved Engineering employee UUIDs via parent query"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*filterGroup)(?=.*\"fieldName\"\s*:\s*\"Department\")'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used `in` operator with valueList for submitter (Engineering UUIDs)"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"submitter\")(?=.*\"operator\"\s*:\s*\"in\")(?=.*valueList)'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified record shape with records get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+get\s+'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT attempt to create / update / delete a choice set via the CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+choice-sets\s+(create|update|delete)'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT write a choice display label (string) into a choice field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+(insert|update).*\"category\"\s*:\s*\"[A-Za-z]'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json captured parent + child entity IDs and 6 employees + 12 expenses"
+    path: "report.json"
+    assertions:
+      - expression: "parent_entity_id"
+        operator: regex
+        expected: "^[0-9a-fA-F-]{8,}"
+      - expression: "child_entity_id"
+        operator: regex
+        expected: "^[0-9a-fA-F-]{8,}"
+      - expression: "length(employee_ids)"
+        operator: equals
+        expected: 6
+      - expression: "length(expense_ids)"
+        operator: equals
+        expected: 12
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Stored relationship value is a UUID (not a label / email)"
+    path: "report.json"
+    assertions:
+      - expression: "stored_submitter_is_uuid"
+        operator: equals
+        expected: true
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Engineering aggregation resolved 3 employee UUIDs and a numeric total"
+    path: "report.json"
+    assertions:
+      - expression: "length(engineering_employee_ids)"
+        operator: equals
+        expected: 3
+      - expression: "engineering_total_amount"
+        operator: gte
+        expected: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py"
+    timeout: 60

--- a/tests/tasks/uipath-data-fabric/integration_choice_relationship.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_choice_relationship.yaml
@@ -1,0 +1,256 @@
+task_id: skill-datafabric-integration-complex-fields
+description: >
+  Integration test: agent builds a two-entity schema with complex fields
+  (CHOICE_SET_SINGLE on a discovered choice set, RELATIONSHIP between parent
+  and child entities), inserts records writing the correct value tokens, and
+  filters by both fields. Verifies the value-form discipline (NumberId for
+  choice, target UUID for relationship) and the resolve-by-unique-key pattern
+  (Email → Id) end-to-end. Choice sets are authored only in the web UI — if
+  none exists in the tenant, the test records the gap and still completes the
+  relationship workflow.
+tags: [uipath-data-fabric, integration, complex-fields]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 60
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Before starting, load the uipath-data-fabric skill and follow its workflow.
+
+  Use --output json on every uip df command.
+
+  This test exercises two complex field types — `CHOICE_SET_SINGLE` and
+  `RELATIONSHIP` — end-to-end. They're regular fields in the type table that
+  happen to need lookup tokens for their values (a `NumberId` integer for
+  choice; the target record's UUID `Id` for relationship).
+
+  1. Check login: run `uip login status --output json`. Do NOT re-login.
+
+  2. List all choice sets in the tenant:
+       uip df choice-sets list --output json
+     Capture the list. Choice sets are authored in the Data Fabric web UI —
+     the CLI is read-only. If the list is empty, set
+     `choice_set_available = false` in your final report and proceed without
+     the choice-set field in step 5. If the list is non-empty, pick the
+     FIRST choice set returned and capture its ID + Name. Save that ID as
+     `chosen_choice_set_id`.
+
+  3. If a choice set was found in step 2, inspect its values:
+       uip df choice-sets get <chosen_choice_set_id> --output json
+     Capture the first value's NumberId and DisplayName. Save the NumberId as
+     `chosen_choice_number_id`.
+
+  4. Create the PARENT entity "IntegrationCustomer<RUN_ID>" where <RUN_ID> is
+     a unique 6-character suffix using ONLY `[a-zA-Z0-9_]` (to satisfy entity
+     name validation: must start with a letter, contain only letters / digits
+     / underscores, 3–100 chars). Use Python `secrets.token_hex(3)` or similar
+     to generate. Fields:
+       - Name  (STRING, isRequired: true)
+       - Email (STRING, isUnique: true)
+     Save the entity ID as `parent_entity_id` in report.json.
+
+  5. Create the CHILD entity "IntegrationOrder<SAME_RUN_ID>" with fields:
+       - amount     (DECIMAL, decimalPrecision 2, isRequired: true)
+       - customerId (RELATIONSHIP — referenceEntityName equal to the parent's
+                     technical Name from step 4, referenceFieldName "Id",
+                     isRequired: true)
+     If `choice_set_available` is true, ALSO add:
+       - status     (CHOICE_SET_SINGLE — choiceSetId = chosen_choice_set_id,
+                     isRequired: true)
+     Save the entity ID as `child_entity_id` in report.json.
+
+  6. Insert two parent records (Customer):
+       a. { "Name": "Alice Co",  "Email": "alice@integration.test" }
+       b. { "Name": "Bravo LLC", "Email": "bravo@integration.test" }
+     Save the two returned UUIDs as `parent_id_a` and `parent_id_b` in
+     report.json.
+
+  7. Resolve a parent UUID by Email (proves the "resolve before insert"
+     pattern for relationships): query the parent entity with a filterGroup
+     filtering on Email == "alice@integration.test" and capture
+     Records[0].Id. Confirm it matches `parent_id_a`.
+
+  8. Insert three child records (Order). The customerId value MUST be the
+     parent's UUID — never the Email, never the Name. If
+     `choice_set_available` is true, include `status` set to the resolved
+     NumberId integer from step 3.
+       a. { "amount": 100, "customerId": parent_id_a [, "status": chosen_choice_number_id] }
+       b. { "amount": 250, "customerId": parent_id_a [, "status": chosen_choice_number_id] }
+       c. { "amount":  50, "customerId": parent_id_b [, "status": chosen_choice_number_id] }
+     Save the three returned UUIDs as `child_id_1`, `child_id_2`, `child_id_3`.
+
+  9. Filter child records on the RELATIONSHIP field:
+       Query Order where customerId == parent_id_a.
+       Confirm exactly 2 records returned.
+
+  10. Read one of the child records back with records get and confirm:
+        - `customerId` is the parent's UUID (string)
+        - if choice set used, `status` is an integer (NumberId), not a string
+
+  11. If `choice_set_available` is true, filter child records on the
+      CHOICE_SET field:
+        Query Order where status == chosen_choice_number_id (pass the
+        NumberId as a string in the filter value).
+        Confirm all 3 records returned.
+
+  12. Save report.json with all captured IDs and observations:
+        {
+          "choice_set_available": <true|false>,
+          "chosen_choice_set_id": "<id-or-null>",
+          "chosen_choice_number_id": <int-or-null>,
+          "parent_entity_id": "<id>",
+          "child_entity_id": "<id>",
+          "parent_id_a": "<id>",
+          "parent_id_b": "<id>",
+          "child_id_1": "<id>",
+          "child_id_2": "<id>",
+          "child_id_3": "<id>",
+          "filter_by_relationship_count": <int>,
+          "filter_by_choice_count": <int-or-null>,
+          "stored_relationship_is_uuid": <bool>,
+          "stored_choice_is_integer": <bool-or-null>
+        }
+
+  Do NOT delete any entity or record manually — cleanup runs post-test.
+  Do NOT attempt to create / update / delete a choice set via the CLI.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent verified login status"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed choice sets with choice-sets list"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+choice-sets\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the parent entity"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+create.*IntegrationCustomer'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the child entity with a RELATIONSHIP field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+create(?=.*IntegrationOrder)(?=.*RELATIONSHIP)(?=.*referenceEntityName)(?=.*referenceFieldName)'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted parent records"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\"(Name|Email)\"'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted child records writing customerId as a UUID (not an email or name)"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\"customerId\"\s*:\s*\"[0-9a-fA-F-]{8,}'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT write an email / non-UUID into a relationship field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+(insert|update).*\"customerId\"\s*:\s*\"[^\"]*@'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent resolved a parent UUID via a filterGroup query on Email"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*filterGroup)(?=.*\"fieldName\"\s*:\s*\"Email\")'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent filtered child records by the RELATIONSHIP field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*filterGroup)(?=.*\"fieldName\"\s*:\s*\"customerId\")'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified record shape with records get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+records\s+get\s+'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT attempt to create / update / delete a choice set via the CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+choice-sets\s+(create|update|delete)'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "report.json captured parent + child entity IDs"
+    path: "report.json"
+    assertions:
+      - expression: "parent_entity_id"
+        operator: regex
+        expected: "^[0-9a-fA-F-]{8,}"
+      - expression: "child_entity_id"
+        operator: regex
+        expected: "^[0-9a-fA-F-]{8,}"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Relationship filter returned exactly 2 records for parent_id_a"
+    path: "report.json"
+    assertions:
+      - expression: "filter_by_relationship_count"
+        operator: equals
+        expected: 2
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Stored relationship value is a UUID (not a label / email)"
+    path: "report.json"
+    assertions:
+      - expression: "stored_relationship_is_uuid"
+        operator: equals
+        expected: true
+    weight: 2.5
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-data-fabric/_shared/cleanup_entities.py"
+    timeout: 60

--- a/tests/tasks/uipath-data-fabric/integration_choice_relationship.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_choice_relationship.yaml
@@ -1,13 +1,16 @@
 task_id: skill-datafabric-integration-complex-fields
 description: >
-  Integration test: agent builds a two-entity schema with complex fields
-  (CHOICE_SET_SINGLE on a discovered choice set, RELATIONSHIP between parent
-  and child entities), inserts records writing the correct value tokens, and
-  filters by both fields. Verifies the value-form discipline (NumberId for
-  choice, target UUID for relationship) and the resolve-by-unique-key pattern
-  (Email → Id) end-to-end. Choice sets are authored only in the web UI — if
-  none exists in the tenant, the test records the gap and still completes the
-  relationship workflow.
+  Integration test: agent builds a two-entity Customer/Order schema with a
+  CHOICE_SET_SINGLE status field (on a discovered choice set) and a
+  RELATIONSHIP from Order back to Customer, inserts records, filters by both
+  fields, and resolves a Customer by Email before writing the related Order.
+  Distinct from e2e_expense_tracker (which covers CHOICE_SET_MULTIPLE +
+  `in`-operator aggregation): this test exercises the resolve-by-unique-key
+  pattern (Email → Id) before a relational write, and uses a plainer
+  customer-style prompt so the two tasks together give breadth coverage
+  across prompt styles. Choice sets are authored only in the web UI — if
+  none exists in the tenant, the test records the gap and still completes
+  the relationship workflow.
 tags: [uipath-data-fabric, integration, complex-fields]
 
 agent:
@@ -22,14 +25,14 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
+  Build a small Customer/Order schema in UiPath Data Fabric. Customer has a
+  Name and an Email (unique). Order belongs to a Customer, has an amount, and
+  (if available in the tenant) a status picked from a choice set. Seed a few
+  Customers and a few Orders, then answer two questions:
+    - How many Orders belong to "alice@integration.test"?
+    - If status is in use, how many Orders are in the chosen status?
 
   Use --output json on every uip df command.
-
-  This test exercises two complex field types — `CHOICE_SET_SINGLE` and
-  `RELATIONSHIP` — end-to-end. They're regular fields in the type table that
-  happen to need lookup tokens for their values (a `NumberId` integer for
-  choice; the target record's UUID `Id` for relationship).
 
   1. Check login: run `uip login status --output json`. Do NOT re-login.
 

--- a/tests/tasks/uipath-data-fabric/smoke_choice_multiple_filter.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_choice_multiple_filter.yaml
@@ -24,8 +24,6 @@ initial_prompt: |
   Run each command exactly once, ignore the auth error, and continue to the next step.
   Do NOT retry any command. Do NOT attempt to login.
 
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   Context:
   - Entity "Expense" with ID "exp-ent-001" has a `CHOICE_SET_MULTIPLE` field
     `tags` backed by choice set "TagSet" (id "cs-tags-001") whose values are
@@ -95,7 +93,7 @@ success_criteria:
   - type: command_executed
     description: "Negative — agent must NOT use `=` with a bare value on tags (HTTP 400)"
     tool_name: "Bash"
-    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"operator\"\s*:\s*\"=\")(?=.*\"value\"\s*:\s*\"\d+\"(?!\s*\]))'
+    command_pattern: '(?s)uip\s+df\s+records\s+query.*\"fieldName\"\s*:\s*\"tags\"\s*,\s*\"operator\"\s*:\s*\"=\"\s*,\s*\"value\"\s*:\s*\"\d+\"'
     min_count: 0
     max_count: 0
     weight: 3.0

--- a/tests/tasks/uipath-data-fabric/smoke_choice_multiple_filter.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_choice_multiple_filter.yaml
@@ -1,0 +1,137 @@
+task_id: skill-datafabric-smoke-choice-multiple-filter
+description: >
+  Smoke test: agent uses the uipath-data-fabric skill to filter records on a
+  CHOICE_SET_MULTIPLE field — picking `contains` for membership and the
+  JSON-array string form of `=` for set equality, and avoiding the two known
+  HTTP 400 failure modes (bare value with `=`, bracket value with `contains`).
+  Verified server behavior — see references/records-query.md §
+  "Filtering on Choice-Set Fields".
+tags: [uipath-data-fabric, smoke, complex-fields]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 25
+
+sandbox:
+  driver: docker
+  python: {}
+
+initial_prompt: |
+  OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.
+  Every uip df command will fail with an auth error — that is expected and normal.
+  Run each command exactly once, ignore the auth error, and continue to the next step.
+  Do NOT retry any command. Do NOT attempt to login.
+
+  Before starting, load the uipath-data-fabric skill and follow its workflow.
+
+  Context:
+  - Entity "Expense" with ID "exp-ent-001" has a `CHOICE_SET_MULTIPLE` field
+    `tags` backed by choice set "TagSet" (id "cs-tags-001") whose values are
+    travel (NumberId 1), meals (NumberId 2), lodging (NumberId 3).
+  - CHOICE_SET_MULTIPLE values are stored server-side as a JSON-encoded
+    integer array (e.g. [1,3]). Filter operator semantics are non-obvious;
+    pick the right operator and value form for each user intent.
+
+  Use --output json on every uip df command. Compose ONE records query per
+  task — do not retry.
+
+  1. User intent: "find every Expense tagged with travel".
+     This is **membership** — does the stored tags array contain NumberId 1?
+     Use the membership operator with the bare NumberId as a string.
+
+  2. User intent: "find every Expense whose tag set is exactly {travel, lodging}".
+     This is **whole-set equality** — the stored array must equal [1,3]
+     (order-insensitive — server normalizes). Use `=` with a JSON-array string.
+
+  3. User intent: "find every Expense tagged with NOT meals" (exclude meals).
+     This is negated membership. Use `not contains` with the bare NumberId.
+
+  4. Group records by tag combination and count each — `groupBy: ["tags"]`
+     with a COUNT aggregate on Id, aliased as `total`.
+
+  Do NOT use any of these — they are known HTTP 400 failure modes:
+  - `tags = "1"` (bare value with `=` — `=` requires a JSON-array string)
+  - `tags contains "[1]"` (bracket value with `contains` — `contains` rejects
+    brackets in the value)
+  - `tags in valueList=...` / `tags startswith ...` / other operators —
+    only `contains` / `not contains` / `=` / `!=` are supported on
+    `CHOICE_SET_MULTIPLE`.
+
+success_criteria:
+  - type: command_executed
+    description: "Task 1 — agent used `contains` with a bare NumberId string for membership"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"operator\"\s*:\s*\"contains\")(?=.*\"value\"\s*:\s*\"1\")'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Task 2 — agent used `=` with a JSON-array string for set equality"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"operator\"\s*:\s*\"=\")(?=.*\"value\"\s*:\s*\"\[1,\s*3\]\")'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Task 3 — agent used `not contains` for negated membership"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"operator\"\s*:\s*\"not contains\")'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Task 4 — agent used groupBy on tags with COUNT aggregate"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"groupBy\"\s*:\s*\[\s*\"tags\")(?=.*\"function\"\s*:\s*\"COUNT\")'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Negative — agent must NOT use `=` with a bare value on tags (HTTP 400)"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"operator\"\s*:\s*\"=\")(?=.*\"value\"\s*:\s*\"\d+\"(?!\s*\]))'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Negative — agent must NOT use `contains` with a bracketed value on tags (HTTP 400)"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"operator\"\s*:\s*\"contains\")(?=.*\"value\"\s*:\s*\"\[)'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Negative — agent must NOT use unsupported operators on a CHOICE_SET_MULTIPLE field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"operator\"\s*:\s*\"(in|not in|startswith|endswith|>|<|>=|<=)\")'
+    min_count: 0
+    max_count: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Negative — agent must NOT pass a display label (`travel`/`meals`/`lodging`) into a tags filter"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*\"fieldName\"\s*:\s*\"tags\")(?=.*\"value\"\s*:\s*\"(travel|meals|lodging)\")'
+    min_count: 0
+    max_count: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip df commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+.*--output\s+json'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_choice_relationship.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_choice_relationship.yaml
@@ -25,13 +25,12 @@ initial_prompt: |
   Run each command exactly once, ignore the auth error, and continue to the next step.
   Do NOT retry any command. Do NOT attempt to login.
 
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
-  This scenario exercises complex field types — they're just types in the
-  Data Fabric type table, but they require extra config (a `choiceSetId` on
-  `CHOICE_SET_*`, `referenceEntityName` + `referenceFieldName` on
-  `RELATIONSHIP`) and lookup tokens for their values (a `NumberId` integer or
-  array for choice; the target record's UUID `Id` for relationship).
+  This scenario exercises three field types — `CHOICE_SET_SINGLE`,
+  `CHOICE_SET_MULTIPLE`, and `RELATIONSHIP`. On the schema side each one needs
+  an extra config key (`choiceSetId` for the choice fields; `referenceEntityName`
+  + `referenceFieldName` for relationship). On records, choice values use the
+  `NumberId` integer (or array for multi-select) and relationship values use
+  the target record's UUID `Id`.
 
   Pre-seeded placeholders (treat as real values for command construction):
   - Choice set "ExpenseCategories"   ID: "cs-cat-001"

--- a/tests/tasks/uipath-data-fabric/smoke_choice_relationship.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_choice_relationship.yaml
@@ -1,0 +1,217 @@
+task_id: skill-datafabric-smoke-complex-fields
+description: >
+  Smoke test: agent uses the uipath-data-fabric skill to add complex field
+  types (CHOICE_SET_SINGLE, CHOICE_SET_MULTIPLE, RELATIONSHIP) to an entity,
+  insert records writing the correct value tokens (NumberId integer / integer
+  array for choice; target UUID for relationship), filter records on those
+  fields, and refuse to author / modify a choice set from the CLI (read-only).
+  Exercises the same entity / record / query commands as the other smoke
+  tests, but on fields whose value form requires lookup tokens.
+tags: [uipath-data-fabric, smoke, complex-fields]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 35
+
+sandbox:
+  driver: docker
+  python: {}
+
+initial_prompt: |
+  OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.
+  Every uip df command will fail with an auth error — that is expected and normal.
+  Run each command exactly once, ignore the auth error, and continue to the next step.
+  Do NOT retry any command. Do NOT attempt to login.
+
+  Before starting, load the uipath-data-fabric skill and follow its workflow.
+
+  This scenario exercises complex field types — they're just types in the
+  Data Fabric type table, but they require extra config (a `choiceSetId` on
+  `CHOICE_SET_*`, `referenceEntityName` + `referenceFieldName` on
+  `RELATIONSHIP`) and lookup tokens for their values (a `NumberId` integer or
+  array for choice; the target record's UUID `Id` for relationship).
+
+  Pre-seeded placeholders (treat as real values for command construction):
+  - Choice set "ExpenseCategories"   ID: "cs-cat-001"
+      values: travel (NumberId 1), meals (NumberId 2), lodging (NumberId 3)
+  - Choice set "ExpenseTags"         ID: "cs-tag-002"
+      values: urgent (NumberId 1), reimbursable (NumberId 2), client (NumberId 3)
+  - Existing entity "Employee"       ID: "emp-ent-100"  (technical Name: "Employee")
+      one employee record ID: "emp-rec-500"
+  - Existing entity "Project"        ID: "proj-ent-200" (technical Name: "Project")
+
+  Do the following in order. Use --output json on every uip df command.
+
+  1. List native-only entities to discover what already exists.
+
+  2. List all choice sets to confirm "ExpenseCategories" and "ExpenseTags"
+     exist and capture their IDs (use the placeholder values above).
+
+  3. Get the values for the "ExpenseCategories" choice set so you know the
+     NumberId for each category. Use placeholder choice set ID "cs-cat-001".
+
+  4. Create a new entity "Expense" with these fields:
+       - amount      (DECIMAL, decimalPrecision 2, required)
+       - category    (CHOICE_SET_SINGLE   pointing at choice set "cs-cat-001", required)
+       - tags        (CHOICE_SET_MULTIPLE pointing at choice set "cs-tag-002")
+       - submitter   (RELATIONSHIP to Employee — referenceEntityName "Employee",
+                      referenceFieldName "Id", required)
+       - project     (RELATIONSHIP to Project  — referenceEntityName "Project",
+                      referenceFieldName "Id")
+
+  5. Add a CHOICE_SET_SINGLE field "status" to the existing Employee entity
+     using entities update with addFields. Point it at choice set "cs-tag-002".
+
+  6. Insert one Expense record using a JSON object body. Use placeholder
+     entity ID "exp-ent-300". Choice values MUST be passed as NumberId
+     integers (NOT the display label string). Relationship values MUST be
+     the target record's UUID Id:
+       - amount:    250
+       - category:  1                   (travel — NumberId)
+       - tags:      [1, 2]              (NumberId array for CHOICE_SET_MULTIPLE)
+       - submitter: "emp-rec-500"       (Employee record UUID)
+
+  7. Filter Expense records on category == "travel" (NumberId 1) using a
+     filterGroup query. Pass the NumberId as a string in the filter value.
+
+  8. Filter Expense records linked to a specific Employee using a filterGroup
+     query — fieldName "submitter", value "emp-rec-500" (the target UUID).
+
+  9. The user then asks you to *create* a brand-new choice set called
+     "PaymentStatus" via the CLI. Refuse: the CLI is read-only for choice
+     sets — they must be authored in the Data Fabric web UI. Explain this in
+     your final message. Do NOT run any uip df choice-sets create / update /
+     delete command.
+
+  Additional constraints:
+  - NEVER write a choice value as a display label (e.g. "category":"travel")
+    or as the value's UUID Id — only NumberId integers.
+  - NEVER write a relationship value as anything other than the target
+    record's UUID Id (e.g. do not pass an email or a Name).
+  - Do NOT use removeFields. Do NOT delete any entity. Do NOT create or modify
+    a choice set via the CLI.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed native-only entities"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+entities\s+list\s+.*--native-only'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent browsed choice sets with choice-sets list"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+choice-sets\s+list'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inspected choice-set values with choice-sets get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+choice-sets\s+get\s+'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent declared a CHOICE_SET_SINGLE field with choiceSetId in entities create"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+create(?=.*CHOICE_SET_SINGLE)(?=.*choiceSetId)'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent declared a CHOICE_SET_MULTIPLE field with choiceSetId in entities create"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+create(?=.*CHOICE_SET_MULTIPLE)(?=.*choiceSetId)'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent declared a RELATIONSHIP field with referenceEntityName + referenceFieldName"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+create(?=.*RELATIONSHIP)(?=.*referenceEntityName)(?=.*referenceFieldName)'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a CHOICE_SET field via addFields on entities update"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+entities\s+update(?=.*addFields)(?=.*CHOICE_SET_SINGLE)'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted a record writing NumberId integer for CHOICE_SET_SINGLE (no display label)"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\"category\"\s*:\s*\d+'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted a record writing NumberId array for CHOICE_SET_MULTIPLE"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\"tags\"\s*:\s*\[\s*\d+'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent inserted a record writing target UUID for RELATIONSHIP field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert.*\"submitter\"\s*:\s*\"emp-rec-500\"'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT pass a display label (any string starting with a letter) for a choice-set field"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+(insert|update).*\"category\"\s*:\s*\"[A-Za-z]'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent filtered records on a CHOICE_SET field via filterGroup"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*filterGroup)(?=.*\"fieldName\"\s*:\s*\"category\")'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent filtered records on a RELATIONSHIP field via filterGroup"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+query(?=.*filterGroup)(?=.*\"fieldName\"\s*:\s*\"submitter\")'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT attempt to create / update / delete a choice set via the CLI"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+choice-sets\s+(create|update|delete)'
+    min_count: 0
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip df commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+.*--output\s+json'
+    min_count: 3
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_csv_complex_drop.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_csv_complex_drop.yaml
@@ -1,0 +1,112 @@
+task_id: skill-datafabric-smoke-csv-complex-drop
+description: >
+  Smoke test: agent uses the uipath-data-fabric skill to seed an entity whose
+  schema includes complex field types (CHOICE_SET_SINGLE, CHOICE_SET_MULTIPLE,
+  RELATIONSHIP). `records import` silently drops complex-field columns —
+  verified server behavior in BulkUploadCSVHelper. The agent must use
+  `records insert --file <json>` instead and must NOT put complex-field
+  columns in a CSV file.
+tags: [uipath-data-fabric, smoke, complex-fields, bulk-import]
+
+agent:
+  type: claude-code
+
+run_limits:
+  max_turns: 25
+
+sandbox:
+  driver: docker
+  python: {}
+
+initial_prompt: |
+  OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.
+  Every uip df command will fail with an auth error — that is expected and normal.
+  Run each command exactly once, ignore the auth error, and continue to the next step.
+  Do NOT retry any command. Do NOT attempt to login.
+
+  Before starting, load the uipath-data-fabric skill and follow its workflow.
+
+  Context — existing entity "Expense" (ID "exp-ent-001") with fields:
+  - amount       (DECIMAL)
+  - description  (MULTILINE_TEXT)
+  - category     (CHOICE_SET_SINGLE,   choiceSetId "cs-cat-001")
+  - tags         (CHOICE_SET_MULTIPLE, choiceSetId "cs-tags-001")
+  - customerId   (RELATIONSHIP → Customer)
+
+  Seed 3 Expense records covering plain + complex fields:
+    R1: amount=100, description="taxi", category=1 (travel), tags=[1,3],
+        customerId="c-uuid-A"
+    R2: amount=250, description="dinner", category=2 (meals), tags=[2],
+        customerId="c-uuid-A"
+    R3: amount=400, description="hotel", category=3 (lodging), tags=[3],
+        customerId="c-uuid-B"
+
+  IMPORTANT — picking the right bulk path:
+  - `uip df records import <id> --file data.csv` only processes Basic field
+    types (STRING, INTEGER, DECIMAL, BOOLEAN, DATE, DATETIME, MULTILINE_TEXT,
+    UUID). For CHOICE_SET_*, RELATIONSHIP, FILE, and AUTO_NUMBER columns it
+    silently drops the row value — column header is accepted but the field
+    inserts as null with no warning. Verified server behavior.
+  - For entities that include any complex field, write a JSON array to a
+    file and pass it via `uip df records insert <id> --file <json>`. The
+    insert endpoint handles all field types.
+
+  Do this in order. Use --output json on every uip df command.
+
+  1. Write the 3 seed records to a file. Pick the format that works for an
+     entity with complex fields. Name the file accordingly. Do not write
+     `category`, `tags`, or `customerId` columns into a CSV.
+  2. Run the matching uip df command to load the file.
+  3. Save a one-paragraph note in `decision.md` explaining which command you
+     chose (`records import` vs `records insert`) and why — specifically
+     referencing the CSV silent-drop behavior for complex fields.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent used `records insert --file <json>` for the entity with complex fields"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+insert\s+exp-ent-001\s+.*--file\s+\S+\.json'
+    min_count: 1
+    weight: 3.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT call `records import` on an entity with complex fields"
+    tool_name: "Bash"
+    command_pattern: '(?s)uip\s+df\s+records\s+import\s+exp-ent-001'
+    min_count: 0
+    max_count: 0
+    weight: 3.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent must NOT produce a .csv file for this entity (would silently drop complex fields)"
+    tool_name: "Bash"
+    command_pattern: '\.csv\b'
+    min_count: 0
+    max_count: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "decision.md was written"
+    path: "decision.md"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "decision.md cites the silent-drop reason and the `records insert` choice"
+    path: "decision.md"
+    includes:
+      - "silent"
+      - "records insert"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip df commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+df\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-data-fabric/smoke_csv_complex_drop.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_csv_complex_drop.yaml
@@ -24,8 +24,6 @@ initial_prompt: |
   Run each command exactly once, ignore the auth error, and continue to the next step.
   Do NOT retry any command. Do NOT attempt to login.
 
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   Context — existing entity "Expense" (ID "exp-ent-001") with fields:
   - amount       (DECIMAL)
   - description  (MULTILINE_TEXT)
@@ -80,9 +78,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent must NOT produce a .csv file for this entity (would silently drop complex fields)"
+    description: "Agent must NOT produce a .csv file or call records import with one (would silently drop complex fields)"
     tool_name: "Bash"
-    command_pattern: '\.csv\b'
+    command_pattern: '(uip\s+df\s+records\s+import\b.*\.csv|>\s*\S*\.csv\b|tee\s+\S*\.csv\b)'
     min_count: 0
     max_count: 0
     weight: 2.5


### PR DESCRIPTION
…V silent-drop

Treat CHOICE_SET_SINGLE / CHOICE_SET_MULTIPLE / RELATIONSHIP as complex field types (extras + lookup tokens), aligned with the existing type table — not as first-class concepts.

Skill changes:
- SKILL.md: 3 new Critical Rules (complex-field extras, choice-sets read-only, lookup-token value form); Rule 7 extended with the CSV silent-drop limitation for complex types
- references/choice-sets.md: new file — browse list/get, value form, decision tree, add-field workflow
- references/entity-schema.md: Choice Set + Relationship sections with the verified entities-get-doesn't-echo-extras finding; combined create example shows scalar options work on complex types
- references/records-query.md: Filtering on Choice-Set Fields (incl. the verified CHOICE_SET_MULTIPLE = vs contains operator semantics + HTTP 400 failure modes), Filtering on Relationship Fields, Writing Choice-Set and Relationship Values
- references/bulk-import.md: records import silently drops complex field types (verified server behavior, BulkUploadCSVHelper) — use records insert --file <json> instead

Test changes:
- smoke_choice_relationship.yaml: complex-field syntax + value form
- smoke_choice_multiple_filter.yaml: CHOICE_SET_MULTIPLE operator wrinkles (contains for membership, = for set equality) + 3 HTTP 400 negative guards
- smoke_csv_complex_drop.yaml: enforces records insert --file <json> for entities with complex fields
- integration_choice_relationship.yaml: live-tenant parent/child + RELATIONSHIP
  + email→UUID resolve, asserts 2 records for Alice
- e2e_expense_tracker.yaml: full Employee→Expense scenario; in operator with UUID valueList; stored-shape assertions
- _shared/cleanup_entities.py: also resolves child_entity_id / parent_entity_id from report.json in FK-safe order