### PR TITLE
docs: cross-reference `solution resource add`/`remove` in sibling skills

### DIFF
--- a/skills/uipath-agents/references/lowcode/project-lifecycle.md
+++ b/skills/uipath-agents/references/lowcode/project-lifecycle.md
@@ -367,6 +367,8 @@ All solution lifecycle operations go through `uip solution` CLI. Never call Auto
 | List guardrail validators | `uip agent guardrails list --output json` | Any directory | — |
 | Discover resources | `uip solution resource list --kind <Kind> --source remote [--search <term>] --output json` | Solution directory | — |
 | Refresh resources | `uip solution resource refresh --output json` | Solution directory | — |
+| Add one resource (local stub or remote import) | `uip solution resource add --source local\|remote --kind <Kind> --name <NAME> [--folder-path <FOLDER>] --output json` | Solution directory | Idempotent on `(kind, name, folder)` for local, on key for remote |
+| Remove one resource by key | `uip solution resource remove <KEY> --output json` | Solution directory | Offline; doesn't touch `bindings_v2.json` |
 | Upload to Studio Web | `uip solution upload . --output json` | Solution directory | — |
 | Pack | `uip solution pack . ./dist -v "1.0.0" --output json` | Solution directory | — |
 | Publish | `uip solution publish ./dist/<PKG>.zip --output json` | Any directory | — |

--- a/skills/uipath-agents/references/lowcode/project-lifecycle.md
+++ b/skills/uipath-agents/references/lowcode/project-lifecycle.md
@@ -369,6 +369,7 @@ All solution lifecycle operations go through `uip solution` CLI. Never call Auto
 | Refresh resources | `uip solution resource refresh --output json` | Solution directory | — |
 | Add one resource (local stub or remote import) | `uip solution resource add --source local\|remote --kind <Kind> --name <NAME> [--folder-path <FOLDER>] --output json` | Solution directory | Idempotent on `(kind, name, folder)` for local, on key for remote |
 | Remove one resource by key | `uip solution resource remove <KEY> --output json` | Solution directory | Offline; doesn't touch `bindings_v2.json` |
+| Edit one resource's spec | `uip solution resource edit <KEY> --patch '{...}'` (or `--set <prop>=<value>`) `--output json` | Solution directory | Only command that mutates an existing resource; `refresh` never overwrites. Unknown/reference/read-only props silently ignored |
 | Upload to Studio Web | `uip solution upload . --output json` | Solution directory | — |
 | Pack | `uip solution pack . ./dist -v "1.0.0" --output json` | Solution directory | — |
 | Publish | `uip solution publish ./dist/<PKG>.zip --output json` | Any directory | — |

--- a/skills/uipath-agents/references/lowcode/project-lifecycle.md
+++ b/skills/uipath-agents/references/lowcode/project-lifecycle.md
@@ -369,7 +369,7 @@ All solution lifecycle operations go through `uip solution` CLI. Never call Auto
 | Refresh resources | `uip solution resource refresh --output json` | Solution directory | — |
 | Add one resource (local stub or remote import) | `uip solution resource add --source local\|remote --kind <Kind> --name <NAME> [--folder-path <FOLDER>] --output json` | Solution directory | Idempotent on `(kind, name, folder)` for local, on key for remote |
 | Remove one resource by key | `uip solution resource remove <KEY> --output json` | Solution directory | Offline; doesn't touch `bindings_v2.json` |
-| Edit one resource's spec | `uip solution resource edit <KEY> --patch '{...}'` (or `--set <prop>=<value>`) `--output json` | Solution directory | Only command that mutates an existing resource; `refresh` never overwrites. Unknown/reference/read-only props silently ignored |
+| Edit one resource's spec | `uip solution resource edit <KEY> --patch '{...}' --output json` | Solution directory | Only command that mutates an existing resource; `refresh` never overwrites. Unknown/reference/read-only props silently ignored. JSON is the only input — types preserved verbatim |
 | Upload to Studio Web | `uip solution upload . --output json` | Solution directory | — |
 | Pack | `uip solution pack . ./dist -v "1.0.0" --output json` | Solution directory | — |
 | Publish | `uip solution publish ./dist/<PKG>.zip --output json` | Any directory | — |

