### PR TITLE
docs(uipath-maestro-case): tighten stage/task entry & exit condition …

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -38,6 +38,7 @@ build the case in the Case Designer without guessing.
    - `required-tasks-completed` — all required tasks in stage completed
    - `wait-for-connector` — an Integration Service event received
    - `adhoc` — ad-hoc / manual trigger
+   - `runs-sequentially` — runs sequentially
 
 4. **Exit conditions:** Every exit condition MUST specify:
    - **Exit Type:** `exit-only` | `return-to-origin` | `wait-for-user`
@@ -47,8 +48,8 @@ build the case in the Case Designer without guessing.
    **WHEN ↔ Marks Complete pairing (hard constraint — schema-enforced; applies identically to STAGE exit and CASE exit):**
 
    *Stage exit:*
-   - `Marks Stage Complete: Yes` → WHEN MUST be `required-tasks-completed` (typical) or `required-stages-completed`. **NEVER** `selected-tasks-completed(...)`.
-   - `Marks Stage Complete: No` (routing / divergent exits) → WHEN may be `selected-tasks-completed("TaskA")`, `selected-stage-completed(...)`, `wait-for-connector`, etc.
+   - `Marks Stage Complete: Yes` → WHEN MUST be `required-tasks-completed` (typical) or `wait-for-connector`. **NEVER** `required-stages-completed` or  `selected-tasks-completed(...)`.
+   - `Marks Stage Complete: No` (routing / divergent exits) → WHEN may be `selected-tasks-completed("TaskA")`, `wait-for-connector`, etc.
    - Same stage may carry one completion exit (`Yes` + `required-tasks-completed`) plus zero or more routing exits (`No` + `selected-tasks-completed`).
 
    *Case exit (preferred pattern: one row, `Yes` + `required-stages-completed`):*
@@ -277,13 +278,19 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 #### Stage Entry Conditions
 
+> **Valid WHEN rule types for stage entry (strict subset of Key Rule 3):** `case-entered` (first stage of the case — no target), `selected-stage-completed("StageName")`, `selected-stage-exited("StageName")`, `user-selected-stage` (target of an upstream `wait-for-user` exit — no target; stage opts into the picker by declaring this rule), `wait-for-connector` (event-driven entry / interrupt — typically pairs with `Interrupting: Yes`). Other rule types from Key Rule 3 are NOT valid here.
+>
+> **Interrupting column:** `Yes` lets the condition fire while another stage is active and interrupt it — used for exception / fraud / escalation flows on `ExceptionStage`. `No` for normal sequential entry on regular stages.
+>
+> Each row is a separate entry condition. List multiple rows when a stage can be entered through more than one path (e.g., normal completion of an upstream stage AND an interrupting connector event).
+
 | WHEN | IF | Interrupting |
 |------|-----|-------------|
-| {rule type with target, e.g., selected-stage-completed("Previous Stage Name")} | {conditionExpression, or "—" if none} | {Yes \| No} |
+| {one of: `case-entered` \| `selected-stage-completed("StageName")` \| `selected-stage-exited("StageName")` \| `user-selected-stage` \| `wait-for-connector`} | {conditionExpression, or "—" if none} | {Yes \| No} |
 
 #### Stage Exit Conditions
 
-> **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed` (or `required-stages-completed`); `No` row MAY use `selected-tasks-completed(...)`. Mixing is invalid.
+> **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed`; `No` row MAY use `selected-tasks-completed(...)`. Mixing is invalid.
 
 | WHEN | IF | Exit Type | Marks Stage Complete |
 |------|-----|-----------|---------------------|
@@ -314,9 +321,13 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 **Entry Condition:**
 
