### PR TITLE
Fix for coder evals

### DIFF
--- a/tests/tasks/uipath-agents/batch_transform_coded/check_batch_transform_graph.py
+++ b/tests/tasks/uipath-agents/batch_transform_coded/check_batch_transform_graph.py
@@ -24,6 +24,7 @@ The project root is whichever of `<cwd>/pyproject.toml` or
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 import sys
@@ -50,13 +51,27 @@ def find_graph_module(root: Path) -> Path:
     sys.exit(f"FAIL: neither main.py nor graph.py found under {root}")
 
 
-def assert_import(text: str, module: str, symbols: list[str]) -> None:
-    pat = rf"from\s+{re.escape(module)}\s+import\s+[^\n]*"
-    matches = re.findall(pat, text)
-    if not matches:
+def imported_symbols(tree: ast.AST, module: str) -> set[str]:
+    """Return the set of symbol names imported from `module` in `tree`.
+
+    Robust to single-line, multi-line parenthesized, backslash-continued,
+    and aliased imports — anything Python itself accepts as `from <mod>
+    import ...`.
+    """
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == module:
+            for alias in node.names:
+                found.add(alias.name)
+    return found
+
+
+def assert_import(tree: ast.AST, text: str, module: str, symbols: list[str]) -> None:
+    found = imported_symbols(tree, module)
+    if not found:
         sys.exit(f"FAIL: graph module never imports from {module}")
     for sym in symbols:
-        if not any(re.search(rf"\b{re.escape(sym)}\b", m) for m in matches):
+        if sym not in found:
             sys.exit(f"FAIL: graph module does not import {sym} from {module}")
 
 
@@ -70,10 +85,14 @@ def main() -> None:
     root = find_project_root()
     module = find_graph_module(root)
     text = module.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=str(module))
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: graph module is not valid Python ({exc})")
 
-    assert_import(text, "uipath.platform.common", ["CreateBatchTransform", "CreateEphemeralIndex"])
-    assert_import(text, "uipath.platform.context_grounding", ["BatchTransformOutputColumn", "EphemeralIndexUsage"])
-    assert_import(text, "uipath_langchain._utils.durable_interrupt", ["durable_interrupt"])
+    assert_import(tree, text, "uipath.platform.common", ["CreateBatchTransform", "CreateEphemeralIndex"])
+    assert_import(tree, text, "uipath.platform.context_grounding", ["BatchTransformOutputColumn", "EphemeralIndexUsage"])
+    assert_import(tree, text, "uipath_langchain._utils.durable_interrupt", ["durable_interrupt"])
 
     if not re.search(r"\bCreateBatchTransform\s*\(", text):
         sys.exit("FAIL: graph module never calls CreateBatchTransform(...)")

--- a/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
@@ -33,8 +33,7 @@ initial_prompt: |
        from a @durable_interrupt node
     4. yield CreateBatchTransform(is_ephemeral_index=True, ...) from
        another @durable_interrupt node, passing two
-       BatchTransformOutputColumn entries (imported from
-       uipath.platform.context_grounding — do NOT use plain dicts)
+       BatchTransformOutputColumn entries
     5. finalize and return the local destination_path
 
   Take the agent through scaffold → init. Do NOT run, publish, upload,

--- a/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
@@ -33,7 +33,8 @@ initial_prompt: |
        from a @durable_interrupt node
     4. yield CreateBatchTransform(is_ephemeral_index=True, ...) from
        another @durable_interrupt node, passing two
-       BatchTransformOutputColumn entries
+       BatchTransformOutputColumn entries (imported from
+       uipath.platform.context_grounding — do NOT use plain dicts)
     5. finalize and return the local destination_path
 
   Take the agent through scaffold → init. Do NOT run, publish, upload,
@@ -47,14 +48,6 @@ success_criteria:
     command_pattern: 'uip\s+codedagent\s+init'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command

--- a/tests/tasks/uipath-agents/deeprag_coded/check_deep_rag_graph.py
+++ b/tests/tasks/uipath-agents/deeprag_coded/check_deep_rag_graph.py
@@ -23,6 +23,7 @@ The project root is whichever of `<cwd>/pyproject.toml` or
 
 from __future__ import annotations
 
+import ast
 import os
 import re
 import sys
@@ -49,13 +50,27 @@ def find_graph_module(root: Path) -> Path:
     sys.exit(f"FAIL: neither main.py nor graph.py found under {root}")
 
 
