### PR TITLE
fix(uipath-planner): keep single-project inline-HITL flows out of the planner; never pre-bake HITL schema

### DIFF
--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uipath-planner
 description: "UiPath task planner — reads SDDs from uipath-solution or elicits non-PDD requests, derives multi-skill task lists, emits live TaskCreate calls. Detects project type (.cs, .xaml, .flow, .bpmn, .py). For PDDs→uipath-solution first."
-when_to_use: "User makes a non-trivial UiPath request — 'build a UiPath solution for X', 'set up a process from scratch', 'help me plan this' — OR provides an SDD path. Skip when project type and scope are already clear for a single-skill task — invoke the specialist directly."
+when_to_use: "User makes a non-trivial UiPath request that spans SEPARATE buildable projects — e.g. 'build a UiPath solution for X', 'set up a process from scratch', a Flow that orchestrates standalone RPA processes or agents — OR provides an SDD path. Skip when the request targets a SINGLE project, even a Flow/Agent/RPA project with inline HITL, script, or connector nodes wrapped in its own solution (e.g. a Flow with an inline approval step is one uipath-maestro-flow task, not a plan) — invoke that specialist directly."
 allowed-tools: Bash, Read, Glob, Grep, AskUserQuestion, EnterPlanMode, ExitPlanMode, TaskCreate, TaskUpdate, TaskList
 ---
 
@@ -18,12 +18,12 @@ The lane is decided by the **Entry Guard** below.
 
 ## When to Use This Skill
 
-- The request is **non-trivial** — multi-step, multi-skill, UI automation, or unclear scope
+- The request is **non-trivial** — spans **separate buildable projects** that each need their own specialist (e.g. a Flow orchestrating standalone RPA processes or agents), or UI automation with unclear scope
 - The request is **ambiguous** — no single specialist skill clearly matches
 - The user asks "what can I build?" or needs help choosing a project type
 - The user provides an SDD path — Lane A runs
 
-Skip this planner for simple, well-defined single-skill tasks (e.g., "create a workflow that sends an email") — load the specialist directly.
+Skip this planner for single-project tasks — load the specialist directly. A request is **single-project** (one specialist owns it end-to-end) even when it bundles several things *inside one project*: a Flow with script nodes plus an inline HITL approval step plus its own solution wrapper is **one** `uipath-maestro-flow` task. Inline nodes (HITL QuickForm, script, connector, inline agent) and the solution scaffolding are author sub-steps the specialist performs itself — they are **not** separate skills to orchestrate. Counting them as distinct skills ("solution + flow + human-in-the-loop") and emitting a plan is the most common mis-trigger. The planner is only for requests spanning **separate buildable projects** — distinct `.uipx` projects (a Flow consuming standalone RPA processes, an Agent using published processes as tools).
 
 ## Critical Rules
 
