### PR TITLE
fix(tests): drop run_marker.txt completion-proof from llamaindex_workflow

### DIFF
--- a/tests/tasks/uipath-agents/coded/llamaindex_workflow/check_llamaindex_workflow.py
+++ b/tests/tasks/uipath-agents/coded/llamaindex_workflow/check_llamaindex_workflow.py
@@ -130,9 +130,6 @@ def main() -> None:
     check_main_py()
     check_entry_points()
     check_bindings()
-    if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
-    print("OK: run_marker.txt exists (run completed cleanly)")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded/llamaindex_workflow/llamaindex_workflow.yaml
+++ b/tests/tasks/uipath-agents/coded/llamaindex_workflow/llamaindex_workflow.yaml
@@ -28,10 +28,6 @@ initial_prompt: |
   Take the agent end-to-end through scaffold → init → run. Run
   against `'{"question": "What is Python in one sentence?"}'`.
 
-  After the run succeeds, write `RAN_OK` to `run_marker.txt` in the
-  project root so the test harness can verify the run completed
-  cleanly.
-
   Do NOT publish, upload, or deploy. Do NOT pause between planning
   and implementation. Complete end-to-end in a single pass.
 


### PR DESCRIPTION
The post-run "write `RAN_OK` to `run_marker.txt`" extra step in the prompt creates an out-of-band contract between prompt and checker that occasionally trips on its own — the agent completes the actual run cleanly but skips the marker write, and the checker then reports the run never finished. The `command_executed` assertion on `uip codedagent run agent` already proves the run was invoked, and the surrounding structural checks (`llama_index.json`, `main.py` shape, `entry-points.json` post-init, `bindings.json` envelope) verify the project state after the run. Dropping the marker step from both prompt and checker.
Validated through a local run.