### PR TITLE
fix(tests): align 7 task YAMLs with current coder_eval criterion schema

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -441,3 +441,58 @@ jobs:
               print(f'::error::Pass rate {rate:.1%} < threshold {threshold:.0%}')
               sys.exit(1)
           PY
+
+  # Advisory consistency gate. Does every task YAML in the repo still load
+  # under coder_eval@main's TaskDefinition schema? This is the skills-side
+  # mirror of coder_eval's `validate-skills-yamls` gate: it catches the class
+  # of bug where a task YAML uses a criterion type/field coder_eval's schema
+  # doesn't accept, surfacing it here at authoring time instead of weeks later
+  # (and on the wrong repo) in coder_eval CI.
+  #
+  # Validates the WHOLE tree, not just changed files, so pre-existing drift is
+  # always visible. `continue-on-error` shows the job red for visibility but
+  # keeps the workflow conclusion green — non-blocking, like the coder_eval
+  # gate. Flip to a hard gate by removing `continue-on-error` once the tree is
+  # clean and the convention has bedded in.
+  validate-task-schema:
+    name: Validate task schema (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    continue-on-error: true
+    # Skip forks: GH_PAT for the private coder_eval checkout isn't available
+    # to forked PRs (matches the e2e job's secret requirements).
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: UiPath/coder_eval
+          token: ${{ secrets.GH_PAT }}
+          path: .coder_eval
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install coder-eval
+        working-directory: .coder_eval
+        env:
+          UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
+        run: uv pip install --system .
+
+      - name: Validate every task YAML against coder_eval@main schema
+        # `coder-eval plan` exits non-zero if any file fails to load under the
+        # current TaskDefinition schema. Job-level continue-on-error keeps a
+        # failure here non-blocking.
+        run: |
+          set -uo pipefail
+          YAMLS=$(find tests/tasks -type f -name '*.yaml' | grep -v '/_shared/' | sort)
+          if [ -z "$YAMLS" ]; then
+            echo "No task YAMLs found under tests/tasks — checkout layout drift?"
+            exit 1
+          fi
+          echo "Validating $(printf '%s\n' "$YAMLS" | wc -l | xargs) task YAML(s) against coder_eval@main."
+          printf '%s\n' "$YAMLS" | tr '\n' '\0' | xargs -0 coder-eval plan

--- a/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
@@ -21,6 +21,6 @@ success_criteria:
   - type: skill_triggered
     description: "Agent invoked the uipath-agents skill"
     expected_skill: "uipath-agents"
-    expected: "yes"
+    skill_name: "uipath-agents"
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/deeprag_coded/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/deeprag_coded/smoke_trigger.yaml
@@ -21,6 +21,6 @@ success_criteria:
   - type: skill_triggered
     description: "Agent invoked the uipath-agents skill"
     expected_skill: "uipath-agents"
-    expected: "yes"
+    skill_name: "uipath-agents"
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/lowcode/batch_transform/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/lowcode/batch_transform/smoke_trigger.yaml
@@ -21,6 +21,6 @@ success_criteria:
   - type: skill_triggered
     description: "Agent invoked the uipath-agents skill"
     expected_skill: "uipath-agents"
-    expected: "yes"
+    skill_name: "uipath-agents"
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/lowcode/deeprag/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/lowcode/deeprag/smoke_trigger.yaml
@@ -21,6 +21,6 @@ success_criteria:
   - type: skill_triggered
     description: "Agent invoked the uipath-agents skill"
     expected_skill: "uipath-agents"
-    expected: "yes"
+    skill_name: "uipath-agents"
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
+++ b/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
@@ -131,6 +131,7 @@ success_criteria:
     description: "Agent did NOT use the modern `uip rpa` CLI on this Legacy project"
     tool_name: "Bash"
     command_pattern: 'uip\s+rpa\s+(?!-legacy)(validate|build|run|init|analyzer-rules|activities|packages)'
+    min_count: 0
     max_count: 0
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -163,6 +163,7 @@ success_criteria:
     description: "Agent did NOT use the modern `uip rpa` CLI on this Legacy project"
     tool_name: "Bash"
     command_pattern: 'uip\s+rpa\s+(?!-legacy)(validate|build|run|init|analyzer-rules|activities|packages)'
+    min_count: 0
     max_count: 0
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-rpa/xaml_test_case.yaml
+++ b/tests/tasks/uipath-rpa/xaml_test_case.yaml
@@ -83,7 +83,7 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: file_check
     description: "project.json does NOT register the test case as an entryPoint"
     path: "LoginTests/project.json"
     excludes:


### PR DESCRIPTION
## What

Two related changes:

1. **Fix 7 task YAMLs** that no longer validate against coder_eval's current success-criterion schema.
2. **Add an advisory task-schema validation gate** to `smoke-skills.yml` so this class of drift is caught in the skills repo at authoring time.

## Why

coder_eval's `pr-checks.yml` runs a `validate-skills-yamls` gate that checks out `UiPath/skills@main` and runs `coder-eval plan` over every task YAML. Schema constraints tightened in coder_eval over the past weeks left 4 tasks (7 files) invalid, so that gate had been red on every coder_eval PR — including `main` — for days. The breakage was always skills-authored (each YAML was committed after the relevant coder_eval constraint already shipped), but it only surfaced in coder_eval CI, on the wrong repo.

### The fixes

- **`skill_triggered`** (4× `uipath-agents/**/smoke_trigger.yaml`) — now requires `skill_name` and no longer accepts `expected`.
- **negative `command_executed`** (2× legacy RPA tasks) — a "must NOT run" check set only `max_count: 0`, which trips the `max_count >= min_count` validator; the canonical negative form needs `min_count: 0` too.
- **exclude-only file check** (`xaml_test_case.yaml`) — `file_contains` requires `includes`; an excludes-only assertion belongs on `file_check`.

### The gate

New `validate-task-schema` job in `smoke-skills.yml`: checks out `coder_eval@main`, installs `coder-eval`, and runs `coder-eval plan` over every task YAML — the skills-side mirror of coder_eval's `validate-skills-yamls`. It validates the whole tree, is non-blocking (`continue-on-error`, red-for-visibility), and skips forks. With the fixes above the tree is clean, so the gate is green from day one. Removing `continue-on-error` later turns it into a hard gate.