### PR TITLE
feat(uipath-maestro-case): author connector-bound wait-for-connector rules in all condition scopes

### DIFF
--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -176,6 +176,8 @@ Completion report + **HARD STOP** AskUserQuestion (Step 13): `Run debug session`
 | [task-entry-conditions](references/plugins/conditions/task-entry-conditions/planning.md) | Task starts |
 | [case-exit-conditions](references/plugins/conditions/case-exit-conditions/planning.md) | Case completes/exits |
 
+> **Connector-bound rules:** a `wait-for-connector` rule in any condition scope must carry the connector binding under `rule.uipath` (built from `case spec --type trigger`, like the connector-trigger task) — bare connector rules are invalid in Studio Web and are NOT caught by CLI `validate`. See [connector-trigger-common.md § Target: connector-bound condition rule](references/connector-trigger-common.md#target-connector-bound-condition-rule).
+
 ## Anti-patterns
 
 - **Do NOT leave stages without an inbound edge.** Orphaned and unreachable. Every stage needs ≥1 inbound edge from Trigger or another stage.

--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -176,7 +176,7 @@ Completion report + **HARD STOP** AskUserQuestion (Step 13): `Run debug session`
 | [task-entry-conditions](references/plugins/conditions/task-entry-conditions/planning.md) | Task starts |
 | [case-exit-conditions](references/plugins/conditions/case-exit-conditions/planning.md) | Case completes/exits |
 
-> **Connector-bound rules:** a `wait-for-connector` rule in any condition scope must carry the connector binding under `rule.uipath` (built from `case spec --type trigger`, like the connector-trigger task) — bare connector rules are invalid in Studio Web and are NOT caught by CLI `validate`. See [connector-trigger-common.md § Target: connector-bound condition rule](references/connector-trigger-common.md#target-connector-bound-condition-rule).
+> **Connector-bound rules:** a `wait-for-connector` rule in any condition scope must carry the connector configuration under `rule.uipath` (built from `case spec --type trigger`, like the connector-trigger task) — bare connector rules are invalid in Studio Web and are NOT caught by CLI `validate`. See [connector-trigger-common.md § Target: connector-bound condition rule](references/connector-trigger-common.md#target-connector-bound-condition-rule).
 
 ## Anti-patterns
 

--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -60,6 +60,17 @@ build the case in the Case Designer without guessing.
 6. **Entry/exit conditions use WHEN + IF format:**
    - **WHEN** = the rule type (event that triggers evaluation, e.g., `selected-stage-completed("Intake")`)
    - **IF** = the optional `conditionExpression` (JavaScript expression evaluated against case variables, e.g., `applicationStatus == "Approved"`)
+   - **`wait-for-connector` WHEN** binds an Integration Service connector event. Name it inline in the WHEN cell (e.g. `wait-for-connector (Outlook "Email Received", Inbox)`) AND add a **Connector Rule Detail** block under the condition table. Applies to stage-entry, stage-exit, case-exit, and task-entry conditions. The IF cell is then an optional gate on the event payload (e.g. `event.subject` test) — on top of, not instead of, the connector binding. A connector **rule** does NOT bind outputs to case variables (unlike a connector task); the event only gates the transition.
+
+   **Connector Rule Detail block** — reproduce under any condition table whose WHEN is `wait-for-connector`. Connector / Connection / Event come from the IS CLI cache like Connector Task Detail; the skill resolves them into the rule's `uipath` (`serviceType: Intsvc.WaitForEvent`):
+   ```markdown
+   **Connector Rule Detail:**
+   - Connector: {e.g., Microsoft Outlook 365}
+   - Connection: {instance name, or "Tenant default"}
+   - Event: {e.g., Email Received}
+   - Filter: {filter in business terms, or "—"}
+   - Event Parameters: {name=value pairs, e.g., parentFolderId="Inbox"; or "—"}
+   ```
 
 7. **Task types — closed enum of 9 values. Choose based on WHAT THE TASK DOES, not its surface label.** Any other value (e.g., `external-agent`, `connector-activity`, `wait-for-event`) is invalid and breaks downstream JSON generation. Consider all 9 for every task:
    - `action` — a human must review, approve, or make a judgment call. The task PAUSES for a person.
@@ -188,6 +199,8 @@ DO NOT include in Configuration:
 |------|-----|------|---------------------|
 | {`required-stages-completed` for Yes; `selected-stage-completed("StageName")` or other rule for No} | {conditionExpression, or "—" if none} | Case exited | {Yes \| No} |
 
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6) — it binds the IS connector event the rule waits for.
+
 ### Case Variables
 
 > Complete inventory of all case-level variables and arguments. Every row's `Category` column is REQUIRED — drives classification at build time. Inference from other columns is no longer supported.
@@ -281,6 +294,8 @@ The runtime engine resolves the binding when the task completes, writing the res
 |------|-----|-------------|
 | {rule type with target, e.g., selected-stage-completed("Previous Stage Name")} | {conditionExpression, or "—" if none} | {Yes \| No} |
 
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
+
 #### Stage Exit Conditions
 
 > **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed` (or `required-stages-completed`); `No` row MAY use `selected-tasks-completed(...)`. Mixing is invalid.
@@ -288,6 +303,8 @@ The runtime engine resolves the binding when the task completes, writing the res
 | WHEN | IF | Exit Type | Marks Stage Complete |
 |------|-----|-----------|---------------------|
 | {`required-tasks-completed` for Yes; `selected-tasks-completed("TaskName")` or other rule for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} |
+
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
 #### Stage SLA
 
@@ -317,6 +334,8 @@ The runtime engine resolves the binding when the task completes, writing the res
 | WHEN | IF |
 |------|-----|
 | {rule type with target, or "current-stage-entered" for first task} | {conditionExpression, or "—" if none} |
+
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
 ---
 

--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -381,7 +381,7 @@ Rules = Rule[][]
 
 | `rule` | Additional fields | Description |
 |--------|-------------------|-------------|
-| `wait-for-connector` | `id?`, `conditionExpression?`, `uipath?` | Wait for an external connector event |
+| `wait-for-connector` | `id?`, `uipath` (connector binding — required), `conditionExpression?` | Wait for an external connector event — see § Connector-bound rule below |
 | `case-entered` | `id?`, `conditionExpression?` | Fires when the case is first entered |
 | `selected-stage-completed` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has completed |
 | `selected-stage-exited` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has been exited |
@@ -401,6 +401,27 @@ Not every rule type is valid at every level — see each condition plugin's `imp
 { "rule": "selected-tasks-completed", "id": "<id>", "selectedTasksIds": ["<taskId1>", "<taskId2>"] }
 { "rule": "adhoc", "id": "<id>", "conditionExpression": "in.Score > 700" }
 ```
+
+### Connector-bound `wait-for-connector` rule
+
+A `wait-for-connector` rule binds an IS connector trigger under **`uipath`** — the same block the in-stage `wait-for-connector` task carries under `data`. A bare rule (no `uipath`) is rejected by Studio Web (the FE validator requires the connector activity to resolve). It is authored from a `case spec --type trigger` scaffold; the CLI does not bind it (`buildRule` emits the bare form). `conditionExpression` is an optional payload gate. Inputs/outputs `elementId` = `<stageId>-<ruleId>` (stage-entry / stage-exit / task-entry — all stage-scoped) or `root-<ruleId>` (case-exit). Full recipe: [connector-trigger-common.md § Target: connector-bound condition rule](connector-trigger-common.md#target-connector-bound-condition-rule).
+
+```json
+{
+  "rule": "wait-for-connector",
+  "id": "<ruleId>",
+  "uipath": {
+    "serviceType": "Intsvc.WaitForEvent",
+    "context": [ { "name": "connectorKey", "value": "<key>", "type": "string" }, { "name": "connection", "value": "=bindings.<id>", "type": "string" }, { "name": "folderKey", "value": "=bindings.<id>", "type": "string" }, { "name": "resourceKey", "value": "<connection-id>", "type": "string" }, { "name": "objectName", "value": "<object>", "type": "string" }, { "name": "metadata", "type": "json", "body": { } } ],
+    "inputs": [ ],
+    "outputs": [ ],
+    "bindings": []
+  },
+  "conditionExpression": "=js:<optional payload gate>"
+}
+```
+
+> CLI `validate` does NOT check `rule.uipath` — the case-tool connector validator is task-only (reads `task.data`). Confirm connector rules via Studio Web.
 
 ---
 

--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -381,7 +381,7 @@ Rules = Rule[][]
 
 | `rule` | Additional fields | Description |
 |--------|-------------------|-------------|
-| `wait-for-connector` | `id?`, `uipath` (connector binding — required), `conditionExpression?` | Wait for an external connector event — see § Connector-bound rule below |
+| `wait-for-connector` | `id?`, `uipath` (connector configuration — required), `conditionExpression?` | Wait for an external connector event — see § Connector-bound rule below |
 | `case-entered` | `id?`, `conditionExpression?` | Fires when the case is first entered |
 | `selected-stage-completed` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has completed |
 | `selected-stage-exited` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has been exited |

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -1,10 +1,11 @@
 # Connector Trigger — Shared Pipeline
 
-Shared planning and implementation logic for connector-based triggers. Used by both:
-- [connector-trigger task](plugins/tasks/connector-trigger/planning.md) — in-stage `wait-for-connector`
-- [event trigger](plugins/triggers/event/planning.md) — case-level `Intsvc.EventTrigger`
+Shared planning and implementation logic for connector-based triggers. Used by three:
+- [connector-trigger task](plugins/tasks/connector-trigger/planning.md) — in-stage `wait-for-connector` task
+- [event trigger](plugins/triggers/event/planning.md) — case-level `Intsvc.EventTrigger` (case start)
+- **connector-bound condition rule** — a `wait-for-connector` rule in any condition scope (stage-entry / stage-exit / case-exit / task-entry). See [§ Target: connector-bound condition rule](#target-connector-bound-condition-rule) and each condition plugin's `impl-json.md`.
 
-Both use the same TypeCache (`typecache-triggers-index.json`), same single-call `case spec` discovery, same FE-canonical `caseShape` consumption. Only the target (task vs trigger node), `serviceType`, and a few node-shape details differ — see each plugin's own docs for those specifics.
+All three use the same TypeCache (`typecache-triggers-index.json`), same single-call `case spec` discovery, same FE-canonical `caseShape` consumption. Only the target (task `data` / trigger node `data.uipath` / rule `uipath`), `serviceType`, and a few shape details differ — see each plugin's own docs.
 
 > Mirrors the [connector-activity](plugins/tasks/connector-activity/planning.md) flow. Same CLI surface (`uip maestro case spec` with `--skip-case-shape` for planning, `--input-details` for Phase 3); `--type trigger` swaps in trigger-shaped inputs/outputs and the trigger-specific `metadata.body.bindings[Property]` registration entry.
 
@@ -319,7 +320,7 @@ Per-plugin: each plugin's `impl-json.md` mints these onto `caseShape.inputs[]` /
 Conventions (shared with activity):
 - `var` = `v` + 8 alphanumeric chars (unique across the case — see [global-vars/impl-json.md § Uniqueness Rule](plugins/variables/global-vars/impl-json.md#uniqueness-rule))
 - `id` = same as `var`
-- `elementId` = the task's elementId (for in-stage `wait-for-connector` task) or the trigger node's id (for case-level event trigger)
+- `elementId` = the task's elementId (in-stage `wait-for-connector` task), the trigger node's id (case-level event trigger), or `<ownerNodeId>-<ruleId>` (connector-bound condition rule — see [§ Target: connector-bound condition rule](#target-connector-bound-condition-rule))
 
 For **outputs** apply the dedup rule: collect existing output `var` values across every task / trigger already in `caseplan.json`; if a `var` already exists (e.g. `response`, `error` collide across multiple connector tasks/triggers), append a counter starting at 2 (`response2`, `error2`). Update `var`, `id`, `value`, `target` (when present); keep `name`, `displayName`, `source` unchanged.
 
@@ -363,6 +364,55 @@ Dedup per [§ Deduplication](plugins/variables/bindings/impl-json.md). Source-of
 After writing root bindings, populate IS connection cache per [bindings-v2-sync.md § Populate IS connection cache](bindings-v2-sync.md). Skip if `case spec` failed.
 
 > **`bindings_v2.json` regeneration is deferred** — runs once at end of Step 9.7 (after all connector tasks/triggers), not per-task. See [bindings-v2-sync.md § When to Run](bindings-v2-sync.md).
+
+---
+
+## Target: connector-bound condition rule
+
+A `wait-for-connector` rule inside a condition (`…conditions[].rules[i][j]`) binds the connector under the rule's **`uipath`** — structurally the same block the in-stage task writes under `data`. **The CLI cannot author this** (`buildRule` in `case-tool` emits a bare `{ rule, id, conditionExpression }` with no `uipath`); write `rule.uipath` directly per this recipe. Used by all four condition plugins.
+
+### Differences vs the in-stage task
+
+| Aspect | In-stage task | Connector-bound rule |
+|---|---|---|
+| Container | `task.data` | `rule.uipath` |
+| `serviceType` | `Intsvc.WaitForEvent` | `Intsvc.WaitForEvent` (same) |
+| `elementId` on inputs/outputs | `<stageId>-<taskId>` | `<ownerNodeId>-<ruleId>` |
+| Task-level fields (`type`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) | yes | none — it's a rule, not a node |
+| `conditionExpression` | n/a | optional extra payload gate on the event |
+
+`<ownerNodeId>` = the **stage id** for stage-entry / stage-exit / task-entry rules (all stage-scoped); **`root`** for case-exit rules (v19 `root.caseExitConditions` / v20 `metadata.caseExitRules`).
+
+### Procedure (Phase 3)
+
+1. Resolve the connector in planning exactly as the task does — [§ Planning Pipeline](#planning-pipeline). The condition plugin's `planning.md` records the same fields (`connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter`).
+2. Run `case spec --type trigger --input-details` ([§ Phase 3 Implementation](#phase-3-implementation--single-cli-call)) to mint the populated `caseShape`.
+3. Substitute `{{CONN_BINDING_ID}}` / `{{FOLDER_BINDING_ID}}` in `caseShape.context` ([§ Step 4](#step-4--substitute-placeholders-in-caseshapecontext)). **No trigger-registration key applies to a rule.**
+4. Mint `var` / `id` / `elementId` on `caseShape.inputs[]` / `outputs[]` ([§ Step 5](#step-5--mint-var--id--elementid-on-inputs-and-outputs)), with `elementId = <ownerNodeId>-<ruleId>`. Apply the output dedup rule.
+5. Write the rule:
+
+```json
+{
+  "id": "<ruleId>",
+  "rule": "wait-for-connector",
+  "uipath": {
+    "serviceType": "Intsvc.WaitForEvent",
+    "context": "<caseShape.context — placeholders substituted>",
+    "inputs":  "<caseShape.inputs  — var/id/elementId minted>",
+    "outputs": "<caseShape.outputs — var/id/elementId minted, dedup applied>",
+    "bindings": []
+  },
+  "conditionExpression": "<optional =js: payload gate>"
+}
+```
+
+6. Append root bindings (ConnectionId + FolderKey) and run the deferred `bindings_v2` sync — identical to the task ([§ Root-level bindings](#root-level-bindings)).
+
+### Caveats
+
+- **No entry-points.json entry and no trigger-registration key.** A connector rule compiles to an in-flight wait (ReceiveTask / event subprocess), not a case-start trigger. FE `PackagingUtil` registration is gated on `Intsvc.EventTrigger` start events only; the registration binding is derived downstream at packaging — never authored here.
+- **CLI `validate` does NOT check `rule.uipath`.** The case-tool connector validator is task-only (reads `task.data`). A passing Phase-4 validate does **not** confirm a connector rule is valid — Studio Web (or an FE round-trip) is the real check. Emit the `uipath` block correctly; do not rely on validate to catch omissions.
+- **Graceful degradation** mirrors the task: on `case spec` failure, leave the bare rule (`{ rule, id, conditionExpression? }`) + `<UNRESOLVED>` marker per Rule 8, and log per [logging/impl-json.md](plugins/logging/impl-json.md).
 
 ---
 

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -324,7 +324,7 @@ Conventions (shared with activity):
 
 For **outputs** apply the dedup rule: collect existing output `var` values across every task / trigger already in `caseplan.json`; if a `var` already exists (e.g. `response`, `error` collide across multiple connector tasks/triggers), append a counter starting at 2 (`response2`, `error2`). Update `var`, `id`, `value`, `target` (when present); keep `name`, `displayName`, `source` unchanged.
 
-> **Trigger inputs:** trigger inputs do **not** get `elementId` (different from in-stage task inputs). See each plugin's `impl-json.md` for the target-specific shape.
+> **Trigger-NODE inputs only:** the case-level event-**trigger node** gets no `elementId` on its inputs (different from in-stage task inputs). This does **NOT** apply to connector-bound **condition rules** — a rule's inputs AND outputs BOTH get `elementId = <ownerNodeId>-<ruleId>` (= `root-<ruleId>` for case-exit). See [§ Target: connector-bound condition rule](#target-connector-bound-condition-rule), and each plugin's `impl-json.md` for the target-specific shape.
 
 ---
 

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -7,7 +7,7 @@ Shared planning and implementation logic for connector-based triggers. Used by t
 
 All three use the same TypeCache (`typecache-triggers-index.json`), same single-call `case spec` discovery, same FE-canonical `caseShape` consumption. Only the target (task `data` / trigger node `data.uipath` / rule `uipath`), `serviceType`, and a few shape details differ — see each plugin's own docs.
 
-> Mirrors the [connector-activity](plugins/tasks/connector-activity/planning.md) flow. Same CLI surface (`uip maestro case spec` with `--skip-case-shape` for planning, `--input-details` for Phase 3); `--type trigger` swaps in trigger-shaped inputs/outputs and the trigger-specific `metadata.body.bindings[Property]` registration entry.
+> Mirrors the [connector-activity](plugins/tasks/connector-activity/planning.md) flow. Same CLI surface (`uip maestro case spec` with `--skip-case-shape` for planning, `--input-details` for Phase 3); `--type trigger` swaps in trigger-shaped inputs/outputs and, for event-parameter connectors, a `metadata.body.bindings[Property]` registration entry (Step 4).
 
 ---
 
@@ -385,9 +385,9 @@ A `wait-for-connector` rule inside a condition (`…conditions[].rules[i][j]`) b
 
 ### Procedure (Phase 3)
 
-1. Resolve the connector in planning exactly as the task does — [§ Planning Pipeline](#planning-pipeline). The condition plugin's `planning.md` records the same fields (`connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter`).
+1. Resolve the connector in planning exactly as the task does — [§ Planning Pipeline](#planning-pipeline). The condition plugin's `planning.md` records the same fields (`type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter`).
 2. Run `case spec --type trigger --input-details` ([§ Phase 3 Implementation](#phase-3-implementation--single-cli-call)) to mint the populated `caseShape`.
-3. Substitute `{{CONN_BINDING_ID}}` / `{{FOLDER_BINDING_ID}}` in `caseShape.context` ([§ Step 4](#step-4--substitute-placeholders-in-caseshapecontext)). **No trigger-registration key applies to a rule.**
+3. Substitute `{{CONN_BINDING_ID}}` / `{{FOLDER_BINDING_ID}}` in `caseShape.context` ([§ Step 4](#step-4--substitute-placeholders-in-caseshapecontext)). If the caseShape carries a `{{TRIGGER_REGISTRATION_KEY}}` entry (event-parameter connectors only), substitute it exactly as the task does ([§ Step 3](#step-3--mint-binding-ids-and-when-applicable-trigger-registration-key)) — there is no rule-specific variant.
 4. Mint `var` / `id` / `elementId` on `caseShape.inputs[]` / `outputs[]` ([§ Step 5](#step-5--mint-var--id--elementid-on-inputs-and-outputs)), with `elementId = <ownerNodeId>-<ruleId>`. Apply the output dedup rule.
 5. Write the rule:
 
@@ -408,9 +408,28 @@ A `wait-for-connector` rule inside a condition (`…conditions[].rules[i][j]`) b
 
 6. Append root bindings (ConnectionId + FolderKey) and run the deferred `bindings_v2` sync — identical to the task ([§ Root-level bindings](#root-level-bindings)).
 
+### tasks.md fields (planning)
+
+A connector-bound rule's condition T-entry records these (alongside the scope's normal fields):
+
+```markdown
+- rule-type: wait-for-connector
+- type-id: "<uiPathActivityTypeId>"
+- connection-id: "<connection-id>"
+- connector-key: "<connector-key>"
+- object-name: "<object>"
+- event-operation: "<EVENT_OP>"
+- event-mode: "polling"               # or "webhooks"
+- input-values: { "eventParameters": { ... } }   # resolved IDs; omit when none
+- filter: { ... }                     # optional FilterTree; omit when none
+- condition-expression: "=js:..."     # optional payload gate
+```
+
+Rule `id`s are opaque to the FE (no format validation on import) — `Rule_xxxxxx` and `rxxxxxxxx` both work. The only hard requirement is `elementId = <ownerNodeId>-<ruleId>` built from the exact id written.
+
 ### Caveats
 
-- **No entry-points.json entry and no trigger-registration key.** A connector rule compiles to an in-flight wait (ReceiveTask / event subprocess), not a case-start trigger. FE `PackagingUtil` registration is gated on `Intsvc.EventTrigger` start events only; the registration binding is derived downstream at packaging — never authored here.
+- **Not a case-start trigger.** A connector rule compiles to an in-flight wait (ReceiveTask / event subprocess), so it gets **no entry-points.json entry** and **no rule-specific registration key** — FE `PackagingUtil` trigger registration is gated on `Intsvc.EventTrigger` start events only, which a rule is not. If the `case spec` caseShape carries a `metadata.body.bindings[Property]` registration entry (event-parameter connectors), substitute it exactly as the task does (Step 3 / Step 4); there is nothing rule-specific.
 - **CLI `validate` does NOT check `rule.uipath`.** The case-tool connector validator is task-only (reads `task.data`). A passing Phase-4 validate does **not** confirm a connector rule is valid — Studio Web (or an FE round-trip) is the real check. Emit the `uipath` block correctly; do not rely on validate to catch omissions.
 - **Graceful degradation** mirrors the task: on `case spec` failure, leave the bare rule (`{ rule, id, conditionExpression? }`) + `<UNRESOLVED>` marker per Rule 8, and log per [logging/impl-json.md](plugins/logging/impl-json.md).
 

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -239,6 +239,8 @@ Skip the re-Read between sibling Edits. One validate at section end. Per-scope c
 - Task entry → [`plugins/conditions/task-entry-conditions/impl-json.md`](plugins/conditions/task-entry-conditions/impl-json.md)
 - Case exit → [`plugins/conditions/case-exit-conditions/impl-json.md`](plugins/conditions/case-exit-conditions/impl-json.md)
 
+> **Connector-bound rules need a CLI gather.** A `wait-for-connector` rule in any scope is NOT a pure JSON write — it requires a `uip maestro case spec --type trigger` call (like Step 9.7 connector tasks) to mint its `uipath` block, plus root bindings + deferred `bindings_v2` sync. Gather per `(scope, target)`, then write. See [connector-trigger-common.md § Target: connector-bound condition rule](connector-trigger-common.md#target-connector-bound-condition-rule). CLI `validate` does NOT check `rule.uipath`.
+
 ## Step 11 — SLA and escalation (per-target Edit batch)
 
 One Read of `caseplan.json` at Step 11 entry. Group `tasks.md §4.8` entries by target (root or stage). For each target, one Edit replacing that target's full `slaRules[]` array per [`plugins/sla/impl-json.md`](plugins/sla/impl-json.md). Skip the re-Read between sibling Edits. Supports per-conditional-rule escalations, ExceptionStage SLA, and multi-recipient single rules. One validate at section end.

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -230,7 +230,7 @@ One Read of `caseplan.json` at Step 10 entry. Group `tasks.md §4.7` entries by 
 | Stage entry | one stage | `nodes[stage].data.entryConditions` |
 | Stage exit | one stage | `nodes[stage].data.exitConditions` |
 | Task entry | one task | `data.entryConditions` on the task object |
-| Case exit | root | v19: `root.data.caseExitConditions`; v20: `metadata.caseExitRules` |
+| Case exit | root | v19: `root.caseExitConditions`; v20: `metadata.caseExitRules` |
 
 Skip the re-Read between sibling Edits. One validate at section end. Per-scope composition rules live in the matching plugin's `impl-json.md`:
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -67,26 +67,7 @@ Requires `marksCaseComplete: false`. Swap `rule` to `selected-stage-exited` for 
 
 ### wait-for-connector — bind a connector event
 
-Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) — a bare rule (no `uipath`) is rejected by Studio Web. **Case-exit is root-scoped: `elementId = root-<ruleId>`** (not a stage id). Run the shared `case spec --type trigger` pipeline, `serviceType: "Intsvc.WaitForEvent"`, append root bindings + `bindings_v2` sync.
-
-```json
-"rules": [[
-  {
-    "id": "Rule_xxxxxx",
-    "rule": "wait-for-connector",
-    "uipath": {
-      "serviceType": "Intsvc.WaitForEvent",
-      "context": "<caseShape.context — placeholders substituted>",
-      "inputs": "<minted, elementId = root-<ruleId>>",
-      "outputs": "<minted, dedup applied>",
-      "bindings": []
-    },
-    "conditionExpression": "=js:event.type === 'case_closed'"
-  }
-]]
-```
-
-Valid for both `marksCaseComplete: true` and `false`. The connector configuration (`uipath`) is required; `conditionExpression` is optional.
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Root-scoped: `elementId = root-<ruleId>`** (not a stage id). Valid for both `marksCaseComplete: true` and `false`. `conditionExpression` optional.
 
 ## Rule-Type × marksCaseComplete Matrix
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -65,29 +65,38 @@ Requires `marksCaseComplete: true`. Completes when every stage flagged `data.isR
 
 Requires `marksCaseComplete: false`. Swap `rule` to `selected-stage-exited` for exit-without-completion semantics.
 
-### wait-for-connector — external event
+### wait-for-connector — bind a connector event
+
+Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) — a bare rule (no `uipath`) is rejected by Studio Web. **Case-exit is root-scoped: `elementId = root-<ruleId>`** (not a stage id). Run the shared `case spec --type trigger` pipeline, `serviceType: "Intsvc.WaitForEvent"`, append root bindings + `bindings_v2` sync.
 
 ```json
 "rules": [[
   {
     "id": "Rule_xxxxxx",
     "rule": "wait-for-connector",
+    "uipath": {
+      "serviceType": "Intsvc.WaitForEvent",
+      "context": "<caseShape.context — placeholders substituted>",
+      "inputs": "<minted, elementId = root-<ruleId>>",
+      "outputs": "<minted, dedup applied>",
+      "bindings": []
+    },
     "conditionExpression": "=js:event.type === 'case_closed'"
   }
 ]]
 ```
 
-Valid for both `marksCaseComplete: true` and `false`.
+Valid for both `marksCaseComplete: true` and `false`. The connector binding (`uipath`) is required; `conditionExpression` is optional.
 
 ## Rule-Type × marksCaseComplete Matrix
 
 | `marksCaseComplete` | `rule` | Required extra field |
 |---|---|---|
 | `true` | `required-stages-completed` | — |
-| `true` | `wait-for-connector` | — |
+| `true` | `wait-for-connector` | `uipath` connector binding |
 | `false` | `selected-stage-completed` | `selectedStageId` |
 | `false` | `selected-stage-exited` | `selectedStageId` |
-| `false` | `wait-for-connector` | — |
+| `false` | `wait-for-connector` | `uipath` connector binding |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
@@ -98,3 +107,5 @@ Confirm the schema-appropriate array contains the new object with `id`, `marksCa
 - **v20** → `metadata.caseExitRules[]`
 
 Verify NO leakage: in v19 mode there is no `metadata.caseExitRules`; in v20 mode there is no `root` key at all.
+
+For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `root-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -67,7 +67,7 @@ Requires `marksCaseComplete: false`. Swap `rule` to `selected-stage-exited` for 
 
 ### wait-for-connector — bind a connector event
 
-Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Root-scoped: `elementId = root-<ruleId>`** (not a stage id). Valid for both `marksCaseComplete: true` and `false`. `conditionExpression` optional.
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Root-scoped: `elementId = root-<ruleId>` on BOTH `uipath.inputs[]` and `uipath.outputs[]`** (not a stage id; the input `body` gets it too, not only the outputs). Valid for both `marksCaseComplete: true` and `false`. `conditionExpression` optional.
 
 ## Rule-Type × marksCaseComplete Matrix
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -86,17 +86,17 @@ Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 ]]
 ```
 
-Valid for both `marksCaseComplete: true` and `false`. The connector binding (`uipath`) is required; `conditionExpression` is optional.
+Valid for both `marksCaseComplete: true` and `false`. The connector configuration (`uipath`) is required; `conditionExpression` is optional.
 
 ## Rule-Type × marksCaseComplete Matrix
 
 | `marksCaseComplete` | `rule` | Required extra field |
 |---|---|---|
 | `true` | `required-stages-completed` | — |
-| `true` | `wait-for-connector` | `uipath` connector binding |
+| `true` | `wait-for-connector` | `uipath` connector configuration |
 | `false` | `selected-stage-completed` | `selectedStageId` |
 | `false` | `selected-stage-exited` | `selectedStageId` |
-| `false` | `wait-for-connector` | `uipath` connector binding |
+| `false` | `wait-for-connector` | `uipath` connector configuration |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -20,7 +20,8 @@ Every case-exit condition declared in sdd.md gets its own T-task — **including
 | `marks-case-complete` | sdd.md | `true` for normal completion, `false` for non-completing exits |
 | `rule-type` | From catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
-| `condition-expression` | Required for `wait-for-connector` rule-type | |
+| `connector fields` | Required for `wait-for-connector` rule-type | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) |
 
 ## Rule-Type Catalog (case-exit scope)
 
@@ -31,7 +32,7 @@ Allowed `ruleType` values depend on `marks-case-complete`:
 | Rule type | Meaning | Extra fields |
 |-----------|---------|--------------|
 | `required-stages-completed` | **Preferred.** Case completes when every stage with `isRequired: true` (set in the stage node's `data.isRequired`) has completed. No stage list needed. | — |
-| `wait-for-connector` | Wait for an external connector event to close the case. | `conditionExpression` |
+| `wait-for-connector` | Wait for an external connector event to close the case (binds `uipath`). | connector fields; `conditionExpression` optional |
 
 **When `marks-case-complete: false`** (the case exits without closing):
 
@@ -39,7 +40,7 @@ Allowed `ruleType` values depend on `marks-case-complete`:
 |-----------|---------|--------------|
 | `selected-stage-completed` | Exit triggered by a specific stage completing. | `selectedStageId` |
 | `selected-stage-exited` | Exit triggered by a specific stage being exited (even without completing). | `selectedStageId` |
-| `wait-for-connector` | Wait for an external connector event. | `conditionExpression` |
+| `wait-for-connector` | Wait for an external connector event (binds `uipath`). | connector fields; `conditionExpression` optional |
 
 ## Preferred Pattern
 
@@ -59,7 +60,7 @@ Case exit conditions are created **after** all stages exist (so `selectedStageId
 - marks-case-complete: true
 - rule-type: required-stages-completed
 - selected-stage: "<stage-name>"        # only for selected-stage-* rule-types
