### PR TITLE
fix(uipath-maestro-case): wait-for-timer repeat must be a string, not…

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/impl-json.md
@@ -60,10 +60,10 @@ Write the timer task directly to `caseplan.json`. No CLI command needed.
 
 ISO 8601 duration format (e.g., `PT3M`, `PT1H30M`, `P2D`). Time units use `PT` prefix, date units use `P` (no `T`). Weeks → `P7D` (Luxon doesn't output `W`).
 
-**Bounded repetition** — when tasks.md specifies `repeat: N`, add `data.repeat` as an integer alongside `timeDuration`. Omit `data.repeat` entirely for a single fire.
+**Bounded repetition** — when tasks.md specifies `repeat: N`, add `data.repeat` as a string alongside `timeDuration`. Omit `data.repeat` entirely for a single fire.
 
 ```json
-"data": { "timerType": "timeDuration", "timeDuration": "PT1H", "repeat": 5 }
+"data": { "timerType": "timeDuration", "timeDuration": "PT1H", "repeat": "5" }
 ```
 
 Pairs with `timeDuration` only. For bounded repetition with a start datetime, use `timeCycle` instead.


### PR DESCRIPTION
fix(uipath-maestro-case): wait-for-timer repeat must be a string, not an integer

The wait-for-timer task's `data.repeat` field was documented as an integer.
Emit it as a string ("5") to match the expected caseplan.json schema.
