### PR TITLE
docs(uipath-rpa): REFramework guide + XAML authoring pitfalls (UV-14650)

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -333,6 +333,7 @@ The XAML file anatomy template (namespace declarations, root Activity element, b
 
 - [xaml/xaml-basics-and-rules.md](references/xaml/xaml-basics-and-rules.md) — XAML anatomy, safety rules, editing operations (read before any XAML work)
 - [xaml/common-pitfalls.md](references/xaml/common-pitfalls.md) — Activity gotchas, scope requirements, property conflicts
+- [reframework-guide.md](references/reframework-guide.md) — REFramework execution modes, SetTransactionStatus queue-guard fix, Config.xlsx leftover trap
 - [xaml/csharp-activity-binding-guide.md](references/xaml/csharp-activity-binding-guide.md) — Canonical C# binding forms per common activity property (LogMessage, GetText, StartProcess, …) — flat lookup table + recipes
 - [xaml/csharp-expression-pitfalls.md](references/xaml/csharp-expression-pitfalls.md) — C#-specific expression failures (attribute-form VB JIT, ThrowIfNotInTree, OutArgument parse errors)
 - [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) — Flowchart, State Machine, and Long Running Workflow canvas layout with ViewState

--- a/skills/uipath-rpa/references/legacy/activity-docs/_REFRAMEWORK.md
+++ b/skills/uipath-rpa/references/legacy/activity-docs/_REFRAMEWORK.md
@@ -405,14 +405,14 @@ When processing data from Excel/CSV/DataTable without Orchestrator queues, modif
    ' Read Range: in_Config("DataSourcePath"), Sheet: in_Config("DataSourceSheet") → io_dt_TransactionData
    ```
 
-2. In `GetTransactionData.xaml`, use `in_TransactionNumber` as a row counter:
+2. In `GetTransactionData.xaml`, use `in_TransactionNumber` as a row counter (1-indexed — matches the Config.xlsx default `TransactionNumber = 1`, incremented by `SetTransactionStatus.xaml`):
    ```vb
    ' Check if more rows exist:
-   If in_TransactionNumber >= io_dt_TransactionData.Rows.Count Then
+   If in_TransactionNumber > io_dt_TransactionData.Rows.Count Then
        out_TransactionItem = Nothing   ' Signals "no more data" → End Process
    Else
-       ' Return current row as the transaction item:
-       out_TransactionItem = io_dt_TransactionData.Rows(in_TransactionNumber)
+       ' Return current row as the transaction item (1-indexed → 0-based row access):
+       out_TransactionItem = io_dt_TransactionData.Rows(in_TransactionNumber - 1)
    End If
    ```
 

--- a/skills/uipath-rpa/references/reframework-guide.md
+++ b/skills/uipath-rpa/references/reframework-guide.md
@@ -1,0 +1,178 @@
+# REFramework Guide
+
+Patterns for building and customizing Robotic Enterprise Framework projects on Windows, Portable, or Legacy targets. State-machine internals are in [legacy/activity-docs/_REFRAMEWORK.md](legacy/activity-docs/_REFRAMEWORK.md) — that guide's architecture sections are mode-agnostic.
+
+## When to Use REFramework
+
+Use:
+- Multi-item transactional processing (invoices, queue items, data rows).
+- Production-grade retry, logging, and exception handling.
+- Multi-robot horizontal scaling on a shared Orchestrator queue.
+
+Don't use:
+- Simple linear processes (read → do one thing → exit). Plain `Sequence` is enough.
+- Attended automations with continuous user interaction.
+- Single-call jobs under ~30 seconds total. The four-state ceremony costs more than it saves.
+
+## The Four States
+
+| State | Role |
+|-------|------|
+| `Init` | `InitAllSettings.xaml` reads `Config.xlsx` → `Config` dictionary; `KillAllProcesses.xaml`; `InitAllApplications.xaml` opens/authenticates apps. |
+| `Get Transaction Data` | `GetTransactionData.xaml` returns the next item or `Nothing`. `Nothing` → End Process. |
+| `Process Transaction` | `Process.xaml` (your business logic) → `SetTransactionStatus.xaml` (Success / BusinessRuleException / System Exception). |
+| `End Process` | `CloseAllApplications.xaml` runs on every exit (success or abort). |
+
+Full state machine, transitions, and per-state counter semantics: [legacy/activity-docs/_REFRAMEWORK.md § State Machine Architecture](legacy/activity-docs/_REFRAMEWORK.md).
+
+## Execution Mode: Queue-Driven (Canonical)
+
+The default and most common mode. Dispatcher project populates an Orchestrator queue; this Performer project consumes one item per transaction. Multi-robot parallelism comes for free via queue locking.
+
+**Wiring — keep the template as-is.** The shipped REFramework is built for this mode end-to-end.
+
+1. `Config.xlsx` Settings sheet: set `OrchestratorQueueName` (case-sensitive, must match the queue in Orchestrator) and optionally `OrchestratorQueueFolder`.
+2. `Framework\GetTransactionData.xaml`: uses the `Get Transaction Item` activity. Returns a `QueueItem` or `Nothing` (queue empty → End Process).
+3. `Framework\Process.xaml`: implement business logic. Access fields via:
+   ```vb
+   in_TransactionItem.SpecificContent("FieldName").ToString()
+   in_TransactionItem.Reference
+   in_TransactionItem.Priority
+   in_TransactionItem.DueDate
+   ```
+4. `Framework\SetTransactionStatus.xaml`: keep the three Set Transaction Status calls — they update item status in Orchestrator.
+
+**Dispatcher pattern (separate project).** Read input data, then for each row emit `Add Queue Item` with a unique `Reference`, optional `Priority` / `DueDate`, and the fields as `SpecificContent`. Dispatcher does not need REFramework — a simple `Sequence` is sufficient.
+
+**Concurrency.** Orchestrator locks each item to one robot for the duration of processing. Design `Process.xaml` **stateless** so any robot can pick up any item. To scale throughput, add robots — do not add intra-robot parallelism.
+
+## Execution Mode: Tabular Data
+
+Single robot, no Orchestrator queue. Source data is an Excel/CSV/DataTable. The Academy course "REFramework with Tabular Data" (v2024.10) is the reference pattern.
+
+**Wiring — customize these surfaces.**
+
+1. `Config.xlsx` Settings sheet: blank or remove `OrchestratorQueueName`; add `DataSourcePath` and `DataSourceSheet`.
+2. `Framework\InitAllSettings.xaml` (or a custom init step): Read Range → `io_dt_TransactionData`. **Read the source once**, not per transaction — repeated reads cause file locks and waste cycles.
+3. `Framework\GetTransactionData.xaml`:
+   ```vb
+   If in_TransactionNumber > io_dt_TransactionData.Rows.Count Then
+     out_TransactionItem = Nothing                  ' signals "no more data"
+   Else
+     out_TransactionItem = io_dt_TransactionData.Rows(in_TransactionNumber - 1)
+   End If
+   ```
+   Assumes `TransactionNumber` is 1-indexed (Config.xlsx default `TransactionNumber = 1`, incremented by `SetTransactionStatus.xaml`). If your template starts at 0, use `>=` and drop the `- 1`.
+4. `Framework\Process.xaml`: access fields via `in_TransactionItem("ColumnName").ToString()`.
+5. `Framework\SetTransactionStatus.xaml`: **delete the three Set Transaction Status activities.** They target Orchestrator queues and have no purpose here. Replace with a status-column write-back to the source DataTable, an output Excel/CSV, or `Log Message` calls keyed by row index.
+
+**Type migration.** Changing `TransactionItem`'s type from `QueueItem` to `DataRow` cascades across every `TransactionItem` argument in the Framework workflows and every matching `InvokeWorkflowFile` binding in `Main.xaml`. Update them together or `InvokeWorkflowFile` reports argument-mismatch errors at design time. See [Gotchas § type migration](#gotchas) for the file/argument list.
+
+## Execution Mode: Single-Shot
+
+One execution, no transaction loop. Useful for scheduled jobs that just need REFramework's init/cleanup discipline (open apps, do one thing, close apps).
+
+**Wiring.**
+
+1. `Config.xlsx`: blank `OrchestratorQueueName`.
+2. `Framework\GetTransactionData.xaml`: return a sentinel on call 1, `Nothing` on call 2:
+   ```vb
+   If in_TransactionNumber = 1 Then
+     out_TransactionItem = New Object()             ' placeholder, NOT New QueueItem()
+   Else
+     out_TransactionItem = Nothing
+   End If
+   ```
+3. `Framework\Process.xaml`: implement the single unit of work. `in_TransactionItem` is a sentinel — ignore it.
+4. `Framework\SetTransactionStatus.xaml`: **delete the three Set Transaction Status activities** (same reason as tabular). Log-only is fine.
+
+**Type migration.** Type `TransactionItem` as `System.Object` across every Framework workflow and every `InvokeWorkflowFile` binding. See [Gotchas § type migration](#gotchas).
+
+## Exception Handling Strategy
+
+| Exception | Class | Retry? | Counter behavior |
+|-----------|-------|--------|------------------|
+| Business Rule Exception | `UiPath.Core.BusinessRuleException` | No — data won't fix itself | `ConsecutiveSystemExceptions` resets to 0 |
+| System Exception | `System.Exception` (any other) | Yes — retry per transaction up to `MaxRetryNumber`; re-initialize apps between retries | `ConsecutiveSystemExceptions` increments; hitting `MaxConsecutiveSystemExceptions` aborts to End Process |
+
+Throw business exceptions explicitly in `Process.xaml`:
+
+```vb
+Throw New BusinessRuleException("Invoice amount cannot be negative")
+```
+
+Do NOT wrap `Process.xaml` in a catch-all `TryCatch` — the framework's outer handler is what classifies and routes the exception. Catch only exceptions you intend to translate to a `BusinessRuleException`.
+
+Counter semantics — `MaxRetryNumber` (per transaction, resets per item) vs `MaxConsecutiveSystemExceptions` (global, resets on any success or BusinessRuleException): see [legacy/activity-docs/_REFRAMEWORK.md § MaxRetryNumber vs MaxConsecutiveSystemExceptions](legacy/activity-docs/_REFRAMEWORK.md).
+
+## Configuration Management
+
+- Store all configurable values in `Config.xlsx` — three sheets: `Settings` (key-value, edited per environment), `Constants` (rarely change), `Assets` (Orchestrator asset names, fetched at runtime).
+- Sensitive values (credentials, API keys, tokens) → **Orchestrator Assets**, never `Config.xlsx` cell values.
+- Asset names on the Assets sheet must match Orchestrator exactly (case-sensitive).
+- Config values come back as `String` — convert explicitly: `CInt(in_Config("MaxRetryNumber"))`, `CDate(in_Config("Deadline"))`.
+- Guard missing keys: check `in_Config.ContainsKey(<name>)` or set defaults before first read.
+- Never hardcode paths, URLs, credentials, or environment-specific settings in workflows. Always indirect through `in_Config(<name>)`.
+
+## Idempotency and Concurrency (Queue-Driven)
+
+Performer workflows must be safe to retry. The framework re-executes `Process.xaml` after a System Exception with the same `TransactionItem`.
+
+- Avoid double-posting (check-then-act, or use idempotency tokens from the source system).
+- Avoid relying on in-memory state from a prior transaction — design stateless.
+- Orchestrator handles queue-item locking; do not add custom locking logic.
+- Multiple robots on the same queue: each locks one item while processing. To scale throughput, add robots — not intra-robot parallelism.
+- Validate `SpecificContent` fields at the start of `Process.xaml` — don't trust the Dispatcher.
+
+## Gotchas
+
+### Don't return `New QueueItem()` as a sentinel in non-queue modes
+
+`Framework\SetTransactionStatus.xaml` gates its Orchestrator calls on `in_TransactionItem.GetType is GetType(UiPath.Core.QueueItem)`. `New QueueItem()` satisfies this check — so a synthetic empty `QueueItem` returned from a tabular or single-shot `GetTransactionData.xaml` cascades into 6 retries × 3 branches of `OrchestratorHttpException: 404 (Not Found)`.
+
+**Right fix:** delete the Set Transaction Status activities from `SetTransactionStatus.xaml` for non-queue modes (see the per-mode wiring above) and return `Nothing` / non-`QueueItem` sentinels from `GetTransactionData.xaml`.
+
+### `Config.xlsx OrchestratorQueueName="ProcessABCQueue"` template leftover
+
+The shipped template ships with the sample value `OrchestratorQueueName = "ProcessABCQueue"`. Tabular and single-shot users rarely overwrite it. A Config-string check (e.g., `Not String.IsNullOrEmpty(in_Config("OrchestratorQueueName").ToString())`) is therefore insufficient on its own — the leftover sample value passes. **Blank or remove the row** in non-queue projects.
+
+### Type migration cascade
+
+If you migrate `TransactionItem`'s type away from `QueueItem` (tabular → `DataRow` or `Object`; single-shot → `Object`), update every site, not just `Main.xaml`'s variable:
+
+| File | Argument |
+|------|----------|
+| `Main.xaml` | `TransactionItem` variable |
+| `Framework\GetTransactionData.xaml` | `out_TransactionItem` |
+| `Framework\Process.xaml` | `in_TransactionItem` |
+| `Framework\SetTransactionStatus.xaml` | `in_TransactionItem` |
+| `Framework\RetryCurrentTransaction.xaml` | `in_TransactionItem` (if present) |
+| `Main.xaml` `InvokeWorkflowFile` bindings | every `in_/out_/io_TransactionItem` binding |
+
+Updating one file but not the others surfaces as `InvokeWorkflowFile` argument-mismatch errors at design time.
+
+### Advanced: one `SetTransactionStatus.xaml` for all modes
+
+If you want a single `SetTransactionStatus.xaml` that handles all three modes (rare — usually it's cleaner to delete the Orchestrator calls in non-queue modes), type `in_TransactionItem` as `System.Object` and replace the three FlowDecision conditions with a type-safe guard:
+
+```vb
+TypeOf in_TransactionItem Is UiPath.Core.QueueItem AndAlso DirectCast(in_TransactionItem, UiPath.Core.QueueItem).QueueDefinitionId > 0
+```
+
+`TypeOf ... Is` short-circuits on non-`QueueItem` references; `QueueDefinitionId > 0` filters out empty `New QueueItem()` instances. Requires the full `Object`-typed migration above.
+
+## Customization Checklist
+
+Before first run:
+
+- [ ] **Pick execution mode** — queue-driven / tabular / single-shot.
+- [ ] **Set or blank `OrchestratorQueueName`** in `Config.xlsx` per mode. Sample value `ProcessABCQueue` must not survive into non-queue projects.
+- [ ] **Configure `GetTransactionData.xaml`** for the chosen mode. Never return `New QueueItem()` as a sentinel in non-queue modes — return `Nothing` (terminating) or a non-`QueueItem` value.
+- [ ] **For tabular / single-shot:** delete the three Set Transaction Status activities from `SetTransactionStatus.xaml`. Replace with status-column write-back or log-only.
+- [ ] **For tabular / single-shot:** migrate every `TransactionItem` argument type (see [Gotchas § type migration](#type-migration-cascade)).
+- [ ] **`InitAllApplications.xaml`** — implement app-open/login for every application the process touches.
+- [ ] **`CloseAllApplications.xaml`** + **`KillAllProcesses.xaml`** — graceful close + force-kill fallback for every app process name.
+- [ ] **Classify exceptions in `Process.xaml`** — throw `BusinessRuleException` for data issues; let everything else propagate.
+- [ ] **Move secrets to Orchestrator Assets** — credentials, API keys, environment-specific URLs.
+- [ ] **Set `MaxRetryNumber = 0` during development** to surface failures fast; restore the production value before deployment.
+- [ ] **Verify**: run a synthetic transaction through every exit branch (Success, BusinessRuleException, System Exception → retry, System Exception → abort).

--- a/skills/uipath-rpa/references/xaml/common-pitfalls.md
+++ b/skills/uipath-rpa/references/xaml/common-pitfalls.md
@@ -523,6 +523,30 @@ Use `uip rpa activities get-default-xaml` to get correct xmlns declarations — 
 - **LookupDataTable column resolution**: When multiple column identifiers are set (shouldn't happen due to OverloadGroups), only the first non-null is used: `LookupColumnIndex ?? LookupColumnName ?? LookupDataColumn`
 - **FilterDataTable**: Column must exist AND be type-compatible with the filter operator. Filtering a DateTime column with "Contains" fails at CacheMetadata validation.
 - **BuildDataTable**: Uses a security-related allowed types list. DataTables with certain .NET types may fail to serialize/deserialize.
+- **BuildDataTable — `TableInfo` is designer-only.** The required `TableInfo` property is a serialized string with no documented format; activity docs say "configure through the designer instead". **Cannot be authored in agent-written XAML.** Skip the activity. Build the DataTable inline with `Assign` + `InvokeMethod` instead. Requires the standard `sd` namespace alias (matches the rest of the activity-docs corpus — see `ForEachRow.md` and `AddDataRow.md`) and `xmlns:s`.
+
+  **VB XAML** (`expressionLanguage: VisualBasic` — bracket shorthand `[expr]`, `New T()`, `GetType(T)`):
+  ```xml
+  <!-- Modern (Windows/Portable):
+       xmlns:sd="clr-namespace:System.Data;assembly=System.Data"
+       xmlns:s="clr-namespace:System;assembly=System.Private.CoreLib" -->
+  <!-- Legacy (.NET Framework 4.6.1):
+       xmlns:sd="clr-namespace:System.Data;assembly=System.Data"
+       xmlns:s="clr-namespace:System;assembly=mscorlib" -->
+  <Variable x:TypeArguments="sd:DataTable" Name="dt" Default="[New System.Data.DataTable()]" />
+  ...
+  <InvokeMethod TargetObject="[dt.Columns]" MethodName="Add">
+    <InArgument x:TypeArguments="x:String">Name</InArgument>
+    <InArgument x:TypeArguments="s:Type">[GetType(System.String)]</InArgument>
+  </InvokeMethod>
+  <InvokeMethod TargetObject="[dt.Columns]" MethodName="Add">
+    <InArgument x:TypeArguments="x:String">Amount</InArgument>
+    <InArgument x:TypeArguments="s:Type">[GetType(System.Decimal)]</InArgument>
+  </InvokeMethod>
+  ```
+  **C# XAML** (`expressionLanguage: CSharp`): replace bracket-shorthand expressions with `<CSharpValue x:TypeArguments="T">...</CSharpValue>` / `<CSharpReference x:TypeArguments="T">...</CSharpReference>` wrappers inside the `<InArgument>`/`<Default>` elements. See [csharp-activity-binding-guide.md](csharp-activity-binding-guide.md) for the full binding form per property.
+
+  Note the `s:Type` argument — `x:Type` resolves to `TypeExtension` and fails (see § Invalid Use of `x:` Prefix). `assembly=System.Data` works in both targets via .NET type forwarding; `System.Data.Common` is the canonical home in modern .NET but the bundled UiPath docs standardize on `System.Data`.
 - **GetRowItem**: Must specify at least one of `Column`, `ColumnIndex`, or `ColumnName` — all three empty causes validation error.
 
 ## Testing Activity Gotchas
@@ -676,6 +700,7 @@ The error occurs because the XAML language schema does not register `DateTime`, 
 | `x:Guid` | `s:Guid` | — |
 | `x:Uri` | `s:Uri` | — |
 | `x:Exception` | `s:Exception` | `<Catch x:TypeArguments="s:Exception">`, `Throw` argument types |
+| `x:Type` | `s:Type` | `<InArgument x:TypeArguments="x:Type">` silently resolves to `System.Activities.XamlIntegration.TypeExtension`, NOT `System.Type`. Passing `[GetType(System.String)]` fails with `BC30311: Value of type 'Type' cannot be converted to 'TypeExtension'`. Required by `InvokeMethod` calls into APIs that take `System.Type` (e.g. `DataColumnCollection.Add(name, type)`). |
 
 For types outside of `System`, add the matching CLR namespace alias. Examples:
 ```xml
@@ -713,6 +738,40 @@ Correct — requires `xmlns:s="clr-namespace:System;assembly=System.Private.Core
 ```
 
 The same rule applies anywhere a type argument appears: `x:TypeArguments` on `Variable`, `InArgument`, `OutArgument`, `CSharpValue`, `CSharpReference`, `ActivityAction`, `DelegateInArgument`, etc.
+
+---
+
+## Array Types in `Variable` Declarations
+
+The XAML parser rejects CLR array syntax in `<Variable x:TypeArguments="...">`. `<Variable x:TypeArguments="x:String[]">` fails to load with `Cannot create unknown type ... Variable(String[])`. The error message does not hint at the fix.
+
+**Use `scg:List(<T>)` instead of `<T>[]`** for variable declarations. Required `xmlns:scg` declaration depends on `targetFramework`:
+
+- **Modern (Windows/Portable):** `xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib"`
+- **Legacy (.NET Framework 4.6.1):** `xmlns:scg="clr-namespace:System.Collections.Generic;assembly=mscorlib"`
+
+Wrong:
+```xml
+<Variable x:TypeArguments="x:String[]" Name="paths" />
+```
+
+Correct — **VB XAML** (`expressionLanguage: VisualBasic`, bracket shorthand for the default expression):
+```xml
+<Variable x:TypeArguments="scg:List(x:String)" Name="paths" Default="[New List(Of String)()]" />
+```
+
+Correct — **C# XAML** (`expressionLanguage: CSharp`): drop the `Default` attribute and use `<Variable.Default>` with `<CSharpValue>` instead; see [csharp-activity-binding-guide.md](csharp-activity-binding-guide.md).
+
+**`InArgument` with array `x:TypeArguments` — context-dependent.** The canonical XAML for `AddDataRow.ArrayRow` (see [`../activity-docs/UiPath.System.Activities/26.4/activities/AddDataRow.md`](../activity-docs/UiPath.System.Activities/26.4/activities/AddDataRow.md)) uses `<InArgument x:TypeArguments="x:Object[]">[New Object() { ... }]</InArgument>` and Studio accepts it. Some agent-authored variants of the same form have been reported to fail at parse time — root cause unverified. **If `InArgument x:TypeArguments="x:Object[]"` fails in your project, fall back to calling the underlying params overload via `InvokeMethod`** (only safe when the target method has a `ParamArray Object()` / `params object[]` overload — `DataRowCollection.Add` does):
+
+```xml
+<InvokeMethod TargetObject="[dt.Rows]" MethodName="Add">
+  <InArgument x:TypeArguments="x:String">Alice</InArgument>
+  <InArgument x:TypeArguments="x:Int32">42</InArgument>
+</InvokeMethod>
+```
+
+This pattern is NOT a general substitute for fixed-arity array parameters — only for `ParamArray`/`params` overloads where the runtime builds the array from N positional arguments. For non-params arrays (e.g. `Method(int[] arr)`), `InvokeMethod` with N separate `<InArgument>` children does not work; the array must be constructed in a preceding `Assign`.
 
 ---
 


### PR DESCRIPTION
## Summary
- New `references/reframework-guide.md` covering queue-driven (canonical), tabular, and single-shot modes with explicit per-mode wiring. UV-14650 friction points (SetTransactionStatus 404 cascade on synthetic `New QueueItem()`, `OrchestratorQueueName="ProcessABCQueue"` template leftover, type-migration cascade) are demoted to a Gotchas section so the canonical usage stays at the top.
- Extends `xaml/common-pitfalls.md` with `BuildDataTable` (`TableInfo` is designer-only), `x:Type` resolving to `TypeExtension` (use `s:Type`), and array-typed `Variable` declarations. Each new snippet is labeled **VB XAML** or **C# XAML**, with Modern (`System.Private.CoreLib`) and Legacy (`mscorlib`) namespace declarations spelled out separately.
- Aligns `legacy/activity-docs/_REFRAMEWORK.md` tabular indexing with the new guide (1-indexed: `> Rows.Count`, `Rows(n - 1)`) — the legacy guide previously contradicted its own `TransactionNumber = 1` default.
- Adds the `reframework-guide.md` link under `SKILL.md` XAML Key References.

Source material: UV-14650 (12 friction points from a Google Finance UI automation in a Windows REFramework project), Academy courses 01 / 14 / 15 (REFramework intro, queue-based, tabular-data), and the existing `legacy/_REFRAMEWORK.md` for state-machine architecture.

Scope: points 4–10 of UV-14650 (REFramework + XAML authoring). Points 1, 2, 3, 11, 12 are out of scope for this PR.

## Test plan
- [ ] `bash skills/uipath-rpa/hooks/validate-skill-descriptions.sh` exits 0
- [ ] All new internal links resolve (`reframework-guide.md` → `legacy/_REFRAMEWORK.md`, `common-pitfalls.md` → `csharp-activity-binding-guide.md`)
- [ ] Spot-check on a real REFramework project (`~/Documents/UiPath/`): replace `SetTransactionStatus.xaml` type-identity guard per the guide, run a synthetic single-shot, confirm no Orchestrator 404 cascade in the log
- [ ] Author a workflow with `Variable<scg:List(x:String)>` and `<InArgument x:TypeArguments="s:Type">[GetType(System.String)]</InArgument>`; confirm `uip rpa validate` + `uip rpa build` pass on both Modern and Legacy targets