--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -11,6 +11,7 @@ All commands output `{ "Result": "Success"|"Failure", "Code": "...", "Data": { .
 | Commands | What | Auth |
 |----------|------|------|
 | `solution init`, `solution project add`, `solution resource refresh`, `solution upload` | Solution scaffold + resource sync + Studio Web upload | Yes (for `upload`) |
+| `solution resource add --source local\|remote`, `solution resource remove <key>` | Atomic single-resource mutations (local stub or remote import; delete by key) — see [uipath-solution Step 9–10](/uipath:uipath-solution) | Only `--source remote` requires auth |
 | `registry pull/list/search`, `get-connector`, `get-connection`, `tasks describe`, `is resources/triggers describe` | Registry + metadata discovery (read-only) | Yes (for `pull`) |
 | `validate` | Validate `caseplan.json` | No |
 | `instance`, `processes`, `incidents`, `process run`, `job traces`, `debug` | Query/manage live Orchestrator state | Yes |

--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -11,7 +11,7 @@ All commands output `{ "Result": "Success"|"Failure", "Code": "...", "Data": { .
 | Commands | What | Auth |
 |----------|------|------|
 | `solution init`, `solution project add`, `solution resource refresh`, `solution upload` | Solution scaffold + resource sync + Studio Web upload | Yes (for `upload`) |
-| `solution resource add --source local\|remote`, `solution resource remove <key>` | Atomic single-resource mutations (local stub or remote import; delete by key) — see [uipath-solution Step 9–10](/uipath:uipath-solution) | Only `--source remote` requires auth |
+| `solution resource add --source local\|remote`, `solution resource remove <key>`, `solution resource edit <key>` | Atomic single-resource mutations (local stub or remote import; delete by key; patch spec via `--patch`/`--set`) — see [uipath-solution Step 9–11](/uipath:uipath-solution) | Only `--source remote` requires auth; `remove`/`edit` are offline |
 | `registry pull/list/search`, `get-connector`, `get-connection`, `tasks describe`, `is resources/triggers describe` | Registry + metadata discovery (read-only) | Yes (for `pull`) |
 | `validate` | Validate `caseplan.json` | No |
 | `instance`, `processes`, `incidents`, `process run`, `job traces`, `debug` | Query/manage live Orchestrator state | Yes |

--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -11,7 +11,7 @@ All commands output `{ "Result": "Success"|"Failure", "Code": "...", "Data": { .
 | Commands | What | Auth |
 |----------|------|------|
 | `solution init`, `solution project add`, `solution resource refresh`, `solution upload` | Solution scaffold + resource sync + Studio Web upload | Yes (for `upload`) |
-| `solution resource add --source local\|remote`, `solution resource remove <key>`, `solution resource edit <key>` | Atomic single-resource mutations (local stub or remote import; delete by key; patch spec via `--patch`/`--set`) — see [uipath-solution Step 9–11](/uipath:uipath-solution) | Only `--source remote` requires auth; `remove`/`edit` are offline |
+| `solution resource add --source local\|remote`, `solution resource remove <key>`, `solution resource edit <key>` | Atomic single-resource mutations (local stub or remote import; delete by key; patch spec via `--patch '<json>'`) — see [uipath-solution Step 9–11](/uipath:uipath-solution) | Only `--source remote` requires auth; `remove`/`edit` are offline |
 | `registry pull/list/search`, `get-connector`, `get-connection`, `tasks describe`, `is resources/triggers describe` | Registry + metadata discovery (read-only) | Yes (for `pull`) |
 | `validate` | Validate `caseplan.json` | No |
 | `instance`, `processes`, `incidents`, `process run`, `job traces`, `debug` | Query/manage live Orchestrator state | Yes |

--- a/skills/uipath-maestro-case/references/troubleshooting-guide.md
+++ b/skills/uipath-maestro-case/references/troubleshooting-guide.md
@@ -2,7 +2,7 @@
 
 Diagnostic workflow for failed debug runs and deployed case process runs. All commands require `uip login`.
 
-> **`--folder-key` is required for `incident get`.** Most `instance` subcommands accept `--folder-key <FOLDER_KEY>` and auto-detect from the authenticated folder if omitted, but `incident get` requires it explicitly. Get the folder key from `uip or folder list --output json` or from the job/process context.
+> **`--folder-key` is required for `incident get`.** Most `instance` subcommands accept `--folder-key <FOLDER_KEY>` and auto-detect from the authenticated folder if omitted, but `incident get` requires it explicitly. Get the folder key from `uip or folders list --output json` or from the job/process context.
 
 ## Diagnostic priority
 

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -98,6 +98,23 @@ uip solution resource refresh <SolutionDir> --output json
 
 The argument is the solution directory (containing the `.uipx` file). Defaults to the current directory if omitted.
 
+## uip solution resource add / remove
+
+Atomic single-resource mutations. Use these when you need to add or delete one resource and don't want to scan every project's bindings the way `refresh` does — for example, when a flow needs a new local queue but no `bindings_v2.json` change is involved yet.
+
+```bash
+# Local virtual stub (offline, no auth)
+uip solution resource add --source local --kind Queue --name InvoiceQueue --output json
+
+# Import an existing Orchestrator resource
+uip solution resource add --source remote --kind Queue --name InvoiceQueue --folder-path Sales/CRM --output json
+
+# Delete one resource by key
+uip solution resource remove <KEY> --output json
+```
+
+`add` is idempotent on `(kind, name, folder)` for local and on resource key for remote; a retry returns `Status: "Unchanged"`. Neither command touches `bindings_v2.json` — if a flow node still binds the resource, the next `refresh` will re-import it. See [uipath-solution Step 9–10](/uipath:uipath-solution) for the full contract.
+
 ## uip solution upload
 
 Upload a solution directly to Studio Web. **Requires `uip login`.**

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -112,9 +112,12 @@ uip solution resource add --source remote --kind Queue --name InvoiceQueue --fol
 # Delete one resource by key
 uip solution resource remove <KEY> --output json
 
-# Patch an existing resource's spec by key
+# Patch an existing resource's spec by key (JSON object is the only input)
 uip solution resource edit <KEY> --patch '{"maxNumberOfRetries":5}' --output json
-uip solution resource edit <KEY> --set acceptAutomaticallyRetry=false --output json
+uip solution resource edit <KEY> --patch '{"acceptAutomaticallyRetry":false,"retentionPeriod":14}' --output json
+
+# Read the patch from stdin
+echo '{"slaInHours":"4"}' | uip solution resource edit <KEY> --patch - --output json
 ```
 
 `add` is idempotent on `(kind, name, folder)` for local and on resource key for remote; a retry returns `Status: "Unchanged"`. `edit` is the only command that mutates an existing resource's spec — `refresh` never overwrites; it skips resources already in the solution. None of these touch `bindings_v2.json` — if a flow node still binds the resource, the next `refresh` will re-import it. See [uipath-solution Step 9–11](/uipath:uipath-solution) for the full contract.

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -98,9 +98,9 @@ uip solution resource refresh <SolutionDir> --output json
 
 The argument is the solution directory (containing the `.uipx` file). Defaults to the current directory if omitted.
 
-## uip solution resource add / remove
+## uip solution resource add / remove / edit
 
-Atomic single-resource mutations. Use these when you need to add or delete one resource and don't want to scan every project's bindings the way `refresh` does — for example, when a flow needs a new local queue but no `bindings_v2.json` change is involved yet.
+Atomic single-resource mutations. Use these when you need to add, delete, or change one resource and don't want to scan every project's bindings the way `refresh` does — for example, when a flow needs a new local queue but no `bindings_v2.json` change is involved yet.
 
 ```bash
 # Local virtual stub (offline, no auth)
@@ -111,9 +111,13 @@ uip solution resource add --source remote --kind Queue --name InvoiceQueue --fol
 
 # Delete one resource by key
 uip solution resource remove <KEY> --output json
+
+# Patch an existing resource's spec by key
+uip solution resource edit <KEY> --patch '{"maxNumberOfRetries":5}' --output json
+uip solution resource edit <KEY> --set acceptAutomaticallyRetry=false --output json
 ```
 
-`add` is idempotent on `(kind, name, folder)` for local and on resource key for remote; a retry returns `Status: "Unchanged"`. Neither command touches `bindings_v2.json` — if a flow node still binds the resource, the next `refresh` will re-import it. See [uipath-solution Step 9–10](/uipath:uipath-solution) for the full contract.
+`add` is idempotent on `(kind, name, folder)` for local and on resource key for remote; a retry returns `Status: "Unchanged"`. `edit` is the only command that mutates an existing resource's spec — `refresh` never overwrites; it skips resources already in the solution. None of these touch `bindings_v2.json` — if a flow node still binds the resource, the next `refresh` will re-import it. See [uipath-solution Step 9–11](/uipath:uipath-solution) for the full contract.
 
 ## uip solution upload
 

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -72,7 +72,7 @@ Manage assets, queues, triggers, buckets, libraries, and webhooks. See [`uipath-
 
 ## Solution (`uip solution`)
 
-`uip solution` (init/new, project add|remove|import, resource list|refresh|get, pack, publish, deploy run|status|list|activate|uninstall, deploy config get|set|link|unlink, upload, download, packages list|delete|download) is owned by [`uipath-solution`](/uipath:uipath-solution). Load that skill for any `.uipx` lifecycle work.
+`uip solution` (init/new, project add|remove|import, resource list|refresh|get|add|remove, pack, publish, deploy run|status|list|activate|uninstall, deploy config get|set|link|unlink, upload, download, packages list|delete|download) is owned by [`uipath-solution`](/uipath:uipath-solution). Load that skill for any `.uipx` lifecycle work.
 
 ---
 

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -72,7 +72,7 @@ Manage assets, queues, triggers, buckets, libraries, and webhooks. See [`uipath-
 
 ## Solution (`uip solution`)
 
-`uip solution` (init/new, project add|remove|import, resource list|refresh|get|add|remove, pack, publish, deploy run|status|list|activate|uninstall, deploy config get|set|link|unlink, upload, download, packages list|delete|download) is owned by [`uipath-solution`](/uipath:uipath-solution). Load that skill for any `.uipx` lifecycle work.
+`uip solution` (init/new, project add|remove|import, resource list|refresh|get|add|remove|edit, pack, publish, deploy run|status|list|activate|uninstall, deploy config get|set|link|unlink, upload, download, packages list|delete|download) is owned by [`uipath-solution`](/uipath:uipath-solution). Load that skill for any `.uipx` lifecycle work.
 
 ---
 


### PR DESCRIPTION
## Summary

Split out of #1027 so that PR (uipath-solution docs for `resource add`/`remove`) only needs its own CODEOWNERS. These four edits touch other skills' reference docs purely to keep their command lists complete now that the CLI ships `uip solution resource add` / `remove` ([UiPath/cli#2221](https://github.com/UiPath/cli/pull/2221)):

- **uipath-platform** (`references/uip-commands.md`): add `add|remove` to the `uip solution` subcommand enumeration so the list isn't stale.
- **uipath-agents** (`references/lowcode/project-lifecycle.md`): two rows in the solution-lifecycle cheat sheet.
- **uipath-maestro-case** (`references/case-commands.md`): one command-table row.
- **uipath-maestro-flow** (`references/shared/cli-commands.md`): a dedicated `## uip solution resource add / remove` section, parity with the existing per-command sections.

The commands themselves are owned and fully documented by the **uipath-solution** skill (#1027). All links here point *into* uipath-solution; nothing in uipath-solution depends on these files.

## Why split

Each file lives under a different CODEOWNERS path, so bundling them into #1027 pulled in ~5 teams' review. Isolating them lets each owning team review their own one-liner without blocking the solution doc.

## Test plan

- [x] Docs-only; no code paths. Links resolve to `/uipath:uipath-solution`.
- [ ] Owning teams confirm the command descriptions match their skill's conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)