### PR TITLE
feat(uipath-maestro-case): connector-rule ↔ FE parity (stacked on #1047)

### DIFF
--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -176,6 +176,8 @@ Completion report + **HARD STOP** AskUserQuestion (Step 13): `Run debug session`
 | [task-entry-conditions](references/plugins/conditions/task-entry-conditions/planning.md) | Task starts |
 | [case-exit-conditions](references/plugins/conditions/case-exit-conditions/planning.md) | Case completes/exits |
 
+> **Connector-bound rules:** a `wait-for-connector` rule in any condition scope must carry the connector configuration under `rule.uipath` (built from `case spec --type trigger`, like the connector-trigger task) — bare connector rules are invalid in Studio Web and are NOT caught by CLI `validate`. See [connector-trigger-common.md § Target: connector-bound condition rule](references/connector-trigger-common.md#target-connector-bound-condition-rule).
+
 ## Anti-patterns
 
 - **Do NOT leave stages without an inbound edge.** Orphaned and unreachable. Every stage needs ≥1 inbound edge from Trigger or another stage.

--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -60,6 +60,24 @@ build the case in the Case Designer without guessing.
 6. **Entry/exit conditions use WHEN + IF format:**
    - **WHEN** = the rule type (event that triggers evaluation, e.g., `selected-stage-completed("Intake")`)
    - **IF** = the optional `conditionExpression` (JavaScript expression evaluated against case variables, e.g., `applicationStatus == "Approved"`)
+   - **`wait-for-connector` WHEN** binds an Integration Service connector event. Name it inline in the WHEN cell (e.g. `wait-for-connector (Outlook "Email Received", Inbox)`) AND add a **Connector Rule Detail** block under the condition table. Applies to stage-entry, stage-exit, case-exit, and task-entry conditions. The IF cell is then an optional `=js:` gate on **case state** (`=js:vars.X`); the event payload is NOT directly accessible (no `event` namespace). To gate on payload, use **extract-then-gate**: bind `response.field -> caseVar` in the rule's Outputs block, then reference `=js:vars.caseVar` in the IF cell.
+
+   **Connector Rule Detail block** — reproduce under any condition table whose WHEN is `wait-for-connector`:
+   ```markdown
+   **Connector Rule Detail:**
+   - Connector: {e.g., Microsoft Outlook 365}
+   - Connection: {instance name, or "Tenant default"}
+   - Event: {e.g., Email Received}
+   - Filter: {filter in business terms, or "—"}
+   - Event Parameters: {name=value pairs, e.g., parentFolderId="Inbox"; or "—"}
+
+   **Connector Rule Outputs:** *(optional — omit when the rule is gate-only; target case variable MUST exist in the Case Variables table)*
+
+   | Field | Binding / Value |
+   |-------|------------------|
+   | {schema field name, e.g., response.subject} | -> {case variable that receives this value} |
+   | — | {case variable} = {literal, =js:expression, or =vars.X.Y} |
+   ```
 
 7. **Task types — closed enum of 9 values. Choose based on WHAT THE TASK DOES, not its surface label.** Any other value (e.g., `external-agent`, `connector-activity`, `wait-for-event`) is invalid and breaks downstream JSON generation. Consider all 9 for every task:
    - `action` — a human must review, approve, or make a judgment call. The task PAUSES for a person.
@@ -188,6 +206,8 @@ DO NOT include in Configuration:
 |------|-----|------|---------------------|
 | {`required-stages-completed` for Yes; `selected-stage-completed("StageName")` or other rule for No} | {conditionExpression, or "—" if none} | Case exited | {Yes \| No} |
 
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6) — it binds the IS connector event the rule waits for.
+
 ### Case Variables
 
 > Complete inventory of all case-level variables and arguments. Every row's `Category` column is REQUIRED — drives classification at build time. Inference from other columns is no longer supported.
@@ -281,6 +301,8 @@ The runtime engine resolves the binding when the task completes, writing the res
 |------|-----|-------------|
 | {rule type with target, e.g., selected-stage-completed("Previous Stage Name")} | {conditionExpression, or "—" if none} | {Yes \| No} |
 
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
+
 #### Stage Exit Conditions
 
 > **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed` (or `required-stages-completed`); `No` row MAY use `selected-tasks-completed(...)`. Mixing is invalid.
@@ -288,6 +310,8 @@ The runtime engine resolves the binding when the task completes, writing the res
 | WHEN | IF | Exit Type | Marks Stage Complete |
 |------|-----|-----------|---------------------|
 | {`required-tasks-completed` for Yes; `selected-tasks-completed("TaskName")` or other rule for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} |
+
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
 #### Stage SLA
 
@@ -317,6 +341,8 @@ The runtime engine resolves the binding when the task completes, writing the res
 | WHEN | IF |
 |------|-----|
 | {rule type with target, or "current-stage-entered" for first task} | {conditionExpression, or "—" if none} |
+
+> If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
 ---
 

--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -45,7 +45,7 @@ Every `=`-prefixed value in `caseplan.json` is dispatched to one of two runtime 
 | Path | Trigger | Capabilities |
 |---|---|---|
 | **Lookup** | Value starts with `=vars.<id>` or `=bindings.<id>` | Strip prefix, look up by id, return value. NO operators, NO dotted access, NO `=metadata.` |
-| **JS eval** | Value starts with `=js:<expr>` | Full JS evaluation. Scope: `vars`, `metadata`, `bindings`, `response`, `event`, `Error`, `datafabric`, `orchestrator`. Operators, function calls, dotted access all work. (`event` available only on `wait-for-connector` rules — bound to the incoming event payload.) |
+| **JS eval** | Value starts with `=js:<expr>` | Full JS evaluation. Predefined namespaces: `vars`, `response`, `bindings`, `iterator`, `metadata`. Operators, function calls, dotted access all work. **A condition / rule `conditionExpression` can reference only case variables (`vars.X`) and `metadata`** — there is no `event` namespace (referencing `event` errors with "event not found"). For event-payload gating, use extract-then-gate (bind `response.X -> caseVar` in the rule's Outputs, then `=js:vars.caseVar`). |
 
 `data.inputs[].value` on non-connector tasks runs **lookup** when the value matches `^=vars\.\w+$` or `^=bindings\.\w+$`; **JS eval** otherwise. Connector body fields, filter expressions, and condition expressions ALL run **JS eval** — they require `=js:` wrap regardless of value shape.
 

--- a/skills/uipath-maestro-case/references/bindings-v2-sync.md
+++ b/skills/uipath-maestro-case/references/bindings-v2-sync.md
@@ -17,12 +17,13 @@ Field shape inside the array is identical across schemas — only the source pat
 
 **Batched, not per-task.** `bindings_v2.json` is only consumed by `uip solution resource refresh` (which runs once before upload/debug). No intermediate step reads it. Regenerating after every task wastes Read→convert→Write cycles on a growing file.
 
-Run at these two points only:
+Run at these three points only:
 
 1. **End of Phase 2 Step 9** (after all non-connector tasks written) — covers all process/agent/rpa/action/api-workflow/case-management bindings
-2. **End of Phase 3 Step 9.7** (after all connector tasks populated) — adds Connection bindings + populates IS cache
+2. **End of Phase 3 Step 9.7** (after all connector tasks populated) — adds Connection bindings + populates IS cache for tasks
+3. **End of Phase 3 Step 10** (after all connector condition RULES written across the 4 scopes — stage-entry, stage-exit, case-exit, task-entry) — adds Connection bindings + populates IS cache for rules. Required because connector rules are written in Step 10 (conditions), not Step 9.7 (tasks); without this third sync point, rule-introduced Connection/Folder bindings + IS-cache entries wouldn't land until the post-Phase-3 catch-all, and `resource refresh` would miss them.
 
-Individual task plugins write bindings to `caseplan.json` per-task as normal (path per § Schema-dependent source path above). The batch regeneration reads the full bindings array once from the schema-appropriate path and converts everything in one pass.
+Individual task / rule plugins write bindings to `caseplan.json` per-target as normal (path per § Schema-dependent source path above). The batch regeneration reads the full bindings array once from the schema-appropriate path and converts everything in one pass.
 
 ---
 
@@ -73,7 +74,7 @@ File envelope: `{ "version": "2.0", "resources": [ /* one entry per resource */ 
 
 ## § Populate IS connection cache
 
-`uip solution resource refresh` reads a local IS cache that connector plugins must populate after `get-connection`.
+`uip solution resource refresh` reads a local IS cache that connector plugins must populate after `get-connection`. Applies to all three connector-resolving paths: connector **tasks** (Step 9.7), connector **triggers** (Step 8), and connector **condition rules** in any of the 4 scopes (Step 10).
 
 **Path:** `~/.uipath/cache/integrationservice/<connectorKey>/connections.json`
 
@@ -134,8 +135,8 @@ All three required for `uip solution upload` and `uip maestro case debug` to wor
 
 ---
 
-## Cleanup on task removal
+## Cleanup on task or rule removal
 
-When any task is removed and its root bindings are pruned (per [case-editing-operations.md](case-editing-operations.md) § node deletion cascade):
+When any task or connector condition rule is removed and its root bindings are pruned (per [case-editing-operations.md](case-editing-operations.md) § Delete a node / § Delete a connector condition rule):
 
 1. After pruning root bindings, regenerate `bindings_v2.json` from the updated array.

--- a/skills/uipath-maestro-case/references/case-editing-operations.md
+++ b/skills/uipath-maestro-case/references/case-editing-operations.md
@@ -270,8 +270,22 @@ Details per plugin — see [bindings-and-expressions.md](bindings-and-expression
 1. Read `caseplan.json`.
 2. Remove the node from `schema.nodes` by ID.
 3. Remove every edge where `source` or `target` equals the removed node's ID.
-4. If the node was a stage containing a connector task, prune entries from the bindings array (v19: `root.data.uipath.bindings`; v20: top-level `bindings`) referenced only by that task.
-5. Edit — separate slices for `schema.nodes`, `schema.edges`, and (if applicable) the bindings array. Never whole-file Write.
+4. If the node was a stage containing a connector task **or a connector condition rule** (in `entryConditions[]` / `exitConditions[]` / task `entryConditions[]`), prune entries from the bindings array (v19: `root.data.uipath.bindings`; v20: top-level `bindings`) referenced only by that task/rule. A connector rule contributes the same Connection/Folder binding pair as a task — `rule.uipath.context[name="connection"|"folderKey"]` references `=bindings.<bindingId>`. Walk every remaining task/trigger/rule; an entry whose `resourceKey` is no longer referenced anywhere is the one to prune. Case-exit rules are NOT in scope here — they live on root, not inside a node; use § Delete a connector condition rule for those.
+5. If the removed node held connector rule outputs that were bound to case variables (B/C feature), prune the matching companion entries from `root.inputOutputs[]` whose `elementId` was `<removedStageId>-<ruleId>` and that no longer have a producer.
+6. Regenerate `bindings_v2.json` per [bindings-v2-sync.md § Cleanup on task or rule removal](bindings-v2-sync.md#cleanup-on-task-or-rule-removal).
+7. Edit — separate slices for `schema.nodes`, `schema.edges`, the bindings array, and (if applicable) `inputOutputs[]`. Never whole-file Write.
+
+### Delete a connector condition rule
+
+When removing a single rule from a condition (without deleting the parent stage/task/case-exit), the cascade is the same as deleting a connector node — but scoped to one rule:
+
+1. Read `caseplan.json`.
+2. Locate the rule by `id`. **FE composes one rule per condition** (OR-style across multiple condition objects), so the target is almost always a condition object that contains exactly this one rule. The underlying shape is DNF (`rules[][]`), so honor it: if other rules share the inner AND-array, remove just the rule; if the rule is the sole entry, remove the entire condition object.
+3. Remove the rule (or the parent condition object when it becomes empty).
+4. Walk all remaining tasks/triggers/rules; prune root `bindings[]` entries whose `resourceKey` is no longer referenced.
+5. Prune `root.inputOutputs[]` companions that were tied to this rule's outputs (`elementId = <ownerNodeId>-<ruleId>`) and whose case variable has no other producer.
+6. Regenerate `bindings_v2.json` per [bindings-v2-sync.md § Cleanup on task or rule removal](bindings-v2-sync.md#cleanup-on-task-or-rule-removal).
+7. Edit — separate slices for the conditions array, the bindings array, and (if applicable) `inputOutputs[]`. Never whole-file Write.
 
 ### Delete an edge
 

--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -381,7 +381,7 @@ Rules = Rule[][]
 
 | `rule` | Additional fields | Description |
 |--------|-------------------|-------------|
-| `wait-for-connector` | `id?`, `conditionExpression?`, `uipath?` | Wait for an external connector event |
+| `wait-for-connector` | `id?`, `uipath` (connector configuration — required), `conditionExpression?` | Wait for an external connector event — see § Connector-bound rule below |
 | `case-entered` | `id?`, `conditionExpression?` | Fires when the case is first entered |
 | `selected-stage-completed` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has completed |
 | `selected-stage-exited` | `id?`, `selectedStageId?`, `conditionExpression?` | A specific stage has been exited |
@@ -401,6 +401,27 @@ Not every rule type is valid at every level — see each condition plugin's `imp
 { "rule": "selected-tasks-completed", "id": "<id>", "selectedTasksIds": ["<taskId1>", "<taskId2>"] }
 { "rule": "adhoc", "id": "<id>", "conditionExpression": "in.Score > 700" }
 ```
+
+### Connector-bound `wait-for-connector` rule
+
+A `wait-for-connector` rule binds an IS connector trigger under **`uipath`** — the same block the in-stage `wait-for-connector` task carries under `data`. A bare rule (no `uipath`) is rejected by Studio Web (the FE validator requires the connector activity to resolve). It is authored from a `case spec --type trigger` scaffold; the CLI does not bind it (`buildRule` emits the bare form). `conditionExpression` is an optional `=js:` gate on **case state** (`vars.X` / `metadata`) — NOT the event payload (no `event` namespace). Inputs/outputs `elementId` = `<stageId>-<ruleId>` (stage-entry / stage-exit / task-entry — all stage-scoped) or `root-<ruleId>` (case-exit). Full recipe: [connector-trigger-common.md § Target: connector-bound condition rule](connector-trigger-common.md#target-connector-bound-condition-rule).
+
+```json
+{
+  "rule": "wait-for-connector",
+  "id": "<ruleId>",
+  "uipath": {
+    "serviceType": "Intsvc.WaitForEvent",
+    "context": [ { "name": "connectorKey", "value": "<key>", "type": "string" }, { "name": "connection", "value": "=bindings.<id>", "type": "string" }, { "name": "folderKey", "value": "=bindings.<id>", "type": "string" }, { "name": "resourceKey", "value": "<connection-id>", "type": "string" }, { "name": "objectName", "value": "<object>", "type": "string" }, { "name": "metadata", "type": "json", "body": { } } ],
+    "inputs": [ ],
+    "outputs": [ ],
+    "bindings": []
+  },
+  "conditionExpression": "=js:<optional case-state gate, e.g. vars.X — NOT the event payload>"
+}
+```
+
+> CLI `validate` does NOT check `rule.uipath` — the case-tool connector validator is task-only (reads `task.data`). Confirm connector rules via Studio Web.
 
 ---
 

--- a/skills/uipath-maestro-case/references/connector-trigger-common.md
+++ b/skills/uipath-maestro-case/references/connector-trigger-common.md
@@ -1,12 +1,13 @@
 # Connector Trigger — Shared Pipeline
 
-Shared planning and implementation logic for connector-based triggers. Used by both:
-- [connector-trigger task](plugins/tasks/connector-trigger/planning.md) — in-stage `wait-for-connector`
-- [event trigger](plugins/triggers/event/planning.md) — case-level `Intsvc.EventTrigger`
+Shared planning and implementation logic for connector-based triggers. Used by three:
+- [connector-trigger task](plugins/tasks/connector-trigger/planning.md) — in-stage `wait-for-connector` task
+- [event trigger](plugins/triggers/event/planning.md) — case-level `Intsvc.EventTrigger` (case start)
+- **connector-bound condition rule** — a `wait-for-connector` rule in any condition scope (stage-entry / stage-exit / case-exit / task-entry). Also called "connector rule" or "connector condition rule" in shorthand; "wait-for-connector rule" when the rule-type is the salient property. All four refer to the same construct. See [§ Target: connector-bound condition rule](#target-connector-bound-condition-rule) and each condition plugin's `impl-json.md`.
 
-Both use the same TypeCache (`typecache-triggers-index.json`), same single-call `case spec` discovery, same FE-canonical `caseShape` consumption. Only the target (task vs trigger node), `serviceType`, and a few node-shape details differ — see each plugin's own docs for those specifics.
+All three use the same TypeCache (`typecache-triggers-index.json`), same single-call `case spec` discovery, same FE-canonical `caseShape` consumption. Only the target (task `data` / trigger node `data.uipath` / rule `uipath`), `serviceType`, and a few shape details differ — see each plugin's own docs.
 
-> Mirrors the [connector-activity](plugins/tasks/connector-activity/planning.md) flow. Same CLI surface (`uip maestro case spec` with `--skip-case-shape` for planning, `--input-details` for Phase 3); `--type trigger` swaps in trigger-shaped inputs/outputs and the trigger-specific `metadata.body.bindings[Property]` registration entry.
+> Mirrors the [connector-activity](plugins/tasks/connector-activity/planning.md) flow. Same CLI surface (`uip maestro case spec` with `--skip-case-shape` for planning, `--input-details` for Phase 3); `--type trigger` swaps in trigger-shaped inputs/outputs and, for event-parameter connectors, a `metadata.body.bindings[Property]` registration entry (Step 4).
 
 ---
 
@@ -319,11 +320,11 @@ Per-plugin: each plugin's `impl-json.md` mints these onto `caseShape.inputs[]` /
 Conventions (shared with activity):
 - `var` = `v` + 8 alphanumeric chars (unique across the case — see [global-vars/impl-json.md § Uniqueness Rule](plugins/variables/global-vars/impl-json.md#uniqueness-rule))
 - `id` = same as `var`
-- `elementId` = the task's elementId (for in-stage `wait-for-connector` task) or the trigger node's id (for case-level event trigger)
+- `elementId` = the task's elementId (in-stage `wait-for-connector` task), the trigger node's id (case-level event trigger), or `<ownerNodeId>-<ruleId>` (connector-bound condition rule — see [§ Target: connector-bound condition rule](#target-connector-bound-condition-rule))
 
-For **outputs** apply the dedup rule: collect existing output `var` values across every task / trigger already in `caseplan.json`; if a `var` already exists (e.g. `response`, `error` collide across multiple connector tasks/triggers), append a counter starting at 2 (`response2`, `error2`). Update `var`, `id`, `value`, `target` (when present); keep `name`, `displayName`, `source` unchanged.
+For **outputs** apply the dedup rule: collect existing output `var` values across every task / trigger / **connector-bound condition rule** already in `caseplan.json`; if a `var` already exists (e.g. `response`, `error` collide across multiple connector tasks / triggers / rules), append a counter starting at 2 (`response2`, `error2`). Update `var`, `id`, `value`, `target` (when present); keep `name`, `displayName`, `source` unchanged. **Rule outputs participate in the same global pool** — the dedup must walk condition `rules[][].uipath.outputs[]` across all 4 condition scopes (stage-entry / stage-exit / case-exit / task-entry, plus root `caseExitConditions` v19 / `metadata.caseExitRules` v20) in **both directions**: when a rule mints outputs, dedupe against tasks + triggers + rules; when a task / trigger mints outputs, dedupe against existing rule outputs. See [global-vars/impl-json.md § Uniqueness Rule](plugins/variables/global-vars/impl-json.md#uniqueness-rule) for the full enumeration.
 
-> **Trigger inputs:** trigger inputs do **not** get `elementId` (different from in-stage task inputs). See each plugin's `impl-json.md` for the target-specific shape.
+> **Trigger-NODE inputs only:** the case-level event-**trigger node** gets no `elementId` on its inputs (different from in-stage task inputs). This does **NOT** apply to connector-bound **condition rules** — a rule's inputs AND outputs BOTH get `elementId = <ownerNodeId>-<ruleId>` (= `root-<ruleId>` for case-exit). See [§ Target: connector-bound condition rule](#target-connector-bound-condition-rule), and each plugin's `impl-json.md` for the target-specific shape.
 
 ---
 
@@ -362,7 +363,83 @@ Dedup per [§ Deduplication](plugins/variables/bindings/impl-json.md). Source-of
 
 After writing root bindings, populate IS connection cache per [bindings-v2-sync.md § Populate IS connection cache](bindings-v2-sync.md). Skip if `case spec` failed.
 
-> **`bindings_v2.json` regeneration is deferred** — runs once at end of Step 9.7 (after all connector tasks/triggers), not per-task. See [bindings-v2-sync.md § When to Run](bindings-v2-sync.md).
+> **`bindings_v2.json` regeneration is deferred and batched.** Runs at three points, not per-target: end of Phase 2 Step 9 (non-connector tasks), end of Phase 3 Step 9.7 (connector tasks + triggers), and end of Phase 3 **Step 10** (connector condition rules across all 4 scopes). See [bindings-v2-sync.md § When to Run](bindings-v2-sync.md#when-to-run).
+
+---
+
+## Target: connector-bound condition rule
+
+A `wait-for-connector` rule inside a condition (`…conditions[].rules[i][j]`) binds the connector under the rule's **`uipath`** — structurally the same block the in-stage task writes under `data`. **The CLI cannot author this** (`buildRule` in `case-tool` emits a bare `{ rule, id, conditionExpression }` with no `uipath`); write `rule.uipath` directly per this recipe. Used by all four condition plugins.
+
+### Differences vs the in-stage task
+
+| Aspect | In-stage task | Connector-bound rule |
+|---|---|---|
+| Container | `task.data` | `rule.uipath` |
+| `serviceType` | `Intsvc.WaitForEvent` | `Intsvc.WaitForEvent` (same) |
+| `elementId` on inputs/outputs | `<stageId>-<taskId>` | `<ownerNodeId>-<ruleId>` |
+| Task-level fields (`type`, `displayName`, `isRequired`, `shouldRunOnlyOnce`) | yes | none — it's a rule, not a node |
+| `conditionExpression` | n/a | optional extra `=js:` gate on **case state** (`vars.X` / `metadata`) — NOT the event payload (no `event` namespace) |
+
+`<ownerNodeId>` = the **stage id** for stage-entry / stage-exit / task-entry rules (all stage-scoped); **`root`** for case-exit rules (v19 `root.caseExitConditions` / v20 `metadata.caseExitRules`).
+
+### Procedure (Phase 3)
+
+1. Resolve the connector in planning exactly as the task does — [§ Planning Pipeline](#planning-pipeline). The condition plugin's `planning.md` records the same fields (`type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter`). **Event parameters and filter accept `=vars.X` / `=js:` expressions exactly like the task** — they compile into `rule.uipath.context` / filter via `case spec --type trigger --input-details` (`input-values` + filter). Only the literal request `body` input is value-less (an event sends no body).
+2. Run `case spec --type trigger --input-details` ([§ Phase 3 Implementation](#phase-3-implementation--single-cli-call)) to mint the populated `caseShape`.
+3. Substitute `{{CONN_BINDING_ID}}` / `{{FOLDER_BINDING_ID}}` in `caseShape.context` ([§ Step 4](#step-4--substitute-placeholders-in-caseshapecontext)). If the caseShape carries a `{{TRIGGER_REGISTRATION_KEY}}` entry (event-parameter connectors only), substitute it exactly as the task does ([§ Step 3](#step-3--mint-binding-ids-and-when-applicable-trigger-registration-key)) — there is no rule-specific variant.
+4. Mint `var` / `id` / `elementId` on `caseShape.inputs[]` / `outputs[]` ([§ Step 5](#step-5--mint-var--id--elementid-on-inputs-and-outputs)), with `elementId = <ownerNodeId>-<ruleId>`. Apply the output dedup rule.
+5. Write the rule:
+
+```json
+{
+  "id": "<ruleId>",
+  "rule": "wait-for-connector",
+  "uipath": {
+    "serviceType": "Intsvc.WaitForEvent",
+    "context": "<caseShape.context — placeholders substituted>",
+    "inputs":  "<caseShape.inputs  — var/id/elementId minted>",
+    "outputs": "<caseShape.outputs — var/id/elementId minted, dedup applied>",
+    "bindings": []
+  },
+  "conditionExpression": "<optional =js: gate on case state, e.g. vars.X — NOT the event payload>"
+}
+```
+
+6. Append root bindings (ConnectionId + FolderKey) and run the deferred `bindings_v2` sync — identical to the task ([§ Root-level bindings](#root-level-bindings)).
+
+### tasks.md fields (planning)
+
+A connector-bound rule's condition T-entry records these (alongside the scope's normal fields):
+
+```markdown
+- rule-type: wait-for-connector
+- type-id: "<uiPathActivityTypeId>"
+- connection-id: "<connection-id>"
+- connector-key: "<connector-key>"
+- object-name: "<object>"
+- event-operation: "<EVENT_OP>"
+- event-mode: "polling"               # or "webhooks"
+- input-values: { "eventParameters": { ... } }   # resolved IDs; omit when none
+- filter: { ... }                     # optional FilterTree; omit when none
+- condition-expression: "=js:vars.X..."  # optional gate on case state — NOT the event payload
+- outputs:                            # optional — bind rule outputs to case variables
+  - "<schemaField> -> <caseVar>"      # extract — rule's response field to case variable
+  - "<caseVar> = <expression>"        # assign — literal / =js: expression / =vars.X
+```
+
+The `outputs:` block (optional) binds the rule's `response` / `Error` to case variables — same `->` / `=` operator semantics as a connector task. Full shapes + dispatcher: [io-binding/impl-json.md § Output Binding Shapes for Connector Condition Rules](plugins/variables/io-binding/impl-json.md#output-binding-shapes-for-connector-condition-rules).
+
+Rule `id`s are opaque to the FE (no format validation on import) — `Rule_xxxxxx` and `rxxxxxxxx` both work. Two hard requirements: (a) `elementId = <ownerNodeId>-<ruleId>` built from the exact id written; (b) **`rule.id` must be unique within the case** — the BPMN node id `ConnectorEvent_${rule.id}_${elementId}` derives from it, so a collision corrupts the case graph.
+
+### Caveats
+
+- **Not a case-start trigger.** A connector rule compiles to an in-flight wait (ReceiveTask / event subprocess), so it gets **no entry-points.json entry** and **no rule-specific registration key** — FE `PackagingUtil` trigger registration is gated on `Intsvc.EventTrigger` start events only, which a rule is not. If the `case spec` caseShape carries a `metadata.body.bindings[Property]` registration entry (event-parameter connectors), substitute it exactly as the task does (Step 3 / Step 4); there is nothing rule-specific.
+- **CLI `validate` does NOT check `rule.uipath`.** The case-tool connector validator is task-only (reads `task.data`). A passing Phase-4 validate does **not** confirm a connector rule is valid — Studio Web (or an FE round-trip) is the real check. Emit the `uipath` block correctly; do not rely on validate to catch omissions.
+
+### Placeholder fallback
+
+On `case spec` failure or `<UNRESOLVED>` `type-id` / `connection-id` / `connector-key`, emit the rule **without** its `uipath` block — `{ id, rule: "wait-for-connector", conditionExpression? }`. The rule itself is not a placeholder; only the connector configuration (the `uipath` payload) is deferred until the registry resolves, exactly like task connector data deferred via `data:{}`. Absence of `uipath` naturally skips the dependent subsystems: io-binding has no `outputs[]` to wire, root bindings has no Connection/Folder pair to add, IS-cache has no entry to register, global var-id dedup has no outputs to consider, and the Step-10 `bindings_v2` sync has nothing to regenerate for this rule. Stamp the `tasks.md` entry with `<UNRESOLVED>` markers per Rule 8 and log per [logging/impl-json.md](plugins/logging/impl-json.md). Upgrade by re-running the [§ Procedure](#procedure-phase-3) once the connector resolves; same upgrade flow as `placeholder-tasks.md § Upgrade Procedure` for connector tasks.
 
 ---
 

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -230,7 +230,7 @@ One Read of `caseplan.json` at Step 10 entry. Group `tasks.md §4.7` entries by 
 | Stage entry | one stage | `nodes[stage].data.entryConditions` |
 | Stage exit | one stage | `nodes[stage].data.exitConditions` |
 | Task entry | one task | `data.entryConditions` on the task object |
-| Case exit | root | v19: `root.data.caseExitConditions`; v20: `metadata.caseExitRules` |
+| Case exit | root | v19: `root.caseExitConditions`; v20: `metadata.caseExitRules` |
 
 Skip the re-Read between sibling Edits. One validate at section end. Per-scope composition rules live in the matching plugin's `impl-json.md`:
 
@@ -238,6 +238,10 @@ Skip the re-Read between sibling Edits. One validate at section end. Per-scope c
 - Stage exit → [`plugins/conditions/stage-exit-conditions/impl-json.md`](plugins/conditions/stage-exit-conditions/impl-json.md)
 - Task entry → [`plugins/conditions/task-entry-conditions/impl-json.md`](plugins/conditions/task-entry-conditions/impl-json.md)
 - Case exit → [`plugins/conditions/case-exit-conditions/impl-json.md`](plugins/conditions/case-exit-conditions/impl-json.md)
+
+> **Connector-bound rules need a CLI gather.** A `wait-for-connector` rule in any scope is NOT a pure JSON write — it requires a `uip maestro case spec --type trigger` call (like Step 9.7 connector tasks) to mint its `uipath` block, plus root bindings + IS-cache + deferred `bindings_v2` sync. Gather per `(scope, target)`, then write. See [connector-trigger-common.md § Target: connector-bound condition rule](connector-trigger-common.md#target-connector-bound-condition-rule). CLI `validate` does NOT check `rule.uipath`.
+
+> **Step 10 ends with a `bindings_v2` sync.** After all connector rules across the 4 scopes are written, run the third batched `bindings_v2.json` regeneration + IS-cache population — see [bindings-v2-sync.md § When to Run](bindings-v2-sync.md#when-to-run) (point 3). Without this third sync, rule-introduced Connection/Folder bindings + IS-cache entries don't land until the post-Phase-3 catch-all and `resource refresh` misses them.
 
 ## Step 11 — SLA and escalation (per-target Edit batch)
 

--- a/skills/uipath-maestro-case/references/placeholder-tasks.md
+++ b/skills/uipath-maestro-case/references/placeholder-tasks.md
@@ -75,6 +75,10 @@ Timers are a built-in type — they are never placeholders because they have no 
 
 Case-level event triggers (`type: "case-management:Trigger"` with `serviceType: "Intsvc.EventTrigger"`) follow the same pattern but use a different shape — trigger nodes need `data.label` / `description` / `parentElement` to render at all, so the placeholder keeps those plus `data.uipath: { serviceType: "Intsvc.EventTrigger" }`. Full spec in [`plugins/triggers/event/impl-json.md` § Placeholder fallback](plugins/triggers/event/impl-json.md). Manual and timer triggers are never placeholders (no registry dependency).
 
+### Connector condition rules
+
+When a `wait-for-connector` rule's connector hasn't resolved at write-time, the rule is emitted without `uipath` — the rule itself is not a placeholder; only its connector configuration is deferred (same pattern as task `data:{}`). Full recipe + skip behavior + upgrade path: [connector-trigger-common.md § Placeholder fallback](connector-trigger-common.md#placeholder-fallback).
+
 ## `tasks.md` Planning-Entry Shape
 
 A placeholder-bound entry keeps every structural field and moves the lost wiring into a fenced code block the user will act on later:

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -65,29 +65,21 @@ Requires `marksCaseComplete: true`. Completes when every stage flagged `data.isR
 
 Requires `marksCaseComplete: false`. Swap `rule` to `selected-stage-exited` for exit-without-completion semantics.
 
-### wait-for-connector — external event
+### wait-for-connector — bind a connector event
 
-```json
-"rules": [[
-  {
-    "id": "Rule_xxxxxx",
-    "rule": "wait-for-connector",
-    "conditionExpression": "=js:event.type === 'case_closed'"
-  }
-]]
-```
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Root-scoped: `elementId = root-<ruleId>` on BOTH `uipath.inputs[]` and `uipath.outputs[]`** (not a stage id; the input `body` gets it too, not only the outputs). Valid for both `marksCaseComplete: true` and `false`. `conditionExpression` optional. If `type-id` / `connection-id` / `connector-key` is `<UNRESOLVED>`, omit `uipath` (rule emitted without its connector configuration; see [connector-trigger-common.md § Placeholder fallback](../../../connector-trigger-common.md#placeholder-fallback)).
 
-Valid for both `marksCaseComplete: true` and `false`.
+**Rule output binding.** If the T-entry has `outputs:`, dispatch `rule.uipath.outputs[]` per [io-binding/impl-json.md § Output Binding Shapes for Connector Condition Rules](../../variables/io-binding/impl-json.md#output-binding-shapes-for-connector-condition-rules) **as the last step — after rule write, before root bindings**. `elementId` stays `root-<ruleId>` on every output entry. Skip when `uipath` is absent.
 
 ## Rule-Type × marksCaseComplete Matrix
 
 | `marksCaseComplete` | `rule` | Required extra field |
 |---|---|---|
 | `true` | `required-stages-completed` | — |
-| `true` | `wait-for-connector` | — |
+| `true` | `wait-for-connector` | `uipath` connector configuration |
 | `false` | `selected-stage-completed` | `selectedStageId` |
 | `false` | `selected-stage-exited` | `selectedStageId` |
-| `false` | `wait-for-connector` | — |
+| `false` | `wait-for-connector` | `uipath` connector configuration |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
@@ -98,3 +90,5 @@ Confirm the schema-appropriate array contains the new object with `id`, `marksCa
 - **v20** → `metadata.caseExitRules[]`
 
 Verify NO leakage: in v19 mode there is no `metadata.caseExitRules`; in v20 mode there is no `root` key at all.
+
+For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `root-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -20,7 +20,9 @@ Every case-exit condition declared in sdd.md gets its own T-task — **including
 | `marks-case-complete` | sdd.md | `true` for normal completion, `false` for non-completing exits |
 | `rule-type` | From catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
-| `condition-expression` | Required for `wait-for-connector` rule-type | |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional on any rule-type | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning). |
 
 ## Rule-Type Catalog (case-exit scope)
 
@@ -31,7 +33,7 @@ Allowed `ruleType` values depend on `marks-case-complete`:
 | Rule type | Meaning | Extra fields |
 |-----------|---------|--------------|
 | `required-stages-completed` | **Preferred.** Case completes when every stage with `isRequired: true` (set in the stage node's `data.isRequired`) has completed. No stage list needed. | — |
-| `wait-for-connector` | Wait for an external connector event to close the case. | `conditionExpression` |
+| `wait-for-connector` | Wait for an external connector event to close the case (fills `uipath`). | connector fields; `conditionExpression` optional |
 
 **When `marks-case-complete: false`** (the case exits without closing):
 
@@ -39,7 +41,7 @@ Allowed `ruleType` values depend on `marks-case-complete`:
 |-----------|---------|--------------|
 | `selected-stage-completed` | Exit triggered by a specific stage completing. | `selectedStageId` |
 | `selected-stage-exited` | Exit triggered by a specific stage being exited (even without completing). | `selectedStageId` |
-| `wait-for-connector` | Wait for an external connector event. | `conditionExpression` |
+| `wait-for-connector` | Wait for an external connector event (fills `uipath`). | connector fields; `conditionExpression` optional |
 
 ## Preferred Pattern
 
@@ -59,7 +61,9 @@ Case exit conditions are created **after** all stages exist (so `selectedStageId
 - marks-case-complete: true
 - rule-type: required-stages-completed
 - selected-stage: "<stage-name>"        # only for selected-stage-* rule-types
-- condition-expression: "<expr>"         # only for wait-for-connector
+- condition-expression: "=js:vars.X..."  # optional gate on case state, NOT the event payload (wait-for-connector also needs connector fields — see catalog)
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -66,21 +66,11 @@ Swap `rule` to `selected-stage-completed` when completion semantics are required
 
 Fires when an upstream stage exits via a `wait-for-user` exit condition and the user picks this stage as the next one. The stage must opt in by declaring this rule — only stages with `user-selected-stage` are presented in the picker.
 
-### wait-for-connector — interrupting on external event
+### wait-for-connector — bind a connector event
 
-```json
-"rules": [[
-  {
-    "id": "Rule_xxxxxx",
-    "rule": "wait-for-connector",
-    "conditionExpression": "=js:event.fraudScore > 0.8"
-  }
-]]
-```
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Stage-scoped: `elementId = <stageId>-<ruleId>`.** `conditionExpression` is optional — an extra `=js:` gate on **case state** (`vars.X`), NOT the event payload (no `event` namespace); set `isInterrupting: true` on the condition for exception/fraud/escalation flows. If `type-id` / `connection-id` / `connector-key` is `<UNRESOLVED>`, omit `uipath` (rule emitted without its connector configuration; see [connector-trigger-common.md § Placeholder fallback](../../../connector-trigger-common.md#placeholder-fallback)).
 
-Set `isInterrupting: true` for exception/fraud/escalation flows.
-
-`conditionExpression` uses bare `=js:<expr>` (no outer parens). For combined boolean expressions, wrap each sub-clause in parens before joining: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
+**Rule output binding.** If the T-entry has `outputs:`, dispatch `rule.uipath.outputs[]` per [io-binding/impl-json.md § Output Binding Shapes for Connector Condition Rules](../../variables/io-binding/impl-json.md#output-binding-shapes-for-connector-condition-rules) **as the last step — after rule write, before root bindings**. `elementId` stays `<stageId>-<ruleId>` on every output entry. Skip when `uipath` is absent.
 
 ## Rule-Type Catalog
 
@@ -90,10 +80,10 @@ Set `isInterrupting: true` for exception/fraud/escalation flows.
 | `selected-stage-completed` | `selectedStageId` |
 | `selected-stage-exited` | `selectedStageId` |
 | `user-selected-stage` | — |
-| `wait-for-connector` | — |
+| `wait-for-connector` | `uipath` connector configuration (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires.
 
 ## Post-Write Verification
 
-Confirm target stage's `data.entryConditions[]` contains the new object with `id`, `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.
+Confirm target stage's `data.entryConditions[]` contains the new object with `id`, `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `<stageId>-<ruleId>`, and the ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -21,7 +21,9 @@ Every stage with an **Entry Condition** declared in sdd.md gets its own stage-en
 | `is-interrupting` | sdd.md (default `false`) | `true` if the condition interrupts the current stage |
 | `rule-type` | Pick from the catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | ID of the referenced stage |
-| `condition-expression` | Required for `wait-for-connector` rule-type (and optional for others) | |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — resolved via [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional on any rule-type | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning). |
 
 ## Rule-Type Catalog (stage-entry scope)
 
@@ -33,7 +35,7 @@ Allowed `ruleType` values and when to pick each:
 | `selected-stage-completed` | Fires when a specific upstream stage completes | `selectedStageId` |
 | `selected-stage-exited` | Fires when a specific upstream stage exits (even without completing) | `selectedStageId` |
 | `user-selected-stage` | Fires when an upstream stage exits via a `wait-for-user` exit condition and the user selects this stage as the next one. Only stages carrying this rule appear in the picker. | — |
-| `wait-for-connector` | Waits for a connector event | `conditionExpression` |
+| `wait-for-connector` | Waits for a connector event (binds an IS connector trigger under `uipath`) | connector fields (above); `conditionExpression` optional |
 
 `is-interrupting: true` means the condition can fire **while another stage is active** and will interrupt it. Use for exception/interrupt flows.
 
@@ -53,3 +55,5 @@ Stage entry conditions are created **after** all stages exist (Step 7 in impleme
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -67,19 +67,11 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 `selectedTasksIds` is a JSON string array, not a comma-separated string.
 
-### wait-for-connector — external event
+### wait-for-connector — bind a connector event
 
-```json
-"type": "exit-only",
-"marksStageComplete": true,
-"rules": [[
-  {
-    "id": "Rule_xxxxxx",
-    "rule": "wait-for-connector",
-    "conditionExpression": "=js:event.type === 'approved'"
-  }
-]]
-```
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Stage-scoped: `elementId = <stageId>-<ruleId>`.** Place it in the exit condition with `type` / `marksStageComplete` like the other exit rules above. `conditionExpression` optional. If `type-id` / `connection-id` / `connector-key` is `<UNRESOLVED>`, omit `uipath` (rule emitted without its connector configuration; see [connector-trigger-common.md § Placeholder fallback](../../../connector-trigger-common.md#placeholder-fallback)).
+
+**Rule output binding.** If the T-entry has `outputs:`, dispatch `rule.uipath.outputs[]` per [io-binding/impl-json.md § Output Binding Shapes for Connector Condition Rules](../../variables/io-binding/impl-json.md#output-binding-shapes-for-connector-condition-rules) **as the last step — after rule write, before root bindings**. `elementId` stays `<stageId>-<ruleId>` on every output entry. Skip when `uipath` is absent.
 
 ### wait-for-user — manual decision gate
 
@@ -106,9 +98,9 @@ Routes the case back to the originating stage.
 | `marksStageComplete` | `rule` | Required extra field |
 |---|---|---|
 | `true` | `required-tasks-completed` | — |
-| `true` | `wait-for-connector` | — |
+| `true` | `wait-for-connector` | `uipath` connector configuration |
 | `false` | `selected-tasks-completed` | `selectedTasksIds` (array) |
-| `false` | `wait-for-connector` | — |
+| `false` | `wait-for-connector` | `uipath` connector configuration |
 
 `conditionExpression` is optional on every rule — add it to any rule to further gate when it fires. Use bare `=js:<expr>` (no outer parens); for combined boolean expressions wrap each sub-clause in parens: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -23,7 +23,9 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | `marks-stage-complete` | sdd.md (default depends on type) | `true` for completion exits, `false` for diverging routes |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `condition-expression` | Required for `wait-for-connector` | |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional on any rule-type | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning). |
 
 ## Exit Type Catalog
 
@@ -41,13 +43,13 @@ Allowed `ruleType` values depend on `marks-stage-complete`:
 | Rule type | Extra fields |
 |-----------|--------------|
 | `required-tasks-completed` | — |
-| `wait-for-connector` | `conditionExpression` |
+| `wait-for-connector` | connector fields (fills `uipath`); `conditionExpression` optional |
 
 **When `marks-stage-complete: false` (exit-only, routing):**
 | Rule type | Extra fields |
 |-----------|--------------|
 | `selected-tasks-completed` | `selectedTasksIds` (comma-separated) |
-| `wait-for-connector` | `conditionExpression` |
+| `wait-for-connector` | connector fields (fills `uipath`); `conditionExpression` optional |
 
 ## Ordering
 
@@ -67,3 +69,5 @@ Stage exit conditions are created **after** all tasks in the stage have been add
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -72,17 +72,11 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 `conditionExpression` uses bare `=js:<expr>` (no outer parens) — per FE convention for conditions. Operators (`>`, `<`, `===`, etc.) and function calls go inline. For combined boolean expressions, wrap each sub-clause in parens before joining: `=js:(vars.X === 'foo') && (vars.Y > 5)`. Full per-sink rule: [bindings-and-expressions.md § Canonical form per sink](../../../bindings-and-expressions.md#canonical-form-per-sink).
 
-### wait-for-connector — external event
+### wait-for-connector — bind a connector event
 
-```json
-"rules": [[
-  {
-    "id": "rxxxxxxxx",
-    "rule": "wait-for-connector",
-    "conditionExpression": "=js:event.type === 'order_received'"
-  }
-]]
-```
+Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule) (canonical rule JSON + procedure there) — a bare rule (no `uipath`) is rejected by Studio Web. **Stage-scoped: `elementId = <stageId>-<ruleId>`.** `conditionExpression` optional. If `type-id` / `connection-id` / `connector-key` is `<UNRESOLVED>`, omit `uipath` (rule emitted without its connector configuration; see [connector-trigger-common.md § Placeholder fallback](../../../connector-trigger-common.md#placeholder-fallback)).
+
+**Rule output binding.** If the T-entry has `outputs:`, dispatch `rule.uipath.outputs[]` per [io-binding/impl-json.md § Output Binding Shapes for Connector Condition Rules](../../variables/io-binding/impl-json.md#output-binding-shapes-for-connector-condition-rules) **as the last step — after rule write, before root bindings**. `elementId` stays `<stageId>-<ruleId>` on every output entry. Skip when `uipath` is absent.
 
 ### runs-sequentially — sequential group with optional parallel siblings
 
@@ -98,7 +92,7 @@ Rules use DNF — outer array is OR, inner array is AND.
 |---|---|
 | `current-stage-entered` | — |
 | `selected-tasks-completed` | `selectedTasksIds` (array) |
-| `wait-for-connector` | — |
+| `wait-for-connector` | `uipath` connector configuration (see [common](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
 | `adhoc` | — |
 | `runs-sequentially` | — |
 
@@ -106,4 +100,4 @@ Rules use DNF — outer array is OR, inner array is AND.
 
 ## Post-Write Verification
 
-Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`) and `rules` with the expected `rule` value plus any required side field.
+Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`) and `rules` with the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated, inputs/outputs `elementId` is `<stageId>-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -20,7 +20,9 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `display-name` | sdd.md (optional) | |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
-| `condition-expression` | Optional | |
+| `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
+| `condition-expression` | Optional | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning). |
 
 ## Rule-Type Catalog (task-entry scope)
 
@@ -28,7 +30,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 |-----------|---------|--------------|
 | `current-stage-entered` | Fires when the containing stage is entered | — |
 | `selected-tasks-completed` | Fires when specific sibling tasks in the same stage complete | `selectedTasksIds` |
-| `wait-for-connector` | Waits for a connector event | `conditionExpression` |
+| `wait-for-connector` | Waits for a connector event (binds an IS connector trigger under `uipath`) | connector fields; `conditionExpression` optional |
 | `adhoc` | Ad hoc tasks run only when a user triggers them from the case app. | `conditionExpression` (optional) |
 | `runs-sequentially` | Sequential tasks run in the order they appear in the stage from top to bottom. Parallel members of the group share a `lane`; solo members get own lane. | `conditionExpression` (optional) |
 
@@ -45,7 +47,9 @@ Task entry conditions are created **after** all tasks in the stage have been add
 - display-name: "<name>"
 - rule-type: selected-tasks-completed
 - selected-tasks: "<Task A>, <Task B>"
-- condition-expression: "<expr>"          # for adhoc / wait-for-connector
+- condition-expression: "<expr>"          # optional gate (adhoc / wait-for-connector); wait-for-connector also needs connector fields
 - order: after T<m>
 - verify: Confirm Result: Success, capture ConditionId
 ```
+
+> `rule-type: wait-for-connector` also needs the connector fields — see [connector-trigger-common.md § tasks.md fields (planning)](../../../connector-trigger-common.md#tasksmd-fields-planning).

--- a/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
@@ -86,6 +86,23 @@ Every `var` / `id` must be globally unique across the case. When a name collides
 
 The `source` and `name` fields keep the original value — only `var` / `id` / `target` get the suffix.
 
+### Pool composition (what to scan)
+
+Build the uniqueness pool from EVERY `var` / `id` currently in `caseplan.json`. The pool is global — minting in any one location must consult ALL of the following:
+
+| Source | JSON path | Notes |
+|---|---|---|
+| Root variables | `root.data.uipath.variables.{inputs,outputs,inputOutputs}[]` (v19) / `variables.{inputs,outputs,inputOutputs}[]` (v20) | The canonical case-variable namespace |
+| Task outputs | `nodes[<stage>].data.tasks[<lane>][].data.outputs[]` (for every task) | Self-declared task outputs |
+| Trigger outputs | `nodes[<trigger>].data.uipath.outputs[]` (for every trigger node) | Plain-name auto-emit + Pattern C wires |
+| **Stage entry / exit rule outputs** | `nodes[<stage>].entryConditions[].rules[][].uipath.outputs[]` AND `nodes[<stage>].exitConditions[].rules[][].uipath.outputs[]` | Connector-bound condition rules — outputs minted under `elementId = <stageId>-<ruleId>` |
+| **Case-exit rule outputs** | `root.caseExitConditions[].rules[][].uipath.outputs[]` (v19) / `metadata.caseExitRules[].rules[][].uipath.outputs[]` (v20) | Connector-bound case-exit rules — outputs minted under `elementId = root-<ruleId>` |
+| **Task-entry rule outputs** | `nodes[<stage>].data.tasks[<lane>][].entryConditions[].rules[][].uipath.outputs[]` (for every task) | Connector-bound task-entry rules — outputs minted under `elementId = <stageId>-<ruleId>` |
+
+**Both directions.** When a connector rule mints outputs, dedupe against the union {tasks ∪ triggers ∪ rules ∪ root}. When a task or trigger mints outputs, dedupe against existing rule outputs too — NOT just tasks + triggers. The shared FE form (`FPSFormServiceTypeFields`) registers rule outputs in the same global pool (`getAllVariables()`), so any duplicate `var` / `id` across the {task, trigger, rule} space collapses in `allInputOutputsByElementMap` and cross-wires ownership at round-trip.
+
+**Skip guard.** Rules with no `uipath.outputs[]` (connector configuration unresolved — see [`connector-trigger-common.md § Placeholder fallback`](../../../connector-trigger-common.md#placeholder-fallback)) contribute zero outputs to the pool and must be skipped during enumeration. Same skip pattern as placeholder tasks (`data:{}`).
+
 ## Inputs the plugin reads at Phase 3 Step 6.2
 
 1. **`tasks.md`** variable T-entries — for category, type, default, sourceTrigger(s), sourceField(s)
@@ -404,3 +421,17 @@ This is the **reassign shape** (FE Scenario B/D). The `originalVar` field tells 
 For `=` operator rows (Scenario E), the task plugin emits a separate `custom: true` entry — see Custom Outputs section above.
 
 Per Out-arg companion rule above, the variables plugin ALWAYS writes a `root.inputOutputs[]` companion for Out-args (no longer conditional on Default). For case Variables sourced via `->` from tasks, the companion is also written so the variable is picker-visible at Case Variables panel.
+
+## Connector-Rule Output → variable resolution
+
+Connector condition rules (`rule.uipath.outputs[]`) participate in the case-variable namespace through the same shapes as task outputs — the FE renders the SAME `FPSFormServiceTypeFields` form for both, and `updateRootVariables` is dispatched for rule outputs too (`FPSFormServiceTypeFields.tsx:80`). The variable resolution path is:
+
+- **Extract (`->`)** — rule emits a reassign-shape entry on `rule.uipath.outputs[]` with `originalVar` (load-bearing for `mutateRootVariables` to skip root-mirroring), and Loop B emits the matching `root.inputOutputs[]` companion (`elementId: "root"`, `custom: true`) from the SDD's `Category=Variable` row. The rule's `elementId` on the output entry is `<ownerNodeId>-<ruleId>` (= `<stageId>-<ruleId>` stage-scoped, `root-<ruleId>` case-exit).
+- **Assign (`=`)** — rule emits a `custom: true` Scenario E entry on `rule.uipath.outputs[]` with `value: "<expression>"`. No root mirror per `isUpdateExistingOutput` filter. Loop B emits the companion only if the case variable is declared as `Category=Variable` with a Default.
+- **Bare** (no operator) — rule output is gate-local (named like the spec field, e.g. `response` / `Error`); not a case variable. No companion written.
+
+The dispatcher logic lives in [io-binding/impl-json.md § Output Binding Shapes for Connector Condition Rules](../io-binding/impl-json.md#output-binding-shapes-for-connector-condition-rules) (the 3rd dispatch path, parallel to task dispatch). The condition plugins (`plugins/conditions/*/impl-json.md`) invoke it as the last step of their `wait-for-connector` recipe.
+
+Loop B (this file) handles the COMPANION emission — it scans `tasks.md` Case Variables rows agnostically of producer type. A `Category=Variable` row whose producer is a connector rule's `->` extract gets the same companion shape as one whose producer is a task's `->` extract. The producer (task plugin OR condition plugin) is responsible for writing the upstream `outputs[]` entry referencing the companion via `var: <caseVar.id>`.
+
+> **Skip guard.** Rules with no `uipath` (connector configuration unresolved) contribute no outputs to the global pool and no companions to Loop B — see [`connector-trigger-common.md § Placeholder fallback`](../../../connector-trigger-common.md#placeholder-fallback).

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -48,6 +48,26 @@ Cross-cutting rules:
 - Target case variable on both `->` and `=` MUST exist in Case Variables table (validated at planning time).
 - [Uniqueness rule](../global-vars/impl-json.md#uniqueness-rule) applies to `var`/`id` on collision; `source` is never suffixed.
 
+## Output Binding Shapes for Connector Condition Rules
+
+The Output Binding Shapes above are operator-driven, not task-specific. The SAME shapes (`->` reassign with `originalVar`, `=` Scenario E with `custom: true`, bare-name auto-mint) apply when the SDD declares `Outputs:` rows on a `wait-for-connector` **condition rule** (in any of the 4 scopes: stage-entry, stage-exit, case-exit, task-entry). The connector-rule dispatch mirrors the connector-task dispatch with three targeting overrides:
+
+| Aspect | Connector task | Connector condition rule |
+|---|---|---|
+| Target array | `task.data.outputs[]` | `rule.uipath.outputs[]` |
+| Step 0 schema source | `tasks describe` / `case spec --input-details` `caseShape.outputs[]` | `case spec --type trigger --input-details` `caseShape.outputs[]` (already minted on `rule.uipath.outputs[]` by the connector-rule recipe — see [connector-trigger-common.md § Target: connector-bound condition rule](../../../connector-trigger-common.md#target-connector-bound-condition-rule)) |
+| `elementId` on each entry | `<stageId>-<taskId>` | `<ownerNodeId>-<ruleId>` — `<stageId>-<ruleId>` for stage-entry / stage-exit / task-entry; `root-<ruleId>` for case-exit |
+| Companion in `root.inputOutputs[]` (for `->` extract) | Required — `elementId: "root"`, `custom: true` | Required — same shape (`elementId: "root"`, `custom: true`) |
+| `=` Scenario E (custom output) | Permitted | Permitted — case variable assigned from rule response (`caseVar = response.X`), a literal, or an expression. NO root mirror per `isUpdateExistingOutput` filter. |
+
+**Uniqueness.** The [global pool](../global-vars/impl-json.md#uniqueness-rule) now includes rule outputs across all condition scopes — apply dedup against the union of tasks ∪ triggers ∪ rules ∪ root before minting.
+
+**When invoked.** Each condition plugin's `impl-json.md` invokes this dispatch as the LAST step of its `wait-for-connector` recipe — after writing `rule.uipath` (Step 5 of [connector-trigger-common.md § Procedure](../../../connector-trigger-common.md#procedure-phase-3)) and BEFORE running root bindings (Step 6). Iterate the rule's SDD `Outputs:` rows against the already-minted `rule.uipath.outputs[]` entries; rewrite each matched entry per the operator (`->` / `=` / bare). See the 4 condition `impl-json.md` files for the invocation site.
+
+**Skip guard.** Rules with no `rule.uipath` (connector configuration unresolved — see [`connector-trigger-common.md § Placeholder fallback`](../../../connector-trigger-common.md#placeholder-fallback)) — log `SKIPPED` and move on, same pattern as placeholder tasks (`data:{}`). Nothing to bind against until the connector resolves.
+
+**Runtime order.** The ReceiveTask captures the response into the bound case variables BEFORE the gateway evaluates `conditionExpression` — so extract-then-gate (`response.X -> caseVar`, then `=js:vars.caseVar…`) works.
+
 ## Binding Procedure
 
 For each task input in `tasks.md`:
@@ -218,6 +238,7 @@ All issues go to the shared issue list per [logging/impl-json.md](../../logging/
 | Check | Severity | Action |
 |---|---|---|
 | Placeholder task (no `data.inputs[]`) | `SKIPPED` | Skip all bindings |
+| Placeholder connector rule (no `rule.uipath`) | `SKIPPED` | Skip rule output bindings (nothing minted) |
 | Input name not found (exact match) | `ERROR` | Skip binding — log available inputs |
 | Source output not found (exact match) | `ERROR` | Skip binding — log available outputs |
 | `=vars.X` not in any task `outputs[].id` or root `inputOutputs[].id` / `inputs[].id` | `ERROR` | Skip binding |

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -310,7 +310,7 @@ Defines per-task detail blocks. Every task opens with an **Entry Condition** blo
 |---|---|
 | `current-stage-entered` | First task in stage (REQUIRED; emit explicitly, never imply). Connector tasks auto-inject this — render it first even when explicit rows follow. |
 | `selected-tasks-completed("<Task>")` | Sibling-gated task (e.g., after upstream task in same stage). Multiple tasks comma-separated inside the parens. |
-| `wait-for-connector` | Async connector callback. Pair with `conditionExpression` for inbound payload shape. |
+| `wait-for-connector` | Async connector callback. Pair with `conditionExpression` to gate on **case state** (`vars.X`); the event payload is not accessible (no `event` namespace). To gate on payload content, use **extract-then-gate**: bind `response.field -> caseVar` in the rule's Outputs block, then reference `=js:vars.caseVar` in the expression. |
 | `adhoc` | Manual fire from the case app. Optional gating expression. |
 | `runs-sequentially` | Tasks in a lane that should run top-to-bottom in declaration order. |
 
@@ -648,7 +648,7 @@ Before Approve atomic-renames `sdd.draft.md` → `sdd.md`, Phase 0 runs these ch
 2. **Render-contract check.** Every required cell in §Case content rules, §Stage content rules, §Task content rules has a concrete value (no banned `—` / `<UNRESOLVED>`).
 3. **Decision-task button check.** Every `action` task with `is_decision: Yes` has ≥ 2 buttons; every button's `Maps To` LHS references a declared §1.5 variable (by `Name`) or `taskOutcome`.
 4. **Recipient encoding check.** Every `action` task recipient uses one of the five typed prefixes (`Email:` / `User:` / `UserGroup:` / `Role:` / `Expression:`) — no bare strings.
-5. **Connector-id check.** Every `wait-for-connector` / `execute-connector-activity` task has concrete `Connection ID` AND `Activity Type ID`, OR a paired `high`-severity review item.
+5. **Connector-id check.** Every `wait-for-connector` / `execute-connector-activity` **task** has concrete `Connection ID` AND `Activity Type ID`. Every `wait-for-connector` **condition rule** (in any scope — stage-entry / stage-exit / case-exit / task-entry) has a `Connector Rule Detail` block resolving to a concrete `Connector Key` AND `Event Operation` (and `Connection ID` when not a tenant-default). Missing identity → paired `high`-severity review item.
 6. **Variable-lineage check.** Every variable closes (producer before consumer; no orphans).
 7. **Override-conflict check.** No compliance trigger phrase paired with a non-`action` task type without explicit user reconciliation in the transcript.
 8. **Alt-disposition coverage.** If ≥ 1 ExceptionStage exists, Section 1.4a is non-empty OR a `high`-severity review item is open.


### PR DESCRIPTION
Stacked on #1047. Brings the `uipath-maestro-case` skill's `wait-for-connector` **condition rule** support to full parity with how the FE treats a connector rule. Today (after #1047) rules get only body injection (`rule.uipath` + `elementId` + root bindings). This PR makes the rule a first-class cross-cutting citizen — matching every connector-task behavior the FE applies, or explicitly documenting where it differs by design.

## Why

FE (`PO.Frontend@develop`) renders the SAME `FPSFormServiceTypeFields` form for both connector tasks and connector rules — including the output-binding UI that dispatches `updateRootVariables`. The skill's bindings/dedup/sync subsystems were task-shaped only, so an SDD `Outputs:` block on a rule was silently dropped, rule outputs didn't participate in the global var-id uniqueness pool, the `bindings_v2` sync didn't cover Step 10, and the unresolved-rule branch was indistinguishable from the FU-1 bug in the docs.

## Plan + Audit

Full planning artifact (FE truths, gap table A–S, ordered work, Definition of Done) lives at `case_knowledge/connector-rule-fe-parity-plan.md` (OneDrive; outside the repo per the personal-paths rule). It is the audit source — each phase commit references it.

## Phases (5 sequenced commits — tests deferred to a follow-up branch)

| Phase | Gap | Commit | Files | Scope |
|---|---|---|---|---|
| 1 | F · D · S · G/H | `2d9fb14b` | 2 | Doc fixes — kill the "inbound payload shape" misconception on conditionExpression; clarify event-params/filter ARE bindable on rules (only literal `body` is empty); `rule.id` must be unique; extend SDD-review connector-id check to rules |
| 2 | **A** (P0) | `9ddb82a2` | 2 | Global var-id uniqueness pool now includes `rules[][].uipath.outputs[]` across all 4 condition scopes + root case-exit. Bidirectional — task/trigger minting consults rules too |
| 3 | **B/C** (P1, must-keep) | `e75bb6cb` | 12 | Rule output → case-var binding. 3rd dispatch path in io-binding/impl-json.md; Connector-Rule Output → variable resolution section in global-vars; `Outputs:` block in connector-trigger-common's tasks.md fields; `outputs` in all 4 condition planning.md; io-binding invocation in all 4 condition impl-json.md; **Connector Rule Outputs** table in sdd-template.md (and corrected line 63 which previously said "does NOT bind outputs") |
| 4 | E1 + E2 | `de72bbaf` | 4 | Third `bindings_v2` sync point at end of Step 10 (after connector rules); rule-removal cleanup path; case-editing-operations node-deletion cascade extended to rules + new "Delete a connector condition rule" composite operation |
| 5 | **P** (task-model) | `d5ffa427` | 7 | Bare-rule placeholder is the legitimate shape (analog of task `data:{}` — `rule:"wait-for-connector"` is the discriminator). New "Connector condition rules" subsection in `placeholder-tasks.md` (shape, when-created, tasks.md placeholder shape, full upgrade procedure). "Placeholder branch" subsections in all 4 condition impl-json.md files. Skip-plumbing wired through io-binding + global-vars + bindings-v2-sync |

## Decisive FE truths driving this PR (verified against `PO.Frontend@develop`)

1. **Var/id uniqueness is GLOBAL.** `addVarIdsToInputsOutputs` (`CanvasTaskElementUtils.tsx:18-96`) seeds its uniqueness pool from `getAllVariables()` — every `id`/`var` across rules + tasks + triggers + root.
2. **Rule outputs CAN bind to case variables.** The shared `FPSFormServiceTypeFields` (`tsx:80`) dispatches `updateRootVariables` for rules too. `response.x -> caseVar` and `caseVar = expr` both work — same UX as a task. *(Earlier doc claim that rules can't bind outputs was wrong; sdd-template.md line 63 corrected in Phase 3.)*
3. **`conditionExpression` scope is case-state only** (`vars.X` / `metadata`) — no `event`/`response` namespace (FU-8 reaffirmed in this PR via gap F).
4. **Inputs: event-params + filter ARE bindable** via the shared `case spec --input-details` pipeline; only the literal request `body` input is empty.
5. **Bare rule placeholder shape is task-model.** `rule:"wait-for-connector"` is the discriminator (no `uipath` key). FE renders the rule with a "no configuration" warning, structure stays reviewable. Distinct from the connector-trigger placeholder (which keeps `data.uipath.serviceType` for render robustness).

## Enabled patterns

- **Extract-then-gate.** Bind `response.subject -> reviewSubject` on the rule, then gate `=js:vars.reviewSubject.includes("Review")` on the same rule. The ReceiveTask captures the response before the gateway evaluates the expression. This is the only way to gate on event payload content given the conditionExpression scope.
- **Multi-rule same-connector dedup.** Two stages each waiting on the same event get distinct output `var`/`id` automatically (`response` / `response2`).
- **Graceful placeholder fallback.** Unresolved connector → bare-rule placeholder + `<UNRESOLVED>` markers; build proceeds; upgrade procedure documented.

## Out of scope (filed in the plan as non-goals)

- Case-tool CLI validator gap (`connector-validator.ts` is task-only; rule.uipath validation should be added to `uip maestro case validate`).
- FE rule-renderer hardening on bare rules (FE-side concern).
- FE `CaseManagementGenerateConditionRules.ts` optional-chain audit.

## Test status

Coder_eval test authoring is **out of scope for this PR** — will land in a follow-up branch. Suggested test coverage (locked-in regressions):

- Rule-output dedup regression — 2 connector rules with default `response`; assert dedupe (gap A).
- Rule output → case-var extract — 1 rule with `response.subject -> caseSubject`; downstream gate references `vars.caseSubject` (gap B/C + F).
- Placeholder rule — unregistered connector; assert bare rule + `<UNRESOLVED>` markers + no root binding (gap P).

T1/T3/T5 from the existing alpha-published test suite (`case_coding_agent_tests/wait-for-connector-in-rules/`) continue to validate manually; T5 in particular should be **rebuilt** on this branch to exercise the now-supported extract-then-gate pattern (currently still ships with the simpler `vars.reviewStatus == "Open"` gate).

## Merge order

This PR depends on #1047. Merge order: #1047 first → this PR second. Squash-merge recommended per phase commit; the per-phase commit messages cite the gap rows for audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
