### PR TITLE
fix(automerge): gate catalog-refresh on required checks only

### DIFF
--- a/.github/workflows/automerge-catalog-refresh.yml
+++ b/.github/workflows/automerge-catalog-refresh.yml
@@ -53,6 +53,32 @@ jobs:
             exit 0
           fi
 
+          # Gate on the branch's REQUIRED status checks only — the same
+          # contexts GitHub enforces via the ruleset — not the full rollup.
+          # Advisory / non-required checks (CLI Verb Gate, Claude review,
+          # Socket, ...) must NOT block a refresh: a refresh only changes the
+          # catalog snapshot, so any verb-gate drift it surfaces is
+          # pre-existing doc-debt swept separately. Fetched dynamically so a
+          # renamed/added required check needs no edit here.
+          # `| unique` dedupes contexts declared by more than one ruleset —
+          # without it REQ_COUNT inflates while GREEN (also unique'd) can't
+          # catch up, deadlocking the merge.
+          REQUIRED=$(gh api "repos/$GITHUB_REPOSITORY/rules/branches/main" \
+            --jq '[.[] | select(.type=="required_status_checks")
+                        | .parameters.required_status_checks[].context] | unique' \
+            || echo '[]')
+          REQ_COUNT=$(echo "$REQUIRED" | jq 'length')
+          echo "Required status checks ($REQ_COUNT): $(echo "$REQUIRED" | jq -c .)"
+
+          # Fail closed: if we couldn't resolve the required-check list (API
+          # error, or a misconfigured branch with zero required checks), do
+          # NOT auto-merge — an empty required set would otherwise pass every
+          # PR vacuously.
+          if [ "$REQ_COUNT" -eq 0 ]; then
+            echo "No required status checks resolved for main — refusing to auto-merge."
+            exit 1
+          fi
+
           for PR in $CANDIDATES; do
             echo "::group::PR #$PR"
 
@@ -68,17 +94,36 @@ jobs:
                 ;;
             esac
 
-            ROLLUP=$(gh pr view "$PR" --json statusCheckRollup --jq .statusCheckRollup)
-            UNFINISHED=$(echo "$ROLLUP" | jq '[.[] | select(.status != null and .status != "COMPLETED")] | length')
-            FAILED=$(echo "$ROLLUP" | jq '[.[] | select(.conclusion != null and (.conclusion | IN("SUCCESS","SKIPPED","NEUTRAL") | not))] | length')
+            # Restrict the rollup to the required contexts before judging.
+            # `select(.name != null)` keeps CheckRun nodes (Actions checks)
+            # and intentionally drops StatusContext nodes (classic commit
+            # statuses expose .context/.state, not .name). All required
+            # checks here are Actions check runs; a future commit-status
+            # required check would need .context matching added below.
+            ROLLUP=$(gh pr view "$PR" --json statusCheckRollup \
+              --jq '[.statusCheckRollup[] | select(.name != null)]')
+            REQ_ROLLUP=$(echo "$ROLLUP" | jq --argjson req "$REQUIRED" \
+              '[.[] | select(.name as $n | $req | index($n))]')
+
+            UNFINISHED=$(echo "$REQ_ROLLUP" | jq '[.[] | select(.status != null and .status != "COMPLETED")] | length')
+            FAILED=$(echo "$REQ_ROLLUP" | jq '[.[] | select(.conclusion != null and (.conclusion | IN("SUCCESS","SKIPPED","NEUTRAL") | not))] | length')
+            # Every required context must be present AND green — guards
+            # against a required check that never reported (admin bypass
+            # would otherwise let the merge skip past a still-pending gate).
+            GREEN=$(echo "$REQ_ROLLUP" | jq '[.[] | select(.status=="COMPLETED" and (.conclusion | IN("SUCCESS","SKIPPED","NEUTRAL"))) | .name] | unique | length')
 
             if [ "$UNFINISHED" -gt 0 ]; then
-              echo "Skipping: $UNFINISHED checks still running."
+              echo "Skipping: $UNFINISHED required checks still running."
               echo "::endgroup::"
               continue
             fi
             if [ "$FAILED" -gt 0 ]; then
-              echo "Skipping: $FAILED checks failed — leaving open for human review."
+              echo "Skipping: $FAILED required checks failed — leaving open for human review."
+              echo "::endgroup::"
+              continue
+            fi
+            if [ "$GREEN" -lt "$REQ_COUNT" ]; then
+              echo "Skipping: only $GREEN/$REQ_COUNT required checks present and green."
               echo "::endgroup::"
               continue
             fi


### PR DESCRIPTION
## Problem

The nightly catalog-refresh PR (#1048, from the #833 pipeline) never auto-merged. Investigation showed the deadlock wasn't a *required* check failing — it was the automerger's own logic.

`automerge-catalog-refresh.yml` judged the **entire status-check rollup**: it skipped the merge if *any* check was non-green (`FAILED > 0` over all checks). But on a refresh PR the catalog snapshot changes, which fans the **CLI Verb Gate** out to every skill and re-surfaces the pre-existing doc-drift backlog as failures. The CLI Verb Gate, Claude review, and Socket are **not required checks** on `main` — only the two smoke jobs are:

- `Run skill smoke tests`
- `Run RPA skill smoke tests (Windows)`

So a refresh PR that passed every *required* check still got blocked by non-required gate failures, and since the refresh cron skips while any `auto/refresh-uip-catalog-*` PR is open, the whole pipeline wedged.

## Fix

`automerge-catalog-refresh.yml` now gates on the branch's **required** status checks only:

- Fetches the required check contexts dynamically from the ruleset (`gh api repos/$REPO/rules/branches/main`) — no hard-coded list, so a renamed/added required check needs no edit here.
- Restricts the rollup to those contexts before judging unfinished/failed.
- **Fail-closed:** refuses to merge if the required-check list can't be resolved (API error or zero required checks), so an empty set can't pass a PR vacuously.
- Requires every required context to be **present and green** (guards against a required check that never reported slipping through the admin-bypass merge).

Non-required checks (CLI Verb Gate, Claude review, Socket) no longer block a refresh from auto-merging. This is the intended contract: **auto-merge when all *required* checks pass**, even if the verb gate is flagging the pre-existing stale-verb backlog (which is swept separately).

## Scope — deliberately NOT changed

- **CLI install stays on `@alpha`/GitHub Packages** across the pipeline (catalog refresh, Linux smoke, `run-coder-eval`) — consistent with coder_eval (`daily.sh` + runner #276).
- **RPA smoke stays on public-npm `@latest`.** Verified against `cli/main`: `@uipath/rpa-tool` is a separate pipeline (not in the cli monorepo) whose `alpha` dist-tag is stale (`1.0.0-alpha`, April), so moving the RPA gate to `@alpha` would regress it. Tracked separately with the team.

## Follow-ups (out of scope here)

- Close #1048 once this lands so the refresh cron produces a fresh PR that exercises the new auto-merge path.
- Sweep the ~24 genuinely-stale verbs (`uip flow*`→`uip maestro flow*`, `uip orchestrator*`, `uip auth login`, `uip apw`, `uip case registry`) to clear the gate annotations.
- Team decision on `rpa-tool@alpha` / `cli@alpha`-lagging-`main` before any registry change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)