-- condition-expression: "<expr>"         # only for wait-for-connector
+- condition-expression: "<expr>"         # optional payload gate (wait-for-connector also needs connector fields — see catalog)
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -20,7 +20,7 @@ Every case-exit condition declared in sdd.md gets its own T-task — **including
 | `marks-case-complete` | sdd.md | `true` for normal completion, `false` for non-completing exits |
 | `rule-type` | From catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
-| `connector fields` | Required for `wait-for-connector` rule-type | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) |
 
 ## Rule-Type Catalog (case-exit scope)

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -20,7 +20,7 @@ Every case-exit condition declared in sdd.md gets its own T-task — **including
 | `marks-case-complete` | sdd.md | `true` for normal completion, `false` for non-completing exits |
 | `rule-type` | From catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
-| `connector fields` | Required for `wait-for-connector` rule-type | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | Required for `wait-for-connector` rule-type | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) |
 
 ## Rule-Type Catalog (case-exit scope)
@@ -64,3 +64,5 @@ Case exit conditions are created **after** all stages exist (so `selectedStageId
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -32,7 +32,7 @@ Allowed `ruleType` values depend on `marks-case-complete`:
 | Rule type | Meaning | Extra fields |
 |-----------|---------|--------------|
 | `required-stages-completed` | **Preferred.** Case completes when every stage with `isRequired: true` (set in the stage node's `data.isRequired`) has completed. No stage list needed. | — |
-| `wait-for-connector` | Wait for an external connector event to close the case (binds `uipath`). | connector fields; `conditionExpression` optional |
+| `wait-for-connector` | Wait for an external connector event to close the case (fills `uipath`). | connector fields; `conditionExpression` optional |
 
 **When `marks-case-complete: false`** (the case exits without closing):
 
@@ -40,7 +40,7 @@ Allowed `ruleType` values depend on `marks-case-complete`:
 |-----------|---------|--------------|
 | `selected-stage-completed` | Exit triggered by a specific stage completing. | `selectedStageId` |
 | `selected-stage-exited` | Exit triggered by a specific stage being exited (even without completing). | `selectedStageId` |
-| `wait-for-connector` | Wait for an external connector event (binds `uipath`). | connector fields; `conditionExpression` optional |
+| `wait-for-connector` | Wait for an external connector event (fills `uipath`). | connector fields; `conditionExpression` optional |
 
 ## Preferred Pattern
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -66,21 +66,28 @@ Swap `rule` to `selected-stage-completed` when completion semantics are required
 
 Fires when an upstream stage exits via a `wait-for-user` exit condition and the user picks this stage as the next one. The stage must opt in by declaring this rule — only stages with `user-selected-stage` are presented in the picker.
 
-### wait-for-connector — interrupting on external event
+### wait-for-connector — bind a connector event
+
+A `wait-for-connector` entry rule MUST carry the connector binding under `rule.uipath`; a bare rule (no `uipath`) is rejected by Studio Web. Build it per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule): run the shared `case spec --type trigger` pipeline, write `rule.uipath` with `serviceType: "Intsvc.WaitForEvent"`, mint `elementId = <stageId>-<ruleId>` on inputs/outputs, append root bindings + `bindings_v2` sync.
 
 ```json
 "rules": [[
   {
     "id": "Rule_xxxxxx",
     "rule": "wait-for-connector",
+    "uipath": {
+      "serviceType": "Intsvc.WaitForEvent",
+      "context": "<caseShape.context — placeholders substituted>",
+      "inputs": "<caseShape.inputs — var/id minted, elementId = <stageId>-<ruleId>>",
+      "outputs": "<caseShape.outputs — minted, dedup applied>",
+      "bindings": []
+    },
     "conditionExpression": "=js:event.fraudScore > 0.8"
   }
 ]]
 ```
 
-Set `isInterrupting: true` for exception/fraud/escalation flows.
-
-`conditionExpression` uses bare `=js:<expr>` (no outer parens). For combined boolean expressions, wrap each sub-clause in parens before joining: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
+The connector binding (`uipath`) is required; `conditionExpression` is OPTIONAL — an extra payload gate on the event (bare `=js:<expr>`; wrap sub-clauses in parens when combining: `=js:(vars.X === 'foo') && (vars.Y > 5)`; full rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink)). Set `isInterrupting: true` on the condition for exception/fraud/escalation flows.
 
 ## Rule-Type Catalog
 
@@ -90,10 +97,10 @@ Set `isInterrupting: true` for exception/fraud/escalation flows.
 | `selected-stage-completed` | `selectedStageId` |
 | `selected-stage-exited` | `selectedStageId` |
 | `user-selected-stage` | — |
-| `wait-for-connector` | — |
+| `wait-for-connector` | `uipath` connector binding (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
 
 ## Post-Write Verification
 
-Confirm target stage's `data.entryConditions[]` contains the new object with `id`, `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.
+Confirm target stage's `data.entryConditions[]` contains the new object with `id`, `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `<stageId>-<ruleId>`, and the ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -68,26 +68,7 @@ Fires when an upstream stage exits via a `wait-for-user` exit condition and the 
 
 ### wait-for-connector — bind a connector event
 
-A `wait-for-connector` entry rule MUST carry the connector configuration under `rule.uipath`; a bare rule (no `uipath`) is rejected by Studio Web. Build it per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule): run the shared `case spec --type trigger` pipeline, write `rule.uipath` with `serviceType: "Intsvc.WaitForEvent"`, mint `elementId = <stageId>-<ruleId>` on inputs/outputs, append root bindings + `bindings_v2` sync.
-
-```json
-"rules": [[
-  {
-    "id": "Rule_xxxxxx",
-    "rule": "wait-for-connector",
-    "uipath": {
-      "serviceType": "Intsvc.WaitForEvent",
-      "context": "<caseShape.context — placeholders substituted>",
-      "inputs": "<caseShape.inputs — var/id minted, elementId = <stageId>-<ruleId>>",
-      "outputs": "<caseShape.outputs — minted, dedup applied>",
-      "bindings": []
-    },
-    "conditionExpression": "=js:event.fraudScore > 0.8"
-  }
-]]
-```
-
-The connector configuration (`uipath`) is required; `conditionExpression` is OPTIONAL — an extra payload gate on the event (bare `=js:<expr>`; wrap sub-clauses in parens when combining: `=js:(vars.X === 'foo') && (vars.Y > 5)`; full rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink)). Set `isInterrupting: true` on the condition for exception/fraud/escalation flows.
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Stage-scoped: `elementId = <stageId>-<ruleId>`.** `conditionExpression` is optional (extra payload gate); set `isInterrupting: true` on the condition for exception/fraud/escalation flows.
 
 ## Rule-Type Catalog
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -68,7 +68,7 @@ Fires when an upstream stage exits via a `wait-for-user` exit condition and the 
 
 ### wait-for-connector — bind a connector event
 
