### PR TITLE
docs(uipath-test): add customfield, objectlabel, and project owners commands [TMHUB-31940]

### DIFF
--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -48,7 +48,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm project delete --project-key <PROJECT_KEY>` | Delete a Test Manager project. |
 | `uip tm project set-default-folder --project-key <PROJECT_KEY> --folder-key <FOLDER_KEY>` | Set the default Orchestrator folder for a project. |
 | `uip tm project clear-default-folder --project-key <PROJECT_KEY>` | Clear the default Orchestrator folder from a project. |
-| `uip tm project owners list --project-key <PROJECT_KEY> [<PROJECT_KEY> ...]` | List the owners of one or more Test Manager projects. `--project-key` is variadic — pass multiple space-separated keys or repeat the flag. |
+| `uip tm project owners list --project-key <PROJECT_KEY> [<PROJECT_KEY> ...]` | List the owners of one or more Test Manager projects. |
 
 > Get folder keys with `uip or folders list -n <name> --all --output json` — returns all folders visible to the current user.
 
@@ -150,7 +150,7 @@ Common `uip tm` commands organized by resource type.
 
 ### Custom Field Commands
 
-Custom fields are project-scoped schema you attach to **Requirement**, **TestCase**, or **TestSet** objects. The top-level `customfield` verbs operate on the **definitions** (the schema). The nested `label` and `value` subgroups operate on the **per-object rows** that fill in those fields. The `--object-type` flag is case-sensitive and accepts only `Requirement`, `TestCase`, or `TestSet`. The `--data-type` flag accepts only `Text` or `Label` (also PascalCase).
+Custom fields are project-scoped field definitions you attach to **Requirement**, **TestCase**, or **TestSet** objects. The top-level customfield commands manage these definitions. The nested `label` and `value` subgroups operate on the **per-object rows** that fill in those fields. The `--object-type` flag is case-sensitive and accepts only `Requirement`, `TestCase`, or `TestSet`. The `--data-type` flag accepts only `Text` or `Label` (also PascalCase).
 
 | Command | Purpose |
 |---|---|
@@ -170,7 +170,7 @@ All `customfield label` verbs require `--object-type <Requirement\|TestCase\|Tes
 | `uip tm customfield label get --project-key <PROJECT_KEY> --object-type <TYPE> --label-id <UUID>` | Get a single label row by UUID. |
 | `uip tm customfield label create --project-key <PROJECT_KEY> --object-type <TYPE> --object-id <UUID> --values '{"Field":["v1","v2"]}'` | Upsert a label row on one object. `--values` is a JSON object mapping field names to string arrays. |
 | `uip tm customfield label add --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> --values <value...>` | Append values to a label field across multiple objects. Optional `--replace-existing-values` for authoritative-set semantics. |
-| `uip tm customfield label remove --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> (--values <value...> \| --remove-all-values)` | Remove values; `--values` and `--remove-all-values` are mutually exclusive. |
+| `uip tm customfield label remove --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> (--values <value...> \| --remove-all-values)` | Remove values from a label field across multiple objects. |
 
 #### Custom Field — Text-type rows
 
