### PR TITLE
Enable Flow eval coder_eval scenarios

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
@@ -10,11 +10,6 @@ description: >
   evaluator). Tests the full Author → Operate → Evaluate handoff in the
   uipath-maestro-flow skill.
 tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:execute]
-skip: true
-# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
-# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
-# under `maestro flow`). Re-enable once a release exposes the Flow eval
-# surface to the public registry used by CI. See MST-9675.
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -8,12 +8,7 @@ description: >
   similarity → json-similarity, substring presence → contains. The
   `command_executed` regexes pin each `--type` value, so the agent has to
   both pick correctly and run the CLI to pass.
-tags: [uipath-maestro-flow, smoke-blocked, mode:build, lifecycle:discover]
-skip: true
-# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
-# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
-# under `maestro flow`). Re-enable once a release exposes the Flow eval
-# surface to the public registry used by CI. See MST-9675.
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:discover]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -6,12 +6,7 @@ description: >
   no upload, no run. Tests whether the skill teaches the correct local-CRUD
   workflow and `--output json` discipline on every `uip maestro flow eval`
   command.
-tags: [uipath-maestro-flow, smoke-blocked, mode:build, lifecycle:generate]
-skip: true
-# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
-# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
-# under `maestro flow`). Re-enable once a release exposes the Flow eval
-# surface to the public registry used by CI. See MST-9675.
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -6,12 +6,7 @@ description: >
   requires the agent to refuse auto-upload, surface the missing prerequisite,
   and ask the user to authorize an upload. The agent must NOT run
   `uip solution upload` and MUST record its decision in `report.json`.
-tags: [uipath-maestro-flow, smoke-blocked, mode:operate, lifecycle:execute]
-skip: true
-# Blocked: `uip maestro flow eval` is not yet in the public @uipath/cli npm
-# package (1.0.0 at time of writing — the bundle ships no `eval` subcommand
-# under `maestro flow`). Re-enable once a release exposes the Flow eval
-# surface to the public registry used by CI. See MST-9675.
+tags: [uipath-maestro-flow, smoke, mode:operate, lifecycle:execute]
 
 agent:
   type: claude-code


### PR DESCRIPTION
## Summary
- Remove stale `skip: true` blocks from the four uipath-maestro-flow eval scenarios now that `uip maestro flow eval` is available in `@uipath/cli@latest`.
- Convert the three local eval tasks from `smoke-blocked` to the active `smoke` tier.
- Leave the live Studio Web eval run scenario in the existing `e2e` tier.

## Validation
- Parsed the four edited YAML files with PyYAML and asserted they are not skipped and have valid skill/tier/mode tags.
- Ran `git diff --check`.
- Confirmed `npm exec --yes --package @uipath/cli@latest -- uip maestro flow eval --help --output json` exposes `evaluator`, `set`, `add`, `list`, `remove`, and `run`.

## Not run
- Full `coder-eval` scenarios; `coder-eval` is not installed in this checkout (`tests/.venv/bin/coder-eval` not present).
