### PR TITLE
fix(tests): stabilize skill-agent-coded-llamaindex-rag

### DIFF
--- a/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
+++ b/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
@@ -59,8 +59,8 @@ def main() -> None:
     workflows = cfg.get("workflows") or cfg.get("graphs") or {}
     if not workflows:
         fail("llama_index.json has no `workflows` entries")
-    if not any("./main.py" in str(v) for v in workflows.values()):
-        fail(f"llama_index.json workflows do not point at ./main.py: {workflows}")
+    if not any("main.py:" in str(v) for v in workflows.values()):
+        fail(f"llama_index.json workflows do not point at main.py: {workflows}")
     print("OK: llama_index.json points at a workflow in main.py")
 
     if not MAIN.is_file():

--- a/tests/tasks/uipath-agents/coded/llamaindex_rag/llamaindex_rag.yaml
+++ b/tests/tasks/uipath-agents/coded/llamaindex_rag/llamaindex_rag.yaml
@@ -32,6 +32,9 @@ initial_prompt: |
   Outputs:
     - `answer` (string)
 
+  Scaffold the agent project inside an `hr-helper/` directory at
+  the working-directory root.
+
   Take the agent through scaffold → schema sync. Do NOT run,
   publish, upload, or deploy. Do NOT call `uip login`. Do NOT
   pause between planning and implementation. Complete end-to-end
@@ -56,7 +59,7 @@ success_criteria:
 
   - type: file_exists
     description: "LlamaIndex framework marker present (proves framework selection)"
-    path: "llama_index.json"
+    path: "hr-helper/llama_index.json"
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
`uip codedagent new <name>` creates files in the CURRENT directory, not in a `<name>/` subdirectory (verified empirically — it even prints "Creating new agent <name> in current directory"). The skill teaches `mkdir my-agent && cd my-agent && uip codedagent new`, which puts the project at `hr-helper/llama_index.json` with the workflow registered as `main.py:workflow` (no `./` prefix). The previous `file_exists` asserted the wrong path and the checker required a `./` prefix the skill never documents — and the prompt didn't pin the layout, so agents that skipped the `mkdir && cd` step also broke the assertion. This PR pins the layout in the prompt and aligns both assertions to what `uip codedagent new` actually emits.