### PR TITLE
fix(uipath-agents): add missing sandbox block to rag_langgraph task

### DIFF
--- a/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
@@ -15,6 +15,10 @@ agent:
 run_limits:
   turn_timeout: 1200
 
+sandbox:
+  driver: tempdir
+  python: {}
+
 initial_prompt: |
   Build a LangGraph UiPath coded agent named `policy-rag` that
   answers natural-language questions by retrieving relevant snippets


### PR DESCRIPTION
## Summary

Adds the required `sandbox:` block to `rag_langgraph.yaml`. The field is now required by coder-eval — without it the task is skipped entirely with a validation error before the agent even runs.

## Why it failed in the daily run

`sandbox:` became a required field in a recent coder-eval update. The task was being silently skipped (0 tasks executed), which surfaced as a failure in the nightly report.

## Test plan

- [x] 3/3 passes after the fix — score 1.0, avg 60 turns / 4 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)