### PR TITLE
fix(uipath-agents): redesign push_pull_roundtrip eval

### DIFF
--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/bindings.json
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/bindings.json
@@ -1,0 +1,1 @@
+{"version": "2.0", "resources": []}

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/main.py
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/main.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class Input(BaseModel):
+    message: str
+
+
+class Output(BaseModel):
+    echoed: str
+
+
+async def main(payload: Input) -> Output:
+    return Output(echoed=payload.message)

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/pyproject.toml
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "roundtrip-agent"
+version = "0.0.1"
+description = "Roundtrip sync fixture"
+authors = [{ name = "Test" }]
+requires-python = ">=3.11"
+dependencies = ["uipath"]
+
+[dependency-groups]
+dev = ["uipath-dev"]

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/uipath.json
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent/uipath.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://cloud.uipath.com/draft/2024-12/uipath",
+  "runtimeOptions": {"isConversational": false},
+  "functions": {"main": "./main.py:main"}
+}

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/check_push_pull_roundtrip.py
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/check_push_pull_roundtrip.py
@@ -23,7 +23,7 @@ PULLED_MAIN = PULLED / "main.py"
 LOCAL_ENV = LOCAL / ".env"
 
 EDIT_MARKER = "echo: "
-EXPECTED_PROJECT_ID = "a54c3bf0-985c-45a7-a1c4-92e6d8888faa"
+EXPECTED_PROJECT_ID = "89852b5d-8559-4c57-b752-0e2b500902fc"
 
 
 def fail(msg: str) -> None:

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
@@ -1,139 +1,49 @@
 task_id: skill-agent-coded-push-pull-roundtrip
 description: >
-  Coded-agent push/pull file-sync roundtrip against an existing Studio
-  Web project. The seed wires a minimal Simple Function agent with
-  `.env` already containing `UIPATH_PROJECT_ID`, so the skill must
-  short-circuit the delivery fork and use sync directly. Verifies the
-  agent uploads local edits, then pulls a fresh copy, without
-  scaffolding a new project or mutating `.env`. Closes the file-sync
-  coverage gap. **Cloud auth required** — the test harness must be
-  authenticated against the cloud environment with org `agenthubdri`
-  (the org that owns the Studio Web project referenced in `.env`).
-tags: [uipath-agents, e2e, mode:operate, coded, lifecycle:execute, feature:file-sync]
-max_iterations: 1
-task_timeout: 1800
+  Verifies the agent knows to use uip codedagent push and pull when
+  UIPATH_PROJECT_ID is already wired in .env. Project is pre-seeded;
+  tests command selection, not cloud connectivity.
+tags: [uipath-agents, integration, mode:operate, coded, lifecycle:execute, feature:file-sync]
 
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1800
+
+run_limits:
+  max_turns: 30
+  task_timeout: 600
+  turn_timeout: 300
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+pre_run:
+  - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent ."
+    timeout: 10
 
 initial_prompt: |
-  Recreate the working tree below exactly — this is an existing
-  UiPath coded agent whose Studio Web project is already set up
-  on the cloud side. The goal is keeping local and remote in sync.
+  I've been working on my `roundtrip-agent` project and need to sync
+  my local changes up to the linked Studio Web project.
 
