### PR TITLE
docs(uipath-maestro-flow): clarify connections list JSON contract

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -64,6 +64,25 @@ Discovery call is **always**:
 uip is connections list "<connector-key>" --all-folders --output json
 ```
 
+`connections list` returns `Data` as a flat array. Do **not** parse `Data.Connections` or `Data.Items`; those wrapper objects are not part of the CLI JSON contract. Read each candidate from `Data[]` and use PascalCase fields:
+
+```json
+{
+  "Data": [
+    {
+      "Id": "<connection-id>",
+      "Name": "<display-name>",
+      "State": "Enabled",
+      "IsDefault": "Yes",
+      "Folder": "<folder-name>",
+      "FolderKey": "<folder-key>"
+    }
+  ]
+}
+```
+
+Use `Data[i].Id` as the `--connection-id` value and `Data[i].FolderKey` as the `folderKey` value in `node configure --detail`.
+
 > **MUST READ before any `uip is connections ...` call:** [/uipath:uipath-platform — connections.md](../../../../../../uipath-platform/references/integration-service/connections.md). Single source of truth for selection rules (auto-select, personal workspace), BYOA filtering, empty-result recovery, ping verification.
 
 End state: a healthy connection `Id` + `FolderKey` for Step 2 (`registry get --connection-id`) and Step 6 (`node configure --detail`).


### PR DESCRIPTION
## Summary

Documents the `uip is connections list --output json` shape in the connector implementation workflow:

- `Data` is a flat array, not `Data.Connections` or `Data.Items`
- connection rows use PascalCase fields such as `Id`, `State`, `IsDefault`, and `FolderKey`
- `Id` feeds `--connection-id`; `FolderKey` feeds `node configure --detail.folderKey`

## Why

The run logs showed agents wasting turns probing connection-list wrappers before extracting the connection UUID and folder key. This puts the shape at the exact Step 1 handoff from connection discovery to enriched `registry get` and `node configure`.

## Validation

- `git diff --check`
- `python3 scripts/check-skill-verbs.py --json skills/uipath-maestro-flow` reports `blocking: 0`


---
🤖 Generated with Claude Code
Co-Authored-By: Claude noreply@anthropic.com