### PR TITLE
tests(uipath-maestro-case): align case checks with live debug behavior

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -349,7 +349,7 @@ def run_debug(
         refresh_timeout=refresh_timeout,
     )
     status = (payload or {}).get("finalStatus")
-    if status != "Completed":
+    if status != "Completed" and status != "Successful":
         _fail(f"Case did not complete (finalStatus={status})\nPayload: {json.dumps(payload, default=str)[:2000]}")
     return payload
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
@@ -76,7 +76,7 @@ initial_prompt: |
   ### 1.5 Case Variables
   | Variable | Category | Type | Default | Description |
   |---|---|---|---|---|
-  | - | - | - | - | No case-level variables declared. |
+  | decision | Variable | string | approved | Routing decision evaluated by the Triage stage-exit connector expressions; selects which downstream branch (approved/rejected/pending) the case exits to. |
 
   ## Section 2: Stages & Tasks
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/check_fan_in_join.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/check_fan_in_join.py
@@ -83,7 +83,6 @@ def main():
 
     expected_skeleton_types_per_stage = {
         "Triage": {"rpa", "api-workflow"},
-        "Validate": {"action"},
         "Enrich": {"agent"},
         "Join": {"case-management"},
     }
@@ -111,6 +110,13 @@ def main():
                     f"connector tasks); got data keys {sorted(data.keys())}"
                 )
 
+    # Validate is an intentional empty pass-through branch (no tasks). A
+    # skeleton action UserTask cannot survive a live debug run, so this stage
+    # carries no task — see check history / fan_in_join.yaml.
+    validate_lanes = (validate.get("data") or {}).get("tasks") or []
+    if any(t for lane in validate_lanes for t in (lane or [])):
+        sys.exit("FAIL: Validate stage must be an empty pass-through (no tasks)")
+
     payload = start_debug(timeout=540)
     payload_contains(
         payload, "Triage", "Validate", "Enrich", "Join", require_all=False
@@ -120,9 +126,9 @@ def main():
     print(
         "OK: diamond topology Triage→{Validate,Enrich}→Join with two "
         "selected-stage-completed entry rules on Join referencing both upstream "
-        "stages; 5 skeleton tasks across 4 stages cover 5 plugin types "
-        "(Triage:{rpa, api-workflow}, Validate:action, Enrich:agent, "
-        f"Join:case-management) all with empty data; debug payload returned (status={status})"
+        "stages; 4 skeleton tasks across 3 stages cover 4 plugin types "
+        "(Triage:{rpa, api-workflow}, Enrich:agent, Join:case-management), "
+        f"Validate empty; debug payload returned (status={status})"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -5,17 +5,18 @@ description: >
   a single Join stage. Join carries two stage-entry conditions, one
   selected-stage-completed per upstream branch, exercising the
   multi-upstream fan-in topology that no other multi_stages_tasks test covers.
-  In addition, the four stages collectively contain FIVE non-timer
-  tasks of FIVE DIFFERENT plugin types (rpa, api-workflow, action,
-  agent, case-management) — Triage carries both rpa and api-workflow
-  skeletons; the other three stages carry one task each. All
-  registry-unresolved, all emitted as skeletons per the skill's
-  unresolved-fallback rule. This closes five task-type plugin paths
-  (rpa, api-workflow, action, agent, case-management) inside a
-  multi-stage flow. Validates and asserts on edge structure (4
-  stage→stage edges into a single target), both entry rules on Join,
-  and the five skeleton task types each in its assigned stage.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:edges, feature:conditions, feature:fan-in, feature:tasks, feature:skeleton-task, feature:rpa, feature:api-workflow, feature:action, feature:agent, feature:case-management-task]
+  In addition, the four stages collectively contain FOUR non-timer
+  tasks of FOUR DIFFERENT plugin types (rpa, api-workflow, agent,
+  case-management) — Triage carries both rpa and api-workflow
+  skeletons; Enrich and Join carry one task each; Validate is an
+  empty pass-through branch with no tasks. All registry-unresolved,
+  all emitted as skeletons per the skill's unresolved-fallback rule.
+  This closes four task-type plugin paths (rpa, api-workflow, agent,
+  case-management) inside a multi-stage flow. Validates and asserts on
+  edge structure (4 stage→stage edges into a single target), both
+  entry rules on Join, and the four skeleton task types each in its
+  assigned stage.
+tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:edges, feature:conditions, feature:fan-in, feature:tasks, feature:skeleton-task, feature:rpa, feature:api-workflow, feature:agent, feature:case-management-task]
 max_iterations: 1
 
 agent:
