### PR TITLE
[codex] Simplify Maestro BPMN dependency guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,6 +177,7 @@ Links to reference documents in the `references/` folder for detailed topics.
 - **Specify `--output json`** for any CLI commands whose output needs to be parsed programmatically.
 - **Include anti-patterns.** A "What NOT to Do" section saves more time than a "What to Do" section.
 - **Link to references for depth.** Keep SKILL.md focused on workflow and rules. Move detailed API docs, schemas, and examples into `references/`.
+- **Ground prompt weight in evals.** Add or reuse an eval before expanding or simplifying guidance. Prefer generic, reusable contracts over task-specific workaround text, avoid documenting one-off failures as permanent instructions, and keep all examples public-safe with no tenant, customer, internal, or personal details.
 
 ### 4. Add Reference Documents (Optional)
 
@@ -199,8 +200,9 @@ Static files like code templates go in `assets/`:
 1. **Read before editing.** Understand the existing SKILL.md and references before making changes.
 2. **Preserve the Critical Rules section.** These exist for a reason. If you need to change a rule, explain why in your PR description.
 3. **Don't break frontmatter.** The `name` and `description` fields are parsed by the plugin system. Validate your YAML.
-4. **Test your changes.** After editing, verify the skill still activates correctly for its intended scenarios.
-5. **Coordinate with CODEOWNERS.** Check who owns the skill and tag them in your PR.
+4. **Use A/B/C evidence for behavioral edits.** For changes that alter guidance weight, specificity, workflows, or examples, run baseline/current/candidate evals on representative tasks. If simplification regresses output quality, restore the smallest generic contract that fixes the behavior.
+5. **Keep fixes generic and public-facing.** Do not add narrow instructions for a single observed error, tenant, customer, internal environment, or temporary workaround. Distill the durable rule, boundary, or contract instead.
+6. **Coordinate with CODEOWNERS.** Check who owns the skill and tag them in your PR.
 
 ## Hooks
 

--- a/skills/uipath-maestro-bpmn/references/author/references/plugins/script/impl.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/plugins/script/impl.md
@@ -24,31 +24,9 @@ The model may edit:
   expressions such as `=vars.Var_CaseId`, not bare names such as `=caseId`.
 - Return or map explicit outputs instead of mutating undeclared globals.
 - Script output mappings must target variables through the `var` attribute.
-  Do not put the target variable id in `name`. Use `name` for the output
-  field/display name and `var` for the declared BPMN variable id:
-
-  ```xml
-  <bpmn:process id="Process_RiskScore" isExecutable="true">
-    <bpmn:extensionElements>
-      <uipath:variables version="v1">
-        <uipath:input id="Var_Amount" name="amount" type="number" elementId="Start_Manual" />
-        <uipath:input id="Var_DaysOverdue" name="daysOverdue" type="number" elementId="Start_Manual" />
-        <uipath:output id="Var_RiskScore" name="riskScore" type="number" />
-      </uipath:variables>
-    </bpmn:extensionElements>
-    ...
-  </bpmn:process>
-  ```
-
-  ```xml
-  <uipath:mapping version="v1">
-    <uipath:type value="BPMN.ScriptTask" version="v1" />
-    <uipath:input name="args"><![CDATA[
-      {"amount":"=vars.Var_Amount","daysOverdue":"=vars.Var_DaysOverdue"}
-    ]]></uipath:input>
-    <uipath:output name="riskScore" type="number" var="Var_RiskScore" source="=result.response" />
-  </uipath:mapping>
-  ```
+  `name` is the output field/display name; `var` is the declared BPMN variable
+  id. Map scalar returns from `=result.response` and object fields from
+  `=result.response.<field>`.
 - Prefer `uipath:scriptVersion value="v3"` unless preserving an imported version.
 - Available helpers are limited to `uipath.aggregate`, `uipath._aggregate`, `uipath._pipe`, and no-op `console` methods.
 - Do not use npm packages, filesystem, network, browser globals, or long-running async behavior.
@@ -97,13 +75,13 @@ Required pieces:
 | `bpmn:script` CDATA | top-level identifiers (`amount`, `daysOverdue`); not `args.amount` | Jint sees the merged JSON as top-level vars |
 | `uipath:output` | `source="=result.response"` for scalar returns, or `source="=result.response.<field>"` for object fields; `var` points at a declared variable id | Maps the script return back to a declared variable |
 