-A `wait-for-connector` entry rule MUST carry the connector binding under `rule.uipath`; a bare rule (no `uipath`) is rejected by Studio Web. Build it per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule): run the shared `case spec --type trigger` pipeline, write `rule.uipath` with `serviceType: "Intsvc.WaitForEvent"`, mint `elementId = <stageId>-<ruleId>` on inputs/outputs, append root bindings + `bindings_v2` sync.
+A `wait-for-connector` entry rule MUST carry the connector configuration under `rule.uipath`; a bare rule (no `uipath`) is rejected by Studio Web. Build it per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule): run the shared `case spec --type trigger` pipeline, write `rule.uipath` with `serviceType: "Intsvc.WaitForEvent"`, mint `elementId = <stageId>-<ruleId>` on inputs/outputs, append root bindings + `bindings_v2` sync.
 
 ```json
 "rules": [[
@@ -87,7 +87,7 @@ A `wait-for-connector` entry rule MUST carry the connector binding under `rule.u
 ]]
 ```
 
-The connector binding (`uipath`) is required; `conditionExpression` is OPTIONAL — an extra payload gate on the event (bare `=js:<expr>`; wrap sub-clauses in parens when combining: `=js:(vars.X === 'foo') && (vars.Y > 5)`; full rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink)). Set `isInterrupting: true` on the condition for exception/fraud/escalation flows.
+The connector configuration (`uipath`) is required; `conditionExpression` is OPTIONAL — an extra payload gate on the event (bare `=js:<expr>`; wrap sub-clauses in parens when combining: `=js:(vars.X === 'foo') && (vars.Y > 5)`; full rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink)). Set `isInterrupting: true` on the condition for exception/fraud/escalation flows.
 
 ## Rule-Type Catalog
 
@@ -97,7 +97,7 @@ The connector binding (`uipath`) is required; `conditionExpression` is OPTIONAL 
 | `selected-stage-completed` | `selectedStageId` |
 | `selected-stage-exited` | `selectedStageId` |
 | `user-selected-stage` | — |
-| `wait-for-connector` | `uipath` connector binding (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
+| `wait-for-connector` | `uipath` connector configuration (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -21,7 +21,8 @@ Every stage with an **Entry Condition** declared in sdd.md gets its own stage-en
 | `is-interrupting` | sdd.md (default `false`) | `true` if the condition interrupts the current stage |
 | `rule-type` | Pick from the catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | ID of the referenced stage |
-| `condition-expression` | Required for `wait-for-connector` rule-type (and optional for others) | |
+| `connector fields` | Required for `wait-for-connector` rule-type | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — resolved via [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) on the event |
 
 ## Rule-Type Catalog (stage-entry scope)
 
@@ -33,7 +34,7 @@ Allowed `ruleType` values and when to pick each:
 | `selected-stage-completed` | Fires when a specific upstream stage completes | `selectedStageId` |
 | `selected-stage-exited` | Fires when a specific upstream stage exits (even without completing) | `selectedStageId` |
 | `user-selected-stage` | Fires when an upstream stage exits via a `wait-for-user` exit condition and the user selects this stage as the next one. Only stages carrying this rule appear in the picker. | — |
-| `wait-for-connector` | Waits for a connector event | `conditionExpression` |
+| `wait-for-connector` | Waits for a connector event (binds an IS connector trigger under `uipath`) | connector fields (above); `conditionExpression` optional |
 
 `is-interrupting: true` means the condition can fire **while another stage is active** and will interrupt it. Use for exception/interrupt flows.
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -21,7 +21,7 @@ Every stage with an **Entry Condition** declared in sdd.md gets its own stage-en
 | `is-interrupting` | sdd.md (default `false`) | `true` if the condition interrupts the current stage |
 | `rule-type` | Pick from the catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | ID of the referenced stage |
-| `connector fields` | Required for `wait-for-connector` rule-type | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — resolved via [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — resolved via [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) on the event |
 
 ## Rule-Type Catalog (stage-entry scope)

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -21,7 +21,7 @@ Every stage with an **Entry Condition** declared in sdd.md gets its own stage-en
 | `is-interrupting` | sdd.md (default `false`) | `true` if the condition interrupts the current stage |
 | `rule-type` | Pick from the catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | ID of the referenced stage |
-| `connector fields` | Required for `wait-for-connector` rule-type | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — resolved via [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | Required for `wait-for-connector` rule-type | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — resolved via [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) on the event |
 
 ## Rule-Type Catalog (stage-entry scope)
@@ -54,3 +54,5 @@ Stage entry conditions are created **after** all stages exist (Step 7 in impleme
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -69,28 +69,7 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 ### wait-for-connector — bind a connector event
 
-Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) — a bare rule (no `uipath`) is rejected by Studio Web. Run the shared `case spec --type trigger` pipeline, `serviceType: "Intsvc.WaitForEvent"`, `elementId = <stageId>-<ruleId>`, append root bindings + `bindings_v2` sync.
-
-```json
-"type": "exit-only",
-"marksStageComplete": true,
-"rules": [[
-  {
-    "id": "Rule_xxxxxx",
-    "rule": "wait-for-connector",
-    "uipath": {
-      "serviceType": "Intsvc.WaitForEvent",
-      "context": "<caseShape.context — placeholders substituted>",
-      "inputs": "<minted, elementId = <stageId>-<ruleId>>",
-      "outputs": "<minted, dedup applied>",
-      "bindings": []
-    },
-    "conditionExpression": "=js:event.type === 'approved'"
-  }
-]]
-```
-
-The connector configuration (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Stage-scoped: `elementId = <stageId>-<ruleId>`.** Place it in the exit condition with `type` / `marksStageComplete` like the other exit rules above. `conditionExpression` optional.
 
 ### wait-for-user — manual decision gate
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -67,7 +67,9 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 `selectedTasksIds` is a JSON string array, not a comma-separated string.
 
-### wait-for-connector — external event
+### wait-for-connector — bind a connector event
+
+Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) — a bare rule (no `uipath`) is rejected by Studio Web. Run the shared `case spec --type trigger` pipeline, `serviceType: "Intsvc.WaitForEvent"`, `elementId = <stageId>-<ruleId>`, append root bindings + `bindings_v2` sync.
 
 ```json
 "type": "exit-only",
