### PR TITLE
docs(uipath-maestro-flow): document registry search output shape

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -41,7 +41,7 @@ To classify a node, read `Node.form.sections[0].fields[0].componentProps.connect
 
 If you cannot run `node configure` (no live connection, sandbox forbids it, the user asked for planning only):
 
-1. Confirm the connector operation exists: `uip maestro flow registry search <keyword>` and `registry get <nodeType>`.
+1. Confirm the connector operation exists: `uip maestro flow registry search <keyword>` and `registry get <nodeType>` (see [cli-commands.md — registry](../../../../shared/cli-commands.md#uip-maestro-flow-registry) for the `search` output shape).
 2. Add the connector node with `uip maestro flow node add <file> <nodeType> --output json`. This is still required — it inserts the node and copies the definition into `definitions[]`.
 3. Write the planned `--detail` payload to a separate file (e.g. `<nodeId>.detail.json`) with placeholder values for missing connection/folder UUIDs. Do **not** put a partial `inputs.detail` on the node.
 4. **The node will not pass `flow validate` until `node configure` is run.** Surface this explicitly in your completion report under "Missing connections" or "Open questions" — do not let the user discover it via a validation failure later.

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -309,6 +309,22 @@ uip maestro flow registry search <keyword> --output json   # search by name, tag
 uip maestro flow registry get <nodeType> --output json     # get full schema for a node type
 ```
 
+`registry search` returns `Data` as a flat array (not `Data.Nodes`); fields are PascalCase. `NodeType` is the identifier you pass to `registry get <nodeType>` (and later `node add`).
+
+```json
+{ "Data": [
+  {
+    "NodeType": "uipath.connector.uipath-salesforce-sfdc.list-records",
+    "Category": "connector.196536",
+    "DisplayName": "List Records",
+    "Description": "(Salesforce) List records in Salesforce",
+    "Version": "1.0.0",
+    "Tags": "connector, activity",
+    "AvailableOnTenant": true
+  }
+] }
+```
+
 The `Data.Node` object from `registry get` is what you paste into your `.flow` file's `definitions` array.
 
 Run `uip maestro flow registry <subcommand> --help` for additional options (e.g., `--force`, `--filter`, `--connection-id`).


### PR DESCRIPTION
## What

Document the `uip maestro flow registry search --output json` output shape in the maestro-flow skill.

- [cli-commands.md](skills/uipath-maestro-flow/references/shared/cli-commands.md): `Data` is a **flat array** (not `Data.Nodes`), fields are **PascalCase** (`NodeType`, `Category`, `DisplayName`, …). `NodeType` is the string passed to `node add`. 
- [connector/impl.md](skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md): one-line pointer from the connector discovery step to the ref doc.

## Why this is needed — wasted agent turns on `search`

The `search` output shape was undocumented, so the agent has to reverse-engineer it at runtime. In a live e2e run (`salesforce_opportunity_list`), the connector step ate **~6 Bash turns just probing the JSON shape** before any real work:

1. Assumed `Data.Nodes` (a dict) with lowercase `type`/`category` → `AttributeError: 'list' object has no attribute 'get'`
2. Retried with defensive `isinstance` branching → still 0 results
3. Dumped `type(data)`, then `type(Data)`, then first-item keys, then a full item — purely to learn the schema
4. Finally landed on the flat-array + PascalCase `NodeType` shape and proceeded

That is pure discovery overhead the skill should eliminate. Getting the connection itself was a single `is connections list --all-folders` call; the schema-guessing was the real cost. Documenting the shape (with one verified example) removes those turns.

## Verification

Example fields confirmed against the live CLI (`uip maestro flow registry search salesforce --output json` → 188 items, `Data` is a list, fields PascalCase).