### PR TITLE
GH-hosted Run Coder Eval workflow

### DIFF
--- a/.github/workflows/nightly-skills-gh.yml
+++ b/.github/workflows/nightly-skills-gh.yml
@@ -1,0 +1,221 @@
+name: Nightly Skill Tests (GH-hosted)
+
+# GH-hosted mirror of the VM cron (coder_eval/dashboard/scripts/ci/daily.sh).
+# Runs the full skills task tree against experiments/nightly.yaml on the
+# largest GH-hosted tier in UiPath (ubuntu-latest-16-cores = 16 vCPU /
+# 64 GB RAM). Manual dispatch — paired with smoke-skills.yml's per-PR
+# subset. Eventually intended to replace the coder-eval-runner VM cron;
+# this draft is the feasibility validation.
+
+on:
+  workflow_dispatch:
+    inputs:
+      task_globs:
+        description: 'space-separated globs under tests/ (e.g. "tasks/uipath-agents/**/*.yaml"). Default: full tree minus Windows-only RPA + opt-in benchmarks.'
+        type: string
+        default: ''
+      runner_size:
+        description: 'GH-hosted runner tier'
+        type: choice
+        default: ubuntu-latest-16-cores
+        options:
+          - ubuntu-latest-16-cores
+          - ubuntu-latest
+      task_parallelism:
+        description: 'Concurrent tasks (-j). 4-6 is a safe ceiling for docker-driver tasks on 16-cores.'
+        type: string
+        default: '4'
+      model_override:
+        description: 'Override BEDROCK_MODEL (full Bedrock id, e.g. eu.anthropic.claude-sonnet-4-6). Blank → repo secret.'
+        type: string
+        default: ''
+
+concurrency:
+  group: nightly-skills-gh-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  nightly:
+    runs-on: ${{ inputs.runner_size }}
+    # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. The 16-core
+    # tier with j=4 should land ~1-1.5h; 330 min covers worst-case stalls.
+    timeout-minutes: 330
+    name: Run nightly suite
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: UiPath/coder_eval
+          token: ${{ secrets.GH_PAT }}
+          path: .coder_eval
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - uses: astral-sh/setup-uv@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Verify Docker is available
+        run: docker info > /dev/null
+
+      - name: Free up disk
+        run: |
+          df -h /
+          docker system prune -af --volumes >/dev/null 2>&1 || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL 2>/dev/null || true
+          df -h /
+
+      - name: Install coder-eval
+        working-directory: .coder_eval
+        env:
+          UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
+        run: uv pip install --system .
+
+      - name: Build coder-eval Docker image
+        working-directory: .coder_eval
+        env:
+          UV_INDEX_UIPATH_USERNAME: ${{ secrets.UV_INDEX_UIPATH_USERNAME }}
+          UV_INDEX_UIPATH_PASSWORD: ${{ secrets.UV_INDEX_UIPATH_PASSWORD }}
+        run: make docker-image
+
+      # Build the skills extension image (`@uipath/cli` + `@uipath/admin-tool`
+      # @alpha on top of coder-eval-agent). Matches smoke-skills.yml + daily.sh.
+      - name: Build skills Docker image
+        run: |
+          docker build \
+            --build-arg CODER_EVAL_IMAGE=coder-eval-agent:latest \
+            --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
+            -t skills-image:latest \
+            -f tests/docker/Dockerfile \
+            .
+
+      - name: Mint UiPath service-account token + enable env-auth
+        env:
+          UIPATH_CLIENT_ID:     ${{ secrets.UIPATH_CLIENT_ID }}
+          UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          TOKEN=$(curl -fsS -X POST \
+            "https://alpha.uipath.com/identity_/connect/token" \
+            -H "Content-Type: application/x-www-form-urlencoded" \
+            -d "grant_type=client_credentials" \
+            -d "client_id=$UIPATH_CLIENT_ID" \
+            -d "client_secret=$UIPATH_CLIENT_SECRET" \
+            -d "scope=OR.Default OR.Execution OR.Robots OR.Machines.Read TM.Projects TM.TestCases TM.TestSets TM.TestExecutions TM.Requirements TM.ObjectLabels TM.Attachments" \
+            | python -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
+          echo "::add-mask::$TOKEN"
+          {
+            echo "UIPATH_CLI_ENABLE_ENV_AUTH=true"
+            echo "UIPATH_CLI_AUTH_TOKEN=$TOKEN"
+            echo "UIPATH_CLI_ORGANIZATION_NAME=${{ secrets.UIPATH_ORG_NAME }}"
+            echo "UIPATH_CLI_ORGANIZATION_ID=${{ secrets.UIPATH_ORG_ID }}"
+            echo "UIPATH_CLI_TENANT_NAME=${{ secrets.UIPATH_TENANT_NAME }}"
+            echo "UIPATH_CLI_TENANT_ID=${{ secrets.UIPATH_TENANT_ID }}"
+            echo "TRACES_SMOKE_PROCESS_KEY=${{ secrets.TRACES_SMOKE_PROCESS_KEY }}"
+          } >> "$GITHUB_ENV"
+          mkdir -p ~/.uipath
+
+      - name: Resolve task globs
+        id: globs
+        run: |
+          if [ -n "${{ inputs.task_globs }}" ]; then
+            echo "globs=${{ inputs.task_globs }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Default: full tree minus Windows-only and opt-in benchmarks
+          # (same exclusion set smoke-skills.yml uses).
+          shopt -s globstar nullglob
+          GLOBS=""
+          for f in tests/tasks/**/*.yaml; do
+            case "$f" in
+              tests/tasks/uipath-rpa/*)  continue ;;
+              tests/tasks/activation/*)  continue ;;
+            esac
+            GLOBS="$GLOBS ${f#tests/}"
+          done
+          GLOBS=$(echo "$GLOBS" | xargs)
+          echo "globs=$GLOBS" >> "$GITHUB_OUTPUT"
+
+      - name: Run nightly suite
+        env:
+          SKILLS_REPO_PATH:        ${{ github.workspace }}
+          API_BACKEND:             bedrock
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION:              ${{ secrets.AWS_REGION }}
+          BEDROCK_MODEL:           ${{ inputs.model_override != '' && inputs.model_override || secrets.BEDROCK_MODEL }}
+          ANTHROPIC_API_KEY:       ${{ secrets.ANTHROPIC_API_KEY }}
+          TASK_PARALLELISM:        ${{ inputs.task_parallelism }}
+        working-directory: tests
+        id: nightly
+        run: |
+          echo "Running: coder-eval run ${{ steps.globs.outputs.globs }} -e experiments/nightly.yaml -j $TASK_PARALLELISM"
+          coder-eval run ${{ steps.globs.outputs.globs }} \
+            -e experiments/nightly.yaml \
+            -j "$TASK_PARALLELISM" -v \
+            --run-dir /tmp/runs
+        continue-on-error: true
+
+      - name: Fix permissions on /tmp/runs
+        if: always()
+        run: sudo chown -R $(id -u):$(id -g) /tmp/runs && sudo chmod -R 755 /tmp/runs 2>/dev/null || true
+
+      - name: Summarize results
+        if: always()
+        run: |
+          run_dir=$(ls -td /tmp/runs/*/ 2>/dev/null | head -n 1)
+          if [ -z "$run_dir" ]; then
+            echo "::warning::No run directory found"
+            exit 0
+          fi
+          python - <<'PY'
+          import json, pathlib
+          run_dir = sorted(pathlib.Path('/tmp/runs').glob('*/'))[-1]
+          tasks = sorted(run_dir.rglob('task.json'))
+          rows = [json.loads(p.read_text(encoding='utf-8')) for p in tasks]
+          by_status = {}
+          for d in rows:
+              s = d.get('final_status', '?')
+              by_status[s] = by_status.get(s, 0) + 1
+          n = len(rows)
+          succ = by_status.get('SUCCESS', 0)
+          if n:
+              print(f'## Nightly results: {n} tasks, {succ} SUCCESS ({100*succ/n:.1f}%)')
+          else:
+              print('## Nightly results: (none)')
+          for s, c in sorted(by_status.items(), key=lambda x: -x[1]):
+              print(f'  {s}: {c}')
+          print()
+          print('### Non-SUCCESS tasks')
+          for d in rows:
+              if d.get('final_status') != 'SUCCESS':
+                  print(f"  {d.get('task_id', '?')}: {d.get('final_status', '?')}")
+          PY
+
+      - name: Clean up artifact subdirs
+        if: always()
+        run: find /tmp/runs -type d \( -name .venv -o -name node_modules \) -path "*/artifacts/*" -exec rm -rf {} + || true
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-report-${{ github.run_id }}
+          path: |
+            /tmp/runs/*/experiment.html
+            /tmp/runs/*/experiment.md
+            /tmp/runs/*/experiment.json
+            /tmp/runs/*/experiment.log
+            /tmp/runs/*/*/variant.html
+            /tmp/runs/*/*/variant.md
+            /tmp/runs/*/*/variant.json
+            /tmp/runs/**/task.html
+            /tmp/runs/**/task.json
+            /tmp/runs/**/task.log
+            /tmp/runs/**/artifacts
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -36,7 +36,7 @@ concurrency:
 
 jobs:
   run:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest
     # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. 16-core
     # runner with j=20 should land ~30-45min; 330 min covers worst-case
     # stalls (one slow task pinning a slot, network hiccups, etc.).

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -31,6 +31,11 @@ concurrency:
 
 jobs:
   run:
