### PR TITLE
test(uipath-agents): pin coded-hitl-create-task-with-app prompt to named scaffold folder

### DIFF
--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -39,6 +39,9 @@ initial_prompt: |
     - `issue_refund` (bool)
     - `reviewer_note` (string|null)
 
+  Scaffold the agent project inside a `refund-gate/` directory at
+  the working-directory root.
+
   Take the agent through scaffold → schema sync. Do NOT run,
   publish, upload, or deploy. Do NOT call `uip login`. Do NOT pause
   between planning and implementation. Complete end-to-end in a


### PR DESCRIPTION
`uip codedagent new <name>` creates files in the CURRENT directory, not in a `<name>/` subdirectory. The test's `file_exists` assertion expects `refund-gate/langgraph.json`, but the prompt didn't pin the scaffold location — so agents that didn't first `mkdir refund-gate && cd refund-gate` ended up with files at cwd root and missed the assertion. Same fix pattern as #1002 (coded-hitl-wait-task) and #985 (coded-in-flow-published): one sentence in the prompt naming the target folder.
Validated with a local run.