### PR TITLE
ci(test-helpers): run all maestro-flow checker unit tests, not just _shared

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -3,14 +3,14 @@ name: Test Helpers
 on:
   pull_request:
     paths:
-      - 'tests/tasks/uipath-maestro-flow/_shared/**'
+      - 'tests/tasks/uipath-maestro-flow/**'
       - '.github/workflows/test-helpers.yml'
   workflow_dispatch:
 
 jobs:
   pytest-flow-check:
     runs-on: ubuntu-latest
-    name: flow_check.py unit tests
+    name: maestro-flow checker unit tests
     steps:
       - uses: actions/checkout@v4
 
@@ -22,4 +22,4 @@ jobs:
         run: pip install pytest
 
       - name: Run pytest
-        run: pytest tests/tasks/uipath-maestro-flow/_shared/ -v
+        run: pytest tests/tasks/uipath-maestro-flow/ -v


### PR DESCRIPTION
## Why

Fast-follow to #1031 per @bai-uipath's review note. The `Test Helpers` pytest job is scoped to `tests/tasks/uipath-maestro-flow/_shared/` on **both** its `paths:` trigger and its `run:` command, so the per-task checker unit tests never run in CI:

| Test file | Ran in CI before? |
|---|---|
| `_shared/test_flow_check.py` | ✅ yes |
| `e2e/test_check_devcon_expense_approval.py` | ❌ no |
| `multi_node/customer_escalation/test_check_customer_escalation_flow.py` | ❌ no |
| `single_node/api_workflow/test_check_api_workflow_flow.py` | ❌ no |
| `single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py` | ❌ no |

The regression net for those four checkers only fired when someone ran `pytest` locally. #1031 added a checker test that, without this, would never run in CI.

## What

Broaden both the path trigger and the run command from `tests/tasks/uipath-maestro-flow/_shared/` to `tests/tasks/uipath-maestro-flow/` (whole dir), and rename the job to reflect the wider scope.

```diff
-      - 'tests/tasks/uipath-maestro-flow/_shared/**'
+      - 'tests/tasks/uipath-maestro-flow/**'
...
-    name: flow_check.py unit tests
+    name: maestro-flow checker unit tests
...
-        run: pytest tests/tasks/uipath-maestro-flow/_shared/ -v
+        run: pytest tests/tasks/uipath-maestro-flow/ -v
```

## Safe to widen

Ran the full directory before widening the net — green on both bases, so CI won't go red on merge:
- clean `main`: **49 passed**
- with #1031's additions: **52 passed**

## Test plan

- [x] `pytest tests/tasks/uipath-maestro-flow/ -v` on `main` → 49 passed
- [x] YAML validates (`yaml.safe_load`)
- [ ] Confirm the `Test Helpers` check appears on this PR (it edits its own workflow, so the path trigger fires)

> Touches `.github/` → CODEOWNERS routes review to @uipreliga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)