+    # TODO: switch to `ubuntu-latest-16-cores` (16 vCPU / 64 GB RAM) once
+    # the UiPath/skills repo is allowlisted for that runner group. Standard
+    # ubuntu-latest is fine for ad-hoc single-task / small-folder runs at
+    # j=20; the larger tier is needed for the full nightly sweep to finish
+    # in ~30-45min instead of multi-hour.
     runs-on: ubuntu-latest
     # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. 330 min
     # covers worst-case stalls (one slow task pinning a slot, network

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -22,16 +22,9 @@ on:
         type: string
         default: main
       cli_version:
-        description: '@uipath/cli tag or pinned version (e.g. alpha, latest, 0.1.21). Tag/version semantics depend on cli_registry.'
+        description: '@uipath/cli tag or pinned version published to GH Packages (e.g. alpha, 0.1.22-alpha.20260520.1234).'
         type: string
         default: alpha
-      cli_registry:
-        description: 'CLI registry. github-packages tracks @alpha (published every cli/main merge); npmjs tracks public releases (lags by days).'
-        type: choice
-        default: github-packages
-        options:
-          - github-packages
-          - npmjs
       model_override:
         description: 'Override BEDROCK_MODEL (full Bedrock id, e.g. eu.anthropic.claude-sonnet-4-6). Blank → repo secret.'
         type: string
@@ -134,7 +127,6 @@ jobs:
             --build-arg CODER_EVAL_IMAGE=coder-eval-agent:latest \
             --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
             --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
-            --build-arg CLI_REGISTRY="${{ inputs.cli_registry }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
             .

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -7,6 +7,10 @@ name: Run Coder Eval
 # Long-term replacement for the coder-eval-runner VM.
 
 on:
+  # TEMP: pull_request trigger lets us exercise the workflow before it
+  # exists on main (workflow_dispatch needs the file on the default
+  # branch). Strip before final merge.
+  pull_request:
   workflow_dispatch:
     inputs:
       task_globs:
@@ -57,7 +61,8 @@ jobs:
       - name: Resolve task globs + enforce large-run gate
         id: globs
         env:
-          INPUT_GLOBS: ${{ inputs.task_globs }}
+          # On pull_request triggers (TEMP), fall back to a single quick task.
+          INPUT_GLOBS: ${{ inputs.task_globs || 'tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml' }}
           CONFIRMED:   ${{ inputs.confirm_large_run }}
         run: |
           set -euo pipefail

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -22,9 +22,16 @@ on:
         type: string
         default: main
       cli_version:
