### PR TITLE
test(uipath-maestro-case): clean up Studio Web solutions after debug

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Delete Studio Web solutions uploaded by ``uip maestro case debug`` during a task.
+
+Wired in via ``post_run`` in case e2e task YAMLs. Runs from the sandbox CWD
+after evaluation completes; finds every ``.uipx`` file under it, reads
+``SolutionId``, and best-effort deletes each via ``uip solution delete``.
+``.uipx`` files without a ``SolutionId`` are skipped.
+
+Cleanup policy is controlled by the ``CASE_E2E_CLEANUP`` env var:
+
+* ``always`` (default) — delete regardless of outcome. Use in CI.
+* ``never`` — delete nothing. Use when actively debugging locally so the
+  solution stays available in Studio Web for inspection.
+
+Best-effort: failures here never affect pass/fail (post_run results are
+informational only), so this script always exits 0.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import os
+import subprocess
+import sys
+
+logging.basicConfig(level=logging.INFO, format="cleanup_solutions: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _resolve_policy() -> str:
+    policy = os.environ.get("CASE_E2E_CLEANUP", "always").lower()
+    if policy not in ("always", "never"):
+        logger.warning(
+            "CASE_E2E_CLEANUP=%r is invalid (expected always|never); treating as 'always'",
+            policy,
+        )
+        return "always"
+    return policy
+
+
+def main() -> int:
+    paths = glob.glob("**/*.uipx", recursive=True)
+    if not paths:
+        logger.info("no .uipx files under cwd; nothing to do.")
+        return 0
+
+    policy = _resolve_policy()
+    deleted: list[str] = []
+    preserved: list[str] = []
+    skipped: list[str] = []
+    failed: list[str] = []
+
+    for path in paths:
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("could not read %s: %s", path, e)
+            skipped.append(path)
+            continue
+
+        sid = data.get("SolutionId")
+        if not sid:
+            logger.info("no SolutionId in %s, skipping", path)
+            skipped.append(path)
+            continue
+
+        if policy == "never":
+            logger.info(
+                "CASE_E2E_CLEANUP=never; preserving %s (delete later with: uip solution delete %s)",
+                sid,
+                sid,
+            )
+            preserved.append(sid)
+            continue
+
+        r = subprocess.run(
+            ["uip", "solution", "delete", sid, "--output", "json"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if r.returncode == 0:
+            logger.info("deleted %s (from %s)", sid, path)
+            deleted.append(sid)
+        else:
+            logger.warning(
+                "failed to delete %s (exit %d): %s",
+                sid,
+                r.returncode,
+                r.stderr.strip()[:300],
+            )
+            failed.append(sid)
+
+    logger.info(
+        "summary policy=%s deleted=%d preserved=%d skipped=%d failed=%d",
+        policy,
+        len(deleted),
+        len(preserved),
+        len(skipped),
+        len(failed),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
@@ -271,3 +271,7 @@ success_criteria:
         expected: "High"
     weight: 2.5
     pass_threshold: 0.75
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
@@ -235,3 +235,7 @@ success_criteria:
         expected: ""
     weight: 2.0
     pass_threshold: 0.75
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
@@ -306,3 +306,7 @@ success_criteria:
         expected: "approved"
     weight: 2.5
     pass_threshold: 0.75
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
@@ -287,3 +287,7 @@ success_criteria:
         expected: true
     weight: 1.5
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
@@ -143,3 +143,7 @@ success_criteria:
         expected: ""
     weight: 2.0
     pass_threshold: 0.75
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
@@ -195,3 +195,7 @@ success_criteria:
       - "selected-tasks-completed"
     weight: 1.5
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
@@ -230,3 +230,7 @@ success_criteria:
         expected: "approved"
     weight: 2.0
     pass_threshold: 0.75
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
@@ -184,3 +184,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
@@ -153,3 +153,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
@@ -186,3 +186,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -284,3 +284,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
@@ -212,3 +212,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
@@ -122,3 +122,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
@@ -146,3 +146,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
@@ -262,3 +262,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -129,3 +129,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -129,3 +129,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -120,3 +120,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -119,3 +119,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -129,3 +129,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120


### PR DESCRIPTION
test(uipath-maestro-case): clean up Studio Web solutions after debug

Add _shared/cleanup_solutions.py mirroring the uipath-maestro-flow helper
and wire it into post_run for the 21 case task YAMLs whose checkers invoke
`uip maestro case debug`. Gated by CASE_E2E_CLEANUP=always|never (default
always) so local debugging can keep solutions in Studio Web for inspection.
