### PR TITLE
fix(uipath-agents): move ContextGroundingRetriever inside node bodies and add folder_path

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/context-grounding.md
+++ b/skills/uipath-agents/references/coded/capabilities/context-grounding.md
@@ -79,10 +79,9 @@ class GraphState(MessagesState):
     query: str
     answer: str | None = None
 
-retriever = ContextGroundingRetriever(index_name="company_docs")
-
 async def retrieve_context(state: GraphState) -> Command:
     """Retrieve relevant documents from context grounding."""
+    retriever = ContextGroundingRetriever(index_name="company_docs", folder_path="Shared")
     documents = await retriever.ainvoke(state["query"])
     context = "\n".join([doc.page_content for doc in documents])
     return Command(update={
@@ -151,7 +150,7 @@ async def search_company_docs(query: str) -> str:
     Returns:
         Relevant documents matching the query
     """
-    retriever = ContextGroundingRetriever(index_name="company_docs")
+    retriever = ContextGroundingRetriever(index_name="company_docs", folder_path="Shared")
     documents = await retriever.ainvoke(query)
     return "\n".join([doc.page_content for doc in documents])
 
@@ -186,7 +185,7 @@ tools = [search_company_docs]
 
 ```python
 async def qa_system(question: str) -> dict:
-    retriever = ContextGroundingRetriever(index_name="faq_docs")
+    retriever = ContextGroundingRetriever(index_name="faq_docs", folder_path="Shared")
     docs = await retriever.ainvoke(question)
 
     if not docs:


### PR DESCRIPTION
## Summary

- Moved `ContextGroundingRetriever` instantiation from module level into node/function bodies in the LangGraph Integration example — the pattern the lazy-init rule requires
- Added `folder_path=` to three examples that were missing it (LangGraph Integration, Agent Integration `@tool`, QA System pattern)

## Why

The `context-grounding.md` LangGraph Integration example showed the retriever constructed at **module level without `folder_path`**. Agents reading this example would either omit `folder_path` or place the retriever outside a node body, leading to ~50% failure rate on the `rag_langgraph` eval.

Also addresses all review comments from PR #990 (fork-based, closing in favour of this one).

## Test plan

- [x] Ran `rag_langgraph` eval 5 times — 5/5 passed (score 1.0 each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)