-        description: '@uipath/cli npm tag or pinned version (e.g. alpha, latest, 0.1.21).'
+        description: '@uipath/cli tag or pinned version (e.g. alpha, latest, 0.1.21). Tag/version semantics depend on cli_registry.'
         type: string
         default: alpha
+      cli_registry:
+        description: 'CLI registry. github-packages tracks @alpha (published every cli/main merge); npmjs tracks public releases (lags by days).'
+        type: choice
+        default: github-packages
+        options:
+          - github-packages
+          - npmjs
       model_override:
         description: 'Override BEDROCK_MODEL (full Bedrock id, e.g. eu.anthropic.claude-sonnet-4-6). Blank → repo secret.'
         type: string
@@ -127,6 +134,7 @@ jobs:
             --build-arg CODER_EVAL_IMAGE=coder-eval-agent:latest \
             --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
             --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
+            --build-arg CLI_REGISTRY="${{ inputs.cli_registry }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
             .

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -25,10 +25,6 @@ on:
         description: '@uipath/cli tag or pinned version published to GH Packages (e.g. alpha, 0.1.22-alpha.20260520.1234).'
         type: string
         default: alpha
-      model_override:
-        description: 'Override BEDROCK_MODEL (full Bedrock id, e.g. eu.anthropic.claude-sonnet-4-6). Blank → repo secret.'
-        type: string
-        default: ''
 
 concurrency:
   group: run-coder-eval-${{ github.ref }}
@@ -57,20 +53,6 @@ jobs:
           python-version: '3.13'
 
       - uses: astral-sh/setup-uv@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Verify Docker is available
-        run: docker info > /dev/null
-
-      - name: Free up disk
-        run: |
-          df -h /
-          docker system prune -af --volumes >/dev/null 2>&1 || true
-          sudo rm -rf /opt/hostedtoolcache/CodeQL 2>/dev/null || true
-          df -h /
 
       - name: Resolve task globs + enforce large-run gate
         id: globs
@@ -131,40 +113,32 @@ jobs:
             -f tests/docker/Dockerfile \
             .
 
-      - name: Mint UiPath service-account token + enable env-auth
+      # ROPC bot-user auth via coder_eval's shared script (same as VM cron).
+      # Required because `uip flow debug` needs a real user `sub` claim —
+      # s2s/client_credentials tokens lack one. Writes ~/.uipath/.auth which
+      # experiments/nightly.yaml mounts into each eval container.
+      - name: Mint UiPath bot token (ROPC)
         env:
-          UIPATH_CLIENT_ID:     ${{ secrets.UIPATH_CLIENT_ID }}
-          UIPATH_CLIENT_SECRET: ${{ secrets.UIPATH_CLIENT_SECRET }}
-        run: |
-          set -euo pipefail
-          TOKEN=$(curl -fsS -X POST \
-            "https://alpha.uipath.com/identity_/connect/token" \
-            -H "Content-Type: application/x-www-form-urlencoded" \
-            -d "grant_type=client_credentials" \
-            -d "client_id=$UIPATH_CLIENT_ID" \
-            -d "client_secret=$UIPATH_CLIENT_SECRET" \
-            -d "scope=OR.Default OR.Execution OR.Robots OR.Machines.Read TM.Projects TM.TestCases TM.TestSets TM.TestExecutions TM.Requirements TM.ObjectLabels TM.Attachments" \
-            | python -c "import sys,json;print(json.load(sys.stdin)['access_token'])")
-          echo "::add-mask::$TOKEN"
-          {
-            echo "UIPATH_CLI_ENABLE_ENV_AUTH=true"
-            echo "UIPATH_CLI_AUTH_TOKEN=$TOKEN"
-            echo "UIPATH_CLI_ORGANIZATION_NAME=${{ secrets.UIPATH_ORG_NAME }}"
-            echo "UIPATH_CLI_ORGANIZATION_ID=${{ secrets.UIPATH_ORG_ID }}"
-            echo "UIPATH_CLI_TENANT_NAME=${{ secrets.UIPATH_TENANT_NAME }}"
-            echo "UIPATH_CLI_TENANT_ID=${{ secrets.UIPATH_TENANT_ID }}"
-            echo "TRACES_SMOKE_PROCESS_KEY=${{ secrets.TRACES_SMOKE_PROCESS_KEY }}"
-          } >> "$GITHUB_ENV"
-          mkdir -p ~/.uipath
+          UIPATH_URL:               https://alpha.uipath.com
+          UIPATH_ORGANIZATION_NAME: ${{ secrets.UIPATH_ORG_NAME }}
+          UIPATH_ORGANIZATION_ID:   ${{ secrets.UIPATH_ORG_ID }}
+          UIPATH_TENANT_NAME:       ${{ secrets.UIPATH_TENANT_NAME }}
+          UIPATH_TENANT_ID:         ${{ secrets.UIPATH_TENANT_ID }}
+          CLIENT_ID:                ${{ secrets.UIPATH_ROPC_CLIENT_ID }}
+          CLIENT_SECRET:            ${{ secrets.UIPATH_ROPC_CLIENT_SECRET }}
+          CE_USERNAME:              ${{ secrets.UIPATH_BOT_USERNAME }}
+          CE_PASSWORD:              ${{ secrets.UIPATH_BOT_PASSWORD }}
+        run: bash .coder_eval/dashboard/scripts/ci/refresh-auth.sh
 
       - name: Run coder-eval
         env:
