### PR TITLE
ci(nightly): forward E2E_PROCESS_KEY + E2E_LONG_PROCESS_KEY secrets

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -145,6 +145,8 @@ jobs:
           BEDROCK_MODEL:            ${{ secrets.BEDROCK_MODEL }}
           ANTHROPIC_API_KEY:        ${{ secrets.ANTHROPIC_API_KEY }}
           TRACES_SMOKE_PROCESS_KEY: ${{ secrets.TRACES_SMOKE_PROCESS_KEY }}
+          E2E_PROCESS_KEY:          ${{ secrets.E2E_PROCESS_KEY }}
+          E2E_LONG_PROCESS_KEY:     ${{ secrets.E2E_LONG_PROCESS_KEY }}
           TASK_GLOBS:               ${{ steps.globs.outputs.globs }}
           TASK_COUNT:               ${{ steps.globs.outputs.count }}
         working-directory: tests


### PR DESCRIPTION
## Summary

Follow-up to #815. The 16 lifecycle E2E tests merged in that PR read
\`E2E_PROCESS_KEY\` and \`E2E_LONG_PROCESS_KEY\` from env in their
\`pre_run\` (\`seed.py\`). The nightly cron workflow only forwarded the
legacy \`TRACES_SMOKE_PROCESS_KEY\` — adding the two new ones now.

The secrets themselves must be added to repo settings before nightly
picks them up. Provisioning steps documented in \`tests/fixtures/
packages/README.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)