### PR TITLE
[codex] Fix Maestro BPMN runtime dependency guidance

### DIFF
--- a/skills/uipath-maestro-bpmn/.maintenance/check-real-pack.sh
+++ b/skills/uipath-maestro-bpmn/.maintenance/check-real-pack.sh
@@ -56,8 +56,8 @@ if uip login status --output json >"$TMPDIR/login-status.json" 2>&1 \
     solution_file="$solution_dir/solution-$name.uipx"
     solution_count=$((solution_count + 1))
 
-    if ! run_json_command "solution-new-$name" \
-      uip solution new "$solution_dir" --output json; then
+    if ! run_json_command "solution-init-$name" \
+      uip solution init "$solution_dir" --output json; then
       errors=1
       continue
     fi

--- a/skills/uipath-maestro-bpmn/.maintenance/check-validation-fixtures.py
+++ b/skills/uipath-maestro-bpmn/.maintenance/check-validation-fixtures.py
@@ -199,6 +199,8 @@ class Validator:
     def validate_regressions(self) -> list[str]:
         errors: list[str] = []
         errors.extend(self.validate_gateway_misnamed_repro())
+        errors.extend(self.validate_bindings_version_repro())
+        errors.extend(self.validate_script_result_response_repro())
         return errors
 
     def validate_gateway_misnamed_repro(self) -> list[str]:
@@ -234,6 +236,65 @@ class Validator:
                 "error for a copied project whose single BPMN file no longer matches "
                 "the project directory name; "
                 f"observed: {details}"
+            ]
+
+    def validate_bindings_version_repro(self) -> list[str]:
+        """Assert bindings_v2.json without version is rejected."""
+
+        fixture = FIXTURES / "linear-process"
+        if not fixture.is_dir():
+            return [
+                "regression bindings-version-repro: "
+                "source fixture linear-process is missing"
+            ]
+
+        with tempfile.TemporaryDirectory(prefix="bindings-version-repro-", dir=ROOT) as tmp:
+            project = Path(tmp) / "linear-process"
+            shutil.copytree(fixture, project)
+            bindings_path = project / "bindings_v2.json"
+            data = json.loads(bindings_path.read_text(encoding="utf-8"))
+            data.pop("version", None)
+            bindings_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+            regression = Validator()
+            regression.validate_project(project)
+            if any("version must be 2.0" in err for err in regression.errors):
+                return []
+
+            details = "; ".join(regression.errors) or "no validation error"
+            return [
+                "regression bindings-version-repro failed: expected bindings_v2.json "
+                f"version validation error; observed: {details}"
+            ]
+
+    def validate_script_result_response_repro(self) -> list[str]:
+        """Assert script output mappings cannot read result fields above response."""
+
+        fixture = FIXTURES / "subprocess-multi-instance"
+        if not fixture.is_dir():
+            return [
+                "regression script-result-response-repro: "
+                "source fixture subprocess-multi-instance is missing"
+            ]
+
+        with tempfile.TemporaryDirectory(prefix="script-result-response-repro-", dir=ROOT) as tmp:
+            project = Path(tmp) / "subprocess-multi-instance"
+            shutil.copytree(fixture, project)
+            bpmn = project / "subprocess-multi-instance.bpmn"
+            text = bpmn.read_text(encoding="utf-8")
+            text = text.replace('source="=result.response"', 'source="=result.outcome"', 1)
+            bpmn.write_text(text, encoding="utf-8")
+
+            regression = Validator()
+            regression.validate_project(project)
+            expected = "BPMN.ScriptTask output source must read result.response"
+            if any(expected in err for err in regression.errors):
+                return []
+
+            details = "; ".join(regression.errors) or "no validation error"
+            return [
+                "regression script-result-response-repro failed: expected script output "
+                f"result.response validation error; observed: {details}"
             ]
 
     def validate_public_safety(self, path: Path, text: str) -> None:
@@ -759,6 +820,8 @@ class Validator:
                 continue
             if local(elem.tag) in {"activity", "event"}:
                 self.validate_activity_or_event(path, elem, bindings, parent_map)
+            if local(elem.tag) == "mapping":
+                self.validate_script_mapping(path, elem, parent_map)
             if local(elem.tag) == "output":
                 target = elem.attrib.get("var") or elem.attrib.get("target")
                 if target and target not in variables["writable"]:
@@ -779,6 +842,29 @@ class Validator:
                 variables,
                 f"uipath:{local(elem.tag)} text",
             )
+
+    def validate_script_mapping(
+        self,
+        path: Path,
+        elem: ET.Element,
+        parent_map: dict[int, ET.Element],
+    ) -> None:
+        type_elem = elem.find(f"{{{UIPATH_NS}}}type")
+        mapping_type = type_elem.attrib.get("value") if type_elem is not None else None
+        extension_elements = parent_map.get(id(elem))
+        bpmn_parent = parent_map.get(id(extension_elements))
+        is_script_parent = bpmn_parent is not None and local(bpmn_parent.tag) == "scriptTask"
+        if mapping_type != "BPMN.ScriptTask" and not is_script_parent:
+            return
+
+        for output in elem.findall(f"{{{UIPATH_NS}}}output"):
+            source = output.attrib.get("source", "")
+            if source.startswith("=result.") and not source.startswith("=result.response"):
+                self.error(
+                    path,
+                    "BPMN.ScriptTask output source must read result.response "
+                    f"or result.response.<field>, found {source}",
+                )
 
     def validate_activity_or_event(
         self,
@@ -912,6 +998,16 @@ class Validator:
             )
         if data["operate.json"].get("contentType") != "ProcessOrchestration":  # type: ignore[union-attr]
             self.error(project / "operate.json", "contentType must be ProcessOrchestration")
