### PR TITLE
test(uipath-agents): grade deploy_my_workspace on deploy command, not cloud success

### DIFF
--- a/tests/tasks/uipath-agents/coded/deploy_my_workspace/check_deploy_my_workspace.py
+++ b/tests/tasks/uipath-agents/coded/deploy_my_workspace/check_deploy_my_workspace.py
@@ -7,9 +7,9 @@ deployment guide flags as required (`name`, `version`, `description`,
 `authors`). Without `authors`, packaging fails with `Project authors
 cannot be empty`.
 
-The `invoke` command's signal is captured by a `command_executed`
-criterion in the YAML — this script focuses on the file artifacts
-produced by pack/deploy.
+This script focuses on the file artifacts produced by pack/deploy;
+that the deploy command ran is graded separately by a
+`command_executed` criterion in the YAML.
 
 Checks:
   1. `deploy-smoke/pyproject.toml` has `name`, `version`,

--- a/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
@@ -1,11 +1,12 @@
 task_id: skill-agent-coded-deploy-my-workspace
 description: >
   Coded-agent deploy lifecycle. Verifies the skill guides the agent
-  through `uip codedagent pack` → `uip codedagent publish
-  --my-workspace` (or the combined `uip codedagent deploy
-  --my-workspace`), then `uip codedagent invoke` to start a cloud
-  job and surface the monitoring URL. Exercises the entire production
-  packaging path the existing test suite never reaches.
+  to package and run `uip codedagent deploy --my-workspace` (the
+  combined pack + publish path) and produce a deployable `.nupkg`.
+  Runs against a real tenant: grades that the deploy command ran and
+  the package was built — a "version already exists" publish conflict
+  does not fail the task. Exercises the production packaging path the
+  rest of the suite never reaches.
 tags: [uipath-agents, e2e, coded, lifecycle:deploy, feature:deploy]
 
 agent:
@@ -19,14 +20,14 @@ run_limits:
   max_turns: 40
 
 initial_prompt: |
-  Build a minimal Simple Function UiPath coded agent named
-  `deploy-smoke` that echoes the input message. Input: `message`
-  (string). Output: `echoed` (string). Take it through scaffold →
-  init → run, then deploy to the personal workspace and invoke the
-  published version with `{"message": "deployed"}`. The invoke
-  should surface a monitoring URL.
+  Build a minimal no-LLM UiPath coded agent named `deploy-smoke`
+  that echoes the input message. Input: `message` (string). Output:
+  `echoed` (string). Then deploy it to the personal workspace.
 
-  The test harness has UiPath auth pre-configured.
+  The test harness has UiPath auth pre-configured. The workspace may
+  already hold this package from an earlier run — if the deploy
+  reports the version already exists, that is expected; consider the
+  deploy step done and do not re-deploy.
 
   Do NOT pause between planning and implementation. Complete
   end-to-end in a single pass.
@@ -36,14 +37,6 @@ success_criteria:
     description: "Agent packed and published to my-workspace (deploy or pack+publish)"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedagent\s+(deploy|publish)\s+.*--my-workspace'
-    min_count: 1
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent invoked the published agent"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+codedagent\s+invoke\s+main'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0


### PR DESCRIPTION
## What

Make `deploy_my_workspace` grade that the agent **ran the deploy command and built a package**, instead of requiring a successful cloud deploy + invoke.

## Why

The task runs against a real, persistent Orchestrator tenant (`smoke.yaml` passes through real auth and mounts `~/.uipath`). Re-runs accumulate published package versions in the shared personal-workspace feed, so deploy returns `409 version already exists`. The agent followed the skill's documented remedy — bump patch, redeploy — but every bump also collided, burning the turn budget before it reached `invoke`: `MAX_TURNS_EXHAUSTED`.

The invoke step was the only criterion that needed a live deployment, which is exactly the brittle, environment-dependent part.

## Changes

- **Removed** the `uip codedagent invoke main` criterion (required a successful cloud deploy).
- **Prompt:** deploy once; treat "version already exists" as expected and stop — no redeploy loop.
- **Prompt wording:** "Simple Function" → "no-LLM" so it can't drift onto the distinct standalone `uip functions` artifact lifecycle.
- **`max_turns`:** reverted to 40 — grading is satisfied at the first deploy attempt.
- **Description / checker docstring:** updated to match the narrowed scope.

## Grading now

- `command_executed`: `uip codedagent deploy --my-workspace` ran.
- `run_command`: local `.nupkg` produced + `pyproject.toml` well-formed (pack is local — no tenant-success dependency).