-Anti-patterns the checker rejects:
+Common mistakes:
 
 - `uipath:input` with `name` other than `args`.
 - Bare `=amount` style expressions instead of `=vars.Var_Amount`.
 - `args.amount` style reads inside the script body.
 - Missing `uipath:scriptVersion` when the canvas requires it.
-- Returning a bare value instead of `{ response: ... }` for `v2+` mappings.
+- Returning a bare value when the mapping expects `result.response`.
 - Mapping object returns with `source="=result.summary"` after returning
   `{ summary: "..." }`; use `source="=result.response.summary"` instead.
 

--- a/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/task-recipes/agent-job.md
@@ -1,11 +1,9 @@
 # Agent Job Recipe
 
-Agent wrappers are authored as `bpmn:serviceTask`, but the executable runtime
-contract depends on the process type reported by
-`uip or processes list --all-fields`, not the source project label. Some coded
-Python "agents" are published as `processType: "Function"` and are not the same
-runtime contract as low-code Agent Builder processes published as
-`processType: "Agent"`.
+Agent wrappers are `bpmn:serviceTask`. Choose the runtime contract from
+discovery (`uip or processes list --all-fields`), not from the source project
+label: coded Python dependencies may publish as `processType: "Function"`,
+while low-code Agent Builder dependencies publish as `processType: "Agent"`.
 
 | Agent deployment style | Wrapper shell | Notes |
 | --- | --- | --- |
@@ -14,12 +12,10 @@ runtime contract as low-code Agent Builder processes published as
 | External A2A agent addressed by URL / skillId / authToken | `A2A.AgentExecution` | Studio Web renders this as an external A2A node and disables the Action dropdown. Do not use for folder-deployed agents — the canvas will treat the task as misconfigured. |
 | Integration Service external agent | `Intsvc.SyncAgentExecution`, `Intsvc.AsyncAgentExecution`, or legacy `Intsvc.AsyncExecution` | CLI must enrich connector resource key, connection binding, dynamic schemas, and operation metadata. |
 