+> **Valid WHEN rule types for task entry (strict subset of Key Rule 3):** `current-stage-entered` (default — fires when the containing stage is entered; typical for first task or any task with no sibling gate), `selected-tasks-completed("TaskA", "TaskB")` (fires when specific sibling tasks in the same stage complete), `wait-for-connector` (waits for a connector event), `adhoc` (user-triggered from the case app — task does not auto-start), `runs-sequentially` (sequential ordering within the stage; parallel members of the group share a lane, solo members get their own lane). Other rule types from Key Rule 3 are NOT valid here.
+>
+> Each row is a separate entry condition. List multiple rows when a task can be entered through more than one path. Connector tasks (`execute-connector-activity`, `wait-for-connector`) receive a default `current-stage-entered` condition on creation — still author the row explicitly if it applies.
+
 | WHEN | IF |
 |------|-----|
-| {rule type with target, or "current-stage-entered" for first task} | {conditionExpression, or "—" if none} |
+| {one of: `current-stage-entered` \| `selected-tasks-completed("TaskA", "TaskB")` \| `wait-for-connector` \| `adhoc` \| `runs-sequentially`} | {conditionExpression, or "—" if none} |
 
 ---
 

--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -39,6 +39,7 @@ build the case in the Case Designer without guessing.
    - `wait-for-connector` — an Integration Service event received
    - `adhoc` — ad-hoc / manual trigger
    - `runs-sequentially` — runs sequentially
+   - `user-selected-stage` - target of an upstream `wait-for-user` exit
 
 4. **Exit conditions:** Every exit condition MUST specify:
    - **Exit Type:** `exit-only` | `return-to-origin` | `wait-for-user`
@@ -290,11 +291,11 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 #### Stage Exit Conditions
 
-> **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed`; `No` row MAY use `selected-tasks-completed(...)`. Mixing is invalid.
+> **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed` or `wait-for-connector`; `No` row MAY use `selected-tasks-completed(...)` or `wait-for-connector`. Mixing is invalid.
 
 | WHEN | IF | Exit Type | Marks Stage Complete |
 |------|-----|-----------|---------------------|
-| {`required-tasks-completed` for Yes; `selected-tasks-completed("TaskName")` or other rule for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} |
+| {`required-tasks-completed` or `wait-for-connector` for Yes; `selected-tasks-completed("TaskName")` or `wait-for-connector` for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} |
 
 #### Stage SLA
 

--- a/skills/uipath-maestro-case/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-case/references/troubleshooting-guide.md
@@ -2,7 +2,7 @@
 
 Diagnostic workflow for failed debug runs and deployed case process runs. All commands require `uip login`.
 
-> **`--folder-key` is required for `incident get`.** Most `instance` subcommands accept `--folder-key <FOLDER_KEY>` and auto-detect from the authenticated folder if omitted, but `incident get` requires it explicitly. Get the folder key from `uip orchestrator folder list --output json` or from the job/process context.
+> **`--folder-key` is required for `incident get`.** Most `instance` subcommands accept `--folder-key <FOLDER_KEY>` and auto-detect from the authenticated folder if omitted, but `incident get` requires it explicitly. Get the folder key from `uip or folder list --output json` or from the job/process context.
 
 ## Diagnostic priority
 


### PR DESCRIPTION
docs(uipath-maestro-case): tighten stage/task entry & exit condition rules in SDD template

- Stage Entry Conditions: add catalog of the 5 valid WHEN rule types
  (case-entered, selected-stage-completed, selected-stage-exited,
  user-selected-stage, wait-for-connector) plus Interrupting column
  semantics and multi-row guidance.
- Task Entry Conditions: add catalog of the 5 valid WHEN rule types
  (current-stage-entered, selected-tasks-completed, wait-for-connector,
  adhoc, runs-sequentially) with lane-sharing note for runs-sequentially.
- Key Rule 3: add runs-sequentially to the global rule-type catalog.
- Key Rule 4 / Stage Exit guidance: correct the Marks Stage Complete: Yes
  pairing — required-tasks-completed (typical) or wait-for-connector;
  remove the incorrect required-stages-completed option (that rule is
  case-exit only).
