### PR TITLE
docs(uipath-maestro-case): document external case identifier authoring

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -138,7 +138,7 @@ The generated SDD must start with:
 |----------|-------|
 | Case Name | {PascalCase name} |
 | Case Description | {2-3 sentence description of what the case manages} |
-| Case Identifier | Prefix: {2-4 char UPPER prefix}, Type: {constant \| external} |
+| Case Identifier | Type: {constant \| external}. Constant → Prefix: {2-4 char UPPER prefix}. External → Source: {=vars.<In/InOut variable> \| =js:`expression`} |
 | Priority | Choiceset: {comma-separated values} — Default: {value} |
 | Case-Level SLA | {count} {unit: h/d/w/m} |
 | SLA Type | {time-based \| condition-based} |

--- a/skills/uipath-maestro-case/assets/templates/sdd-viewer.html
+++ b/skills/uipath-maestro-case/assets/templates/sdd-viewer.html
@@ -497,8 +497,9 @@
       "case": {
         "name": string,                       // PascalCase
         "description": string,
-        "prefix": string,                     // 2-4 UPPER
+        "prefix": string,                     // 2-4 UPPER (constant only)
         "identifierType": "constant" | "external",
+        "identifierExpression": string | null, // external only: =vars.<id> or =js:`...`
         "priority": { "values": string[], "default": string } | null,
         "sla": { "count": number, "unit": "h"|"d"|"w"|"m", "type": "Static"|"Variable" } | null,
         "slaEscalation": [{ "status": "At-Risk"|"Breached", "threshold": string, "action": string }],
@@ -611,7 +612,11 @@
       const t = $("#case-title");
       t.innerHTML = "";
       t.appendChild(document.createTextNode(c.name || "Untitled Case"));
-      if (c.prefix) {
+      if (c.identifierType === "external" && c.identifierExpression) {
+        const s = document.createElement("small");
+        s.textContent = "id " + c.identifierExpression;
+        t.appendChild(s);
+      } else if (c.prefix) {
         const s = document.createElement("small");
         s.textContent = "prefix " + c.prefix;
         t.appendChild(s);
@@ -675,7 +680,9 @@
       const rows = [
         ["Case Name", c.name],
         ["Description", c.description],
-        ["Identifier", c.prefix ? `${c.prefix} (${c.identifierType || "constant"})` : null],
+        ["Identifier", c.identifierType === "external"
+          ? `${c.identifierExpression || "—"} (external)`
+          : (c.prefix ? `${c.prefix} (${c.identifierType || "constant"})` : null)],
         ["Priority", c.priority ? `${(c.priority.values || []).join(", ")} — default ${c.priority.default || "—"}` : null],
         ["Case-Level SLA", c.sla ? `${c.sla.count} ${c.sla.unit} — ${c.sla.type || "Static"}` : null]
       ];

--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -141,8 +141,8 @@ Metadata and configuration for the case definition. **v19** wraps everything und
 | `id` | string | Unique ID (auto-generated) |
 | `name` | string | Human-readable name |
 | `type` | `"case-management:root"` | Literal — do not change |
-| `caseIdentifier` | string | Identifier used at runtime |
-| `caseIdentifierType` | `"constant"` \| `"external"` | How the identifier is resolved |
+| `caseIdentifier` | string | Runtime identifier. `constant` → literal prefix. `external` → `=`-prefixed expression. See § Case identifier below. |
+| `caseIdentifierType` | `"constant"` \| `"external"` | Selects how `caseIdentifier` is read. Default `constant`. |
 | `caseAppEnabled` | boolean | Whether the Case App UI is enabled |
 | `version` | string | Schema version — `"v19"` for current schema. Emitted by the `case` plugin at T01. |
 | `publishVersion` | number? | Publish version — `2` for current schema |
@@ -151,6 +151,13 @@ Metadata and configuration for the case definition. **v19** wraps everything und
 | `data.uipath` | object? | Variable and binding declarations |
 | `caseExitConditions` | CaseExitCondition[]? | Conditions that mark the case as complete |
 | `description` | string? | Case description |
+
+### Case identifier (constant vs external)
+
+`caseIdentifierType` picks how `caseIdentifier` resolves at runtime:
+
+- **`constant`** (default) — `caseIdentifier` is a literal 2-4 char prefix (`"LOAN"`). Runtime emits the case external id as `<prefix>-<generated>`.
+- **`external`** — `caseIdentifier` is a `=`-prefixed expression (bare `=vars.<id>` or `=js:<expr>`). Runtime evaluates it; the result becomes the case external id verbatim (no prefix). Same `=vars.<id>` / `=js:` convention as [bindings-and-expressions.md](bindings-and-expressions.md) — no other engine. v20: field lives under `metadata` (see field-mapping table). Authoring forms + variable eligibility: [`plugins/case/planning.md` § External identifier value](plugins/case/planning.md).
 
 ### CaseExitCondition
 

--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -253,6 +253,8 @@ Title format: `Create case file "<name>"`
 
 Consult [`plugins/case/planning.md`](plugins/case/planning.md) for required fields (name, file path, case-identifier, identifier-type, case-app-enabled, description). Source all fields from sdd.md.
 
+When `identifier-type: external`, `case-identifier` carries the sdd.md expression verbatim (`=vars.<varId>` or `=js:…`); any `=vars.<varId>` it references must be a variable declared in §4.2.1 (an **In** argument or **Variable**). See [`plugins/case/planning.md` § External identifier value](plugins/case/planning.md).
+
 ### 4.2.1 Declare global variables and arguments
 
 Title format: `Declare <category> "<name>"` where category is `In argument`, `Out argument`, or `variable`.

--- a/skills/uipath-maestro-case/references/plugins/case/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/case/impl-json.md
@@ -308,6 +308,13 @@ Adds top-level `description` field (NOT inside `metadata`):
 
 > **`intsvcActivityConfig` always emitted in v20** — set `metadata.intsvcActivityConfig: "v2"` on every v20 caseplan. Mirrors the v19 `root.data.intsvcActivityConfig` field, relocated under `metadata`.
 
+## caseIdentifier — constant vs external
+
+Set `caseIdentifierType` from the T01 `identifier-type` (default `constant`); same field in v19 (`root.*`) and v20 (`metadata.*`).
+
+- **`constant`** — write the literal prefix from sdd.md (`"caseIdentifier": "LOAN"`).
+- **`external`** — copy the T01 `case-identifier` expression **verbatim** into `caseIdentifier` (e.g. `"=vars.poNumber"` or `` "=js:`${metadata.InstanceId}-${vars.region}`" ``). Do NOT transform or `=js:`-wrap it — unlike task-input sinks ([bindings-and-expressions.md](../../bindings-and-expressions.md)), this value is written as authored. Valid forms + variable eligibility: [planning.md § External identifier value](planning.md).
+
 ## Formatting
 
 - Indent: 4 spaces.

--- a/skills/uipath-maestro-case/references/plugins/case/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/case/planning.md
@@ -19,10 +19,19 @@ Always. This plugin is invoked for the very first T-entry (`T01`) in every `task
 
 ## identifier-type Guidance
 
-- `constant` — **Default.** Use when sdd.md does not mention external identifier sources. The case identifier is fixed across instances (typically matches `name`).
-- `external` — Use when sdd.md says something like "the case is identified by the incoming PO number" or "the case uses the external ticket ID." Runtime will pull the identifier from case data.
+- `constant` — **Default.** Use when sdd.md does not mention external identifier sources. The identifier is a fixed 2-4 char prefix; runtime emits `<prefix>-<generated>`.
+- `external` — Use when sdd.md says the identifier comes from upstream data ("identified by the incoming PO number", "uses the external ticket ID"). `case-identifier` becomes a `=`-prefixed expression; runtime evaluates it and the result IS the case external id.
 
 When ambiguous, use **AskUserQuestion** with both options + "Something else".
+
+### External identifier value
+
+`case-identifier` is carried verbatim from sdd.md — one of two forms (no other engine):
+
+- **Bare var** — `=vars.<varId>`, where `<varId>` is a single variable declared in the §4.2.1 block. It MUST be an **In** argument or a **Variable** — not an **Out** argument (produced at case end).
+- **`=js:` expression** — for string ops / concatenation, e.g. `` =js:`${metadata.InstanceId}-${vars.region}` ``. May read `vars.<id>` and `metadata.InstanceId` / `metadata.FolderKey` / `metadata.ProcessKey` — never `metadata.ExternalId` (the field being set).
+
+A referenced variable must have its own §4.2.1 T-entry (the completeness cross-check requires it).
 
 ## Registry Resolution
 
@@ -44,6 +53,8 @@ The case plugin writes a pure skeleton at T01 — no trigger node. The primary t
 - order: first
 - verify: Confirm caseplan.json written and parses; root.id == "root", nodes == [], edges == []
 ```
+
+> **External variant.** Replace the two identifier lines with `identifier-type: external` + `case-identifier: "=vars.<varId>"` (or a `=js:` expression). See § External identifier value.
 
 ## Project Structure Prerequisites
 


### PR DESCRIPTION
## What

Documents how to author an **external** case identifier (`caseIdentifierType: "external"`) in the `uipath-maestro-case` skill. The enum value already existed in every schema/recipe placeholder, but only the `constant` path was ever exemplified — there was no recipe for the external form.

## Why

An external identifier lets the case external id come from upstream data (PO number, ticket id, etc.) instead of a fixed prefix. Agents had no guidance on the value shape, so they couldn't author it.

## Source of truth

Behavior verified against `PO.Frontend` and `PO.BpmnEngine`, not assumed:

- **FE** (`useCaseManagementRootGeneralForm.tsx`): `external` renders a variable control; stored value is a `=`-prefixed expression (`useCaseManagementRootGeneralForm.test.tsx:74` → `"=vars.AbC123"`). Picker is filtered to `input`/`inputOutput` variables.
- **Runtime** (`PostExecutionPhaseHandler.cs`): constant → `<prefix>-<generated>`; external → `IsExpressionLike()` (`=` prefix) then evaluate, result is the id verbatim.
- **Engine** (`BpmnDataManager.cs`): `=js:` → JavaScript, otherwise default evaluator. Available metadata vars: `InstanceId` / `FolderKey` / `ProcessKey` (`ExternalId` excluded — self-referential).

## Contract documented

External `caseIdentifier` is one of **two forms only** (deliberately matching the skill's existing `=vars.<id>` / `=js:` convention — no third engine documented):

| Form | When |
|------|------|
| bare `=vars.<id>` | identifier is exactly one eligible variable |
| `=js:<expr>` | string ops, concatenation, metadata refs |

Referenced variable must be an **In** argument or a **Variable** (not an **Out** argument).

## Files

- `references/case-schema.md` — constant vs external field semantics
- `references/plugins/case/impl-json.md` — **canonical** form table + rules + v19/v20 example
- `references/planning.md` + `plugins/case/planning.md` — T01 representation + forward-reference dependency on the variable's §4.2.1 T-entry
- `assets/templates/sdd-template.md` + `sdd-viewer.html` — capture/render the external source

## Scope

Docs + SDD only. A coder-eval test task (grading `caseIdentifierType: "external"` + a `=`-prefixed `caseIdentifier`) is intentionally deferred to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)