@@ -76,10 +78,19 @@ Rules use DNF — outer array is OR, inner array is AND.
   {
     "id": "Rule_xxxxxx",
     "rule": "wait-for-connector",
+    "uipath": {
+      "serviceType": "Intsvc.WaitForEvent",
+      "context": "<caseShape.context — placeholders substituted>",
+      "inputs": "<minted, elementId = <stageId>-<ruleId>>",
+      "outputs": "<minted, dedup applied>",
+      "bindings": []
+    },
     "conditionExpression": "=js:event.type === 'approved'"
   }
 ]]
 ```
+
+The connector binding (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
 
 ### wait-for-user — manual decision gate
 
@@ -106,9 +117,9 @@ Routes the case back to the originating stage.
 | `marksStageComplete` | `rule` | Required extra field |
 |---|---|---|
 | `true` | `required-tasks-completed` | — |
-| `true` | `wait-for-connector` | — |
+| `true` | `wait-for-connector` | `uipath` connector binding |
 | `false` | `selected-tasks-completed` | `selectedTasksIds` (array) |
-| `false` | `wait-for-connector` | — |
+| `false` | `wait-for-connector` | `uipath` connector binding |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); for combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -90,7 +90,7 @@ Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 ]]
 ```
 
-The connector binding (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+The connector configuration (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
 
 ### wait-for-user — manual decision gate
 
@@ -117,9 +117,9 @@ Routes the case back to the originating stage.
 | `marksStageComplete` | `rule` | Required extra field |
 |---|---|---|
 | `true` | `required-tasks-completed` | — |
-| `true` | `wait-for-connector` | `uipath` connector binding |
+| `true` | `wait-for-connector` | `uipath` connector configuration |
 | `false` | `selected-tasks-completed` | `selectedTasksIds` (array) |
-| `false` | `wait-for-connector` | `uipath` connector binding |
+| `false` | `wait-for-connector` | `uipath` connector configuration |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); for combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -23,7 +23,8 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | `marks-stage-complete` | sdd.md (default depends on type) | `true` for completion exits, `false` for diverging routes |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `condition-expression` | Required for `wait-for-connector` | |
+| `connector fields` | Required for `wait-for-connector` | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) |
 
 ## Exit Type Catalog
 
