### PR TITLE
feat(skills): skill lifecycle-status mechanism (manifest + README table + CI)

### DIFF
--- a/.claude/rules/skill-review.md
+++ b/.claude/rules/skill-review.md
@@ -20,13 +20,14 @@ Does the skill follow the canonical layout and conventions?
 - `description` is under 1024 characters (repo cap; Claude Code's hard truncation for `description` + `when_to_use` is 1,536 chars — run `hooks/validate-skill-descriptions.sh` to verify)
 - `description` front-loads the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`) within the first ~100 characters
 - `description` includes compact `→` redirects for commonly confused sibling skills (e.g., `For XAML→uipath-rpa`)
-- `description` starts with the brand/domain identity (e.g., `UiPath`, `UiPath RPA`) — NOT a metadata tag like `[PREVIEW]`. Preview status belongs in the SKILL.md body
+- `description` starts with the brand/domain identity (e.g., `UiPath`, `UiPath RPA`) — NOT a metadata tag like `[PREVIEW]`. Lifecycle status lives only in `assets/skill-status.json`, never in the frontmatter or body
 - SKILL.md body follows the expected section order: Title, When to Use, Critical Rules, Workflow/Quick Start, Reference Navigation, Anti-patterns
 - Reference files use kebab-case naming with `-guide.md` / `-template.md` suffixes
 - Folder organization is logical (references/, assets/, scripts/)
 - No orphaned files (every file is reachable from SKILL.md)
+- Skill has an entry in `assets/skill-status.json` with a valid status (`ga` / `public-preview` / `private-preview` / `in-development`), and no stale status markers in the frontmatter `description` or body — verify with `scripts/check-skill-status.py`
 
-**Red flags:** missing frontmatter fields, name mismatch, description over 1024 chars, description prefixed with `[PREVIEW]` or other metadata tags (displaces high-value matching tokens), verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files.
+**Red flags:** missing frontmatter fields, name mismatch, description over 1024 chars, description prefixed with `[PREVIEW]` or other metadata tags (displaces high-value matching tokens), verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files, missing or invalid `assets/skill-status.json` entry, stale `> **Preview**` callout or `[PREVIEW]` tag in SKILL.md.
 
 ### 2. Consistency (1-5)
 

--- a/.claude/rules/skill-review.md
+++ b/.claude/rules/skill-review.md
@@ -25,7 +25,7 @@ Does the skill follow the canonical layout and conventions?
 - Reference files use kebab-case naming with `-guide.md` / `-template.md` suffixes
 - Folder organization is logical (references/, assets/, scripts/)
 - No orphaned files (every file is reachable from SKILL.md)
-- Skill has an entry in `assets/skill-status.json` with a valid status (`stable` / `public-preview` / `private-preview` / `in-development`), and no stale status markers in the frontmatter `description` or body — verify with `scripts/check-skill-status.py`
+- Skill has an entry in `assets/skill-status.json` with a valid status (`stable` / `preview` / `in-development`), and no stale status markers in the frontmatter `description` or body — verify with `scripts/check-skill-status.py`
 
 **Red flags:** missing frontmatter fields, name mismatch, description over 1024 chars, description prefixed with `[PREVIEW]` or other metadata tags (displaces high-value matching tokens), verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files, missing or invalid `assets/skill-status.json` entry, stale `> **Preview**` callout or `[PREVIEW]` tag in SKILL.md.
 

--- a/.claude/rules/skill-review.md
+++ b/.claude/rules/skill-review.md
@@ -25,7 +25,7 @@ Does the skill follow the canonical layout and conventions?
 - Reference files use kebab-case naming with `-guide.md` / `-template.md` suffixes
 - Folder organization is logical (references/, assets/, scripts/)
 - No orphaned files (every file is reachable from SKILL.md)
-- Skill has an entry in `assets/skill-status.json` with a valid status (`ga` / `public-preview` / `private-preview` / `in-development`), and no stale status markers in the frontmatter `description` or body — verify with `scripts/check-skill-status.py`
+- Skill has an entry in `assets/skill-status.json` with a valid status (`stable` / `public-preview` / `private-preview` / `in-development`), and no stale status markers in the frontmatter `description` or body — verify with `scripts/check-skill-status.py`
 
 **Red flags:** missing frontmatter fields, name mismatch, description over 1024 chars, description prefixed with `[PREVIEW]` or other metadata tags (displaces high-value matching tokens), verbose TRIGGER/DO NOT TRIGGER clauses, frontmatter fields nested under `metadata:`, no Critical Rules section, unreachable files, missing or invalid `assets/skill-status.json` entry, stale `> **Preview**` callout or `[PREVIEW]` tag in SKILL.md.
 

--- a/.claude/rules/skill-structure.md
+++ b/.claude/rules/skill-structure.md
@@ -32,7 +32,7 @@ description: "<identity> (<unique signal>). <core actions>. For <confusing-case>
 - `description` MUST be under 1024 characters. Claude Code truncates `description` + `when_to_use` at 1,536 chars in the skill listing ([source](https://code.claude.com/docs/en/skills.md)); 1024 is the repo cap to keep descriptions focused and leave headroom
 - `description` MUST front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`) within the first ~100 characters — the first ~100 chars carry the most matching signal
 - `description` MUST start with the brand or domain identity (e.g., `UiPath`, `UiPath RPA`, `UiPath Maestro Flow`). Do NOT prefix with metadata tags like `[PREVIEW]`, `[BETA]`, etc. — those displace high-value matching tokens and semantically de-prioritize the skill