@@ -31,7 +31,7 @@ Skip this planner for simple, well-defined single-skill tasks (e.g., "create a w
 2. **For PDDs, hard-block and redirect to `uipath-solution`.** A PDD (PDF, docx, or markdown describing process steps + applications + exceptions) does NOT belong in this skill. The dedicated PDD→SDD skill produces a much better deliverable. The only escape is the user explicitly saying "skip SDD".
 3. **Never exceed 5 `AskUserQuestion` calls in any planning session.** Each call is one user-facing prompt; batch related questions (e.g., the Step 4 UI elicitation in Lane B batches App type, Targeting approach, App state into one call). If you cannot fit the elicitation in 5 calls, plan with best available info and note the assumption. Lane A typically uses 0–2 calls.
 4. **Always include a mandatory Testing task per generation skill** in the plan. Testing is non-negotiable — happy path + edge cases + error scenarios + e2e for Master Projects. The Testing task routes to the specialist's testing references and does NOT describe the testing procedure inline.
-5. **Route — do not redescribe.** The plan says WHICH skill to load and IN WHAT ORDER. It does NOT describe specialist-internal flows (target configuration, OR registration, XAML authoring pipelines, auth flows, testing procedures). Each specialist's docs own those details.
+5. **Route — do not redescribe.** The plan says WHICH skill to load and IN WHAT ORDER. It does NOT describe specialist-internal flows (target configuration, OR registration, XAML authoring pipelines, **HITL field/outcome schema design**, auth flows, testing procedures). Each specialist's docs own those details. **For a HITL step, pass the business intent only** ("manager approves or rejects an expense; can add a reason if rejected") — never a field-level spec (do not prescribe field names, types like `approved: boolean`, `required` flags, or outcome lists). The HITL specialist chooses the schema shape (boolean decision field vs Approve/Reject outcomes) from the intent; a field-level prescription forces one shape and defeats that choice.
 
 ## Entry Guard
 

--- a/skills/uipath-planner/references/multi-skill-patterns-guide.md
+++ b/skills/uipath-planner/references/multi-skill-patterns-guide.md
@@ -20,6 +20,8 @@ A request is **single-skill** when:
 
 > **Important:** Single-app UI automation (one project, one live app, one workflow) is **not** a multi-skill pattern — it's a single-skill `uipath-rpa` task. `uipath-rpa` owns UI automation authoring end-to-end, including live-app exploration and probing.
 
+> **Important — inline nodes are not components.** A Flow whose only "components" are **inline nodes** (HITL QuickForm, script, connector activity, inline agent) is a **single-skill** `uipath-maestro-flow` task, **not** a multi-skill plan. The flow author journey scaffolds the solution and authors every inline node itself — it reads the HITL plugin reference inline; it does not hand off to `uipath-human-in-the-loop` as a separate task. Counting inline pieces as separate skills ("solution + flow + human-in-the-loop") is a mis-classification. A flow only becomes **multi-skill** (Pattern 2/3) when it orchestrates **separate buildable projects** — distinct `.uipx` projects such as a standalone RPA process, a coded agent, or a coded app, each of which needs its own specialist.
+
 ## Pattern 1 — RPA build + deploy to Orchestrator
 
 **When it applies:** user wants to build an RPA workflow and deploy it to Orchestrator (most common production flow).
@@ -34,7 +36,7 @@ A request is **single-skill** when:
 
 ## Pattern 2 — Flow with local resources
 
-**When it applies:** Flow and the components it orchestrates are peer sibling projects under one `.uipx` solution at the current working directory. Each component is scaffolded as part of this plan (or replaced by a placeholder contract when not built here). The flow runs locally / publishes to Studio Web per the plan's `Solution scope`.
+**When it applies:** Flow and the components it orchestrates are peer sibling projects under one `.uipx` solution at the current working directory. **Components here means separate buildable projects** (a standalone RPA `.xaml`/`.cs` process, a coded agent, a coded app) — each scaffolded as a distinct project routed to its own specialist. Inline flow nodes (HITL QuickForm, script, connector, inline agent) are **not** components; `uipath-maestro-flow` authors them itself in steps 1/4, so a flow whose only "extras" are inline nodes is single-skill (load `uipath-maestro-flow` directly, no plan). Each component is scaffolded as part of this plan (or replaced by a placeholder contract when not built here). The flow runs locally / publishes to Studio Web per the plan's `Solution scope`.
 
 ```
 1. uipath-maestro-flow   → create solution, init flow project

--- a/skills/uipath-planner/references/multi-skill-patterns-guide.md
+++ b/skills/uipath-planner/references/multi-skill-patterns-guide.md
@@ -66,7 +66,7 @@ A request is **single-skill** when:
 **When it applies:** the flow exists; user wants it deployed to Orchestrator (not Studio Web).
 
 ```
-1. uipath-maestro-flow → validate, `uip flow pack`
+1. uipath-maestro-flow → validate, `uip maestro flow pack`
 2. uipath-maestro-flow → testing (mandatory)
 3. uipath-solution     → publish and deploy to Orchestrator via `uip solution`
 ```

--- a/skills/uipath-planner/references/multi-skill-patterns-guide.md
+++ b/skills/uipath-planner/references/multi-skill-patterns-guide.md
@@ -36,7 +36,7 @@ A request is **single-skill** when:
 
 ## Pattern 2 — Flow with local resources
 
-**When it applies:** Flow and the components it orchestrates are peer sibling projects under one `.uipx` solution at the current working directory. **Components here means separate buildable projects** (a standalone RPA `.xaml`/`.cs` process, a coded agent, a coded app) — each scaffolded as a distinct project routed to its own specialist. Inline flow nodes (HITL QuickForm, script, connector, inline agent) are **not** components; `uipath-maestro-flow` authors them itself in steps 1/4, so a flow whose only "extras" are inline nodes is single-skill (load `uipath-maestro-flow` directly, no plan). Each component is scaffolded as part of this plan (or replaced by a placeholder contract when not built here). The flow runs locally / publishes to Studio Web per the plan's `Solution scope`.
+**When it applies:** Flow and the components it orchestrates are peer sibling projects under one `.uipx` solution at the current working directory. **Components here means separate buildable projects** (a standalone RPA `.xaml`/`.cs` process, a coded agent, a coded app) — each scaffolded as a distinct project routed to its own specialist. Inline flow nodes are **not** components (see the blockquote above); `uipath-maestro-flow` authors them itself in steps 1/4. Each component is scaffolded as part of this plan (or replaced by a placeholder contract when not built here). The flow runs locally / publishes to Studio Web per the plan's `Solution scope`.
 
 ```
 1. uipath-maestro-flow   → create solution, init flow project


### PR DESCRIPTION
## Why

Companion to #1031. That PR fixes the DevCon expense-approval *checker* (which had a contradictory `len(outcomes) < 2` gate). This PR addresses the *upstream agent behavior* that made the checker go red, so the eval is robust regardless of which valid HITL pattern the agent picks.

### Background (full analysis: `docs/uipath-skills/2026-05-26-skill-flow-e2e-devcon-expense-approval-regression.md`)

`skill-flow-e2e-devcon-expense-approval` passed for 4 days then failed on 05-25/05-26. Root cause of the behavior shift was an eval **runtime swap** (Claude Code `2.1.123→2.1.145`, `api_routing` `aws_bedrock→anthropic_direct`) that flipped how `claude-sonnet-4-6` routes the prompt:

- **Before:** first tool call = `uipath-maestro-flow` (direct). The specialist designed the HITL schema from intent → **Approve/Reject outcomes**.
- **After:** first tool call = `uipath-planner`. The model reasoned *"spans multiple skills (solution, flow, human-in-the-loop)"*, routed through the planner, which decomposed `"approved (yes/no)"` into a field-level spec (`approved: boolean, required`) and handed it to the HITL specialist → forced the **single-`Submit` boolean** schema → tripped the checker.

The misclassification is the bug: a Flow with an inline HITL approval step + script nodes + its own solution wrapper is **one** `uipath-maestro-flow` task, not a multi-skill plan. Inline nodes and solution scaffolding are author sub-steps the flow specialist performs itself.

## What

Three layered guards, all within `skills/uipath-planner/`:

1. **`when_to_use` + "When to Use This Skill" (routing-time).** Explicitly scopes the planner to requests spanning **separate buildable projects**, and names the anti-pattern: a single project with inline HITL/script/connector nodes is one specialist task. This is the frontmatter the model reads *before* deciding which skill to invoke. Combined `description`+`when_to_use` = **740 chars**, under the 1,536 listing-truncation cap (validated).
2. **`multi-skill-patterns-guide.md` (post-invoke safety net).** Clarifies inline nodes are not "components"; Pattern 2 fires only for separate buildable `.uipx` projects. If the planner *is* invoked anyway, it emits a single maestro-flow task rather than a separate `uipath-human-in-the-loop` task.
3. **Rule 5 "Route — do not redescribe" (robustness).** Adds HITL field/outcome schema design to the don't-redescribe list. The planner passes **business intent only** ("manager approves or rejects; can add a reason") — never a field-level spec — so the HITL specialist keeps the freedom to choose boolean-field vs Approve/Reject. This makes the *outcome* correct even if routing still lands on the planner.

## Honest scope

LLM routing can't be made deterministic by prompt text — only strongly biased. Guard 1 reduces the chance the planner is invoked; guards 2–3 make the result correct *when* it is. The deterministic guarantee remains #1031 (the test accepts both valid patterns). Defense in depth.

## Blast radius

Guard 1 reshapes planner routing for **all** requests, so the negative scope is written to fire only on *single-project* requests and preserve planner routing for genuinely multi-project flows (Flow + standalone RPA/agents). Worth a careful read from @RaduAna-Maria (CODEOWNERS for `skills/uipath-planner/`).

## Test plan

- [x] `hooks/validate-skill-descriptions.sh skills/uipath-planner/SKILL.md` — passes (229 chars ≤ 1024).
- [x] Combined `description`+`when_to_use` = 740 chars (< 1536 listing cap), so the new negative-scope clause is not truncated in the skill listing.
- [ ] Re-run `skill-flow-e2e-devcon-expense-approval` on the current runtime; confirm first tool call is `uipath-maestro-flow` (or, if planner is still chosen, that the HITL handoff carries intent not a field spec).
- [ ] Spot-check a genuinely multi-project request (Flow + standalone RPA) still routes through the planner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)