-          SKILLS_REPO_PATH:        ${{ github.workspace }}
-          API_BACKEND:             bedrock
+          SKILLS_REPO_PATH:         ${{ github.workspace }}
+          API_BACKEND:              bedrock
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
-          AWS_REGION:              ${{ secrets.AWS_REGION }}
-          BEDROCK_MODEL:           ${{ inputs.model_override != '' && inputs.model_override || secrets.BEDROCK_MODEL }}
-          ANTHROPIC_API_KEY:       ${{ secrets.ANTHROPIC_API_KEY }}
+          AWS_REGION:               ${{ secrets.AWS_REGION }}
+          BEDROCK_MODEL:            ${{ secrets.BEDROCK_MODEL }}
+          ANTHROPIC_API_KEY:        ${{ secrets.ANTHROPIC_API_KEY }}
+          TRACES_SMOKE_PROCESS_KEY: ${{ secrets.TRACES_SMOKE_PROCESS_KEY }}
         working-directory: tests
         id: eval
         run: |
@@ -173,64 +147,26 @@ jobs:
             -e experiments/nightly.yaml \
             -j 20 -v \
             --run-dir /tmp/runs
-        continue-on-error: true
 
       - name: Fix permissions on /tmp/runs
         if: always()
         run: sudo chown -R $(id -u):$(id -g) /tmp/runs && sudo chmod -R 755 /tmp/runs 2>/dev/null || true
 
-      - name: Summarize results
+      - name: Plaintext summary + verdict
         if: always()
         run: |
-          run_dir=$(ls -td /tmp/runs/*/ 2>/dev/null | head -n 1)
+          set -uo pipefail
+          run_dir=$(ls -td /tmp/runs/*/ 2>/dev/null | head -n 1 || true)
           if [ -z "$run_dir" ]; then
-            echo "::warning::No run directory found"
-            exit 0
+            echo "FAIL — no run directory produced" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi
-          python - <<'PY'
-          import json, pathlib
-          run_dir = sorted(pathlib.Path('/tmp/runs').glob('*/'))[-1]
-          tasks = sorted(run_dir.rglob('task.json'))
-          rows = [json.loads(p.read_text(encoding='utf-8')) for p in tasks]
-          by_status = {}
-          for d in rows:
-              s = d.get('final_status', '?')
-              by_status[s] = by_status.get(s, 0) + 1
-          n = len(rows)
-          succ = by_status.get('SUCCESS', 0)
-          if n:
-              print(f'## Coder eval results: {n} tasks, {succ} SUCCESS ({100*succ/n:.1f}%)')
-          else:
-              print('## Coder eval results: (none)')
-          for s, c in sorted(by_status.items(), key=lambda x: -x[1]):
-              print(f'  {s}: {c}')
-          print()
-          print('### Non-SUCCESS tasks')
-          for d in rows:
-              if d.get('final_status') != 'SUCCESS':
-                  print(f"  {d.get('task_id', '?')}: {d.get('final_status', '?')}")
+          python - "$run_dir" <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import json, pathlib, sys
+          rows = [json.loads(p.read_text()) for p in sorted(pathlib.Path(sys.argv[1]).rglob('task.json'))]
+          for r in rows:
+              print(f"{r.get('task_id','?')}: {r.get('final_status','?')}")
+          ok = sum(1 for r in rows if r.get('final_status') == 'SUCCESS')
+          print(f"\n{ok}/{len(rows)} PASS")
+          sys.exit(0 if rows and ok == len(rows) else 1)
           PY
-
-      - name: Clean up artifact subdirs
-        if: always()
-        run: find /tmp/runs -type d \( -name .venv -o -name node_modules \) -path "*/artifacts/*" -exec rm -rf {} + || true
-
-      - name: Upload eval report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coder-eval-report-${{ github.run_id }}
-          path: |
-            /tmp/runs/*/experiment.html
-            /tmp/runs/*/experiment.md
-            /tmp/runs/*/experiment.json
-            /tmp/runs/*/experiment.log
-            /tmp/runs/*/*/variant.html
-            /tmp/runs/*/*/variant.md
-            /tmp/runs/*/*/variant.json
-            /tmp/runs/**/task.html
-            /tmp/runs/**/task.json
-            /tmp/runs/**/task.log
-            /tmp/runs/**/artifacts
-          if-no-files-found: warn
-          retention-days: 14

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -1,52 +1,54 @@
-name: Nightly Skill Tests (GH-hosted)
+name: Run Coder Eval
 
-# GH-hosted mirror of the VM cron (coder_eval/dashboard/scripts/ci/daily.sh).
-# Runs the full skills task tree against experiments/nightly.yaml on the
-# largest GH-hosted tier in UiPath (ubuntu-latest-16-cores = 16 vCPU /
-# 64 GB RAM). Manual dispatch — paired with smoke-skills.yml's per-PR
-# subset. Eventually intended to replace the coder-eval-runner VM cron;
-# this draft is the feasibility validation.
+# GH-hosted runner for coder-eval against the skills task tree. Use cases:
+# single task ad-hoc, a folder, or (with explicit confirmation) the full
+# suite that the VM cron runs nightly. Runs on the largest GH-hosted tier
+# in UiPath (ubuntu-latest-16-cores = 16 vCPU / 64 GB RAM) at j=20.
+# Long-term replacement for the coder-eval-runner VM.
 
 on:
   workflow_dispatch:
     inputs:
       task_globs:
-        description: 'space-separated globs under tests/ (e.g. "tasks/uipath-agents/**/*.yaml"). Default: full tree minus Windows-only RPA + opt-in benchmarks.'
+        description: 'REQUIRED. Space-separated globs under tests/. Examples: "tasks/uipath-test/foo.yaml" (single), "tasks/uipath-agents/**/*.yaml" (folder), "tasks/**/*.yaml" (full suite — also tick confirm_large_run).'
         type: string
-        default: ''
-      runner_size:
-        description: 'GH-hosted runner tier'
-        type: choice
-        default: ubuntu-latest-16-cores
-        options:
-          - ubuntu-latest-16-cores
-          - ubuntu-latest
-      task_parallelism:
-        description: 'Concurrent tasks (-j). 4-6 is a safe ceiling for docker-driver tasks on 16-cores.'
+        required: true
+      confirm_large_run:
+        description: 'Tick to allow runs that match more than 50 tasks. Guardrail against accidental full-suite ($$$).'
+        type: boolean
+        default: false
+      coder_eval_ref:
+        description: 'coder_eval branch/SHA to install + use.'
         type: string