-Common authoring mistake: assuming local validation or packaging proves the
-agent wrapper is executable. Validation checks structure and package shape; an
-authorized target-environment run is needed before claiming runtime behavior.
-Put the `JobArguments` input payload and `Process response` output payload as
-direct children of `uipath:activity`; do not put them in a sibling
-`uipath:mapping`.
+Local validation and packaging prove structure, not executable agent behavior;
+claim runtime success only after an authorized target-environment run. Put
+`JobArguments` and `Process response` directly under `uipath:activity`, not in a
+sibling `uipath:mapping`.
 
 The model may draft:
 

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -98,9 +98,9 @@ do not invent `contentFiles` as a substitute for `content`.
 }
 ```
 
-This empty resource file is a package-shape placeholder only for projects with
-no generated resource dependencies. It is not evidence that dependency refresh
-imported an external process, queue, connector, or agent.
+This empty resource file is only a package-shape placeholder for projects with
+no generated resource dependencies. It does not prove that process, queue,
+connector, or agent dependencies were imported.
 
 `package-descriptor.json`:
 
@@ -133,22 +133,17 @@ Generated `bindings_v2.json` must be a top-level object with
 single resource object, or an unversioned `{ "resources": [] }` object; those
 shapes are not the package contract consumed by solution resource refresh.
 
-The resource array has two consumers with different tolerance:
+The `resources` array serves both local binding references and solution
+resource refresh. Entries referenced as `=bindings.<id>` must be id-addressable.
+Entries expected to import remote resources must be parseable concrete
+resources.
 
-- Local/package binding expressions may need id-addressable entries that mirror
-  root `uipath:binding` IDs.
-- `uip solution resource refresh` reads the same `resources` array and imports
-  concrete dependencies only when it contains parseable resource entries.
-  Process resources should come from CLI generation or fixture-backed binding
-  entries with `id`, `kind`, `name`, `resourceKey`, `metadata`, `resource`,
-  `resourceSubType`, and, for name/folder-path binding pairs,
-  `propertyAttribute`.
-
-When an executable BPMN depends on remote Orchestrator processes, include
-generated process binding resources before refresh so it can import the
-process/package resources and write debug overwrites. If resource dependencies
-are expected, verify that refresh produced matching generated resource files or
-explicitly report that no dependency resources were imported.
+For remote Orchestrator process dependencies, prefer CLI-generated entries. If
+using fixture-backed public-safe entries, preserve `id`, `kind`, `name`,
+`resourceKey`, `metadata`, `resource`, `resourceSubType`, and any
+`propertyAttribute` used for name/folder-path pairs. If dependency resources are
+expected, verify that refresh produced matching generated resources or report
+that no dependency resources were imported.
 
 Generated id-addressable entries should preserve:
 

--- a/skills/uipath-maestro-bpmn/references/shared/variables-bindings-expressions.md
+++ b/skills/uipath-maestro-bpmn/references/shared/variables-bindings-expressions.md
@@ -117,34 +117,12 @@ entry value as a start-scoped `uipath:inputOutput`.
 
 ## Script tasks
 
-Script tasks use BPMN `script` CDATA with `scriptFormat="JavaScript"`. UiPath
-script inputs are declared in a single JSON `uipath:input name="args"` body
-with an `inputSchema` in context, but the Jint script body receives the mapped
-fields as top-level identifiers. For example, a mapped `caseId` field is read
-as `caseId` in script source, not `args.caseId`. Script outputs must map back
-to declared variable ids through the `var` attribute, usually with sources such
-as `=result.response` for a scalar return or `=result.response.<field>` for an
-object return:
+Script tasks use BPMN `script` CDATA with `scriptFormat="JavaScript"` and a
+single JSON `uipath:input name="args"` mapping. Jint exposes mapped fields as
+top-level identifiers, so read `caseId`, not `args.caseId`. Script outputs map
+to declared variable ids through `var`; `name` is only the output field/display
+name. Map scalar returns from `=result.response` and object fields from
+`=result.response.<field>`.
 
-```xml
-<uipath:mapping version="v1">
-  <uipath:type value="BPMN.ScriptTask" version="v1" />
-  <uipath:input name="args"><![CDATA[
-    {"caseId":"=vars.Var_CaseId"}
-  ]]></uipath:input>
-  <uipath:output name="status" type="string" var="Var_Status" source="=result.response" />
-</uipath:mapping>
-```
-
-If the script returns `{ status: "ok" }`, map the status with
-`source="=result.response.status"`. `source="=result.status"` can complete the
-script task while leaving the target variable null.
-
-Do not use `name="Var_Status"` as a substitute for `var="Var_Status"`. The
-`name` field identifies the output field; `var` identifies the target BPMN
-variable.
-
-For the exact required XML shape — including `uipath:input name="args"` with
-`=vars.<variableId>` mapping bodies and a Jint-safe top-level identifier
-script — see [../author/references/plugins/script/impl.md](../author/references/plugins/script/impl.md#minimal-jint-script-task-shell)
-and [wrapper-shells.md](wrapper-shells.md).
+For the exact XML shell, read
+[script/impl.md](../author/references/plugins/script/impl.md#minimal-jint-script-task-shell).

--- a/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
+++ b/skills/uipath-maestro-bpmn/references/shared/wrapper-shells.md
@@ -103,54 +103,53 @@ bindings, schemas, and authorized debug/run have been verified.
 </bpmn:serviceTask>
 ```
 
