### PR TITLE
docs(uipath-maestro-flow): document registry availability semantics

### DIFF
--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -325,6 +325,11 @@ uip maestro flow registry get <nodeType> --output json     # get full schema for
 ] }
 ```
 
+`AvailableOnTenant` is a usability gate, not extra metadata to ignore:
+
+- `true` — the tenant registry can return this node; it is valid to continue with `registry get <NodeType>` or `node add <NodeType>`.
+- `false` — the SDK knows about this node type, but the current tenant registry did not return it. Treat it as not enabled or not available for this tenant. Do **not** try nonexistent flags such as `--include-unavailable`; they are not supported. Choose an enabled alternative, use `--local` for in-solution resources, or report the feature/resource as unavailable.
+
 The `Data.Node` object from `registry get` is what you paste into your `.flow` file's `definitions` array.
 
 Run `uip maestro flow registry <subcommand> --help` for additional options (e.g., `--force`, `--filter`, `--connection-id`).


### PR DESCRIPTION
## Summary

Documents how to interpret `AvailableOnTenant` in the shared flow CLI command reference:

- `true` rows can continue to `registry get` / `node add`
- `false` rows are SDK-known but unavailable in the current tenant registry
- agents should not try unsupported flags such as `--include-unavailable`

## Why

The run logs showed agents seeing `AvailableOnTenant: false` and then spending calls on `registry get` or nonexistent flags. This makes the branch explicit so agents choose an enabled alternative, use `--local` where appropriate, or report the resource as unavailable.

## Validation

- `git diff --check`
- `python3 scripts/check-skill-verbs.py --json skills/uipath-maestro-flow` reports `blocking: 0`


---
🤖 Generated with Claude Code
Co-Authored-By: Claude noreply@anthropic.com