### PR TITLE
fix(tests): accept boolean-decision HITL in DevCon expense approval checker

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -68,8 +68,8 @@ def main() -> None:
     outcomes = schema.get("outcomes")
     if not isinstance(fields, list) or not fields:
         fail("HITL schema must define fields")
-    if not isinstance(outcomes, list) or len(outcomes) < 2:
-        fail("HITL schema must define at least two outcomes")
+    if not isinstance(outcomes, list) or not outcomes:
+        fail("HITL schema must define outcomes")
 
     if not any(
         (field_text(f, "id") == "amount" or "amount" in field_text(f, "label")) and f.get("type") == "number"

--- a/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
@@ -6,73 +6,92 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 
 CHECKER = Path(__file__).with_name("check_devcon_expense_approval.py")
 
 
-def _write_flow(tmp_path: Path, binding: str) -> None:
+def _flow_doc(
+    *,
+    fields: list[dict[str, Any]],
+    outcomes: list[dict[str, Any]],
+    script_body: str = "return $vars.reviewExpense.output.rejectionreason;",
+) -> dict[str, Any]:
+    return {
+        "nodes": [
+            {
+                "id": "fetchExpense",
+                "type": "core.action.script",
+                "inputs": {
+                    "script": "return { amount: 42, category: 'Travel' };"
+                },
+            },
+            {
+                "id": "reviewExpense",
+                "type": "uipath.human-in-the-loop",
+                "typeVersion": "1.0",
+                "inputs": {
+                    "schema": {
+                        "fields": fields,
+                        "outcomes": outcomes,
+                    }
+                },
+            },
+            {
+                "id": "logOutcome",
+                "type": "core.action.script",
+                "inputs": {"script": script_body},
+            },
+        ],
+        "edges": [
+            {
+                "sourceNodeId": "reviewExpense",
+                "sourcePort": "completed",
+                "targetNodeId": "logOutcome",
+                "targetPort": "input",
+            }
+        ],
+    }
+
+
+def _write_flow(tmp_path: Path, doc: dict[str, Any]) -> None:
     project = tmp_path / "ExpenseApproval" / "ExpenseApproval"
     project.mkdir(parents=True)
-    flow = project / "ExpenseApproval.flow"
-    flow.write_text(
-        json.dumps(
-            {
-                "nodes": [
-                    {
-                        "id": "fetchExpense",
-                        "type": "core.action.script",
-                        "inputs": {
-                            "script": "return { amount: 42, category: 'Travel' };"
-                        },
-                    },
-                    {
-                        "id": "reviewExpense",
-                        "type": "uipath.human-in-the-loop",
-                        "typeVersion": "1.0",
-                        "inputs": {
-                            "schema": {
-                                "fields": [
-                                    {
-                                        "id": "amount",
-                                        "label": "Amount",
-                                        "type": "number",
-                                        "direction": "input",
-                                        "binding": binding,
-                                    },
-                                    {
-                                        "id": "rejectionreason",
-                                        "label": "Rejection Reason",
-                                        "type": "text",
-                                        "direction": "output",
-                                    },
-                                ],
-                                "outcomes": [
-                                    {"id": "approve", "name": "Approve"},
-                                    {"id": "reject", "name": "Reject"},
-                                ],
-                            }
-                        },
-                    },
-                    {
-                        "id": "logOutcome",
-                        "type": "core.action.script",
-                        "inputs": {
-                            "script": "return $vars.reviewExpense.output.rejectionreason;"
-                        },
-                    },
-                ],
-                "edges": [
-                    {
-                        "sourceNodeId": "reviewExpense",
-                        "sourcePort": "completed",
-                        "targetNodeId": "logOutcome",
-                        "targetPort": "input",
-                    }
-                ],
-            }
+    (project / "ExpenseApproval.flow").write_text(json.dumps(doc), encoding="utf-8")
+
+
+def _approve_reject_fields(binding: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "id": "amount",
+            "label": "Amount",
+            "type": "number",
+            "direction": "input",
+            "binding": binding,
+        },
+        {
+            "id": "rejectionreason",
+            "label": "Rejection Reason",
+            "type": "text",
+            "direction": "output",
+        },
+    ]
+
+
+_APPROVE_REJECT_OUTCOMES: list[dict[str, Any]] = [
+    {"id": "approve", "name": "Approve"},
+    {"id": "reject", "name": "Reject"},
+]
+
+
+def _write_approve_reject_flow(tmp_path: Path, binding: str) -> None:
+    _write_flow(
+        tmp_path,
+        _flow_doc(
+            fields=_approve_reject_fields(binding),
+            outcomes=_APPROVE_REJECT_OUTCOMES,
         ),
-        encoding="utf-8",
     )
 
 
@@ -87,7 +106,7 @@ def _run_checker(tmp_path: Path) -> subprocess.CompletedProcess[str]:
 
 
 def test_accepts_documented_raw_hitl_input_binding(tmp_path: Path) -> None:
-    _write_flow(tmp_path, "vars.fetchExpense.output.amount")
+    _write_approve_reject_flow(tmp_path, "vars.fetchExpense.output.amount")
 
     result = _run_checker(tmp_path)
 
@@ -95,7 +114,7 @@ def test_accepts_documented_raw_hitl_input_binding(tmp_path: Path) -> None:
 
 
 def test_accepts_expression_hitl_input_binding(tmp_path: Path) -> None:
-    _write_flow(tmp_path, "=js:$vars.fetchExpense.output.amount")
+    _write_approve_reject_flow(tmp_path, "=js:$vars.fetchExpense.output.amount")
 
     result = _run_checker(tmp_path)
 
@@ -103,7 +122,7 @@ def test_accepts_expression_hitl_input_binding(tmp_path: Path) -> None:
 
 
 def test_rejects_hardcoded_hitl_input_binding(tmp_path: Path) -> None:
-    _write_flow(tmp_path, "hardcoded-value")
+    _write_approve_reject_flow(tmp_path, "hardcoded-value")
 
     result = _run_checker(tmp_path)
 
@@ -112,9 +131,103 @@ def test_rejects_hardcoded_hitl_input_binding(tmp_path: Path) -> None:
 
 
 def test_rejects_hitl_input_binding_without_output_segment(tmp_path: Path) -> None:
-    _write_flow(tmp_path, "vars.fetchExpense.amount")
+    _write_approve_reject_flow(tmp_path, "vars.fetchExpense.amount")
 
     result = _run_checker(tmp_path)
 
     assert result.returncode != 0
     assert "HITL input bindings must use" in result.stderr
+
+
+def test_accepts_boolean_decision_with_single_submit_outcome(tmp_path: Path) -> None:
+    """The docstring promises the boolean-decision pattern is valid; lock it in.
+
+    Mirrors the HITL skill's data-enrichment example (single Submit outcome with
+    a boolean output field carrying the decision). Used by agents that translate
+    "approved yes/no" literally from the user's prompt.
+    """
+    fields = [
+        {
+            "id": "amount",
+            "label": "Amount",
+            "type": "number",
+            "direction": "input",
+            "binding": "vars.fetchExpense.output.amount",
+        },
+        {
+            "id": "approved",
+            "label": "Approved",
+            "type": "boolean",
+            "direction": "output",
+            "required": True,
+        },
+        {
+            "id": "rejectionreason",
+            "label": "Rejection Reason",
+            "type": "text",
+            "direction": "output",
+        },
+    ]
+    _write_flow(
+        tmp_path,
+        _flow_doc(
+            fields=fields,
+            outcomes=[
+                {
+                    "id": "submit",
+                    "name": "Submit",
+                    "type": "string",
+                    "isPrimary": True,
+                    "action": "Continue",
+                }
+            ],
+            script_body=(
+                "return { approved: $vars.reviewExpense.output.approved, "
+                "reason: $vars.reviewExpense.output.rejectionreason };"
+            ),
+        ),
+    )
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_rejects_empty_outcomes(tmp_path: Path) -> None:
+    _write_flow(
+        tmp_path,
+        _flow_doc(
+            fields=_approve_reject_fields("vars.fetchExpense.output.amount"),
+            outcomes=[],
+        ),
+    )
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode != 0
+    assert "HITL schema must define outcomes" in result.stderr
+
+
+def test_rejects_single_submit_outcome_without_decision_capture(tmp_path: Path) -> None:
+    """One outcome named Submit + no boolean decision field must still fail —
+    the disjunctive decision-capture check at the bottom of the script enforces this."""
+    _write_flow(
+        tmp_path,
+        _flow_doc(
+            fields=_approve_reject_fields("vars.fetchExpense.output.amount"),
+            outcomes=[
+                {
+                    "id": "submit",
+                    "name": "Submit",
+                    "type": "string",
+                    "isPrimary": True,
+                    "action": "Continue",
+                }
+            ],
+        ),
+    )
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode != 0
+    assert "manager decision" in result.stderr


### PR DESCRIPTION
## Summary

The DevCon expense approval test (`skill-flow-e2e-devcon-expense-approval`) failed in run [`2026-05-26_04-05-02`](https://coder-evalboard.uipath-dev.com/runs/2026-05-26_04-05-02/skill-flow-e2e-devcon-expense-approval) with:

```
FAIL: HITL schema must define at least two outcomes
```

The agent built a structurally valid flow that `uip maestro flow validate` accepted, but the semantic checker rejected it.

## Root cause

`check_devcon_expense_approval.py` contains a logical contradiction:

- **Docstring** (lines 5–8) — "approval can be represented either as a boolean output field or as approve/reject outcomes."
- **Disjunctive check** (lines 86–92) — already enforces exactly that semantic: pass if there's a boolean decision field, *or* if outcomes contain both "approve" and "reject" names.
- **Hard gate** (lines 71–72) — unconditionally required `len(outcomes) >= 2`, making the boolean-only path unreachable.

The HITL skill teaches both idioms (Example 1 — Approve/Reject outcomes for approvals; Example 3 — data-enrichment with a boolean output + Submit). The failing run produced Example 3's shape, which the docstring promised was acceptable but the gate prevented.

## Why this started failing after 4 days of passing

The cause is **not** a skill or doc change — the relevant skill descriptions (`uipath-maestro-flow`, `uipath-planner`, `uipath-human-in-the-loop` YAML frontmatter) are byte-identical between the last passing commit (`d5441840`) and the first failing commit (`eb648ade`). The cause is the coder-eval **runtime environment swap**, recorded in `task.json/environment_info`:

| Field | 05-22 PASS | 05-25 / 05-26 FAIL |
|---|---|---|
| `claude_code_cli` | **2.1.123** | **2.1.145** (+22 patches) |
| `api_routing` | **aws_bedrock** (`eu-north-1`, `eu.anthropic.claude-sonnet-4-6`) | **anthropic_direct** |
| `anthropic` SDK | 0.102.0 | 0.104.1 |
| `pydantic` / `uv` | 2.12.5 / 0.11.8 | 2.13.4 / 0.11.15 |

The shift is directly observable in the agent's **first** tool call:

- **05-22**: `Skill: uipath:uipath-maestro-flow` — straight to the specialist; specialist autonomously chose Approve/Reject outcomes.
- **05-25 & 05-26**: `Skill: uipath:uipath-planner` — routed through the planner; the planner translated the user's literal "approved (yes/no) boolean" into a prescriptive HITL spec (`approved: boolean (yes/no), required`); the HITL specialist obediently produced Pattern 3 (boolean field + single Submit outcome).

Same model name, but `claude-sonnet-4-6` served by Bedrock vs Anthropic-Direct is not necessarily the same snapshot, and Claude Code's system prompt / skill-listing format can shift across 22 patch versions. The cumulative effect was a different first-step routing decision on a borderline prompt, which propagated into the alternate (still-valid) schema shape.

The check's hard `≥2 outcomes` gate then turned that valid alternate into a hard failure.

## Fix

- Relax the outcomes gate to `outcomes` must be a non-empty list. The downstream decision-capture check at L86-92 already enforces the real semantic.
- Replace the lone shared `_write_flow` helper with a small builder so tests can vary fields and outcomes independently.
- Add three tests:
  - `test_accepts_boolean_decision_with_single_submit_outcome` — locks in the fix (this is exactly the failing run's shape).
  - `test_rejects_empty_outcomes` — guards the relaxed gate.
  - `test_rejects_single_submit_outcome_without_decision_capture` — confirms a degenerate Submit-only schema (no boolean decision) still fails, via the existing disjunctive check.

## Test plan

- [x] `pytest tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py -v` — 7/7 pass on the branch.
- [x] Replay: ran the fixed checker against the agent's actual `ExpenseApproval.flow` from the failed 05-26 run → `OK`.
- [x] Replay: ran the unmodified checker on the same flow → still `FAIL` (confirms reproducer).
- [x] Confirmed 05-25 and 05-26 produced the same schema shape and hit the same check failure (review.json tags differ but the actual `FAIL:` line is identical).
- [x] Diffed `uipath-maestro-flow` / `uipath-planner` / `uipath-human-in-the-loop` SKILL.md YAML frontmatter at `d5441840` vs `eb648ade` — no relevant change in routing metadata.
- [ ] Re-run `skill-flow-e2e-devcon-expense-approval` against the new runtime to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)