@@ -186,11 +186,11 @@ All `customfield value` verbs require `--object-type <Requirement\|TestCase\|Tes
 
 ### Object Label Commands
 
-Object labels are tag-style metadata applied to TestCase, TestSet, TestExecution, TestCaseLog (and were available on Requirement). Use `--object-type` for the parent kind and `--object-ids` for the target objects.
+Object labels are tag-style metadata applied to Requirement, TestCase, TestSet, TestExecution, TestCaseLog. Use `--object-type` for the parent kind and `--object-ids` for the target objects.
 
 | Command | Purpose |
 |---|---|
-| `uip tm objectlabel list --project-key <PROJECT_KEY> --object-type <TestCase\|TestSet\|TestExecution\|TestCaseLog>` | List distinct label names for one `--object-type` (paginated). Optional `--object-ids <UUID...>`, `--label-types <UserLabel\|SystemLabel\|InternalLabel ...>`, `--filter <text>`, `--sort-by`, `--limit`, `--offset`. |
+| `uip tm objectlabel list --project-key <PROJECT_KEY> --object-type <Requirement\|TestCase\|TestSet\|TestExecution\|TestCaseLog>` | List distinct label names for one `--object-type` (paginated). Optional `--object-ids <UUID...>`, `--label-types <UserLabel\|SystemLabel\|InternalLabel ...>`, `--filter <text>`, `--sort-by`, `--limit`, `--offset`. |
 | `uip tm objectlabel get --project-key <PROJECT_KEY> --label-id <UUID>` | Get a single label-assignment row by UUID. |
 | `uip tm objectlabel add --project-key <PROJECT_KEY> --object-type <TYPE> --object-ids <UUID...> --labels <name...>` | Attach labels to objects (variadic; one-to-one, one-to-many, many-to-many). Optional `--remove-other-labels` for authoritative-set semantics. |
 | `uip tm objectlabel remove --project-key <PROJECT_KEY> --object-type <TYPE> --object-ids <UUID...> (--labels <name...> \| --remove-all-labels)` | Detach labels from objects. `--labels` and `--remove-all-labels` are mutually exclusive. |

--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -48,6 +48,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm project delete --project-key <PROJECT_KEY>` | Delete a Test Manager project. |
 | `uip tm project set-default-folder --project-key <PROJECT_KEY> --folder-key <FOLDER_KEY>` | Set the default Orchestrator folder for a project. |
 | `uip tm project clear-default-folder --project-key <PROJECT_KEY>` | Clear the default Orchestrator folder from a project. |
+| `uip tm project owners list --project-key <PROJECT_KEY> [<PROJECT_KEY> ...]` | List the owners of one or more Test Manager projects. `--project-key` is variadic — pass multiple space-separated keys or repeat the flag. |
 
 > Get folder keys with `uip or folders list -n <name> --all --output json` — returns all folders visible to the current user.
 
@@ -146,6 +147,53 @@ Common `uip tm` commands organized by resource type.
 | Command | Purpose |
 |---|---|
 | `uip tm user get` | Get profile data for the currently authenticated user. |
