### PR TITLE
test(uipath-agents): add coded_function_validator e2e task

### DIFF
--- a/tests/tasks/uipath-agents/coded_function_validator/check_coded_function_validator.py
+++ b/tests/tasks/uipath-agents/coded_function_validator/check_coded_function_validator.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Python Coded Function (uip functions CLI) — project-shape check.
+
+Verifies that the agent used the updated `uip functions` CLI, chose the Python
+Coded Function pattern for a naturally-phrased validation request, and produced
+a project that satisfies all structural invariants.
+
+Checks performed:
+
+  1. `invoice-validator/pyproject.toml` has `[project]` with `authors`, no
+     `[build-system]`, and declares `[tool.uipath] type = "function"` (required
+     to identify this as a Python Coded Function, not a coded agent).
+     No LLM framework dependencies.
+  2. `invoice-validator/main.py` uses `@dataclass` for Input and Output (not
+     BaseModel), declares all required fields (`invoice_number`, `vendor_name`,
+     `total_amount`, `currency`, `is_valid`, `validation_errors`,
+     `normalized_currency`), includes the `@traced` decorator (SDK integration),
+     and contains no LLM imports.
+  3. `invoice-validator/uipath.json` has a `functions` key with a valid
+     `<file>:<function_name>` entrypoint.
+  4. `invoice-validator/entry-points.json` has at least one entrypoint whose
+     schema mentions `invoice_number` and `is_valid` — proves `uip functions init`
+     ran after the dataclass models were written.
+  5. `invoice-validator/run_marker.txt` exists — proves `uip functions run`
+     completed successfully.
+
+Exits 0 on PASS, `sys.exit("FAIL: ...")` on the first violation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("invoice-validator")
+
+_LLM_IMPORT_TOKENS = (
+    "llm_gateway",
+    "UiPathChat",
+    "UiPathChatOpenAI",
+    "UiPathAzureChatOpenAI",
+    "from openai import",
+    "import openai",
+    "from langchain",
+    "from llama_index",
+    "from agents import",
+)
+
+_LLM_PACKAGES = (
+    "uipath-langchain",
+    "uipath-openai-agents",
+    "uipath-llama-index",
+)
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def check_pyproject() -> None:
+    text = _read_text(ROOT / "pyproject.toml")
+    if "[build-system]" in text:
+        sys.exit(
+            "FAIL: pyproject.toml contains a [build-system] section — "
+            "Python Coded Functions must not use a build system (Critical Rule C1)."
+        )
+    if "[project]" not in text:
+        sys.exit("FAIL: pyproject.toml has no [project] section")
+    if "authors" not in text:
+        sys.exit("FAIL: pyproject.toml has no `authors` entry")
+    if 'type = "function"' not in text and "type='function'" not in text:
+        sys.exit(
+            "FAIL: pyproject.toml is missing `[tool.uipath] type = \"function\"` — "
+            "this declaration is required to identify the project as a Python Coded "
+            "Function. Without it the runtime treats it as a coded agent."
+        )
+    for pkg in _LLM_PACKAGES:
+        if pkg in text:
+            sys.exit(
+                f"FAIL: pyproject.toml declares `{pkg}` — Python Coded Functions "
+                f"are deterministic and must not depend on LLM frameworks."
+            )
+    print("OK: pyproject.toml — [project], authors, no [build-system], "
+          "[tool.uipath] type=function, no LLM packages")
+
+
+def check_main_py() -> None:
+    main_path = ROOT / "main.py"
+    text = _read_text(main_path)
+
+    # Schema must use @dataclass, not BaseModel
+    if "class Input(BaseModel)" in text or "class Output(BaseModel)" in text:
+        sys.exit(
+            "FAIL: main.py uses Pydantic BaseModel for Input/Output. "
+            "Python Coded Functions use @dataclass (not BaseModel) for schemas."
+        )
+    if "@dataclass" not in text:
+        sys.exit(
+            "FAIL: main.py does not use @dataclass — Python Coded Function schemas "
+            "must be defined as dataclasses, not Pydantic models."
+        )
+
+    for needle in ("class Input", "class Output"):
+        if needle not in text:
+            sys.exit(f"FAIL: main.py is missing `{needle}`")
+
+    input_fields = ("invoice_number", "vendor_name", "total_amount", "currency")
+    output_fields = ("is_valid", "validation_errors", "normalized_currency")
+    for field in (*input_fields, *output_fields):
+        if field not in text:
+            sys.exit(f"FAIL: main.py is missing field `{field}` in schema or logic")
+
+    if "traced" not in text:
+        sys.exit(
+            "FAIL: main.py does not use the `@traced` decorator — "
+            "SDK tracing integration is required for Python Coded Functions."
+        )
+
+    print("OK: main.py — @dataclass Input/Output, all required fields, @traced present")
+
+    for token in _LLM_IMPORT_TOKENS:
+        if token in text:
+            sys.exit(
+                f"FAIL: main.py imports or references `{token}` — Python Coded "
+                f"Functions must be deterministic with no LLM calls."
+            )
+    print("OK: main.py — no LLM imports")
+
+
+def check_uipath_json() -> None:
+    doc = _load_json(ROOT / "uipath.json")
+    functions = doc.get("functions") or {}
+    if not functions:
+        sys.exit(
+            "FAIL: uipath.json has no `functions` key — the entrypoint is not "
+            "registered. `uip functions init` may not have run."
+        )
+    # Any key is valid (not required to be "main"); value must be file:function
+    entrypoint = next(iter(functions.values()), "")
+    if ":" not in str(entrypoint):
+        sys.exit(
+            f"FAIL: uipath.json functions entrypoint should be `<file>:<function_name>`, "
+            f"got {entrypoint!r}"
+        )
+    print(f"OK: uipath.json registers functions entrypoint -> {entrypoint!r}")
+
+
+def check_entry_points() -> None:
+    doc = _load_json(ROOT / "entry-points.json")
+    entrypoints = doc.get("entryPoints") or []
+    if not entrypoints:
+        sys.exit(
+            "FAIL: entry-points.json has no entryPoints — "
+            "`uip functions init` (Python-only) did not run successfully."
+        )
+    raw = json.dumps(entrypoints)
+    for field in ("invoice_number", "is_valid"):
+        if field not in raw:
+            sys.exit(
+                f"FAIL: entry-points.json schemas do not mention `{field}`. "
+                f"Either `uip functions init` ran before the dataclass models "
+                f"were written, or the models did not declare the expected fields. "
+                f"Got: {raw}"
+            )
+    print("OK: entry-points.json reflects Input schema (invoice_number) and "
+          "Output schema (is_valid)")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    check_pyproject()
+    check_main_py()
+    check_uipath_json()
+    check_entry_points()
+    # Agent may write the marker in the project dir or the sandbox root
+    marker = ROOT / "run_marker.txt"
+    sandbox_marker = ROOT.parent / "run_marker.txt"
+    if not marker.is_file() and not sandbox_marker.is_file():
+        sys.exit(
+            f"FAIL: run_marker.txt not found in {ROOT} or {ROOT.parent} — "
+            "`uip functions run` likely never completed."
+        )
+    print("OK: run_marker.txt exists (run completed cleanly)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded_function_validator/coded_function_validator.yaml
+++ b/tests/tasks/uipath-agents/coded_function_validator/coded_function_validator.yaml
@@ -1,0 +1,68 @@
+task_id: skill-agent-coded-function-validator
+description: >
+  Coded Function inference via the updated `uip functions` CLI. A naturally-phrased
+  validation request — no mention of LLM, AI, or frameworks — must be recognised as
+  a Python Coded Function. Verifies the agent passes `-l py` to `uip functions new`,
+  runs `uip functions init`, produces a correct @dataclass schema, includes SDK
+  tracing, declares `[tool.uipath] type = "function"` in pyproject.toml, and
+  contains no LLM imports.
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, lifecycle:execute, feature:framework-simple]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  I need a UiPath Python Coded Function named `invoice-validator` that checks
+  whether invoice data is complete and well-formed.
+
+  It takes `invoice_number` (str), `vendor_name` (str), `total_amount` (float),
+  and `currency` (str). Return `is_valid` (bool), `validation_errors` (list of
+  strings), and `normalized_currency` (the currency code uppercased).
+  Use this hardcoded list of accepted currencies: ["USD", "EUR", "GBP", "JPY", "CHF", "AUD", "CAD"].
+  Validate the currency field against this list. Make execution observable through UiPath tracing.
+
+  Run it with:
+  `'{"invoice_number": "INV-001", "vendor_name": "Acme Corp", "total_amount": 1500.0, "currency": "usd"}'`
+  and write `RAN_OK` to `run_marker.txt` after success. Do NOT deploy.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded a Python Functions project with uip functions new -l py"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+functions\s+new\s+.*(-l\s+(py|python)|--language\s+(py|python))'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip functions init to generate entry-points.json (Python-only command)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+functions\s+init'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran the function locally with uip functions run"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+functions\s+run'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Correct @dataclass schema, [tool.uipath] type=function, no LLM imports, init ran, SDK tracing present"
+    command: "python3 $TASK_DIR/check_coded_function_validator.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- Adds `coded_function_validator` e2e task for the `uipath-agents` skill
- Verifies the agent scaffolds a Python Coded Function with `uip functions new -l py`, runs `uip functions init`, executes locally via `uip functions run`, and produces a correct `@dataclass` schema with no LLM imports
- Uses hardcoded accepted currencies — no Orchestrator dependency

## Test plan

- [x] Validated locally: `SUCCESS 1.00` (4/4 criteria passed) against `experiments/e2e.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)