+
+        bindings_file = data["bindings_v2.json"]
+        if not isinstance(bindings_file, dict):
+            self.error(project / "bindings_v2.json", "must be a JSON object")
+            return
+        if bindings_file.get("version") != "2.0":
+            self.error(project / "bindings_v2.json", "version must be 2.0")
+        if not isinstance(bindings_file.get("resources"), list):
+            self.error(project / "bindings_v2.json", "resources must be an array")
+            return
 
         descriptor_content = set(data["package-descriptor.json"].get("content", []))  # type: ignore[union-attr]
         for required in (

--- a/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/impl.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/impl.md
@@ -7,7 +7,11 @@ This document defines the implementation boundary for agent task recipes. Agents
 The model may edit:
 
 - `bpmn:serviceTask` wrapper for agent invocation.
-- `Orchestrator.StartAgentJob` activity shell for any folder-deployed agent (coded Python or low-code) with the required binding pair (`name` + `folderPath`, `resource="process"`, `resourceSubType="Agent"`, paired `propertyAttribute` values).
+- Draft `Orchestrator.StartAgentJob` activity shell only for folder-deployed
+  dependencies confirmed as `processType: "Agent"`. Use resolved process
+  identity context from the current shell guidance, and treat runtime
+  `releaseKey` faults as product/runtime blockers until live debug proves the
+  shell executable.
 - `A2A.AgentExecution` activity shell for external A2A agents addressed by URL/skillId/authToken.
 - Input CDATA for public-safe invocation payloads.
 - Output mappings for job ID, status, result, and structured fields.
@@ -23,7 +27,9 @@ The CLI or operator must resolve:
 
 ## Validation expectations
 
-- Agent binding resolves before upload/run.
+- Agent resource binding resolves before upload/run. For `StartAgentJob`, local
+  validation only proves source structure; live debug is still required before
+  claiming the wrapper is executable.
 - Input variables and output variables exist.
 - Timeout and invalid-output paths are modeled when needed.
 - High-impact outputs have review or validation gates when required by user intent.

--- a/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/impl.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/impl.md
@@ -9,9 +9,8 @@ The model may edit:
 - `bpmn:serviceTask` wrapper for agent invocation.
 - Draft `Orchestrator.StartAgentJob` activity shell only for folder-deployed
   dependencies confirmed as `processType: "Agent"`. Use resolved process
-  identity context from the current shell guidance, and treat runtime
-  `releaseKey` faults as product/runtime blockers until live debug proves the
-  shell executable.
+  identity context from the current shell guidance, generated bindings, and
+  current input/output schema metadata.
 - `A2A.AgentExecution` activity shell for external A2A agents addressed by URL/skillId/authToken.
 - Input CDATA for public-safe invocation payloads.
 - Output mappings for job ID, status, result, and structured fields.
@@ -28,8 +27,8 @@ The CLI or operator must resolve:
 ## Validation expectations
 
 - Agent resource binding resolves before upload/run. For `StartAgentJob`, local
-  validation only proves source structure; live debug is still required before
-  claiming the wrapper is executable.
+  validation only proves source and package structure; an authorized run in the
+  target environment is required before claiming runtime behavior.
 - Input variables and output variables exist.
 - Timeout and invalid-output paths are modeled when needed.
 - High-impact outputs have review or validation gates when required by user intent.

--- a/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/planning.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/planning.md
@@ -20,8 +20,16 @@ Use this reference when planning agent execution from BPMN. Agents are resource 
 
 ## Model may draft
 
-- `bpmn:serviceTask` wrapper with the wrapper shell that matches the agent deployment style (`Orchestrator.StartAgentJob` for folder-deployed coded or low-code agents; `A2A.AgentExecution` for external A2A; `Intsvc.*AgentExecution` for Integration Service external agents) — see [../../task-recipes/agent-job.md](../../task-recipes/agent-job.md) for the decision table.
-- For `Orchestrator.StartAgentJob`, the required binding pair (`name` + `folderPath`, same `resourceKey`, `resource="process"`, `resourceSubType="Agent"`) and the matching context inputs `=bindings.<bindingId>`.
+- `bpmn:serviceTask` wrapper with the wrapper shell that matches the process
+  type and invocation style (`Orchestrator.StartAgentJob` draft shell for
+  folder-deployed dependencies confirmed as `processType: "Agent"`;
+  `A2A.AgentExecution` for external A2A; `Intsvc.*AgentExecution` for
+  Integration Service external agents). See
+  [../../task-recipes/agent-job.md](../../task-recipes/agent-job.md) for the
+  decision table.
+- For `Orchestrator.StartAgentJob`, resolved process identity context and
+  solution-style process bindings from the current shell guidance. Do not treat
+  local validation as proof of executable agent invocation.
 - Input/output mappings, boundary timeout/error paths, and gateways.
 - Public-safe resource placeholders.
 

--- a/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/planning.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/plugins/agents/planning.md
@@ -28,7 +28,7 @@ Use this reference when planning agent execution from BPMN. Agents are resource 
   [../../task-recipes/agent-job.md](../../task-recipes/agent-job.md) for the
   decision table.
 - For `Orchestrator.StartAgentJob`, resolved process identity context and
-  solution-style process bindings from the current shell guidance. Do not treat
+  generated process bindings from the current shell guidance. Do not treat
   local validation as proof of executable agent invocation.
 - Input/output mappings, boundary timeout/error paths, and gateways.
 - Public-safe resource placeholders.

--- a/skills/uipath-maestro-bpmn/references/author/references/plugins/script/impl.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/plugins/script/impl.md
@@ -61,7 +61,8 @@ The model may edit:
 Copy this shape when authoring a new BPMN script task. It is the exact
 mapping shape Maestro expects: `uipath:input name="args"`
 wraps the mapped fields, the script body reads top-level identifiers,
-and the output maps back through `=result.<field>`.
+and the output maps back through `=result.response` for scalar returns or
+`=result.response.<field>` for object fields.
 
 ```xml
 <bpmn:scriptTask id="Task_RiskScore" name="Risk Score" scriptFormat="JavaScript">
@@ -94,7 +95,7 @@ Required pieces:
 | `uipath:input` | `name="args"` | The canvas merges `args` JSON into top-level script identifiers |
 | `uipath:input` body | `=vars.<variableId>` for each mapped field | Reads root variables by id, not by name |
 | `bpmn:script` CDATA | top-level identifiers (`amount`, `daysOverdue`); not `args.amount` | Jint sees the merged JSON as top-level vars |
-| `uipath:output` | `source="=result.<field>"` for `v2+`; `var` points at a declared variable id | Maps the script return back to a declared variable |
+| `uipath:output` | `source="=result.response"` for scalar returns, or `source="=result.response.<field>"` for object fields; `var` points at a declared variable id | Maps the script return back to a declared variable |
 
 Anti-patterns the checker rejects:
 
@@ -103,6 +104,8 @@ Anti-patterns the checker rejects:
 - `args.amount` style reads inside the script body.
 - Missing `uipath:scriptVersion` when the canvas requires it.
 - Returning a bare value instead of `{ response: ... }` for `v2+` mappings.
+- Mapping object returns with `source="=result.summary"` after returning
+  `{ summary: "..." }`; use `source="=result.response.summary"` instead.
 
 ## Validation expectations
 
@@ -110,4 +113,6 @@ Anti-patterns the checker rejects:
 - Output variables exist and are writable.
 - Script CDATA is syntactically coherent.
 - `uipath:scriptVersion` is present when required by the local contract.
-- For `v2` and later, returned JSON may map through `=result.response`; older script versions must return a JSON object.
+- For `v2` and later, returned JSON maps through `=result.response` or a field
+  below it, such as `=result.response.status`; older script versions must
+  return a JSON object.

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
@@ -9,22 +9,14 @@ runtime contract as low-code Agent Builder processes published as
 
 | Agent deployment style | Wrapper shell | Notes |
 | --- | --- | --- |
-| Coded Python dependency published as `Function` | Not yet live-debug verified for `StartAgentJob`; if using `StartJob`, use the process wrapper context including `folderId` | Direct Orchestrator `jobs start` can work, but BPMN wrappers may fault before creating a child job. Record `debug-instance incidents` and treat unresolved wrapper faults as product/runtime blockers. |
-| Low-code Agent Builder agent published as `Agent` | `Orchestrator.StartAgentJob` draft shell | Use resolved process identity fields. Current debug runs may still fault with `Required field 'releaseKey' missing in the input args to RPA task` after solution refresh imports the agent and debug variables show `releaseKey` populated; do not claim executable success until a tenant debug run proves it. |
+| Coded Python dependency published as `Function` | Use the process wrapper contract, not `StartAgentJob`, unless discovery documents a different wrapper | Resolve process identity, folder scope, input schema, and output schema before Operate. |
+| Low-code Agent Builder agent published as `Agent` | `Orchestrator.StartAgentJob` shell | Use resolved process identity fields, generated bindings, and current input/output schema metadata. Do not claim executable success from local XML validation alone. |
 | External A2A agent addressed by URL / skillId / authToken | `A2A.AgentExecution` | Studio Web renders this as an external A2A node and disables the Action dropdown. Do not use for folder-deployed agents — the canvas will treat the task as misconfigured. |
 | Integration Service external agent | `Intsvc.SyncAgentExecution`, `Intsvc.AsyncAgentExecution`, or legacy `Intsvc.AsyncExecution` | CLI must enrich connector resource key, connection binding, dynamic schemas, and operation metadata. |
 
 Common authoring mistake: assuming local validation or packaging proves the
-agent wrapper is executable. The validator may accept stale shapes that fault
-before child-job creation. Always inspect
-`uip maestro bpmn debug-instance incidents <INSTANCE_ID> --output json` after a
-faulted debug run.
-If the incident reports a missing `releaseKey`, inspect
-`uip maestro bpmn debug-instance variables <INSTANCE_ID> --output json` before
-editing the XML. If variables already contain the process identity and no child
-job exists in the target folder, treat the result as a wrapper/runtime blocker
-rather than continuing to move the same fields between context, direct inputs,
-`JobArguments`, and `body`.
+agent wrapper is executable. Validation checks structure and package shape; an
+authorized target-environment run is needed before claiming runtime behavior.
 Put the `JobArguments` input payload and `Process response` output payload as
 direct children of `uipath:activity`; do not put them in a sibling
 `uipath:mapping`.

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
@@ -9,7 +9,7 @@ runtime contract as low-code Agent Builder processes published as
 
 | Agent deployment style | Wrapper shell | Notes |
 | --- | --- | --- |
-| Coded Python dependency published as `Function` | Not yet live-debug verified for `StartAgentJob` | Direct Orchestrator `jobs start` can work, but BPMN `StartAgentJob` may fault before creating a child job. Record `debug-instance incidents` and treat as a product/runtime blocker. |
+| Coded Python dependency published as `Function` | Not yet live-debug verified for `StartAgentJob`; if using `StartJob`, use the process wrapper context including `folderId` | Direct Orchestrator `jobs start` can work, but BPMN wrappers may fault before creating a child job. Record `debug-instance incidents` and treat unresolved wrapper faults as product/runtime blockers. |
 | Low-code Agent Builder agent published as `Agent` | `Orchestrator.StartAgentJob` draft shell | Use resolved process identity fields. Current debug runs may still fault with `Required field 'releaseKey' missing in the input args to RPA task` after solution refresh imports the agent and debug variables show `releaseKey` populated; do not claim executable success until a tenant debug run proves it. |
 | External A2A agent addressed by URL / skillId / authToken | `A2A.AgentExecution` | Studio Web renders this as an external A2A node and disables the Action dropdown. Do not use for folder-deployed agents — the canvas will treat the task as misconfigured. |
 | Integration Service external agent | `Intsvc.SyncAgentExecution`, `Intsvc.AsyncAgentExecution`, or legacy `Intsvc.AsyncExecution` | CLI must enrich connector resource key, connection binding, dynamic schemas, and operation metadata. |

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
@@ -1,25 +1,30 @@
 # Agent Job Recipe
 
-The current supported implementation wrapper for confirmed agent execution is
-`bpmn:serviceTask`. Pick the shell from agent deployment style, not from the
-agent's implementation language. Coded Python agents (LangGraph / LlamaIndex /
-OpenAI Agents) and low-code Agent Builder agents use the same wire format when
-both are deployed to an Orchestrator folder.
+Agent wrappers are authored as `bpmn:serviceTask`, but the executable runtime
+contract depends on the process type reported by
+`uip or processes list --all-fields`, not the source project label. Some coded
+Python "agents" are published as `processType: "Function"` and are not the same
+runtime contract as low-code Agent Builder processes published as
+`processType: "Agent"`.
 
 | Agent deployment style | Wrapper shell | Notes |
 | --- | --- | --- |
-| Coded Python agent published to an Orchestrator folder | `Orchestrator.StartAgentJob` | Required binding pair: two `uipath:binding` entries sharing one `resourceKey`, `resource="process"`, `resourceSubType="Agent"`, with `propertyAttribute="name"` and `propertyAttribute="folderPath"`. Context inputs MUST be `name` and `folderPath`, both `value="=bindings.<bindingId>"`. Studio Web's palette generates this shape under the "Coded Agent" service-task option. |
-| Low-code Agent Builder agent published to an Orchestrator folder | `Orchestrator.StartAgentJob` | Identical wire format to the coded case above. Agent type is opaque at the BPMN layer. |
+| Coded Python dependency published as `Function` | Not yet live-debug verified for `StartAgentJob` | Direct Orchestrator `jobs start` can work, but BPMN `StartAgentJob` may fault before creating a child job. Record `debug-instance incidents` and treat as a product/runtime blocker. |
+| Low-code Agent Builder agent published as `Agent` | `Orchestrator.StartAgentJob` draft shell | Use resolved process identity fields. Current debug runs may still fault with `Required field 'releaseKey' missing in the input args to RPA task` after solution refresh imports the agent and debug variables show `releaseKey` populated; do not claim executable success until a tenant debug run proves it. |
 | External A2A agent addressed by URL / skillId / authToken | `A2A.AgentExecution` | Studio Web renders this as an external A2A node and disables the Action dropdown. Do not use for folder-deployed agents — the canvas will treat the task as misconfigured. |
 | Integration Service external agent | `Intsvc.SyncAgentExecution`, `Intsvc.AsyncAgentExecution`, or legacy `Intsvc.AsyncExecution` | CLI must enrich connector resource key, connection binding, dynamic schemas, and operation metadata. |
 
-Common authoring mistake: drafting `Orchestrator.StartAgentJob` with a literal
-`agentName` context input, or with `releaseKey` / `folderId`. The Maestro
-BPMN packager validator rejects all three. Always use the binding-pair shape
-shown in
-[../../../shared/wrapper-shells.md](../../../shared/wrapper-shells.md#orchestratorstartagentjob-folder-deployed-agent--coded-python-or-low-code)
-and in the
-[agent-invocation fixture](../../../../fixtures/validation/agent-invocation/).
+Common authoring mistake: assuming local validation or packaging proves the
+agent wrapper is executable. The validator may accept stale shapes that fault
+before child-job creation. Always inspect
+`uip maestro bpmn debug-instance incidents <INSTANCE_ID> --output json` after a
+faulted debug run.
+If the incident reports a missing `releaseKey`, inspect
+`uip maestro bpmn debug-instance variables <INSTANCE_ID> --output json` before
+editing the XML. If variables already contain the process identity and no child
+job exists in the target folder, treat the result as a wrapper/runtime blocker
+rather than continuing to move the same fields between context, direct inputs,
+`JobArguments`, and `body`.
 Put the `JobArguments` input payload and `Process response` output payload as
 direct children of `uipath:activity`; do not put them in a sibling
 `uipath:mapping`.

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/api-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/api-workflow.md
@@ -3,6 +3,16 @@
 The current supported implementation wrapper for confirmed API workflow
 invocation is `bpmn:serviceTask` with `Orchestrator.ExecuteApiWorkflowAsync`.
 
+Live-debug verified context fields:
+
+- `ReleaseKey` = Orchestrator process GUID from `uip or processes list`.
+- `FolderKey` = target folder GUID.
+- `FolderPath` = target folder path.
+- `Name` = process display name.
+
+Use `type="string"` on those context inputs. Do not rely on a lone `name`
+context input or on lower-case registry field names for executable debug runs.
+
 The model may draft:
 
 - Service task wrapper and BPMN DI.
@@ -12,6 +22,7 @@ The model may draft:
 CLI or operator must resolve:
 
 - API workflow resource identity, folder binding, and generated package resources.
+- Solution-style `bindings_v2.json` entries for `uip solution resource refresh`.
 - Dynamic request and response schemas.
 - Fire-and-forget versus wait behavior when the product contract exposes that choice.
 

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/api-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/api-workflow.md
@@ -3,15 +3,15 @@
 The current supported implementation wrapper for confirmed API workflow
 invocation is `bpmn:serviceTask` with `Orchestrator.ExecuteApiWorkflowAsync`.
 
-Live-debug verified context fields:
+Use these context fields:
 
 - `ReleaseKey` = Orchestrator process GUID from `uip or processes list`.
 - `FolderKey` = target folder GUID.
 - `FolderPath` = target folder path.
 - `Name` = process display name.
 
-Use `type="string"` on those context inputs. Do not rely on a lone `name`
-context input or on lower-case registry field names for executable debug runs.
+Use `type="string"` on those context inputs. Do not rely on a lone display
+name when the wrapper requires resolved process and folder identity.
 
 The model may draft:
 

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/rpa-job.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/rpa-job.md
@@ -3,10 +3,9 @@
 The current supported implementation wrapper for confirmed RPA process
 execution is `bpmn:serviceTask` with `Orchestrator.StartJob`.
 
-Live-debug verified `StartJob` context includes the process GUID, folder GUID,
-integer folder ID, folder path, and process name. A wrapper that has
-`FolderKey` but omits lower-case `folderId` can fault before child-job creation
-with `Required field 'folderId' missing in the input args to RPA task`.
+Use a complete `StartJob` context: process key, folder key, folder ID, folder
+path, and process name. Resolve these values from process and folder discovery
+before execution; keep examples public-safe.
 
 The model may draft:
 

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/rpa-job.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/rpa-job.md
@@ -3,6 +3,11 @@
 The current supported implementation wrapper for confirmed RPA process
 execution is `bpmn:serviceTask` with `Orchestrator.StartJob`.
 
+Live-debug verified `StartJob` context includes the process GUID, folder GUID,
+integer folder ID, folder path, and process name. A wrapper that has
+`FolderKey` but omits lower-case `folderId` can fault before child-job creation
+with `Required field 'folderId' missing in the input args to RPA task`.
+
 The model may draft:
 
 - Stable service task ID, display name, incoming/outgoing flows, and BPMN DI.

--- a/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
@@ -42,42 +42,6 @@ Fix ownership: CLI enrichment/generation owns connector metadata, connection bin
 and generated package resources.
 The model may adjust BPMN structure around the connector but must not invent connection IDs or private connector payloads.
 
-## Agent wrapper releaseKey fault
-
-A folder-deployed agent task using `Orchestrator.StartAgentJob` can fault before
-child-job creation with `Required field 'releaseKey' missing in the input args
-to RPA task`.
-
-Signs:
-
-- The faulting BPMN element is the agent service task.
-- Solution resource refresh imported the agent process successfully.
-- Debug variables show the process identity is present under `JobArguments` or
-  `body`, but the incident still reports missing `releaseKey`.
-- Orchestrator job queries in the target agent folder show no child job created
-  after the debug run started.
-
-Fix ownership: record the incident and variables, then treat this as a
-wrapper/runtime blocker. Do not keep reshuffling the same identity fields across
-context inputs, direct activity inputs, `JobArguments`, and `body` unless a new
-runtime contract is available.
-
-## StartJob folderId fault
-
-An `Orchestrator.StartJob` service task can fault before child-job creation with
-`Required field 'folderId' missing in the input args to RPA task`, even when
-`FolderKey` is present in context.
-
-Signs:
-
-- The faulting BPMN element is a `StartJob` service task.
-- The task context includes the process GUID and folder GUID, but not the
-  integer Orchestrator folder ID as lower-case `folderId`.
-- No child job appears in the target folder after the debug run starts.
-
-Fix ownership: add `folderId` to the `StartJob` context, revalidate, and run a
-new debug only with explicit consent.
-
 ## Stale generated package files
 
 Generated JSON no longer reflects the BPMN source.

--- a/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
@@ -62,6 +62,22 @@ wrapper/runtime blocker. Do not keep reshuffling the same identity fields across
 context inputs, direct activity inputs, `JobArguments`, and `body` unless a new
 runtime contract is available.
 
+## StartJob folderId fault
+
+An `Orchestrator.StartJob` service task can fault before child-job creation with
+`Required field 'folderId' missing in the input args to RPA task`, even when
+`FolderKey` is present in context.
+
+Signs:
+
+- The faulting BPMN element is a `StartJob` service task.
+- The task context includes the process GUID and folder GUID, but not the
+  integer Orchestrator folder ID as lower-case `folderId`.
+- No child job appears in the target folder after the debug run starts.
+
+Fix ownership: add `folderId` to the `StartJob` context, revalidate, and run a
+new debug only with explicit consent.
+
 ## Stale generated package files
 
 Generated JSON no longer reflects the BPMN source.

--- a/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
@@ -42,6 +42,26 @@ Fix ownership: CLI enrichment/generation owns connector metadata, connection bin
 and generated package resources.
 The model may adjust BPMN structure around the connector but must not invent connection IDs or private connector payloads.
 
+## Agent wrapper releaseKey fault
+
+A folder-deployed agent task using `Orchestrator.StartAgentJob` can fault before
+child-job creation with `Required field 'releaseKey' missing in the input args
+to RPA task`.
+
+Signs:
+
+- The faulting BPMN element is the agent service task.
+- Solution resource refresh imported the agent process successfully.
+- Debug variables show the process identity is present under `JobArguments` or
+  `body`, but the incident still reports missing `releaseKey`.
+- Orchestrator job queries in the target agent folder show no child job created
+  after the debug run started.
+
+Fix ownership: record the incident and variables, then treat this as a
+wrapper/runtime blocker. Do not keep reshuffling the same identity fields across
+context inputs, direct activity inputs, `JobArguments`, and `body` unless a new
+runtime contract is available.
+
 ## Stale generated package files
 
 Generated JSON no longer reflects the BPMN source.

--- a/skills/uipath-maestro-bpmn/references/diagnose/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/references/troubleshooting-guide.md
@@ -22,13 +22,18 @@ Collect public-safe identifiers:
 
 Do not record secrets, tenant URLs, connection IDs, or payload data in public notes.
 
-If you only have a job key, start with:
+If you only have a deployed-process job key, start with:
 
 ```bash
-uip maestro bpmn job status <JOB_KEY> --output json
+uip maestro bpmn job status <JOB_KEY> --folder-key <FOLDER_KEY> --output json
 ```
 
 Parse the instance ID, folder context, process key, final status, and any trace/run identifiers from the JSON output.
+For debug runs, prefer the `instanceId` returned by
+`uip maestro bpmn debug` and inspect it with `debug-instance` commands. If
+`job status` returns a different key or an old creation time for a debug ID,
+treat that as non-authoritative and continue with debug-instance incidents and
+variables.
 
 ## Step 2 - Read incidents
 

--- a/skills/uipath-maestro-bpmn/references/diagnose/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/references/troubleshooting-guide.md
@@ -30,10 +30,8 @@ uip maestro bpmn job status <JOB_KEY> --folder-key <FOLDER_KEY> --output json
 
 Parse the instance ID, folder context, process key, final status, and any trace/run identifiers from the JSON output.
 For debug runs, prefer the `instanceId` returned by
-`uip maestro bpmn debug` and inspect it with `debug-instance` commands. If
-`job status` returns a different key or an old creation time for a debug ID,
-treat that as non-authoritative and continue with debug-instance incidents and
-variables.
+`uip maestro bpmn debug` and inspect it with `debug-instance` commands. Keep
+deployed-instance status reads and debug-session inspection separate.
 
 ## Step 2 - Read incidents
 

--- a/skills/uipath-maestro-bpmn/references/operate/references/run.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/run.md
@@ -19,6 +19,18 @@ Before any debug or process run:
 Use debug when the user wants to upload a local BPMN project to Studio Web and run a debug session with full Studio Web
 visibility.
 
+Debug requires a solution context. If direct project debug fails with
+`SolutionStorage.json is missing and no .uipx file was found`, initialize a
+solution, import the BPMN project, refresh resources, and run debug from the
+solution directory:
+
+```bash
+uip solution init <SolutionName> --output json
+uip solution project import --source <ProjectDir> --solutionFile <SolutionName>/<SolutionName>.uipx --output json
+uip solution resource refresh --solution-folder <SolutionName> --output json
+cd <SolutionName> && uip maestro bpmn debug <ProjectDirName> --output json
+```
+
 ```bash
 uip maestro bpmn debug <ProjectDir> --output json
 ```
@@ -58,7 +70,7 @@ or the process discovery output clearly identifies them.
 Use status first, then incidents and variables if the status is faulted or ambiguous:
 
 ```bash
-uip maestro bpmn job status <JOB_KEY> --output json
+uip maestro bpmn job status <JOB_KEY> --folder-key <FOLDER_KEY> --output json
 uip maestro bpmn instance get <INSTANCE_ID> -f <FOLDER_KEY> --output json
 uip maestro bpmn instance incidents <INSTANCE_ID> -f <FOLDER_KEY> --output json
 ```
@@ -67,6 +79,18 @@ Use traces only when status, incidents, variables, and deployed BPMN correlation
 
 ```bash
 uip maestro bpmn job traces <JOB_KEY> --output json
+```
+
+For debug instances, prefer the `debug-instance` inspection commands when
+`instance get/incidents` return 404 or empty data. They expose runtime wrapper
+errors that normal traces may omit. If `job status` returns a key or timestamp
+that does not match the debug instance, do not use that status as the source of
+truth; continue with the debug-instance commands returned by the debug run.
+
+```bash
+uip maestro bpmn debug-instance incidents <INSTANCE_ID> --output json
+uip maestro bpmn debug-instance variables <INSTANCE_ID> --output json
+uip maestro bpmn debug-instance variables-all <INSTANCE_ID> --output json
 ```
 
 ## Execution summary

--- a/skills/uipath-maestro-bpmn/references/operate/references/run.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/run.md
@@ -19,10 +19,9 @@ Before any debug or process run:
 Use debug when the user wants to upload a local BPMN project to Studio Web and run a debug session with full Studio Web
 visibility.
 
-Debug requires a solution context. If direct project debug fails with
-`SolutionStorage.json is missing and no .uipx file was found`, initialize a
-solution, import the BPMN project, refresh resources, and run debug from the
-solution directory:
+For local project debug, prefer a solution context so generated resources,
+bindings, and debug metadata are available. Initialize a solution, import the
+BPMN project, refresh resources, and run debug from the solution directory:
 
 ```bash
 uip solution init <SolutionName> --output json
@@ -82,10 +81,8 @@ uip maestro bpmn job traces <JOB_KEY> --output json
 ```
 
 For debug instances, prefer the `debug-instance` inspection commands when
-`instance get/incidents` return 404 or empty data. They expose runtime wrapper
-errors that normal traces may omit. If `job status` returns a key or timestamp
-that does not match the debug instance, do not use that status as the source of
-truth; continue with the debug-instance commands returned by the debug run.
+standard deployed-instance commands do not have debug-session context. Use the
+identifiers returned by the debug command as the source of truth.
 
 ```bash
 uip maestro bpmn debug-instance incidents <INSTANCE_ID> --output json

--- a/skills/uipath-maestro-bpmn/references/operate/references/ship.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/ship.md
@@ -21,6 +21,11 @@ Before upload, publish, deploy, or debug:
    CLI contract says otherwise. Use
    [local-metadata-regeneration-guide.md](../../shared/local-metadata-regeneration-guide.md) for the local drift
    checks that connect BPMN source, entry points, bindings, and `Intsvc.*` payload enrichment.
+   When the BPMN references external Orchestrator processes, `uip solution
+   resource refresh` expects solution-style process bindings in
+   `bindings_v2.json` (`resource`, `key`, `value.name.defaultValue`,
+   `value.folderPath.defaultValue`, and metadata), not only the older
+   id-addressable BPMN mirror entries.
 5. Confirm login for cloud actions:
 
    ```bash
@@ -54,6 +59,10 @@ uip solution upload <SolutionDir> --output json
 
 If the solution has resource declarations, refresh them with the supported solution tooling in the local CLI.
 Do not invent a `solution resource` command path; verify the installed CLI help before documenting a refresh step.
+Treat `Result: Success` with `Created: 0`, `Imported: 0`, and `Skipped: 0` as
+suspicious when project `bindings_v2.json` files contain resources. Inspect
+stderr/log output for binding serializer errors and verify that files appeared
+under `resources/solution_folder/` and `userProfile/.../debug_overwrites.json`.
 
 Report the Studio Web URL or solution ID when the CLI returns one.
 If the upload succeeds but returns no URL, say `<not returned by CLI>` instead of omitting the field.

--- a/skills/uipath-maestro-bpmn/references/operate/references/ship.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/ship.md
@@ -60,13 +60,9 @@ uip solution upload <SolutionDir> --output json
 
 If the solution has resource declarations, refresh them with the supported solution tooling in the local CLI.
 Do not invent a `solution resource` command path; verify the installed CLI help before documenting a refresh step.
-Treat `Result: Success` with `Created: 0`, `Imported: 0`, and `Skipped: 0` as
-suspicious when project `bindings_v2.json` files contain resources. Inspect
-stderr/log output for binding serializer errors and verify that files appeared
-under `resources/solution_folder/` and `userProfile/.../debug_overwrites.json`.
-If `0/0/0` appears only after `resources` was deliberately emptied, treat the
-run as a hard-coded-context debug workaround rather than dependency refresh
-coverage.
+When the project declares resource dependencies, verify that refresh produced
+matching generated resource files and debug overwrite metadata. An empty
+`resources` array is valid only for projects with no generated dependencies.
 
 Report the Studio Web URL or solution ID when the CLI returns one.
 If the upload succeeds but returns no URL, say `<not returned by CLI>` instead of omitting the field.

--- a/skills/uipath-maestro-bpmn/references/operate/references/ship.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/ship.md
@@ -22,10 +22,11 @@ Before upload, publish, deploy, or debug:
    [local-metadata-regeneration-guide.md](../../shared/local-metadata-regeneration-guide.md) for the local drift
    checks that connect BPMN source, entry points, bindings, and `Intsvc.*` payload enrichment.
    When the BPMN references external Orchestrator processes, `uip solution
-   resource refresh` expects solution-style process bindings in
-   `bindings_v2.json` (`resource`, `key`, `value.name.defaultValue`,
-   `value.folderPath.defaultValue`, and metadata), not only the older
-   id-addressable BPMN mirror entries.
+   resource refresh` expects a versioned `bindings_v2.json` object with a
+   `resources` array. Process resources should be generated or fixture-backed
+   entries with `id`, `kind`, `name`, `resourceKey`, `metadata`, `resource`,
+   `resourceSubType`, and `propertyAttribute` for name/folder-path pairs, not
+   an unwrapped array or unversioned placeholder.
 5. Confirm login for cloud actions:
 
    ```bash
@@ -63,6 +64,9 @@ Treat `Result: Success` with `Created: 0`, `Imported: 0`, and `Skipped: 0` as
 suspicious when project `bindings_v2.json` files contain resources. Inspect
 stderr/log output for binding serializer errors and verify that files appeared
 under `resources/solution_folder/` and `userProfile/.../debug_overwrites.json`.
+If `0/0/0` appears only after `resources` was deliberately emptied, treat the
+run as a hard-coded-context debug workaround rather than dependency refresh
+coverage.
 
 Report the Studio Web URL or solution ID when the CLI returns one.
 If the upload succeeds but returns no URL, say `<not returned by CLI>` instead of omitting the field.

--- a/skills/uipath-maestro-bpmn/references/shared/expression-authoring.md
+++ b/skills/uipath-maestro-bpmn/references/shared/expression-authoring.md
@@ -12,8 +12,10 @@ them with expressions only after the variables and scopes exist.
   `=vars.Var_RequestId`.
 - Do not use bare variable names such as `=requestId` in generated runtime XML.
 - Context bindings use `=bindings.<bindingId>`.
-- Current element outputs use `result` only in output mappings for that element,
-  for example `source="=result.response"` for script task results.
+- Current element outputs use `result` only in output mappings for that
+  element. Script task return values are exposed under `result.response`; use
+  `source="=result.response"` for scalar returns or
+  `source="=result.response.<field>"` for object fields.
 - Multi-instance task bodies read the current item from `iterator.item`.
 - Multi-instance subprocess bodies read the current item from
   `iterator[0].item`. Use `iterator[1].item` (and so on) inside nested

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -123,7 +123,21 @@ JSON schema variables use their CDATA body as the property schema. Strip `$schem
 
 ## Binding Rules
 
-Generated `bindings_v2.json` must include one resource for each root binding that is not only a folder helper attribute. The resource should preserve:
+Generated `bindings_v2.json` has two consumers with different tolerance:
+
+- Local/package binding expressions may need id-addressable entries that mirror
+  root `uipath:binding` IDs.
+- `uip solution resource refresh` expects solution-style resource entries such
+  as `resource`, `key`, `value.name.defaultValue`, and
+  `value.folderPath.defaultValue`.
+
+When an executable BPMN depends on remote Orchestrator processes, include the
+solution-style process binding so refresh can import the process/package
+resources and write debug overwrites. A refresh result of
+`Created:0 Imported:0 Skipped:0` while non-empty bindings exist is a failure
+signal, even if the JSON wrapper says `Result: Success`.
+
+Generated id-addressable entries should preserve:
 
 - `id`, `name`, kind/type, and `resourceKey`.
 - `metadata.BindingsVersion` for the source binding version.

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -98,9 +98,9 @@ do not invent `contentFiles` as a substitute for `content`.
 }
 ```
 
-This empty resource file is a local package/debug placeholder only when every
-runtime identity field is supplied directly in BPMN context. It is not evidence
-that dependency refresh imported any external process, queue, or connection.
+This empty resource file is a package-shape placeholder only for projects with
+no generated resource dependencies. It is not evidence that dependency refresh
+imported an external process, queue, connector, or agent.
 
 `package-descriptor.json`:
 
@@ -131,8 +131,7 @@ JSON schema variables use their CDATA body as the property schema. Strip `$schem
 Generated `bindings_v2.json` must be a top-level object with
 `"version": "2.0"` and a `resources` array. Do not use a bare resource array, a
 single resource object, or an unversioned `{ "resources": [] }` object; those
