### PR TITLE
feat(uipath-agents): coded Integration Service capability + tests

### DIFF
--- a/skills/uipath-agents/SKILL.md
+++ b/skills/uipath-agents/SKILL.md
@@ -39,6 +39,7 @@ Determine the agent mode before proceeding:
 | Create/build/deploy coded agent | Coded | [coded/quickstart.md](references/coded/quickstart.md) | `coded/lifecycle/*`, `coded/frameworks/*` |
 | Select coded framework | Coded | [coded/quickstart.md](references/coded/quickstart.md) § Framework Selection | |
 | Add coded capabilities (HITL, RAG, tracing) | Coded | [coded/quickstart.md](references/coded/quickstart.md) | `coded/capabilities/*` |
+| Call an Integration Service connector (Slack, Jira, Web Search) from a coded agent | Coded | [coded/capabilities/integration-service.md](references/coded/capabilities/integration-service.md) **+ then immediately read** [`uipath-platform/references/integration-service/agent-workflow.md`](../uipath-platform/references/integration-service/agent-workflow.md) — discovery lives there, not in `uipath-agents` | `coded/capabilities/sdk-services.md` § Connections |
 | Run coded evaluations | Coded | [coded/quickstart.md](references/coded/quickstart.md) § Evaluate | `coded/lifecycle/evaluate.md` |
 | Create or scaffold a new low-code agent project | Low-code | [lowcode/lowcode.md](references/lowcode/lowcode.md) § Quick Start | `lowcode/project-lifecycle.md`, `lowcode/agent-definition.md` |
 | Edit `agent.json` (prompts, model, schemas, contentTokens, entry-points.json) | Low-code | [lowcode/lowcode.md](references/lowcode/lowcode.md) § Capability Registry | `lowcode/agent-definition.md` |