-- Preview / beta status MUST be indicated in the SKILL.md body (e.g., a `> **Preview**` callout under the H1), NOT in the frontmatter description
+- Lifecycle status (GA / Public Preview / Private Preview / In-development) MUST be recorded ONLY in [`assets/skill-status.json`](../../assets/skill-status.json) — the single source of truth. Do NOT put status markers in the frontmatter `description` OR the body (no `> **Preview**` callouts). See [Lifecycle Status](#lifecycle-status) below
 - `description` MUST include compact redirects for commonly confused sibling skills using `→` notation (e.g., `For XAML→uipath-rpa`)
 - `description` MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — these waste characters and get truncated. Use `→` redirects for sibling disambiguation instead
 - All frontmatter fields (`allowed-tools`, `user-invocable`, etc.) MUST be at the top level — NOT nested under a `metadata:` key (Claude Code only reads top-level fields)
@@ -48,6 +48,25 @@ The markdown body SHOULD follow this order:
 4. **Quick Start / Workflow** — step-by-step common use case
 5. **Reference Navigation** — links to files in `references/`
 6. **Anti-patterns** (optional) — "What NOT to Do" section
+
+## Lifecycle Status
+
+Every skill has a maturity status recorded in [`assets/skill-status.json`](../../assets/skill-status.json) — the single source of truth. There is NO status marker in SKILL.md (frontmatter or body). Keeping status in one machine-readable file lets agents and the generated README table report it consistently, and keeps status changes out of frontmatter (so they don't trigger the `activation-gate.yml` recall-eval gate).
+
+| Status | Meaning |
+|--------|---------|
+| `ga` | Generally available; stable surface, safe for production. |
+| `public-preview` | Pre-GA but available to all tenants; surface and behavior may change. |
+| `private-preview` | Gated or allowlisted; may be inaccessible in a tenant. |
+| `in-development` | Skill itself is incomplete or unstable; coverage is partial. |
+
+When adding or changing a skill, set its entry under `skills` in the manifest to one of these values, then regenerate the README table:
+
+```bash
+python3 scripts/check-skill-status.py --write-readme
+```
+
+`scripts/check-skill-status.py` (run in CI by `validate-skill-status.yml`) enforces that every skill has a manifest entry with a valid status, that the README table is current, and that no status markers leak into SKILL.md frontmatter or body.
 
 ## Naming Conventions
 

--- a/.claude/rules/skill-structure.md
+++ b/.claude/rules/skill-structure.md
@@ -32,7 +32,7 @@ description: "<identity> (<unique signal>). <core actions>. For <confusing-case>
 - `description` MUST be under 1024 characters. Claude Code truncates `description` + `when_to_use` at 1,536 chars in the skill listing ([source](https://code.claude.com/docs/en/skills.md)); 1024 is the repo cap to keep descriptions focused and leave headroom
 - `description` MUST front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`) within the first ~100 characters — the first ~100 chars carry the most matching signal
 - `description` MUST start with the brand or domain identity (e.g., `UiPath`, `UiPath RPA`, `UiPath Maestro Flow`). Do NOT prefix with metadata tags like `[PREVIEW]`, `[BETA]`, etc. — those displace high-value matching tokens and semantically de-prioritize the skill
-- Lifecycle status (Stable / Public Preview / Private Preview / In-development) MUST be recorded ONLY in [`assets/skill-status.json`](../../assets/skill-status.json) — the single source of truth. Do NOT put status markers in the frontmatter `description` OR the body (no `> **Preview**` callouts). See [Lifecycle Status](#lifecycle-status) below
+- Lifecycle status (Stable / Preview / In-development) MUST be recorded ONLY in [`assets/skill-status.json`](../../assets/skill-status.json) — the single source of truth. Do NOT put status markers in the frontmatter `description` OR the body (no `> **Preview**` callouts). See [Lifecycle Status](#lifecycle-status) below
 - `description` MUST include compact redirects for commonly confused sibling skills using `→` notation (e.g., `For XAML→uipath-rpa`)
 - `description` MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — these waste characters and get truncated. Use `→` redirects for sibling disambiguation instead
 - All frontmatter fields (`allowed-tools`, `user-invocable`, etc.) MUST be at the top level — NOT nested under a `metadata:` key (Claude Code only reads top-level fields)
@@ -56,8 +56,7 @@ Every skill has a maturity status recorded in [`assets/skill-status.json`](../..
 | Status | Meaning |
 |--------|---------|
 | `stable` | Stable, production-ready surface; safe for production. |
-| `public-preview` | Not yet stable but available to all tenants; surface and behavior may change. |
-| `private-preview` | Gated or allowlisted; may be inaccessible in a tenant. |
+| `preview` | Not yet stable; may be broadly available or gated/allowlisted, and surface and behavior may change. |
 | `in-development` | Skill itself is incomplete or unstable; coverage is partial. |
 
 When adding or changing a skill, set its entry under `skills` in the manifest to one of these values, then regenerate the README table:

--- a/.claude/rules/skill-structure.md
+++ b/.claude/rules/skill-structure.md
@@ -32,7 +32,7 @@ description: "<identity> (<unique signal>). <core actions>. For <confusing-case>
 - `description` MUST be under 1024 characters. Claude Code truncates `description` + `when_to_use` at 1,536 chars in the skill listing ([source](https://code.claude.com/docs/en/skills.md)); 1024 is the repo cap to keep descriptions focused and leave headroom
 - `description` MUST front-load the skill identity and unique file/domain signals (e.g., `.cs`, `.xaml`, `.flow`) within the first ~100 characters — the first ~100 chars carry the most matching signal
 - `description` MUST start with the brand or domain identity (e.g., `UiPath`, `UiPath RPA`, `UiPath Maestro Flow`). Do NOT prefix with metadata tags like `[PREVIEW]`, `[BETA]`, etc. — those displace high-value matching tokens and semantically de-prioritize the skill
-- Lifecycle status (GA / Public Preview / Private Preview / In-development) MUST be recorded ONLY in [`assets/skill-status.json`](../../assets/skill-status.json) — the single source of truth. Do NOT put status markers in the frontmatter `description` OR the body (no `> **Preview**` callouts). See [Lifecycle Status](#lifecycle-status) below
+- Lifecycle status (Stable / Public Preview / Private Preview / In-development) MUST be recorded ONLY in [`assets/skill-status.json`](../../assets/skill-status.json) — the single source of truth. Do NOT put status markers in the frontmatter `description` OR the body (no `> **Preview**` callouts). See [Lifecycle Status](#lifecycle-status) below
 - `description` MUST include compact redirects for commonly confused sibling skills using `→` notation (e.g., `For XAML→uipath-rpa`)
 - `description` MUST NOT use verbose `TRIGGER when:` / `DO NOT TRIGGER when:` clauses — these waste characters and get truncated. Use `→` redirects for sibling disambiguation instead
 - All frontmatter fields (`allowed-tools`, `user-invocable`, etc.) MUST be at the top level — NOT nested under a `metadata:` key (Claude Code only reads top-level fields)
@@ -55,8 +55,8 @@ Every skill has a maturity status recorded in [`assets/skill-status.json`](../..
 
 | Status | Meaning |
 |--------|---------|
-| `ga` | Generally available; stable surface, safe for production. |
-| `public-preview` | Pre-GA but available to all tenants; surface and behavior may change. |
+| `stable` | Stable, production-ready surface; safe for production. |
+| `public-preview` | Not yet stable but available to all tenants; surface and behavior may change. |
 | `private-preview` | Gated or allowlisted; may be inaccessible in a tenant. |
 | `in-development` | Skill itself is incomplete or unstable; coverage is partial. |
 

--- a/.github/workflows/validate-skill-status.yml
+++ b/.github/workflows/validate-skill-status.yml
@@ -1,0 +1,30 @@
+name: Validate Skill Status
+
+on:
+  pull_request:
+    paths:
+      - 'skills/*/SKILL.md'
+      - 'assets/skill-status.json'
+      - 'scripts/check-skill-status.py'
+      - 'README.md'
+      - '.github/workflows/validate-skill-status.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-status:
+    runs-on: ubuntu-latest
+    name: Validate skill status manifest & README
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Validate status manifest
+        run: python3 scripts/check-skill-status.py
+
+      - name: Check README status table is current
+        run: python3 scripts/check-skill-status.py --check-readme

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,28 @@ Links to reference documents in the `references/` folder for detailed topics.
 - **Include anti-patterns.** A "What NOT to Do" section saves more time than a "What to Do" section.
 - **Link to references for depth.** Keep SKILL.md focused on workflow and rules. Move detailed API docs, schemas, and examples into `references/`.
 
-### 4. Add Reference Documents (Optional)
+### 4. Register Lifecycle Status
+
+Every skill must declare its maturity in [`assets/skill-status.json`](assets/skill-status.json) — the single source of truth (status is NOT stored in SKILL.md). Add an entry under `skills`:
+
+```json
+"uipath-<your-skill>": {
+  "status": "public-preview",
+  "confluence": { "page_id": null, "url": null },
+  "last_synced": null
+}
+```
+
+Use one of: `ga`, `public-preview`, `private-preview`, `in-development`. Then regenerate the README status table and validate:
+
+```bash
+python3 scripts/check-skill-status.py --write-readme
+python3 scripts/check-skill-status.py
+```
+
+CI (`validate-skill-status.yml`) fails if a skill is missing from the manifest, has an invalid status, leaves a stale `[PREVIEW]` / `> **Preview**` marker in SKILL.md, or if the README table is out of date.
+
+### 5. Add Reference Documents (Optional)
 
 Reference files go in `references/` and follow these conventions:
 
@@ -187,7 +208,7 @@ Reference files go in `references/` and follow these conventions:
 - **Organize by subdomain** when a skill covers multiple areas (e.g., `references/integration-service/`, `references/lifecycle/`)
 - **Link from SKILL.md** so the agent can discover them
 
-### 5. Add Templates/Assets (Optional)
+### 6. Add Templates/Assets (Optional)
 
 Static files like code templates go in `assets/`:
 
@@ -292,6 +313,7 @@ Before submitting your PR, verify:
 - [ ] Anti-patterns / "What NOT to Do" section is included for non-trivial skills
 - [ ] No references to other skills (skills must be self-contained)
 - [ ] All links to reference files use relative paths and point to existing files
+- [ ] Lifecycle status registered in `assets/skill-status.json` and README table regenerated (run `python3 scripts/check-skill-status.py`)
 
 ### References
 - [ ] File names use kebab-case

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,13 +184,13 @@ Every skill must declare its maturity in [`assets/skill-status.json`](assets/ski
 
 ```json
 "uipath-<your-skill>": {
-  "status": "public-preview",
+  "status": "preview",
   "confluence": { "page_id": null, "url": null },
   "last_synced": null
 }
 ```
 
-Use one of: `stable`, `public-preview`, `private-preview`, `in-development`. Then regenerate the README status table and validate:
+Use one of: `stable`, `preview`, `in-development`. Then regenerate the README status table and validate:
 
 ```bash
 python3 scripts/check-skill-status.py --write-readme

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -190,7 +190,7 @@ Every skill must declare its maturity in [`assets/skill-status.json`](assets/ski
 }
 ```
 
-Use one of: `ga`, `public-preview`, `private-preview`, `in-development`. Then regenerate the README status table and validate:
+Use one of: `stable`, `public-preview`, `private-preview`, `in-development`. Then regenerate the README status table and validate:
 
 ```bash
 python3 scripts/check-skill-status.py --write-readme

--- a/README.md
+++ b/README.md
@@ -90,29 +90,29 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | Skill | Status |
 |-------|--------|
 | `uipath-admin` | Public Preview |
-| `uipath-agents` | GA |
+| `uipath-agents` | Stable |
 | `uipath-api-workflow` | Public Preview |
 | `uipath-coded-apps` | Public Preview |
 | `uipath-data-fabric` | Public Preview |
-| `uipath-feedback` | GA |
+| `uipath-feedback` | Stable |
 | `uipath-governance` | Public Preview |
 | `uipath-human-in-the-loop` | Public Preview |
 | `uipath-ixp` | Public Preview |
-| `uipath-maestro-bpmn` | GA |
+| `uipath-maestro-bpmn` | Stable |
 | `uipath-maestro-case` | Public Preview |
-| `uipath-maestro-flow` | GA |
-| `uipath-planner` | GA |
-| `uipath-platform` | GA |
+| `uipath-maestro-flow` | Stable |
+| `uipath-planner` | Stable |
+| `uipath-platform` | Stable |
 | `uipath-review` | Public Preview |
-| `uipath-rpa` | GA |
-| `uipath-solution` | GA |
+| `uipath-rpa` | Stable |
+| `uipath-solution` | Stable |
 | `uipath-tasks` | Public Preview |
 | `uipath-test` | Public Preview |
-| `uipath-troubleshoot` | GA |
+| `uipath-troubleshoot` | Stable |
 
 **Status legend:**
-- **GA** — Generally available; stable surface, safe for production.
-- **Public Preview** — Pre-GA but available to all tenants; surface and behavior may change.
+- **Stable** — Stable, production-ready surface; safe for production.
+- **Public Preview** — Not yet stable but available to all tenants; surface and behavior may change.
 - **Private Preview** — Gated or allowlisted; may be inaccessible in a tenant.
 - **In-development** — Skill itself is incomplete or unstable; coverage is partial.
 <!-- END GENERATED SKILL STATUS -->

--- a/README.md
+++ b/README.md
@@ -82,6 +82,41 @@ The repository ships skills covering authoring, platform operations, and diagnos
 | **uipath-troubleshoot** | Root-cause investigation across any UiPath product — errors, failures, regressions, stuck jobs, traces, incidents. |
 | **uipath-feedback** | Submit bug reports and improvement suggestions via `uip feedback send`. |
 
+### Lifecycle Status
+
+Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-status.json) — the source of truth. The table below is generated; refresh it with `python3 scripts/check-skill-status.py --write-readme`.
+
+<!-- BEGIN GENERATED SKILL STATUS -->
+| Skill | Status |
+|-------|--------|
+| `uipath-admin` | Public Preview |
+| `uipath-agents` | GA |
+| `uipath-api-workflow` | Public Preview |
+| `uipath-coded-apps` | Public Preview |
+| `uipath-data-fabric` | Public Preview |
+| `uipath-feedback` | GA |
+| `uipath-governance` | Public Preview |
+| `uipath-human-in-the-loop` | Public Preview |
+| `uipath-ixp` | Public Preview |
+| `uipath-maestro-bpmn` | GA |
+| `uipath-maestro-case` | Public Preview |
+| `uipath-maestro-flow` | GA |
+| `uipath-planner` | GA |
+| `uipath-platform` | GA |
+| `uipath-review` | Public Preview |
+| `uipath-rpa` | GA |
+| `uipath-solution` | GA |
+| `uipath-tasks` | Public Preview |
+| `uipath-test` | Public Preview |
+| `uipath-troubleshoot` | GA |
+
+**Status legend:**
+- **GA** — Generally available; stable surface, safe for production.
+- **Public Preview** — Pre-GA but available to all tenants; surface and behavior may change.
+- **Private Preview** — Gated or allowlisted; may be inaccessible in a tenant.
+- **In-development** — Skill itself is incomplete or unstable; coverage is partial.
+<!-- END GENERATED SKILL STATUS -->
+
 ## Agents
 
 | Agent | Description |

--- a/README.md
+++ b/README.md
@@ -89,31 +89,30 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 <!-- BEGIN GENERATED SKILL STATUS -->
 | Skill | Status |
 |-------|--------|
-| `uipath-admin` | Public Preview |
+| `uipath-admin` | Preview |
 | `uipath-agents` | Stable |
-| `uipath-api-workflow` | Public Preview |
-| `uipath-coded-apps` | Public Preview |
-| `uipath-data-fabric` | Public Preview |
+| `uipath-api-workflow` | Preview |
+| `uipath-coded-apps` | Preview |
+| `uipath-data-fabric` | Preview |
 | `uipath-feedback` | Stable |
-| `uipath-governance` | Public Preview |
-| `uipath-human-in-the-loop` | Public Preview |
-| `uipath-ixp` | Public Preview |
+| `uipath-governance` | Preview |
+| `uipath-human-in-the-loop` | Preview |
+| `uipath-ixp` | Preview |
 | `uipath-maestro-bpmn` | Stable |
-| `uipath-maestro-case` | Public Preview |
+| `uipath-maestro-case` | Preview |
 | `uipath-maestro-flow` | Stable |
 | `uipath-planner` | Stable |
 | `uipath-platform` | Stable |
-| `uipath-review` | Public Preview |
+| `uipath-review` | Preview |
 | `uipath-rpa` | Stable |
 | `uipath-solution` | Stable |
-| `uipath-tasks` | Public Preview |
-| `uipath-test` | Public Preview |
+| `uipath-tasks` | Preview |
+| `uipath-test` | Preview |
 | `uipath-troubleshoot` | Stable |
 
 **Status legend:**
 - **Stable** — Stable, production-ready surface; safe for production.
-- **Public Preview** — Not yet stable but available to all tenants; surface and behavior may change.
-- **Private Preview** — Gated or allowlisted; may be inaccessible in a tenant.
+- **Preview** — Not yet stable; may be broadly available or gated/allowlisted, and surface and behavior may change.
 - **In-development** — Skill itself is incomplete or unstable; coverage is partial.
 <!-- END GENERATED SKILL STATUS -->
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-api-workflow` | Preview |
 | `uipath-coded-apps` | Preview |
 | `uipath-data-fabric` | Preview |
+| `uipath-design` | Preview |
 | `uipath-feedback` | Stable |
 | `uipath-governance` | Preview |
 | `uipath-human-in-the-loop` | Preview |
@@ -101,6 +102,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-maestro-bpmn` | Stable |
 | `uipath-maestro-case` | Preview |
 | `uipath-maestro-flow` | Stable |
+| `uipath-mcp-servers` | Preview |
 | `uipath-planner` | Stable |
 | `uipath-platform` | Stable |
 | `uipath-review` | Preview |

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -7,13 +7,9 @@
       "label": "Stable",
       "meaning": "Stable, production-ready surface; safe for production."
     },
-    "public-preview": {
-      "label": "Public Preview",
-      "meaning": "Not yet stable but available to all tenants; surface and behavior may change."
-    },
-    "private-preview": {
-      "label": "Private Preview",
-      "meaning": "Gated or allowlisted; may be inaccessible in a tenant."
+    "preview": {
+      "label": "Preview",
+      "meaning": "Not yet stable; may be broadly available or gated/allowlisted, and surface and behavior may change."
     },
     "in-development": {
       "label": "In-development",
@@ -22,7 +18,7 @@
   },
   "skills": {
     "uipath-admin": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -32,17 +28,17 @@
       "last_synced": null
     },
     "uipath-api-workflow": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-coded-apps": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-data-fabric": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -52,17 +48,17 @@
       "last_synced": null
     },
     "uipath-governance": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-human-in-the-loop": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-ixp": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -72,7 +68,7 @@
       "last_synced": null
     },
     "uipath-maestro-case": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -92,7 +88,7 @@
       "last_synced": null
     },
     "uipath-review": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -107,12 +103,12 @@
       "last_synced": null
     },
     "uipath-tasks": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-test": {
