### PR TITLE
fix(tests): disallow Task* tools in guardrail_escalation_app to stop max_turns flake

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/guardrail_escalation_app/guardrail_escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrail_escalation_app/guardrail_escalation_app.yaml
@@ -14,6 +14,11 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+  # Disallow built-in todo tools — they aren't gated by allowed_tools, and the
+  # agent variably spends 6–20 of its 40-turn budget on TaskCreate/TaskUpdate,
+  # which pushes long-workflow tasks (validate + migrate at the end) past the
+  # turn cap. Empirically: 6 Task* calls → SUCCESS, 20 Task* calls → FAIL.
+  disallowed_tools: ["TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
   max_turns: 40
   turn_timeout: 1200
 


### PR DESCRIPTION
## What changed?

Added `disallowed_tools: ["TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]` to the `agent:` block of `tests/tasks/uipath-agents/lowcode/guardrail_escalation_app/guardrail_escalation_app.yaml`.

### Root cause

The task was flaking with `MAX_TURNS_EXHAUSTED` (e.g. score=0.667, "Agent did not run `uip agent validate`, `.agent-builder/agent.json` was not generated").

`allowed_tools` in the task YAML is **not a strict whitelist** in the Claude Code SDK — built-in agent tools like `TaskCreate` / `TaskUpdate` fire unless explicitly listed in `disallowed_tools`. Each `Task*` call burns a tool-use turn from the 40-turn budget, and the agent decides per-run how aggressively to maintain a todo list. On heavy-`Task*` runs the agent ran out of budget before reaching `uip agent validate` / `migrate` — `.agent-builder/agent.json` was never regenerated and the guardrail check failed.

## How has this been tested?

Reproduced the flake locally with the default experiment (`make` not used — single-task `coder-eval run` against `experiments/default.yaml`), then ran 3 more times with the fix applied.

**Before fix** — 1/3 failed (33% flake rate):

| Run | Task* calls | Bash calls | Total cmds | Status | Score |
|-----|-------------|------------|------------|--------|-------|
| 1   | 6           | 19         | 36         | SUCCESS, no exhaustion | 1.000 |
| 2   | 14          | 16         | 40         | SUCCESS, max_turns_exhausted (just made it) | 1.000 |
| 3   | **20**      | 13         | 45         | **FAIL — MAX_TURNS_EXHAUSTED** | **0.875** |

In run-3, turns 13–19 were 7 sequential `TaskCreate` calls; another 13 turns went to `TaskUpdate`. By the time the agent finished editing `agent.json`, the budget was gone — `uip agent validate` never ran, matching the failure mode in the reported error log.

**After fix** — 3/3 passed:

| Run | Task* calls | Bash calls | Total cmds | Status | Score |
|-----|-------------|------------|------------|--------|-------|
| fix-1 | 0 | 14 | 23 | SUCCESS, no exhaustion | 1.000 |
| fix-2 | 0 | 26 | 36 | SUCCESS, no exhaustion | 1.000 |
| fix-3 | 0 | 18 | 29 | SUCCESS, no exhaustion | 1.000 |

`fix-2` used more Bash than any pre-fix run (26 vs max 19) and still completed cleanly — the recovered tool-turns absorb Bash variance instead of bookkeeping noise.

## Are there any breaking changes?

- [x] None
- [ ] Under Feature Flag
- [ ] DB migrations
- [ ] API removals

## Follow-up

Sibling tasks (`guardrail_pii_detection`, `guardrail_custom_word`, `guardrail_escalation_app_validation`, other `uipath-agents/lowcode/*` tasks) have the same `allowed_tools` shape and no `disallowed_tools`. They're likely flaky on the same axis — just less visibly because their workflows are shorter. Not addressed in this PR (scope limited to the reported failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)