-        default: '4'
+        default: main
+      cli_version:
+        description: '@uipath/cli npm tag or pinned version (e.g. alpha, latest, 0.1.21).'
+        type: string
+        default: alpha
       model_override:
         description: 'Override BEDROCK_MODEL (full Bedrock id, e.g. eu.anthropic.claude-sonnet-4-6). Blank → repo secret.'
         type: string
         default: ''
 
 concurrency:
-  group: nightly-skills-gh-${{ github.ref }}
+  group: run-coder-eval-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  nightly:
-    runs-on: ${{ inputs.runner_size }}
-    # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. The 16-core
-    # tier with j=4 should land ~1-1.5h; 330 min covers worst-case stalls.
+  run:
+    runs-on: ubuntu-latest-16-cores
+    # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. 16-core
+    # runner with j=20 should land ~30-45min; 330 min covers worst-case
+    # stalls (one slow task pinning a slot, network hiccups, etc.).
     timeout-minutes: 330
-    name: Run nightly suite
+    name: Run coder-eval
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/checkout@v4
         with:
           repository: UiPath/coder_eval
+          ref: ${{ inputs.coder_eval_ref }}
           token: ${{ secrets.GH_PAT }}
           path: .coder_eval
 
@@ -70,6 +72,40 @@ jobs:
           sudo rm -rf /opt/hostedtoolcache/CodeQL 2>/dev/null || true
           df -h /
 
+      - name: Resolve task globs + enforce large-run gate
+        id: globs
+        env:
+          INPUT_GLOBS: ${{ inputs.task_globs }}
+          CONFIRMED:   ${{ inputs.confirm_large_run }}
+        run: |
+          set -euo pipefail
+          if [ -z "$INPUT_GLOBS" ]; then
+            echo "::error::task_globs is required"
+            exit 1
+          fi
+          # Expand globs against the skills checkout to count matches.
+          # Run from tests/ so the glob syntax matches what coder-eval consumes.
+          shopt -s globstar nullglob
+          cd tests
+          MATCHES=()
+          for pat in $INPUT_GLOBS; do
+            for f in $pat; do
+              [ -f "$f" ] && MATCHES+=("$f")
+            done
+          done
+          COUNT=${#MATCHES[@]}
+          echo "Matched $COUNT task file(s) for: $INPUT_GLOBS"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::No task files matched the provided globs"
+            exit 1
+          fi
+          if [ "$COUNT" -gt 50 ] && [ "$CONFIRMED" != "true" ]; then
+            echo "::error::Glob matches $COUNT tasks (> 50). Tick confirm_large_run to authorize."
+            exit 1
+          fi
+          echo "globs=$INPUT_GLOBS" >> "$GITHUB_OUTPUT"
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+
       - name: Install coder-eval
         working-directory: .coder_eval
         env:
@@ -84,12 +120,13 @@ jobs:
         run: make docker-image
 
       # Build the skills extension image (`@uipath/cli` + `@uipath/admin-tool`
-      # @alpha on top of coder-eval-agent). Matches smoke-skills.yml + daily.sh.
+      # on top of coder-eval-agent). Matches smoke-skills.yml + daily.sh.
       - name: Build skills Docker image
         run: |
           docker build \
             --build-arg CODER_EVAL_IMAGE=coder-eval-agent:latest \
             --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
+            --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
             .
@@ -120,28 +157,7 @@ jobs:
           } >> "$GITHUB_ENV"
           mkdir -p ~/.uipath
 