-shapes can pass casual JSON inspection but fail solution resource refresh
-deserialization.
+shapes are not the package contract consumed by solution resource refresh.
 
 The resource array has two consumers with different tolerance:
 
@@ -147,11 +146,9 @@ The resource array has two consumers with different tolerance:
 
 When an executable BPMN depends on remote Orchestrator processes, include
 generated process binding resources before refresh so it can import the
-process/package resources and write debug overwrites. A refresh result of
-`Created:0 Imported:0 Skipped:0` while non-empty resources exist is a failure
-signal, even if the JSON wrapper says `Result: Success`. The same `0/0/0`
-result after intentionally emptying `resources` is only a debug workaround for
-hard-coded BPMN context identity, not a successful dependency refresh.
+process/package resources and write debug overwrites. If resource dependencies
+are expected, verify that refresh produced matching generated resource files or
+explicitly report that no dependency resources were imported.
 
 Generated id-addressable entries should preserve:
 

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -93,9 +93,14 @@ do not invent `contentFiles` as a substitute for `content`.
 
 ```json
 {
+  "version": "2.0",
   "resources": []
 }
 ```
+
+This empty resource file is a local package/debug placeholder only when every
+runtime identity field is supplied directly in BPMN context. It is not evidence
+that dependency refresh imported any external process, queue, or connection.
 
 `package-descriptor.json`:
 
