### PR TITLE
docs: document agent PR conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,19 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Key rules:
 6. **No secrets or personal paths** in committed files
 7. **CLI commands must use `--output json`** when output is parsed programmatically
 
+## Agent-Created Commits and PRs
+
+For commits and pull requests created from agent sessions in this repository:
+
+- Do not prefix PR titles with `[codex]`.
+- Use the repository's conventional scope in PR titles when applicable, e.g. `docs(uipath-maestro-flow): ...`.
+- Footnote every agent-created commit message and PR description with:
+
+```text
+🤖 Generated with Claude Code
+Co-Authored-By: Claude noreply@anthropic.com
+```
+
 ## File Conventions
 
 | File | Convention |


### PR DESCRIPTION
## Summary

Adds repo-level agent instructions for generated commits and pull requests:

- do not prefix PR titles with `[codex]`
- prefer repository conventional scopes in PR titles
- footnote agent-created commit messages and PR descriptions with the requested Claude Code footer

## Why

This makes the convention visible to future agent sessions through `CLAUDE.md` / `AGENTS.md`, instead of relying only on chat context.

## Validation

- `git diff --check`
- inspected commit message footer with `git log -1 --format=%B`

---
🤖 Generated with Claude Code
Co-Authored-By: Claude noreply@anthropic.com