### PR TITLE
feat(uipath-ixp): document new `documents upload` command

### DIFF
--- a/skills/uipath-ixp/SKILL.md
+++ b/skills/uipath-ixp/SKILL.md
@@ -50,7 +50,7 @@ If the user provides a taxonomy file, use `--skip-taxonomy` and `import-taxonomy
 
 | User request | Action |
 |-------------|--------|
-| "Create an IXP project" / "Upload documents" | [Project Setup Guide](references/project-setup-guide.md) |
+| "Create an IXP project" / "Upload documents to a new project" | [Project Setup Guide](references/project-setup-guide.md) — **new** projects only (uploads + taxonomy in one call). For **existing** projects, see the "Upload a document" row below. |
 | "Import this taxonomy" / provides a taxonomy file | [Project Setup Guide](references/project-setup-guide.md) — Option B (`--skip-taxonomy` + `import-taxonomy`) |
 | "Label documents" / "Review predictions" | [Label Documents Guide](references/label-documents-guide.md) |
 | "Improve scores" / "Fix prompts" / "Improve F1" | [Improve Prompts Guide](references/improve-prompts-guide.md) |
@@ -58,6 +58,7 @@ If the user provides a taxonomy file, use `--skip-taxonomy` and `import-taxonomy
 | "Show metrics" / "What are the scores?" | `uip ixp projects get-metrics <project-name> --output json` |
 | "List projects" | `uip ixp projects list --output json` |
 | "Configure the model" / "Change preprocessing" | `uip ixp projects configure-model <project-name> [options] --output json` |
