### PR TITLE
test(uipath-agents): relax rag_langgraph check to accept inline literals and constants

### DIFF
--- a/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
@@ -62,10 +62,14 @@ def check_imports_and_calls(text: str) -> None:
             "`uipath_langchain.retrievers` — the canonical path the skill teaches."
         )
     print("OK: main.py imports ContextGroundingRetriever from uipath_langchain.retrievers")
-    if not re.search(r'index_name\s*=\s*["\']company_docs["\']', text):
-        sys.exit('FAIL: ContextGroundingRetriever call does not pass index_name="company_docs"')
-    if not re.search(r'folder_path\s*=\s*["\']Shared["\']', text):
-        sys.exit('FAIL: ContextGroundingRetriever call does not pass folder_path="Shared"')
+    if not re.search(r'index_name\s*=', text):
+        sys.exit('FAIL: ContextGroundingRetriever must use index_name as a keyword argument')
+    if not re.search(r'["\']company_docs["\']', text):
+        sys.exit('FAIL: index name "company_docs" not found in file')
+    if not re.search(r'folder_path\s*=', text):
+        sys.exit('FAIL: ContextGroundingRetriever must use folder_path as a keyword argument')
+    if not re.search(r'["\']Shared["\']', text):
+        sys.exit('FAIL: folder path "Shared" not found in file')
     print('OK: retriever is constructed with index_name="company_docs" / folder_path="Shared"')
 
 

--- a/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/check_rag_langgraph.py
@@ -6,8 +6,9 @@ Asserts:
      `uipath_langchain.retrievers` (the canonical import path the
      skill teaches across context-grounding examples and the
      LangGraph integration tools table) and references it.
-  2. The retriever is constructed with `index_name="company_docs"`
-     and `folder_path="Shared"`.
+  2. `index_name` and `folder_path` are used as keyword arguments with
+     values "company_docs" and "Shared" — accepted as inline literals
+     or constant variables.
   3. `bindings.json` declares the `index` resource for
      company_docs / Shared with the standard binding shape.
   4. No module-level UiPath* construction — both the retriever and

--- a/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
@@ -22,10 +22,8 @@ initial_prompt: |
   `Shared`, then composing the answer with the platform LLM gateway
   at `temperature=0` for reproducibility.
 
-  Input: `question` (string). Output: `answer` (string), `snippets`
-  (list of string).
-
-  Sync `bindings.json` so the index resource is declared.
+  It takes a question as input and returns an answer together with
+  the retrieved snippets.
 
   Take the agent through scaffold → init. Do NOT run, publish,
   upload, or deploy. Do NOT pause between planning and


### PR DESCRIPTION
## Summary

- Splits `index_name` / `folder_path` assertions into two checks each: keyword-name present + value anywhere in file
- Relaxes docstring to reflect the new behaviour
- Simplifies initial_prompt: more natural I/O description, removes bindings hint

## Why

The previous regex required inline string literals, causing ~50% failure rate when agents used constant-variable style. The relaxed check still enforces keyword-arg usage (required by the bindings scanner) without caring whether the value is inline or in a constant.

Companion skill-doc fix: #1012. Supersedes fork-based PR #991.

## Test plan

- [x] Ran `rag_langgraph` eval 5 times — 5/5 passed (score 1.0 each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)