### PR TITLE
test(uipath-maestro-flow): file-attachment and Salesforce list-records e2e tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -32,15 +32,23 @@ from typing import Any, Iterable, Sequence
 def run_debug(
     *,
     inputs: dict | None = None,
+    attachments: dict[str, str] | None = None,
     timeout: int = 240,
     project_glob: str = "**/project.uiproj",
 ) -> dict:
     """Locate the project, run ``uip maestro flow debug --output json``, and return the
-    parsed ``Data`` payload. Exits on any step failing."""
+    parsed ``Data`` payload. Exits on any step failing.
+
+    ``attachments`` maps a file-typed input variable ``id`` to a local file path;
+    each pair is passed as ``--attachment <id>=<path>`` (repeatable). The variable
+    ``id`` must match a ``variables.globals[]`` entry with ``direction:"in"`` and
+    ``type:"file"`` — see :func:`read_flow_file_input_vars`."""
     project_dir = _find_project(project_glob)
     cmd = ["uip", "maestro", "flow", "debug", project_dir, "--output", "json"]
     if inputs is not None:
         cmd.extend(["--inputs", json.dumps(inputs)])
+    for var_id, local_path in (attachments or {}).items():
+        cmd.extend(["--attachment", f"{var_id}={local_path}"])
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     if r.returncode != 0:
         _fail(f"flow debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}")
@@ -233,6 +241,23 @@ def read_flow_input_vars(project_dir: str) -> list[str]:
         v["id"]
         for v in (variables.get("globals") or [])
         if v.get("direction") in ("in", "inout")
+    ]
+
+
+def read_flow_file_input_vars(project_dir: str) -> list[str]:
+    """Return the ordered list of file-typed input variable IDs (``direction:"in"``,
+    ``type:"file"``) declared on the first ``.flow`` file in ``project_dir``. These
+    are the ids eligible for ``uip maestro flow debug --attachment <id>=<path>``."""
+    flows = glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
+    if not flows:
+        _fail(f"No .flow file found under {project_dir}")
+    with open(flows[0]) as f:
+        flow = json.load(f)
+    variables = flow.get("variables") or flow.get("workflow", {}).get("variables") or {}
+    return [
+        v["id"]
+        for v in (variables.get("globals") or [])
+        if v.get("direction") == "in" and v.get("type") == "file"
     ]
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/check_file_attachment_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/check_file_attachment_flow.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""File attachment: bind a local file to a file-typed input via
+``uip maestro flow debug --attachment <varId>=<path>`` and assert the runtime
+uploaded it and the flow surfaced the file's name as output.
+
+The attachment filename is generated here at check time with a random token the
+agent never saw, so the only way it can appear in the flow output is if the
+attachment was actually uploaded, resolved to a Flow Attachment object, read by
+the Script node, and mapped to an output variable — i.e. the full
+``--attachment`` path works end to end. An agent that hardcodes a filename
+literal cannot pass.
+"""
+
+import os
+import sys
+import tempfile
+import uuid
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_outputs_contain,
+    find_project_dir,
+    read_flow_file_input_vars,
+    run_debug,
+)
+
+
+def main():
+    # A Script node must read the attachment — prevents echoing a hardcoded literal.
+    assert_flow_has_node_type(["core.action.script"])
+
+    project_dir = find_project_dir()
+    file_vars = read_flow_file_input_vars(project_dir)
+    if not file_vars:
+        sys.exit(
+            "FAIL: No file-typed input variable (direction:'in', type:'file') "
+            "found in the flow — nothing to bind an --attachment to."
+        )
+
+    # Unique basename the agent could not have hardcoded.
+    token = uuid.uuid4().hex[:12]
+    basename = f"evidence-{token}.txt"
+    path = os.path.join(tempfile.mkdtemp(), basename)
+    with open(path, "w") as f:
+        f.write(f"attachment payload {token}\n")
+
+    var_id = file_vars[0]
+    print(f"Binding --attachment {var_id}={path}")
+    payload = run_debug(attachments={var_id: path}, timeout=240)
+
+    # The runtime resolves a file attachment to {ID, FullName, MimeType, Metadata};
+    # FullName is the uploaded file's basename. A passing flow reads it and surfaces
+    # it as an output variable.
+    assert_outputs_contain(payload, basename)
+    print(f"OK: Script node present; flow completed; output surfaced attachment FullName {basename!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -1,0 +1,74 @@
+task_id: skill-flow-file-attachment-debug
+description: >
+  Build a Flow whose trigger exposes a file-typed input variable, read the
+  uploaded attachment in a Script node, and surface its file name as flow
+  output. Then verify the operate path: `uip maestro flow debug
+  --attachment <varId>=<localPath>` uploads the local file, the runtime
+  resolves it to a Flow Attachment object ({ID, FullName, MimeType, Metadata}),
+  and the flow completes. The checker binds a randomly-named local file the
+  agent never saw and asserts that name appears in the output — proving the
+  attachment actually flowed through, not a hardcoded literal.
+tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:generate, shape:single-node]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "AttachmentEcho" that accepts a file as
+  input and echoes the file's name back as output.
+
+  Requirements:
+  - The flow has one `in` variable of `type: "file"` named `inputDoc`, bound to
+    the trigger (`triggerNodeId`). Its runtime payload is a full Flow Attachment
+    object with PascalCase keys: `{ ID, FullName, MimeType, Metadata }`.
+  - A Script node reads the attachment from the trigger output and returns the
+    file name, e.g. `return { fileName: $vars.<triggerId>.output.inputDoc.FullName };`
+  - An End node surfaces that file name as a flow output variable named `fileName`.
+
+  Validate the flow, then run it with `uip maestro flow debug`, binding a local
+  file to `inputDoc` via `--attachment inputDoc=<localPath>`. The task is not
+  complete until the debug run reports `finalStatus: "Completed"` and the output
+  reflects the attached file's name.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build, validate, and run end-to-end in a single
+  pass. Before starting, load the uipath-maestro-flow skill and follow its
+  workflow steps exactly — in particular the `--attachment <variableId>=<path>`
+  pre-flight and the requirement to run `solution resource refresh` before debug.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate AttachmentEcho/AttachmentEcho/AttachmentEcho.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Agent invoked debug with an --attachment binding ───────────────────
+  - type: command_executed
+    description: "Agent ran flow debug with an --attachment binding and --output json"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug.*--attachment\s+\S+=\S+.*--output\s+json|(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug.*--output\s+json.*--attachment\s+\S+=\S+'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # ── Execution: attachment uploads, binds, and the file name round-trips ─
+  - type: run_command
+    description: "Debug with --attachment completes and the uploaded file name appears in the output"
+    command: "python3 $TASK_DIR/check_file_attachment_flow.py"
+    timeout: 240
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -20,26 +20,19 @@ run_limits:
 
 initial_prompt: |
   Create a UiPath Flow project named "AttachmentEcho" that accepts a file as
-  input and echoes the file's name back as output.
-
-  Requirements:
-  - The flow has one `in` variable of `type: "file"` named `inputDoc`, bound to
-    the trigger (`triggerNodeId`). Its runtime payload is a full Flow Attachment
-    object with PascalCase keys: `{ ID, FullName, MimeType, Metadata }`.
-  - A Script node reads the attachment from the trigger output and returns the
-    file name, e.g. `return { fileName: $vars.<triggerId>.output.inputDoc.FullName };`
-  - An End node surfaces that file name as a flow output variable named `fileName`.
+  input and echoes the uploaded file's name back as a flow output. Use a
+  file-typed input variable named `inputDoc` and surface the name as an output
+  variable named `fileName`.
 
   Validate the flow, then run it with `uip maestro flow debug`, binding a local
-  file to `inputDoc` via `--attachment inputDoc=<localPath>`. The task is not
-  complete until the debug run reports `finalStatus: "Completed"` and the output
-  reflects the attached file's name.
+  file to the input. The task is not complete until the debug run reports
+  `finalStatus: "Completed"` and the output reflects the attached file's name.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build, validate, and run end-to-end in a single
   pass. Before starting, load the uipath-maestro-flow skill and follow its
-  workflow steps exactly — in particular the `--attachment <variableId>=<path>`
-  pre-flight and the requirement to run `solution resource refresh` before debug.
+  workflow steps exactly — in particular the file-attachment binding pre-flight
+  and the requirement to run `solution resource refresh` before debug.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/check_salesforce_opportunity_list.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/check_salesforce_opportunity_list.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Salesforce list-records on Opportunity (live execution).
+
+Structural pre-checks fail fast and prevent gaming, then a live `flow debug`
+proves the connector actually called Salesforce and returned records:
+
+1. A connector node targets the Salesforce connector (`uipath-salesforce-sfdc`)
+   using the generic `list-records` operation on `objectName: "Opportunity"`.
+2. `flow debug` completes (`finalStatus == "Completed"`).
+3. The output holds a non-empty array of record objects, each carrying a
+   Salesforce `Id` — i.e. real Opportunity rows came back, not an empty list,
+   a scalar, or a hardcoded literal.
+
+Grounded against the codereval tenant's Salesforce connection (76 Opportunity
+records): the IS connector returns FLATTENED records (top-level `Id`, `Name`,
+`Amount`, `StageName`, …) with no `attributes.type` envelope, so the runtime
+assertion keys off `Id`, not `attributes`.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_uses_connector_target,
+    find_project_dir,
+    run_debug,
+)
+
+CONNECTOR_KEY = "uipath-salesforce-sfdc"
+OPERATION = "list-records"
+OBJECT_NAME = "Opportunity"
+
+
+def _load_flow_nodes(project_dir: str) -> list[dict]:
+    flows = glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
+    if not flows:
+        sys.exit(f"FAIL: No .flow file found under {project_dir}")
+    with open(flows[0]) as f:
+        flow = json.load(f)
+    return flow.get("nodes") or []
+
+
+def _detail_object_name(detail: dict) -> str | None:
+    """Resolve the configured object name for a generic connector node.
+
+    `node configure` stores it in a few places depending on CLI version: a
+    top-level `inputs.detail.objectName`, or inside the serialized
+    `configuration` string (`=jsonString:{...}`) at `objectName`,
+    `essentialConfiguration.objectName`, or `…instanceParameters.objectName`."""
+    if detail.get("objectName"):
+        return detail["objectName"]
+    cfg = detail.get("configuration")
+    if isinstance(cfg, str):
+        prefix = "=jsonString:"
+        body = cfg[len(prefix):] if cfg.startswith(prefix) else cfg
+        try:
+            obj = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        ess = obj.get("essentialConfiguration") if isinstance(obj, dict) else None
+        ess = ess if isinstance(ess, dict) else {}
+        params = ess.get("instanceParameters") if isinstance(ess, dict) else None
+        params = params if isinstance(params, dict) else {}
+        return obj.get("objectName") or ess.get("objectName") or params.get("objectName")
+    return None
+
+
+def _assert_structure() -> None:
+    # A real Salesforce connector node must be present (native connector node).
+    assert_flow_uses_connector_target(CONNECTOR_KEY)
+
+    nodes = _load_flow_nodes(find_project_dir())
+    list_nodes = [
+        n
+        for n in nodes
+        if CONNECTOR_KEY in str(n.get("type", "")).lower()
+        and OPERATION in str(n.get("type", "")).lower()
+    ]
+    if not list_nodes:
+        types = sorted({str(n.get("type", "")) for n in nodes})
+        sys.exit(
+            f"FAIL: No Salesforce {OPERATION!r} connector node found. "
+            f"Node types seen: {types}"
+        )
+
+    # The configured object must be Opportunity. Generic list-records carries
+    # objectName on inputs.detail (top-level) or inside the serialized
+    # `configuration` payload — accept either.
+    found = []
+    for node in list_nodes:
+        detail = (node.get("inputs") or {}).get("detail") or {}
+        if not isinstance(detail, dict):
+            continue
+        name = _detail_object_name(detail)
+        found.append(name)
+        if name == OBJECT_NAME:
+            return
+    sys.exit(
+        f"FAIL: Salesforce {OPERATION} node found but objectName != {OBJECT_NAME!r} "
+        f"(resolved object names: {found}). The list-records activity is generic — "
+        f"it must set the object name to {OBJECT_NAME!r}."
+    )
+
+
+def _assert_records_returned(payload: dict) -> None:
+    globals_ = (payload.get("variables") or {}).get("globals") or {}
+    # Find any output variable holding a non-empty array of record objects.
+    for name, value in globals_.items():
+        if (
+            isinstance(value, list)
+            and value
+            and all(isinstance(r, dict) for r in value)
+            and any("Id" in r for r in value)
+        ):
+            print(
+                f"OK: connector returned {len(value)} Opportunity record(s) "
+                f"in output {name!r} (first Id={value[0].get('Id')!r})"
+            )
+            return
+    sys.exit(
+        "FAIL: No output variable holds a non-empty array of Salesforce records "
+        f"with an 'Id' field. globals keys: {sorted(globals_)}"
+    )
+
+
+def main():
+    _assert_structure()
+    payload = run_debug(timeout=300)
+    _assert_records_returned(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/salesforce_opportunity_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/salesforce_opportunity_list.yaml
@@ -1,0 +1,77 @@
+task_id: skill-flow-salesforce-opportunity-list
+description: >
+  End-to-end: build a Flow whose process calls Salesforce to list records in the
+  Opportunity object via a generic connector node
+  (`uipath.connector.uipath-salesforce-sfdc.list-records`, `objectName:
+  "Opportunity"`), bind it to the tenant's Salesforce connection, then run
+  `flow debug` and assert real Opportunity records come back. Exercises connector
+  discovery (including connections in non-default folders), generic-activity
+  object-name resolution, connection binding, and live execution. The IS Salesforce
+  connector returns flattened records (top-level `Id`, `Name`, …), so the checker
+  asserts a non-empty array of objects carrying a Salesforce `Id`.
+tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:generate, shape:single-node, connector, uipath-salesforce]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  task_timeout: 1500
+  max_turns: 120
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "OpportunityList" with a manual trigger.
+  The process must call Salesforce to list all records in the Opportunity
+  object, then surface the returned records as a flow output variable.
+
+  Use the Salesforce connector. Discover the right operation for listing
+  records of an object and configure it against the Opportunity object, bound
+  to the tenant's Salesforce connection (the connection may live in a
+  non-default folder — discover it across all folders). Then run the flow with
+  `uip maestro flow debug` to confirm it returns Opportunity records.
+
+  The task is not complete until `uip maestro flow validate` passes and the
+  debug run reports `finalStatus: "Completed"` with Opportunity records in the
+  output.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build, validate, and run end-to-end in a single
+  pass. Before starting, load the uipath-maestro-flow skill and follow its
+  workflow — in particular the connector node configuration steps (discover the
+  connection, `registry get --connection-id`, `node configure --detail`) and the
+  requirement to run `solution resource refresh` before debug. Do NOT substitute
+  a mock for the connector.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate OpportunityList/OpportunityList/OpportunityList.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Agent invoked debug ────────────────────────────────────────────────
+  - type: command_executed
+    description: "Agent ran flow debug with --output json"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # ── Execution: connector calls Salesforce and returns Opportunity rows ──
+  - type: run_command
+    description: "Salesforce list-records node on Opportunity executes and returns real records"
+    command: "python3 $TASK_DIR/check_salesforce_opportunity_list.py"
+    timeout: 320
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/salesforce_opportunity_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/salesforce_opportunity_list.yaml
@@ -9,7 +9,7 @@ description: >
   object-name resolution, connection binding, and live execution. The IS Salesforce
   connector returns flattened records (top-level `Id`, `Name`, …), so the checker
   asserts a non-empty array of objects carrying a Salesforce `Id`.
-tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:generate, shape:single-node, connector, uipath-salesforce]
+tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:generate, shape:single-node, connector, uipath-salesforce-sfdc]
 
 agent:
   type: claude-code
@@ -26,10 +26,9 @@ initial_prompt: |
   The process must call Salesforce to list all records in the Opportunity
   object, then surface the returned records as a flow output variable.
 
-  Use the Salesforce connector. Discover the right operation for listing
-  records of an object and configure it against the Opportunity object, bound
-  to the tenant's Salesforce connection (the connection may live in a
-  non-default folder — discover it across all folders). Then run the flow with
+  Use the Salesforce connector, configured against the Opportunity object and
+  bound to the tenant's Salesforce connection. The connection may live in a
+  non-default folder, so discover it wherever it is. Then run the flow with
   `uip maestro flow debug` to confirm it returns Opportunity records.
 
   The task is not complete until `uip maestro flow validate` passes and the
@@ -39,10 +38,8 @@ initial_prompt: |
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build, validate, and run end-to-end in a single
   pass. Before starting, load the uipath-maestro-flow skill and follow its
-  workflow — in particular the connector node configuration steps (discover the
-  connection, `registry get --connection-id`, `node configure --detail`) and the
-  requirement to run `solution resource refresh` before debug. Do NOT substitute
-  a mock for the connector.
+  connector node configuration workflow. Do NOT substitute a mock for the
+  connector.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds two live debug-execution (`mode:operate`) e2e tasks for `uipath-maestro-flow`, plus shared-helper support.

