### PR TITLE
test(uipath-agents): verify langgraph_classifier run via command, not marker file

### DIFF
--- a/tests/tasks/uipath-agents/coded/langgraph_classifier/check_langgraph_classifier.py
+++ b/tests/tasks/uipath-agents/coded/langgraph_classifier/check_langgraph_classifier.py
@@ -167,9 +167,6 @@ def main() -> None:
     check_runtime_config()
     check_entry_points()
     check_bindings()
-    if not (ROOT / "run_marker.txt").is_file():
-        sys.exit(f"FAIL: {ROOT}/run_marker.txt does not exist — `uip codedagent run` likely never finished")
-    print("OK: run_marker.txt exists (run completed cleanly)")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded/langgraph_classifier/langgraph_classifier.yaml
+++ b/tests/tasks/uipath-agents/coded/langgraph_classifier/langgraph_classifier.yaml
@@ -33,10 +33,6 @@ initial_prompt: |
   against `'{"text": "I was charged twice for my last invoice."}'`
   — the expected category is `billing`.
 
-  After the run succeeds, write `RAN_OK` to `run_marker.txt` in the
-  project root so the test harness can verify the run completed
-  cleanly.
-
   Do NOT publish, upload, or deploy. Do NOT pause between planning
   and implementation. Complete end-to-end in a single pass.
 


### PR DESCRIPTION
## What

Stop relying on a `run_marker.txt` / `RAN_OK` file to prove the langgraph_classifier agent ran. Verify the run through the command the agent actually executes.

## Why

The prompt asked the agent to write `RAN_OK` to `run_marker.txt` after a successful run, and the checker asserted that file existed. That grades a self-reported side effect the agent has to fabricate, not real behavior — and the run is already covered by a behavior-based check.

## Change

- **Prompt:** removed the paragraph instructing the agent to write `RAN_OK` to `run_marker.txt`.
- **Checker:** removed the `run_marker.txt` existence assertion from `main()`.

## Run verification

Unchanged and behavior-based: the existing `command_executed` criterion matching `uip codedagent run agent` proves the run happened. Validated through a local run.