### PR TITLE
docs(uipath-maestro-flow): clarify registry get node shape

### DIFF
--- a/skills/uipath-maestro-flow/references/shared/action-nodes.md
+++ b/skills/uipath-maestro-flow/references/shared/action-nodes.md
@@ -29,7 +29,14 @@ uip maestro flow registry get <node-type> --output json
 }
 ```
 
-Inspect `Data.Node.handleConfiguration` for the input port name and output port name(s), `Data.Node.inputDefinition` for required inputs, `Data.Node.outputDefinition` for downstream payloads, and `Data.Node.model.serviceType` where applicable. `handleConfiguration` is an array of position groups, not a map with a top-level `handles` field. Plugin `impl.md` records what to confirm for that specific node type.
+Inspect:
+
+- `Data.Node.handleConfiguration` — input port name and output port name(s). Array of position groups, not a map with a top-level `handles` field.
+- `Data.Node.inputDefinition` — required inputs.
+- `Data.Node.outputDefinition` — downstream payloads.
+- `Data.Node.model.serviceType` — where applicable.
+
+Plugin `impl.md` records what to confirm for that specific node type.
 
 ## Standard JSON skeleton
 

--- a/skills/uipath-maestro-flow/references/shared/action-nodes.md
+++ b/skills/uipath-maestro-flow/references/shared/action-nodes.md
@@ -10,7 +10,26 @@ Every action node should validate its registry contract before authoring:
 uip maestro flow registry get <node-type> --output json
 ```
 
-Inspect `Data.Node.handleConfiguration` for the input port name, output port name(s), required inputs, and (where applicable) the model `serviceType`. Plugin `impl.md` records what to confirm for that specific node type.
+`registry get` returns the manifest at `Data.Node`. Do **not** inspect `Data` directly as if it were the node manifest.
+
+```json
+{
+  "Data": {
+    "Node": {
+      "nodeType": "core.action.script",
+      "version": "1.0",
+      "handleConfiguration": [
+        { "position": "left", "handles": [{ "id": "input", "type": "target" }] },
+        { "position": "right", "handles": [{ "id": "success", "type": "source" }] }
+      ],
+      "inputDefinition": {},
+      "outputDefinition": {}
+    }
+  }
+}
+```
+
+Inspect `Data.Node.handleConfiguration` for the input port name and output port name(s), `Data.Node.inputDefinition` for required inputs, `Data.Node.outputDefinition` for downstream payloads, and `Data.Node.model.serviceType` where applicable. `handleConfiguration` is an array of position groups, not a map with a top-level `handles` field. Plugin `impl.md` records what to confirm for that specific node type.
 
 ## Standard JSON skeleton
 


### PR DESCRIPTION
## Summary

Clarifies the `registry get --output json` response shape in the shared action-node guide:

- the manifest lives at `Data.Node`
- `handleConfiguration` is an array of position groups, not a map
- agents should read `inputDefinition`, `outputDefinition`, and `model.serviceType` from `Data.Node`

## Why

The run logs showed many `registry get` inspect/error loops where agents treated `Data` as the manifest or misread nested fields. This makes the high-frequency lookup contract explicit at the guide agents use before authoring action nodes.

## Validation

- `git diff --check`
- `python3 scripts/check-skill-verbs.py --json skills/uipath-maestro-flow` reports `blocking: 0`


---
🤖 Generated with Claude Code
Co-Authored-By: Claude noreply@anthropic.com