-      - name: Resolve task globs
-        id: globs
-        run: |
-          if [ -n "${{ inputs.task_globs }}" ]; then
-            echo "globs=${{ inputs.task_globs }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Default: full tree minus Windows-only and opt-in benchmarks
-          # (same exclusion set smoke-skills.yml uses).
-          shopt -s globstar nullglob
-          GLOBS=""
-          for f in tests/tasks/**/*.yaml; do
-            case "$f" in
-              tests/tasks/uipath-rpa/*)  continue ;;
-              tests/tasks/activation/*)  continue ;;
-            esac
-            GLOBS="$GLOBS ${f#tests/}"
-          done
-          GLOBS=$(echo "$GLOBS" | xargs)
-          echo "globs=$GLOBS" >> "$GITHUB_OUTPUT"
-
-      - name: Run nightly suite
+      - name: Run coder-eval
         env:
           SKILLS_REPO_PATH:        ${{ github.workspace }}
           API_BACKEND:             bedrock
@@ -149,14 +165,13 @@ jobs:
           AWS_REGION:              ${{ secrets.AWS_REGION }}
           BEDROCK_MODEL:           ${{ inputs.model_override != '' && inputs.model_override || secrets.BEDROCK_MODEL }}
           ANTHROPIC_API_KEY:       ${{ secrets.ANTHROPIC_API_KEY }}
-          TASK_PARALLELISM:        ${{ inputs.task_parallelism }}
         working-directory: tests
-        id: nightly
+        id: eval
         run: |
-          echo "Running: coder-eval run ${{ steps.globs.outputs.globs }} -e experiments/nightly.yaml -j $TASK_PARALLELISM"
+          echo "Running: coder-eval run ${{ steps.globs.outputs.globs }} -e experiments/nightly.yaml -j 20 (${{ steps.globs.outputs.count }} task files)"
           coder-eval run ${{ steps.globs.outputs.globs }} \
             -e experiments/nightly.yaml \
-            -j "$TASK_PARALLELISM" -v \
+            -j 20 -v \
             --run-dir /tmp/runs
         continue-on-error: true
 
@@ -184,9 +199,9 @@ jobs:
           n = len(rows)
           succ = by_status.get('SUCCESS', 0)
           if n:
-              print(f'## Nightly results: {n} tasks, {succ} SUCCESS ({100*succ/n:.1f}%)')
+              print(f'## Coder eval results: {n} tasks, {succ} SUCCESS ({100*succ/n:.1f}%)')
           else:
-              print('## Nightly results: (none)')
+              print('## Coder eval results: (none)')
           for s, c in sorted(by_status.items(), key=lambda x: -x[1]):
               print(f'  {s}: {c}')
           print()
@@ -204,7 +219,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-report-${{ github.run_id }}
+          name: coder-eval-report-${{ github.run_id }}
           path: |
             /tmp/runs/*/experiment.html
             /tmp/runs/*/experiment.md

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -134,6 +134,8 @@ jobs:
           CE_PASSWORD:              ${{ secrets.UIPATH_BOT_PASSWORD }}
         run: bash .coder_eval/dashboard/scripts/ci/refresh-auth.sh
 
+      # Pass globs / count via env to avoid `${{ }}` shell injection — the
+      # value of task_globs is user-supplied and flows through this step.
       - name: Run coder-eval
         env:
           SKILLS_REPO_PATH:         ${{ github.workspace }}
@@ -143,11 +145,14 @@ jobs:
           BEDROCK_MODEL:            ${{ secrets.BEDROCK_MODEL }}
           ANTHROPIC_API_KEY:        ${{ secrets.ANTHROPIC_API_KEY }}
           TRACES_SMOKE_PROCESS_KEY: ${{ secrets.TRACES_SMOKE_PROCESS_KEY }}
+          TASK_GLOBS:               ${{ steps.globs.outputs.globs }}
+          TASK_COUNT:               ${{ steps.globs.outputs.count }}
         working-directory: tests
         id: eval
         run: |
-          echo "Running: coder-eval run ${{ steps.globs.outputs.globs }} -e experiments/nightly.yaml -j 20 (${{ steps.globs.outputs.count }} task files)"
-          coder-eval run ${{ steps.globs.outputs.globs }} \
+          echo "Running: coder-eval run $TASK_GLOBS -e experiments/nightly.yaml -j 20 ($TASK_COUNT task files)"
+          # TASK_GLOBS must word-split into multiple glob args; do not quote.
+          coder-eval run $TASK_GLOBS \
             -e experiments/nightly.yaml \
             -j 20 -v \
             --run-dir /tmp/runs
@@ -155,6 +160,35 @@ jobs:
       - name: Fix permissions on /tmp/runs
         if: always()
         run: sudo chown -R $(id -u):$(id -g) /tmp/runs && sudo chmod -R 755 /tmp/runs 2>/dev/null || true
+
+      # Strip heavy task scratch dirs before upload to keep artifact size
+      # manageable. Matches smoke-skills.yml.
+      - name: Clean up artifacts (remove .venv and node_modules)
+        if: always()
+        run: |
+          find /tmp/runs -type d \( -name .venv -o -name node_modules \) -path "*/artifacts/*" -exec rm -rf {} + || true
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coder-eval-${{ github.run_id }}
+          # ** so the pattern matches the replicate-index segment that
+          # coder_eval adds to per-task run dirs (/tmp/runs/<ts>/<variant>/<task>/<NN>/).
+          path: |
+            /tmp/runs/*/experiment.html
+            /tmp/runs/*/experiment.md
+            /tmp/runs/*/experiment.json
+            /tmp/runs/*/experiment.log
+            /tmp/runs/*/*/variant.html
+            /tmp/runs/*/*/variant.md
+            /tmp/runs/*/*/variant.json
+            /tmp/runs/**/task.html
+            /tmp/runs/**/task.json
+            /tmp/runs/**/task.log
+            /tmp/runs/**/artifacts
+          if-no-files-found: warn
+          retention-days: 14
 
       - name: Plaintext summary + verdict
         if: always()

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -2,15 +2,10 @@ name: Run Coder Eval
 
 # GH-hosted runner for coder-eval against the skills task tree. Use cases:
 # single task ad-hoc, a folder, or (with explicit confirmation) the full
-# suite that the VM cron runs nightly. Runs on the largest GH-hosted tier
-# in UiPath (ubuntu-latest-16-cores = 16 vCPU / 64 GB RAM) at j=20.
-# Long-term replacement for the coder-eval-runner VM.
+# suite that the VM cron runs nightly. Long-term replacement for the
+# coder-eval-runner VM.
 
 on:
-  # TEMP: pull_request trigger lets us exercise the workflow before it
-  # exists on main (workflow_dispatch needs the file on the default
-  # branch). Strip before final merge.
-  pull_request:
   workflow_dispatch:
     inputs:
       task_globs:
@@ -37,9 +32,9 @@ concurrency:
 jobs:
   run:
     runs-on: ubuntu-latest
-    # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. 16-core
-    # runner with j=20 should land ~30-45min; 330 min covers worst-case
-    # stalls (one slow task pinning a slot, network hiccups, etc.).
+    # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. 330 min
+    # covers worst-case stalls (one slow task pinning a slot, network
+    # hiccups, etc.) on ubuntu-latest at j=20.
     timeout-minutes: 330
     name: Run coder-eval
     steps:
@@ -48,8 +43,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: UiPath/coder_eval
-          # inputs.* is empty on pull_request triggers — fall back to defaults.
-          ref: ${{ inputs.coder_eval_ref || 'main' }}
+          ref: ${{ inputs.coder_eval_ref }}
           token: ${{ secrets.GH_PAT }}
           path: .coder_eval
 
@@ -62,8 +56,7 @@ jobs:
       - name: Resolve task globs + enforce large-run gate
         id: globs
         env:
-          # On pull_request triggers (TEMP), fall back to a single quick task.
-          INPUT_GLOBS: ${{ inputs.task_globs || 'tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml' }}
+          INPUT_GLOBS: ${{ inputs.task_globs }}
           CONFIRMED:   ${{ inputs.confirm_large_run }}
         run: |
           set -euo pipefail