-For `uip solution resource refresh`, `bindings_v2.json` must use a versioned
-package resource wrapper. A process dependency usually has separate resource
-entries for the process name and folder path; do not use an unwrapped resource
-array or unversioned placeholder as the source of dependency resources:
+For solution resource refresh, process dependencies need concrete
+`bindings_v2.json` resources, not just an empty package placeholder. Use the
+top-level `{ "version": "2.0", "resources": [...] }` shape and include
+parseable process entries for dependency name/folder-path bindings when they
+are expected; see [local-metadata-regeneration-guide.md](local-metadata-regeneration-guide.md#binding-rules).
+
+Generic process dependency resource pair:
 
 ```json
 {
   "version": "2.0",
   "resources": [
     {
-      "id": "Binding_AgentName",
+      "id": "Binding_ProcessName",
       "kind": "process",
       "resource": "process",
-      "resourceSubType": "Agent",
+      "resourceSubType": "<PROCESS_TYPE>",
       "propertyAttribute": "name",
-      "name": "Synthetic Agent",
-      "resourceKey": "synthetic-agent",
+      "name": "Synthetic Process",
+      "resourceKey": "synthetic-process",
       "metadata": {
         "BindingsVersion": "v1",
-        "DisplayLabel": "Synthetic Agent",
+        "DisplayLabel": "Synthetic Process",
         "SolutionsSupport": "Required",
-        "SubType": "Agent",
+        "SubType": "<PROCESS_TYPE>",
         "PropertyAttribute": "name"
       }
     },
     {
-      "id": "Binding_AgentFolderPath",
+      "id": "Binding_ProcessFolderPath",
       "kind": "process",
       "resource": "process",
-      "resourceSubType": "Agent",
+      "resourceSubType": "<PROCESS_TYPE>",
       "propertyAttribute": "folderPath",
-      "name": "Synthetic Agent",
-      "resourceKey": "synthetic-agent",
+      "name": "Synthetic Process",
+      "resourceKey": "synthetic-process",
       "metadata": {
         "BindingsVersion": "v1",
-        "DisplayLabel": "Synthetic Agent",
+        "DisplayLabel": "Synthetic Process",
         "SolutionsSupport": "Required",
-        "SubType": "Agent",
+        "SubType": "<PROCESS_TYPE>",
         "PropertyAttribute": "folderPath"
       }
     }
   ]
 }
 ```
-
-An empty `resources` array is valid for package-shape verification when the
-BPMN has no generated resource dependencies. It does not represent imported
-dependencies for a process, queue, connector, or agent.
 
 `Var_RequestId` must already exist as a `uipath:inputOutput` variable readable at the task — see [variables-bindings-expressions.md](variables-bindings-expressions.md#entry-point-inputs-used-downstream) for the start-scoped input pattern.
 

--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
@@ -110,7 +110,10 @@ def require_sequence_integrity(root: ET.Element) -> None:
             fail(f"sequence flow {attr(flow, 'id')} has unresolved refs {source!r}->{target!r}")
 
 
-def require_no_private_connector_values(root: ET.Element) -> None:
+def require_no_private_connector_values(
+    root: ET.Element, allowed_tokens: set[str] | None = None
+) -> None:
+    allowed_tokens = allowed_tokens or set()
     private_tokens = [
         "connectionId",
         "connectionKey",
@@ -120,6 +123,8 @@ def require_no_private_connector_values(root: ET.Element) -> None:
         "https://",
     ]
     xml = ET.tostring(root, encoding="unicode")
-    present = [token for token in private_tokens if token in xml]
+    present = [
+        token for token in private_tokens if token not in allowed_tokens and token in xml
+    ]
     if present:
         fail(f"connector boundary leaked private or CLI-owned fields: {present}")

--- a/tests/tasks/uipath-maestro-bpmn/e2e/check_dependency_invocation_author_pack.py
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/check_dependency_invocation_author_pack.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Assert generic BPMN dependency invocation contracts in a generated project."""
+
+from __future__ import annotations
+
+import json
+import sys
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+BPMNDI_NS = "http://www.omg.org/spec/BPMN/20100524/DI"
+UIPATH_NS = "http://uipath.org/schema/bpmn"
+
+PROJECT = Path("DependencyInvocationLab/DependencyInvocationLab")
+BPMN_NAME = "DependencyInvocationLab.bpmn"
+FOLDER_KEY = "99999999-9999-9999-9999-999999999999"
+FOLDER_PATH = "Shared/SyntheticLab"
+FOLDER_ID = "123456"
+
+
+@dataclass(frozen=True)
+class Dependency:
+    name: str
+    process_key: str
+    wrapper_type: str
+    require_folder_id: bool
+
+
+EXPECTED = [
+    Dependency(
+        "SyntheticPolicyScoreApi",
+        "11111111-1111-1111-1111-111111111111",
+        "Orchestrator.ExecuteApiWorkflowAsync",
+        False,
+    ),
+    Dependency(
+        "SyntheticInvoiceRobot",
+        "22222222-2222-2222-2222-222222222222",
+        "Orchestrator.StartJob",
+        True,
+    ),
+    Dependency(
+        "SyntheticReviewAgent",
+        "44444444-4444-4444-4444-444444444444",
+        "Orchestrator.StartAgentJob",
+        False,
+    ),
+    Dependency(
+        "SyntheticEchoFunction",
+        "33333333-3333-3333-3333-333333333333",
+        "Orchestrator.StartJob",
+        True,
+    ),
+]
+
+
+def fail(message: str) -> None:
+    sys.exit(f"FAIL: {message}")
+
+
+def load_json(path: Path) -> dict:
+    if not path.is_file():
+        fail(f"missing JSON file: {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"{path} is not parseable JSON: {exc}")
+
+
+def parse_bpmn() -> ET.Element:
+    path = PROJECT / BPMN_NAME
+    if not path.is_file():
+        fail(f"missing BPMN file: {path}")
+    try:
+        return ET.parse(path).getroot()
+    except ET.ParseError as exc:
+        fail(f"{path} is not parseable XML: {exc}")
+
+
+def bpmn_elements(root: ET.Element, local_name: str) -> list[ET.Element]:
+    return root.findall(f".//{{{BPMN_NS}}}{local_name}")
+
+
+def activity_type(element: ET.Element) -> str | None:
+    type_elem = element.find(
+        f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}activity/{{{UIPATH_NS}}}type"
+    )
+    return type_elem.attrib.get("value") if type_elem is not None else None
+
+
+def context_inputs(element: ET.Element) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for item in element.findall(
+        f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}activity/"
+        f"{{{UIPATH_NS}}}context/{{{UIPATH_NS}}}input"
+    ):
+        name = item.attrib.get("name")
+        if name:
+            values[name] = item.attrib.get("value", "")
+    return values
+
+
+def direct_activity_inputs(element: ET.Element) -> list[ET.Element]:
+    return element.findall(
+        f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}activity/{{{UIPATH_NS}}}input"
+    )
+
+
+def activity_outputs(element: ET.Element) -> list[ET.Element]:
+    return element.findall(
+        f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}activity/{{{UIPATH_NS}}}output"
+    )
+
+
+def variable_ids(root: ET.Element) -> set[str]:
+    ids: set[str] = set()
+    for var in root.findall(f".//{{{UIPATH_NS}}}variables/*"):
+        variable_id = var.attrib.get("id")
+        if variable_id:
+            ids.add(variable_id)
+    return ids
+
+
+def assert_shape(root: ET.Element, bpmn_id: str) -> None:
+    shape = root.find(f".//{{{BPMNDI_NS}}}BPMNShape[@bpmnElement='{bpmn_id}']")
+    if shape is None:
+        fail(f"missing BPMN DI shape for {bpmn_id}")
+
+
+def assert_edge_count(root: ET.Element) -> None:
+    flows = bpmn_elements(root, "sequenceFlow")
+    edges = root.findall(f".//{{{BPMNDI_NS}}}BPMNEdge")
+    if len(edges) < max(1, len(flows) - 1):
+        fail(
+            "expected BPMN DI edges for sequence flows, "
+            f"found {len(edges)} for {len(flows)} flows"
+        )
+
+
+def find_task_for_dependency(tasks: list[ET.Element], dependency: Dependency) -> ET.Element:
+    tasks_with_key = [
+        task
+        for task in tasks
+        if context_inputs(task).get("ReleaseKey") == dependency.process_key
+    ]
+    if not tasks_with_key:
+        seen = sorted(
+            {
+                value
+                for task in tasks
+                for value in [context_inputs(task).get("ReleaseKey")]
+                if value
+            }
+        )
+        fail(f"missing service task for {dependency.name}; seen ReleaseKey values: {seen}")
+
+    typed = [task for task in tasks_with_key if activity_type(task) == dependency.wrapper_type]
+    if len(typed) != 1:
+        seen_types = [activity_type(task) for task in tasks_with_key]
+        fail(
+            f"{dependency.name} should use {dependency.wrapper_type}; "
+            f"found wrapper types {seen_types}"
+        )
+    return typed[0]
+
+
+def assert_dependency_task(root: ET.Element, tasks: list[ET.Element], dependency: Dependency) -> None:
+    task = find_task_for_dependency(tasks, dependency)
+    context = context_inputs(task)
+
+    expected_context = {
+        "ReleaseKey": dependency.process_key,
+        "FolderKey": FOLDER_KEY,
+        "FolderPath": FOLDER_PATH,
+        "Name": dependency.name,
+    }
+    if dependency.require_folder_id:
+        expected_context["folderId"] = FOLDER_ID
+
+    for field, expected_value in expected_context.items():
+        if context.get(field) != expected_value:
+            fail(
+                f"{dependency.name} context {field} should be {expected_value!r}; "
+                f"found {context.get(field)!r}"
+            )
+
+    if not direct_activity_inputs(task):
+        fail(f"{dependency.name} should map dependency input arguments")
+
+    outputs = activity_outputs(task)
+    if not outputs:
+        fail(f"{dependency.name} should map dependency outputs")
+
+    declared = variable_ids(root)
+    output_targets = {
+        output.attrib.get("var") or output.attrib.get("target")
+        for output in outputs
+        if output.attrib.get("var") or output.attrib.get("target")
+    }
+    undeclared = sorted(target for target in output_targets if target not in declared)
+    if undeclared:
+        fail(f"{dependency.name} outputs target undeclared variables: {undeclared}")
+
+    assert_shape(root, task.attrib.get("id", ""))
+
+
+def assert_no_wrong_coded_function_wrapper(tasks: list[ET.Element]) -> None:
+    for task in tasks:
+        context = context_inputs(task)
+        if context.get("ReleaseKey") != "33333333-3333-3333-3333-333333333333":
+            continue
+        if activity_type(task) == "Orchestrator.StartAgentJob":
+            fail("coded Function dependency was modeled as an Agent job")
+
+
+def assert_package_metadata(root: ET.Element) -> None:
+    project = load_json(PROJECT / "project.uiproj")
+    operate = load_json(PROJECT / "operate.json")
+    entry_points = load_json(PROJECT / "entry-points.json")
+    descriptor = load_json(PROJECT / "package-descriptor.json")
+    bindings = load_json(PROJECT / "bindings_v2.json")
+
+    if project.get("main") != BPMN_NAME:
+        fail("project.uiproj main does not reference the BPMN file")
+    if operate.get("main") != BPMN_NAME:
+        fail("operate.json main does not reference the BPMN file")
+    if operate.get("contentType") != "ProcessOrchestration":
+        fail("operate.json contentType must be ProcessOrchestration")
+
+    starts = bpmn_elements(root, "startEvent")
+    if not starts:
+        fail("missing start event")
+    start_ids = {start.attrib.get("id") for start in starts}
+    entry_file_paths = {
+        entry.get("filePath") for entry in entry_points.get("entryPoints", [])
+    }
+    if not any(
+        f"/content/{BPMN_NAME}#{start_id}" in entry_file_paths for start_id in start_ids
+    ):
+        fail("entry-points.json does not point at a BPMN start event")
+
+    content = set(descriptor.get("content") or [])
+    for required in (
+        f"content/{BPMN_NAME}",
+        "content/bindings_v2.json",
+        "content/entry-points.json",
+        "content/operate.json",
+    ):
+        if required not in content:
+            fail(f"package-descriptor.json missing {required}")
+
+    if bindings.get("version") != "2.0":
+        fail("bindings_v2.json must use version 2.0")
+    resources = bindings.get("resources")
+    if not isinstance(resources, list):
+        fail("bindings_v2.json resources must be an array")
+
+    resource_text = json.dumps(resources)
+    missing_names = [
+        dependency.name for dependency in EXPECTED if dependency.name not in resource_text
+    ]
+    if missing_names:
+        fail(f"bindings_v2.json missing dependency resource entries for: {missing_names}")
+
+
+def main() -> None:
+    root = parse_bpmn()
+    raw_xml = (PROJECT / BPMN_NAME).read_text(encoding="utf-8")
+    for token in ("invoiceId", "amount", "riskLevel", "requestedBy"):
+        if token not in raw_xml:
+            fail(f"missing start/input variable token: {token}")
+
+    tasks = bpmn_elements(root, "serviceTask")
+    if len(tasks) < 4:
+        fail(f"expected at least four service tasks for dependencies, found {len(tasks)}")
+
+    for dependency in EXPECTED:
+        assert_dependency_task(root, tasks, dependency)
+
+    assert_no_wrong_coded_function_wrapper(tasks)
+    assert_edge_count(root)
+    assert_package_metadata(root)
+    print(
+        "OK: dependency invocation wrappers, mappings, DI, "
+        "and package metadata are present"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/e2e/dependency_invocation_author_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/dependency_invocation_author_pack.yaml
@@ -1,0 +1,149 @@
+task_id: skill-bpmn-dependency-invocation-author-pack
+description: >
+  Skill-guided evaluation: a fresh agent authors a local Maestro BPMN project
+  that invokes API workflow, RPA/process, low-code agent, and coded-function
+  dependencies from a synthetic discovery inventory. This measures whether the
+  skill teaches generic dependency wrapper selection without the task prompt
+  naming exact UiPath wrapper types.
+tags: [uipath-maestro-bpmn, e2e, lifecycle:generate, "feature:dependencies"]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  max_turns: 100
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Create a synthetic UiPath Maestro BPMN Process Orchestration project at:
+    DependencyInvocationLab/DependencyInvocationLab
+
+  The main BPMN file must be:
+    DependencyInvocationLab/DependencyInvocationLab/DependencyInvocationLab.bpmn
+
+  Use this public-safe dependency inventory as if it came from discovery. Do
+  not perform cloud discovery and do not call cloud-side UiPath commands.
+
+  Folder:
+  - folderPath: Shared/SyntheticLab
+  - folderKey: 99999999-9999-9999-9999-999999999999
+  - folderId: 123456
+
+  Dependencies:
+  - displayName: SyntheticPolicyScoreApi
+    dependencyKind: API workflow
+    processType: Api
+    processKey: 11111111-1111-1111-1111-111111111111
+    inputs: invoiceId string, amount number, riskLevel string
+    outputs: score number, recommendation string
+  - displayName: SyntheticInvoiceRobot
+    dependencyKind: RPA/process
+    processType: Process
+    processKey: 22222222-2222-2222-2222-222222222222
+    inputs: invoiceId string, amount number
+    outputs: robotStatus string
+  - displayName: SyntheticReviewAgent
+    dependencyKind: folder-deployed low-code agent
+    processType: Agent
+    processKey: 44444444-4444-4444-4444-444444444444
+    inputs: invoiceId string, policyRecommendation string
+    outputs: reviewSummary string
+  - displayName: SyntheticEchoFunction
+    dependencyKind: coded Python function
+    processType: Function
+    processKey: 33333333-3333-3333-3333-333333333333
+    inputs: invoiceId string, message string
+    outputs: echoText string
+
+  Model a compact invoice routing workflow:
+  - Manual start with invoiceId, amount, riskLevel, and requestedBy inputs.
+  - Prepare a request summary using variables or a script task.
+  - Invoke each listed dependency using the documented BPMN dependency wrapper
+    that matches its discovered dependency kind and processType.
+  - Route high-risk invoices through the review agent, then continue to the
+    coded function; low-risk invoices may skip the review agent but the agent
+    invocation node must still be modeled in the process.
+  - Produce a final summary output variable.
+  - Include BPMN DI for visible nodes and sequence flows.
+
+  Also create the standard local package files next to the BPMN:
+    project.uiproj, operate.json, entry-points.json, bindings_v2.json,
+    package-descriptor.json
+
+  Keep the scope local:
+  - Validate with `uip maestro bpmn validate DependencyInvocationLab/DependencyInvocationLab/DependencyInvocationLab.bpmn --output json`.
+  - Package with `uip maestro bpmn pack DependencyInvocationLab/DependencyInvocationLab dist --output json`.
+  - Do not upload, publish, deploy, debug, run a process, ask for approval, or
+    call cloud-side UiPath commands.
+
+  The task is complete only after local validation passes, local packaging
+  succeeds, and a package artifact exists under dist.
+
+success_criteria:
+  - type: file_exists
+    description: "Dependency invocation BPMN file was created"
+    path: "DependencyInvocationLab/DependencyInvocationLab/DependencyInvocationLab.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "UiPath project metadata was created"
+    path: "DependencyInvocationLab/DependencyInvocationLab/project.uiproj"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the BPMN project locally"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+maestro\s+bpmn\s+validate\s+DependencyInvocationLab/DependencyInvocationLab/DependencyInvocationLab\.bpmn\s+--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent packaged the BPMN project locally"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+maestro\s+bpmn\s+pack\s+DependencyInvocationLab/DependencyInvocationLab\s+dist\s+--output\s+json'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN source validates successfully in the scored workspace"
+    command: "uip maestro bpmn validate DependencyInvocationLab/DependencyInvocationLab/DependencyInvocationLab.bpmn --output json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN project packs successfully in the scored workspace"
+    command: "uip maestro bpmn pack DependencyInvocationLab/DependencyInvocationLab dist --output json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated BPMN uses the expected generic dependency contracts"
+    command: "python3 $TASK_DIR/check_dependency_invocation_author_pack.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Local package artifact exists under dist"
+    command: "find dist -type f -name '*.nupkg' | grep -q ."
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_hitl_rpa_wrappers.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_hitl_rpa_wrappers.py
@@ -29,7 +29,7 @@ def main() -> None:
         fail("missing bpmn:userTask with Actions.HITL uipath:activity shell")
     if not rpa:
         fail("missing bpmn:serviceTask with Orchestrator.StartJob uipath:activity shell")
-    require_no_private_connector_values(root)
+    require_no_private_connector_values(root, allowed_tokens={"folderId"})
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)
     print(f"OK: {path} contains documented HITL and RPA wrappers")

--- a/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
@@ -27,8 +27,9 @@ initial_prompt: |
     `uipath:activity` shell.
   - Model the RPA invocation as a `bpmn:serviceTask` using a documented
     `Orchestrator.StartJob` `uipath:activity` shell.
-  - Use synthetic placeholder resource names only. Do not include tenant URLs,
-    folder keys, connection IDs, or real user names.
+  - Use public-safe synthetic placeholder resource names and process/folder
+    identity values. Do not include tenant URLs, connection IDs, or real user
+    names.
   - Include BPMN DI for every visible node and sequence flow.
   - Do not upload, publish, deploy, debug, or run the process.
 


### PR DESCRIPTION
## Summary

- Add a public-safe Maestro BPMN dependency invocation eval covering API workflow, RPA/process, low-code agent, and coded-function dependencies.
- Simplify Maestro BPMN guidance while preserving the generic contracts that affected fresh-agent output quality.
- Apply a broader BPMN skill simplification pass: de-duplicate script/Jint guidance, keep the exact XML shell in one reference, and correct the HITL/RPA eval contract around documented synthetic folder identity values.
- Add the repo-level skill development principle: behavioral skill edits should be A/B/C-eval grounded, generic, public-facing, and avoid one-off workaround or internal-environment wording.

## Why

The merged runtime dependency guidance fixed real behavior, but the first simplification attempt showed that removing the generic resource contract entirely caused fresh agents to fall back to `resources: []`. This PR keeps the smallest generic contract that preserves output quality, then applies the same simplification principle across the BPMN skill references covered by representative evals.

## A/B/C Eval Evidence

Dependency-focused eval:

- A: pre-guidance baseline `51d7200f` scored `0.647`; validate/pack passed, but dependency package metadata missed required process identity context.
- B: merged main `60de4b8e` scored `1.000`; wrapper, context, package metadata, validate, and pack checks passed.
- C-v1: over-simplified candidate scored `0.647`; wrappers/context passed, but `bindings_v2.json` regressed to an empty `resources` array.
- C-v2: PR candidate scored `1.000`; it matched B while retaining a shorter generic resource template.

Full BPMN scan suite:

- Tasks: `author_validate_pack`, `dependency_invocation_author_pack`, `script_jint_lifecycle`, `integration_service_boundary`, `contract_variant_wrappers`, `hitl_rpa_wrappers`, `imported_xml_inspect`.
- A: merged main `60de4b8e` scored `0.711 +/- 0.394` with 4/7 passing.
- B: PR before full-scan cleanup `7fa35355` scored `0.881 +/- 0.315` with 6/7 raw passing. The remaining miss was an eval-contract contradiction: the documented RPA `StartJob` shell includes `folderId`, while the checker still forbade that token.
- C: final candidate `bc04f2cb` scored `1.000 +/- 0.000` with 7/7 passing after simplifying duplicated guidance and correcting the HITL/RPA checker generically.

## Validation

- `python3 -m py_compile tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py tests/tasks/uipath-maestro-bpmn/nodes/check_hitl_rpa_wrappers.py tests/tasks/uipath-maestro-bpmn/e2e/check_dependency_invocation_author_pack.py tests/tasks/uipath-maestro-bpmn/authoring/check_script_jint_lifecycle.py tests/tasks/uipath-maestro-bpmn/connector/check_integration_service_boundary.py`
- `SKILLS_REPO_PATH=/Users/gongzhang/code/skills tests/.venv/bin/coder-eval plan tests/tasks/uipath-maestro-bpmn/e2e/author_validate_pack.yaml tests/tasks/uipath-maestro-bpmn/e2e/dependency_invocation_author_pack.yaml tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml -e tests/experiments/default.yaml`
- `git diff --check HEAD^..HEAD`
