### PR TITLE
docs(uipath-maestro-flow): clarify registry search JSON contract

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/planning.md
@@ -41,10 +41,20 @@ Examples:
 ## Discovery
 
 ```bash
-uip maestro flow registry search <service> --output json
+uip maestro flow registry search <service> --output json \
+  --output-filter "[*].{NodeType:NodeType,DisplayName:DisplayName,Description:Description,AvailableOnTenant:AvailableOnTenant}"
 ```
 
-Confirm `category: "connector"` in the results. If the connector key fails, list all connectors:
+`registry search` returns `Data` as a flat array, and each row uses PascalCase fields (`NodeType`, `DisplayName`, `Description`, `AvailableOnTenant`). Do **not** parse `Data.Nodes`, lowercase `type`, or lowercase `category`; those shapes do not exist in the CLI JSON output.
+
+For connector activities, use `NodeType` as the source of truth:
+
+- Activity rows start with `uipath.connector.<connector-key>.`
+- Trigger rows start with `uipath.connector.trigger.` and belong to the connector-trigger guide
+- `NodeType` is the exact value to pass to `registry get` and `node add`
+- `Category` can be tenant/internal metadata such as `connector.<id>` and is not a reliable connector-key source
+
+If the connector key fails, list all connectors:
 
 ```bash
 uip is connectors list --output json


### PR DESCRIPTION
## Summary

Documents the exact `registry search --output json` shape in connector planning:

- `Data` is a flat array, not `Data.Nodes`
- rows use PascalCase fields such as `NodeType`, `DisplayName`, and `AvailableOnTenant`
- connector activity discovery should derive the connector key from `NodeType`, not `Category`

## Why

Run logs showed repeated wasted tool turns where agents parsed `Data.Nodes` or lowercase fields, hit `list has no attribute get`, and then issued follow-up commands just to inspect the response shape. PR #1085 fixed the shared CLI reference; this puts the contract directly in the connector discovery path.

## Validation

- `git diff --check`
- `python3 scripts/check-skill-verbs.py --json skills/uipath-maestro-flow` reports `blocking: 0`


---
🤖 Generated with Claude Code
Co-Authored-By: Claude noreply@anthropic.com