@@ -114,7 +107,7 @@ jobs:
           docker build \
             --build-arg CODER_EVAL_IMAGE=coder-eval-agent:latest \
             --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
-            --build-arg CLI_VERSION="${{ inputs.cli_version || 'alpha' }}" \
+            --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
             .

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -48,7 +48,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: UiPath/coder_eval
-          ref: ${{ inputs.coder_eval_ref }}
+          # inputs.* is empty on pull_request triggers — fall back to defaults.
+          ref: ${{ inputs.coder_eval_ref || 'main' }}
           token: ${{ secrets.GH_PAT }}
           path: .coder_eval
 
@@ -113,7 +114,7 @@ jobs:
           docker build \
             --build-arg CODER_EVAL_IMAGE=coder-eval-agent:latest \
             --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
-            --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
+            --build-arg CLI_VERSION="${{ inputs.cli_version || 'alpha' }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
             .

--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide, including:
 
 For questions, ideas, or feedback, please [open an issue](https://github.com/UiPath/uipath-claude-plugins/issues).
 
+### Running coder-eval on demand
+
+[**Run Coder Eval**](https://github.com/UiPath/skills/actions/workflows/run-coder-eval.yml) — GH-hosted workflow that runs `coder-eval` against the skills task tree (`tests/tasks/...`). Use for ad-hoc single-task verification or a folder-scoped sweep on the same infra as the nightly cron. Trigger from the Actions tab → "Run workflow" → fill in `task_globs`. Definition: [`.github/workflows/run-coder-eval.yml`](.github/workflows/run-coder-eval.yml).
+
 ## Resources
 
 - [UiPath Documentation](https://docs.uipath.com/)

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -5,23 +5,16 @@ FROM ${CODER_EVAL_IMAGE}
 
 ARG NPM_AUTH_TOKEN=
 ARG CLI_VERSION=alpha
-# Pin @uipath/* to GH Packages — this must persist for both build-time install
-# AND the CLI's runtime tool auto-install (`uip maestro flow ...` shells out
-# to `npm install @uipath/maestro-tool@<x>`). Earlier this file wrote to
-# `npm config get globalconfig` which is the lowest-precedence config file —
-# user-level config silently overrode it and resolved @alpha to the npmjs
-# version (1.0.0-alpha.20260422, which hardcodes maestro-tool@1.0.4 — a
-# stable build that exists on npmjs but not GH Packages). Writing the same
-# config to /root/.npmrc (user-level) makes the registry pin actually stick.
 RUN set -euo pipefail && \
     if [ -z "$NPM_AUTH_TOKEN" ]; then \
       echo "Error: NPM_AUTH_TOKEN must be passed as build arg"; exit 1; \
     fi && \
+    npmrc="$(npm config get globalconfig)" && \
+    mkdir -p "$(dirname "$npmrc")" && \
     printf '%s\n' \
       '@uipath:registry=https://npm.pkg.github.com/' \
       "//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}" \
-      > /root/.npmrc && \
-    chmod 600 /root/.npmrc && \
+      > "$npmrc" && \
     npm install -g "@uipath/cli@${CLI_VERSION}" && \
     uip --version
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -5,27 +5,16 @@ FROM ${CODER_EVAL_IMAGE}
 
 ARG NPM_AUTH_TOKEN=
 ARG CLI_VERSION=alpha
-# github-packages: install @uipath/cli@<CLI_VERSION> from GH Packages
-#   (tracks @alpha — published every cli/main merge).
-# npmjs: install from default public npm registry (tracks GH releases).
-ARG CLI_REGISTRY=github-packages
 RUN set -euo pipefail && \
-    case "$CLI_REGISTRY" in \
-      github-packages) \
-        if [ -z "$NPM_AUTH_TOKEN" ]; then \
-          echo "Error: NPM_AUTH_TOKEN required for github-packages registry"; exit 1; \
-        fi; \
-        npmrc="$(npm config get globalconfig)"; \
-        mkdir -p "$(dirname "$npmrc")"; \
-        printf '%s\n' \
-          '@uipath:registry=https://npm.pkg.github.com/' \
-          "//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}" \
-          > "$npmrc" ;; \
-      npmjs) \
-        : ;; \
-      *) \
-        echo "Error: CLI_REGISTRY must be 'github-packages' or 'npmjs', got: $CLI_REGISTRY"; exit 1 ;; \
-    esac && \
+    if [ -z "$NPM_AUTH_TOKEN" ]; then \
+      echo "Error: NPM_AUTH_TOKEN must be passed as build arg"; exit 1; \
+    fi && \
+    npmrc="$(npm config get globalconfig)" && \
+    mkdir -p "$(dirname "$npmrc")" && \
+    printf '%s\n' \
+      '@uipath:registry=https://npm.pkg.github.com/' \
+      "//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}" \
+      > "$npmrc" && \
     npm install -g "@uipath/cli@${CLI_VERSION}" && \
     uip --version
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -5,16 +5,27 @@ FROM ${CODER_EVAL_IMAGE}
 
 ARG NPM_AUTH_TOKEN=
 ARG CLI_VERSION=alpha
+# github-packages: install @uipath/cli@<CLI_VERSION> from GH Packages
+#   (tracks @alpha — published every cli/main merge).
+# npmjs: install from default public npm registry (tracks GH releases).
+ARG CLI_REGISTRY=github-packages
 RUN set -euo pipefail && \
