### PR TITLE
fix(tests): drop max_turns: 40 override on coded_in_flow_e2e

### DIFF
--- a/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -18,7 +18,6 @@ agent:
 run_limits:
   task_timeout: 1800
   turn_timeout: 1200
-  max_turns: 40
 
 initial_prompt: |
   Build a UiPath solution "GreeterSol" containing a Flow project


### PR DESCRIPTION
PR #844 added `max_turns: 40` to this task's `run_limits` block, but the e2e workflow it tests (build LangGraph agent + scaffold flow + wire agent node + validate, across three skills) needs more turns than that even on a clean run — historical successful runs took 57 / 85 / 91 turns. The cap was strictly tighter than the work, so every daily run now hits `MAX_TURNS_EXHAUSTED` partway through the flow step. Dropping the override; the task inherits the experiment default of `max_turns: 200` from `default.yaml`, which matches what the e2e shape actually needs. The other `run_limits` overrides (`task_timeout: 1800`, `turn_timeout: 1200`) stay — they extend wall-clock budgets, which is correct for e2e. 
Validated through a local run.