@@ -123,19 +128,30 @@ JSON schema variables use their CDATA body as the property schema. Strip `$schem
 
 ## Binding Rules
 
-Generated `bindings_v2.json` has two consumers with different tolerance:
+Generated `bindings_v2.json` must be a top-level object with
+`"version": "2.0"` and a `resources` array. Do not use a bare resource array, a
+single resource object, or an unversioned `{ "resources": [] }` object; those
+shapes can pass casual JSON inspection but fail solution resource refresh
+deserialization.
+
+The resource array has two consumers with different tolerance:
 
 - Local/package binding expressions may need id-addressable entries that mirror
   root `uipath:binding` IDs.
-- `uip solution resource refresh` expects solution-style resource entries such
-  as `resource`, `key`, `value.name.defaultValue`, and
-  `value.folderPath.defaultValue`.
+- `uip solution resource refresh` reads the same `resources` array and imports
+  concrete dependencies only when it contains parseable resource entries.
+  Process resources should come from CLI generation or fixture-backed binding
+  entries with `id`, `kind`, `name`, `resourceKey`, `metadata`, `resource`,
+  `resourceSubType`, and, for name/folder-path binding pairs,
+  `propertyAttribute`.
 
-When an executable BPMN depends on remote Orchestrator processes, include the
-solution-style process binding so refresh can import the process/package
-resources and write debug overwrites. A refresh result of
-`Created:0 Imported:0 Skipped:0` while non-empty bindings exist is a failure
-signal, even if the JSON wrapper says `Result: Success`.
+When an executable BPMN depends on remote Orchestrator processes, include
+generated process binding resources before refresh so it can import the
+process/package resources and write debug overwrites. A refresh result of
+`Created:0 Imported:0 Skipped:0` while non-empty resources exist is a failure
+signal, even if the JSON wrapper says `Result: Success`. The same `0/0/0`
+result after intentionally emptying `resources` is only a debug workaround for
+hard-coded BPMN context identity, not a successful dependency refresh.
 
 Generated id-addressable entries should preserve:
 

--- a/skills/uipath-maestro-bpmn/references/shared/variables-bindings-expressions.md
+++ b/skills/uipath-maestro-bpmn/references/shared/variables-bindings-expressions.md
@@ -123,7 +123,8 @@ with an `inputSchema` in context, but the Jint script body receives the mapped
 fields as top-level identifiers. For example, a mapped `caseId` field is read
 as `caseId` in script source, not `args.caseId`. Script outputs must map back
 to declared variable ids through the `var` attribute, usually with sources such
-as `=result.response`:
+as `=result.response` for a scalar return or `=result.response.<field>` for an
+object return:
 
 ```xml
 <uipath:mapping version="v1">
