### PR TITLE
feat(uipath-maestro-flow): add Connection-binding regression evals

### DIFF
--- a/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
+++ b/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Validate Connection-binding shape in produced .flow files.
+
+Regression coverage for MST-10236 / UiPath/cli#2197: `uip maestro flow node
+configure` previously appended brand-new Connection bindings instead of
+claiming the empty-keyed stubs that flow-core hoists at `node add` time.
+The produced .flow shipped with two binding rows per real connection;
+Studio Web's runtime resolved the empty stub first and failed with
+`Value cannot be null. (Parameter 'Connection')`.
+
+Usage:
+    check_bindings.py <subcommand> <flow_glob> [<extra>...]
+
+Subcommands:
+    structure       <flow_glob>
+        Flow file exists, valid JSON, has nodes + bindings.
+
+    no_empty_stubs  <flow_glob>
+        Zero Connection bindings with empty resourceKey.
+
+    no_duplicates   <flow_glob>
+        No duplicate (name, propertyAttribute) under Connection resource.
+
+    matched_default <flow_glob>
+        Every ConnectionId binding has non-empty resourceKey == default.
+
+    bindings_v2_no_empty_stubs <flow_glob_for_v2>
+        bindings_v2.json (derived artifact), if emitted, has no empty-keyed
+        Connection rows. Silently passes if not emitted.
+
+    count_equal      <flow_a> <flow_b>
+        Two flow snapshots have the same bindings array length (idempotency).
+
+    same_connection_id <flow_a> <flow_b>
+        Two flow snapshots agree on the ConnectionId binding's resourceKey.
+
+    has_connection_key <flow_glob> <connection_id>
+        Flow has at least one Connection binding with the given resourceKey.
+
+    no_connection_leak <flow_glob> <old_connection_id>
+        Flow has zero references to the given old connection id (resourceKey
+        or default).
+
+    connection_id_is  <flow_glob> <expected_connection_id>
+        Every ConnectionId binding has resourceKey == expected_connection_id.
+
+    no_triplet_dups  <flow_glob>
+        No (name, propertyAttribute, resourceKey) triplet duplicates across
+        Connection bindings.
+
+    both_ids_present <flow_glob> <connection_a_id> <connection_b_id>
+        Both connection ids appear as ConnectionId resourceKey values, each
+        on its own binding row.
+
+    has_connection_key_from_json <flow_glob> <json_path> <key>
+    no_connection_leak_from_json <flow_glob> <json_path> <key>
+    connection_id_is_from_json <flow_glob> <json_path> <key>
+        Same as their non-`_from_json` counterparts, but read the connection
+        id from `json_path[key]` (string). Lets the YAML pass conn_ids.json
+        without inline jq/python wrapping.
+
+    both_ids_present_from_json <flow_glob> <json_path>
+        Reads `a` and `b` from json_path and runs both_ids_present.
+
+Exit 0 on success; non-zero with stderr message on failure.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import sys
+from collections import Counter
+from typing import Any, NoReturn
+
+
+def _fail(message: str) -> NoReturn:
+    sys.exit(f"FAIL: {message}")
+
+
+def _load_one(pattern: str) -> tuple[str, dict[str, Any]]:
+    matches = sorted(glob.glob(pattern, recursive=True))
+    if not matches:
+        _fail(f"No file found for {pattern!r}")
+    if len(matches) > 1:
+        _fail(f"Multiple files found for {pattern!r}: {matches}")
+    try:
+        with open(matches[0], encoding="utf-8") as fh:
+            return matches[0], json.load(fh)
+    except json.JSONDecodeError as exc:
+        _fail(f"{matches[0]} is not valid JSON: {exc}")
+
+
+def _load_flow_bindings(pattern: str) -> tuple[str, list[dict[str, Any]]]:
+    path, flow = _load_one(pattern)
+    bindings = flow.get("bindings")
+    if not isinstance(bindings, list):
+        _fail(f"{path} has no `bindings` array (got {type(bindings).__name__})")
+    return path, bindings
+
+
+def _connection_rows(bindings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [b for b in bindings if isinstance(b, dict) and b.get("resource") == "Connection"]
+
+
+def _connection_id_rows(bindings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [b for b in _connection_rows(bindings) if b.get("propertyAttribute") == "ConnectionId"]
+
+
+def cmd_structure(pattern: str) -> None:
+    path, flow = _load_one(pattern)
+    if "nodes" not in flow:
+        _fail(f"{path} missing `nodes`")
+    if "bindings" not in flow:
+        _fail(f"{path} missing `bindings`")
+    print(f"OK: {path} valid JSON with nodes + bindings")
+
+
+def cmd_no_empty_stubs(pattern: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    empty = [b for b in _connection_rows(bindings) if not b.get("resourceKey")]
+    if empty:
+        _fail(
+            f"{path}: found {len(empty)} empty-keyed Connection binding(s) "
+            f"after configure (would cause Studio Web `Value cannot be null` "
+            f"errors at runtime): {empty}"
+        )
+    print(f"OK: {path} has no empty-keyed Connection bindings")
+
+
+def cmd_no_duplicates(pattern: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    keys = [(b.get("name"), b.get("propertyAttribute")) for b in _connection_rows(bindings)]
+    dups = [k for k, c in Counter(keys).items() if c > 1]
+    if dups:
+        _fail(f"{path}: duplicate (name, propertyAttribute) under Connection resource: {dups}")
+    print(f"OK: {path} has no duplicate Connection binding (name, propertyAttribute) pairs")
+
+
+def cmd_matched_default(pattern: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    conn = _connection_id_rows(bindings)
+    if not conn:
+        _fail(f"{path}: no ConnectionId binding emitted")
+    bad = [b for b in conn if not (b.get("resourceKey") and b["resourceKey"] == b.get("default"))]
+    if bad:
+        _fail(f"{path}: ConnectionId binding(s) with mismatched/empty resourceKey vs default: {bad}")
+    print(f"OK: {path} ConnectionId binding has non-empty resourceKey == default")
+
+
+def cmd_bindings_v2_no_empty_stubs(pattern: str) -> None:
+    matches = sorted(glob.glob(pattern, recursive=True))
+    if not matches:
+        print(f"OK: no {pattern!r} emitted on this code path (criterion skipped)")
+        return
+    try:
+        with open(matches[0], encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except json.JSONDecodeError as exc:
+        _fail(f"{matches[0]} is not valid JSON: {exc}")
+    rows = payload if isinstance(payload, list) else payload.get("bindings", [])
+    empty = [
+        x
+        for x in rows
+        if isinstance(x, dict) and x.get("resource") == "Connection" and not x.get("resourceKey")
+    ]
+    if empty:
+        _fail(f"{matches[0]}: empty-keyed Connection row(s) in derived bindings_v2.json: {empty}")
+    print(f"OK: {matches[0]} has no empty-keyed Connection rows")
+
+
+def cmd_count_equal(pattern_a: str, pattern_b: str) -> None:
+    path_a, bindings_a = _load_flow_bindings(pattern_a)
+    path_b, bindings_b = _load_flow_bindings(pattern_b)
+    if len(bindings_a) != len(bindings_b):
+        _fail(
+            f"bindings count changed across snapshots: "
+            f"{path_a} has {len(bindings_a)}, {path_b} has {len(bindings_b)}"
+        )
+    print(f"OK: {path_a} and {path_b} have equal bindings count = {len(bindings_a)}")
+
+
+def cmd_same_connection_id(pattern_a: str, pattern_b: str) -> None:
+    path_a, bindings_a = _load_flow_bindings(pattern_a)
+    path_b, bindings_b = _load_flow_bindings(pattern_b)
+    a_keys = {b.get("resourceKey") for b in _connection_id_rows(bindings_a)}
+    b_keys = {b.get("resourceKey") for b in _connection_id_rows(bindings_b)}
+    if not a_keys or a_keys != b_keys:
+        _fail(f"ConnectionId resourceKey differs across snapshots: {path_a}={a_keys} vs {path_b}={b_keys}")
+    print(f"OK: ConnectionId resourceKey stable across snapshots ({a_keys})")
+
+
+def cmd_has_connection_key(pattern: str, connection_id: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    keys = {b.get("resourceKey") for b in _connection_rows(bindings)}
+    if connection_id not in keys:
+        _fail(f"{path}: connection {connection_id!r} not present in Connection bindings (got {keys})")
+    print(f"OK: {path} references connection {connection_id!r}")
+
+
+def cmd_no_connection_leak(pattern: str, old_connection_id: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    leaked = [
+        b
+        for b in bindings
+        if isinstance(b, dict)
+        and (b.get("resourceKey") == old_connection_id or b.get("default") == old_connection_id)
+    ]
+    if leaked:
+        _fail(f"{path}: stale binding(s) referencing old connection {old_connection_id!r}: {leaked}")
+    print(f"OK: {path} has no references to old connection {old_connection_id!r}")
+
+
+def cmd_connection_id_is(pattern: str, expected: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    conn = _connection_id_rows(bindings)
+    if not conn:
+        _fail(f"{path}: no ConnectionId binding emitted")
+    bad = [b for b in conn if b.get("resourceKey") != expected]
+    if bad:
+        _fail(f"{path}: some ConnectionId binding does not point at {expected!r}: {bad}")
+    print(f"OK: {path} all ConnectionId bindings point at {expected!r}")
+
+
+def cmd_no_triplet_dups(pattern: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    trips = [
+        (b.get("name"), b.get("propertyAttribute"), b.get("resourceKey"))
+        for b in _connection_rows(bindings)
+    ]
+    dups = [k for k, c in Counter(trips).items() if c > 1]
+    if dups:
+        _fail(f"{path}: duplicate Connection binding triplet(s): {dups}")
+    print(f"OK: {path} has no duplicate Connection (name, propertyAttribute, resourceKey) triplets")
+
+
+def cmd_both_ids_present(pattern: str, conn_a: str, conn_b: str) -> None:
+    path, bindings = _load_flow_bindings(pattern)
+    conn_id_rows = _connection_id_rows(bindings)
+    a_rows = [b for b in conn_id_rows if b.get("resourceKey") == conn_a]
+    b_rows = [b for b in conn_id_rows if b.get("resourceKey") == conn_b]
+    if not a_rows or not b_rows:
+        _fail(
+            f"{path}: each connection must have at least one ConnectionId binding "
+            f"(A={a_rows}, B={b_rows})"
+        )
+    print(f"OK: {path} both connections present in ConnectionId bindings")
+
+
+def _read_json_value(json_path: str, key: str) -> str:
+    try:
+        with open(json_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        _fail(f"cannot read {json_path!r}: {exc}")
+    if not isinstance(data, dict) or key not in data:
+        _fail(f"{json_path}: missing required key {key!r}")
+    value = data[key]
+    if not isinstance(value, str) or not value:
+        _fail(f"{json_path}: key {key!r} must be a non-empty string (got {value!r})")
+    return value
+
+
+def cmd_has_connection_key_from_json(pattern: str, json_path: str, key: str) -> None:
+    cmd_has_connection_key(pattern, _read_json_value(json_path, key))
+
+
+def cmd_no_connection_leak_from_json(pattern: str, json_path: str, key: str) -> None:
+    cmd_no_connection_leak(pattern, _read_json_value(json_path, key))
+
+
+def cmd_connection_id_is_from_json(pattern: str, json_path: str, key: str) -> None:
+    cmd_connection_id_is(pattern, _read_json_value(json_path, key))
+
+
+def cmd_both_ids_present_from_json(pattern: str, json_path: str) -> None:
+    cmd_both_ids_present(
+        pattern,
+        _read_json_value(json_path, "a"),
+        _read_json_value(json_path, "b"),
+    )
+
+
+_COMMANDS = {
+    "structure": cmd_structure,
+    "no_empty_stubs": cmd_no_empty_stubs,
+    "no_duplicates": cmd_no_duplicates,
+    "matched_default": cmd_matched_default,
+    "bindings_v2_no_empty_stubs": cmd_bindings_v2_no_empty_stubs,
+    "count_equal": cmd_count_equal,
+    "same_connection_id": cmd_same_connection_id,
+    "has_connection_key": cmd_has_connection_key,
+    "no_connection_leak": cmd_no_connection_leak,
+    "connection_id_is": cmd_connection_id_is,
+    "no_triplet_dups": cmd_no_triplet_dups,
+    "both_ids_present": cmd_both_ids_present,
+    "has_connection_key_from_json": cmd_has_connection_key_from_json,
+    "no_connection_leak_from_json": cmd_no_connection_leak_from_json,
+    "connection_id_is_from_json": cmd_connection_id_is_from_json,
+    "both_ids_present_from_json": cmd_both_ids_present_from_json,
+}
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _fail(f"usage: check_bindings.py <subcommand> [...] (subcommands: {sorted(_COMMANDS)})")
+    sub = sys.argv[1]
+    fn = _COMMANDS.get(sub)
+    if fn is None:
+        _fail(f"unknown subcommand {sub!r}; choose from {sorted(_COMMANDS)}")
+    fn(*sys.argv[2:])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
@@ -1,0 +1,81 @@
+task_id: skill-flow-bindings-idempotent-reconfigure
+description: >
+  Step 1 of the DAPField-mirrored upsert in `upsertConnectionResourceBinding`
+  is the exact `(name, resource, resourceKey)` match path that refreshes
+  `default` instead of appending. This eval covers it: configuring the same
+  connector node twice with the same connection details must not grow the
+  bindings array. The second configure should be a no-op on row count.
+  See https://github.com/UiPath/cli/pull/2197 — the "Step 1: exact match"
+  branch of `upsertConnectionResourceBinding`.
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, connector, bindings, regression]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 3600
+  max_turns: 60
+  turn_timeout: 1200
+
+initial_prompt: |
+  Load the uipath-maestro-flow skill and follow its workflow exactly.
+
+  Build a flow named "BindingsIdempotent" — Manual Trigger → IS connector
+  node → End — saved as `BindingsIdempotent/flow_files/BindingsIdempotent.flow`
+  with `BindingsIdempotent/project.uiproj`.
+
+  Snapshot the .flow after the first configure:
+      cp BindingsIdempotent/flow_files/BindingsIdempotent.flow after_first_configure.flow
+
+  Then run the EXACT SAME `node configure` invocation a second time (same
+  node id, same --detail JSON). Snapshot again:
+      cp BindingsIdempotent/flow_files/BindingsIdempotent.flow after_second_configure.flow
+
+  Both snapshots go at the sandbox root.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent called `node configure` at least twice"
+    tool_name: "Bash"
+    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
+    min_count: 2
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Both snapshots exist, valid JSON with bindings"
+    command: "python3 $TASK_DIR/check_bindings.py structure 'after_first_configure.flow' && python3 $TASK_DIR/check_bindings.py structure 'after_second_configure.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Bindings count did not grow on second configure (idempotent)"
+    command: "python3 $TASK_DIR/check_bindings.py count_equal 'after_first_configure.flow' 'after_second_configure.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No empty-keyed Connection bindings in final snapshot"
+    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs 'after_second_configure.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "ConnectionId resourceKey stable across both snapshots"
+    command: "python3 $TASK_DIR/check_bindings.py same_connection_id 'after_first_configure.flow' 'after_second_configure.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
@@ -1,0 +1,97 @@
+task_id: skill-flow-bindings-multi-connector-independence
+description: >
+  Two distinct connector nodes (different connector keys) in the same flow,
+  each configured with its own connection, must produce independent Connection
+  bindings — no cross-aliasing between nodes, even when both manifests share
+  common binding `name`/`propertyAttribute` values like `ConnectionId` and
+  `FolderKey`. This is the cross-connector aliasing case that
+  flow-workbench#1726 had to harden against because stale empty-keyed rows
+  collided on `(resourceKey, propertyAttribute)`. With PR #2197 in place
+  there should be no empty rows at all and no aliasing should be possible
+  in the first place. See https://github.com/UiPath/cli/pull/2197 and
+  https://github.com/UiPath/flow-workbench/pull/1726.
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, bindings, regression]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 3600
+  max_turns: 80
+  turn_timeout: 1200
+
+initial_prompt: |
+  Load the uipath-maestro-flow skill and follow its workflow exactly.
+
+  Build a flow named "BindingsMulti" with TWO IS connector nodes backed
+  by DIFFERENT connector keys, saved as
+  `BindingsMulti/flow_files/BindingsMulti.flow` with
+  `BindingsMulti/project.uiproj`.
+
+  Configure each node with its own distinct connection. Record the
+  connection ids and connector keys at the sandbox root:
+
+      echo '{"a":"<conn-id-1>","ka":"<connector-key-1>","b":"<conn-id-2>","kb":"<connector-key-2>"}' > conn_ids.json
+
+success_criteria:
+  - type: command_executed
+    description: "Agent added two connector nodes"
+    tool_name: "Bash"
+    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+add"
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent configured two nodes"
+    tool_name: "Bash"
+    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "conn_ids.json declares two distinct connection ids backed by different connector keys"
+    command: "python3 -c \"import json; d=json.load(open('conn_ids.json')); assert d['a']!=d['b'], 'connection ids must differ'; assert d['ka']!=d['kb'], 'connector keys must differ'\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow file exists and is valid JSON"
+    command: "python3 $TASK_DIR/check_bindings.py structure '**/BindingsMulti*.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Both connection ids appear in Connection bindings, each on its own ConnectionId row"
+    command: "python3 $TASK_DIR/check_bindings.py both_ids_present_from_json '**/BindingsMulti*.flow' conn_ids.json"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No empty-keyed Connection bindings (cross-node aliasing surface)"
+    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs '**/BindingsMulti*.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No (name, propertyAttribute, resourceKey) triplet duplicates"
+    command: "python3 $TASK_DIR/check_bindings.py no_triplet_dups '**/BindingsMulti*.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
@@ -1,0 +1,87 @@
+task_id: skill-flow-bindings-no-duplicates
+description: >
+  Regression for MST-10236 — `uip maestro flow node configure` previously
+  appended brand-new Connection bindings instead of claiming the empty-keyed
+  stubs that flow-core hoists at `node add` time. The produced .flow shipped
+  with two binding rows per real connection; Studio Web's runtime resolved
+  the empty stub first and failed with `Value cannot be null. (Parameter
+  'Connection')`. This eval asserts the configured .flow contains no
+  empty-keyed Connection bindings and no duplicate (name, propertyAttribute)
+  rows under the Connection resource. See:
+  https://github.com/UiPath/cli/pull/2197 and
+  https://uipath.atlassian.net/browse/MST-10236
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, connector, bindings, regression]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 3600
+  max_turns: 50
+  turn_timeout: 1200
+
+initial_prompt: |
+  Load the uipath-maestro-flow skill and follow its workflow exactly.
+
+  Build a flow named "BindingsRegression" — Manual Trigger → IS connector
+  node → End — saved as `BindingsRegression/flow_files/BindingsRegression.flow`
+  with `BindingsRegression/project.uiproj`.
+
+  Configure the connector node exactly once. Do not invoke any "refresh
+  schema" workaround afterwards — the bindings shape immediately after
+  `node configure` is what this eval inspects.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent called `node configure`"
+    tool_name: "Bash"
+    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow file exists and is valid JSON with nodes + bindings"
+    command: "python3 $TASK_DIR/check_bindings.py structure '**/BindingsRegression*.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No empty-keyed Connection bindings remain after configure"
+    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs '**/BindingsRegression*.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No duplicate (name, propertyAttribute) under Connection resource"
+    command: "python3 $TASK_DIR/check_bindings.py no_duplicates '**/BindingsRegression*.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "ConnectionId binding has non-empty resourceKey matching default"
+    command: "python3 $TASK_DIR/check_bindings.py matched_default '**/BindingsRegression*.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "bindings_v2.json (derived artifact), if emitted, also has no empty-keyed Connection rows"
+    command: "python3 $TASK_DIR/check_bindings.py bindings_v2_no_empty_stubs '**/bindings_v2.json'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
@@ -1,0 +1,101 @@
+task_id: skill-flow-bindings-reconfigure-different-connection
+description: >
+  When the same connector node is reconfigured against a different connection,
+  the resulting .flow must reference ONLY the new connection — no stale
+  bindings from the previous configure should remain, and no empty-keyed
+  stubs should be left behind. This exercises the fallback-by-(name, resource)
+  path of `upsertConnectionResourceBinding` against a non-empty-keyed row.
+  See https://github.com/UiPath/cli/pull/2197.
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, connector, bindings, regression]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 3600
+  max_turns: 60
+  turn_timeout: 1200
+
+initial_prompt: |
+  Load the uipath-maestro-flow skill and follow its workflow exactly.
+
+  Build a flow named "BindingsReconfigure" — Manual Trigger → IS connector
+  node → End — saved as `BindingsReconfigure/flow_files/BindingsReconfigure.flow`
+  with `BindingsReconfigure/project.uiproj`.
+
+  Pick two distinct connections (different connectionIds) backed by the same
+  connector — if the tenant only has one connection for a given connector,
+  fall back to any connector that has two live connections.
+
+  Record the ids at the sandbox root and snapshot the .flow after each configure:
+
+      echo '{"a":"<connection-a-id>","b":"<connection-b-id>"}' > conn_ids.json
+
+  After configuring with A:
+      cp BindingsReconfigure/flow_files/BindingsReconfigure.flow after_a.flow
+
+  After reconfiguring the SAME node with B:
+      cp BindingsReconfigure/flow_files/BindingsReconfigure.flow after_b.flow
+
+success_criteria:
+  - type: command_executed
+    description: "Agent called `node configure` at least twice"
+    tool_name: "Bash"
+    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Snapshots and conn_ids.json exist with two distinct ids"
+    command: "python3 -c \"import json; d=json.load(open('conn_ids.json')); a,b=d['a'],d['b']; assert a and b and a!=b, f'Expected two distinct connection ids, got a={a} b={b}'\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "after_a.flow references connection A"
+    command: "python3 $TASK_DIR/check_bindings.py has_connection_key_from_json after_a.flow conn_ids.json a"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "after_b.flow has zero references to connection A (no stale rows)"
+    command: "python3 $TASK_DIR/check_bindings.py no_connection_leak_from_json after_b.flow conn_ids.json a"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "after_b.flow ConnectionId binding points at connection B"
+    command: "python3 $TASK_DIR/check_bindings.py connection_id_is_from_json after_b.flow conn_ids.json b"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Reconfigure did not grow bindings count"
+    command: "python3 $TASK_DIR/check_bindings.py count_equal 'after_a.flow' 'after_b.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No empty-keyed Connection bindings in final snapshot"
+    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs 'after_b.flow'"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120


### PR DESCRIPTION
## Summary

- Adds `tests/tasks/uipath-maestro-flow/bindings/` with 4 task YAMLs and one shared validator script (`check_bindings.py`).
- Ports the Connection-binding regression coverage from [coder_eval#311](https://github.com/UiPath/coder_eval/pull/311) / [#312](https://github.com/UiPath/coder_eval/pull/312) / [#313](https://github.com/UiPath/coder_eval/pull/313) / [#314](https://github.com/UiPath/coder_eval/pull/314) into the skills repo so the evals run on the daily skill test schedule rather than only ad-hoc.

## Why

[MST-10236](https://uipath.atlassian.net/browse/MST-10236) — `uip maestro flow node configure` previously appended brand-new Connection bindings instead of claiming the empty-keyed stubs that flow-core hoists at `node add` time. The produced `.flow` shipped with two binding rows per real connection; Studio Web's runtime resolved the empty stub first and failed with `Value cannot be null. (Parameter 'Connection')`. The fix landed in [UiPath/cli#2197](https://github.com/UiPath/cli/pull/2197). The existing unit tests didn't catch it because the test fixture manifest didn't carry the `model.bindings.values` template that triggers the hoist — these evals close that gap with end-to-end agent runs against real connectors.

## What the evals cover

| Task | Branch of upsert it exercises |
|---|---|
| `no_duplicate_connection_bindings` | Single configure → clean shape (the original MST-10236 repro) |
| `idempotent_reconfigure` | Step 1: exact `(name, resource, resourceKey)` match → refresh `default` |
| `reconfigure_different_connection` | Step 2: fallback by `(name, resource)` against a non-empty-keyed row |
| `multi_connector_independence` | Cross-connector aliasing case sister PR [flow-workbench#1726](https://github.com/UiPath/flow-workbench/pull/1726) hardened against |

## Conventions

- `task_id` prefix `skill-flow-bindings-*`, colon-style tags (`lifecycle:generate`, `shape:single-node` / `shape:multi-node`), `bindings` + `regression` tags for filtering.
- No `sandbox.node.env_packages` per [tests/README.md](https://github.com/UiPath/skills/blob/main/tests/README.md) — runner installs `@uipath/cli` globally.
- All assertions packaged as subcommands in `check_bindings.py` (12 subcommands; the `*_from_json` variants read connection ids out of a sandbox `conn_ids.json` so YAMLs stay declarative).
- `post_run` calls the shared `_shared/cleanup_solutions.py`.
- Slim prompts that rely on the `uipath-maestro-flow` skill for the playbook — the eval only sets the goal plus the regression-specific control (snapshot points, connection-id recording).

## Test plan

- [ ] `Validate Skills Task YAMLs` CI passes (`coder-eval plan tests/tasks/uipath-maestro-flow/bindings/*.yaml`)
- [ ] Smoke-tested validator subcommands locally against synthetic fixtures (no-empty, duplicate, leak, idempotent, multi-connector cases all behave as expected — captured in the commit message references).
- [ ] First production run on the daily schedule (post-merge) shows passing.

References:
- https://github.com/UiPath/cli/pull/2197
- https://github.com/UiPath/flow-workbench/pull/1726
- https://uipath.atlassian.net/browse/MST-10236

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[MST-10236]: https://uipath.atlassian.net/browse/MST-10236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