@@ -41,13 +42,13 @@ Allowed `ruleType` values depend on `marks-stage-complete`:
 | Rule type | Extra fields |
 |-----------|--------------|
 | `required-tasks-completed` | — |
-| `wait-for-connector` | `conditionExpression` |
+| `wait-for-connector` | connector fields (binds `uipath`); `conditionExpression` optional |
 
 **When `marks-stage-complete: false` (exit-only, routing):**
 | Rule type | Extra fields |
 |-----------|--------------|
 | `selected-tasks-completed` | `selectedTasksIds` (comma-separated) |
-| `wait-for-connector` | `conditionExpression` |
+| `wait-for-connector` | connector fields (binds `uipath`); `conditionExpression` optional |
 
 ## Ordering
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -42,13 +42,13 @@ Allowed `ruleType` values depend on `marks-stage-complete`:
 | Rule type | Extra fields |
 |-----------|--------------|
 | `required-tasks-completed` | — |
-| `wait-for-connector` | connector fields (binds `uipath`); `conditionExpression` optional |
+| `wait-for-connector` | connector fields (fills `uipath`); `conditionExpression` optional |
 
 **When `marks-stage-complete: false` (exit-only, routing):**
 | Rule type | Extra fields |
 |-----------|--------------|
 | `selected-tasks-completed` | `selectedTasksIds` (comma-separated) |
