### PR TITLE
[TMHUB-31936] test(uipath-test): drop env_packages sandbox block from coder-eval tasks

### DIFF
--- a/tests/tasks/uipath-test/auth_project_discovery.yaml
+++ b/tests/tasks/uipath-test/auth_project_discovery.yaml
@@ -8,11 +8,6 @@ description: >
   teach the auth-first ordering and the `--output json` flag.
 tags: [uipath-test, smoke, mode:operate, lifecycle:discover]
 
-sandbox:
-  node:
-    env_packages:
-    - '@uipath/test-manager-tool'
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 

--- a/tests/tasks/uipath-test/flaky_tests_analysis.yaml
+++ b/tests/tasks/uipath-test/flaky_tests_analysis.yaml
@@ -17,11 +17,6 @@ agent:
 run_limits:
   max_turns: 35
 
-sandbox:
-  node:
-    env_packages:
-    - '@uipath/test-manager-tool'
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 

--- a/tests/tasks/uipath-test/link_automation_and_run.yaml
+++ b/tests/tasks/uipath-test/link_automation_and_run.yaml
@@ -18,11 +18,6 @@ agent:
 run_limits:
   max_turns: 35
 
-sandbox:
-  node:
-    env_packages:
-    - '@uipath/test-manager-tool'
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 

--- a/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
+++ b/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
@@ -15,11 +15,6 @@ agent:
 run_limits:
   max_turns: 35
 
-sandbox:
-  node:
-    env_packages:
-    - '@uipath/test-manager-tool'
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -23,11 +23,6 @@ agent:
 run_limits:
   max_turns: 50
 
-sandbox:
-  node:
-    env_packages:
-    - '@uipath/test-manager-tool'
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 

--- a/tests/tasks/uipath-test/test_report_junit_export.yaml
+++ b/tests/tasks/uipath-test/test_report_junit_export.yaml
@@ -15,11 +15,6 @@ agent:
 run_limits:
   max_turns: 35
 
-sandbox:
-  node:
-    env_packages:
-    - '@uipath/test-manager-tool'
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 

--- a/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
@@ -16,11 +16,6 @@ agent:
 run_limits:
   max_turns: 30
 
-sandbox:
-  node:
-    env_packages:
-    - '@uipath/test-manager-tool'
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 


### PR DESCRIPTION
## Summary

Removes the `sandbox.node.env_packages` block from all `tests/tasks/uipath-test/*.yaml` tasks that declared it. Unblocks the `uipath-test` smoke CI gate (currently failing at 50% pass rate, below the 95% threshold).

**Jira:** [TMHUB-31936](https://uipath.atlassian.net/browse/TMHUB-31936)

## Root cause

Each task declared:

```yaml
sandbox:
  node:
    env_packages:
      - '@uipath/test-manager-tool'
```

The GH smoke runner already builds its Docker image with `@uipath/cli@alpha` installed globally (bundles the Test Manager tool) and wires up service-account auth via `UIPATH_CLI_AUTH_TOKEN` env vars. Installing a **separate** `@uipath/test-manager-tool` into the sandbox `node_modules` shadows the global CLI, and the local copy doesn't pick up the env-auth context. Result: `uip login status` reports "Logged in" but `uip tm project list` fails with "Not logged in".

Same env-auth failure mode tracked under [TMHUB-31922](https://uipath.atlassian.net/browse/TMHUB-31922) (`uip tm` + robot/service-account creds), surfacing here at the test-harness layer.

## Change

Remove the sandbox block from the 7 tasks that declared it:

- `auth_project_discovery.yaml`
- `testset_hierarchy_discovery.yaml`
- `report_generation.yaml`
- `flaky_tests_analysis.yaml`
- `link_automation_and_run.yaml`
- `organize_testcases_into_testsets.yaml`
- `test_report_junit_export.yaml`

They now inherit the sandbox driver (`tempdir` / `docker`) from the experiment defaults — the **same pattern the already-merged BANK + SHIP integration tasks use** (neither declares a sandbox block, and both run green).

Diff is deletions-only: 7 files, 35 lines removed.

## Test plan

- [ ] Smoke CI for `uipath-test` returns to a green pass rate (this is the gate this PR targets).
- [ ] Confirm no `tests/tasks/uipath-test/*.yaml` still lists `@uipath/test-manager-tool` or `@uipath/cli` under `sandbox.node.env_packages`:
  ```
  grep -rl "test-manager-tool" tests/tasks/uipath-test/   # expect: no matches
  ```

## Related

- [TMHUB-31922](https://uipath.atlassian.net/browse/TMHUB-31922) — underlying `uip tm` env-auth bug. Once that lands, the local-install path would work too; this PR is the harness-side unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TMHUB-31936]: https://uipath.atlassian.net/browse/TMHUB-31936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMHUB-31922]: https://uipath.atlassian.net/browse/TMHUB-31922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMHUB-31922]: https://uipath.atlassian.net/browse/TMHUB-31922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