--- a/skills/uipath-agents/references/coded/capabilities/integration-service.md
+++ b/skills/uipath-agents/references/coded/capabilities/integration-service.md
@@ -1,0 +1,318 @@
+# Integration Service (Coded)
+
+Call IS connector activities (Slack, Jira, Web Search, …) from a coded Python agent via `sdk.connections.invoke_activity()`.
+
+## When to Use
+
+- Coded Python agent needs SaaS / API via IS (Slack, Salesforce, Jira, ServiceNow, Web Search, …).
+- Connection exists or user creates one via `uip is connections create <CONNECTOR_KEY>`.
+
+## When NOT to Use
+
+- Calling an Orchestrator process / queue / asset → [process-invocation.md](process-invocation.md), `sdk.processes` / `sdk.queues` / `sdk.assets`.
+- LLM-step-bound static IS tool inside Studio Web (no Python agent, just a tool resource) → [../../lowcode/capabilities/integration-service/integration-service.md](../../lowcode/capabilities/integration-service/integration-service.md).
+- Vendor exposes a stable public REST API and you do NOT need IS auth/governance → call the vendor directly with `httpx`; IS adds no value.
+
+## Discovery — Use the `uipath-platform` Skill First (Mandatory)
+
+Integration Service discovery — connector → connection → ping → describe, reference-field resolution, parent-driven custom fields — is owned by the **`uipath-platform`** skill. Run its IS discovery workflow before authoring any `invoke_activity` create/update call; do not infer the shape from the worked examples below. If those reads fail, stop and surface — do not improvise.
+
+Discovery is auth-gated (`uip login` + connection selection precede `describe`). **Coded consequence:** you can't author `body_fields` / `ActivityMetadata` without `describe` output, so for IS-using agents do auth + discovery *before* Build, not after.
+
+Read these from the `uipath-platform` skill (`references/integration-service/`) — required even for tenant-free / shape-only authoring (you read them for the workflow, field-resolution, and error-recovery contract regardless of tenant; only the live `describe` step and `uip login` defer when no tenant is available).
+
+**`agent-workflow.md` is ALWAYS mandatory. Reading it does not excuse skipping `reference-resolution.md`** when the target activity carries reference or required fields — that second read is the contract for curated create/update calls, and skipping it is the #1 cause of rejections:
+
+- `agent-workflow.md` — **(always)** Steps 1–4: connector → connection → ping → describe.
+- `reference-resolution.md` — **(mandatory before any create/update whose schema has reference or required fields — Jira `project`/`issuetype`/`versions`/`components`, Salesforce lookups, etc.)** reference-field resolution + **Validate Required Fields Before Executing**. Flat-body activities with no reference fields (e.g. Slack `send_message_to_channel_v2`) do not need it.
+
+Then, as needed:
+
+- `resources.md` § Parent-Field-Driven Custom Fields — Jira project/issuetype, Salesforce SOQL, Dataservice V3.
+- `connectors.md` — connector disambiguation + option-label format.
+
+Coded-specific layers:
+
+1. **Reuse before discover** — grep cwd for existing `ActivityMetadata` constants before re-running describe.
+2. **Present concrete options, then echo every pick.** At each stop point call `AskUserQuestion` with the actual candidates as selectable options (one per candidate: short label + one-line description, per the option-label format in the `uipath-platform` skill's `connectors.md`). Recommend the safest default; let the user choose. Never ask open-ended — derive options from the discovery output. After the pick, echo the chosen option back before the next call. Ambiguous answer or "other" → follow up to narrow; do not infer.
+   - **Stop points:** connector (multi-hit on `connectors list --filter`), curated-vs-raw object, ambiguous operation verb (`Update` vs `Replace`), parent-field `-f` values, custom-field-by-name with >1 candidate.
+   - Silent inference produces wrong-connector / wrong-form / wrong-customfield writes.
+
+## Coded vs Low-code IS Tools
+
+| | Coded | Low-code |
+|---|---|---|
+| Artifact | Inline `ActivityMetadata` literal in Python | `resources/<Tool>/resource.json` |
+| Selection | Author code or LLM tool-call routing | Studio Web binds tool to LLM step |
+| Runtime | `sdk.connections.invoke_activity(...)` | Engine dispatches via `properties.toolPath` |
+| Bindings | `bindings.json` `resource: "connection"` | Solution-level `connection/<KEY>/…json` (auto-generated) |
+
+## `describe` Output → `ActivityMetadata` Mapping
+
+```python
+from uipath.platform.connections import ActivityMetadata, ActivityParameterLocationInfo
+```
+
+| `describe` field | → | `ActivityMetadata` | Notes |
+|---|---|---|---|
+| `operation.path` | → | `object_path` | direct |
+| `operation.method` | → | `method_name` | direct |
+| (not surfaced) | → | `content_type` | `"application/json"` for non-multipart |
+| `parameters[type=query][].name` | → | `query_params` | direct |
+| `parameters[type=path][].name` | → | `path_params` | direct |
+| `parameters[type=header][]` | → | `header_params` | filtered out of compact summary; raw cache only — see Limitations |
+| `parameters[type=multipart][]` | → | `multipart_params` | same filter — see Limitations |
+| `requestFields[].name` first-segment, deduped | → | `body_fields` | see Body-Field Reframing |
+| (not surfaced) | → | `json_body_section` | Multipart only — name of the form-part that holds the JSON body. `None` → SDK defaults to `"body"`. Override only when the connector expects a different wrapper (e.g., `"RagRequest"`). Ignored for non-multipart. |
+
+### Body-Field Reframing (Non-Obvious)
+
+`requestFields[].name` from describe is emitted as **dotted leaf paths** (`fields.project.key`, `attachment.image_url`) — a flat encoding of a nested schema, NOT routing keys.
+
+`body_fields` is the **top-level envelope whitelist**: first segment of each `requestFields[].name`, deduped. Match is against `activity_input.items()` top-level keys only. Caller pre-nests the body and passes it as one input value; SDK slots it in as-is.
+
+## Constructing `ActivityMetadata` — Worked Examples
+
+**Slack `send_message_to_channel_v2`** — flat body schema; `body_fields` is the full deduped top-level set; single `query_params=["send_as"]`.
+
+```python
+SLACK_SEND_MESSAGE = ActivityMetadata(
+    object_path="/send_message_to_channel_v2",
+    method_name="POST",
+    content_type="application/json",
+    parameter_location_info=ActivityParameterLocationInfo(
+        query_params=["send_as"],
+        body_fields=[
+            "channel", "messageToSend", "attachment", "buttons", "fields",
+            "icon_emoji", "icon_url", "image", "link_names", "metadata",
+            "mrkdwn", "parse", "reply_broadcast", "thread_ts",
+            "unfurl_links", "unfurl_media", "username",
+        ],
+    ),
+)
+```
+
+**Jira `curated_create_issue`** — every requestField starts with `fields.`; `body_fields` collapses to one entry. First run GenerateSchema discovery (auth-required) to surface the project- and issuetype-specific custom + reference fields — do this BEFORE writing the literal:
+
+```bash
+uip is resources describe "uipath-atlassian-jira" "curated_create_issue" \
+  --connection-id "<CONNECTION_ID>" --operation Create \
+  -f fields.project.key=ENGCE -f fields.issuetype.id=3 \
+  --action GenerateSchema --output json
+```
+
+Resolve any reference fields it reports (`versions`, `components`, assignee, …) per the `uipath-platform` skill's `reference-resolution.md` — passing a name where the connector wants a reference ID is the most common curated-activity rejection.
+
+```python
+JIRA_CREATE_ISSUE = ActivityMetadata(
+    object_path="/curated_create_issue",
+    method_name="POST",
+    content_type="application/json",
+    parameter_location_info=ActivityParameterLocationInfo(body_fields=["fields"]),
+)
+```
+
+**Pass the body NESTED, not as dotted keys.** `body_fields=["fields"]` + a pre-nested `{"fields": {...}}` is the shape `curated_create_issue` accepts. Passing flat dotted keys (`body_fields=["fields.project.key", ...]` + `activity_input={"fields.project.key": "ENGCE"}`) is rejected by the connector with `project: Specify a valid project ID or key` — the SDK ships dotted keys as literal top-level JSON keys, which the curated activity does not unflatten.
+
+```python
+sdk.connections.invoke_activity(
+    activity_metadata=JIRA_CREATE_ISSUE,
+    connection_id=connection.id,
+    activity_input={
+        "fields": {
+            "project": {"key": "ENGCE"},
+            "issuetype": {"id": "3"},
+            "summary": "Triage: agent failure",
+            "description": "Auto-filed by coded agent.",
+        }
+    },
+)
+```
+
+## Runtime Invocation Pattern
+
+```python
+from uipath.platform import UiPath
+from uipath.platform.connections import ActivityMetadata, ActivityParameterLocationInfo
+
+# SLACK_SEND_MESSAGE literal: see "Worked Examples" above.
+
+def post_to_slack(channel: str, message: str) -> dict:
+    sdk = UiPath()
+    # Binding key, NOT a UUID. Locally this 400s unless resourceOverwrites
+    # is set — see § Local runtime binding. Do NOT add a try/except or a
+    # state health-check around it; gate any deployed-only probe on env.
+    connection = sdk.connections.retrieve("slack-triage")
+    return sdk.connections.invoke_activity(
+        activity_metadata=SLACK_SEND_MESSAGE,
+        connection_id=connection.id,
+        activity_input={"channel": channel, "messageToSend": message},
+    )
+```
+
+- **`activity_input` is the single bucket** for query, path, header, multipart, and body values. SDK routes by `parameter_location_info`. No `query=`/`path=`/`header=` kwarg exists.
+- **`invoke_activity` calls `retrieve()` internally** (`_connections_service.py:675`), so `connection_id` can be a UUID or a binding-key string — the `@resource_override` decorator on `retrieve` resolves it. The pattern above (explicit retrieve, then pass `connection.id`) is preferred because it gives the agent a typed `Connection` for `metadata()` / `retrieve_token()`; one-shots can use `invoke_activity(connection_id="slack-triage", ...)` directly.
+- **Return value** is `response.json()` — keys mirror `responseFields[].name`. Flat connectors return top-level; some wrap in `Data` / `result`. Auto-traced via `@traced`; see [tracing.md](tracing.md).
+- **Silent drops** — `None` values and any key not in `parameter_location_info` are skipped (`_connections_service.py:753-770`). Mistyped keys never surface as errors; echo-check writes per Error Handling § "Silent rename / typo".
+
+### Multipart endpoints (silent in describe)
+
+Compact `describe` omits `contentType`. Curated file-attachment activities (Outlook `send-mail-v2`, Slack `send_files_to_channel`, …) are multipart/form-data — `content_type="application/json"` returns `400 "Unable to parse multipart body"`. Read the raw cache (path under Limitations) and set `content_type="multipart/form-data"` with `multipart_params` + `json_body_section`:
+
+```python
+ActivityMetadata(
+    object_path="/send-mail-v2", method_name="POST",
+    content_type="multipart/form-data",
+    parameter_location_info=ActivityParameterLocationInfo(
+        multipart_params=["body", "file"], query_params=["saveAsDraft"]),
+    json_body_section="body",
+)
+```
+
+Each `multipart_params` value (`_connections_service.py:800-815`) is a 3-tuple `(filename, bytes, content_type)` for file uploads (preferred), raw `bytes` (filename defaults to the field name, `application/octet-stream`), or a scalar string (plain form field, e.g. `saveAsDraft="true"`). The JSON body section (default `"body"`) auto-injects as `(filename="", json.dumps(body), "application/json")`.
+
+### Async variant
+
+Suffix `_async` and `await` the call. Identical semantics, same args. Use inside `async def` framework nodes.
+
+### Other `sdk.connections` methods
+
+| Method | Use when | Cite |
+|---|---|---|
+| `list(name=, folder_path=, connector_key=, skip=, top=)` | Connection key unknown — enumerate or filter. Sync + `list_async`. Returns `List[Connection]`. | `_connections_service.py:152` |
+| `retrieve_token(key, token_type=ConnectionTokenType.DIRECT)` | Need the raw bearer to call the vendor's own REST API directly (e.g., Microsoft Graph) — bypasses `invoke_activity`. Sync + `retrieve_token_async`. Returns `ConnectionToken{access_token,...}`. | `_connections_service.py:368` |
+| `retrieve_event_payload(event_args: EventArguments)` | Agent invoked by an IS trigger / webhook — input carries `EventArguments`; unwrap the inbound payload before processing. Sync + `retrieve_event_payload_async`. | `_connections_service.py:421` |
+| `metadata(element_instance_id, connector_key, tool_path, parameters=, schema_mode=True, max_jit_depth=5)` | Compact `describe` dropped headers / multipart / JIT-cascaded custom fields. Pass `parameters={...}` to auto-walk JIT URLs up to depth 5. Sync + `metadata_async`. | `_connections_service.py:79` |
+
+**`retrieve_token` escape hatch** is the supported way to fall back to the vendor's own API when an IS curated activity is missing (canonical example: `uipath-langchain-python/samples/email-triage-agent/graph.py` calls Microsoft Graph with the connection's bearer). Distinct from the anti-pattern of hitting `/elements_/v3/…` directly.
+
+## Framework Integration
+
+Wrap `invoke_activity_async` in the framework's tool primitive — runtime body identical, only decorator/registration differs.
+
+| Framework | Primitive | Reference |
+|---|---|---|
+| LangGraph | Writes (LLM judgment) = node via conditional edge; reads = LLM-callable tool. `invoke_activity_async` inside `async def node(state)`. | [../frameworks/langgraph-integration.md](../frameworks/langgraph-integration.md) |
+| LlamaIndex | `FunctionTool.from_defaults(fn=<RUNTIME_FN>)` | [../frameworks/llamaindex-integration.md](../frameworks/llamaindex-integration.md) |
+| OpenAI Agents | `@function_tool` on `<RUNTIME_FN>` | [../frameworks/openai-agents-integration.md](../frameworks/openai-agents-integration.md) |
+
+## Connection Resolution — `bindings.json`
+
+Invocation URL is `/elements_/v3/element/instances/<UUID>/…`, so the SDK ultimately needs a UUID. To let admins rebind per environment, write code against a binding key string; `@resource_override("connection", resource_identifier="key")` (`_connections_service.py:51`) on `retrieve` maps it to the deployed UUID. `uip codedagent init` writes `resources: []` — author the connection entry after picking the connection.
+
+Minimal connection entry (`uip codedagent init` writes `resources: []`; add this). The entry-type field is **`resource`** (NOT `type`) — the CLI bindings schema is `{ resource, key, value, metadata }`:
+
+```jsonc
+{
+  "version": "2.0",
+  "resources": [
+    {
+      "resource": "connection",
+      "key": "jira-coded-eval",
+      "value": { "ConnectionId": { "defaultValue": "jira-coded-eval" } },
+      "metadata": { "UseConnectionService": "True", "Connector": "", "BindingsVersion": "2.2" }
+    }
+  ]
+}
+```
+
+Full JSON schema lives in [`../lifecycle/bindings-reference.md`](../lifecycle/bindings-reference.md) § Connection. Coded-agent-specific points only:
+
+- Entry type field is `resource` (`"resource": "connection"`), never `type` — matches every other binding entry.
+- `key` is just `<CONNECTION_KEY>` (no `<NAME>.<FOLDER>` dot suffix used by other resources). Same string passed positionally to `retrieve()`.
+- `value.ConnectionId.defaultValue` is the binding key string, NOT a UUID. Capital-C `ConnectionId` (other resources use `name`); no `folderPath`.
+- `metadata.UseConnectionService: "True"` is mandatory; `Connector: ""` (empty); `BindingsVersion: "2.2"` is the per-resource rev and is independent of the top-level envelope `version: "2.0"`.
+- `uip codedagent deploy` repackages as `content/bindings_v2.json` — never hand-author that path.
+
+### Required artifact — `__uipath/uipath.json` (local-run binding)
+
+Every coded IS agent MUST write `__uipath/uipath.json`. It is the file `uipath run` reads for connection overwrites: `cli_run.py` → `read_resource_overwrites_from_file(ctx.runtime_dir)`, `runtime_dir` defaults to `__uipath` (`runtime/context.py`), config name `uipath.json` (`UIPATH_CONFIG_FILE`). Without it, local `retrieve("<KEY>")` 400s with `CNS1026 The value '<KEY>' is not valid` — `bindings.json` is deploy-time only (packed into `content/bindings_v2.json`) and ignored by local run. This is distinct from `./uipath.json` (pack/deploy config). Write both:
+
+```jsonc
+{
+  "functions": { "main": "main.py:main" },
+  "runtime": {
+    "internalArguments": {
+      "resourceOverwrites": {
+        "connection.slack-triage": {
+          "connectionId": "<Id from `uip is connections list`>",
+          "folderKey":    "<FolderKey from `uip is connections list`>"
+        }
+      }
+    }
+  }
+}
+```
+
+`ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`, **NOT** `uipath/_utils/_bindings.py`) requires exactly two fields — `connectionId` (alias accepts `ConnectionId`) and `folderKey` — and has `extra="ignore"`, so `elementInstanceId` and any other extras are silently dropped (see anti-pattern #1). Key format is `connection.<BINDING_KEY>` matching the `bindings.json` `key`. After override, `Connection.element_instance_id` (for `sdk.connections.metadata()` calls) comes from the live IS API response — never write it locally.
+
+**Required outputs — every coded IS agent ships all four:**
+
+| File | Read by | Must contain |
+|---|---|---|
+| `main.py` | runtime | lazy `UiPath()` (not module-scope), inline `ActivityMetadata` literal, `retrieve(<KEY>)` + `invoke_activity` |
+| `bindings.json` | `uip codedagent deploy` | connection resource, `key`, `ConnectionId.defaultValue`=binding key, `UseConnectionService: "True"` |
+| `uipath.json` | `uip` pack/deploy | `functions`, `packOptions` |
+| `__uipath/uipath.json` | `uipath run` (local) | `runtime.internalArguments.resourceOverwrites["connection.<KEY>"]` = `connectionId` + `folderKey` |
+
+Omitting `__uipath/uipath.json` means the agent cannot run locally — incomplete, not optional. Personal-workspace connections also need `UIPATH_FOLDER_KEY=<KEY>` (`FolderKey` from `uip is connections list`) in the environment at local run.
+
+## Error Handling
+
+SDK does NO preflight schema validation — it routes the keys it recognises (per `parameter_location_info`), drops `None` and unknown keys, ships the request. All field-shape validation happens server-side. Four outcomes:
+
+| Outcome | When | Surfaces as | Recover |
+|---|---|---|---|
+| **Misconfigured `ActivityMetadata`** | `content_type` not `*/json` or `*/multipart*` | `ValueError("Unsupported content type: <ct>")` (`_connections_service.py:826`) | Fix the literal; do not retry. |
+| **IS schema reject** | Caller omits a `requestFields[].required: true`, sends wrong dataType | `RuntimeError` with IS-validator body (NOT a pre-HTTP `ValueError`) | Re-run describe; add the field / fix the shape. |
+| **Vendor reject** | Shape OK by IS, vendor's own validators reject (workflow rules, custom validators, auth) | `RuntimeError` with vendor body | Parse vendor message; per `agent-workflow.md § Error Recovery` retry once with the fix. |
+| **Silent rename / typo** | Curated rename (Jira `customfield_10004` → `storyPoints_Customfield10004`) or mistyped key — dropped by `_connections_service.py:753-770` | **No exception. 2xx with field missing.** | Echo-check: re-read created resource; assert the field you sent is present and equal. Mismatch → switch curated⇄raw or fix the key. |
+
+Network / 5xx are retried with exponential backoff by `BaseService.request`; only exhausted retries propagate (as `httpx.HTTPError` subclasses, not `RuntimeError`). For LLM-facing tools return error strings rather than re-raising — keeps the agent loop alive. Cap semantic retries at 2 per `agent-workflow.md § Error Recovery`; never retry the same query unchanged.
+
+## Anti-patterns — silent failures only
+
+These six are the ones the SDK / IS / vendor will NOT tell you about. Positive guidance for everything else lives in the relevant section above; do not pad this list.
+
+1. **Adding `elementInstanceId` to `resourceOverwrites`.** `ConnectionResourceOverwrite` (`_bindings.py:100`) defines only `connectionId` + `folderKey` with `extra="ignore"` — extras are silently dropped. The `element_instance_id` you need for `sdk.connections.metadata()` comes from the live `Connection.element_instance_id` after `retrieve()`, never from local config.
+2. **Hand-authoring `object_path` / `method_name` / `body_fields`.** Curated activities rename fields silently between connector versions. Always source from `uip is resources describe` and re-run after upgrades. Sidecar-JSON literals also drift — keep `ActivityMetadata` literals inline in a `.py` file; `pack` bundles them and mypy / pyright catch shape errors at edit time.
+3. **Typos and unknown keys in `activity_input`.** Anything not in `parameter_location_info` is silently dropped (`_connections_service.py:753-770`); the request goes out missing the field, vendor returns 2xx, the data is just gone. Echo-check writes by reading back the created object (see Error Handling § "Silent rename / typo").
+4. **`invoke_activity` for trigger payloads.** IS-triggered jobs receive `EventArguments` as input — unwrap with `sdk.connections.retrieve_event_payload(event_args)` (`_connections_service.py:421`). Calling `invoke_activity` to "receive" anything is a category error.
+5. **Bypassing `invoke_activity` with raw `httpx` to `/elements_/v3/…`.** Loses retry, tracing, S2S auth. Distinct from the supported escape hatch of calling the **vendor's own** API with `retrieve_token` (see Other `sdk.connections` methods) — that is a different URL space.
+6. **Instantiating `UiPath()` at module level.** `uip codedagent init` and `pack` import the module to introspect entry points; module-level construction fires HTTP at import time and breaks scaffold / deploy. Always lazy: build inside the function that needs it.
+
+## Limitations of the compact describe
+
+`uip is resources describe --output json` filters `parameters` to `path|query` only — multipart and header params survive only in the raw cache at:
+
+```text
+~/.uipath/cache/integrationservice/<TENANT_ID>/<CONNECTOR_KEY>/<CONNECTION_ID>/<OBJECT>.schema.json
+```
+
+Example: `uipath-salesforce-slack` (NOT `uipath-slack` — that key does not exist on the catalog; the SDK docstring example is misleading) / `send_files_to_channel` lists `parameters[type=multipart][0].name = "file"` only in the cache. Workaround — hand-populate from `data.metadata.method.<VERB>.parameters[]`: `type=="multipart"` → `multipart_params`, `type=="header"` → `header_params`. When the cache is empty, runtime fallback:
+
+```python
+md = sdk.connections.metadata(
+    element_instance_id=connection.element_instance_id,
+    connector_key="uipath-salesforce-slack",
+    tool_path="/send_files_to_channel",
+)
+```
+
+Pass `parameters={"<KEY>": "<VALUE>"}` only for connectors with cascading JIT custom fields.
+
+**`-f` precondition.** `uip is resources describe ... -f <KEY>=<VALUE>` fails with `No api-type ObjectAction matched for fields [...]` on connectors without a matching api-type ObjectAction, and requires `--connection-id` + `--operation`. Enumerate valid actions on the cached schema before retrying — the path is `.data.metadata.method.<VERB>.design.actions[]` (NOT `.connectorMethodInfo.design.actions[]`, which does not exist in the cache shape):
+
+```bash
+jq '.data.metadata.method.<VERB>.design.actions[] | select(.actionType=="api") | .name' <CACHED_DESCRIBE>
+```
+
+Replace `<VERB>` with the operation's HTTP method (e.g. `POST` for Create). Full discovery flow lives in `uipath-platform` `resources.md`.
+
+## Reference
+
+- [sdk-services.md](sdk-services.md) § Connections — service surface.
+- [../frameworks/langgraph-integration.md](../frameworks/langgraph-integration.md), [llamaindex-integration.md](../frameworks/llamaindex-integration.md), [openai-agents-integration.md](../frameworks/openai-agents-integration.md) — framework wiring.
+- [../lifecycle/bindings-reference.md](../lifecycle/bindings-reference.md) § Connection — full `bindings.json` schema.
+- `uipath-platform` skill, `references/integration-service/` — `agent-workflow.md` + `resources.md` for the discovery workflow + parent-driven custom fields.
+- [../../lowcode/capabilities/integration-service/integration-service.md](../../lowcode/capabilities/integration-service/integration-service.md) — low-code IS tool (different artifact).

--- a/skills/uipath-agents/references/coded/capabilities/sdk-services.md
+++ b/skills/uipath-agents/references/coded/capabilities/sdk-services.md
@@ -145,9 +145,13 @@ sdk.entities.delete_records(entity_key="Customers", record_ids=["rec-123"])
 connections = sdk.connections.list(name="Salesforce")
 connection = sdk.connections.retrieve(key="conn-key-123")
 token = sdk.connections.retrieve_token(key="conn-key-123", token_type="direct")
-metadata = sdk.connections.metadata(element_instance_id=123, tool_path="/contacts")
+metadata = sdk.connections.metadata(element_instance_id=123, connector_key="uipath-salesforce", tool_path="/contacts")
 payload = sdk.connections.retrieve_event_payload(event_args=event_args)
+result = sdk.connections.invoke_activity(activity_metadata=meta, connection_id="conn-key-123", activity_input={"query": "site:uipath.com"})
+result = await sdk.connections.invoke_activity_async(activity_metadata=meta, connection_id="conn-key-123", activity_input={...})
 ```
+
+See [integration-service.md](integration-service.md) for the full discover-and-invoke flow.
 
 ## LLM
 

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -95,7 +95,9 @@ Steps 8 and 9 are mandatory stops **for greenfield**: always ask, even if the us
    - `existing-coded` → `source .venv/bin/activate`. If `has_venv == false`, run `uv venv --python 3.13 && source .venv/bin/activate && uv sync`. Then `uip codedagent setup --force` (idempotent — refreshes `uipathExePath`). Skip `uip codedagent new`. Run `uip codedagent init` only if `has_entry_points == false` or schemas changed.
    - `greenfield` → Full Workflow in [lifecycle/setup.md](lifecycle/setup.md). Infer the project name from the user's prompt or the current directory.
 
-   **Do NOT authenticate yet** — auth happens after build.
+   **Do NOT authenticate yet** — auth happens after build (step 5).
+
+   **Exception — Integration Service / SaaS-connector agents:** if the agent calls IS connector activities (`sdk.connections.invoke_activity`), you cannot author its `body_fields` / `ActivityMetadata` without `uip is resources describe` output, which is auth-gated. For these agents, do the step-5 auth one-shot **and** IS discovery (per [capabilities/integration-service.md](capabilities/integration-service.md) § Discovery) NOW, before Build, then resume at Build with the discovered metadata in hand. Non-IS agents keep the default order (auth after build).
 3. **Build** — Implement agent logic using the selected framework's patterns. **For `local-workspace`: skip only the scaffold-cleanup sub-step below** — Studio Web supplied a clean shell, so the module-level-client checks aren't needed. Logic edits in `main.py` proceed normally. For `greenfield` / `existing-coded`, after scaffolding and before running `uip codedagent init`, inspect the generated code and clean up scaffold hazards:
    - No module-level `UiPathChat`, `UiPathAzureChatOpenAI`, `UiPath`, or other auth-dependent clients.
    - Instantiate LLM/SDK clients inside graph nodes/functions only.

--- a/skills/uipath-platform/references/integration-service/agent-workflow.md
+++ b/skills/uipath-platform/references/integration-service/agent-workflow.md
@@ -166,7 +166,7 @@ See [reference-resolution.md — Validate Required Fields Before Executing](refe
 ## Step 6: Execute
 
 ```bash
-uip is resources run <verb> "<connector-key>" "<object>" \
+uip is resources execute <verb> "<connector-key>" "<object>" \
   --connection-id "<id>" --body '{"field": "value"}' --output json
 ```
 
@@ -193,7 +193,8 @@ Step 6a: Read the failure response
   ↓
 Step 6b: Diagnose using discovery
   - Field not found → run `is resources describe --operation <op>` to get valid field names
-  - Invalid value → run `is resources run list` on the referenced object to get valid values
+  - Invalid value → run `is resources execute list` on the referenced object to get valid values
+  - Vendor 400 "X is required" but `describe` marked X `required=False` → IS schema and vendor validators disagree; treat vendor as authoritative, list the parent resource and add the missing field (e.g., Jira project-level required `components_arrayRemap_name` is `required=False` in `describe`)
   - Auth error → run `is connections edit <id>` to re-authenticate, then ping again
   - Scope error → inform user, connection needs broader permissions
   - Read-only field → remove the field from --body and retry
@@ -247,7 +248,7 @@ uip is resources describe "uipath-salesforce-sfdc" "Contact" \
 # 5a. All required fields (LastName) have values → proceed
 
 # 6. Execute
-uip is resources run create "uipath-salesforce-sfdc" "Contact" \
+uip is resources execute create "uipath-salesforce-sfdc" "Contact" \
   --connection-id "abc-123" --body '{"LastName": "Doe", "FirstName": "Jane"}' --output json
 ```
 

--- a/skills/uipath-platform/references/integration-service/resources.md
+++ b/skills/uipath-platform/references/integration-service/resources.md
@@ -132,7 +132,7 @@ Use the global `--output-filter` flag with a JMESPath expression to extract spec
 
 ```bash
 # Extract only id, name, and email from a user list
-uip is resources run list "<CONNECTOR_KEY>" "<OBJECT_NAME>" \
+uip is resources execute list "<CONNECTOR_KEY>" "<OBJECT_NAME>" \
   --connection-id "<CONNECTION_ID>" \
   --output json \
   --output-filter "Data[].{id: id, name: name, email: profile.email}"
@@ -152,7 +152,7 @@ Common JMESPath patterns:
 
 ## Pagination
 
-`uip is resources run list` may not return all results in a single call. **Always check for pagination** when searching for a specific item or listing all items.
+`uip is resources execute list` may not return all results in a single call. **Always check for pagination** when searching for a specific item or listing all items.
 
 ### Pagination rules
 
@@ -172,12 +172,12 @@ Most IS connectors use the `elements-*` pagination protocol. The CLI returns pag
 
 ```bash
 # First page (do not pass pageSize unless the user explicitly requests a specific page size)
-uip is resources run list "<connector-key>" "<resource>" \
+uip is resources execute list "<connector-key>" "<resource>" \
   --connection-id "<id>" --output json
 # → Check Data.Pagination.HasMore and Data.Pagination.NextPageToken in the JSON response
 
 # Subsequent pages — use nextPage as the query param name (NOT nextPageToken)
-uip is resources run list "<connector-key>" "<resource>" \
+uip is resources execute list "<connector-key>" "<resource>" \
   --connection-id "<id>" --query "nextPage=<value-from-NextPageToken>" --output json
 # → Continue until Data.Pagination.HasMore is "false" or target item is found
 ```
@@ -208,7 +208,7 @@ Example response:
 Some resources support `offset`/`limit` via `--query`:
 
 ```bash
-uip is resources run list "<connector-key>" "<object>" \
+uip is resources execute list "<connector-key>" "<object>" \
   --connection-id "<id>" --query "limit=50&offset=0" --output json
 # → next page: --query "limit=50&offset=50"
 ```

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -124,4 +124,4 @@ LLM execution trace observability and feedback annotation. See [traces/traces.md
 ## Naming gotchas
 
 - Resource sub-nouns are **plural and hyphenated where shown**: `buckets`, `queues`, `assets`, `libraries`, `queue-items`, `bucket-files`. Never singular, never `queueitems`/`bucketfiles`.
-- The Orchestrator group prefix is `or`, not `orchestrator` (`uip orchestrator` does not exist).
+- The Orchestrator group prefix is `or`, not `orchestrator` (`uip orchestrator` does not exist). <!-- uip-check-skip -->

--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -23,7 +23,7 @@ Review UiPath solutions and individual artifacts for structural validity, qualit
 ## Critical Rules
 
 1. **NEVER modify any files.** This skill is read-only. If fixes are needed, identify them in the report and tell the user which skill to use (uipath-rpa, uipath-agents, uipath-maestro-flow, uipath-coded-apps, uipath-platform, uipath-solution).
-2. **ALWAYS run validation and Workflow Analyzer before manual review.** For RPA projects, run **both** `uip rpa validate` on every entry point AND `uip rpa build "<PROJECT_DIR>"` — `validate` catches structural / analyzer issues, `build` catches compile-time issues `validate` misses (unknown member names, invalid enum values, JIT failures). Run `uip agent validate` on agents, `uip flow validate` on flows. Report every Error, Warning, and Info result from every command. A review without both `validate` AND `build` (for RPA) is incomplete and may ship broken member references.
+2. **ALWAYS run validation and Workflow Analyzer before manual review.** For RPA projects, run **both** `uip rpa validate` on every entry point AND `uip rpa build "<PROJECT_DIR>"` — `validate` catches structural / analyzer issues, `build` catches compile-time issues `validate` misses (unknown member names, invalid enum values, JIT failures). Run `uip agent validate` on agents, `uip maestro flow validate` on flows. Report every Error, Warning, and Info result from every command. A review without both `validate` AND `build` (for RPA) is incomplete and may ship broken member references.
 3. **ALWAYS discover and classify before reviewing.** For solutions: classify every project before reviewing any individual one. For single projects: identify the project type and find the enclosing project directory before reviewing individual files.
 4. **Report severity for every finding.** Use: **Critical** (blocks deployment), **Warning** (should fix), **Info** (improvement opportunity).
 5. **Understand business context first.** Before evaluating optimization, ask or infer what the solution is trying to accomplish. A queue-based architecture is not "better" if the use case processes 5 items/day.
@@ -201,7 +201,7 @@ If `uip rpa analyze` is not available, `uip rpa validate` includes Workflow Anal
 |---|---|---|
 | Agent (Low-Code) | `uip agent validate ./path --output json` | Yes — errors, warnings, info |
 | Agent (Coded) | `uip codedagent eval main evaluations/eval-sets/smoke-test.json --no-report` (if eval sets exist) | Yes — pass/fail per test case |
-| Flow | `uip flow validate <ProjectName>.flow --output json` | Yes — schema errors, reference errors, warnings |
+| Flow | `uip maestro flow validate <ProjectName>.flow --output json` | Yes — schema errors, reference errors, warnings |
 | Coded App | `uip codedapp pack dist --dry-run` | Yes — build errors, pack warnings |
 | Solution | `uip solution pack <SolutionDir> <OutputDir> --output json` | Yes — per-project pack results |
 
@@ -216,7 +216,7 @@ For the review report, create a validation summary:
 |---|---|---|---|---|
 | InvoiceProcessor | uip rpa validate (Main.xaml) | 0 | 3 | 1 |
 | InvoiceProcessor | uip rpa validate (Helper.cs) | 1 | 0 | 0 |
-| InvoiceDispatcher | uip flow validate | 0 | 0 | 0 |
+| InvoiceDispatcher | uip maestro flow validate | 0 | 0 | 0 |
 | ClassifierAgent | uip agent validate | 0 | 1 | 0 |
 
 #### Validation Details

--- a/skills/uipath-review/references/agents/agent-common-issues.md
+++ b/skills/uipath-review/references/agents/agent-common-issues.md
@@ -36,11 +36,11 @@ def main(input: Input) -> Output:
 **Common mistakes:**
 ```python
 # BAD
-from uipath import UiPath          # Wrong module path
+from uipath import UiPath          # ImportError — top-level uipath does not export UiPath
 from uipath.platform import CreateAction, WaitAction  # Renamed classes
 
 # GOOD
-from uipath import UiPath          # Correct (if package supports it)
+from uipath.platform import UiPath  # Correct
 from uipath.platform.common import CreateTask, WaitTask  # Correct HITL imports
 ```
 

--- a/skills/uipath-review/references/agents/agent-review-checklist.md
+++ b/skills/uipath-review/references/agents/agent-review-checklist.md
@@ -140,7 +140,7 @@ Before reviewing implementation details, verify the right agent type was chosen:
 | Pydantic `BaseModel` used for Input and Output | Warning | Check for Input/Output class definitions |
 | `@traced()` decorator on main function and key helpers | Warning | Grep for `@traced` |
 | `@mockable()` decorator on functions calling external services | Warning | Grep for `@mockable` |
-| Correct import: `from uipath import UiPath` | Critical | Check import statements |
+| Correct import: `from uipath.platform import UiPath` (NOT `from uipath import UiPath` — that path does not exist and raises `ImportError`) | Critical | Check import statements |
 | HITL imports correct: `CreateTask`/`WaitTask` (not `CreateAction`/`WaitAction`) | Critical | Check HITL-related imports |
 | Structured output via `with_structured_output(MyModel)` | Info | Check LLM output patterns |
 | No hardcoded API keys or secrets | Critical | Grep for `api_key=`, `secret=` in string literals |

--- a/skills/uipath-review/references/devops-readiness-checklist.md
+++ b/skills/uipath-review/references/devops-readiness-checklist.md
@@ -30,7 +30,7 @@ Source control, CI/CD, and deployment governance checks. Applies to ALL project 
 | Check | Severity | How to Verify |
 |---|---|---|
 | Automated build pipeline exists | Warning | Check for CI config files |
-| Pipeline runs validation (`uip rpa validate` / `uip flow validate` / `uip agent validate`) on every commit | Warning | Inspect pipeline steps |
+| Pipeline runs validation (`uip rpa validate` / `uip maestro flow validate` / `uip agent validate`) on every commit | Warning | Inspect pipeline steps |
 | Pipeline runs Workflow Analyzer with project's analyzer rule set, fails on Error-level violations | Warning | Inspect pipeline; check for analyzer step |
 | Pipeline runs unit / smoke tests | Warning | Inspect pipeline test step |
 | Pipeline publishes packages to a feed (not manual Studio publish) | Critical | Check pipeline; verify production publishes go through pipeline only |

--- a/skills/uipath-review/references/flows/flow-common-issues.md
+++ b/skills/uipath-review/references/flows/flow-common-issues.md
@@ -10,7 +10,7 @@ Catalog of frequently found issues in UiPath Flow projects, with detection metho
 
 **Impact:** Flow validation fails. The flow cannot be executed.
 
-**Detection:** `uip flow validate` will catch this. Also check manually:
+**Detection:** `uip maestro flow validate` will catch this. Also check manually:
 ```bash
 # In the .flow file, look for edges without targetPort
 grep -c '"targetPort"' *.flow
@@ -27,11 +27,11 @@ grep -c '"targetPort"' *.flow
 
 **Detection:** Compare definitions entries against registry output:
 ```bash
-uip flow registry get <node-type> --output json
+uip maestro flow registry get <node-type> --output json
 ```
 If the definition in the .flow file doesn't match the registry output, it was likely hand-written.
 
-**Fix:** Replace hand-written definitions with the exact output from `uip flow registry get`. Never modify registry definitions manually.
+**Fix:** Replace hand-written definitions with the exact output from `uip maestro flow registry get`. Never modify registry definitions manually.
 
 ### Orphan Nodes
 
@@ -51,7 +51,7 @@ If the definition in the .flow file doesn't match the registry output, it was li
 
 **Impact:** Validation fails. Runtime behavior is undefined — the engine may route to the wrong node.
 
-**Detection:** `uip flow validate` catches this. Also check with:
+**Detection:** `uip maestro flow validate` catches this. Also check with:
 ```bash
 # Extract all node IDs and check for duplicates
 python3 -c "import json; f=json.load(open('*.flow')); ids=[n['id'] for n in f['nodes']]; print([x for x in ids if ids.count(x)>1])"
@@ -72,7 +72,7 @@ python3 -c "import json; f=json.load(open('*.flow')); ids=[n['id'] for n in f['n
 grep "core.logic.mock" *.flow
 ```
 
-**Fix:** Replace each mock with the real resource node. Use `uip flow registry get <resource-type>` to get the correct definition, then update the node type, inputs, and definitions.
+**Fix:** Replace each mock with the real resource node. Use `uip maestro flow registry get <resource-type>` to get the correct definition, then update the node type, inputs, and definitions.
 
 ### Missing Output Mapping on End Nodes
 
@@ -151,7 +151,7 @@ grep "console.log" *.flow
 
 **Detection:** Extract resource keys from node types (e.g., `uipath.core.rpa-workflow.invoice-processor`). Verify each resource is published and accessible.
 
-**Fix:** Update resource references to point to current published resources. Re-run `uip flow registry list` to find available resources.
+**Fix:** Update resource references to point to current published resources. Re-run `uip maestro flow registry list` to find available resources.
 
 ### Hardcoded Queue Names
 

--- a/skills/uipath-review/references/flows/flow-review-checklist.md
+++ b/skills/uipath-review/references/flows/flow-review-checklist.md
@@ -21,12 +21,12 @@ Comprehensive quality checklist for UiPath Flow projects (`.flow` files) — orc
 Run the CLI validator first:
 
 ```bash
-uip flow validate <ProjectName>.flow --output json
+uip maestro flow validate <ProjectName>.flow --output json
 ```
 
 | Check | Severity | How to Verify |
 |---|---|---|
-| Flow validates without errors | Critical | `uip flow validate` returns 0 errors |
+| Flow validates without errors | Critical | `uip maestro flow validate` returns 0 errors |
 | All node IDs are unique | Critical | Check for duplicate IDs in nodes array |
 | All edge IDs are unique | Critical | Check for duplicate IDs in edges array |
 | Every edge has `targetPort` field | Critical | Check all edges for targetPort |
@@ -275,12 +275,12 @@ If the project uses the simple Flow format (not full Maestro BPMN):
 
 | Check | Severity | How to Verify |
 |---|---|---|
-| Flow validates without errors | Critical | `uip flow validate` |
+| Flow validates without errors | Critical | `uip maestro flow validate` |
 | All resource bindings resolved | Critical | Check bindings_v2.json |
 | No mock placeholder nodes remain | Critical | Grep for `core.logic.mock` |
 | Entry points correctly defined | Warning | Check entry-points.json |
 | Environment-specific values externalized | Warning | Check for hardcoded URLs/paths |
-| Debug flow succeeds end-to-end | Warning | `uip flow debug <project-dir>` |
+| Debug flow succeeds end-to-end | Warning | `uip maestro flow debug <project-dir>` |
 
 ## 11. Action Center / Human-in-the-Loop
 

--- a/skills/uipath-review/references/review-workflow-guide.md
+++ b/skills/uipath-review/references/review-workflow-guide.md
@@ -184,7 +184,7 @@ uip codedagent eval main evaluations/eval-sets/smoke-test.json --no-report
 ### Flow Validation
 
 ```bash
-uip flow validate <ProjectName>.flow --output json
+uip maestro flow validate <ProjectName>.flow --output json
 ```
 
 **Checks performed by the CLI:**
@@ -223,7 +223,7 @@ Are all required files present, correctly formatted, and schema-compliant?
 | RPA | `project.json`, entry point file (.xaml or .cs) | `uip rpa validate` |
 | Agent (Low-Code) | `agent.json` | `uip agent validate` |
 | Agent (Coded) | `main.py`, framework config, `pyproject.toml` | Import check + eval |
-| Flow | `.flow`, `project.uiproj` | `uip flow validate` |
+| Flow | `.flow`, `project.uiproj` | `uip maestro flow validate` |
 | Coded App | `package.json`, `.uipath/`, build output | `uip codedapp pack --dry-run` |
 | Solution | `.uipx`, project subdirectories | `uip solution pack` |
 
@@ -318,7 +318,7 @@ The review report follows a fixed markdown structure. Produce it in chat — do 
 
 ### Automated Validation & Workflow Analyzer Results
 
-> This section is MANDATORY. Every review must include the output of `uip rpa validate` (for RPA), `uip agent validate` (for agents), `uip flow validate` (for flows), etc. Report ALL Errors, Warnings, and Info.
+> This section is MANDATORY. Every review must include the output of `uip rpa validate` (for RPA), `uip agent validate` (for agents), `uip maestro flow validate` (for flows), etc. Report ALL Errors, Warnings, and Info.
 
 | Project | File | Command | Errors | Warnings | Info |
 |---|---|---|---|---|---|

--- a/tests/tasks/activation/uipath-agents.jsonl
+++ b/tests/tasks/activation/uipath-agents.jsonl
@@ -48,3 +48,11 @@
 {"id": "uipath-agents-048", "prompt": "Job stuck in Running forever in Orchestrator after publish, but works locally. What's different about the serverless runtime?", "expected_skill": "uipath-agents"}
 {"id": "uipath-agents-049", "prompt": "I want to build a Python agent that reads invoices from a queue, extracts fields, asks a human for low-confidence ones, and writes results back", "expected_skill": "uipath-agents"}
 {"id": "uipath-agents-050", "prompt": "Add a multi-classification evaluator to my eval set and threshold the suite at 0.85 macro-F1", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-051", "prompt": "Call a Slack channel from a Python UiPath coded agent via Integration Service", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-052", "prompt": "Use sdk.connections.invoke_activity to file a Jira issue from my coded agent", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-053", "prompt": "How do I write an ActivityMetadata literal for a curated Integration Service activity?", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-054", "prompt": "My coded agent's send-mail call returns 'Unable to parse multipart body' — what's wrong with my ActivityMetadata?", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-055", "prompt": "Bind a Slack connection in bindings.json for a coded Python agent so retrieve(<key>) works locally", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-056", "prompt": "Sync my coded agent's connection resource overwrite — sdk.connections.retrieve is returning CNS1026 locally", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-057", "prompt": "Curated Jira create_issue keeps silently ignoring my custom field — how do I tell if it's a rename mismatch?", "expected_skill": "uipath-agents"}
+{"id": "uipath-agents-058", "prompt": "Add a Salesforce integration tool to my LangGraph coded agent so the model can call it", "expected_skill": "uipath-agents"}

--- a/tests/tasks/uipath-agents/coded/is-e2e-setup.md
+++ b/tests/tasks/uipath-agents/coded/is-e2e-setup.md
@@ -1,0 +1,111 @@
+# Coded IS e2e — Setup & Run
+
+Prerequisites and procedure to run the coded Integration Service **e2e** tasks
+(`coded/is_jira_create_issue`, `coded/is_outlook_send_mail`) locally or in CI.
+The tenant-free `coded/is_smoke` needs none of this — it runs in the smoke lane
+with no tenant.
+
+These e2e tasks **mutate a live tenant**: they create a real Jira issue and send
+a real email. Do not run them casually.
+
+> **Both e2e tasks ship `skip: true`** so the nightly (which runs `e2e`-tagged
+> tasks, unlike the `--tags smoke` PR gate) does not fail on an unprovisioned
+> tenant. Once the folder + connections below exist on the run tenant, flip
+> `skip: false` in `is_jira_create_issue.yaml` / `is_outlook_send_mail.yaml` to
+> activate them.
+
+## What the e2e needs
+
+| Dependency | Provided by | Notes |
+|---|---|---|
+| `uip` auth | local `uip auth` / CI ROPC bot | tempdir agent inherits `~/.uipath/.auth` |
+| Anthropic creds | `ANTHROPIC_API_KEY` (or Bedrock) | the in-sandbox agent |
+| Folder `Shared/uipath-agents` | one-time tenant setup | connections live here |
+| Connection `jira-coded-eval` | one-time OAuth, `uipath-atlassian-jira` | in `Shared/uipath-agents` |
+| Connection `outlook-coded-eval` | one-time OAuth, `uipath-microsoft-outlook365` | in `Shared/uipath-agents`; mailbox can self-send |
+| `JIRA_PROJECT_KEY` | env / CI secret | e.g. `ENGCE` |
+| `JIRA_ISSUETYPE_ID` | env / CI secret | numeric, e.g. `10001` (Task) |
+| `OUTLOOK_TEST_TO` | env / CI secret | a mailbox the connection can send to |
+
+The seed scripts **hard-FAIL** when the env vars are placeholders/missing
+(`seed_jira.py`, `seed_outlook.py`) — by design, so a misconfigured run fails
+loudly instead of silently passing.
+
+## Which tenant / org
+
+- Environment: `https://alpha.uipath.com`.
+- Org/tenant: **confirm against the repo's GitHub Actions secrets**
+  `UIPATH_ORG_NAME` and `UIPATH_TENANT_NAME` (used by `run-coder-eval.yml`).
+  As of 2026-05, the intended org was `codereval` but config had drifted to
+  `autopilot_demo_data` and was unresolved — do NOT assume. Verify with the
+  test-infra DRIs (Bai Li, Tomasz Religa, Gurpreet Chahal, Ganesh Borle).
+- The connections must be created in **that** org/tenant, in folder
+  `Shared/uipath-agents`, and reachable by the user the run authenticates as
+  (the ROPC bot user in CI; your own user locally).
+
+## One-time tenant provisioning
+
+Connection creation is browser-OAuth — it cannot be scripted headlessly. Do it
+once; Integration Service refreshes the token server-side afterward.
+
+```bash
+# 1. Create the folder (if absent) on the target tenant.
+uip or folders create "uipath-agents" --parent "Shared" --output json
+
+# 2. Create the connections (interactive OAuth — opens a browser).
+uip is connections create uipath-atlassian-jira
+uip is connections create uipath-microsoft-outlook365
+```
+
+Then in the cloud UI: name them `jira-coded-eval` / `outlook-coded-eval`, place
+both in `Shared/uipath-agents`, and confirm the Jira project accepts new `Task`
+issues and the Outlook mailbox can self-send. In CI, the **bot user** must have
+access to this folder and these connections.
+
+## Run locally
+
+`default.yaml` uses the `tempdir` driver, so the agent runs on-host and inherits
+your `~/.uipath/.auth`.
+
+```bash
+# from tests/
+SKILLS_REPO_PATH="$(cd .. && pwd)" \
+ANTHROPIC_API_KEY=<key> \
+JIRA_PROJECT_KEY=ENGCE JIRA_ISSUETYPE_ID=10001 \
+  .venv/bin/coder-eval run \
+  tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml \
+  -e experiments/default.yaml -v
+
+OUTLOOK_TEST_TO=<mailbox> \
+  .venv/bin/coder-eval run \
+  tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml \
+  -e experiments/default.yaml -v
+```
+
+`make e2e` runs all `e2e`-tagged tasks.
+
+## Daily / CI runs
+
+The nightly suite authenticates as the **ROPC bot user** (`run-coder-eval.yml`:
+`UIPATH_ROPC_CLIENT_ID/SECRET` + `UIPATH_BOT_USERNAME/PASSWORD` →
+`alpha.uipath.com`) — non-interactive, no browser.
+
+The seed runs automatically as each task's `pre_run` (`seed_jira.py` /
+`seed_outlook.py`), reading the env vars and writing `seed.json`. For daily runs
+to seed correctly, two things must be wired (gap as of 2026-05):
+
+1. **CI env vars** — add `JIRA_PROJECT_KEY`, `JIRA_ISSUETYPE_ID`,
+   `OUTLOOK_TEST_TO` as repo secrets and into the workflow `env:` (and the VM
+   cron env). They are not present today, so daily e2e hits the seed's hard-FAIL.
+   For a Docker e2e lane, also add them to `env_passthrough_extra`.
+2. **Pre-provisioned connections** — the seed does NOT create connections; the
+   `jira-coded-eval` / `outlook-coded-eval` connections must already exist in the
+   bot tenant's `Shared/uipath-agents`. If their OAuth ever lapses, e2e fails
+   until re-authed.
+
+## How the checks verify tenant state
+
+After the agent runs the project, the check scripts query the live tenant via
+`uip is connections list` / `uip is resources run` to confirm the issue/email was
+actually created (`check_is_jira_create_issue.py`,
+`check_is_outlook_send_mail.py`) — not the agent's self-report.

--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/check_is_jira_create_issue.py
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/check_is_jira_create_issue.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Two-phase check for the coded IS Jira create-issue e2e.
+
+  python3 check_coded_is_jira_create_issue.py shape
+  python3 check_coded_is_jira_create_issue.py tenant
+
+`shape` runs offline: validates that the project on disk has the
+ActivityMetadata literal, lazy SDK construction, bindings.json
+connection entry, and a two-field `connection.jira-coded-eval`
+resourceOverwrites block (connectionId + folderKey).
+
+`tenant` runs against the live Jira tenant via `uip is resources run` —
+calls `get_issue` against the new issue key (read from
+`issue_key.txt` produced by the agent), asserts the summary equals the
+seed value, and asserts the issue is filed under the seed `epic_key`
+(parent).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bindings_assertions import (  # noqa: E402
+    assert_metadata_field,
+    assert_value_field,
+    find_resource,
+    load_bindings,
+)
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("jira-filer")
+WORKDIR = Path.cwd()
+
+
+def _read_text(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read_text(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def _load_seed() -> dict:
+    for candidate in (WORKDIR / "seed.json", ROOT / "seed.json"):
+        if candidate.is_file():
+            return _load_json(candidate)
+    sys.exit("FAIL: seed.json not found in workdir or project root")
+
+
+def check_shape() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+
+    # 1. bindings.json connection entry
+    doc = load_bindings(ROOT / "bindings.json")
+    entry = find_resource(doc, resource="connection", key="jira-coded-eval")
+    assert_value_field(entry, field="ConnectionId", expected="jira-coded-eval")
+    assert_metadata_field(entry, field="UseConnectionService", expected="True")
+
+    # 2. ActivityMetadata literal references curated_create_issue
+    literal_found = False
+    for candidate in (ROOT / "activities.py", ROOT / "main.py"):
+        if candidate.is_file() and "ActivityMetadata(" in candidate.read_text() and "curated_create_issue" in candidate.read_text():
+            literal_found = True
+            break
+    if not literal_found:
+        sys.exit(
+            "FAIL: no `ActivityMetadata(...)` referencing `curated_create_issue` "
+            "in activities.py or main.py."
+        )
+    print("OK: ActivityMetadata literal for curated_create_issue is present")
+
+    # 3. main.py uses lazy SDK init
+    main_py = ROOT / "main.py"
+    violations = find_module_level_llm_clients(main_py)
+    if violations:
+        sys.exit("FAIL: module-level UiPath* construction: " + " | ".join(violations))
+    text = main_py.read_text()
+    if "invoke_activity" not in text or "connections.retrieve(" not in text:
+        sys.exit(
+            "FAIL: main.py does not use `sdk.connections.retrieve(<key>)` + "
+            "`invoke_activity(...)` — capability runtime pattern missing."
+        )
+    print("OK: main.py uses lazy UiPath() + retrieve + invoke_activity")
+
+    # 4. resourceOverwrites with the two required fields (NO elementInstanceId)
+    uipath_json = _load_json(ROOT / "__uipath" / "uipath.json")
+    overwrites = (
+        uipath_json.get("runtime", {})
+        .get("internalArguments", {})
+        .get("resourceOverwrites", {})
+    )
+    key = "connection.jira-coded-eval"
+    if key not in overwrites:
+        sys.exit(f"FAIL: __uipath/uipath.json missing resourceOverwrites key `{key}`")
+    entry_keys = set(overwrites[key].keys())
+    has_conn = "connectionId" in entry_keys or "ConnectionId" in entry_keys
+    has_folder = "folderKey" in entry_keys
+    if not (has_conn and has_folder):
+        sys.exit(
+            f"FAIL: resourceOverwrites for `{key}` must carry `connectionId` "
+            "(alias `ConnectionId`) and `folderKey` per "
+            "`ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`)."
+        )
+    if "elementInstanceId" in entry_keys:
+        sys.exit(
+            f"FAIL: resourceOverwrites for `{key}` contains `elementInstanceId`, "
+            "which `ConnectionResourceOverwrite` ignores (`extra=\"ignore\"`). "
+            "Remove it — see capability anti-pattern #1."
+        )
+    print("OK: resourceOverwrites has connectionId + folderKey (and no spurious elementInstanceId)")
+    print("PASS: shape checks complete")
+
+
+def _uip(*args: str, timeout: int = 60) -> dict:
+    uip = shutil.which("uip")
+    if uip is None:
+        sys.exit("FAIL: `uip` not on PATH — required for tenant check")
+    proc = subprocess.run(
+        [uip, *args, "--output", "json"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(
+            f"FAIL: `uip {' '.join(args)}` exited {proc.returncode}: "
+            f"{(proc.stderr or proc.stdout).strip()[:600]}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: `uip {' '.join(args)}` non-JSON output: {e}; raw: {proc.stdout[:300]!r}")
+
+
+def _find_issue_key() -> str:
+    """Read the created issue key from the agent's run output (no manual
+    bookkeeping file). The agent runs `uip codedagent run main ... --output-file
+    out.json`; that file holds the agent's returned output. Tolerant of field
+    naming (issueKey / issue_key / key) and of a Data/output/result wrapper."""
+    candidates = [ROOT / "out.json", ROOT / "__uipath" / "output.json", WORKDIR / "out.json"]
+    field_names = ("issueKey", "issue_key", "key", "issueIdOrKey")
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        for blob in (data, *(data.get(w) for w in ("Data", "output", "result") if isinstance(data, dict))):
+            if isinstance(blob, dict):
+                for k in field_names:
+                    v = blob.get(k)
+                    if isinstance(v, str) and v.strip():
+                        return v.strip()
+    sys.exit(
+        "FAIL: could not read the created issue key from the agent's run "
+        "output. Expected `out.json` (from `uip codedagent run --output-file "
+        "out.json`) carrying an `issueKey`/`issue_key` field."
+    )
+
+
+def check_tenant() -> None:
+    seed = _load_seed()
+    expected_summary = seed["summary"]
+    issue_key = _find_issue_key()
+
+    # Resolve the test folder + connection so we can re-read the issue.
+    folder = _uip("or", "folders", "get", seed["folder_path"])
+    folder_key = (
+        folder.get("Key")
+        or folder.get("Data", {}).get("Key")
+        or folder.get("data", {}).get("Key")
+    )
+    if not folder_key:
+        sys.exit(f"FAIL: could not resolve folder key for {seed['folder_path']!r}: {folder}")
+
+    connections = _uip(
+        "is", "connections", "list", "uipath-atlassian-jira",
+        "--folder-key", folder_key, "--refresh",
+    )
+    conn_list = connections.get("Data") if isinstance(connections.get("Data"), list) else []
+    match = next((c for c in conn_list if c.get("Name") == seed["connection_name"]), None)
+    if not match:
+        sys.exit(
+            f"FAIL: connection {seed['connection_name']!r} not found in "
+            f"{seed['folder_path']!r} (got {[c.get('Name') for c in conn_list]})."
+        )
+    connection_id = match["Id"]
+
+    # Read the issue back via the curated get the connector supports:
+    # `is resources run get <connector> curated_get_issue` with project +
+    # issuetype + issueId in the query string (the form that returns fields +
+    # parent for this connector).
+    result = _uip(
+        "is", "resources", "run", "get", "uipath-atlassian-jira",
+        "curated_get_issue",
+        "--connection-id", connection_id,
+        "--query",
+        f"project={seed['project_key']}&issuetype={seed['issuetype_id']}&issueId={issue_key}",
+        timeout=120,
+    )
+    fields = (
+        result.get("Data", {}).get("fields")
+        or result.get("fields")
+        or {}
+    )
+    actual_summary = fields.get("summary")
+    if actual_summary != expected_summary:
+        sys.exit(
+            f"FAIL: Jira issue {issue_key} summary={actual_summary!r}, "
+            f"expected {expected_summary!r}. The agent either created the "
+            "wrong issue, or `curated_create_issue` silently dropped the "
+            "summary field (rename mismatch — see capability doc § Runtime "
+            "validation layers, row 3)."
+        )
+    print(f"OK: Jira issue {issue_key} carries the seed summary")
+
+    # Epic linkage: the issue must be filed under seed `epic_key`. Modern Jira
+    # exposes the epic as the unified `parent` field; fall back to scanning
+    # field values for the epic key (older epic-link customfield shapes).
+    expected_epic = (seed.get("epic_key") or "").strip()
+    if expected_epic:
+        parent = fields.get("parent") or {}
+        parent_key = parent.get("key") if isinstance(parent, dict) else None
+        if parent_key != expected_epic:
+            scanned = {
+                k: v for k, v in fields.items()
+                if isinstance(v, str) and v == expected_epic
+            }
+            if not scanned:
+                sys.exit(
+                    f"FAIL: Jira issue {issue_key} is not filed under epic "
+                    f"{expected_epic!r} (parent={parent_key!r}). The agent did not "
+                    "resolve/set the parent/epic-link field on the create call — "
+                    "see capability doc § reference-resolution (parent fields)."
+                )
+        print(f"OK: Jira issue {issue_key} is filed under epic {expected_epic}")
+    print("PASS: tenant check complete")
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] not in ("shape", "tenant"):
+        sys.exit("usage: check_coded_is_jira_create_issue.py {shape|tenant}")
+    if sys.argv[1] == "shape":
+        check_shape()
+    else:
+        check_tenant()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
@@ -1,0 +1,132 @@
+task_id: skill-agents-coded-is-jira-create-issue
+description: >
+  End-to-end exercise of the coded Integration Service capability with
+  progressive disclosure. Agent must drive the full discovery flow
+  (connectors filter → connections list → resources describe with parent
+  `-f` fields → ActivityMetadata literal → invoke_activity) against a
+  live Jira connection, then run the coded agent locally and create a
+  real Jira issue. The check script verifies tenant state (issue exists
+  with expected summary) and project shape (bindings + literal +
+  two-field resourceOverwrites: connectionId + folderKey, no elementInstanceId).
+
+  Tenant prerequisite: a `uipath-atlassian-jira` connection in folder
+  `Shared/uipath-agents` named `jira-coded-eval`. The Jira project
+  reachable by that connection must accept new issues of type `Task`,
+  and `JIRA_EPIC_KEY` must name an epic in that project to file under
+  (the check asserts the created issue's parent is that epic).
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, feature:integration-service, uipath-atlassian-jira, connector]
+skip: true
+# Tenant-gated e2e. Requires a `uipath-atlassian-jira` connection named
+# `jira-coded-eval` in folder `Shared/uipath-agents` on the run tenant, plus an
+# epic to file under (JIRA_EPIC_KEY, default PRODEV-685). The nightly runs e2e
+# (the PR gate is --tags smoke only), so this would fail there until the tenant
+# is provisioned. Flip to `skip: false` once set up per coded/is-e2e-setup.md.
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1800
+  max_turns: 80
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/is_jira_create_issue/seed_jira.py"
+    timeout: 30
+
+initial_prompt: |
+  I need a UiPath coded Python agent — call it `jira-filer` — that files
+  a Jira issue through Integration Service when it runs. Build it, run it
+  locally, and confirm the issue actually got created in Jira.
+
+  Use the `uipath-agents` skill to figure out how.
+
+  Use the Jira connection `jira-coded-eval` in the `Shared/uipath-agents`
+  folder. Everything specific about the issue — the summary text, which
+  project and issue type, and the epic it should sit under — is in
+  `seed.json`; read it from there, use the summary exactly as given, and
+  make sure the new issue ends up under that epic.
+
+  The agent should take a `summary` and a `description` and return the
+  new issue key (like "ENG-123") and an `ok` flag. Run it locally with
+  `--output-file out.json` so the result is captured.
+
+  Don't publish or deploy, don't stop to ask — just get it working in one
+  pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent loaded the uipath-agents skill"
+    tool_name: "Skill"
+    command_pattern: "uipath-agents"
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Loaded platform IS discovery reference into context (agent-workflow.md — mandatory preload, not just the coded capability doc)"
+    tool_name: "Read"
+    command_pattern: 'uipath-platform/references/integration-service/agent-workflow\.md'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Loaded platform reference-resolution.md into context — the capability doc mandates reading it before authoring a Jira create (parent/reference fields are the #1 curated-activity rejection)"
+    tool_name: "Read"
+    command_pattern: 'uipath-platform/references/integration-service/reference-resolution\.md'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran a folder-aware `uip is connections list` for the Jira connector (--all-folders, what the IS docs teach, or --folder-key)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+connections\s+list[\s\S]{0,200}?uipath-atlassian-jira[\s\S]{0,200}?(?:--all-folders|--folder-key)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Progressive disclosure: described curated_create_issue with parent `-f fields.project.key=` (Jira GenerateSchema) BEFORE authoring the literal — surfaces project/issuetype-specific custom fields"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+describe[\s\S]+?(?:-f|--field)\s+fields\.project\.key='
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran the coded agent locally"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: commands_efficiency
+    description: "Effort / drift budget: a bloated command count signals the agent flailed (wrong flags, retries, operation guessing). Score = expected / max(actual, expected)."
+    expected_commands: 30
+    weight: 1.0
+    pass_threshold: 0.3
+
+  - type: run_command
+    description: "Project shape: ActivityMetadata literal, lazy SDK init, bindings connection entry, 2-field resourceOverwrites (connectionId + folderKey, no elementInstanceId)"
+    command: "python3 $TASK_DIR/check_is_jira_create_issue.py shape"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Jira tenant state: a new issue with the seed summary exists in the expected project"
+    command: "python3 $TASK_DIR/check_is_jira_create_issue.py tenant"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/seed_jira.py
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/seed_jira.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Seed file for the coded IS Jira create-issue e2e.
+
+Writes `seed.json` in the working directory with:
+
+  - `uuid8`: short unique tag to embed in the issue summary so the check
+    script can locate the agent's new issue deterministically.
+  - `summary`: full summary string the agent must pass verbatim.
+  - `project_key` / `issuetype_id`: env-supplied targets for the
+    progressive-disclosure `-f project=... -f issuetype=...` call.
+  - `epic_key`: env-supplied epic the created issue must be filed under
+    (parent / epic-link), so the test exercises parent-field resolution
+    and lands issues under a known epic.
+
+Env vars (optional — default to the canonical test target):
+
+  JIRA_PROJECT_KEY   — Jira project to file into (default "PRODEV")
+  JIRA_ISSUETYPE_ID  — numeric issuetype id (default "3" = Task)
+  JIRA_EPIC_KEY      — epic in that project to file under (default "PRODEV-685")
+
+Override any of them to point the e2e at a different tenant/project.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sys
+from pathlib import Path
+
+WORKDIR = Path.cwd()
+
+
+def main() -> None:
+    # Non-secret targets default to the canonical test epic
+    # (PRODEV-685 "Test coded agent activity creation E2E" on the test tenant);
+    # override via env for a different tenant/project.
+    project_key = os.environ.get("JIRA_PROJECT_KEY", "PRODEV").strip()
+    issuetype_id = os.environ.get("JIRA_ISSUETYPE_ID", "3").strip()
+    epic_key = os.environ.get("JIRA_EPIC_KEY", "PRODEV-685").strip()
+
+    uuid8 = secrets.token_hex(4)
+    summary = f"uipath-agents coded-is eval {uuid8}"
+    seed = {
+        "uuid8": uuid8,
+        "summary": summary,
+        "project_key": project_key,
+        "issuetype_id": issuetype_id,
+        "epic_key": epic_key,
+        "connection_name": "jira-coded-eval",
+        "folder_path": "Shared/uipath-agents",
+    }
+    (WORKDIR / "seed.json").write_text(json.dumps(seed, indent=2))
+    print(f"OK: wrote seed.json with summary={summary!r}, project={project_key}, epic={epic_key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/check_is_outlook_send_mail.py
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/check_is_outlook_send_mail.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Two-phase check for the Outlook multipart e2e.
+
+  shape   — offline assertions on the on-disk project
+  tenant  — polls Outlook inbox via the test connection to confirm
+            the seed subject token arrived
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bindings_assertions import (  # noqa: E402
+    assert_metadata_field,
+    assert_value_field,
+    find_resource,
+    load_bindings,
+)
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("mailer")
+WORKDIR = Path.cwd()
+
+
+def _read(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        return json.loads(_read(path))
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def _load_seed() -> dict:
+    for candidate in (WORKDIR / "seed.json", ROOT / "seed.json"):
+        if candidate.is_file():
+            return _load_json(candidate)
+    sys.exit("FAIL: seed.json not found")
+
+
+def check_shape() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+
+    doc = load_bindings(ROOT / "bindings.json")
+    entry = find_resource(doc, resource="connection", key="outlook-coded-eval")
+    assert_value_field(entry, field="ConnectionId", expected="outlook-coded-eval")
+    assert_metadata_field(entry, field="UseConnectionService", expected="True")
+
+    # Multipart literal: must declare content_type and multipart_params.
+    literal_text = ""
+    for candidate in (ROOT / "activities.py", ROOT / "main.py"):
+        if candidate.is_file() and "send-mail-v2" in candidate.read_text():
+            literal_text = candidate.read_text()
+            break
+    if not literal_text:
+        sys.exit("FAIL: no ActivityMetadata referencing send-mail-v2 found")
+    if "multipart/form-data" not in literal_text:
+        sys.exit(
+            "FAIL: ActivityMetadata literal does not set "
+            "`content_type=\"multipart/form-data\"` — defaulting to JSON "
+            "returns vendor 400 'Unable to parse multipart body'."
+        )
+    if "multipart_params" not in literal_text:
+        sys.exit(
+            "FAIL: ActivityMetadata literal is missing `multipart_params=[...]` "
+            "— compact `describe` output filters these; agent must harvest "
+            "them from the raw schema cache."
+        )
+    if "json_body_section" not in literal_text:
+        sys.exit(
+            "FAIL: ActivityMetadata literal is missing `json_body_section=` — "
+            "multipart wrapper key required to package the JSON body section."
+        )
+    print("OK: ActivityMetadata declares multipart/form-data + multipart_params + json_body_section")
+
+    main_py = ROOT / "main.py"
+    violations = find_module_level_llm_clients(main_py)
+    if violations:
+        sys.exit("FAIL: module-level UiPath* construction: " + " | ".join(violations))
+    print("OK: main.py uses lazy UiPath() construction")
+
+    uipath_json = _load_json(ROOT / "__uipath" / "uipath.json")
+    overwrites = (
+        uipath_json.get("runtime", {})
+        .get("internalArguments", {})
+        .get("resourceOverwrites", {})
+    )
+    key = "connection.outlook-coded-eval"
+    if key not in overwrites:
+        sys.exit(f"FAIL: resourceOverwrites missing key `{key}`")
+    entry_keys = set(overwrites[key].keys())
+    has_conn = "connectionId" in entry_keys or "ConnectionId" in entry_keys
+    has_folder = "folderKey" in entry_keys
+    if not (has_conn and has_folder):
+        sys.exit(
+            f"FAIL: resourceOverwrites for `{key}` must carry `connectionId` "
+            "(alias `ConnectionId`) and `folderKey` per "
+            "`ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`)."
+        )
+    if "elementInstanceId" in entry_keys:
+        sys.exit(
+            f"FAIL: resourceOverwrites for `{key}` contains `elementInstanceId`, "
+            "which `ConnectionResourceOverwrite` ignores (`extra=\"ignore\"`). "
+            "Remove it — see capability anti-pattern #1."
+        )
+    print("OK: resourceOverwrites has connectionId + folderKey (and no spurious elementInstanceId)")
+    print("PASS: shape checks complete")
+
+
+def _uip(*args: str, timeout: int = 60) -> dict:
+    uip = shutil.which("uip")
+    if uip is None:
+        sys.exit("FAIL: `uip` not on PATH")
+    proc = subprocess.run(
+        [uip, *args, "--output", "json"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if proc.returncode != 0:
+        sys.exit(
+            f"FAIL: `uip {' '.join(args)}` exited {proc.returncode}: "
+            f"{(proc.stderr or proc.stdout).strip()[:600]}"
+        )
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: `uip {' '.join(args)}` non-JSON output: {e}")
+
+
+def check_tenant() -> None:
+    seed = _load_seed()
+    folder = _uip("or", "folders", "get", seed["folder_path"])
+    folder_key = folder.get("Key") or folder.get("data", {}).get("Key")
+    if not folder_key:
+        sys.exit(f"FAIL: cannot resolve folder key for {seed['folder_path']!r}")
+
+    connections = _uip(
+        "is", "connections", "list", "uipath-microsoft-outlook365",
+        "--folder-key", folder_key, "--refresh",
+    )
+    conn_list = connections.get("Data") if isinstance(connections.get("Data"), list) else []
+    match = next((c for c in conn_list if c.get("Name") == seed["connection_name"]), None)
+    if not match:
+        sys.exit(
+            f"FAIL: connection {seed['connection_name']!r} not found in "
+            f"{seed['folder_path']!r}"
+        )
+    connection_id = match["Id"]
+
+    # Poll the inbox for the seeded subject token. Outlook delivery
+    # latency is typically a few seconds — give it up to 90s.
+    deadline = time.monotonic() + 90
+    last_titles: list[str] = []
+    while time.monotonic() < deadline:
+        result = _uip(
+            "is", "resources", "run", "uipath-microsoft-outlook365",
+            "list_messages_v2",
+            "--connection-id", connection_id,
+            "--folder-key", folder_key,
+            "-d", json.dumps({
+                "folder": "Inbox",
+                "top": 100,
+                "orderBy": "receivedDateTime desc",
+                "filter": f"contains(subject, '{seed['subject']}')",
+            }),
+            timeout=60,
+        )
+        messages = (
+            result.get("Data", {}).get("value")
+            or result.get("value")
+            or []
+        )
+        last_titles = [m.get("subject", "") for m in messages]
+        if any(seed["subject"] in title for title in last_titles):
+            print(f"OK: found {seed['subject']!r} in inbox top 25")
+            print("PASS: tenant check complete")
+            return
+        time.sleep(5)
+    sys.exit(
+        f"FAIL: subject {seed['subject']!r} did not arrive in {seed['to_address']!r} "
+        f"within 90s. Last 25 subjects: {last_titles[:5]}…"
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 2 or sys.argv[1] not in ("shape", "tenant"):
+        sys.exit("usage: check_coded_is_outlook_send_mail.py {shape|tenant}")
+    if sys.argv[1] == "shape":
+        check_shape()
+    else:
+        check_tenant()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
@@ -1,0 +1,110 @@
+task_id: skill-agents-coded-is-outlook-send-mail
+description: >
+  Exercises the multipart edge case in the coded Integration Service
+  capability. The agent must read the raw schema cache (since
+  `describe` filters multipart out of the compact summary) to recover
+  `multipart_params` for Outlook's `send-mail-v2`, build the correct
+  `ActivityMetadata(content_type="multipart/form-data",
+  json_body_section="body", multipart_params=[...])` literal, wire
+  bindings + 2-field resourceOverwrites, and send a real email from
+  the test connection. The tenant check polls the destination inbox
+  via the same Outlook connection to confirm delivery.
+
+  Tenant prerequisite: a `uipath-microsoft-outlook365` connection in
+  folder `Shared/uipath-agents` named `outlook-coded-eval`. The mailbox
+  behind it must accept self-sends.
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, feature:integration-service, feature:multipart, uipath-microsoft-outlook365, connector]
+skip: true
+# Tenant-gated e2e. Requires a `uipath-microsoft-outlook365` connection named
+# `outlook-coded-eval` in folder `Shared/uipath-agents` on the run tenant and a
+# self-sendable mailbox (OUTLOOK_TEST_TO). The nightly runs e2e (the PR gate is
+# --tags smoke only), so this would fail there until the tenant is provisioned.
+# Flip to `skip: false` once set up per coded/is-e2e-setup.md.
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1800
+  max_turns: 80
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/is_outlook_send_mail/seed_outlook.py"
+    timeout: 30
+
+initial_prompt: |
+  Build a UiPath coded Python agent named `mailer` that sends an email
+  via the Outlook 365 Integration Service connector. Use the
+  `uipath-agents` skill and its coded Integration Service capability.
+
+  Test connection: in folder `Shared/uipath-agents`, named
+  `outlook-coded-eval`. Bind to it under the key `outlook-coded-eval`.
+
+  Operation: `send-mail-v2`. Read `seed.json` for the recipient
+  (`to_address`) and subject token (`subject`) — pass them through to
+  your agent's input untouched. Agent input shape:
+  `{"to": "<email>", "subject": "<str>", "body": "<str>"}`. Output:
+  `{"ok": bool}`.
+
+  Note: `send-mail-v2` is one of the connectors where the compact
+  `describe` output is incomplete. Follow the capability doc's
+  recovery guidance for that case — do not assume the JSON defaults.
+
+  Run the agent locally with the seeded `to` and `subject` values, then
+  exit. Do NOT publish or deploy. Do NOT pause. Do NOT ask for approval.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent loaded the uipath-agents skill"
+    tool_name: "Skill"
+    command_pattern: "uipath-agents"
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Loaded platform IS discovery reference into context (agent-workflow.md — mandatory preload, not just the coded capability doc)"
+    tool_name: "Read"
+    command_pattern: 'uipath-platform/references/integration-service/agent-workflow\.md'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent read the raw IS schema cache (multipart workaround)"
+    tool_name: "Bash"
+    command_pattern: '\.uipath/cache/integrationservice/[\s\S]+?send-mail-v2\.schema\.json'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran the coded agent locally"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+run'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Project shape: multipart ActivityMetadata literal, bindings, 2-field resourceOverwrites (connectionId + folderKey, no elementInstanceId)"
+    command: "python3 $TASK_DIR/check_is_outlook_send_mail.py shape"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Outlook tenant state: the seeded subject token appears in the destination inbox"
+    command: "python3 $TASK_DIR/check_is_outlook_send_mail.py tenant"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/seed_outlook.py
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/seed_outlook.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Seed for the Outlook multipart e2e.
+
+Env vars (required):
+  OUTLOOK_TEST_TO   — recipient mailbox the test connection can reach
+                      AND can poll (typically the same address as the
+                      connection's bound mailbox, so we can verify
+                      delivery without a second connection).
+
+Writes `seed.json` with a unique `subject` token so the check script
+can locate the email regardless of inbox noise.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import secrets
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    to_address = os.environ.get("OUTLOOK_TEST_TO", "").strip()
+    if not to_address:
+        sys.exit(
+            "FAIL (seed): OUTLOOK_TEST_TO env var is required for the "
+            "Outlook multipart e2e. Set it to an inbox the test connection "
+            "can both send to and read from."
+        )
+
+    uuid8 = secrets.token_hex(4)
+    subject = f"uipath-agents eval {uuid8}"
+    seed = {
+        "uuid8": uuid8,
+        "subject": subject,
+        "to_address": to_address,
+        "connection_name": "outlook-coded-eval",
+        "folder_path": "Shared/uipath-agents",
+    }
+    Path.cwd().joinpath("seed.json").write_text(json.dumps(seed, indent=2))
+    print(f"OK: wrote seed.json with subject={subject!r}, to={to_address}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/is_smoke/check_is_smoke.py
+++ b/tests/tasks/uipath-agents/coded/is_smoke/check_is_smoke.py
@@ -1,0 +1,416 @@
+#!/usr/bin/env python3
+"""Shape check for the coded Integration Service smoke task.
+
+Verifies the invariants the capability doc teaches, AST-linked to the actual
+`invoke_activity(_async)` call so dead-code / unused literals cannot satisfy it:
+
+  1. `bindings.json` carries a `connection` resource with the Connection
+     Service envelope (capital-C `ConnectionId`,
+     `metadata.UseConnectionService == "True"`).
+  2. `main.py` actually calls `sdk.connections.invoke_activity(_async)` and
+     resolves the connection by binding key — either an explicit
+     `retrieve(<key>)` / `retrieve_async(<key>)` or a one-shot
+     `invoke_activity(connection_id="<key>")` (both documented).
+  3. The `ActivityMetadata` passed to that call (inline OR a resolved
+     module/function constant) maps the describe fixture: `object_path`,
+     `method_name`, `query_params`, and `body_fields` (deduped requestField
+     first-segments). Param info may be an inline
+     `ActivityParameterLocationInfo(...)`, a named constant, or a dict; lists
+     and tuples both accepted.
+  4. `main.py` does NOT instantiate `UiPath` at module level (anti-pattern #6),
+     alias-aware, and constructs it somewhere.
+  5. No lowcode-only `resources/<Tool>/resource.json` sidecar.
+  6. `__uipath/uipath.json` resourceOverwrites carries non-empty `connectionId`
+     and `folderKey` (alias `ConnectionId`) for `connection.<key>`;
+     `ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`)
+     defines only those two with `extra="ignore"`, so an `elementInstanceId`
+     entry is rejected here as a skill-hygiene anti-pattern (#1) — the SDK would
+     silently drop it.
+
+Exits 0 on PASS, with `FAIL: ...` on the first violation.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bindings_assertions import (  # noqa: E402
+    assert_metadata_field,
+    assert_value_field,
+    find_resource,
+    load_bindings,
+)
+from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("slack-notifier")
+BINDING_KEY = "slack-notifier"
+
+
+def _read(path: Path) -> str:
+    if not path.is_file():
+        sys.exit(f"FAIL: missing {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    raw = _read(path)
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+# --------------------------------------------------------------------------
+# AST helpers
+# --------------------------------------------------------------------------
+
+def _parse_main() -> ast.Module:
+    path = ROOT / "main.py"
+    if not path.is_file():
+        sys.exit(f"FAIL: missing {path}")
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as e:
+        sys.exit(f"FAIL: main.py is not valid Python: {e}")
+
+
+def _import_aliases(tree: ast.Module) -> dict[str, str]:
+    """Map each locally-bound name → canonical imported symbol (handles `as`)."""
+    aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            for a in node.names:
+                local = a.asname or a.name
+                aliases[local.split(".")[0]] = a.name.split(".")[-1]
+    return aliases
+
+
+def _assignments(tree: ast.Module) -> dict[str, ast.AST]:
+    """name → assigned value node (covers module and function scope; last wins)."""
+    out: dict[str, ast.AST] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name):
+                    out[t.id] = node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.value is not None:
+                out[node.target.id] = node.value
+    return out
+
+
+def _resolves_to(call: ast.Call, target: str, aliases: dict[str, str]) -> bool:
+    fn = call.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr == target
+    if isinstance(fn, ast.Name):
+        return aliases.get(fn.id, fn.id) == target
+    return False
+
+
+def _attr_name(call: ast.Call) -> str | None:
+    fn = call.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    if isinstance(fn, ast.Name):
+        return fn.id
+    return None
+
+
+def _str_seq(node: ast.AST | None) -> list[str] | None:
+    """A list/tuple of string constants → [str]; else None."""
+    if not isinstance(node, (ast.List, ast.Tuple)):
+        return None
+    out: list[str] = []
+    for el in node.elts:
+        if isinstance(el, ast.Constant) and isinstance(el.value, str):
+            out.append(el.value)
+        else:
+            return None
+    return out
+
+
+def _deref(node: ast.AST | None, assigns: dict[str, ast.AST]) -> ast.AST | None:
+    """If node is a Name bound to a value, return that value; else node itself."""
+    if isinstance(node, ast.Name) and node.id in assigns:
+        return assigns[node.id]
+    return node
+
+
+def _kw_or_pos(call: ast.Call, name: str, pos: int) -> ast.AST | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    if pos < len(call.args):
+        return call.args[pos]
+    return None
+
+
+# --------------------------------------------------------------------------
+# Checks
+# --------------------------------------------------------------------------
+
+def check_bindings_connection() -> None:
+    doc = load_bindings(ROOT / "bindings.json")
+    entry = find_resource(doc, resource="connection", key=BINDING_KEY)
+    assert_value_field(entry, field="ConnectionId", expected=BINDING_KEY)
+    assert_metadata_field(entry, field="UseConnectionService", expected="True")
+    print("OK: bindings.json connection envelope is well-formed")
+
+
+def check_no_lowcode_sidecar() -> None:
+    bad = list(ROOT.glob("resources/**/resource.json"))
+    if bad:
+        sys.exit(
+            "FAIL: found lowcode-only `resources/<Tool>/resource.json` sidecar(s) "
+            "in a coded agent — coded agents inline ActivityMetadata in .py "
+            f"(see capability § Coded vs Low-code): {bad}"
+        )
+    print("OK: no lowcode `resources/<Tool>/resource.json` sidecar present")
+
+
+def check_lazy_sdk_init(tree: ast.Module, aliases: dict[str, str]) -> None:
+    violations = find_module_level_llm_clients(ROOT / "main.py")
+    if violations:
+        sys.exit(
+            "FAIL: module-level UiPath* construction detected (anti-pattern #6): "
+            + " | ".join(violations)
+        )
+    constructed = any(
+        isinstance(n, ast.Call) and _resolves_to(n, "UiPath", aliases)
+        for n in ast.walk(tree)
+    )
+    if not constructed:
+        sys.exit(
+            "FAIL: main.py never constructs `UiPath()` (alias-aware) — the agent "
+            "cannot have called `sdk.connections.invoke_activity`."
+        )
+    print("OK: main.py constructs UiPath() lazily (not at module scope)")
+
+
+def _find_invoke_call(tree: ast.Module) -> ast.Call:
+    invokes = [
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call)
+        and _attr_name(n) in ("invoke_activity", "invoke_activity_async")
+        and isinstance(n.func, ast.Attribute)  # must be sdk.connections.invoke_*
+    ]
+    if not invokes:
+        sys.exit(
+            "FAIL: main.py has no executable `sdk.connections.invoke_activity"
+            "(_async)` call — the capability's runtime pattern is missing "
+            "(substrings in comments/strings do not count)."
+        )
+    return invokes[0]
+
+
+def _binding_key_resolves(invoke: ast.Call, tree: ast.Module) -> bool:
+    """The connection must be resolved by the binding key — either the
+    one-shot `connection_id="<key>"` or an explicit retrieve(<key>)."""
+    conn = _kw_or_pos(invoke, "connection_id", 1)
+    if isinstance(conn, ast.Constant) and conn.value == BINDING_KEY:
+        return True
+    for c in ast.walk(tree):
+        if isinstance(c, ast.Call) and _attr_name(c) in ("retrieve", "retrieve_async"):
+            first = _kw_or_pos(c, "key", 0)
+            if isinstance(first, ast.Constant) and first.value == BINDING_KEY:
+                return True
+    return False
+
+
+def _resolve_metadata_call(
+    node: ast.AST | None, assigns: dict[str, ast.AST], aliases: dict[str, str]
+) -> ast.Call | None:
+    node = _deref(node, assigns)
+    if isinstance(node, ast.Call) and _resolves_to(node, "ActivityMetadata", aliases):
+        return node
+    return None
+
+
+def _resolve_param_info(
+    node: ast.AST | None, assigns: dict[str, ast.AST], aliases: dict[str, str]
+) -> dict[str, list[str]] | None:
+    node = _deref(node, assigns)
+    kw: dict[str, ast.AST] = {}
+    if isinstance(node, ast.Call) and _resolves_to(
+        node, "ActivityParameterLocationInfo", aliases
+    ):
+        kw = {k.arg: k.value for k in node.keywords if k.arg}
+    elif isinstance(node, ast.Dict):
+        for k, v in zip(node.keys, node.values):
+            if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                kw[k.value] = v
+    else:
+        return None
+    body = _str_seq(kw.get("body_fields"))
+    if body is None:
+        return None
+    query = _str_seq(kw.get("query_params")) if "query_params" in kw else []
+    if query is None:
+        return None
+    return {"body_fields": body, "query_params": query}
+
+
+def _expected_from_fixture() -> dict:
+    """Derive the ActivityMetadata shape the agent should have mapped from the
+    pre-recorded `uip is resources describe` fixture (staged in the task dir)."""
+    fixture = Path(__file__).resolve().parent / "fixtures" / "slack_send_message_describe.json"
+    doc = _load_json(fixture)
+    body_fields: list[str] = []
+    for f in doc.get("requestFields", []):
+        first = f["name"].split(".", 1)[0]
+        if first not in body_fields:
+            body_fields.append(first)
+    return {
+        "object_path": doc["operation"]["path"],
+        "method": doc["operation"]["method"],
+        "query_params": [
+            p["name"] for p in doc.get("parameters", []) if p.get("type") == "query"
+        ],
+        "body_fields": body_fields,
+    }
+
+
+def check_invocation_and_metadata(
+    tree: ast.Module, assigns: dict[str, ast.AST], aliases: dict[str, str]
+) -> None:
+    invoke = _find_invoke_call(tree)
+
+    if not _binding_key_resolves(invoke, tree):
+        sys.exit(
+            f"FAIL: the invoke_activity call does not resolve connection by the "
+            f"binding key {BINDING_KEY!r} — pass `connection_id=\"{BINDING_KEY}\"` "
+            f"or `retrieve(\"{BINDING_KEY}\")` (do NOT hardcode a raw connection UUID)."
+        )
+    print("OK: main.py invokes invoke_activity and resolves the binding key")
+
+    meta_arg = _kw_or_pos(invoke, "activity_metadata", 0)
+    meta = _resolve_metadata_call(meta_arg, assigns, aliases)
+    if meta is None:
+        sys.exit(
+            "FAIL: the `activity_metadata=` argument of invoke_activity is not an "
+            "`ActivityMetadata(...)` literal (inline or a resolvable constant). The "
+            "SDK builds the request from the object actually passed — keep it a "
+            "literal so the shape is verifiable."
+        )
+
+    kw = {k.arg: k.value for k in meta.keywords if k.arg}
+    # positional fallback: ActivityMetadata(object_path, method_name, content_type, parameter_location_info)
+    pos_names = ["object_path", "method_name", "content_type", "parameter_location_info"]
+    for i, a in enumerate(meta.args):
+        if i < len(pos_names) and pos_names[i] not in kw:
+            kw[pos_names[i]] = a
+
+    object_path = kw.get("object_path")
+    method_name = kw.get("method_name")
+    if not (isinstance(object_path, ast.Constant) and isinstance(object_path.value, str)):
+        sys.exit("FAIL: ActivityMetadata.object_path is not a string literal.")
+    if not (isinstance(method_name, ast.Constant) and isinstance(method_name.value, str)):
+        sys.exit("FAIL: ActivityMetadata.method_name is not a string literal.")
+
+    pinfo = _resolve_param_info(kw.get("parameter_location_info"), assigns, aliases)
+    if pinfo is None:
+        sys.exit(
+            "FAIL: could not resolve `parameter_location_info` to query_params/"
+            "body_fields (accepts inline ActivityParameterLocationInfo(...), a named "
+            "constant, or a dict; list or tuple values)."
+        )
+
+    expected = _expected_from_fixture()
+    if object_path.value != expected["object_path"]:
+        sys.exit(
+            f"FAIL: object_path={object_path.value!r} != describe fixture "
+            f"operation.path={expected['object_path']!r} — map it from the fixture."
+        )
+    if str(method_name.value).upper() != expected["method"].upper():
+        sys.exit(
+            f"FAIL: method_name={method_name.value!r} != fixture "
+            f"operation.method={expected['method']!r}."
+        )
+    if set(pinfo["body_fields"]) != set(expected["body_fields"]):
+        miss = sorted(set(expected["body_fields"]) - set(pinfo["body_fields"]))
+        extra = sorted(set(pinfo["body_fields"]) - set(expected["body_fields"]))
+        sys.exit(
+            "FAIL: body_fields do not match the fixture's deduped requestField "
+            f"first-segments. missing={miss} extra={extra} (Body-Field Reframing)."
+        )
+    if set(pinfo["query_params"]) != set(expected["query_params"]):
+        sys.exit(
+            f"FAIL: query_params={sorted(pinfo['query_params'])} != fixture "
+            f"query parameters={sorted(expected['query_params'])}."
+        )
+    print(
+        "OK: ActivityMetadata passed to invoke_activity is mapped from the describe "
+        "fixture (object_path/method/body_fields/query_params)"
+    )
+
+
+def check_resource_overwrites() -> None:
+    path = ROOT / "__uipath" / "uipath.json"
+    if not path.is_file():
+        sys.exit(
+            "FAIL: missing __uipath/uipath.json — the local-runtime binding "
+            "recipe requires resourceOverwrites to live here "
+            "(cli_run.py reads runtime_dir/uipath.json at local run)."
+        )
+    doc = _load_json(path)
+    overwrites = (
+        doc.get("runtime", {})
+        .get("internalArguments", {})
+        .get("resourceOverwrites", {})
+    )
+    key = f"connection.{BINDING_KEY}"
+    if key not in overwrites:
+        sys.exit(
+            f"FAIL: resourceOverwrites is missing key `{key}` (must match "
+            "the bindings.json connection resource key exactly)."
+        )
+    entry = overwrites[key]
+    if not isinstance(entry, dict):
+        sys.exit(f"FAIL: resourceOverwrites[`{key}`] is not an object.")
+
+    conn_id = entry.get("connectionId", entry.get("ConnectionId"))
+    folder_key = entry.get("folderKey")
+    # Non-empty strings: `ResourceOverwriteParser.parse` would reject null/empty
+    # and the override is silently skipped (`_common.py:217-225`).
+    for field, val in (("connectionId (or ConnectionId)", conn_id), ("folderKey", folder_key)):
+        if not (isinstance(val, str) and val.strip()):
+            sys.exit(
+                f"FAIL: resourceOverwrites for `{key}` field {field} must be a "
+                f"non-empty string (got {val!r}); the SDK skips invalid overrides "
+                "and the binding key 400s at local run."
+            )
+    if "elementInstanceId" in entry:
+        sys.exit(
+            f"FAIL: resourceOverwrites for `{key}` contains `elementInstanceId`. "
+            "`ConnectionResourceOverwrite` has `extra=\"ignore\"` and silently "
+            "drops it (capability anti-pattern #1). Remove it; `element_instance_id` "
+            "is exposed on the live `Connection.element_instance_id` after retrieve()."
+        )
+    print("OK: resourceOverwrites carries non-empty connectionId + folderKey, no elementInstanceId")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    tree = _parse_main()
+    aliases = _import_aliases(tree)
+    assigns = _assignments(tree)
+
+    check_bindings_connection()
+    check_no_lowcode_sidecar()
+    check_lazy_sdk_init(tree, aliases)
+    check_invocation_and_metadata(tree, assigns, aliases)
+    check_resource_overwrites()
+    print("PASS: coded IS smoke shape checks complete")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/is_smoke/fixtures/slack_send_message_describe.json
+++ b/tests/tasks/uipath-agents/coded/is_smoke/fixtures/slack_send_message_describe.json
@@ -1,0 +1,47 @@
+{
+  "connector": "uipath-salesforce-slack",
+  "object": "send_message_to_channel_v2",
+  "operation": {
+    "method": "POST",
+    "name": "Create",
+    "curated": "Send Message to Channel",
+    "description": "Posts a message to a Slack channel.",
+    "path": "/send_message_to_channel_v2"
+  },
+  "parameters": [
+    {
+      "name": "send_as",
+      "type": "query",
+      "dataType": "string",
+      "required": false,
+      "defaultValue": null,
+      "description": "Post as the authed user (user) or as a bot (bot)."
+    }
+  ],
+  "requestFields": [
+    { "name": "channel", "type": "string", "displayName": "Channel", "required": true, "description": "Channel ID to post to." },
+    { "name": "messageToSend", "type": "string", "displayName": "Message", "required": true, "description": "Message text." },
+    { "name": "attachment.image_url", "type": "string", "displayName": "Attachment Image URL", "required": false },
+    { "name": "attachment.text", "type": "string", "displayName": "Attachment Text", "required": false },
+    { "name": "buttons", "type": "array", "displayName": "Buttons", "required": false },
+    { "name": "fields", "type": "array", "displayName": "Fields", "required": false },
+    { "name": "icon_emoji", "type": "string", "displayName": "Icon Emoji", "required": false },
+    { "name": "icon_url", "type": "string", "displayName": "Icon URL", "required": false },
+    { "name": "image", "type": "string", "displayName": "Image", "required": false },
+    { "name": "link_names", "type": "boolean", "displayName": "Link Names", "required": false },
+    { "name": "metadata", "type": "string", "displayName": "Metadata", "required": false },
+    { "name": "mrkdwn", "type": "boolean", "displayName": "Markdown", "required": false },
+    { "name": "parse", "type": "string", "displayName": "Parse", "required": false },
+    { "name": "reply_broadcast", "type": "boolean", "displayName": "Reply Broadcast", "required": false },
+    { "name": "thread_ts", "type": "string", "displayName": "Thread Timestamp", "required": false },
+    { "name": "unfurl_links", "type": "boolean", "displayName": "Unfurl Links", "required": false },
+    { "name": "unfurl_media", "type": "boolean", "displayName": "Unfurl Media", "required": false },
+    { "name": "username", "type": "string", "displayName": "Username", "required": false }
+  ],
+  "responseFields": [
+    { "name": "ok", "type": "boolean", "displayName": "OK" },
+    { "name": "ts", "type": "string", "displayName": "Timestamp" },
+    { "name": "channel", "type": "string", "displayName": "Channel" },
+    { "name": "message", "type": "object", "displayName": "Message" }
+  ]
+}

--- a/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
@@ -1,0 +1,87 @@
+task_id: skill-agents-coded-is-smoke
+description: >
+  Smoke test for the coded Integration Service capability. The agent
+  hand-authors a coded-Python agent that invokes a Slack IS activity
+  via `sdk.connections.invoke_activity`. Validates the artefact shape
+  WITHOUT a live tenant — Critical Rule checks: ActivityMetadata
+  literal is inline (not a JSON sidecar), no module-level `UiPath()`,
+  bindings.json carries a `connection` resource with the documented
+  Connection Service envelope, and no `resources/<Tool>/resource.json`
+  sidecar (that path is lowcode-only and ignored in coded agents).
+tags: [uipath-agents, smoke, coded, mode:build, lifecycle:generate, feature:integration-service]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  turn_timeout: 900
+  max_turns: 30
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: fixtures
+
+initial_prompt: |
+  Hand-author (do NOT scaffold via the CLI) a UiPath coded Python
+  agent at `./slack-notifier/` that posts a Slack message via
+  Integration Service. Operation: Slack's curated `send_message_to_channel_v2`.
+
+  Use the `uipath-agents` skill and its coded Integration Service
+  capability doc to determine what artifacts to write and what shape
+  they need to take. Follow the doc's mandatory discovery step (read the
+  platform `agent-workflow.md` reference) even though discovery's live
+  `uip is resources describe` call is pre-recorded for you here.
+
+  The describe output for this operation is provided at
+  `./slack_send_message_describe.json` (staged in your cwd). Treat it as
+  the live `uip is resources describe --output json` result and map it to
+  your `ActivityMetadata` literal per the capability doc's mapping table.
+  Do NOT invent field names from worked examples; derive them from the
+  provided describe JSON.
+
+  No live tenant: do not run `uip codedagent init` / `run`. For the
+  required `__uipath/uipath.json` resourceOverwrite, use placeholder values
+  per the capability doc's local-run binding recipe (a real run would source
+  them from `uip is connections list`).
+
+  Agent input: `channel` (str), `message` (str). Output: `ok` (bool).
+  Bind to the connection under the key `slack-notifier`.
+
+  Do NOT pause between planning and implementation. Do NOT ask for
+  approval. Complete in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent loaded the uipath-agents skill"
+    tool_name: "Skill"
+    command_pattern: "uipath-agents"
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Loaded the platform IS discovery reference into context (mandatory preload — the capability doc requires reading agent-workflow.md before authoring an invoke_activity call, not just following the coded doc)"
+    tool_name: "Read"
+    command_pattern: 'uipath-platform/references/integration-service/agent-workflow\.md'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "slack-notifier project root exists"
+    path: "slack-notifier/pyproject.toml"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Project shape: bindings.json + ActivityMetadata mapped from describe fixture + lazy SDK init + no lowcode sidecar + 2-field resourceOverwrites"
+    command: "python3 $TASK_DIR/check_is_smoke.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Adds the **coded Integration Service capability** for `uipath-agents` — calling IS connector activities (Slack, Jira, Outlook, …) from coded Python agents via `sdk.connections.invoke_activity` — grounded against the `uipath-python` SDK and the `uip` CLI, with drift corrected.

## Capability doc

`skills/uipath-agents/references/coded/capabilities/integration-service.md`:
- `describe` → `ActivityMetadata` mapping, runtime invocation pattern, error handling, and the silent-failure anti-patterns (e.g. `elementInstanceId` dropped by `ConnectionResourceOverwrite`'s `extra="ignore"`).
- Mandatory platform-IS discovery: read **both** `agent-workflow.md` + `reference-resolution.md` before authoring a create.
- Required output artifacts incl. `__uipath/uipath.json` (the local-run binding bridge — `bindings.json` is deploy-only; verified against `cli_run.py`).
- `AskUserQuestion` stop points now present the **actual candidates as selectable options** (label + description, recommended default) with proper follow-up on ambiguity.

## Tests (`tests/tasks/uipath-agents/coded/`)

| Task | Tier | What it proves |
|---|---|---|
| `is_smoke` | smoke (tenant-free) | Project shape via an **AST-linked** check that ties the `ActivityMetadata` literal to the actual `invoke_activity` call (no dead-code false-pass); allows the one-shot pattern, named-constant/dict/tuple param info, alias-aware `UiPath`; 2-field `resourceOverwrites`. A recorded **describe fixture** lets the agent map from real output instead of fabricating. |
| `is_jira_create_issue` | e2e | Human-like prompt (agent discovers the operation); files the issue **under an epic** (default `PRODEV-685`, env-overridable); locates the result from the runtime `out.json`; verifies summary round-trip **+ epic parent**; gates **both** platform IS docs loaded; `commands_efficiency` as an effort/drift budget. |
| `is_outlook_send_mail` | e2e | Multipart `send-mail-v2`. |
| `is-e2e-setup.md` | — | Tenant/connection/env runbook for running the e2e locally or in CI. |

## Verification

- **Smoke: 4/4** across multiple agentic runs (incl. from the moved path).
- **Jira e2e: 9/9** against a live tenant (created issues under `PRODEV-685`; summary + epic parent confirmed).
- Adversarial review (Codex + Agy) of the smoke check addressed; 7/7 self-tests on the rewritten validator.

## Notes

- IS tasks organized under `coded/` (dropped the redundant `coded_is_` prefix).
- E2e CI wiring (seed env vars + pre-provisioned connections) is documented in `is-e2e-setup.md`; the connections must exist in the test tenant's `Shared/uipath-agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)