### PR TITLE
docs(uipath-rpa): warn agents about [k(...)] tokens in attribute-form Text

### DIFF
--- a/skills/uipath-rpa/references/legacy/activity-docs/UIAutomation.md
+++ b/skills/uipath-rpa/references/legacy/activity-docs/UIAutomation.md
@@ -88,6 +88,18 @@ Legacy desktop UI automation for Windows. Click, type, find elements, manage win
 [k(F1)]         - Function key F1-F12
 ```
 
+**Authoring rule:** when any of these tokens appears in `Text`, write the value with child element syntax — not attribute form. The attribute form `Text="[&quot;13700132[k(enter)]&quot;]"` runs correctly but the value will not render in Studio because the literal `[` / `]` inside the string collide with the outer VB expression markers. Use:
+
+```xml
+<uix:NTypeInto ...>
+  <uix:NTypeInto.Text>
+    <InArgument x:TypeArguments="x:String">["13700132[k(enter)]"]</InArgument>
+  </uix:NTypeInto.Text>
+</uix:NTypeInto>
+```
+
+See `../../xaml/common-pitfalls.md` § "NTypeInto `Text` with literal `[k(...)]` special-key tokens" for alternatives (`Chr(91)`/`Chr(93)` construction, split-activity).
+
 ---
 
 ## Critical Gotchas

--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -118,6 +118,25 @@ Some properties are only required when another property has a specific value:
 
 See `ui-automation.md` NKeyboardShortcuts section for the full hotkey encoding reference.
 
+## NTypeInto `Text` with literal `[k(...)]` special-key tokens
+
+When `Text` contains literal `[k(...)]`, `[d(...)]`, or `[u(...)]` special-key tokens, use the long-form element — never the attribute form. The attribute form runs correctly but the value does not render in Studio, so the workflow looks empty even though it works.
+
+**Wrong:** `Text="[&quot;13700132[k(enter)]&quot;]"` → runs, but `Text` shows blank in Studio.
+
+**Correct:**
+```xml
+<uix:NTypeInto ...>
+  <uix:NTypeInto.Text>
+    <InArgument x:TypeArguments="x:String">["13700132[k(enter)]"]</InArgument>
+  </uix:NTypeInto.Text>
+</uix:NTypeInto>
+```
+
+Alternatives:
+- Build the bracket characters with `Chr(91)` / `Chr(93)` so the string carries no literal `[` / `]`: `Text="[&quot;13700132&quot; &amp; Chr(91) &amp; &quot;k(enter)&quot; &amp; Chr(93)]"`.
+- Split the input: one `NTypeInto` for the digits, one `NKeyboardShortcuts` (or a second `NTypeInto`) for `[k(enter)]`.
+
 ## ActivityAction/ActivityFunc Initialization
 
 Scope activities (like `ExcelApplicationCard`, `Use Application/Browser`) use `ActivityAction` to wrap their child content. The XAML pattern is:

--- a/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
@@ -708,6 +708,8 @@ DisplayName="My Activity" Message="[variable]" Level="Info"
 
 **Complex objects** (BackupSlot, MailboxArgument, ActivityAction, dictionaries) always require child element syntax — they cannot be expressed as a single attribute value.
 
+**Strings containing literal `[` or `]`** (e.g., UIA special-key tokens like `[k(enter)]`, `[d(ctrl)]`, `[u(ctrl)]`) require child element syntax. The attribute form `Foo="[&quot;…[k(enter)]&quot;]"` runs correctly because the runtime VB compiler reads quoted string literals correctly, but the literal brackets inside the string collide with the outer `[ … ]` VB expression markers and the value will not render in Studio. See [common-pitfalls.md § NTypeInto `Text` with literal `[k(...)]` special-key tokens](common-pitfalls.md#ntypeinto-text-with-literal-k-special-key-tokens).
+
 ### Version-Sensitive Properties
 
 Properties may exist in one package version but not another. If `validate` reports "Could not find member 'PropertyName'":


### PR DESCRIPTION
Fixes [PILOT-5353](https://uipath.atlassian.net/browse/PILOT-5353).

## Summary

- Adds a pitfall to the **uipath-rpa** skill: when an `NTypeInto` `Text` value contains a UIA special-key token (`[k(enter)]`, `[d(ctrl)]`, `[u(ctrl)]`, …) written in attribute-form `Text="[&quot;…[k(enter)]&quot;]"`, the value runs correctly but **renders blank in Studio** because the literal brackets inside the string collide with the outer `[ … ]` VB expression markers.
- Fix is for agents to write the value with child element syntax (`<uix:NTypeInto.Text><InArgument …>["…[k(enter)]"]</InArgument></uix:NTypeInto.Text>`). Alternatives documented: `Chr(91)`/`Chr(93)` construction, or splitting digits and key-press into two activities.
- Rule landed in three layered spots so agents catch it from any entry point:
  - `xaml/common-pitfalls.md` — full wrong/correct example + alternatives (canonical entry).
  - `xaml/xaml-basics-and-rules.md` — generic VB-in-XAML bullet alongside the existing attribute-vs-element-form guidance.
  - `legacy/activity-docs/UIAutomation.md` — authoring note immediately under the `[k(...)]` syntax table.

Triggered by analysis in [AlinMihaleaUiPath/HKJockeyTestingProject `TYPE_INTO_POSITION_CODE_EMPTY.md`](https://github.com/AlinMihaleaUiPath/HKJockeyTestingProject/blob/session_2505_1/TYPE_INTO_POSITION_CODE_EMPTY.md).

## Test plan

- [ ] Verify the new section heading in `common-pitfalls.md` matches the anchor referenced from `xaml-basics-and-rules.md`.
- [ ] Verify the relative link from `legacy/activity-docs/UIAutomation.md` (`../../xaml/common-pitfalls.md`) resolves.
- [ ] Spot-check that the three locations don't duplicate the full example — only the canonical entry holds it, the others cross-reference.
- [ ] Confirm the wording avoids prescribing UIA CLI subcommands or flags (per `skills/uipath-rpa/CLAUDE.md` boundary rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PILOT-5353]: https://uipath.atlassian.net/browse/PILOT-5353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