@@ -134,6 +135,10 @@ as `=result.response`:
   <uipath:output name="status" type="string" var="Var_Status" source="=result.response" />
 </uipath:mapping>
 ```
+
+If the script returns `{ status: "ok" }`, map the status with
+`source="=result.response.status"`. `source="=result.status"` can complete the
+script task while leaving the target variable null.
 
 Do not use `name="Var_Status"` as a substitute for `var="Var_Status"`. The
 `name` field identifies the output field; `var` identifies the target BPMN

--- a/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
+++ b/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
@@ -46,13 +46,9 @@ Namespace baseline for greenfield files:
 ## Orchestrator.StartJob (RPA)
 
 `bpmn:serviceTask` with `Orchestrator.StartJob`.
-Live debug uses the process identity fields in `uipath:context`; a lone
-display-name context can validate locally but fail before child-job creation.
-For `StartJob`, live debug has also required the integer Orchestrator folder ID
-as lower-case `folderId`, even when `FolderKey` is present. Use public-safe
-placeholders in examples and resolve real values from
-`uip or processes list --all-fields --output json` and folder discovery during
-tenant-specific work.
+Use a complete process identity context instead of a display-name-only shell.
+For process job wrappers, resolve process and folder identity from discovery
+commands before execution; keep examples placeholder-safe.
 
 ```xml
 <bpmn:serviceTask id="Task_StartRpaJob" name="Start RPA Job">