-def assert_import(text: str, module: str, symbols: list[str]) -> None:
-    pat = rf"from\s+{re.escape(module)}\s+import\s+[^\n]*"
-    matches = re.findall(pat, text)
-    if not matches:
+def imported_symbols(tree: ast.AST, module: str) -> set[str]:
+    """Return the set of symbol names imported from `module` in `tree`.
+
+    Robust to single-line, multi-line parenthesized, backslash-continued,
+    and aliased imports — anything Python itself accepts as `from <mod>
+    import ...`.
+    """
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == module:
+            for alias in node.names:
+                found.add(alias.name)
+    return found
+
+
+def assert_import(tree: ast.AST, text: str, module: str, symbols: list[str]) -> None:
+    found = imported_symbols(tree, module)
+    if not found:
         sys.exit(f"FAIL: graph module never imports from {module}")
     for sym in symbols:
-        if not any(re.search(rf"\b{re.escape(sym)}\b", m) for m in matches):
+        if sym not in found:
             sys.exit(f"FAIL: graph module does not import {sym} from {module}")
 
 
@@ -69,10 +84,14 @@ def main() -> None:
     root = find_project_root()
     module = find_graph_module(root)
     text = module.read_text(encoding="utf-8")
+    try:
+        tree = ast.parse(text, filename=str(module))
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: graph module is not valid Python ({exc})")
 
-    assert_import(text, "uipath.platform.common", ["CreateDeepRag", "CreateEphemeralIndex"])
-    assert_import(text, "uipath.platform.context_grounding", ["EphemeralIndexUsage"])
-    assert_import(text, "uipath_langchain._utils.durable_interrupt", ["durable_interrupt"])
+    assert_import(tree, text, "uipath.platform.common", ["CreateDeepRag", "CreateEphemeralIndex"])
+    assert_import(tree, text, "uipath.platform.context_grounding", ["EphemeralIndexUsage"])
+    assert_import(tree, text, "uipath_langchain._utils.durable_interrupt", ["durable_interrupt"])
 
     if not re.search(r"\bCreateDeepRag\s*\(", text):
         sys.exit("FAIL: graph module never calls CreateDeepRag(...)")

--- a/tests/tasks/uipath-agents/deeprag_coded/e2e_scaffold_graph.yaml
+++ b/tests/tasks/uipath-agents/deeprag_coded/e2e_scaffold_graph.yaml
@@ -46,14 +46,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Graph imports CreateDeepRag / CreateEphemeralIndex / EphemeralIndexUsage / durable_interrupt; passes is_ephemeral_index=True; no module-level UiPath()"
     command: "python3 $TASK_DIR/check_deep_rag_graph.py"


### PR DESCRIPTION
Fix multi-line-import blindness in two uipath-agents coded e2e graph checks

Both check_batch_transform_graph.py and check_deep_rag_graph.py used a
single-line regex to verify imports:

    from <module> import [^\n]*

That pattern stops at the first newline. A canonical parenthesized
multi-line import like

    from uipath.platform.context_grounding import (
        BatchTransformOutputColumn,
        EphemeralIndexUsage,
    )

matches only `from ... import (` — the symbol search then fails even
though the import is correct.

That's why BatchTransform failed and DeepRAG passed in the most recent
run: the BatchTransform context_grounding import is ~91 chars, which
crosses both PEP 8 (79) and Black (88) line widths and gets wrapped.
Every other import in both projects fits on one line and the regex
catches it. The agent and the skill were both correct — the check was
the bug.

DeepRAG's check is fixed too for defensive consistency: identical code
pattern, identical latent bug. Any future 3rd+ symbol or stricter
line-length config would have caused the same false failure there.

Changes

- check_batch_transform_graph.py / check_deep_rag_graph.py: replace
  regex-based import detection with `ast.ImportFrom` walking. Handles
  single-line, parenthesized multi-line, backslash-continued, and
  aliased imports. Adds a syntax-error guard so malformed graph
  modules produce a clear FAIL instead of a traceback.

- deeprag_coded/e2e_scaffold_graph.yaml,
  batch_transform_coded/e2e_scaffold_graph.yaml: drop the
  `uip ... --output json` criterion. The task is scaffold→init only;
  no CLI output is parsed programmatically, so the criterion didn't
  grade real behavior (reviewer flagged this on the DeepRAG run as
  `criteria-bug`). Matches the existing rag_langgraph.yaml e2e
  pattern.

Test plan

- [ ] Re-run skill-agents-batch-transform-coded-e2e-scaffold-graph —
      expect 2/2 criteria pass.
- [ ] Re-run skill-agents-deeprag-coded-e2e-scaffold-graph — expect
      2/2 criteria pass (no regression — was already passing the
      import check).
- [ ] /lint-task on both YAMLs clean.