### PR TITLE
docs: align product name argument references

### DIFF
--- a/skills/uipath-governance/references/aops-policy/aops-policy-overview-guide.md
+++ b/skills/uipath-governance/references/aops-policy/aops-policy-overview-guide.md
@@ -250,7 +250,7 @@ See [configure-aops-policy-data-guide.md](./configure-aops-policy-data-guide.md)
 
 When you finish a mutating operation, report:
 
-1. **Operation & result** — e.g., `Created policy <name> (GUID: <guid>) for product <productName>`.
+1. **Operation & result** — e.g., `Created policy <name> (GUID: <guid>) for product <product-name>`.
 2. **Session directory** — print `$SESSION_DIR` so the user can inspect bootstrapped schemas and the `aops-policy-data.json` that was submitted.
 3. **Non-default fields set** — summary of fields the user configured vs. ones that stayed at defaults. (Omit this line after `delete`.)
 4. **Next step** — render a numbered Markdown list under a `### What would you like to do next?` heading (single post-mutation gate, per Critical Rule #12). Do NOT use `AskUserQuestion`. The user replies with a digit.
@@ -268,7 +268,7 @@ Do not run any of these actions automatically. Wait for the user's selection.
 
 **Per-operation adjustments to the menu:**
 - After `create` or `update`: offer all options above.
-- After `deploy`: replace the three Deploy options with a single **Verify deployment** option that runs `deployed-policy get <license-type> <productName> <tenantIdentifier>` to confirm the assignment took effect. Keep **Query effective rules** (via `deployed-policy list`) as the follow-up check for chain-resolved values.
+- After `deploy`: replace the three Deploy options with a single **Verify deployment** option that runs `deployed-policy get <license-type> <product-name> <tenantIdentifier>` to confirm the assignment took effect. Keep **Query effective rules** (via `deployed-policy list`) as the follow-up check for chain-resolved values.
 - After `delete`: offer only **List policies to verify** and **Something else**.
 
 ## References

--- a/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
@@ -3,7 +3,7 @@ description: >
   Skill-guided evaluation: agent uses the uipath-governance skill to
   query the deployed policy for a given license type / product / tenant
   tuple, and also list every applicable policy. Tests the three-positional
-  argument order of `deployed-policy get <license-type> <productName>
+  argument order of `deployed-policy get <license-type> <product-name>
   <tenant>` and guards against the legacy `--user-identifier` flag name.
 
   Platform note: the smoke test runs without an authenticated tenant, so
@@ -31,7 +31,7 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy deployed-policy get` with three positional args in order (license-type productName tenant)"
+    description: "Agent invoked `uip gov aops-policy deployed-policy get` with three positional args in order (license-type product-name tenant)"
     tool_name: "Bash"
     command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+get\s+["'']?Attended["'']?\s+["'']?StudioX["'']?\s+["'']?[\w-]+["'']?\s+.*--output\s+json'
     min_count: 1


### PR DESCRIPTION
## Summary
- updates governance skill references from <productName> to <product-name>
- keeps output fields such as Data.productName unchanged
- updates the deployed-policy smoke task wording

## Validation
- git diff --check
- bash hooks/validate-skill-descriptions.sh
- rg -n '<productName>|\[productName\]|--product-name <productName>|productName tenant|productName>' skills/uipath-governance tests/tasks/uipath-governance skills tests commands agents README.md CLAUDE.md

## Cross-links
- CLI PR: https://github.com/UiPath/cli/pull/2190