### PR TITLE
test(uipath-agents): pin coded-hitl-wait-task prompt to named scaffold folder

### DIFF
--- a/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
@@ -37,6 +37,9 @@ initial_prompt: |
     - `reviewer_note` (string) — whatever free-form note the
       reviewer left.
 
+  Scaffold the agent project inside a `purchase-gate/` directory at
+  the working-directory root.
+
   Take the agent through scaffold → schema sync. Do NOT run,
   publish, upload, or deploy. Do NOT call `uip login`. Do NOT pause
   between planning and implementation. Complete end-to-end in a


### PR DESCRIPTION
`uip codedagent new <name>` creates files in the CURRENT directory, not in a `<name>/` subdirectory. The test's `file_exists` assertion expects `purchase-gate/langgraph.json`, but the prompt didn't pin the scaffold location — so agents that didn't first `mkdir purchase-gate && cd purchase-gate` ended up with files at cwd root and missed the assertion. Same fix pattern as #985 (coded-in-flow-published): one sentence in the prompt naming the target folder. 

Verified with a passing local eval run.