+| "Upload a document" / "Add documents to an existing project" | `uip ixp documents upload <project-name> <file> --output json` — see [CLI Reference § Uploading documents](references/cli-reference.md#uploading-documents-to-an-existing-project). One file per call; loop for multiple. For brand-new projects use `projects create` instead. |
 
 ## Common Pitfalls
 

--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -24,7 +24,7 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 |---------|-------------|
 | `uip ixp documents list <project-name> [-l <limit>] [--offset <n>] --output json` | List documents — returns `[{ DocumentId, AttachmentRef }]`. Paginated: defaults to 50 items per page (max 10000). Pass `-l` for larger pages or `--offset` to skip ahead. |
 | `uip ixp documents download <project-name> <document-id> -o <path> --output json` | Download the original document file (PDF/PNG/JPG/etc.). The CLI auto-corrects the file extension to match the actual content; use the response `Path` field as the resolved location. |
-| `uip ixp documents upload <project-name> <file> --output json` | Upload a single document file (PDF/PNG/JPG/JPEG/GIF/TIF/TIFF/BMP) to an existing project. Returns `{ ProjectName, FileName, AttachmentRef, DocumentId }`. Use `AttachmentRef` with `suggest-taxonomy` or `import-taxonomy` workflows. For bulk uploads when creating a new project, prefer `projects create <name> <folder>`. |
+| `uip ixp documents upload <project-name> <file> --output json` | Upload a single document file (PDF/PNG/JPG/JPEG/GIF/TIF/TIFF/BMP) to an existing project. Returns `{ ProjectName, FileName, AttachmentRef, DocumentId }`. For taxonomy auto-suggestion when creating a new project, use `uip ixp projects create "<name>" <folder-path> ...`. To import a taxonomy explicitly, use `uip ixp projects import-taxonomy <project-name> <file> --output json`. |
 
 ## Labellings
 

--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -8,7 +8,7 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 |---------|-------------|
 | `uip ixp projects list --output json` | List all IXP projects |
 | `uip ixp projects get <project-name> --output json` | Get a project |
-| `uip ixp projects create "<name>" <folder-path> [-d "<description>"] [--skip-taxonomy] --output json` | Create project and upload all supported docs in `<folder-path>` (see [Supported document files](#supported-document-files); unsupported files are skipped silently). By default suggests+imports taxonomy. `-d` provides context for better taxonomy suggestion. Use `--skip-taxonomy` to create a blank project (import taxonomy separately). Use `ProjectName` from output. |
+| `uip ixp projects create "<name>" <folder-path> [-d "<description>"] [--skip-taxonomy] --output json` | Create project and upload supported docs in `<folder-path>` (top-level only — sub-folders are not scanned; see [Supported document files](#supported-document-files)). By default suggests+imports taxonomy. `-d` provides context for better taxonomy suggestion. Use `--skip-taxonomy` to create a blank project (import taxonomy separately). Use `ProjectName` from output. |
 | `uip ixp projects import-taxonomy <project-name> <file> --output json` | Import taxonomy from a local JSON file. Accepts `{ field_types, label_group }` or `{ entity_defs, label_groups }` format. |
 | `uip ixp projects update-title <project-name> "<new-title>" --output json` | Update the display title of a project |
 | `uip ixp projects get-taxonomy <project-name> --output json` | Get taxonomy (entity_defs + label_groups with field definitions) |
@@ -35,7 +35,7 @@ Both `projects create` (bulk folder upload) and `documents upload` (single file)
 Validation differs by command:
 
 - `documents upload` rejects an unsupported file with `Unsupported file type "<ext>"` before any network call.
-- `projects create` silently skips unsupported files in the folder; fails only when **no** supported files exist (`No supported documents found in <folder>`).
+- `projects create` scans only the top level of `<folder-path>` (sub-folders are ignored), silently skips unsupported files, and fails only when **no** supported files exist (`No supported documents found in <folder>`).
 
 Each upload triggers a retrain — wait ~2 min before reading metrics or predictions for new docs.
 

--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -8,7 +8,7 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 |---------|-------------|
 | `uip ixp projects list --output json` | List all IXP projects |
 | `uip ixp projects get <project-name> --output json` | Get a project |
-| `uip ixp projects create "<name>" <folder-path> [-d "<description>"] [--skip-taxonomy] --output json` | Create project and upload docs. By default suggests+imports taxonomy. `-d` provides context for better taxonomy suggestion. Use `--skip-taxonomy` to create a blank project (import taxonomy separately). Use `ProjectName` from output. |
+| `uip ixp projects create "<name>" <folder-path> [-d "<description>"] [--skip-taxonomy] --output json` | Create project and upload all supported docs in `<folder-path>` (see [Supported document files](#supported-document-files); unsupported files are skipped silently). By default suggests+imports taxonomy. `-d` provides context for better taxonomy suggestion. Use `--skip-taxonomy` to create a blank project (import taxonomy separately). Use `ProjectName` from output. |
 | `uip ixp projects import-taxonomy <project-name> <file> --output json` | Import taxonomy from a local JSON file. Accepts `{ field_types, label_group }` or `{ entity_defs, label_groups }` format. |
 | `uip ixp projects update-title <project-name> "<new-title>" --output json` | Update the display title of a project |
 | `uip ixp projects get-taxonomy <project-name> --output json` | Get taxonomy (entity_defs + label_groups with field definitions) |
@@ -24,7 +24,40 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 |---------|-------------|
 | `uip ixp documents list <project-name> [-l <limit>] [--offset <n>] --output json` | List documents — returns `[{ DocumentId, AttachmentRef }]`. Paginated: defaults to 50 items per page (max 10000). Pass `-l` for larger pages or `--offset` to skip ahead. |
 | `uip ixp documents download <project-name> <document-id> -o <path> --output json` | Download the original document file (PDF/PNG/JPG/etc.). The CLI auto-corrects the file extension to match the actual content; use the response `Path` field as the resolved location. |
-| `uip ixp documents upload <project-name> <file> --output json` | Upload a single document file (PDF/PNG/JPG/JPEG/GIF/TIF/TIFF/BMP) to an existing project. Returns `{ ProjectName, FileName, AttachmentRef, DocumentId }`. For taxonomy auto-suggestion when creating a new project, use `uip ixp projects create "<name>" <folder-path> ...`. To import a taxonomy explicitly, use `uip ixp projects import-taxonomy <project-name> <file> --output json`. |
+| `uip ixp documents upload <project-name> <file> --output json` | Upload a single document file to an existing project. See [Uploading documents](#uploading-documents-to-an-existing-project) below for validation, output shape, and the multi-file loop pattern. |
+
+### Supported document files
+
+Both `projects create` (bulk folder upload) and `documents upload` (single file) validate against the same extension whitelist, case-insensitive:
+
+`.pdf`, `.png`, `.jpg`, `.jpeg`, `.gif`, `.tif`, `.tiff`, `.bmp`
+
+Validation differs by command:
+
+- `documents upload` rejects an unsupported file with `Unsupported file type "<ext>"` before any network call.
+- `projects create` silently skips unsupported files in the folder; fails only when **no** supported files exist (`No supported documents found in <folder>`).
+
+Each upload triggers a retrain — wait ~2 min before reading metrics or predictions for new docs.
+
+### Uploading documents to an existing project
+
+`uip ixp documents upload <project-name> <file> --output json` pushes one document to an existing project.
+
+For supported extensions, validation error strings, and retrain timing, see [Supported document files](#supported-document-files) above.
+
+Returns `{ ProjectName, FileName, AttachmentRef, DocumentId }` (Code: `IxpDocumentsUpload`). Capture `DocumentId` for later `documents download` or `labellings confirm` calls.
+
+**Multiple files** — one file per call; loop the command:
+
+```bash
+cd "<folder-with-docs>"
+for f in *.pdf *.png *.jpg *.jpeg *.gif *.tif *.tiff *.bmp; do
+    [ -e "$f" ] || continue   # skip unmatched glob patterns
+    uip ixp documents upload <project-name> "$f" --output json
+done
+```
+
+**When NOT to use this:** for filling a brand-new project, prefer `projects create <name> <folder-path>` — uploads the whole folder and suggests a taxonomy in one call.
 
 ## Labellings
 

--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -24,6 +24,7 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 |---------|-------------|
 | `uip ixp documents list <project-name> [-l <limit>] [--offset <n>] --output json` | List documents — returns `[{ DocumentId, AttachmentRef }]`. Paginated: defaults to 50 items per page (max 10000). Pass `-l` for larger pages or `--offset` to skip ahead. |
 | `uip ixp documents download <project-name> <document-id> -o <path> --output json` | Download the original document file (PDF/PNG/JPG/etc.). The CLI auto-corrects the file extension to match the actual content; use the response `Path` field as the resolved location. |
+| `uip ixp documents upload <project-name> <file> --output json` | Upload a single document file (PDF/PNG/JPG/JPEG/GIF/TIF/TIFF/BMP) to an existing project. Returns `{ ProjectName, FileName, AttachmentRef, DocumentId }`. Use `AttachmentRef` with `suggest-taxonomy` or `import-taxonomy` workflows. For bulk uploads when creating a new project, prefer `projects create <name> <folder>`. |
 
 ## Labellings
 

--- a/skills/uipath-ixp/references/project-setup-guide.md
+++ b/skills/uipath-ixp/references/project-setup-guide.md
@@ -1,10 +1,14 @@
 # Project Setup Guide
 
-Complete workflow for creating a new IXP project, labelling all documents, and getting initial metrics. Run all steps end-to-end automatically.
+Complete workflow for creating a **new** IXP project, labelling all documents, and getting initial metrics. Run all steps end-to-end automatically.
+
+> **Wrong page if the project already exists.** Use `uip ixp documents upload <project-name> <file>` — see [CLI Reference § Uploading documents](cli-reference.md#uploading-documents-to-an-existing-project).
 
 ## Step 1 — Create the Project
 
 If the user provides a name, use it. If not, generate a temporary name (e.g., `ixp_project_NNNN` with a random number) — the project will be renamed in Step 3 after the taxonomy reveals the document type.
+
+`<folder-path>` is filtered to supported document files — see [CLI Reference § Supported document files](cli-reference.md#supported-document-files).
 
 **Option A — Auto-suggest taxonomy (default):**
 


### PR DESCRIPTION
## Summary

   - Adds the `uip ixp documents upload <project-name> <file> --output json` row to the IXP skill's CLI reference.
   - Pairs with the matching CLI change in [UiPath/cli](https://github.com/UiPath/cli) (`feat(ixp-tool): add documents upload command`), which adds the single-file upload path for projects that already exist — until now the skill could only push documents through `projects create`, which is coupled to the project-creation flow.
   
  cli change: https://github.com/UiPath/cli/pull/2212

 ## Test plan

 - [x] Reviewed `skills/uipath-ixp/references/cli-reference.md` renders correctly in markdown.
 - [x] CLI command exists locally and was smoke-tested against staging in the companion CLI PR.