-| `wait-for-connector` | connector fields (binds `uipath`); `conditionExpression` optional |
+| `wait-for-connector` | connector fields (fills `uipath`); `conditionExpression` optional |
 
 ## Ordering
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -23,7 +23,7 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | `marks-stage-complete` | sdd.md (default depends on type) | `true` for completion exits, `false` for diverging routes |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `connector fields` | Required for `wait-for-connector` | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) |
 
 ## Exit Type Catalog

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -23,7 +23,7 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | `marks-stage-complete` | sdd.md (default depends on type) | `true` for completion exits, `false` for diverging routes |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `connector fields` | Required for `wait-for-connector` | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | Required for `wait-for-connector` | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional on any rule-type | Extra payload gate (`=js:<expr>`) |
 
 ## Exit Type Catalog
@@ -68,3 +68,5 @@ Stage exit conditions are created **after** all tasks in the stage have been add
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -72,17 +72,28 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 `conditionExpression` uses bare `=js:<expr>` (no outer parens) — per FE convention for conditions. Operators (`>`, `<`, `===`, etc.) and function calls go inline. For combined boolean expressions, wrap each sub-clause in parens before joining: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
-### wait-for-connector — external event
+### wait-for-connector — bind a connector event
+
+Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) — a bare rule (no `uipath`) is rejected by Studio Web. Task-entry rules are **stage-scoped**: `elementId = <stageId>-<ruleId>`. Run the shared `case spec --type trigger` pipeline, `serviceType: "Intsvc.WaitForEvent"`, append root bindings + `bindings_v2` sync.
 
 ```json
 "rules": [[
   {
     "id": "rxxxxxxxx",
     "rule": "wait-for-connector",
+    "uipath": {
+      "serviceType": "Intsvc.WaitForEvent",
+      "context": "<caseShape.context — placeholders substituted>",
+      "inputs": "<minted, elementId = <stageId>-<ruleId>>",
+      "outputs": "<minted, dedup applied>",
+      "bindings": []
+    },
     "conditionExpression": "=js:event.type === 'order_received'"
   }
 ]]
 ```