-  **roundtrip-agent/pyproject.toml**:
-  ```toml
-  [project]
-  name = "roundtrip-agent"
-  version = "0.0.1"
-  description = "Roundtrip sync fixture"
-  authors = [{ name = "Test" }]
-  requires-python = ">=3.11"
-  dependencies = ["uipath"]
-
-  [dependency-groups]
-  dev = ["uipath-dev"]
-  ```
-
-  **roundtrip-agent/main.py**:
-  ```python
-  from pydantic import BaseModel
-
-  class Input(BaseModel):
-      message: str
-
-  class Output(BaseModel):
-      echoed: str
-
-  async def main(payload: Input) -> Output:
-      return Output(echoed=payload.message)
-  ```
-
-  **roundtrip-agent/uipath.json**:
-  ```json
-  {
-    "$schema": "https://cloud.uipath.com/draft/2024-12/uipath",
-    "runtimeOptions": {"isConversational": false},
-    "packOptions": {
-      "fileExtensionsIncluded": [],
-      "filesIncluded": [],
-      "filesExcluded": [],
-      "directoriesExcluded": [],
-      "includeUvLock": true
-    },
-    "functions": {"main": "./main.py:main"}
-  }
-  ```
-
-  **roundtrip-agent/entry-points.json**:
-  ```json
-  {
-    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
-    "$id": "entry-points.json",
-    "entryPoints": [
-      {
-        "filePath": "main",
-        "uniqueId": "roundtrip-main",
-        "type": "agent",
-        "input": {"type": "object", "properties": {"message": {"type": "string"}}, "required": ["message"]},
-        "output": {"type": "object", "properties": {"echoed": {"type": "string"}}, "required": ["echoed"]}
-      }
-    ]
-  }
-  ```
-
-  **roundtrip-agent/bindings.json**:
-  ```json
-  {"version": "2.0", "resources": []}
-  ```
-
-  **roundtrip-agent/.env** — leave this file exactly as written
-  (it points the local folder at the Studio Web project on the
-  cloud side):
-  ```
-  UIPATH_PROJECT_ID=a54c3bf0-985c-45a7-a1c4-92e6d8888faa
-  ```
-
-  Then:
-
-  1. Edit `main.py` so the echo prepends `"echo: "` — i.e.
-     `main(message="hi")` should now return `echoed="echo: hi"`.
-  2. Upload the latest local state of this project to the Studio
-     Web project that `.env` is pointing at.
-  3. Bring down a fresh copy from that same Studio Web project
-     into a sibling directory called `roundtrip-agent-pulled/`
-     so we can compare what came back.
-
-  The test harness has UiPath auth pre-configured and the Studio
-  Web project already exists. Do NOT publish to a feed, deploy, or
-  invoke. Do NOT scaffold a fresh local project — the one above is
-  the source of truth. Do NOT pause between planning and
-  implementation. Complete end-to-end in a single pass.
+  Also, can you pull the latest version from Studio Web into a
+  separate folder `roundtrip-agent-pulled/` so I have a clean copy
+  of what's on the remote?
 
 success_criteria:
   - type: command_executed
-    description: "Agent pushed local edits to Studio Web"
+    description: "Agent pushed to Studio Web with uip codedagent push"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedagent\s+push'
     min_count: 1
-    weight: 2.5
+    weight: 3.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent pulled a fresh copy from Studio Web"
+    description: "Agent pulled from Studio Web with uip codedagent pull"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedagent\s+pull'
     min_count: 1
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: run_command
-    description: "Local edit applied, .env UIPATH_PROJECT_ID preserved, pulled directory has the same source"
-    command: "python3 $TASK_DIR/check_push_pull_roundtrip.py"
-    timeout: 30
-    expected_exit_code: 0
-    weight: 6.0
+    weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- Pre-seed sandbox with fixture files via `pre_run` so the agent doesn't waste turns recreating boilerplate
- Replace prescriptive prompt with natural human ask: sync local changes up, pull latest down
- Replace cloud-verification check script with `command_executed` criteria — tests command selection, not cloud connectivity
- Fix project ID mismatch between YAML and check script that caused immediate check failure
- Fix `run_limits` structure

## Why

The old design had a ~20% pass rate:
- `EXPECTED_PROJECT_ID` in check script didn't match the YAML `.env` — immediate check failure
- Agent spent 150+ turns recreating boilerplate files before attempting push/pull
- `max_iterations: 1` and `turn_timeout` inside `agent:` block were unrecognized

## Test plan

- [x] Verified locally 4 times: 4/4 SUCCESS, score 1.0
- [x] Stats over 3 consecutive runs: avg 47 turns, avg 166s, 3/3 pass

Supersedes fork-based PR #998.

🤖 Generated with [Claude Code](https://claude.com/claude-code)