### PR TITLE
fix: correct _shared import paths in coded-agent check scripts

### DIFF
--- a/tests/tasks/uipath-agents/coded/antipattern_module_level_llm/check_antipattern_module_level_llm.py
+++ b/tests/tasks/uipath-agents/coded/antipattern_module_level_llm/check_antipattern_module_level_llm.py
@@ -11,7 +11,7 @@ from pathlib import Path
 ROOT = Path(os.getcwd()) / "legacy-classifier"
 MAIN = ROOT / "main.py"
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 
 

--- a/tests/tasks/uipath-agents/coded/antipattern_openai_agents_hitl/check_antipattern_openai_agents_hitl.py
+++ b/tests/tasks/uipath-agents/coded/antipattern_openai_agents_hitl/check_antipattern_openai_agents_hitl.py
@@ -21,7 +21,7 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("triage-broken")

--- a/tests/tasks/uipath-agents/coded/bindings_asset_subtypes/check_bindings_asset_subtypes.py
+++ b/tests/tasks/uipath-agents/coded/bindings_asset_subtypes/check_bindings_asset_subtypes.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 ROOT = Path(os.getcwd())
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import (  # noqa: E402
     load_bindings,
     find_resource,

--- a/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
+++ b/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/check_bindings_multi_entrypoint.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 ROOT = Path(os.getcwd())
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import (  # noqa: E402
     load_bindings,
     find_resource,

--- a/tests/tasks/uipath-agents/coded/bindings_queue_app_index/check_bindings_queue_app_index.py
+++ b/tests/tasks/uipath-agents/coded/bindings_queue_app_index/check_bindings_queue_app_index.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 ROOT = Path(os.getcwd())
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import (  # noqa: E402
     load_bindings,
     find_resource,

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/check_coded_in_flow_e2e.py
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/check_coded_in_flow_e2e.py
@@ -25,7 +25,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 
 CWD = Path(os.getcwd())

--- a/tests/tasks/uipath-agents/coded/deploy_my_workspace/check_deploy_my_workspace.py
+++ b/tests/tasks/uipath-agents/coded/deploy_my_workspace/check_deploy_my_workspace.py
@@ -24,7 +24,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("deploy-smoke")

--- a/tests/tasks/uipath-agents/coded/deploy_tenant/check_deploy_tenant.py
+++ b/tests/tasks/uipath-agents/coded/deploy_tenant/check_deploy_tenant.py
@@ -27,7 +27,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("tenant-echo")

--- a/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/check_diagnose_deploy_failure.py
+++ b/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/check_diagnose_deploy_failure.py
@@ -26,7 +26,7 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("daily-digest")

--- a/tests/tasks/uipath-agents/coded/eval_exact_match/check_eval_exact_match.py
+++ b/tests/tasks/uipath-agents/coded/eval_exact_match/check_eval_exact_match.py
@@ -31,7 +31,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("adder")

--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/check_eval_llm_judges.py
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/check_eval_llm_judges.py
@@ -23,7 +23,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("intent-classifier")

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/check_eval_mocking_mockito.py
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/check_eval_mocking_mockito.py
@@ -38,7 +38,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("secret-peek")

--- a/tests/tasks/uipath-agents/coded/eval_trajectory_empty_history/check_eval_trajectory_empty_history.py
+++ b/tests/tasks/uipath-agents/coded/eval_trajectory_empty_history/check_eval_trajectory_empty_history.py
@@ -37,7 +37,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("ticket-router")

--- a/tests/tasks/uipath-agents/coded/file_attachment_input/check_file_attachment_input.py
+++ b/tests/tasks/uipath-agents/coded/file_attachment_input/check_file_attachment_input.py
@@ -30,7 +30,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
@@ -27,12 +27,12 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("expense-approver")
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import (  # noqa: E402
     load_bindings,
     find_resource,

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
@@ -23,7 +23,7 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.bindings_assertions import (  # noqa: E402

--- a/tests/tasks/uipath-agents/coded/hitl_wait_task/check_hitl_wait_task.py
+++ b/tests/tasks/uipath-agents/coded/hitl_wait_task/check_hitl_wait_task.py
@@ -21,7 +21,7 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 

--- a/tests/tasks/uipath-agents/coded/langgraph_classifier/check_langgraph_classifier.py
+++ b/tests/tasks/uipath-agents/coded/langgraph_classifier/check_langgraph_classifier.py
@@ -33,7 +33,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402

--- a/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
+++ b/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
@@ -25,7 +25,7 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 

--- a/tests/tasks/uipath-agents/coded/llamaindex_workflow/check_llamaindex_workflow.py
+++ b/tests/tasks/uipath-agents/coded/llamaindex_workflow/check_llamaindex_workflow.py
@@ -25,7 +25,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402

--- a/tests/tasks/uipath-agents/coded/openai_agents_handoff/check_openai_agents_handoff.py
+++ b/tests/tasks/uipath-agents/coded/openai_agents_handoff/check_openai_agents_handoff.py
@@ -38,7 +38,7 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402

--- a/tests/tasks/uipath-agents/coded/process_invoke/check_process_invoke.py
+++ b/tests/tasks/uipath-agents/coded/process_invoke/check_process_invoke.py
@@ -21,12 +21,12 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("data-orchestrator")
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import (  # noqa: E402
     load_bindings,
     find_resource,

--- a/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
@@ -21,12 +21,12 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("policy-rag")
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import (  # noqa: E402
     load_bindings,
     find_resource,

--- a/tests/tasks/uipath-agents/coded/simple_echo/check_simple_echo.py
+++ b/tests/tasks/uipath-agents/coded/simple_echo/check_simple_echo.py
@@ -29,7 +29,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import load_bindings, count_resources_by_type  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402

--- a/tests/tasks/uipath-agents/coded/tracing_redaction/check_tracing_redaction.py
+++ b/tests/tasks/uipath-agents/coded/tracing_redaction/check_tracing_redaction.py
@@ -20,7 +20,7 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("credential-validator")


### PR DESCRIPTION
PR #902 moved scripts from tests/tasks/uipath-agents/<name>/ to tests/tasks/uipath-agents/coded/<name>/, adding one directory level. The sys.path math used dirname() twice; now needs three calls to reach tests/tasks/uipath-agents/ where _shared resides. Fixes ModuleNotFoundError for 25 check scripts.