@@ -36,9 +37,9 @@ initial_prompt: |
   ```
   # SDD — FanInJoin
 
-  **Case Definition Blueprint** · Generic — Diamond Topology with Five Task-Type Coverage
+  **Case Definition Blueprint** · Generic — Diamond Topology with Four Task-Type Coverage
 
-  A diamond topology where Triage splits into two parallel branches (Validate, Enrich) that both feed into a single Join stage. Join carries two selected-stage-completed entry rules. Five non-timer tasks across the four stages cover five distinct plugin types (rpa, api-workflow, action, agent, case-management) — all registry-unresolved skeletons.
+  A diamond topology where Triage splits into two parallel branches (Validate, Enrich) that both feed into a single Join stage. Join carries two selected-stage-completed entry rules. Four non-timer tasks across three of the four stages cover four distinct plugin types (rpa, api-workflow, agent, case-management) — all registry-unresolved skeletons. The Validate stage is an empty pass-through branch (no tasks).
 
   > **Unresolved-fallback rule.** None of the task references below are registered in the tenant. For every task the agent MUST follow the unresolved-fallback rule: leave the identifier (taskTypeId / connection-id) as `<UNRESOLVED: ...>`, omit inputs/outputs/folder fields, and emit a SKELETON task (correct `type` value, empty `data: {}`). DO NOT fabricate a taskTypeId. Each TaskId is still captured.
 
@@ -50,7 +51,7 @@ initial_prompt: |
   | Property | Value |
   |---|---|
   | Case Name | FanInJoin |
-  | Case Description | Diamond topology Triage → {Validate, Enrich} → Join; five skeleton tasks across four stages cover five distinct plugin types. |
+  | Case Description | Diamond topology Triage → {Validate, Enrich} → Join; four skeleton tasks cover four distinct plugin types; Validate is an empty pass-through branch. |
   | Case Identifier | Prefix: FIJ, Type: constant |
   | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
@@ -143,7 +144,7 @@ initial_prompt: |
 
   ### Stage 2: Validate (`validate`)
   **Type:** Stage
-  **Description:** First parallel branch.
+  **Description:** First parallel branch; empty pass-through (no tasks).
   **Required for Case Completion:** Yes
   #### Stage Entry Conditions
   | WHEN | IF | Interrupting |
@@ -160,25 +161,7 @@ initial_prompt: |
   #### Stage Task Summary
   | # | Task ID | Task | Type | Owner |
   |---|---|---|---|---|
-  | 1 | `validate.validateSubmission` | Validate Submission | action | (UNRESOLVED) |
-
-  ##### Task 2.1: Validate Submission (`validate.validateSubmission`)
-
-  **Type:** action
-  **Description:** UiPath Action App reference. Registry-unresolved → emit as skeleton (empty `data: {}`).
-
-  **Entry Condition**
-
-  | WHEN | IF |
-  |---|---|
-  | current-stage-entered | - |
-
-  | Field | Value |
-  |---|---|
-  | Component Type | ACTION (UiPath Action App reference) |
-  | Action App Reference (Name) | Validate Submission |
-  | Folder | Shared |
-  | taskTypeId | `<UNRESOLVED: ...>` (do NOT fabricate) |
+  | - | - | - | - | No tasks — empty pass-through branch. |
 
   ### Stage 3: Enrich (`enrich`)
   **Type:** Stage
@@ -278,7 +261,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Diamond topology: Triage→{Validate,Enrich}→Join with two selected-stage-completed entry rules on Join; FIVE skeleton tasks across 4 stages cover 5 distinct plugin types — Triage:{rpa, api-workflow}, Validate:action, Enrich:agent, Join:case-management — all with empty data (skeleton)"
+    description: "Diamond topology: Triage→{Validate,Enrich}→Join with two selected-stage-completed entry rules on Join; FOUR skeleton tasks across 3 stages cover 4 distinct plugin types — Triage:{rpa, api-workflow}, Enrich:agent, Join:case-management — all with empty data (skeleton); Validate is an empty pass-through branch"
     command: "python3 $TASK_DIR/check_fan_in_join.py"
     timeout: 720
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/check_multi_trigger.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/check_multi_trigger.py
@@ -26,9 +26,13 @@ def main():
         uipath = ((t.get("data") or {}).get("uipath")) or {}
         service_types.append(uipath.get("serviceType"))
 
-    if "None" not in service_types:
+    # Manual trigger accepts either form: no data.uipath key (serviceType None)
+    # OR an explicit serviceType "None". See triggers/manual/impl-json.md.
+    manual_count = sum(1 for s in service_types if s in (None, "None"))
+    if manual_count != 1:
         sys.exit(
-            f"FAIL: no manual trigger (serviceType='None'); got {service_types}"
+            f"FAIL: expected exactly 1 manual trigger (no data.uipath key or "
+            f"serviceType='None'); got {service_types}"
         )
     timer_count = sum(1 for s in service_types if s == "Intsvc.TimerTrigger")
     if timer_count != 2:

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
@@ -193,10 +193,10 @@ def main():
     if not priority:
         names = [v.get("name") for v in io_vars]
         sys.exit(f"FAIL: missing root variable 'priorityScore'; got {names}")
-    if priority.get("type") != "number":
+    if priority.get("type") not in ("integer", "float", "double"):
         sys.exit(
-            f"FAIL: variable 'priorityScore' should be type=number; "
-            f"got {priority.get('type')!r}"
+            f"FAIL: variable 'priorityScore' should be a numeric type "
+            f"(integer/float/double); got {priority.get('type')!r}"
         )
 
     payload = start_debug(timeout=540)

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
@@ -83,7 +83,7 @@ initial_prompt: |
   | Variable | Category | Type | Default | Description | Produced By | Consumed By |
   |---|---|---|---|---|---|---|
   | region | Variable | string | "US" | Case-level region flag referenced inside the Region Check task-entry conditionExpression. | - | finalize.regionCheck |
-  | priorityScore | Variable | number | 0 | Case-level numeric score referenced alongside region inside the same task-entry conditionExpression. | - | finalize.regionCheck |
+  | priorityScore | Variable | integer | 0 | Case-level numeric score referenced alongside region inside the same task-entry conditionExpression. | - | finalize.regionCheck |
 
   ## Section 2: Stages & Tasks
 


### PR DESCRIPTION
fix(uipath-maestro-case): align case checks with live debug behavior

Loosen test assertions and adjust fixtures so the case tests match
actual runtime payloads:

- case_check: accept "Successful" finalStatus alongside "Completed"
- multi_trigger: accept either manual-trigger form (no data.uipath key
  or explicit serviceType "None")
- task_dependency_chain: accept numeric types (integer/float/double)
  for priorityScore instead of literal "number"; declare it as integer
  in the SDD fixture
- fan_in_join: make Validate an empty pass-through branch (a skeleton
  action UserTask cannot survive a live debug run); drop to 4 skeleton
  tasks across 3 stages covering 4 plugin types
- branching_exit: declare the `decision` case variable consumed by the
  Triage stage-exit routing expressions

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