+
+### Custom Field Commands
+
+Custom fields are project-scoped schema you attach to **Requirement**, **TestCase**, or **TestSet** objects. The top-level `customfield` verbs operate on the **definitions** (the schema). The nested `label` and `value` subgroups operate on the **per-object rows** that fill in those fields. The `--object-type` flag is case-sensitive and accepts only `Requirement`, `TestCase`, or `TestSet`. The `--data-type` flag accepts only `Text` or `Label` (also PascalCase).
+
+| Command | Purpose |
+|---|---|
+| `uip tm customfield list --project-key <PROJECT_KEY>` | List custom field definitions. Optional `--object-types <type...>`, `--data-types <type...>` (filter; both variadic, PascalCase), `--name <NAME>` (exact match), `--filter <text>` (substring), `--sort-by <expr>`, `--limit <N>`, `--offset <N>`. |
+| `uip tm customfield get --project-key <PROJECT_KEY> --field-id <UUID>` | Get a custom field definition by UUID, OR identify by `--name <NAME> --object-type <TYPE>`. |
+| `uip tm customfield create --project-key <PROJECT_KEY> --name <NAME> --data-type <Text\|Label> (--object-type <Requirement\|TestCase\|TestSet> \| --scope-list <type...>)` | Create a new custom field definition. Pass `--object-type` for a single-scope field, OR `--scope-list <Requirement TestCase TestSet>` (variadic, mutually exclusive) for multi-scope. Optional `--description <text>`, `--value-hints <text>`, `--default-value <text>`. |
+| `uip tm customfield update --project-key <PROJECT_KEY> --field-id <UUID>` | Update a custom field definition. Identify by `--field-id` OR by `--name + --object-type`. Optional `--rename-to <name>`, `--description`, `--default-value`, `--value-hints`. Unspecified fields keep current values. |
+| `uip tm customfield delete --project-key <PROJECT_KEY> --field-ids <UUID...>` | Delete one or more custom field definitions by UUID (variadic), OR singleton by `--name + --object-type`. |
+
+#### Custom Field — Label-type rows
+
+All `customfield label` verbs require `--object-type <Requirement\|TestCase\|TestSet>`.
+
+| Command | Purpose |
+|---|---|
+| `uip tm customfield label list --project-key <PROJECT_KEY> --object-type <TYPE>` | List label rows. Optional `--object-id <UUID>` to scope to a single object, `--filter <text>`, `--sort-by`, `--limit`, `--offset`. |
+| `uip tm customfield label get --project-key <PROJECT_KEY> --object-type <TYPE> --label-id <UUID>` | Get a single label row by UUID. |
+| `uip tm customfield label create --project-key <PROJECT_KEY> --object-type <TYPE> --object-id <UUID> --values '{"Field":["v1","v2"]}'` | Upsert a label row on one object. `--values` is a JSON object mapping field names to string arrays. |
+| `uip tm customfield label add --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> --values <value...>` | Append values to a label field across multiple objects. Optional `--replace-existing-values` for authoritative-set semantics. |
+| `uip tm customfield label remove --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> (--values <value...> \| --remove-all-values)` | Remove values; `--values` and `--remove-all-values` are mutually exclusive. |
+
+#### Custom Field — Text-type rows
+
+All `customfield value` verbs require `--object-type <Requirement\|TestCase\|TestSet>`. `create` additionally requires `--data-type <Text\|Label>` (must match the field's definition).
+
+| Command | Purpose |
+|---|---|
+| `uip tm customfield value list --project-key <PROJECT_KEY> --object-type <TYPE>` | List value rows. Results are empty unless `--object-id <UUID>` is provided. Optional `--filter <text>`, `--sort-by`, `--limit`, `--offset`. |
+| `uip tm customfield value get --project-key <PROJECT_KEY> --object-type <TYPE> --value-id <UUID>` | Get a value row by UUID, OR by `--name + --object-id`. |
+| `uip tm customfield value create --project-key <PROJECT_KEY> --object-type <TYPE> --name <FIELD_NAME> --object-id <UUID> --data-type <Text\|Label>` | Create a value row. Optional `--value <text>` for the initial content. The `--data-type` must match the existing field definition. |
+| `uip tm customfield value update --project-key <PROJECT_KEY> --object-type <TYPE> --value-id <UUID> --value <text>` | Update a value row by UUID, OR by `--name + --object-id`. Use `--clear` to set the value to empty. |
+| `uip tm customfield value delete --project-key <PROJECT_KEY> --object-type <TYPE> --value-id <UUID>` | Delete a value row by UUID, OR by `--name + --object-id`. |
+
+### Object Label Commands
+
+Object labels are tag-style metadata applied to TestCase, TestSet, TestExecution, TestCaseLog (and were available on Requirement). Use `--object-type` for the parent kind and `--object-ids` for the target objects.
+
+| Command | Purpose |
+|---|---|
+| `uip tm objectlabel list --project-key <PROJECT_KEY> --object-type <TestCase\|TestSet\|TestExecution\|TestCaseLog>` | List distinct label names for one `--object-type` (paginated). Optional `--object-ids <UUID...>`, `--label-types <UserLabel\|SystemLabel\|InternalLabel ...>`, `--filter <text>`, `--sort-by`, `--limit`, `--offset`. |
+| `uip tm objectlabel get --project-key <PROJECT_KEY> --label-id <UUID>` | Get a single label-assignment row by UUID. |
+| `uip tm objectlabel add --project-key <PROJECT_KEY> --object-type <TYPE> --object-ids <UUID...> --labels <name...>` | Attach labels to objects (variadic; one-to-one, one-to-many, many-to-many). Optional `--remove-other-labels` for authoritative-set semantics. |
+| `uip tm objectlabel remove --project-key <PROJECT_KEY> --object-type <TYPE> --object-ids <UUID...> (--labels <name...> \| --remove-all-labels)` | Detach labels from objects. `--labels` and `--remove-all-labels` are mutually exclusive. |
 
 ## Critical Rules
 


### PR DESCRIPTION
## Summary

Adds 20 `uip tm` commands to the `uipath-test` skill that shipped to the CLI on `main` but were never documented in this skill. Agents using `/uipath-test` couldn't discover or invoke these verbs even though they're publicly available.

Tracks [TMHUB-31940].

## What's added

| Group | Commands | Source PR |
|---|---|---|
| `customfield` (definitions) | `list`, `get`, `create`, `update`, `delete` | [UiPath/cli#1209](https://github.com/UiPath/cli/pull/1209) |
| `customfield label` (label-type rows) | `list`, `get`, `create`, `add`, `remove` | [UiPath/cli#1209](https://github.com/UiPath/cli/pull/1209) |
| `customfield value` (text-type rows) | `list`, `get`, `create`, `update`, `delete` | [UiPath/cli#1209](https://github.com/UiPath/cli/pull/1209) |
| `objectlabel` | `list`, `get`, `add`, `remove` | [UiPath/cli#1225](https://github.com/UiPath/cli/pull/1225) |
| `project owners list` | 1 command added to existing Project table | UiPath/cli#1045 |
| **Total** | **20 commands** | |

## Where it lands in the doc

- **`project owners list`**: new row inserted in the existing **Project Commands** table.
- **Custom Field Commands**: new top-level section with intro prose explaining the definition vs label-row vs value-row split, plus three sub-tables (one per group).
- **Object Label Commands**: new top-level section with 4 commands. Mutex semantics on `objectlabel remove` (`--labels` xor `--remove-all-labels`) documented.

Both new sections placed after `### User Commands`, before `## Critical Rules` — sensible ordering (admin/cross-cutting verbs at the end before the behavioral-rules block).

## Signatures cross-checked against

- `packages/test-manager-tool/src/commands/customfield.ts`
- `packages/test-manager-tool/src/commands/customfieldlabel.ts`
- `packages/test-manager-tool/src/commands/customfieldvalue.ts`
- `packages/test-manager-tool/src/commands/objectlabel.ts`
- `packages/test-manager-tool/src/commands/project.ts`
- `packages/test-manager-tool/src/utils/shared.ts`
- live `uip tm <subject> <verb> --help` output for variadic, mutex, and enum semantics

## Review history (pre-PR)

Two reviews ran locally before the PR was opened:

| Reviewer | Findings | Status |
|---|---|---|
| **Claude** (PR-level, inline) | Approve with 1 suggestion (PascalCase enum casing in `--data-type` / `--object-type`) | ✅ Applied |
| **Codex** (working-tree, background, P-rated) | **3 P2 doc-accuracy issues** | ✅ All applied |

Codex's 3 P2 findings were:

1. `customfield create` — accepts only `Text\|Label` (PascalCase) for `--data-type`, only `Requirement\|TestCase\|TestSet` for `--object-type` (NOT `TestExecution`), and there is no `--allowed-values` flag. **Fix**: corrected enum casing; removed `TestExecution`; dropped `--allowed-values`; documented `--scope-list` as the mutually-exclusive alternative to `--object-type`.

2. `customfield label get` — `--object-type` is required (the row UUID is not enough by itself). **Fix**: added to signature.

3. All `customfield value` verbs require `--object-type`; `value create` additionally requires `--data-type`. **Fix**: added to every value-verb signature.

Without those corrections, agents copying the documented commands would have hit `required option … not specified` failures before reaching Test Manager.

## Diff stat

```
 skills/uipath-test/SKILL.md | 48 ++++++++++++++++++++++++++++++++++++++++++++
 1 file changed, 48 insertions(+)
```

Purely additive. No existing content reworded.

## Test plan

- [x] Pre-commit Codex review (background) — no remaining findings after fixups.
- [x] Pre-commit Claude review (inline) — approve.
- [ ] Reviewer spot-check: `uip tm customfield create --project-key DEMO --name X --data-type Text --object-type TestCase` works.
- [ ] Reviewer spot-check: `uip tm customfield create --project-key DEMO --name X --data-type text --object-type TestCase` fails (lowercase enum rejected — confirms the doc's PascalCase warning).
- [ ] Reviewer spot-check: `uip tm objectlabel list --project-key DEMO --object-type TestCase --limit 5 --output json` works.

## Out of scope

- Updating other skills that reference TM verbs (`uipath-rpa`, etc.) — separate review.
- Adding examples to `references/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TMHUB-31940]: https://uipath.atlassian.net/browse/TMHUB-31940