@@ -78,21 +74,14 @@ tenant-specific work.
 ## Orchestrator.StartAgentJob (folder-deployed agent — coded Python or low-code)
 
 `bpmn:serviceTask` with `Orchestrator.StartAgentJob`. Use this wrapper only
-for a tenant dependency that is confirmed by `uip or processes list` as
-`processType: "Agent"`. Coded Python dependencies may surface as
-`processType: "Function"`; do not assume they use this wrapper.
-
-Current runtime caveat: live debug has shown `StartAgentJob` faulting before
-child-job creation with `Required field 'releaseKey' missing in the input args
-to RPA task`, even when solution resource refresh imports the agent and runtime
-variables show `releaseKey` populated under `JobArguments` or `body`. Treat
-this shell as draft-only until a tenant debug run proves it executable. Capture
-`uip maestro bpmn debug-instance incidents <INSTANCE_ID> --output json`,
-`uip maestro bpmn debug-instance variables <INSTANCE_ID> --output json`, and a
-child-job query for the target folder when it faults.
+for a dependency that discovery confirms as `processType: "Agent"`. Coded
+Python dependencies may surface as another process type; do not infer the
+wrapper from the source project label alone.
 
 When drafting the wrapper from a resolved Agent process, use the same identity
-context shape that process wrappers use:
+context shape that process wrappers use. Local validation proves XML/package
+shape only; do not claim executable behavior until the target resource,
+bindings, schemas, and authorized debug/run have been verified.
 
 ```xml
 <bpmn:serviceTask id="Task_StartAgentJob" name="Start Agent Job">
@@ -114,11 +103,10 @@ context shape that process wrappers use:
 </bpmn:serviceTask>
 ```
 
-For `uip solution resource refresh`, `bindings_v2.json` must use the
-versioned package resource wrapper. A process dependency usually has separate
-resource entries for the process name and folder path; the older unwrapped BPMN
-mirror shape and an unversioned `{ "resources": [] }` object are not sufficient
-for refresh:
+For `uip solution resource refresh`, `bindings_v2.json` must use a versioned
+package resource wrapper. A process dependency usually has separate resource
+entries for the process name and folder path; do not use an unwrapped resource
+array or unversioned placeholder as the source of dependency resources:
 
 ```json
 {
@@ -160,10 +148,9 @@ for refresh:
 }
 ```
 