+
+The connector binding (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
 
 ### runs-sequentially — sequential group with optional parallel siblings
 
@@ -98,7 +109,7 @@ Rules use DNF — outer array is OR, inner array is AND.
 |---|---|
 | `current-stage-entered` | — |
 | `selected-tasks-completed` | `selectedTasksIds` (array) |
-| `wait-for-connector` | — |
+| `wait-for-connector` | `uipath` connector binding (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
 | `adhoc` | — |
 | `runs-sequentially` | — |
 
@@ -106,4 +117,4 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 ## Post-Write Verification
 
-Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`) and `rules` with the expected `rule` value plus any required side field.
+Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`) and `rules` with the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated, inputs/outputs `elementId` is `<stageId>-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -74,26 +74,7 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 ### wait-for-connector — bind a connector event
 
-Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) — a bare rule (no `uipath`) is rejected by Studio Web. Task-entry rules are **stage-scoped**: `elementId = <stageId>-<ruleId>`. Run the shared `case spec --type trigger` pipeline, `serviceType: "Intsvc.WaitForEvent"`, append root bindings + `bindings_v2` sync.
-
-```json
-"rules": [[
-  {
-    "id": "rxxxxxxxx",
-    "rule": "wait-for-connector",
-    "uipath": {
-      "serviceType": "Intsvc.WaitForEvent",
-      "context": "<caseShape.context — placeholders substituted>",
-      "inputs": "<minted, elementId = <stageId>-<ruleId>>",
-      "outputs": "<minted, dedup applied>",
-      "bindings": []
-    },
-    "conditionExpression": "=js:event.type === 'order_received'"
-  }
-]]
-```
-
-The connector configuration (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Stage-scoped: `elementId = <stageId>-<ruleId>`.** `conditionExpression` optional.
 
 ### runs-sequentially — sequential group with optional parallel siblings
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -93,7 +93,7 @@ Build `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 ]]
 ```
 
-The connector binding (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+The connector configuration (`uipath`) is required; `conditionExpression` is optional. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
 
 ### runs-sequentially — sequential group with optional parallel siblings
 
@@ -109,7 +109,7 @@ The connector binding (`uipath`) is required; `conditionExpression` is optional.
 |---|---|
 | `current-stage-entered` | — |
 | `selected-tasks-completed` | `selectedTasksIds` (array) |
-| `wait-for-connector` | `uipath` connector binding (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
+| `wait-for-connector` | `uipath` connector configuration (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
 | `adhoc` | — |
 | `runs-sequentially` | — |
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -20,7 +20,8 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `display-name` | sdd.md (optional) | |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `condition-expression` | Optional | |
+| `connector fields` | Required for `wait-for-connector` | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional | Extra payload gate (`=js:<expr>`) |
 
 ## Rule-Type Catalog (task-entry scope)
 
@@ -28,7 +29,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 |-----------|---------|--------------|
 | `current-stage-entered` | Fires when the containing stage is entered | — |
 | `selected-tasks-completed` | Fires when specific sibling tasks in the same stage complete | `selectedTasksIds` |
-| `wait-for-connector` | Waits for a connector event | `conditionExpression` |
+| `wait-for-connector` | Waits for a connector event (binds an IS connector trigger under `uipath`) | connector fields; `conditionExpression` optional |
 | `adhoc` | Ad hoc tasks run only when a user triggers them from the case app. | `conditionExpression` (optional) |
 | `runs-sequentially` | Sequential tasks run in the order they appear in the stage from top to bottom. Parallel members of the group share a `lane`; solo members get own lane. | `conditionExpression` (optional) |
 
@@ -45,7 +46,7 @@ Task entry conditions are created **after** all tasks in the stage have been add
 - display-name: "<name>"
 - rule-type: selected-tasks-completed
 - selected-tasks: "<Task A>, <Task B>"
-- condition-expression: "<expr>"          # for adhoc / wait-for-connector
+- condition-expression: "<expr>"          # optional gate (adhoc / wait-for-connector); wait-for-connector also needs connector fields
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -20,7 +20,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `display-name` | sdd.md (optional) | |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `connector fields` | Required for `wait-for-connector` | `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | Required for `wait-for-connector` | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional | Extra payload gate (`=js:<expr>`) |
 
 ## Rule-Type Catalog (task-entry scope)
