### PR TITLE
fix(uipath-troubleshoot): triage records all signature-fitting playbooks across all confidence levels

### DIFF
--- a/skills/uipath-troubleshoot/agents/triage.md
+++ b/skills/uipath-troubleshoot/agents/triage.md
@@ -35,7 +35,7 @@ Goal: get the error message and match playbooks as fast as possible.
    3. **Fall back to most recent overall** only when no process can be inferred from the user's message OR the working directory.
 
    Write to raw/, write evidence summary.
-6. **Match playbooks** — read the product/package summary for every domain in `state.json.scope.domain`. Match playbooks against the error message/type from the fetched data. Record every match in `state.json.matched_playbooks` with confidence level and full path. Do NOT override confidence levels.
+6. **Match playbooks** — read the product/package summary for every domain in `state.json.scope.domain`. Record EVERY playbook whose signature the error data satisfies, across ALL confidence levels (high + medium + low) — not only the highest-ranked one. When multiple sibling playbooks share an overlapping signature but describe distinct causes or remediations, ALL of them MUST appear in `state.json.matched_playbooks`. The Confidence Gate below decides Pass 1→Pass 2 routing only; it does NOT decide which playbooks are recorded. Each entry carries confidence level and full path. Do NOT override confidence levels.
 
 7. **Confirm source-code availability when the matched playbook needs it.** Some playbooks cannot reach a root cause without inspecting project source — typically runtime exceptions, selector failures, expression-evaluation errors, variable-binding issues, and any case where the error stack names a compiled workflow expression (e.g., `__Expr<n>Get`, `CSharpValue.Execute`, `InArgument.TryPopulateValue`) or a specific activity inside a `.xaml` / `.cs` / `.py` source file. Decide:
 


### PR DESCRIPTION
The triage agent's step 6 'Match playbooks' previously read as 'match playbooks against the error message; record every match.' In practice the LLM interpreted that as 'pick the best fit' and collapsed to a single high-confidence match — even when sibling playbooks at medium / low confidence ALSO fit the same signature but described distinct causes / remediations.

Net effect: the generator only saw one playbook, only drafted one hypothesis, and the tester confirmed it without ever considering alternatives. Variance / wrong-but-related conclusions followed.

This change tightens step 6 to be explicit:
- Record EVERY playbook whose signature the error data satisfies — high + medium + low — not only the highest-ranked one.
- When multiple sibling playbooks share an overlapping signature but describe distinct causes / remediations, ALL of them MUST appear in matched_playbooks.
- The Confidence Gate still gates Pass 1→Pass 2 routing; it does NOT filter which playbooks are recorded.
- The generator drafts hypotheses for every matched playbook in a single round (per shared.md Single-round coverage rule); the tester walks them in priority order (high before medium before low).

Generic phrasing — no product-specific signals or specific playbook names appear in the rule.