### PR TITLE
test(uipath-maestro-case): assert runs-sequentially parallel members …

### DIFF
--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
@@ -36,6 +36,18 @@ def _stage_task_by_label(stage: dict, label: str) -> dict:
     )
 
 
+def _stage_task_lane(stage: dict, label: str) -> int:
+    lanes = (stage.get("data") or {}).get("tasks") or []
+    for lane_idx, lane in enumerate(lanes):
+        for task in lane or []:
+            if (task or {}).get("displayName") == label or (task or {}).get("label") == label:
+                return lane_idx
+    sys.exit(
+        f"FAIL: task with displayName/label={label!r} not found in any lane of stage "
+        f"{(stage.get('data') or {}).get('label')!r}"
+    )
+
+
 def _task_entry_rule(task: dict) -> str | None:
     conds = task.get("entryConditions") or []
     for cond in conds:
@@ -116,6 +128,19 @@ def main():
             sys.exit(
                 f"FAIL: task {name!r} task-entry rule should be {want!r}; got {got!r}"
             )
+
+    # First Step and Second Step are parallel members of the same
+    # runs-sequentially group, so they MUST share one lane (shared lane =
+    # parallel siblings inside the sequential group, semantic — not the
+    # default one-task-per-lane FE layout).
+    first_step_lane = _stage_task_lane(process, "First Step")
+    second_step_lane = _stage_task_lane(process, "Second Step")
+    if first_step_lane != second_step_lane:
+        sys.exit(
+            f"FAIL: 'First Step' and 'Second Step' are parallel members of the "
+            f"runs-sequentially group and must share the same lane in Process "
+            f"data.tasks; got lane {first_step_lane} and lane {second_step_lane}"
+        )
 
     if optional_audit.get("type") != "process":
         sys.exit(
@@ -210,7 +235,9 @@ def main():
         "selected-tasks-completed→Done (marksStageComplete=false); Finalize "
         "entry selected-stage-completed; task-entry rules cover runs-sequentially/"
         "adhoc/wait-for-connector(vars.region+vars.priorityScore+metadata.tier)/"
-        "selected-tasks-completed; First Step uses timeDuration+repeat=5; "
+        "selected-tasks-completed; First Step + Second Step share lane "
+        f"{first_step_lane} (parallel members of the runs-sequentially group); "
+        "First Step uses timeDuration+repeat=5; "
         "Second Step uses timeCycle R3/PT2H; root variables 'region' (string) "
         "and 'priorityScore' (number); 'Optional Audit' is a process-typed "
         f"skeleton task (no data.name / data.folderPath); debug payload "

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
@@ -3,7 +3,8 @@ description: >
   Build a Case Management definition that exercises task-driven stage
   completion, the under-covered task-entry rule-types, and a non-timer
   task type embedded in a multi-stage flow. Process stage contains two
-  sequential timers (task-entry runs-sequentially) and exits via
+  timers forming a runs-sequentially group whose parallel members share
+  one lane (semantic, not FE layout) and exits via
   required-tasks-completed (marks-stage-complete: true). Finalize
   contains a wait-for-connector-gated task referencing a string Variable
   AND a number Variable inside its conditionExpression, a sibling-gated
@@ -89,7 +90,7 @@ initial_prompt: |
 
   ### Stage 1: Process (`process`)
   **Type:** Stage
-  **Description:** Runs a fixed two-step sequence; exits via required-tasks-completed.
+  **Description:** Two timer tasks form a single `runs-sequentially` group and run in parallel with each other; as parallel members of that group they MUST share one lane (lane 0 — shared lane carries execution semantics, not just FE layout). Exits via required-tasks-completed.
   **Required for Case Completion:** Yes
   #### Stage Entry Conditions
   | WHEN | IF | Interrupting |
@@ -104,10 +105,12 @@ initial_prompt: |
   |---|---|---|---|---|
   | No stage exit hand-off declared. | - | exit-only | - | No |
   #### Stage Task Summary
-  | # | Task ID | Task | Type | Owner |
+  | # | Task ID | Task | Type | Lane |
   |---|---|---|---|---|
-  | 1 | `process.firstStep` | First Step | wait-for-timer | (system-driven) |
-  | 2 | `process.secondStep` | Second Step | wait-for-timer | (system-driven) |
+  | 1 | `process.firstStep` | First Step | wait-for-timer | 0 |
+  | 2 | `process.secondStep` | Second Step | wait-for-timer | 0 |
+
+  > Both tasks share lane 0: they are parallel members of the same `runs-sequentially` group, so the shared lane is semantic (parallel siblings inside the sequential group), not the default one-task-per-lane layout.
 
   ##### Task 1.1: First Step (`process.firstStep`)
 
@@ -119,6 +122,8 @@ initial_prompt: |
   | WHEN | IF |
   |---|---|
   | runs-sequentially ("Sequential 1") | - |
+
+  **Lane:** 0 (shared with Second Step — parallel members of the runs-sequentially group).
 
   | Field | Value |
   |---|---|
@@ -137,6 +142,8 @@ initial_prompt: |
   | WHEN | IF |
   |---|---|
   | runs-sequentially ("Sequential 2") | - |
+
+  **Lane:** 0 (shared with First Step — parallel members of the runs-sequentially group).
 
   | Field | Value |
   |---|---|
@@ -256,7 +263,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Process exit=required-tasks-completed; Finalize exit=selected-tasks-completed; Finalize entry=selected-stage-completed; tasks carry runs-sequentially/adhoc/wait-for-connector/selected-tasks-completed task-entry rules; First Step timer carries bounded repeat=5 (timeDuration); Second Step timer uses timeCycle (R3/PT2H); root has string variable 'region' AND number variable 'priorityScore' (both referenced alongside metadata.tier in Region Check conditionExpression); 'Optional Audit' is a process-typed skeleton task in Finalize"
+    description: "Process exit=required-tasks-completed; Finalize exit=selected-tasks-completed; Finalize entry=selected-stage-completed; tasks carry runs-sequentially/adhoc/wait-for-connector/selected-tasks-completed task-entry rules; First Step and Second Step are parallel members of the runs-sequentially group and share one lane (same laneIndex in Process data.tasks); First Step timer carries bounded repeat=5 (timeDuration); Second Step timer uses timeCycle (R3/PT2H); root has string variable 'region' AND number variable 'priorityScore' (both referenced alongside metadata.tier in Region Check conditionExpression); 'Optional Audit' is a process-typed skeleton task in Finalize"
     command: "python3 $TASK_DIR/check_task_dependency_chain.py"
     timeout: 720
     expected_exit_code: 0


### PR DESCRIPTION
test(uipath-maestro-case): assert runs-sequentially parallel members share a lane

The task_dependency_chain test treated First Step and Second Step only as
two sequential timers. They are actually parallel members of the same
runs-sequentially group, which means they must share one lane (lane 0) —
a shared lane is execution semantics here, not the default one-task-per-lane
FE layout.

- check_task_dependency_chain.py: add _stage_task_lane() and assert both
  steps resolve to the same laneIndex in Process data.tasks
- task_dependency_chain.yaml: rework the Process stage prompt, task summary
  table (Owner→Lane), and run_command criterion to specify the shared lane

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
