### PR TITLE
docs: align license type argument references

### DIFF
--- a/skills/uipath-governance/references/aops-policy/aops-governance-recipes-guide.md
+++ b/skills/uipath-governance/references/aops-policy/aops-governance-recipes-guide.md
@@ -201,7 +201,7 @@ When the user asks for a scope-limited rule:
 
 - "Apply to one user only" → deploy at **user** level. Overrides group and tenant for that user.
 - "Apply to the X team / group" → deploy at **group** level. Overrides tenant for group members.
-- "Apply to everyone in this tenant" → deploy at **tenant** level (with a `(product, licenseType)` key). Base-layer default.
+- "Apply to everyone in this tenant" → deploy at **tenant** level (with a `(product, license type)` key). Base-layer default.
 - "Exception for team X that ignores the tenant rule" → deploy a different policy at group level; tenant-level rule still applies to non-members.
 
 Order of effective resolution: **User > Group > Tenant > (no policy)**. See [aops-policy-deploy-guide.md — Deployment precedence](./aops-policy-deploy-guide.md#deployment-precedence) for the decision flow.

--- a/skills/uipath-governance/references/aops-policy/aops-policy-commands.md
+++ b/skills/uipath-governance/references/aops-policy/aops-policy-commands.md
@@ -144,7 +144,7 @@ The positional argument accepts either the product `name` (e.g. `StudioX`) or it
 
 ## uip gov aops-policy license-type list
 
-List license types available to the organization. Required for tenant deployment, where assignments are keyed by `(product, licenseType)`.
+List license types available to the organization. Required for tenant deployment, where assignments are keyed by `(product, license type)`.
 
 ```bash
 uip gov aops-policy license-type list --output json
@@ -162,7 +162,7 @@ Available license types:
 
 > **Two different identifiers — do not confuse them:**
 > - For `deployment tenant configure` entries, the JSON `licenseTypeIdentifier` field takes the license type's **`identifier` (GUID)** from `license-type list`.
-> - For `deployed-policy get` / `deployed-policy list`, the positional `<licenseType>` argument takes the license type's **`name`** (e.g. `Attended`).
+> - For `deployed-policy get` / `deployed-policy list`, the positional `<license-type>` argument takes the license type's **`name`** (e.g. `Attended`).
 
 ---
 
@@ -347,7 +347,7 @@ Add `--license-type <LICENSE_TYPE_NAME>` to remove only one license-type entry f
 
 ## uip gov aops-policy deployed-policy get
 
-Return the single effective deployed policy for a `(licenseType, product, tenant)` tuple — the one policy that actually applies after the user → group → tenant inheritance chain has been walked and any 'No Policy' pins have been honored. Uses the caller's `uip login` token by default.
+Return the single effective deployed policy for a `(license type, product, tenant)` tuple — the one policy that actually applies after the user → group → tenant inheritance chain has been walked and any 'No Policy' pins have been honored. Uses the caller's `uip login` token by default.
 
 ```bash
 uip gov aops-policy deployed-policy get \
@@ -385,7 +385,7 @@ Modes 2 and 3 require an S2S token (read from the `UIP_S2S_TOKEN` environment va
 
 ## uip gov aops-policy deployed-policy list
 
-List every policy that applies to a `(licenseType, product, tenant)` for the calling user, in priority order. Unlike `get`, which returns only the single effective (top-priority) policy, `list` shows every applicable entry — useful for understanding why a particular policy wins. **User token only — does NOT accept `--s2s-token`.** Returns an empty array when nothing applies.
+List every policy that applies to a `(license type, product, tenant)` for the calling user, in priority order. Unlike `get`, which returns only the single effective (top-priority) policy, `list` shows every applicable entry — useful for understanding why a particular policy wins. **User token only — does NOT accept `--s2s-token`.** Returns an empty array when nothing applies.
 
 ```bash
 uip gov aops-policy deployed-policy list \

--- a/skills/uipath-governance/references/aops-policy/aops-policy-deploy-guide.md
+++ b/skills/uipath-governance/references/aops-policy/aops-policy-deploy-guide.md
@@ -44,7 +44,7 @@ When the same product has assignments at multiple scopes, the narrowest wins:
 
 - A **user** assignment (including explicit `null` = No Policy) overrides any group or tenant assignment for that product.
 - A **group** assignment overrides the tenant assignment for that product (for members of that group).
-- A **tenant** assignment is the org-wide default for a `(product, licenseType)` pair.
+- A **tenant** assignment is the org-wide default for a `(product, license type)` pair.
 - A product with no assignment at any scope → inherits the global default (no policy enforced).
 
 **Decision hint:** pick the narrowest scope that matches the user's ask.
@@ -62,7 +62,7 @@ When the same product has assignments at multiple scopes, the narrowest wins:
 
 ## License-type → product compatibility
 
-Tenant deployments are keyed by `(product, licenseType)`. Not every license carries every product — deploying a policy to a `(product, licenseType)` pair whose license does not include that product is a no-op. Common license → product mappings:
+Tenant deployments are keyed by `(product, license type)`. Not every license carries every product — deploying a policy to a `(product, license type)` pair whose license does not include that product is a no-op. Common license → product mappings:
 
 | License type | Products included |
 |--------------|-------------------|
@@ -86,7 +86,7 @@ If the user asks to deploy (for example) an Assistant policy to the `Unattended 
 | "Apply to Alice" / a named individual | user | [3.1](#31-deploy-to-a-user) |
 | "Apply to the Developers group" / named team | group | [3.2](#32-deploy-to-a-group) |
 | "Apply to everyone in the tenant" | tenant | [3.3](#33-deploy-to-a-tenant) |
-| "Apply to a license type org-wide" (requires licenseType) | tenant | [3.3](#33-deploy-to-a-tenant) |
+| "Apply to a license type org-wide" (requires license type) | tenant | [3.3](#33-deploy-to-a-tenant) |
 
 ---
 
@@ -247,9 +247,9 @@ uip gov aops-policy deployment group get "$GROUP_ID" --output json
 
 ### Step 1 — Identify the license type
 
-Tenant deployments are keyed by `(product, licenseType)`. List license types via `uip gov aops-policy license-type list --output json` — see [aops-policy-commands.md — license-type list](./aops-policy-commands.md#uip-gov-aops-policy-license-type-list) for the full output shape and sample rendering.
+Tenant deployments are keyed by `(product, license type)`. List license types via `uip gov aops-policy license-type list --output json` — see [aops-policy-commands.md — license-type list](./aops-policy-commands.md#uip-gov-aops-policy-license-type-list) for the full output shape and sample rendering.
 
-> **Use the license type's `identifier` (GUID) — not its `name`, not its label — as `licenseTypeIdentifier` in tenant assignment entries.** The `name` is only accepted by `deployed-policy get` / `deployed-policy list` as the positional `<licenseType>` argument.
+> **Use the license type's `identifier` (GUID) — not its `name`, not its label — as `licenseTypeIdentifier` in tenant assignment entries.** The `name` is only accepted by `deployed-policy get` / `deployed-policy list` as the positional `<license-type>` argument.
 
 ### Step 2 — Identify the tenant
 
@@ -263,9 +263,9 @@ Optional flags: `--product-name <PRODUCT_NAME>`, `--limit <N>`, `--offset <N>`.
 
 Parse `Data.result[]` (output shape in [aops-policy-commands.md — deployment list](./aops-policy-commands.md#deployment-usergrouptenant-list)). Each tenant entry carries `tenantPolicies[]` — the current assignments, each keyed by `(productIdentifier, licenseTypeIdentifier, policyIdentifier)`. Let the user pick, then store the chosen tenant's `identifier` as `$TENANT_ID` and `name` as `$TENANT_NAME`.
 
-### Step 3 — Pick policies per `(product, licenseType)`
+### Step 3 — Pick policies per `(product, license type)`
 
-1. For each `(product, licenseType)` pair the user wants to assign, run `uip gov aops-policy list --product-name "<PRODUCT_NAME>" --output json` and pick a policy (or match the user's intent).
+1. For each `(product, license type)` pair the user wants to assign, run `uip gov aops-policy list --product-name "<PRODUCT_NAME>" --output json` and pick a policy (or match the user's intent).
 2. Fetch current assignments: `uip gov aops-policy deployment tenant get "$TENANT_ID" --output json`.
 
 ### Step 4 — Write the assignment file
@@ -287,7 +287,7 @@ EOF
 Deploying policies to <TENANT_NAME>:
   AI Trust Layer  / NoLicense    →   aitl-default  (<POLICY_ID>)
   Studio          / Development  →   (No Policy)
-Omitted (product, licenseType) pairs keep their current assignment.
+Omitted (product, license type) pairs keep their current assignment.
 
 Apply these changes to <TENANT_NAME>? (yes / no)
 ```
@@ -296,7 +296,7 @@ Do NOT proceed without an explicit `yes`.
 
 ### Step 6 — Save the assignments
 
-> **FULL-REPLACE semantics.** Any `(product, licenseType)` pair not listed in `$SESSION_DIR/tenant-policies.json` is removed from the tenant and reverts to "no pin". To preserve existing assignments, seed the input file from `deployment tenant get "$TENANT_ID"` before editing.
+> **FULL-REPLACE semantics.** Any `(product, license type)` pair not listed in `$SESSION_DIR/tenant-policies.json` is removed from the tenant and reverts to "no pin". To preserve existing assignments, seed the input file from `deployment tenant get "$TENANT_ID"` before editing.
 
 ```bash
 uip gov aops-policy deployment tenant configure "$TENANT_ID" \

--- a/skills/uipath-governance/references/aops-policy/aops-policy-deployed-guide.md
+++ b/skills/uipath-governance/references/aops-policy/aops-policy-deployed-guide.md
@@ -1,6 +1,6 @@
 # Policy Deployment Query Guide
 
-Query the **single effective deployed policy** for a `(licenseType, product, tenant)` tuple, or the **full list of applicable policies** ordered by priority, for the calling user (or a named user via S2S).
+Query the **single effective deployed policy** for a `(license type, product, tenant)` tuple, or the **full list of applicable policies** ordered by priority, for the calling user (or a named user via S2S).
 
 > **Terminology — read before using.**
 > - `deployed-policy get` returns the **single effective policy** — the one policy that actually applies after the user → group → tenant inheritance chain has been walked and any 'No Policy' pins have been honored. The default mode resolves for the caller's own identity; the S2S `--user-id` mode resolves for a named user; the S2S `--tenant-only` mode skips user/group overrides and returns only the tenant assignment.
@@ -19,7 +19,7 @@ Query the **single effective deployed policy** for a `(licenseType, product, ten
 
 If the user has not provided the positional values, ask **one at a time** in this order — resolve each before moving to the next:
 
-1. `License type?` — if unknown, run `uip gov aops-policy license-type list --output json` and let the user pick by `name` (e.g. `Attended`, `Unattended`), not by `identifier` (GUID) or label. `deployed-policy get/list` take the `name` as the `<licenseType>` positional argument. Store as `$LICENSE_TYPE`.
+1. `License type?` — if unknown, run `uip gov aops-policy license-type list --output json` and let the user pick by `name` (e.g. `Attended`, `Unattended`), not by `identifier` (GUID) or label. `deployed-policy get/list` take the `name` as the `<license-type>` positional argument. Store as `$LICENSE_TYPE`.
 2. `Product name (identifier)?` — run `uip gov aops-policy product list --output json` if unknown.
 3. `Tenant identifier (GUID)?` — if unknown, run `uip gov aops-policy deployment tenant list --output json` and let the user pick from tenants that already have policy assignments. Store as `$TENANT_ID`.
 4. **For specific-user lookup only:** `User identifier (GUID)?` — run `uip gov aops-policy deployment user list --output json` if unknown (output shape in [aops-policy-commands.md — deployment list](./aops-policy-commands.md#deployment-usergrouptenant-list)). Store the matching `identifier` as `$USER_ID`. Then ensure the S2S bearer token is available — set `UIP_S2S_TOKEN` in the caller's environment so the CLI picks it up automatically (see [aops-policy-commands.md — S2S token](./aops-policy-commands.md#s2s-token)).
@@ -30,7 +30,7 @@ Proceed to the matching query below.
 
 ## Get the effective deployed policy (default — caller's own identity)
 
-Returns the single effective policy for the caller for the given `(licenseType, product, tenant)` — the policy that remains after the user → group → tenant inheritance chain has been walked. Uses the caller's `uip login` token. To look up another user's effective policy, add `--s2s-token --user-id`; to skip user/group overrides and see only the tenant-level assignment, add `--s2s-token --tenant-only`.
+Returns the single effective policy for the caller for the given `(license type, product, tenant)` — the policy that remains after the user → group → tenant inheritance chain has been walked. Uses the caller's `uip login` token. To look up another user's effective policy, add `--s2s-token --user-id`; to skip user/group overrides and see only the tenant-level assignment, add `--s2s-token --tenant-only`.
 
 ```bash
 uip gov aops-policy deployed-policy get \
@@ -50,7 +50,7 @@ Effective policy:
   Data payload:    <DATA — pretty-print or attach as a link to a saved file>
 ```
 
-If `Data` is `{ "Message": "No policy applies." }`, `null`, `{}`, or absent, inform the user that no policy applies for this `(licenseType, product, tenant)`. This happens when no rule matches and no default exists — the service returns HTTP 204.
+If `Data` is `{ "Message": "No policy applies." }`, `null`, `{}`, or absent, inform the user that no policy applies for this `(license type, product, tenant)`. This happens when no rule matches and no default exists — the service returns HTTP 204.
 
 ---
 
@@ -88,7 +88,7 @@ uip gov aops-policy deployed-policy get \
 
 ## List every applicable policy for the calling user
 
-Returns every policy that applies to the caller for the given `(licenseType, product, tenant)`, in priority order. Unlike `get`, which returns only the single effective (top-priority) policy, `list` surfaces every applicable entry so you can see why a particular policy wins. **User token only — does NOT accept `--s2s-token`.** Returns an empty array when nothing applies.
+Returns every policy that applies to the caller for the given `(license type, product, tenant)`, in priority order. Unlike `get`, which returns only the single effective (top-priority) policy, `list` surfaces every applicable entry so you can see why a particular policy wins. **User token only — does NOT accept `--s2s-token`.** Returns an empty array when nothing applies.
 
 ```bash
 uip gov aops-policy deployed-policy list \

--- a/skills/uipath-governance/references/aops-policy/aops-policy-overview-guide.md
+++ b/skills/uipath-governance/references/aops-policy/aops-policy-overview-guide.md
@@ -197,7 +197,7 @@ Render next steps as a numbered Markdown list under a `### What would you like t
 
 | Command | Returns | Use when |
 |---------|---------|----------|
-| `deployed-policy get` | Tenant-level deployed policy assignment for a `(licenseType, product, tenant)` | "What policy is deployed to this tenant?" |
+| `deployed-policy get` | Tenant-level deployed policy assignment for a `(license type, product, tenant)` | "What policy is deployed to this tenant?" |
 | `deployed-policy list` | Effective rule values for the calling user after the user → group → tenant chain | "What rules actually apply to me?" |
 
 See [aops-policy-deployed-guide.md](./aops-policy-deployed-guide.md).
@@ -218,7 +218,7 @@ Priority is **NOT** what decides which policy wins across user / group / tenant 
 |-------|-----------------------------------------------------|------------------|
 | User   | No — each `(user, product)` has at most one assignment. | None. Priority has no effect. |
 | Group  | **Yes** — a user can belong to multiple groups, each with its own policy for the same product. | **Tie-breaker.** Lowest priority number wins among the competing group assignments. |
-| Tenant | No — each `(tenant, product, licenseType)` has exactly one assignment. | None. Priority has no effect. |
+| Tenant | No — each `(tenant, product, license type)` has exactly one assignment. | None. Priority has no effect. |
 
 Outside of the group-level tie-breaker, Priority is essentially an admin-facing ordering hint (it controls the order policies appear in the Automation Ops catalog / `aops-policy list`, not which one applies at runtime).
 
@@ -268,7 +268,7 @@ Do not run any of these actions automatically. Wait for the user's selection.
 
 **Per-operation adjustments to the menu:**
 - After `create` or `update`: offer all options above.
-- After `deploy`: replace the three Deploy options with a single **Verify deployment** option that runs `deployed-policy get <licenseType> <productName> <tenantIdentifier>` to confirm the assignment took effect. Keep **Query effective rules** (via `deployed-policy list`) as the follow-up check for chain-resolved values.
+- After `deploy`: replace the three Deploy options with a single **Verify deployment** option that runs `deployed-policy get <license-type> <productName> <tenantIdentifier>` to confirm the assignment took effect. Keep **Query effective rules** (via `deployed-policy list`) as the follow-up check for chain-resolved values.
 - After `delete`: offer only **List policies to verify** and **Something else**.
 
 ## References

--- a/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
@@ -3,7 +3,7 @@ description: >
   Skill-guided evaluation: agent uses the uipath-governance skill to
   query the deployed policy for a given license type / product / tenant
   tuple, and also list every applicable policy. Tests the three-positional
-  argument order of `deployed-policy get <licenseType> <productName>
+  argument order of `deployed-policy get <license-type> <productName>
   <tenant>` and guards against the legacy `--user-identifier` flag name.
 
   Platform note: the smoke test runs without an authenticated tenant, so
@@ -31,7 +31,7 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy deployed-policy get` with three positional args in order (licenseType productName tenant)"
+    description: "Agent invoked `uip gov aops-policy deployed-policy get` with three positional args in order (license-type productName tenant)"
     tool_name: "Bash"
     command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+get\s+["'']?Attended["'']?\s+["'']?StudioX["'']?\s+["'']?[\w-]+["'']?\s+.*--output\s+json'
     min_count: 1


### PR DESCRIPTION
## Summary
- updates AOps governance skill references from <licenseType> to <license-type>
- changes related prose from licenseType tuple wording to license type wording
- keeps JSON/API payload names such as licenseTypeIdentifier unchanged

## Validation
- git diff --check
- bash hooks/validate-skill-descriptions.sh
- rg -n "<licenseType>|\[licenseType\]|licenseType productName|requires licenseType|deployed-policy get <licenseType>|positional <licenseType>" skills tests commands agents README.md CLAUDE.md

## Cross-links
- CLI PR: https://github.com/UiPath/cli/pull/2187