### PR TITLE
docs: align output path argument references

### DIFF
--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -105,14 +105,14 @@ uip solution upload <SolutionDir> --output json
 Pack a Case project directory into a `.nupkg` file. Only used when the user explicitly requests Orchestrator deployment via `uip solution publish` — not the default publish path.
 
 ```bash
-uip maestro case pack <project-path> <outputPath>
+uip maestro case pack <project-path> <output-path>
 uip maestro case pack ./my-case-project ./dist --name MyCase --version 2.0.0
 ```
 
 | Flag | Description |
 |------|-------------|
 | `<project-path>` | **(required)** Path to the Case project directory |
-| `<outputPath>` | **(required)** Output directory for the `.nupkg` |
+| `<output-path>` | **(required)** Output directory for the `.nupkg` |
 | `-n, --name <name>` | Package name (default: project folder name) |
 | `-v, --version <version>` | Package version (default: `1.0.0`) |
 

--- a/skills/uipath-solution/SKILL.md
+++ b/skills/uipath-solution/SKILL.md
@@ -108,7 +108,7 @@ All other `solution` subcommands (`pack`, `publish`, `deploy activate/status/uni
 5. **`.uipx` and `resources/solution_folder/` must always agree on the project set.** Diffing them is the fastest way to detect corrupted state. If they disagree, fix via `uip solution project add/remove` — never by editing either side directly.
 6. **Run `uip solution resource refresh` before `pack` or `upload`.** Bundled artefact files and `userProfile/<userId>/debug_overwrites.json` must reflect current cloud state. Skipping refresh ships stale bindings.
 7. **Coded apps are NOT registered in `.uipx`.** `uip solution project add` does not apply to coded-app directories; they deploy independently via `uip codedapp publish / deploy`. A coded app folder can sit alongside a solution but is not part of its manifest.
-8. **Verify the artifact after every CLI mutation.** Read `project.json`, `.uipx`, or `uip solution deploy status` output — exit codes lie. This mirrors the Design half's "verify the SDD after write" discipline.
+8. **Verify the artifact after every CLI mutation.** Read `project.json`, `.uipx`, or `uip solution deploy status` output — exit codes lie. This mirrors the Design half's "verify the SDD after write" discipline. Verification is additional; it does not replace requested read-only list commands. If the user asks to show or list registered projects, solution resources, packages, deployments, or statuses, run the matching `uip solution ... list/status --output json` command and then inspect files only as a secondary sanity check.
 9. **For multi-environment promotion, the deploy config (`-c <CONFIG_KEY>`) is the environment selector.** Same `.uipx` deploys to dev/staging/prod via different config keys, not different packages.
 
 ### Workflow

--- a/skills/uipath-solution/references/design/tenant-library-search-guide.md
+++ b/skills/uipath-solution/references/design/tenant-library-search-guide.md
@@ -92,7 +92,7 @@ If `uip` is unauthenticated, ask the legacy question:
 > 1. **Skip — no shared libraries** *(recommended)*
 > 2. **Yes — `CommonLibrary`** (the conventional default)
 > 3. **Yes — other** (you name them)
-> 4. **Authenticate first** — run `uip auth login`, then re-invoke the skill
+> 4. **Authenticate first** — run `uip login`, then re-invoke the skill
 
 ## Anti-patterns
 

--- a/skills/uipath-solution/references/operate/develop-solution.md
+++ b/skills/uipath-solution/references/operate/develop-solution.md
@@ -78,6 +78,8 @@ uip solution project remove ./InvoiceAutomation/OldProject --output json
 
 Enumerate the projects registered in the local `.uipx` manifest. Reads only on-disk metadata — no backend call, so safe to use offline or in CI checks.
 
+When the user asks to show or list registered projects, run this command. Reading the `.uipx` directly is useful as a follow-up verification step, but it is not a replacement for the CLI list surface.
+
 ```bash
 # from inside the solution dir
 uip solution project list --output json

--- a/skills/uipath-solution/references/operate/pack-and-deploy.md
+++ b/skills/uipath-solution/references/operate/pack-and-deploy.md
@@ -46,11 +46,11 @@ uip solution pack ./MySolution ./output --name "MySolution" --version "2.0.0" --
 | Option | Description | Default |
 |--------|-------------|---------|
 | `<solutionPath>` | Directory containing a `.uipx` or `.uis` file (required) | -- |
-| `<outputPath>` | Directory where the .zip will be written (required positional, no default — omitting it errors with `missing required argument 'outputPath'`) | -- |
+| `<output-path>` | Directory where the .zip will be written (required positional, no default — omitting it errors with `missing required argument 'output-path'`) | -- |
 | `--name <name>` | Override the package name | Name from `.uipx` |
 | `--version <version>` | Set the package version | `1.0.0` |
 
-The output is a `.zip` file named `<name>.<version>.zip` written under `<outputPath>/` (e.g., `MySolution.2.0.0.zip`). Run `solution resource refresh` first (from inside the solution dir, or with `--solution-folder <path>`) to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
+The output is a `.zip` file named `<name>.<version>.zip` written under `<output-path>/` (e.g., `MySolution.2.0.0.zip`). Run `solution resource refresh` first (from inside the solution dir, or with `--solution-folder <path>`) to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
 
 ## Step 2: Publish to the Solution Feed
 


### PR DESCRIPTION
## Summary
- updates solution and Maestro case skill references from <outputPath> to <output-path>
- updates the documented missing-argument message for solution pack

## Validation
- git diff --check
- bash hooks/validate-skill-descriptions.sh
- rg -n "<outputPath>|\[outputPath\]|missing required argument 'outputPath'|outputPath" skills/uipath-maestro-case skills/uipath-solution skills/uipath-maestro-flow tests commands agents README.md CLAUDE.md

## Cross-links
- CLI PR: https://github.com/UiPath/cli/pull/2192