@@ -50,3 +50,5 @@ Task entry conditions are created **after** all tasks in the stage have been add
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -20,7 +20,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `display-name` | sdd.md (optional) | |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `connector fields` | Required for `wait-for-connector` | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
 | `condition-expression` | Optional | Extra payload gate (`=js:<expr>`) |
 
 ## Rule-Type Catalog (task-entry scope)


### PR DESCRIPTION
## Summary

Makes `uipath-maestro-case` emit **valid connector-bound `wait-for-connector` rules** in all four condition scopes (stage-entry, stage-exit, case-exit, task-entry).

Previously every condition plugin emitted a `wait-for-connector` rule as a bare `{ rule, conditionExpression }` with **no `uipath` connector binding**. Studio Web requires the binding and its validator rejects an unresolved connector activity, so those rules were invalid. The CLI can't author it either (`buildRule` emits the bare form), making a connector-bound rule a FE-only capability until now. This PR teaches the skill to assemble the `uipath` block from the existing `case spec --type trigger` scaffold and write it directly into the rule.

## What changed

- **Shared recipe** (`connector-trigger-common.md`): new `## Target: connector-bound condition rule` section — the single source of truth. Reuses the existing trigger pipeline; documents the rule-vs-task deltas (container `rule.uipath` vs `task.data`, `serviceType: Intsvc.WaitForEvent`, `elementId = <ownerNodeId>-<ruleId>`), the Phase-3 procedure, a `tasks.md` field example, and caveats.
- **4 condition plugins** (`planning.md` + `impl-json.md`): `wait-for-connector` now requires connector fields and emits the full `rule.uipath` block, delegating mechanics to the shared section. `elementId` is `<stageId>-<ruleId>` for stage scopes, `root-<ruleId>` for case-exit. `conditionExpression` is now an optional payload gate.
- **Supporting docs**: `case-schema.md` documents the rule `uipath` shape; `implementation.md` Step 10 notes connector rules need a `case spec` gather; `SKILL.md` adds a conditions note.
- **Drive-by fix**: corrected the v19 case-exit path `root.data.caseExitConditions` → `root.caseExitConditions` (matched the FE root schema; other docs already had it right).

## Verification

Behavior was checked against the Maestro frontend schema + canvas fixtures and the case-tool source: confirmed the persisted `serviceType` (`Intsvc.WaitForEvent`), the `elementId` prefixes, that connector rules are not case-start triggers (no entry-points.json / no registration key), and the root-bindings + `bindings_v2` sync parity with the connector task.

## Known follow-ups (not in this PR)

- **CLI `validate` does not check `rule.uipath`** — the case-tool connector validator is task-only (reads `task.data`). A passing validate does not confirm a connector rule is valid; Studio Web is the real check. Recommend a case-tool enhancement to cover condition-rule `uipath`.
- No coder_eval task yet exercising a connector-bound rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)