-If a live debug run succeeds only after emptying `resources` and hard-coding
-`ReleaseKey`, `FolderKey`, `folderId`, `FolderPath`, and `Name` in BPMN
-context, record that as a debug workaround. Do not report it as dependency
-binding refresh coverage.
+An empty `resources` array is valid for package-shape verification when the
+BPMN has no generated resource dependencies. It does not represent imported
+dependencies for a process, queue, connector, or agent.
 
 `Var_RequestId` must already exist as a `uipath:inputOutput` variable readable at the task — see [variables-bindings-expressions.md](variables-bindings-expressions.md#entry-point-inputs-used-downstream) for the start-scoped input pattern.
 
@@ -193,10 +180,9 @@ start-scoped entry input, see
 ## Orchestrator.ExecuteApiWorkflowAsync
 
 `bpmn:serviceTask` with `Orchestrator.ExecuteApiWorkflowAsync`.
-This wrapper is live-debug verified when context uses the Orchestrator process
-GUID as `ReleaseKey` and the target folder GUID as `FolderKey`. The registry
-may display lower-case `releaseKey` / `folderId`; those names can validate but
-fault at runtime.
+Use the same process identity context pattern as other Orchestrator process
+wrappers. Keep context field names aligned with the wrapper shell and use
+resolved process/folder identifiers before execution.
 
 ```xml
 <bpmn:serviceTask id="Task_ExecuteApiWorkflow" name="Execute API Workflow">

--- a/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
+++ b/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
@@ -46,6 +46,10 @@ Namespace baseline for greenfield files:
 ## Orchestrator.StartJob (RPA)
 
 `bpmn:serviceTask` with `Orchestrator.StartJob`.
+Live debug uses the process identity fields in `uipath:context`; a lone
+display-name context can validate locally but fail before child-job creation.
+Use public-safe placeholders in examples and resolve real values from
+`uip or processes list --all-fields --output json` during tenant-specific work.
 
 ```xml
 <bpmn:serviceTask id="Task_StartRpaJob" name="Start RPA Job">
@@ -53,7 +57,10 @@ Namespace baseline for greenfield files:
     <uipath:activity version="v1">
       <uipath:type value="Orchestrator.StartJob" version="v1" />
       <uipath:context>
-        <uipath:input name="name" type="string" value="Synthetic Process" />
+        <uipath:input name="ReleaseKey" type="string" value="<PROCESS_KEY_GUID>" />
+        <uipath:input name="FolderKey" type="string" value="<FOLDER_KEY_GUID>" />
+        <uipath:input name="FolderPath" type="string" value="Shared/Synthetic" />
+        <uipath:input name="Name" type="string" value="Synthetic Process" />
       </uipath:context>
       <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"requestId":"=vars.Var_RequestId"}]]></uipath:input>
       <uipath:output name="Process response" type="Orchestrator.RunJob" var="Var_JobResult" />
@@ -66,31 +73,33 @@ Namespace baseline for greenfield files:
 
 ## Orchestrator.StartAgentJob (folder-deployed agent — coded Python or low-code)
 
-`bpmn:serviceTask` with `Orchestrator.StartAgentJob`. Use this shell for any agent published to an Orchestrator folder, regardless of whether the agent is a coded Python project (LangGraph / LlamaIndex / OpenAI Agents) or a low-code Agent Builder agent — the wire format is identical. For external A2A agents addressed by URL, use `A2A.AgentExecution` instead.
+`bpmn:serviceTask` with `Orchestrator.StartAgentJob`. Use this wrapper only
+for a tenant dependency that is confirmed by `uip or processes list` as
+`processType: "Agent"`. Coded Python dependencies may surface as
+`processType: "Function"`; do not assume they use this wrapper.
 
-Required binding shape (enforced by the Maestro BPMN packager validator — `uip maestro bpmn pack` and `uip solution pack` share these checks):
+Current runtime caveat: live debug has shown `StartAgentJob` faulting before
+child-job creation with `Required field 'releaseKey' missing in the input args
+to RPA task`, even when solution resource refresh imports the agent and runtime
+variables show `releaseKey` populated under `JobArguments` or `body`. Treat
+this shell as draft-only until a tenant debug run proves it executable. Capture
+`uip maestro bpmn debug-instance incidents <INSTANCE_ID> --output json`,
+`uip maestro bpmn debug-instance variables <INSTANCE_ID> --output json`, and a
+child-job query for the target folder when it faults.
 
-- Context inputs MUST be named exactly `name` and `folderPath`. Do not use `agentName`, `releaseKey`, or `folderId`.
-- Both values MUST be `value="=bindings.<bindingId>"` — literal strings are rejected.
-- Each context input points at its own binding. The pair shares one `resourceKey` and uses `resource="process"`, `resourceSubType="Agent"` (case-sensitive `A`), with `propertyAttribute="name"` on one binding and `propertyAttribute="folderPath"` on the other.
+When drafting the wrapper from a resolved Agent process, use the same identity
+context shape that process wrappers use:
 
 ```xml
-<uipath:bindings version="v1">
-  <uipath:binding id="Binding_AgentName" name="Synthetic Agent" type="process" elementId="Task_StartAgentJob"
-                  resource="process" resourceSubType="Agent" resourceKey="synthetic-agent"
-                  propertyAttribute="name" />
-  <uipath:binding id="Binding_AgentFolderPath" name="Synthetic Agent" type="process" elementId="Task_StartAgentJob"
-                  resource="process" resourceSubType="Agent" resourceKey="synthetic-agent"
-                  propertyAttribute="folderPath" />
-</uipath:bindings>
-
 <bpmn:serviceTask id="Task_StartAgentJob" name="Start Agent Job">
   <bpmn:extensionElements>
     <uipath:activity version="v1">
       <uipath:type value="Orchestrator.StartAgentJob" version="v1" />
       <uipath:context>
-        <uipath:input name="name" type="string" value="=bindings.Binding_AgentName" />
-        <uipath:input name="folderPath" type="string" value="=bindings.Binding_AgentFolderPath" />
+        <uipath:input name="ReleaseKey" type="string" value="<AGENT_PROCESS_KEY_GUID>" />
+        <uipath:input name="FolderKey" type="string" value="<FOLDER_KEY_GUID>" />
+        <uipath:input name="FolderPath" type="string" value="Shared/SyntheticAgentSolution" />
+        <uipath:input name="Name" type="string" value="Synthetic Agent" />
       </uipath:context>
       <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"requestId":"=vars.Var_RequestId"}]]></uipath:input>
       <uipath:output name="Process response" type="Orchestrator.RunJob" var="Var_AgentJobResult" />
@@ -101,30 +110,30 @@ Required binding shape (enforced by the Maestro BPMN packager validator — `uip
 </bpmn:serviceTask>
 ```
 
-`bindings_v2.json` MUST mirror the BPMN pair. Both entries use `kind: "process"` and `metadata.SubType: "Agent"`; the `propertyAttribute` is preserved in `metadata`:
+For `uip solution resource refresh`, use solution-style process bindings in
+`bindings_v2.json`; the older BPMN mirror shape is not sufficient for refresh:
 
 ```json
 {
-  "id": "Binding_AgentName",
-  "name": "Synthetic Agent",
-  "kind": "process",
   "resource": "process",
-  "resourceSubType": "Agent",
-  "propertyAttribute": "name",
-  "resourceKey": "synthetic-agent",
+  "key": "Synthetic Agent",
+  "value": {
+    "name": { "defaultValue": "Synthetic Agent" },
+    "folderPath": { "defaultValue": "Shared/SyntheticAgentSolution" }
+  },
   "metadata": {
-    "BindingsVersion": "v1",
-    "DisplayLabel": "Synthetic Agent",
-    "SolutionsSupport": "Required",
-    "SubType": "Agent",
-    "PropertyAttribute": "name"
+    "subType": "agent",
+    "bindingsVersion": "2.2",
+    "solutionsSupport": "true"
   }
 }
 ```
 
 `Var_RequestId` must already exist as a `uipath:inputOutput` variable readable at the task — see [variables-bindings-expressions.md](variables-bindings-expressions.md#entry-point-inputs-used-downstream) for the start-scoped input pattern.
 
-For the full runnable end-to-end fixture (BPMN + bindings + start-scoped entry input), see [../../fixtures/validation/agent-invocation/](../../fixtures/validation/agent-invocation/).
+For the local validation fixture covering BPMN structure, bindings, and
+start-scoped entry input, see
+[../../fixtures/validation/agent-invocation/](../../fixtures/validation/agent-invocation/).
 
 ## A2A.AgentExecution (external A2A agent addressed by URL)
 
@@ -148,6 +157,10 @@ For the full runnable end-to-end fixture (BPMN + bindings + start-scoped entry i
 ## Orchestrator.ExecuteApiWorkflowAsync
 
 `bpmn:serviceTask` with `Orchestrator.ExecuteApiWorkflowAsync`.
+This wrapper is live-debug verified when context uses the Orchestrator process
+GUID as `ReleaseKey` and the target folder GUID as `FolderKey`. The registry
+may display lower-case `releaseKey` / `folderId`; those names can validate but
+fault at runtime.
 
 ```xml
 <bpmn:serviceTask id="Task_ExecuteApiWorkflow" name="Execute API Workflow">
