### PR TITLE
uipath-rpa: document canonical XAML argument-default syntax STUD-80149

### DIFF
--- a/skills/uipath-rpa/references/testing-guide.md
+++ b/skills/uipath-rpa/references/testing-guide.md
@@ -54,6 +54,10 @@ Required xmlns for `InvokeWorkflowFile`:
 xmlns:ui="http://schemas.uipath.com/workflow/activities"
 ```
 
+### Default Values for Test-Case Arguments
+
+A test case authored with an `<x:Property Name="in_X" Type="InArgument(x:String)" />` argument should generally bake in a default so `uip rpa run --file-path <TestCase>.xaml` is runnable without `--input-arguments`. Use the canonical root-attribute syntax — see [xaml/xaml-basics-and-rules.md § Setting Default Values for Arguments](xaml/xaml-basics-and-rules.md#setting-default-values-for-arguments). The wrong forms (bare attribute, `<x:Property.Value>`, `<InArgument>` child of `<x:Property>`) all produce confusing `member not supported` errors — the doc explicitly lists them so you don't waste time trying.
+
 ### XAML Structure — Standalone Test Case (with Placeholder)
 
 For test cases designed to work with execution templates, use `ui:Placeholder` in the When container:

--- a/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
@@ -310,6 +310,45 @@ Add `x:Property` elements inside the `<x:Members>` block:
 
 Argument naming convention: `in_`, `out_`, `io_` prefixes.
 
+#### Setting Default Values for Arguments
+
+Defaults go on the root `<Activity>` element using the canonical .NET Workflow Foundation self-namespace syntax:
+
+```xml
+<Activity x:Class="TestCase"
+          xmlns:this="clr-namespace:"
+          this:TestCase.in_FileName="report.pdf"
+          xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities"
+          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <x:Members>
+    <x:Property Name="in_FileName" Type="InArgument(x:String)" />
+  </x:Members>
+</Activity>
+```
+
+Two parts are mandatory:
+
+1. **`xmlns:this="clr-namespace:"`** — the empty `clr-namespace:` is what makes `this:` resolve to the class declared by `x:Class`.
+2. **`this:<ClassName>.<argName>="<value>"`** — the attribute name MUST be qualified with `this:` AND the class name; bare `<argName>="<value>"` is rejected.
+
+The default is baked into the compiled assembly at build time as a `Literal<T>` expression in the generated class's constructor. At runtime, when the workflow is invoked without that argument supplied (e.g. `uip rpa run` without `--input-arguments`), the literal is used.
+
+**Three default-value forms that DO NOT work** — every one of them is rejected by the XAML loader. Authoring agents have repeatedly tried these and lost time to confusing errors — don't:
+
+| Bad form | Error |
+|---|---|
+| `<Activity in_FileName="...">` (no `xmlns:this`, no class qualifier) | `member (in_FileName) is not supported by DynamicActivity` |
+| `<x:Property Name="in_FileName" ...><InArgument>...</InArgument></x:Property>` | `DynamicActivityProperty does not have a content property` |
+| `<x:Property.Value>...</x:Property.Value>` | `x:Property member (Value) is not supported by DynamicActivityProperty` |
+
+If you must accept an empty string as a sentinel ("user didn't provide one") and substitute a literal anyway, use a ternary inside each `CSharpValue`/`VisualBasicValue` consumer of the argument:
+
+```xml
+<CSharpValue x:TypeArguments="x:String">string.IsNullOrEmpty(in_FileName) ? "report.pdf" : in_FileName</CSharpValue>
+```
+
+But the root-attribute default above is the cleaner answer — use it first.
+
 ### Adding Variables
 
 Add `Variable` elements inside the workflow container's `.Variables` block:


### PR DESCRIPTION
## Summary

Adds explicit documentation for how to declare default values on XAML `InArgument` properties, so test cases authored by the skill are runnable with `uip rpa run --file-path TestCase.xaml` **without** `--input-arguments`. Tracked as [STUD-80149](https://uipath.atlassian.net/browse/STUD-80149) (resolved as Won't Fix in Studio — the syntax already works, the skill just wasn't emitting it).

## Background

The HKJockey [session_2205_2 analysis](https://github.com/AlinMihaleaUiPath/HKJockeyTestingProject/blob/session_2205_2/SESSION_ANALYSIS.md) burned ~10 minutes after handoff on this — the agent tried three documented WF default-value forms, all rejected by the XAML loader, and settled on an invasive ternary-in-`CSharpValue` workaround. None of the three forms used the canonical `xmlns:this="clr-namespace:"` namespace declaration that's required to qualify the attribute against the class.

## What the canonical form looks like

```xml
<Activity x:Class="TestCase"
          xmlns:this="clr-namespace:"
          this:TestCase.in_FileName="report.pdf"
          xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities"
          xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
  <x:Members>
    <x:Property Name="in_FileName" Type="InArgument(x:String)" />
  </x:Members>
</Activity>
```

The same pattern is used in production at `Robot/IntegrationTests/.../TestBTS/Invoke.xaml`: `this:InvokeWorkflowTest.InvokeType="NonIsolated"`.

Verified by building a Test Automation project with `in_FileName` default-set this way and inspecting the compiled DLL — `report.pdf` lands in the User Strings heap as a `Literal<string>` in the generated class's constructor.

## Files changed

- `skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md` — new "Setting Default Values for Arguments" subsection under "Adding Arguments", with canonical form and a table of the three rejected forms + their exact error messages.
- `skills/uipath-rpa/references/testing-guide.md` — short pointer from "XAML Test Case Structure" → the new subsection, because that's the discovery path agents take when authoring tests.

## Test plan

- [ ] Spot-check the markdown renders cleanly in GitHub.
- [ ] Next session that authors a Test Automation project with input-argument defaults — verify the skill emits `xmlns:this="clr-namespace:"` + `this:<Class>.<arg>="..."` and the test runs without `--input-arguments`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[STUD-80149]: https://uipath.atlassian.net/browse/STUD-80149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