### PR TITLE
uip auth login -> uip login

### DIFF
--- a/skills/uipath-rpa/references/tenant-library-search-guide.md
+++ b/skills/uipath-rpa/references/tenant-library-search-guide.md
@@ -98,7 +98,7 @@ If `uip` is unauthenticated, ask the legacy question:
 > 1. **Skip — no shared libraries** *(recommended)*
 > 2. **Yes — `CommonLibrary`** (the conventional default)
 > 3. **Yes — other** (you name them)
-> 4. **Authenticate first** — run `uip auth login`, then re-invoke the skill
+> 4. **Authenticate first** — run `uip login`, then re-invoke the skill
 
 ## Anti-patterns
 

--- a/skills/uipath-solution/references/design/tenant-library-search-guide.md
+++ b/skills/uipath-solution/references/design/tenant-library-search-guide.md
@@ -92,7 +92,7 @@ If `uip` is unauthenticated, ask the legacy question:
 > 1. **Skip — no shared libraries** *(recommended)*
 > 2. **Yes — `CommonLibrary`** (the conventional default)
 > 3. **Yes — other** (you name them)
-> 4. **Authenticate first** — run `uip auth login`, then re-invoke the skill
+> 4. **Authenticate first** — run `uip login`, then re-invoke the skill
 
 ## Anti-patterns
 


### PR DESCRIPTION
We have a verb check that is failing (thanks @uipreliga for the verb check test) for `uip auth login`: https://github.com/UiPath/skills/actions/runs/26507447568/job/78063439234?pr=1060 .

It seems that command was never supported, so this is not even a uipcli version mismatch issue.