@@ -155,7 +168,10 @@ For the full runnable end-to-end fixture (BPMN + bindings + start-scoped entry i
     <uipath:activity version="v1">
       <uipath:type value="Orchestrator.ExecuteApiWorkflowAsync" version="v1" />
       <uipath:context>
-        <uipath:input name="name" type="string" value="Synthetic API Workflow" />
+        <uipath:input name="ReleaseKey" type="string" value="<API_WORKFLOW_PROCESS_KEY_GUID>" />
+        <uipath:input name="FolderKey" type="string" value="<FOLDER_KEY_GUID>" />
+        <uipath:input name="FolderPath" type="string" value="Shared/Synthetic" />
+        <uipath:input name="Name" type="string" value="Synthetic API Workflow" />
       </uipath:context>
       <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"requestId":"=vars.Var_RequestId"}]]></uipath:input>
       <uipath:output name="Process response" type="Orchestrator.RunJob" var="Var_ApiWorkflowResult" />

--- a/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
+++ b/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
@@ -114,24 +114,56 @@ context shape that process wrappers use:
 </bpmn:serviceTask>
 ```
 
-For `uip solution resource refresh`, use solution-style process bindings in
-`bindings_v2.json`; the older BPMN mirror shape is not sufficient for refresh:
+For `uip solution resource refresh`, `bindings_v2.json` must use the
+versioned package resource wrapper. A process dependency usually has separate
+resource entries for the process name and folder path; the older unwrapped BPMN
+mirror shape and an unversioned `{ "resources": [] }` object are not sufficient
+for refresh:
 
 ```json
 {
-  "resource": "process",
-  "key": "Synthetic Agent",
-  "value": {
-    "name": { "defaultValue": "Synthetic Agent" },
-    "folderPath": { "defaultValue": "Shared/SyntheticAgentSolution" }
-  },
-  "metadata": {
-    "subType": "agent",
-    "bindingsVersion": "2.2",
-    "solutionsSupport": "true"
-  }
+  "version": "2.0",
+  "resources": [
+    {
+      "id": "Binding_AgentName",
+      "kind": "process",
+      "resource": "process",
+      "resourceSubType": "Agent",
+      "propertyAttribute": "name",
+      "name": "Synthetic Agent",
+      "resourceKey": "synthetic-agent",
+      "metadata": {
+        "BindingsVersion": "v1",
+        "DisplayLabel": "Synthetic Agent",
+        "SolutionsSupport": "Required",
+        "SubType": "Agent",
+        "PropertyAttribute": "name"
+      }
+    },
+    {
+      "id": "Binding_AgentFolderPath",
+      "kind": "process",
+      "resource": "process",
+      "resourceSubType": "Agent",
+      "propertyAttribute": "folderPath",
+      "name": "Synthetic Agent",
+      "resourceKey": "synthetic-agent",
+      "metadata": {
+        "BindingsVersion": "v1",
+        "DisplayLabel": "Synthetic Agent",
+        "SolutionsSupport": "Required",
+        "SubType": "Agent",
+        "PropertyAttribute": "folderPath"
+      }
+    }
+  ]
 }
 ```
+
+If a live debug run succeeds only after emptying `resources` and hard-coding
+`ReleaseKey`, `FolderKey`, `folderId`, `FolderPath`, and `Name` in BPMN
+context, record that as a debug workaround. Do not report it as dependency
+binding refresh coverage.
 
 `Var_RequestId` must already exist as a `uipath:inputOutput` variable readable at the task — see [variables-bindings-expressions.md](variables-bindings-expressions.md#entry-point-inputs-used-downstream) for the start-scoped input pattern.
 

--- a/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
+++ b/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
@@ -48,8 +48,11 @@ Namespace baseline for greenfield files:
 `bpmn:serviceTask` with `Orchestrator.StartJob`.
 Live debug uses the process identity fields in `uipath:context`; a lone
 display-name context can validate locally but fail before child-job creation.
-Use public-safe placeholders in examples and resolve real values from
-`uip or processes list --all-fields --output json` during tenant-specific work.
+For `StartJob`, live debug has also required the integer Orchestrator folder ID
+as lower-case `folderId`, even when `FolderKey` is present. Use public-safe
+placeholders in examples and resolve real values from
+`uip or processes list --all-fields --output json` and folder discovery during
+tenant-specific work.
 
 ```xml
 <bpmn:serviceTask id="Task_StartRpaJob" name="Start RPA Job">
@@ -59,6 +62,7 @@ Use public-safe placeholders in examples and resolve real values from
       <uipath:context>
         <uipath:input name="ReleaseKey" type="string" value="<PROCESS_KEY_GUID>" />
         <uipath:input name="FolderKey" type="string" value="<FOLDER_KEY_GUID>" />
+        <uipath:input name="folderId" type="string" value="<FOLDER_ID_INTEGER>" />
         <uipath:input name="FolderPath" type="string" value="Shared/Synthetic" />
         <uipath:input name="Name" type="string" value="Synthetic Process" />
       </uipath:context>


### PR DESCRIPTION
## Summary

Updates the `uipath-maestro-bpmn` skill with reusable generation guidance for BPMN projects that invoke Orchestrator-backed dependencies.

This PR keeps the skill guidance generic and public-safe:
- teaches agents to choose the wrapper from discovered process type, not from source project labels
- documents the complete process identity context shape for RPA/API workflow/process-style BPMN tasks
- keeps folder-deployed agent invocation as a process-type-driven wrapper decision with validation/run caveats, not tenant-specific instructions
- clarifies versioned `bindings_v2.json` package metadata shape and resource entries
- clarifies package metadata expectations for `project.uiproj`, `operate.json`, `entry-points.json`, `bindings_v2.json`, and `package-descriptor.json`
- clarifies script-task output mapping through `result.response`
- adds local regression checks for package metadata shape and script output mapping mistakes
- keeps debug/run guidance generic: use solution context, refresh resources, inspect returned debug identifiers, and avoid treating execution as validation

## Design Notes

The skill content avoids tenant identifiers, run-specific IDs, copied exported BPMN, private runtime artifacts, and incident-by-incident instructions. Private local eval evidence was translated into general authoring rules:

- generate the BPMN source as the record of process structure
- generate/package metadata using documented schemas
- resolve process/folder identity through discovery before execution
- treat Integration Service and dynamic resource metadata as CLI-owned
- validate locally before any cloud-side operation

## Validation

- `bash skills/uipath-maestro-bpmn/.maintenance/check-all.sh`
  - `checked=225 broken=0`
  - `anchors_checked=10 anchors_bad=0`
  - `validation_fixture_projects=9 bpmn_files=9 errors=0`
  - `real_pack_fixtures=9 solution_pack_fixtures=1 errors=0`
  - `commands_checked=38 unknown=0`
  - `All checks passed.`
- `git diff --check`
- public-safety scan over the final PR diff for tenant/eval-specific strings and private runtime wording
- redacted local E2E evals were used only as source evidence; artifacts are not included in this PR
