### PR TITLE
docs: align package delete argument references

### DIFF
--- a/skills/uipath-solution/references/operate/activate-and-manage.md
+++ b/skills/uipath-solution/references/operate/activate-and-manage.md
@@ -109,7 +109,7 @@ Remove a specific version of a published package from the solution feed:
 uip solution packages delete "MySolution" "1.0.0" --output json
 ```
 
-Arguments: `<package-name> <version>`. This deletes only the specified version, not all versions of the package.
+Arguments: `<package-name> <package-version>`. This deletes only the specified version, not all versions of the package.
 
 ## Step 6: Delete from Studio Web
 


### PR DESCRIPTION
## Summary
- updates the solution skill package delete reference to package-name/package-version placeholders
- keeps command examples unchanged because the positional values are still package name and version values

## Validation
- git diff --check
- bash hooks/validate-skill-descriptions.sh
- stale placeholder search for packageName/packageVersion package delete syntax

## Cross-links
- CLI PR: https://github.com/UiPath/cli/pull/2191