-      "status": "public-preview",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -1,0 +1,125 @@
+{
+  "generated_at": "2026-05-27T00:00:00Z",
+  "source": "manual",
+  "schema_version": 1,
+  "statuses": {
+    "ga": {
+      "label": "GA",
+      "meaning": "Generally available; stable surface, safe for production."
+    },
+    "public-preview": {
+      "label": "Public Preview",
+      "meaning": "Pre-GA but available to all tenants; surface and behavior may change."
+    },
+    "private-preview": {
+      "label": "Private Preview",
+      "meaning": "Gated or allowlisted; may be inaccessible in a tenant."
+    },
+    "in-development": {
+      "label": "In-development",
+      "meaning": "Skill itself is incomplete or unstable; coverage is partial."
+    }
+  },
+  "skills": {
+    "uipath-admin": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-agents": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-api-workflow": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-coded-apps": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-data-fabric": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-feedback": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-governance": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-human-in-the-loop": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-ixp": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-maestro-bpmn": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-maestro-case": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-maestro-flow": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-planner": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-platform": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-review": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-rpa": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-solution": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-tasks": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-test": {
+      "status": "public-preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-troubleshoot": {
+      "status": "ga",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    }
+  }
+}

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -3,13 +3,13 @@
   "source": "manual",
   "schema_version": 1,
   "statuses": {
-    "ga": {
-      "label": "GA",
-      "meaning": "Generally available; stable surface, safe for production."
+    "stable": {
+      "label": "Stable",
+      "meaning": "Stable, production-ready surface; safe for production."
     },
     "public-preview": {
       "label": "Public Preview",
-      "meaning": "Pre-GA but available to all tenants; surface and behavior may change."
+      "meaning": "Not yet stable but available to all tenants; surface and behavior may change."
     },
     "private-preview": {
       "label": "Private Preview",
@@ -27,7 +27,7 @@
       "last_synced": null
     },
     "uipath-agents": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -47,7 +47,7 @@
       "last_synced": null
     },
     "uipath-feedback": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -67,7 +67,7 @@
       "last_synced": null
     },
     "uipath-maestro-bpmn": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -77,17 +77,17 @@
       "last_synced": null
     },
     "uipath-maestro-flow": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-planner": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-platform": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -97,12 +97,12 @@
       "last_synced": null
     },
     "uipath-rpa": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-solution": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -117,7 +117,7 @@
       "last_synced": null
     },
     "uipath-troubleshoot": {
-      "status": "ga",
+      "status": "stable",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     }

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -42,6 +42,11 @@
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
+    "uipath-design": {
+      "status": "preview",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
     "uipath-feedback": {
       "status": "stable",
       "confluence": { "page_id": null, "url": null },
@@ -74,6 +79,11 @@
     },
     "uipath-maestro-flow": {
       "status": "stable",
+      "confluence": { "page_id": null, "url": null },
+      "last_synced": null
+    },
+    "uipath-mcp-servers": {
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },

--- a/scripts/check-skill-status.py
+++ b/scripts/check-skill-status.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Validate skill lifecycle status against the manifest at assets/skill-status.json
+(the single source of truth) and generate the status table in README.md.
+
+Checks (default mode):
+  1. Bijection   — every skills/<name>/ has a manifest entry and vice versa.
+  2. Legal status — each skill's status is one of the canonical values.
+  3. Frontmatter guard — SKILL.md description must not carry a status tag
+     like [PREVIEW]/[BETA] (status lives only in the manifest).
+  4. No stale body markers — SKILL.md body must not carry a
+     `> **Preview**` / `> **Status:**` callout (status lives only in the manifest).
+
+README generation:
+  --write-readme  regenerate the status table between the markers
+                  `<!-- BEGIN GENERATED SKILL STATUS -->` / `<!-- END ... -->`.
+  --check-readme  fail if the table is out of date (CI uses this).
+
+Outputs:
+  - Default: one finding per line, human-readable; exit 1 if any.
+  - --json : newline-delimited JSON for downstream tooling.
+
+Usage:
+    python3 scripts/check-skill-status.py
+    python3 scripts/check-skill-status.py --json
+    python3 scripts/check-skill-status.py --write-readme
+    python3 scripts/check-skill-status.py --check-readme
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "assets" / "skill-status.json"
+SKILLS_DIR = REPO_ROOT / "skills"
+README_PATH = REPO_ROOT / "README.md"
+
+# Canonical display order for the README legend.
+STATUS_ORDER = ["ga", "public-preview", "private-preview", "in-development"]
+
+# A status tag wrongly embedded in the frontmatter description.
+FM_TAG_RE = re.compile(r"\[(?:preview|beta|alpha|ga|deprecated|experimental)\]", re.I)
+# A stale status callout in the body — anchored on the status keyword so
+# non-status opening blockquotes (e.g. `> **Two entry points.**`) never match.
+STALE_BODY_RE = re.compile(r"^>\s*\*\*(?:Status:|Preview\b|Beta\b|Alpha\b)", re.I)
+
+BEGIN_MARKER = "<!-- BEGIN GENERATED SKILL STATUS -->"
+END_MARKER = "<!-- END GENERATED SKILL STATUS -->"
+BLOCK_RE = re.compile(
+    re.escape(BEGIN_MARKER) + r"(.*?)" + re.escape(END_MARKER), re.DOTALL
+)
+
+
+def load_manifest():
+    if not MANIFEST_PATH.exists():
+        sys.exit(f"Manifest not found at {MANIFEST_PATH}.")
+    return json.loads(MANIFEST_PATH.read_text())
+
+
+def split_frontmatter(text):
+    """Return (frontmatter_text, body_text). Empty frontmatter if no fences."""
+    if not text.startswith("---"):
+        return "", text
+    lines = text.splitlines()
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return "", text
+    return "\n".join(lines[1:end]), "\n".join(lines[end + 1:])
+
+
+def extract_description(frontmatter_text):
+    for line in frontmatter_text.splitlines():
+        if line.startswith("description:"):
+            return line[len("description:"):]
+    return ""
+
+
+def discover_skills():
+    return {
+        p.name
+        for p in SKILLS_DIR.iterdir()
+        if p.is_dir() and (p / "SKILL.md").exists()
+    }
+
+
+def validate(manifest):
+    """Return a list of findings: {"skill": ..., "error": ...}."""
+    findings = []
+    valid_statuses = set(manifest.get("statuses", {}))
+    entries = manifest.get("skills", {})
+    folders = discover_skills()
+
+    for name in sorted(folders | set(entries)):
+        if name not in entries:
+            findings.append({"skill": name,
+                             "error": "no entry in assets/skill-status.json"})
+            continue
+        if name not in folders:
+            findings.append({"skill": name,
+                             "error": "manifest entry has no skills/<name>/SKILL.md"})
+            continue
+
+        status = entries[name].get("status")
+        if status not in valid_statuses:
+            findings.append({"skill": name,
+                             "error": f"invalid status {status!r} "
+                                      f"(expected one of {sorted(valid_statuses)})"})
+
+        text = (SKILLS_DIR / name / "SKILL.md").read_text()
+        frontmatter, body = split_frontmatter(text)
+        if FM_TAG_RE.search(extract_description(frontmatter)):
+            findings.append({"skill": name,
+                             "error": "status tag (e.g. [PREVIEW]) in frontmatter "
+                                      "description — status belongs only in the manifest"})
+        for lineno, line in enumerate(body.splitlines(), start=1):
+            if STALE_BODY_RE.match(line):
+                findings.append({"skill": name,
+                                 "error": f"stale status callout in body: {line.strip()!r} "
+                                          "— status belongs only in the manifest"})
+                break
+    return findings
+
+
+def build_status_block(manifest):
+    """Render the inner content (table + legend) for the README block."""
+    statuses = manifest["statuses"]
+    entries = manifest["skills"]
+    lines = ["| Skill | Status |", "|-------|--------|"]
+    for name in sorted(entries):
+        label = statuses[entries[name]["status"]]["label"]
+        lines.append(f"| `{name}` | {label} |")
+    lines.append("")
+    lines.append("**Status legend:**")
+    for key in STATUS_ORDER:
+        if key in statuses:
+            lines.append(f"- **{statuses[key]['label']}** — {statuses[key]['meaning']}")
+    return "\n".join(lines)
+
+
+def render_region(manifest):
+    """The exact text expected between the BEGIN and END markers."""
+    return "\n" + build_status_block(manifest) + "\n"
+
+
+def write_readme(manifest):
+    if not README_PATH.exists():
+        sys.exit(f"README not found at {README_PATH}.")
+    text = README_PATH.read_text()
+    if not BLOCK_RE.search(text):
+        sys.exit(f"Marker pair not found in {README_PATH}. Add this block once:\n"
+                 f"{BEGIN_MARKER}\n{END_MARKER}")
+    new_text = BLOCK_RE.sub(
+        lambda m: BEGIN_MARKER + render_region(manifest) + END_MARKER, text
+    )
+    if new_text != text:
+        README_PATH.write_text(new_text)
+        print(f"Updated skill status table in {README_PATH.name}.")
+    else:
+        print(f"{README_PATH.name} skill status table already current.")
+    return 0
+
+
+def check_readme(manifest):
+    if not README_PATH.exists():
+        sys.exit(f"README not found at {README_PATH}.")
+    text = README_PATH.read_text()
+    match = BLOCK_RE.search(text)
+    if not match:
+        print(f"FAIL — marker pair not found in {README_PATH.name}. "
+              f"Add {BEGIN_MARKER} / {END_MARKER}.", file=sys.stderr)
+        return 1
+    if match.group(1) != render_region(manifest):
+        print(f"FAIL — skill status table in {README_PATH.name} is out of date. "
+              "Run: python3 scripts/check-skill-status.py --write-readme",
+              file=sys.stderr)
+        return 1
+    print(f"OK — {README_PATH.name} skill status table is current.")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--json", action="store_true",
+                        help="Emit newline-delimited JSON instead of text")
+    parser.add_argument("--write-readme", action="store_true",
+                        help="Regenerate the README status table in place")
+    parser.add_argument("--check-readme", action="store_true",
+                        help="Fail if the README status table is out of date")
+    args = parser.parse_args()
+
+    manifest = load_manifest()
+
+    if args.write_readme:
+        return write_readme(manifest)
+    if args.check_readme:
+        return check_readme(manifest)
+
+    findings = validate(manifest)
+
+    if args.json:
+        for f in findings:
+            print(json.dumps(f))
+        return 1 if findings else 0
+
+    if not findings:
+        n = len(manifest.get("skills", {}))
+        print(f"OK — {n} skills, manifest valid.")
+        return 0
+
+    print(f"{len(findings)} finding(s):\n")
+    for f in findings:
+        print(f"  {f['skill']}: {f['error']}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-skill-status.py
+++ b/scripts/check-skill-status.py
@@ -39,10 +39,10 @@ SKILLS_DIR = REPO_ROOT / "skills"
 README_PATH = REPO_ROOT / "README.md"
 
 # Canonical display order for the README legend.
-STATUS_ORDER = ["ga", "public-preview", "private-preview", "in-development"]
+STATUS_ORDER = ["stable", "public-preview", "private-preview", "in-development"]
 
 # A status tag wrongly embedded in the frontmatter description.
-FM_TAG_RE = re.compile(r"\[(?:preview|beta|alpha|ga|deprecated|experimental)\]", re.I)
+FM_TAG_RE = re.compile(r"\[(?:preview|beta|alpha|ga|stable|deprecated|experimental)\]", re.I)
 # A stale status callout in the body — anchored on the status keyword so
 # non-status opening blockquotes (e.g. `> **Two entry points.**`) never match.
 STALE_BODY_RE = re.compile(r"^>\s*\*\*(?:Status:|Preview\b|Beta\b|Alpha\b)", re.I)

--- a/scripts/check-skill-status.py
+++ b/scripts/check-skill-status.py
@@ -39,7 +39,7 @@ SKILLS_DIR = REPO_ROOT / "skills"
 README_PATH = REPO_ROOT / "README.md"
 
 # Canonical display order for the README legend.
-STATUS_ORDER = ["stable", "public-preview", "private-preview", "in-development"]
+STATUS_ORDER = ["stable", "preview", "in-development"]
 
 # A status tag wrongly embedded in the frontmatter description.
 FM_TAG_RE = re.compile(r"\[(?:preview|beta|alpha|ga|stable|deprecated|experimental)\]", re.I)

--- a/skills/uipath-admin/SKILL.md
+++ b/skills/uipath-admin/SKILL.md
@@ -6,8 +6,6 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 
 # UiPath Admin
 
-> **Preview** — Under active development. Command coverage will expand.
-
 Administrative operations on UiPath via `uip admin` — Identity Server, Authorization, OMS, IP Restriction, Audit. Per-area workflows, command references, and procedures are in the linked files below — this file is the entry contract.
 
 ## When to Use This Skill

--- a/skills/uipath-api-workflow/SKILL.md
+++ b/skills/uipath-api-workflow/SKILL.md
@@ -1,12 +1,10 @@
 ---
 name: uipath-api-workflow
-description: "[PREVIEW] UiPath API Workflow assistant — author, run, package, publish JSON workflows executed by `uip api-workflow run`. Covers logical/hierarchical structure (Sequence, Assign, JavaScript, If with #Wrapper/#Then/#Else, ForEach, DoWhile, Break, TryCatch, Wait, Response — including nested patterns) AND HTTP / Integration Service connector activities (Gmail, Outlook, GitHub, Slack, etc.) authored via `uip api-workflow registry resolve` + `stub`. Triggers on prompts about UiPath API workflows, project type \"Api\", JSON workflow files containing `document.dsl`/`do[]`, any of those activity types, or fetching data from a public/vendor API. Uses `uip api-workflow run` for local execution and `uip solution pack`/`publish` for deployment. For .flow Maestro→uipath-maestro-flow. For .xaml/coded RPA→uipath-rpa. For coded agents→uipath-agents. For Coded Apps→uipath-coded-apps."
+description: "UiPath API Workflow assistant — author, run, package, publish JSON workflows executed by `uip api-workflow run`. Covers logical/hierarchical structure (Sequence, Assign, JavaScript, If with #Wrapper/#Then/#Else, ForEach, DoWhile, Break, TryCatch, Wait, Response — including nested patterns) AND HTTP / Integration Service connector activities (Gmail, Outlook, GitHub, Slack, etc.) authored via `uip api-workflow registry resolve` + `stub`. Triggers on prompts about UiPath API workflows, project type \"Api\", JSON workflow files containing `document.dsl`/`do[]`, any of those activity types, or fetching data from a public/vendor API. Uses `uip api-workflow run` for local execution and `uip solution pack`/`publish` for deployment. For .flow Maestro→uipath-maestro-flow. For .xaml/coded RPA→uipath-rpa. For coded agents→uipath-agents. For Coded Apps→uipath-coded-apps."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 ---
 
 # UiPath API Workflow Assistant
-
-> **Preview** — this skill is in preview. Behavior, file shapes, and rules may change as the underlying executor and StudioWeb roundtrip story evolve.
 
 Build, run, and publish UiPath API Workflows — JSON files conforming to the CNCF Serverless Workflow DSL 1.0.0 with UiPath activity-type extensions. Executed by `@uipath/api-workflow-executor` via `uip api-workflow run`. Packaged as `Type: "Api"` projects via `uip solution pack`.
 

--- a/skills/uipath-coded-apps/SKILL.md
+++ b/skills/uipath-coded-apps/SKILL.md
@@ -6,8 +6,6 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 
 # UiPath Coded Apps
 
-> **Preview** — skill is under active development; surface and behavior may change.
-
 Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps using the `uip codedapp` CLI and `@uipath/uipath-typescript` SDK.
 
 ## When to Use This Skill

--- a/skills/uipath-data-fabric/SKILL.md
+++ b/skills/uipath-data-fabric/SKILL.md
@@ -5,8 +5,6 @@ description: "UiPath Data Fabric entity/record CRUD via `uip df`. Create entitie
 
 # UiPath Data Fabric — Agent Skill
 
-> **Preview** — skill is under active development; surface and behavior may change.
-
 Data Fabric is UiPath's structured data store. Entities are typed schemas;
 records are rows; file fields store binary attachments.
 

--- a/skills/uipath-governance/SKILL.md
+++ b/skills/uipath-governance/SKILL.md
@@ -6,8 +6,6 @@ allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 
 # UiPath Governance
 
-> **Preview** — skill is under active development; surface and behavior may change.
-
 Uber skill for UiPath governance authoring. Two backing CLI surfaces:
 
 | Surface | Governs | CLI |

--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -6,8 +6,6 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep
 
 # UiPath Human-in-the-Loop Assistant
 
-> **Preview** — skill is under active development; surface and behavior may change.
-
 Recognizes when a business process needs a human decision point, designs the task schema through conversation, and wires the HITL node into the automation — Flow, Maestro, or Agent.
 
 > **Coded agents:** for wiring HITL inside a coded agent, use the `uipath-agents` skill — see `skills/uipath-agents/references/coded/capabilities/human-in-the-loop.md`.

--- a/skills/uipath-ixp/SKILL.md
+++ b/skills/uipath-ixp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-ixp
-description: "[PREVIEW] UiPath IXP (Document Understanding) — review IXP predictions with Claude, confirm valid fields, improve prompts, publish models."
+description: "UiPath IXP (Document Understanding) — review IXP predictions with Claude, confirm valid fields, improve prompts, publish models."
 ---
 
 # UiPath IXP Document Extraction Assistant

--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -6,8 +6,6 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
 
 # UiPath Case Management Authoring Assistant
 
-> **Preview** — skill is under active development; surface and behavior may change.
-
 Builds UiPath Case Management definitions from `sdd.md`. Generates `tasks.md` plan, then writes `caseplan.json` directly via per-plugin JSON recipes. CLI is reserved for read-only metadata fetches (registry, validate, debug, tasks describe, case spec) and solution boundary operations (`uip solution init` / `project add` / `upload`).
 
 When `sdd.md` is absent, **Phase 0 interview** generates one interactively (listen → sketch → progressive ask-walk → resolve → approve, with optional HTML preview before handing off). Complex / multi-product cases redirect to `uipath-design` — see [references/phase-0-interview.md § Thresholds](references/phase-0-interview.md#thresholds) for caps.

--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -7,8 +7,6 @@ user-invocable: true
 
 # UiPath Solution & Artifact Reviewer
 
-> **Preview** — skill is under active development; review surface and report format may change.
-
 Review UiPath solutions and individual artifacts for structural validity, quality, best practices, optimization, and correctness. Produces a structured review report with findings and recommendations.
 
 ## When to Use This Skill

--- a/skills/uipath-tasks/SKILL.md
+++ b/skills/uipath-tasks/SKILL.md
@@ -7,8 +7,6 @@ user-invocable: true
 
 # UiPath Tasks (Action Center) — Agent Skill
 
-> **Preview** — skill is under active development; surface and behavior may change.
-
 Action Center is UiPath's human-in-the-loop platform. Tasks represent work items
 that require human input — form approvals, document validation, data labeling, and more.
 

--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -7,8 +7,6 @@ user-invocable: true
 
 # UiPath Test Assistant
 
-> **Preview** — skill is under active development; surface and behavior may change.
-
 Manage UiPath Test Manager resources (projects, test cases, test sets, executions) and generate persona-tailored shareable test reports.
 
 ## When to Use This Skill


### PR DESCRIPTION
## What

Introduces a **single source of truth** for each skill's lifecycle status — **Stable / Preview / In-development** — so both coding agents and developers can reliably tell a skill's maturity.

This is **v1** (the status mechanism). A **v2** scheduled job that syncs status from internal Confluence is intentionally out of scope; the manifest schema already carries `confluence`/`last_synced` placeholders so v2 can slot in by cloning the `refresh-uip-catalog.yml` + `automerge-catalog-refresh.yml` pattern.

## How

- **`assets/skill-status.json`** — machine-readable manifest, one entry per skill. Mirrors the existing `assets/uip-catalog-snapshot.json` precedent. This is the **only** place status is stored.
- **`scripts/check-skill-status.py`** — validator + README generator:
  - bijection (every skill folder ⇄ manifest entry), legal status value, no `[PREVIEW]`-style tag in the frontmatter `description`, no stale `> **Preview**`/`> **Status:**` callouts in bodies.
  - `--write-readme` / `--check-readme` regenerate/verify the README status table.
- **`README.md`** — generated status table + legend between `<!-- BEGIN/END GENERATED SKILL STATUS -->` markers (the hand-maintained catalog table is untouched).
- **`.github/workflows/validate-skill-status.yml`** — required PR gate running the validator + README sync check.
- **Migration** — removed the 12 inconsistent existing "Preview" markers: 10 body callouts + 2 frontmatter `[PREVIEW]` tags (`uipath-api-workflow`, `uipath-ixp`, which also violated `skill-structure.md`). Status now lives in exactly one place.
- **Docs** — `skill-structure.md`, `skill-review.md`, `CONTRIBUTING.md` updated to formalize the convention (and drop the old body-callout rule).

## Design notes

- **No per-skill body badge.** Status lives only in the manifest + generated README table. This keeps status out of frontmatter, so a status change never triggers `activation-gate.yml` recall evals (only the 2 one-time `description` fixes here do, as expected/desired).
- **Status named `Stable`, not `GA`.** The top maturity tier uses the key/label `stable` / **Stable** rather than the acronym `ga` / **GA** — clearer for both agents and a future CLI consumer. The manifest's key/label split made this a mechanical rename.
- **CLI consumption is out of scope (follow-up PR).** Today the manifest is a docs + CI artifact only; nothing in the install path reads it (the plugin installs all skills wholesale). Making status drive an install-time interaction (e.g. flagging/gating Preview skills) is a separate feature in the `uip` CLI repo. The manifest already ships with the plugin at `<plugin-root>/assets/skill-status.json` and is in a usable shape for it, so no change here is needed to enable it later.

## ⚠️ Needs review: initial statuses are best-effort

Seeded from current signals — **please confirm per skill** (CODEOWNERS):
- **Stable (9):** uipath-agents, uipath-feedback, uipath-maestro-bpmn, uipath-maestro-flow, uipath-planner, uipath-platform, uipath-rpa, uipath-solution, uipath-troubleshoot
- **Preview (11):** uipath-admin, uipath-api-workflow, uipath-coded-apps, uipath-data-fabric, uipath-governance, uipath-human-in-the-loop, uipath-ixp, uipath-maestro-case, uipath-review, uipath-tasks, uipath-test

Change any to `in-development` (or promote to `stable`) by editing `assets/skill-status.json` and running `python3 scripts/check-skill-status.py --write-readme`.

## Verification

- `python3 scripts/check-skill-status.py` → `OK — 20 skills, manifest valid`
- `python3 scripts/check-skill-status.py --check-readme` → table current
- `git diff` confirms frontmatter changed only for `uipath-api-workflow` / `uipath-ixp`; all other SKILL.md edits are body-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

