### PR TITLE
test(uipath-maestro-flow): drop redundant folder-resolution hints from offline tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -33,10 +33,6 @@ initial_prompt: |
   If the Atlassian Jira connector is not present in the registry, stop —
   this test exercises GenerateSchema, which has no managed-HTTP fallback.
 
-  Test connections for this task live in Orchestrator folder "Shared/uipath-maestro-flow".
-  Resolve its key with `uip or folders get "Shared/uipath-maestro-flow" -o json`
-  and pass `--folder-key <key>` on every `uip is connections list` call.
-
 success_criteria:
   - type: run_command
     description: "Flow is valid JSON with Jira Create Issue node, customFieldsRequestDetails has both parent-field tuples under GenerateSchema, and bodyParameters carries a non-empty fields.summary"

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -22,10 +22,6 @@ initial_prompt: |
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
-  Test connections for this task live in Orchestrator folder "Shared/uipath-maestro-flow".
-  Resolve its key with `uip or folders get "Shared/uipath-maestro-flow" -o json`
-  and pass `--folder-key <key>` on every `uip is connections list` call.
-
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -21,10 +21,6 @@ initial_prompt: |
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
-  Test connections for this task live in Orchestrator folder "Shared/uipath-maestro-flow".
-  Resolve its key with `uip or folders get "Shared/uipath-maestro-flow" -o json`
-  and pass `--folder-key <key>` on every `uip is connections list` call.
-
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes"

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -38,10 +38,6 @@ initial_prompt: |
   Step 3 for resolving the `parentFolderId` reference field against the bound
   connection. Do not reuse any folder ID you may have seen before.
 
-  Test connections for this task live in Orchestrator folder "Shared/uipath-maestro-flow".
-  Resolve its key with `uip or folders get "Shared/uipath-maestro-flow" -o json`
-  and pass `--folder-key <key>` on every `uip is connections list` call.
-
 success_criteria:
   # ── Structural: flow builds and validates ──────────────────────────────
   - type: run_command


### PR DESCRIPTION
## Summary
- The `uipath-maestro-flow` skill now mandates `uip is connections list --all-folders` across the `connector`, `connector-trigger`, and `http` plugins (see `skills/uipath-maestro-flow/references/author/references/plugins/*/impl.md`).
- With `--all-folders` doing the cross-folder discovery automatically, the per-task hint telling the model to resolve `Shared/uipath-maestro-flow` and pass `--folder-key <key>` on every `uip is connections list` call is redundant — it adds noise without changing behavior.
- Removes that block from four offline `uipath-maestro-flow` test tasks. No success-criteria or assertion changes.

Affected tasks:
- `tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml`
- `tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml`
- `tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml`
- `tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml`

## Test plan
- [ ] Re-run each affected offline task and confirm the agent still resolves the correct connection via `--all-folders`.
- [ ] Confirm success criteria continue to pass without the explicit folder-key hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)