### PR TITLE
fix(uipath-admin): make create-robot-account smoke test idempotent

### DIFF
--- a/tests/tasks/uipath-admin/cleanup_smoke_test_bot.py
+++ b/tests/tasks/uipath-admin/cleanup_smoke_test_bot.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Best-effort cleanup: delete all 'smoke-test-bot' robot accounts.
+
+Always exits 0 — failures here never affect pass/fail.
+"""
+
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+from admin_helpers import run_cli, find_all
+
+logging.basicConfig(level=logging.INFO, format="cleanup_smoke_test_bot: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main():
+    data = run_cli(["admin", "robot-accounts", "list", "--search", "smoke-test-bot"])
+    if not data or data.get("Result") != "Success":
+        logger.warning("Could not list robot accounts — skipping cleanup")
+        return
+
+    matches = find_all(data, "smoke-test-bot", ["name"])
+    if not matches:
+        logger.info("No 'smoke-test-bot' robot account found — nothing to clean up")
+        return
+
+    for r in matches:
+        robot_id = r.get("id")
+        if not robot_id:
+            continue
+        logger.info("Deleting robot account (id=%s)", robot_id)
+        result = run_cli(["admin", "robot-accounts", "delete", robot_id])
+        if result:
+            logger.info("Delete result: %s — %s", result.get("Result"), result.get("Message", ""))
+        else:
+            logger.warning("Delete call returned no result for id=%s", robot_id)
+
+
+main()
+sys.exit(0)

--- a/tests/tasks/uipath-admin/identity_create_robot_account_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_create_robot_account_smoke.yaml
@@ -9,6 +9,9 @@ initial_prompt: |
   Create a new robot account named "smoke-test-bot" with display name
   "Smoke Test Bot" in my UiPath organization.
 
+  If a robot account with this name already exists, delete it first,
+  then create the new one.
+
   Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
@@ -35,3 +38,7 @@ success_criteria:
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_smoke_test_bot.py''))"'
+    timeout: 30


### PR DESCRIPTION
## Summary
- **Root cause:** `identity_create_robot_account_smoke` passes on first run but fails on re-runs — the agent discovers "smoke-test-bot" already exists and skips the `create` command, failing the `command_executed` criterion
- **Prompt fix:** added instruction to delete and recreate if the robot already exists, ensuring the create command always runs
- **Cleanup fix:** added `post_run` cleanup script (`cleanup_smoke_test_bot.py`) to delete "smoke-test-bot" after each run, matching the pattern used by the e2e test (`cleanup_robot_account.py`)

## Test plan
- [ ] Run `identity_create_robot_account_smoke` twice consecutively — both runs should pass
- [ ] Verify `post_run` cleanup deletes "smoke-test-bot" after each run
- [ ] Confirm no regression on `robot_account_onboarding_e2e` (separate bot name, separate cleanup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)