### `file_attachment` — `flow debug --attachment`
Builds a flow with a file-typed `in` variable echoed by a Script node, then binds a **randomly-named** local file via `flow debug --attachment <varId>=<path>`. Asserts the run completes and the uploaded file name round-trips to a flow output. The random name (the agent never sees it) defeats hardcoding.

### `salesforce_opportunity_list` — generic connector list-records
Builds a generic Salesforce `list-records` node on the Opportunity object, binds the tenant connection (discovered across folders), runs `flow debug`, and asserts a **non-empty array of record objects each carrying an `Id`** — i.e. real Opportunity rows came back, not an empty list or a literal. `objectName` is parsed from the serialized connector `configuration` payload (it is not stored as a top-level `detail` key).

### Shared helpers (`_shared/flow_check.py`)
- `run_debug(attachments=...)` — emits repeatable `--attachment <id>=<path>` flags.
- `read_flow_file_input_vars()` — returns file-typed (`direction:"in"`, `type:"file"`) input variable ids.

Both tasks delete their cloud solution via `post_run` cleanup.

## Passing runs

| Task | Result |
|------|--------|
| `skill-flow-file-attachment-debug` | 3/3 passed, score 1.000 (SUCCESS, 262s) — attachment uploaded, file name round-tripped to output |
| `skill-flow-salesforce-opportunity-list` | 3/3 passed, score 1.000 (SUCCESS, 454s) — live debug returned 76 Opportunity records (`first Id=0064x000005VMAwAAO`) |

Both runs cleaned up their solutions (`deleted=1 preserved=0`).