-    if [ -z "$NPM_AUTH_TOKEN" ]; then \
-      echo "Error: NPM_AUTH_TOKEN must be passed as build arg"; exit 1; \
-    fi && \
-    npmrc="$(npm config get globalconfig)" && \
-    mkdir -p "$(dirname "$npmrc")" && \
-    printf '%s\n' \
-      '@uipath:registry=https://npm.pkg.github.com/' \
-      "//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}" \
-      > "$npmrc" && \
+    case "$CLI_REGISTRY" in \
+      github-packages) \
+        if [ -z "$NPM_AUTH_TOKEN" ]; then \
+          echo "Error: NPM_AUTH_TOKEN required for github-packages registry"; exit 1; \
+        fi; \
+        npmrc="$(npm config get globalconfig)"; \
+        mkdir -p "$(dirname "$npmrc")"; \
+        printf '%s\n' \
+          '@uipath:registry=https://npm.pkg.github.com/' \
+          "//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}" \
+          > "$npmrc" ;; \
+      npmjs) \
+        : ;; \
+      *) \
+        echo "Error: CLI_REGISTRY must be 'github-packages' or 'npmjs', got: $CLI_REGISTRY"; exit 1 ;; \
+    esac && \
     npm install -g "@uipath/cli@${CLI_VERSION}" && \
     uip --version
 

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -4,6 +4,7 @@ ARG CODER_EVAL_IMAGE=coder-eval-agent:latest
 FROM ${CODER_EVAL_IMAGE}
 
 ARG NPM_AUTH_TOKEN=
+ARG CLI_VERSION=alpha
 RUN set -euo pipefail && \
     if [ -z "$NPM_AUTH_TOKEN" ]; then \
       echo "Error: NPM_AUTH_TOKEN must be passed as build arg"; exit 1; \
@@ -14,7 +15,7 @@ RUN set -euo pipefail && \
       '@uipath:registry=https://npm.pkg.github.com/' \
       "//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}" \
       > "$npmrc" && \
-    npm install -g @uipath/cli@alpha && \
+    npm install -g "@uipath/cli@${CLI_VERSION}" && \
     uip --version
 
 # .NET 8 SDK — `uip rpa build` shells out to dotnet for the workflow compiler.

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -5,16 +5,23 @@ FROM ${CODER_EVAL_IMAGE}
 
 ARG NPM_AUTH_TOKEN=
 ARG CLI_VERSION=alpha
+# Pin @uipath/* to GH Packages — this must persist for both build-time install
+# AND the CLI's runtime tool auto-install (`uip maestro flow ...` shells out
+# to `npm install @uipath/maestro-tool@<x>`). Earlier this file wrote to
+# `npm config get globalconfig` which is the lowest-precedence config file —
+# user-level config silently overrode it and resolved @alpha to the npmjs
+# version (1.0.0-alpha.20260422, which hardcodes maestro-tool@1.0.4 — a
+# stable build that exists on npmjs but not GH Packages). Writing the same
+# config to /root/.npmrc (user-level) makes the registry pin actually stick.
 RUN set -euo pipefail && \
     if [ -z "$NPM_AUTH_TOKEN" ]; then \
       echo "Error: NPM_AUTH_TOKEN must be passed as build arg"; exit 1; \
     fi && \
-    npmrc="$(npm config get globalconfig)" && \
-    mkdir -p "$(dirname "$npmrc")" && \
     printf '%s\n' \
       '@uipath:registry=https://npm.pkg.github.com/' \
       "//npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}" \
-      > "$npmrc" && \
+      > /root/.npmrc && \
+    chmod 600 /root/.npmrc && \
     npm install -g "@uipath/cli@${CLI_VERSION}" && \
     uip --version
 


### PR DESCRIPTION
## What

GH-hosted Actions workflow that runs `coder-eval` against the skills task tree (`tests/tasks/...`). Triggerable from the Actions tab with a single task, a folder, or — with explicit confirmation — the full suite that the VM cron runs nightly.

## Why

Long-term replacement for the `coder-eval-runner` VM. The VM is expensive, requires SSH to debug, accumulates stale system state, and runs at j=1 (~3-4h for the full suite). GH-hosted runners are ephemeral, let anyone trigger ad-hoc evals without VM access, and run at j=20.

## Design

- Builds the same `skills-image:latest` Docker image used by `smoke-skills.yml` and `daily.sh` (`tests/docker/Dockerfile` + `@uipath/cli@alpha` from GH Packages)
- Mints ROPC bot-user auth via `coder_eval/dashboard/scripts/ci/refresh-auth.sh` — `uip flow debug` needs a real user `sub` claim, which `client_credentials` tokens lack. Writes `~/.uipath/.auth`; `experiments/nightly.yaml` mounts it into each eval container
- Runs `coder-eval run <globs> -e experiments/nightly.yaml -j 20 --run-dir /tmp/runs`
- Final step parses `task.json` files and emits `task_id: STATUS` per task plus `N/M PASS`; exits nonzero if any task failed
- Guardrail: globs matching >50 tasks require ticking `confirm_large_run`

## Testing

End-to-end validated by temporarily enabling `pull_request:` + defaulting the calculator task on this PR (both reverted before merge). Final clean run on `bai/nightly-on-gh-actions` — [run 26317972599](https://github.com/UiPath/skills/actions/runs/26317972599):

- Duration: 5m25s
- Result: `skill-flow-calculator: SUCCESS` → `1/1 PASS`
- `@uipath/cli@alpha` resolved to `1.1.0-alpha.20260521.7245` from GH Packages — not the stale npmjs `1.0.0-alpha.20260422.4672` that pins `@uipath/maestro-tool@1.0.4` (a stable not on GH Packages, which caused an `ETARGET` failure during earlier debug runs)
- Container CLI matched the host docker build (`docker_runner: Version: 1.1.0-alpha.20260521.7245`)
- ROPC auth propagated through the mount — `uip flow debug` worked end-to-end

## Known dependencies

- Currently runs on `ubuntu-latest` (2 vCPU / 7 GB RAM). For the full nightly sweep the VM remains a better target until `UiPath/skills` is allowlisted for the `ubuntu-latest-16-cores` runner group. Switch is a one-line YAML change once granted.
- Repo secrets added for this workflow: `UIPATH_ROPC_CLIENT_ID`, `UIPATH_ROPC_CLIENT_SECRET`, `UIPATH_BOT_USERNAME`, `UIPATH_BOT_PASSWORD` (existing secrets for `GH_PAT`, AWS Bedrock, UV index reused)