### PR TITLE
chore(tests): prune task YAMLs to inherit experiment defaults

### DIFF
--- a/.claude/commands/lint-task.md
+++ b/.claude/commands/lint-task.md
@@ -180,6 +180,27 @@ The catalog is regenerated nightly by `.github/workflows/refresh-uip-catalog.yml
 
 Severity: **High** — always. No carve-outs; there is no valid reason to re-install the CLI the runner already provides.
 
+### Run-limit fields under agent:
+
+**Raise a Medium issue if** the task's `agent:` block contains any of: `max_turns`, `turn_timeout`, `task_timeout`.
+
+**Why it's wrong:** These fields were moved out of `agent:` into a top-level `run_limits:` block in the c/2026-05-12 unify-run-limits migration (see `coder_eval/src/coder_eval/orchestration/experiment.py:163`). The loader still hoists them with a `DeprecationWarning`, but the legacy location was scheduled for removal on 2026-05-20. Leaving them under `agent:` emits a warning every run and drifts from every other task in the repo.
+
+**Fix:** Move the field to a top-level `run_limits:` block. If `agent:` now has no remaining fields, drop the block entirely (defaults are inherited from the experiment). The `scripts/prune-task-defaults.py` script does this transformation automatically.
+
+```yaml
+# Before
+agent:
+  type: claude-code
+  max_turns: 40
+
+# After
+run_limits:
+  max_turns: 40
+```
+
+Severity: **Medium** — task still runs (loader hoists for now), but the deprecation window has elapsed and the warning pollutes every run.
+
 ## Phase 4 — Compose Per-Task Report
 
 For each task, print:

--- a/scripts/prune-task-defaults.py
+++ b/scripts/prune-task-defaults.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Prune redundant agent/run_limits fields from task YAMLs.
+
+For each task under tests/tasks/, compare every field in `agent:` and
+`run_limits:` against tests/experiments/default.yaml and remove any that match
+the inherited default. Also hoists deprecated `agent.max_turns` / `agent.turn_timeout`
+into top-level `run_limits` before pruning (see coder_eval orchestration/experiment.py:163).
+
+Usage:
+    scripts/prune-task-defaults.py              # apply in place
+    scripts/prune-task-defaults.py --dry-run    # show what would change
+    scripts/prune-task-defaults.py path/to/file.yaml [more.yaml ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from ruamel.yaml import YAML
+
+REPO = Path(__file__).resolve().parent.parent
+DEFAULTS_PATH = REPO / "tests" / "experiments" / "default.yaml"
+TASKS_ROOT = REPO / "tests" / "tasks"
+
+# Fields under `agent:` that coder_eval auto-hoists into top-level `run_limits`
+# (deprecated; warns to be removed 2026-05-20).
+HOISTABLE = ("max_turns", "turn_timeout", "task_timeout")
+
+
+def load_yaml(path: Path):
+    yaml = YAML()
+    yaml.preserve_quotes = True
+    yaml.width = 10_000  # don't reflow long lines
+    # Match the repo's 2-space indented list style: "  - key:" not "- key:".
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    return yaml, yaml.load(path.read_text())
+
+
+def prune_block(block, defaults: dict) -> list[str]:
+    """Remove keys whose value equals the default, or whose value is an empty dict/list.
+
+    Empty `{}` / `[]` carry no config — they're no-ops the coder_eval loader treats
+    the same as "key absent". Returns removed keys.
+    """
+    removed = []
+    if block is None:
+        return removed
+    defaults = defaults or {}
+    for key in list(block.keys()):
+        val = block[key]
+        if key in defaults and val == defaults[key]:
+            del block[key]
+            removed.append(f"{key} (matches default)")
+        elif isinstance(val, (dict, list)) and len(val) == 0:
+            del block[key]
+            removed.append(f"{key} (empty)")
+    return removed
+
+
+def process(path: Path, default_agent: dict, default_rl: dict, default_sandbox: dict, dry_run: bool) -> bool:
+    yaml, data = load_yaml(path)
+    if not isinstance(data, dict):
+        return False
+
+    changes: list[str] = []
+    agent = data.get("agent")
+    run_limits = data.get("run_limits")
+
+    # Hoist deprecated agent.{max_turns,turn_timeout,task_timeout} → run_limits.
+    if isinstance(agent, dict):
+        for field in HOISTABLE:
+            if field not in agent:
+                continue
+            if run_limits is None:
+                from ruamel.yaml.comments import CommentedMap
+
+                run_limits = CommentedMap()
+                data["run_limits"] = run_limits
+                # Visually separate the new block from preceding content.
+                data.yaml_set_comment_before_after_key("run_limits", before="\n")
+            if isinstance(run_limits, dict) and field in run_limits:
+                if run_limits[field] == agent[field]:
+                    del agent[field]
+                    changes.append(f"drop agent.{field} (duplicate of run_limits.{field})")
+                else:
+                    # conflict: prefer the canonical run_limits value, drop deprecated
+                    changes.append(
+                        f"drop agent.{field}={agent[field]!r} (conflicts with run_limits.{field}={run_limits[field]!r}; kept run_limits)"
+                    )
+                    del agent[field]
+            else:
+                run_limits[field] = agent.pop(field)
+                changes.append(f"hoist agent.{field} → run_limits.{field}")
+
+    # Prune fields that match defaults (or are empty {}/[]).
+    sandbox = data.get("sandbox")
+    for block_name, block, defaults in (
+        ("agent", agent, default_agent),
+        ("run_limits", run_limits, default_rl),
+        ("sandbox", sandbox, default_sandbox),
+    ):
+        if isinstance(block, dict):
+            for note in prune_block(block, defaults):
+                changes.append(f"drop {block_name}.{note}")
+
+    # Remove now-empty top-level blocks.
+    for block_name in ("agent", "run_limits", "sandbox"):
+        block = data.get(block_name)
+        if isinstance(block, dict) and not block:
+            del data[block_name]
+            changes.append(f"drop empty {block_name}:")
+
+    if not changes:
+        return False
+
+    rel = path.relative_to(REPO)
+    print(f"{rel}")
+    for c in changes:
+        print(f"  - {c}")
+
+    if not dry_run:
+        import io
+        import re
+
+        buf = io.StringIO()
+        yaml.dump(data, buf)
+        # Collapse runs of 2+ blank lines into 1 (left behind when whole blocks
+        # like `agent:` are dropped — ruamel keeps the blank lines that flanked
+        # the removed key on each side).
+        cleaned = re.sub(r"\n{3,}", "\n\n", buf.getvalue())
+        # Ensure agent/sandbox/run_limits are preceded by a blank line. Internal
+        # blank lines can disappear when ruamel attaches them to a since-deleted
+        # key (e.g. when `agent.turn_timeout` was the last key before `sandbox:`).
+        cleaned = re.sub(
+            r"(?<=\n)(?<!\n\n)(?=(?:agent|sandbox|run_limits):)",
+            "\n",
+            cleaned,
+        )
+        path.write_text(cleaned)
+    return True
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("paths", nargs="*", type=Path, help="Task YAMLs (default: all under tests/tasks/)")
+    ap.add_argument("--dry-run", action="store_true", help="Report changes without writing")
+    args = ap.parse_args()
+
+    _, defaults_doc = load_yaml(DEFAULTS_PATH)
+    defaults_block = defaults_doc.get("defaults") or {}
+    default_agent = defaults_block.get("agent") or {}
+    default_rl = defaults_block.get("run_limits") or {}
+    default_sandbox = defaults_block.get("sandbox") or {}
+
+    if args.paths:
+        files = [p.resolve() for p in args.paths]
+    else:
+        files = sorted(TASKS_ROOT.rglob("*.yaml"))
+
+    changed = 0
+    for f in files:
+        if process(f, default_agent, default_rl, default_sandbox, args.dry_run):
+            changed += 1
+
+    verb = "would update" if args.dry_run else "updated"
+    print(f"\n{verb} {changed} / {len(files)} file(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/prune-task-defaults.py
+++ b/scripts/prune-task-defaults.py
@@ -68,6 +68,31 @@ def process(path: Path, default_agent: dict, default_rl: dict, default_sandbox: 
     agent = data.get("agent")
     run_limits = data.get("run_limits")
 
+    # Hoist deprecated top-level {max_turns,turn_timeout,task_timeout} → run_limits.
+    # These also get auto-hoisted by the coder_eval loader (with a deprecation
+    # warning) — see coder_eval/src/coder_eval/models/tasks.py:484-510.
+    for field in HOISTABLE:
+        if field not in data:
+            continue
+        if run_limits is None:
+            from ruamel.yaml.comments import CommentedMap
+
+            run_limits = CommentedMap()
+            data["run_limits"] = run_limits
+            data.yaml_set_comment_before_after_key("run_limits", before="\n")
+        if isinstance(run_limits, dict) and field in run_limits:
+            if run_limits[field] == data[field]:
+                del data[field]
+                changes.append(f"drop top-level {field} (duplicate of run_limits.{field})")
+            else:
+                changes.append(
+                    f"drop top-level {field}={data[field]!r} (conflicts with run_limits.{field}={run_limits[field]!r}; kept run_limits)"
+                )
+                del data[field]
+        else:
+            run_limits[field] = data.pop(field)
+            changes.append(f"hoist top-level {field} → run_limits.{field}")
+
     # Hoist deprecated agent.{max_turns,turn_timeout,task_timeout} → run_limits.
     if isinstance(agent, dict):
         for field in HOISTABLE:

--- a/tests/tasks/uipath-admin/audit_export_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_e2e.yaml
@@ -12,13 +12,6 @@ description: >
 tags: [uipath-admin, e2e, mode:operate, audit, export]
 max_iterations: 2
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 40
-  turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 initial_prompt: |
   A security reviewer needs the full audit history for the last 7 days
   on the active tenant. They want to:
@@ -75,3 +68,7 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
@@ -29,13 +29,6 @@ description: >
   'audit'`.
 tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 40
-  turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 initial_prompt: |
   Export tenant audit events for the 3-day window from 5 days ago
   through 2 days ago (UTC, whole days) to ./audit-window.zip in the
@@ -113,3 +106,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 4.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-admin/audit_login_history_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_login_history_e2e.yaml
@@ -14,13 +14,6 @@ description: >
 tags: [uipath-admin, e2e, mode:diagnose, audit, investigation, login-history, scope-org]
 max_iterations: 2
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 40
-  turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 initial_prompt: |
   Show me login attempts for jane.doe@example.com over the last month.
 
@@ -57,3 +50,7 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
@@ -38,13 +38,6 @@ description: >
   'audit'`.
 tags: [uipath-admin, e2e, mode:operate, audit, export, scope-org, real-artifact]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 40
-  turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 initial_prompt: |
   Export ORGANIZATION-level audit events (memberships, license changes,
   tenant lifecycle) for the single UTC day **2 days ago** to
@@ -124,3 +117,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 4.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
@@ -11,13 +11,6 @@ description: >
 tags: [uipath-admin, e2e, mode:diagnose, audit, investigation]
 max_iterations: 2
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 40
-  turn_timeout: 600
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 initial_prompt: |
   Find out who deleted the `Sales-Reports` folder on the active tenant
   in the last 7 days.
@@ -55,3 +48,7 @@ success_criteria:
     min_count: 2
     weight: 1.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
@@ -13,11 +13,6 @@ description: >
   Command-construction only — no live tenant available.
 tags: [uipath-admin, e2e, authz, assignment-lifecycle, scope:organization]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_e2e.yaml
@@ -10,11 +10,6 @@ description: >
   Command-construction only — no live tenant available.
 tags: [uipath-admin, e2e, authz, assignment-lifecycle, scope:tenant]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
@@ -12,11 +12,6 @@ description: >
   Command-construction only — no live tenant available.
 tags: [uipath-admin, e2e, authz, assignment-lifecycle, scope:tenant-global]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_org_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_org_e2e.yaml
@@ -12,11 +12,6 @@ description: >
   Command-construction only — no live tenant available.
 tags: [uipath-admin, e2e, authz, role-lifecycle, scope:organization]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
@@ -11,11 +11,6 @@ description: >
   Command-construction only — no live tenant available.
 tags: [uipath-admin, e2e, authz, role-lifecycle, scope:tenant]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_global_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_global_e2e.yaml
@@ -12,11 +12,6 @@ description: >
   Command-construction only — no live tenant available.
 tags: [uipath-admin, e2e, authz, role-lifecycle, scope:tenant-global]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
+++ b/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
@@ -5,11 +5,6 @@ description: >
   credential attached.
 tags: [uipath-admin, e2e, lifecycle:generate]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
+++ b/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
@@ -6,11 +6,6 @@ description: >
   about using user IDs (not usernames) for membership operations.
 tags: [uipath-admin, e2e, lifecycle:generate, lifecycle:edit]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
@@ -5,11 +5,6 @@ description: >
   Validates the agent follows the onboarding workflow from the skill.
 tags: [uipath-admin, e2e, onboarding]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
@@ -4,11 +4,6 @@ description: >
   then lists tokens to verify it exists. Cleanup revokes the PAT.
 tags: [uipath-admin, e2e, lifecycle:generate]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
@@ -5,11 +5,6 @@ description: >
   Validates the agent follows the onboarding workflow from the skill.
 tags: [uipath-admin, e2e, onboarding]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-admin/smtp_configure_e2e.yaml
+++ b/tests/tasks/uipath-admin/smtp_configure_e2e.yaml
@@ -5,11 +5,6 @@ description: >
   saves them, and verifies they were applied.
 tags: [uipath-admin, e2e, lifecycle:generate]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 40
   turn_timeout: 600

--- a/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
@@ -11,16 +11,6 @@ description: >
 tags: [uipath-agents, e2e, coded, lifecycle:generate, context-grounding]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   I want a coded agent named `batch-transform-agent` that performs batch BatchTransform
   on a CSV file uploaded as an attachment. at the end return destination_path of the modified file.
@@ -48,3 +38,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
@@ -6,10 +6,6 @@ description: >
   Python-coded-agent + CSV signal pair.
 tags: [uipath-agents, smoke, coded, lifecycle:discover, context-grounding]
 
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   I have a coded agent project with `pyproject.toml` (deps: uipath,
   uipath-langchain) and `langgraph.json`. I want it to read a CSV of

--- a/tests/tasks/uipath-agents/coded/antipattern_build_system/antipattern_build_system.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_build_system/antipattern_build_system.yaml
@@ -7,11 +7,6 @@ description: >
   the section before any further work.
 tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/antipattern_module_level_llm/antipattern_module_level_llm.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_module_level_llm/antipattern_module_level_llm.yaml
@@ -7,11 +7,6 @@ description: >
   inside a node body before `uip codedagent init` is run.
 tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/antipattern_openai_agents_hitl/antipattern_openai_agents_hitl.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_openai_agents_hitl/antipattern_openai_agents_hitl.yaml
@@ -12,12 +12,6 @@ description: >
 tags: [uipath-agents, smoke, "mode:build", coded, "lifecycle:edit", "feature:antipattern", "feature:framework-openai-agents"]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/antipattern_openai_agents_hitl/seed_antipattern_openai_agents_hitl.py"
     timeout: 30
@@ -60,3 +54,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
@@ -6,11 +6,6 @@ description: >
   import UiPath`. The skill must drive the agent to fix the import.
 tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/auth_one_shot_login/auth_one_shot_login.yaml
+++ b/tests/tasks/uipath-agents/coded/auth_one_shot_login/auth_one_shot_login.yaml
@@ -12,12 +12,6 @@ description: >
 tags: [uipath-agents, integration, mode:build, coded, lifecycle:activate, feature:auth]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Connect to UiPath with these details:
 
@@ -78,3 +72,6 @@ success_criteria:
       - "Status"
     weight: 1.5
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/bindings_asset_subtypes/bindings_asset_subtypes.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_asset_subtypes/bindings_asset_subtypes.yaml
@@ -9,11 +9,6 @@ description: >
   `booleanAsset`).
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
@@ -10,11 +10,6 @@ description: >
   entrypoint.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/bindings_queue_app_index/bindings_queue_app_index.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_queue_app_index/bindings_queue_app_index.yaml
@@ -8,11 +8,6 @@ description: >
   `<connection_key>` for connections) and metadata fields.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -10,11 +10,6 @@ description: >
   `(resourceKey, propertyAttribute)` pair.
 tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, shape:single-node, resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1800
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
@@ -15,12 +15,6 @@ tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, shape:single-n
 max_iterations: 1
 task_timeout: 1800
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1500
-
 initial_prompt: |
   Build a LangGraph UiPath coded agent named `tone-classifier` that
   reads a short message and uses an LLM to label it as `friendly`,
@@ -107,3 +101,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1500

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
@@ -13,7 +13,6 @@ description: >
   real published resource in the tenant's personal workspace.
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, shape:single-node, resource, feature:framework-langgraph]
 max_iterations: 1
-task_timeout: 1800
 
 initial_prompt: |
   Build a LangGraph UiPath coded agent named `tone-classifier` that
@@ -104,3 +103,4 @@ success_criteria:
 
 run_limits:
   turn_timeout: 1500
+  task_timeout: 1800

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_register/coded_in_flow_register.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_register/coded_in_flow_register.yaml
@@ -8,13 +8,7 @@ description: >
   `uip solution resource list` surfaces it as a Local resource.
 tags: [uipath-agents, smoke, coded, mode:build, lifecycle:generate, resource, feature:registry]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
-  task_timeout: 1200
   turn_timeout: 1200
   max_turns: 100
 

--- a/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/deploy_folder_and_rebump.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/deploy_folder_and_rebump.yaml
@@ -5,19 +5,10 @@ description: >
   version 0.0.1 (already deployed once); agent must bump and redeploy.
 tags: [uipath-agents, integration, mode:build, coded, lifecycle:deploy, feature:deploy]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 100
   task_timeout: 600
   turn_timeout: 300
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/_fixtures/acme-echo ."

--- a/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
@@ -9,11 +9,6 @@ description: >
   rest of the suite never reaches.
 tags: [uipath-agents, e2e, coded, lifecycle:deploy, feature:deploy]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1800
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/deploy_tenant/deploy_tenant.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_tenant/deploy_tenant.yaml
@@ -12,13 +12,6 @@ tags: [uipath-agents, e2e, coded, mode:build, feature:deploy]
 max_iterations: 1
 task_timeout: 1500
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 60
-  turn_timeout: 1500
-
 initial_prompt: |
   Build a Simple Function UiPath coded agent named `tenant-echo`
   that takes a `message` (string) and returns
@@ -75,3 +68,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 4.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 60
+  turn_timeout: 1500

--- a/tests/tasks/uipath-agents/coded/deploy_tenant/deploy_tenant.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_tenant/deploy_tenant.yaml
@@ -10,7 +10,6 @@ description: >
   publish permission required** for the host running coder-eval.
 tags: [uipath-agents, e2e, coded, mode:build, feature:deploy]
 max_iterations: 1
-task_timeout: 1500
 
 initial_prompt: |
   Build a Simple Function UiPath coded agent named `tenant-echo`
@@ -72,3 +71,4 @@ success_criteria:
 run_limits:
   max_turns: 60
   turn_timeout: 1500
+  task_timeout: 1500

--- a/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/diagnose_deploy_failure.yaml
+++ b/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/diagnose_deploy_failure.yaml
@@ -12,13 +12,6 @@ tags: [uipath-agents, e2e, coded, mode:diagnose, feature:deploy]
 max_iterations: 1
 task_timeout: 2100
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 60
-  turn_timeout: 2100
-
 initial_prompt: |
   Recreate the Simple Function UiPath coded agent under
   `daily-digest/` from the snapshot below. Shipping it to the
@@ -99,3 +92,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 60
+  turn_timeout: 2100

--- a/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/diagnose_deploy_failure.yaml
+++ b/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/diagnose_deploy_failure.yaml
@@ -10,8 +10,6 @@ description: >
   to the user's personal workspace. **Cloud auth pre-configured.**
 tags: [uipath-agents, e2e, coded, mode:diagnose, feature:deploy]
 max_iterations: 1
-task_timeout: 2100
-
 initial_prompt: |
   Recreate the Simple Function UiPath coded agent under
   `daily-digest/` from the snapshot below. Shipping it to the
@@ -96,3 +94,4 @@ success_criteria:
 run_limits:
   max_turns: 60
   turn_timeout: 2100
+  task_timeout: 2100

--- a/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
@@ -6,11 +6,6 @@ description: >
   spec. The evaluator must be wired into an eval set and run successfully.
 tags: [uipath-agents, smoke, coded, lifecycle:validate, feature:eval]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
   max_turns: 60

--- a/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
@@ -9,11 +9,6 @@ description: >
   and report PASSED in the output file.
 tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
@@ -10,11 +10,6 @@ description: >
   the judges are reproducible.
 tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1800
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -10,7 +10,6 @@ description: >
   pipeline runs offline.
 tags: [uipath-agents, e2e, coded, mode:build, feature:eval, feature:eval-mocking, feature:framework-simple]
 max_iterations: 1
-task_timeout: 1800
 
 initial_prompt: |
   Build a Simple Function UiPath coded agent named `secret-peek` that
@@ -89,3 +88,4 @@ success_criteria:
 run_limits:
   max_turns: 80
   turn_timeout: 1800
+  task_timeout: 1800

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -12,13 +12,6 @@ tags: [uipath-agents, e2e, coded, mode:build, feature:eval, feature:eval-mocking
 max_iterations: 1
 task_timeout: 1800
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 80
-  turn_timeout: 1800
-
 initial_prompt: |
   Build a Simple Function UiPath coded agent named `secret-peek` that
   returns a structured summary of a UiPath asset: the first 4
@@ -92,3 +85,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 80
+  turn_timeout: 1800

--- a/tests/tasks/uipath-agents/coded/eval_trajectory_empty_history/eval_trajectory_empty_history.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_trajectory_empty_history/eval_trajectory_empty_history.yaml
@@ -13,12 +13,6 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:diagnose, feature:eval, feature:framework-langgraph]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Recreate the LangGraph coded agent project under `ticket-router/`
   exactly as below. The agent routes support tickets between
@@ -142,3 +136,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/existing_project_resume/existing_project_resume.yaml
+++ b/tests/tasks/uipath-agents/coded/existing_project_resume/existing_project_resume.yaml
@@ -10,12 +10,6 @@ description: >
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:edit, feature:framework-langgraph, feature:schema-sync]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Recreate the half-finished coded agent project under
   `mood-meter/` exactly as below, then pick it up from this
@@ -119,3 +113,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/deterministic/deterministic.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/deterministic/deterministic.yaml
@@ -9,14 +9,9 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
-  turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_fixtures/SimpleCodedAgent
@@ -38,3 +33,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/pii_middleware/pii_middleware.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/pii_middleware/pii_middleware.yaml
@@ -8,14 +8,9 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
-  turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_fixtures/SimpleCodedAgent
@@ -38,3 +33,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_all/recommend_all.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_all/recommend_all.yaml
@@ -11,17 +11,9 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
-  max_turns: 40
-  turn_timeout: 1200
-
-task_timeout: 1800
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_fixtures/SimpleCodedAgent
@@ -68,3 +60,8 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  task_timeout: 1800
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/recommend_scoped.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/recommend_scoped.yaml
@@ -10,17 +10,9 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
-  max_turns: 40
-  turn_timeout: 1200
-
-task_timeout: 1800
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_fixtures/SimpleCodedAgent
@@ -68,3 +60,8 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  task_timeout: 1800
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/smoke/smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/smoke/smoke.yaml
@@ -7,14 +7,9 @@ description: >
 tags: [uipath-agents, smoke, coded, mode:build, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
-  turn_timeout: 300
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_fixtures/SimpleCodedAgent
@@ -51,3 +46,6 @@ success_criteria:
       - "BlockAction"
     weight: 2.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 300

--- a/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
@@ -8,14 +8,9 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
-  turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_fixtures/SimpleCodedAgent
@@ -38,3 +33,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
@@ -11,17 +11,9 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
-  max_turns: 40
-  turn_timeout: 1200
-
-task_timeout: 1800
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_fixtures/SimpleCodedAgent
@@ -89,3 +81,8 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  task_timeout: 1800
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
@@ -7,11 +7,6 @@ description: >
   binding for the Action Center app the escalation targets.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:hitl-coded]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -11,12 +11,6 @@ description: >
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-langgraph, feature:hitl-coded]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Build a UiPath agent named `refund-gate`. When asked to issue a
   refund over $500, the agent must pause and file a structured
@@ -71,3 +65,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 7.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
@@ -10,12 +10,6 @@ description: >
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-langgraph, feature:hitl-coded]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Build a UiPath agent named `purchase-gate` that closes the loop
   on purchase requests already opened for human review elsewhere.
@@ -69,3 +63,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 7.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
@@ -22,19 +22,10 @@ skip: true
 # (the PR gate is --tags smoke only), so this would fail there until the tenant
 # is provisioned. Flip to `skip: false` once set up per coded/is-e2e-setup.md.
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1800
   max_turns: 80
   turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/is_jira_create_issue/seed_jira.py"

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
@@ -21,19 +21,10 @@ skip: true
 # --tags smoke only), so this would fail there until the tenant is provisioned.
 # Flip to `skip: false` once set up per coded/is-e2e-setup.md.
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1800
   max_turns: 80
   turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/is_outlook_send_mail/seed_outlook.py"

--- a/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
@@ -10,18 +10,10 @@ description: >
   sidecar (that path is lowcode-only and ignored in coded agents).
 tags: [uipath-agents, smoke, coded, mode:build, lifecycle:generate, feature:integration-service]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
-  turn_timeout: 900
   max_turns: 30
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: fixtures

--- a/tests/tasks/uipath-agents/coded/langgraph_classifier/langgraph_classifier.yaml
+++ b/tests/tasks/uipath-agents/coded/langgraph_classifier/langgraph_classifier.yaml
@@ -10,11 +10,6 @@ description: >
   `uip codedagent run agent`.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-langgraph, feature:schema-sync]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/llamaindex_rag/llamaindex_rag.yaml
+++ b/tests/tasks/uipath-agents/coded/llamaindex_rag/llamaindex_rag.yaml
@@ -10,12 +10,6 @@ description: >
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-llamaindex, feature:rag-coded]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Build a UiPath coded agent named `hr-helper` that answers
   employee questions about HR policy. The agent reads the
@@ -70,3 +64,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/llamaindex_workflow/llamaindex_workflow.yaml
+++ b/tests/tasks/uipath-agents/coded/llamaindex_workflow/llamaindex_workflow.yaml
@@ -9,11 +9,6 @@ description: >
   `uip codedagent run`.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-llamaindex]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/local_workspace_iterate/local_workspace_iterate.yaml
+++ b/tests/tasks/uipath-agents/coded/local_workspace_iterate/local_workspace_iterate.yaml
@@ -13,12 +13,6 @@ description: >
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:edit, feature:framework-langgraph, feature:local-workspace]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Recreate the working tree below exactly — Studio Web has already
   set this Local Workspace solution up; nothing here should be
@@ -166,3 +160,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
+++ b/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
@@ -10,11 +10,6 @@ description: >
   `uip codedagent init`), and runs the triage agent end-to-end.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-openai-agents]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/process_invoke/process_invoke.yaml
+++ b/tests/tasks/uipath-agents/coded/process_invoke/process_invoke.yaml
@@ -7,11 +7,6 @@ description: >
   binding for the invoked process.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:process-invocation]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
@@ -5,19 +5,10 @@ description: >
   tests command selection, not cloud connectivity.
 tags: [uipath-agents, integration, mode:operate, coded, lifecycle:execute, feature:file-sync]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 30
   task_timeout: 600
   turn_timeout: 300
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent ."

--- a/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
@@ -10,10 +10,6 @@ tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:rag-coded]
 run_limits:
   turn_timeout: 1200
 
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   Build a LangGraph UiPath coded agent named `policy-rag` that
   answers natural-language questions by retrieving relevant snippets

--- a/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
@@ -7,11 +7,6 @@ description: >
   Context Grounding index.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:rag-coded]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/coded/simple_echo/simple_echo.yaml
+++ b/tests/tasks/uipath-agents/coded/simple_echo/simple_echo.yaml
@@ -7,11 +7,6 @@ description: >
   `uip codedagent run main` to execute deterministically (no LLM,
   no cloud auth needed).
 tags: [uipath-agents, smoke, coded, lifecycle:generate, lifecycle:execute, feature:framework-simple]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   # Default smoke max_turns is 20, but the full scaffold -> init -> run
   # loop (uv venv, uv sync, uip codedagent setup, uip codedagent new,
   # rewrite main.py, init, run, write marker) lands at ~25 turns even

--- a/tests/tasks/uipath-agents/coded/subtype_credential_asset/subtype_credential_asset.yaml
+++ b/tests/tasks/uipath-agents/coded/subtype_credential_asset/subtype_credential_asset.yaml
@@ -10,11 +10,6 @@ description: >
   in Orchestrator.
 tags: [uipath-agents, e2e, coded, bindings]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 900
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/tracing_redaction/tracing_redaction.yaml
+++ b/tests/tasks/uipath-agents/coded/tracing_redaction/tracing_redaction.yaml
@@ -6,11 +6,6 @@ description: >
   output are redacted before they reach the trace store.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:trace]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1800
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded_function_validator/coded_function_validator.yaml
+++ b/tests/tasks/uipath-agents/coded_function_validator/coded_function_validator.yaml
@@ -8,17 +8,8 @@ description: >
   contains no LLM imports.
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, lifecycle:execute, feature:framework-simple]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 initial_prompt: |
   I need a UiPath Python Coded Function named `invoice-validator` that checks

--- a/tests/tasks/uipath-agents/deeprag_coded/e2e_scaffold_graph.yaml
+++ b/tests/tasks/uipath-agents/deeprag_coded/e2e_scaffold_graph.yaml
@@ -10,16 +10,6 @@ description: >
 tags: [uipath-agents, e2e, coded, lifecycle:generate, context-grounding]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   I want a coded agent named `deep-rag-agent` that takes a PDF file
   uploaded as an attachment and returns a grounded summary with
@@ -45,3 +35,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/deeprag_coded/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/deeprag_coded/smoke_trigger.yaml
@@ -6,10 +6,6 @@ description: >
   Python-coded-agent + PDF/TXT signal pair.
 tags: [uipath-agents, smoke, coded, lifecycle:discover, context-grounding]
 
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   I have a Python coded-agent project (`pyproject.toml` with uipath +
   uipath-langchain, plus `langgraph.json`). I want it to receive a PDF

--- a/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
@@ -7,11 +7,6 @@ description: >
   (type=internal, referenceKey=null, properties.toolType=batch-transform).
 tags: [uipath-agents, e2e, low-code, lifecycle:generate, context-grounding]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/batch_transform/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/lowcode/batch_transform/smoke_trigger.yaml
@@ -6,10 +6,6 @@ description: >
   for the low-code + CSV signal pair.
 tags: [uipath-agents, smoke, low-code, lifecycle:discover, context-grounding]
 
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   I'm building a low-code agent in Studio Web Agent Builder (`agent.json`
   with `"type": "lowCode"`). I want it to take a CSV upload and add two

--- a/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
@@ -9,11 +9,6 @@ description: >
   batch-transform).
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
@@ -8,11 +8,6 @@ description: >
   regenerates `.agent-builder/`.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
@@ -7,11 +7,6 @@ description: >
   referenceKey=null, properties.toolType=deep-rag).
 tags: [uipath-agents, e2e, low-code, lifecycle:generate, context-grounding]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/deeprag/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/lowcode/deeprag/smoke_trigger.yaml
@@ -6,10 +6,6 @@ description: >
   Verifies the skill fires for the low-code + PDF/TXT signal pair.
 tags: [uipath-agents, smoke, low-code, lifecycle:discover, context-grounding]
 
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   I'm building a low-code agent in Studio Web Agent Builder
   (`agent.json` with `"type": "lowCode"`). It receives multiple PDF

--- a/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
@@ -10,11 +10,6 @@ description: >
   judge to score the system prompt for dispute-domain coverage.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
@@ -9,11 +9,6 @@ description: >
   none of which are covered by create-from-scratch tests.
 tags: [uipath-agents, smoke, mode:build]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 60
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
@@ -14,11 +14,6 @@ description: >
   `location: "solution"`.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
@@ -13,11 +13,6 @@ description: >
   the deployed name + folder.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
@@ -9,11 +9,6 @@ description: >
   ActionCenter app.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
@@ -13,11 +13,6 @@ description: >
   binding kind) pinned to the deployed name + folder.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
@@ -13,11 +13,6 @@ description: >
   uses `location: "solution"`.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
@@ -6,14 +6,6 @@ description: >
   guardrail uses correct discriminator fields ($guardrailType, $ruleType,
   $selectorType, $actionType), PascalCase scope values, and a unique UUID.
 tags: [uipath-agents, e2e, low-code, guardrail]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 30
-  turn_timeout: 1200
-
 initial_prompt: |
   Create a UiPath solution "GuardSol" containing a low-code agent
   "SafeAgent" that answers user questions. Then add a custom guardrail
@@ -89,3 +81,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 30
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
@@ -9,14 +9,6 @@ description: >
 # (currently 0.9.0 on public npm). Re-enable smoke tag once CLI >= 1.0.0
 # is published.
 tags: [uipath-agents, smoke-blocked, low-code, guardrail]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 50
-  turn_timeout: 1200
-
 initial_prompt: |
   Create a UiPath solution "DiscoverSol" containing a low-code agent
   "DiscoverAgent". Then discover what guardrail validators are available
@@ -87,3 +79,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 50
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -16,7 +16,6 @@ agent:
   # which pushes long-workflow tasks (validate + migrate at the end) past the
   # turn cap. Empirically: 6 Task* calls → SUCCESS, 20 Task* calls → FAIL.
   disallowed_tools: ["TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-task_timeout: 1800
 
 initial_prompt: |
   Create a UiPath solution "EscalateSol" with an agent "ComplianceAgent" for
@@ -120,3 +119,4 @@ success_criteria:
 run_limits:
   max_turns: 40
   turn_timeout: 1200
+  task_timeout: 1800

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -11,17 +11,11 @@ description: >
 tags: [uipath-agents, e2e, low-code, guardrail]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
   # Disallow built-in todo tools — they aren't gated by allowed_tools, and the
   # agent variably spends 6–20 of its 40-turn budget on TaskCreate/TaskUpdate,
   # which pushes long-workflow tasks (validate + migrate at the end) past the
   # turn cap. Empirically: 6 Task* calls → SUCCESS, 20 Task* calls → FAIL.
   disallowed_tools: ["TaskCreate", "TaskUpdate", "TaskList", "TaskGet"]
-  max_turns: 40
-  turn_timeout: 1200
-
 task_timeout: 1800
 
 initial_prompt: |
@@ -122,3 +116,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
@@ -7,14 +7,6 @@ description: >
   The agent must validate the action schema and reject the app with the
   error message instead of writing the guardrail.
 tags: [uipath-agents, e2e, low-code, guardrail]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 40
-  turn_timeout: 1200
-
 initial_prompt: |
   Create a UiPath solution "ValidationSol" containing a low-code agent
   "ReviewAgent" that handles compliance review requests.
@@ -85,3 +77,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
@@ -7,14 +7,6 @@ description: >
   PascalCase entity names, enum-list and map-enum parameter types, and
   PascalCase scope values.
 tags: [uipath-agents, e2e, low-code, guardrail]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 30
-  turn_timeout: 1200
-
 initial_prompt: |
   Create a UiPath solution "PiiGuardSol" containing a low-code agent
   "PiiSafeAgent" that answers user questions about their accounts.
@@ -92,3 +84,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 30
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
@@ -6,14 +6,6 @@ description: >
   scopes to ["Llm"] only (not Agent or Tool), uses $parameterType "number"
   for the threshold parameter, and does not add it to PostExecution stage.
 tags: [uipath-agents, e2e, low-code, guardrail]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 30
-  turn_timeout: 1200
-
 initial_prompt: |
   Create a UiPath solution "InjGuardSol" containing a low-code agent
   "InjSafeAgent" that answers user questions. Then add a built-in
@@ -88,3 +80,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 30
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/recommend_all.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/recommend_all.yaml
@@ -9,8 +9,6 @@ description: >
 tags: [uipath-agents, e2e, low-code, guardrail]
 max_iterations: 1
 
-task_timeout: 1800
-
 sandbox:
   template_sources:
     - type: template_dir
@@ -61,3 +59,4 @@ success_criteria:
 run_limits:
   max_turns: 40
   turn_timeout: 1200
+  task_timeout: 1800

--- a/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/recommend_all.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/recommend_all.yaml
@@ -9,19 +9,12 @@ description: >
 tags: [uipath-agents, e2e, low-code, guardrail]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 40
-  turn_timeout: 1200
-
 task_timeout: 1800
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../../skills/uipath-agents/fixtures/WebResearchBriefingSolution
+    - type: template_dir
+      path: ../../../../../skills/uipath-agents/fixtures/WebResearchBriefingSolution
 
 initial_prompt: |
   I have a web research agent at WebResearchBriefingSolution/WebResearchBriefingAgent.
@@ -64,3 +57,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/recommend_scoped/recommend_scoped.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/recommend_scoped/recommend_scoped.yaml
@@ -8,17 +8,10 @@ description: >
 tags: [uipath-agents, e2e, low-code, guardrail]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 40
-  turn_timeout: 1200
-
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../../skills/uipath-agents/fixtures/WebResearchBriefingSolution
+    - type: template_dir
+      path: ../../../../../skills/uipath-agents/fixtures/WebResearchBriefingSolution
 
 initial_prompt: |
   I have a web research agent at WebResearchBriefingSolution/WebResearchBriefingAgent
@@ -61,3 +54,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/validate/validate.yaml
@@ -8,17 +8,10 @@ description: >
 tags: [uipath-agents, e2e, low-code, guardrail]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  max_turns: 40
-  turn_timeout: 1200
-
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../../skills/uipath-agents/fixtures/WebResearchBriefingSolution
+    - type: template_dir
+      path: ../../../../../skills/uipath-agents/fixtures/WebResearchBriefingSolution
 
 initial_prompt: |
   I have a web research agent at WebResearchBriefingSolution/WebResearchBriefingAgent.
@@ -89,3 +82,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/init_validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/init_validate.yaml
@@ -5,11 +5,6 @@ description: >
   the skill teaches the correct solution-first workflow and CLI usage.
 tags: [uipath-agents, smoke, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
@@ -10,11 +10,6 @@ description: >
   wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
@@ -10,11 +10,6 @@ description: >
   Indexes always live externally to the solution.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -10,11 +10,6 @@ description: >
   to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -9,11 +9,6 @@ description: >
   node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -9,11 +9,6 @@ description: >
   to the autonomous agent node's `escalation` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -10,11 +10,6 @@ description: >
   agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -9,11 +9,6 @@ description: >
   flow node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
@@ -10,11 +10,6 @@ description: >
   `uipath.agent.autonomous` node and edges.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -14,11 +14,6 @@ description: >
   `uipath-uipath-airdk` (GenAI Activities) connector available.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -9,11 +9,6 @@ description: >
   flow node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -10,11 +10,6 @@ description: >
   to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -9,11 +9,6 @@ description: >
   node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
@@ -9,11 +9,6 @@ description: >
   to the autonomous agent node's `escalation` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -9,11 +9,6 @@ description: >
   node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -10,11 +10,6 @@ description: >
   autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, low-code, inline-flow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
@@ -12,11 +12,6 @@ description: >
   Activities) connector available.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
@@ -7,11 +7,6 @@ description: >
   MCP shape (id, name, description, isEnabled, tools).
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
@@ -10,11 +10,6 @@ description: >
   coverage.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
+++ b/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
@@ -8,11 +8,6 @@ description: >
   deep equivalence of the two schema files.
 tags: [uipath-agents, smoke, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
@@ -9,11 +9,6 @@ description: >
   and distinct projectId UUIDs across agents.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
@@ -7,11 +7,6 @@ description: >
   `folderPath: "solution_folder"`.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
@@ -10,11 +10,6 @@ description: >
   an ActionCenter app that lives externally in Orchestrator.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
@@ -7,11 +7,6 @@ description: >
   `folderPath: "solution_folder"`.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
@@ -7,11 +7,6 @@ description: >
   `folderPath: "solution_folder"`.
 tags: [uipath-agents, e2e, low-code]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-agents/openai_agents_structured_output/openai_agents_structured_output.yaml
+++ b/tests/tasks/uipath-agents/openai_agents_structured_output/openai_agents_structured_output.yaml
@@ -9,17 +9,8 @@ description: >
   `UiPathChatOpenAI` setup breaks `uip codedagent init`).
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, lifecycle:execute, feature:framework-openai-agents, feature:schema-sync]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 initial_prompt: |
   Build an OpenAI Agents UiPath coded agent named `review-analyzer` that

--- a/tests/tasks/uipath-api-workflow/smoke/if_else_grade.yaml
+++ b/tests/tasks/uipath-api-workflow/smoke/if_else_grade.yaml
@@ -7,14 +7,6 @@ description: >
   literals (${'PASS'} for StudioWeb roundtrip), and Response with then:end.
 tags: [uipath-api-workflow, smoke, lifecycle:generate, feature:if-else]
 
-agent:
-  type: claude-code
-  max_turns: 30
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   Make a UiPath API Workflow JSON file at Workflow.json that:
   - Takes a numeric `score` input
@@ -107,3 +99,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 30

--- a/tests/tasks/uipath-coded-apps/auth_no_manual_tokens.yaml
+++ b/tests/tasks/uipath-coded-apps/auth_no_manual_tokens.yaml
@@ -4,10 +4,6 @@ description: >
   handling and prefer CLI-managed authentication for coded app sync/deploy.
 tags: [uipath-coded-apps, smoke, "lifecycle:validate"]
 
-sandbox:
-  driver: tempdir
-  node: {}
-
 initial_prompt: |
   Before starting, load the uipath-coded-apps skill and follow its workflow.
 

--- a/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
@@ -10,9 +10,6 @@ description: >
   queries in a single end-to-end run.
 tags: [uipath-data-fabric, e2e, employee-directory]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 600

--- a/tests/tasks/uipath-data-fabric/e2e_expense_tracker.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_expense_tracker.yaml
@@ -11,16 +11,9 @@ description: >
   finishes the relationship workflow.
 tags: [uipath-data-fabric, e2e, expense-tracker, complex-fields]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 60
   turn_timeout: 600
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 initial_prompt: |
   Finance needs an expense tracker in UiPath Data Fabric where each Expense is

--- a/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
@@ -8,9 +8,6 @@ description: >
   loop for a realistic e-commerce use case.
 tags: [uipath-data-fabric, e2e, product-catalogue]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 600

--- a/tests/tasks/uipath-data-fabric/integration_choice_relationship.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_choice_relationship.yaml
@@ -13,16 +13,9 @@ description: >
   the relationship workflow.
 tags: [uipath-data-fabric, integration, complex-fields]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 60
   turn_timeout: 600
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 initial_prompt: |
   Build a small Customer/Order schema in UiPath Data Fabric. Customer has a

--- a/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
@@ -7,9 +7,6 @@ description: >
   with records list. Tests the Discover → Act → Verify pattern for bulk data loading.
 tags: [uipath-data-fabric, integration, records, import]
 
-agent:
-  type: claude-code
-
 run_limits:
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
@@ -8,9 +8,6 @@ description: >
   folder ID and verifies the error. Covers S-SC-01 through S-SC-05.
 tags: [uipath-data-fabric, integration, entity-scope]
 
-agent:
-  type: claude-code
-
 run_limits:
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
@@ -12,9 +12,6 @@ description: >
   not retry or call the REST API directly.
 tags: [uipath-data-fabric, integration, error-paths]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 600

--- a/tests/tasks/uipath-data-fabric/integration_files.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_files.yaml
@@ -8,9 +8,6 @@ description: >
   upload/download/delete workflow including overwrite semantics and byte integrity.
 tags: [uipath-data-fabric, integration, files]
 
-agent:
-  type: claude-code
-
 run_limits:
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
@@ -12,9 +12,6 @@ description: >
   constraints, and record CRUD in one multi-step run.
 tags: [uipath-data-fabric, integration, entities, records]
 
-agent:
-  type: claude-code
-
 run_limits:
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/integration_large_pagination.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_large_pagination.yaml
@@ -10,9 +10,6 @@ description: >
   offset-based page jumps.
 tags: [uipath-data-fabric, integration, bulk-pagination]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 60
   turn_timeout: 600

--- a/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
@@ -9,9 +9,6 @@ description: >
   Entity is never deleted.
 tags: [uipath-data-fabric, integration, pre-seeded, discover]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 600

--- a/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
@@ -8,9 +8,6 @@ description: >
   and the no-body pagination path end-to-end.
 tags: [uipath-data-fabric, integration, records]
 
-agent:
-  type: claude-code
-
 run_limits:
   turn_timeout: 600
 

--- a/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
@@ -6,9 +6,6 @@ description: >
   excluded, and records import --file is the correct command (not records insert).
 tags: [uipath-data-fabric, smoke, records, import]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 30
 

--- a/tests/tasks/uipath-data-fabric/smoke_choice_multiple_filter.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_choice_multiple_filter.yaml
@@ -8,15 +8,11 @@ description: >
   "Filtering on Choice-Set Fields".
 tags: [uipath-data-fabric, smoke, complex-fields]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 25
 
 sandbox:
   driver: docker
-  python: {}
 
 initial_prompt: |
   OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.

--- a/tests/tasks/uipath-data-fabric/smoke_choice_relationship.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_choice_relationship.yaml
@@ -9,15 +9,11 @@ description: >
   tests, but on fields whose value form requires lookup tokens.
 tags: [uipath-data-fabric, smoke, complex-fields]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 35
 
 sandbox:
   driver: docker
-  python: {}
 
 initial_prompt: |
   OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.

--- a/tests/tasks/uipath-data-fabric/smoke_csv_complex_drop.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_csv_complex_drop.yaml
@@ -8,15 +8,11 @@ description: >
   columns in a CSV file.
 tags: [uipath-data-fabric, smoke, complex-fields, bulk-import]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 25
 
 sandbox:
   driver: docker
-  python: {}
 
 initial_prompt: |
   OFFLINE SMOKE TEST: The uip CLI is available but NOT connected to a live tenant.

--- a/tests/tasks/uipath-data-fabric/smoke_entities.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_entities.yaml
@@ -9,9 +9,6 @@ description: >
   all entity command syntax in a single pass.
 tags: [uipath-data-fabric, smoke, entities]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 30
 

--- a/tests/tasks/uipath-data-fabric/smoke_files.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_files.yaml
@@ -8,9 +8,6 @@ description: >
   upload, --destination flag for download, and --output json on all commands.
 tags: [uipath-data-fabric, smoke, files]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 30
 

--- a/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
@@ -8,9 +8,6 @@ description: >
   sections of the skill without requiring a live tenant.
 tags: [uipath-data-fabric, smoke, entities, records]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 30
 

--- a/tests/tasks/uipath-data-fabric/smoke_records.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_records.yaml
@@ -9,9 +9,6 @@ description: >
   array-body routing rule in a single pass.
 tags: [uipath-data-fabric, smoke, records]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
 

--- a/tests/tasks/uipath-governance/access-policy/access-policy_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-governance/access-policy/access-policy_lifecycle_e2e.yaml
@@ -24,9 +24,6 @@ description: >
   policy behind, delete it manually before the next run.
 tags: [uipath-governance, e2e, access-policy, mode:build]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 40
 

--- a/tests/tasks/uipath-governance/aops-policy/aops-policy_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops-policy_lifecycle_e2e.yaml
@@ -18,9 +18,6 @@ description: >
   policy behind, delete it manually before the next run.
 tags: [uipath-governance, e2e, aops-policy, mode:build]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 40
 

--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -10,9 +10,6 @@ description: >
   Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write-back]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 60
   turn_timeout: 1200

--- a/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
@@ -9,9 +9,6 @@ description: >
   Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, brown-field, escalation, ai-agent]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 40
   turn_timeout: 1200

--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -10,9 +10,6 @@ description: >
   Build -> Verify loop. Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, green-field, compliance, gdpr]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 40
   turn_timeout: 1200

--- a/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
@@ -9,9 +9,6 @@ description: >
   validation of the authored .flow file. Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, brown-field, multi-hitl, hr-onboarding]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 1200

--- a/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
@@ -9,9 +9,6 @@ description: >
   (validate). Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, brown-field]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 70
   turn_timeout: 1200

--- a/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
@@ -8,9 +8,6 @@ description: >
   C5 (completed handle), F1 (validate after add). Does not deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, green-field]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 40
   turn_timeout: 1200

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -15,9 +15,6 @@ skip: true
 # credentials. Cannot be run in tempdir sandbox without real infrastructure.
 # Unblock when a shared staging app + tenant are available for CI.
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 1800

--- a/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
@@ -5,9 +5,6 @@ description: >
   in the next script node. Tests C5, C6, F2.
 tags: [uipath-human-in-the-loop, integration, edge-wiring]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 600

--- a/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
@@ -5,9 +5,6 @@ description: >
   and C4 (timeout ISO 8601).
 tags: [uipath-human-in-the-loop, integration, options]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   task_timeout: 500

--- a/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
@@ -5,9 +5,6 @@ description: >
   $vars.<NodeId>.status. Tests G1 and G2.
 tags: [uipath-human-in-the-loop, integration, runtime-variables]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
   turn_timeout: 600

--- a/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
@@ -6,13 +6,8 @@ description: >
   confuse the variable property with the access key.
 tags: [uipath-human-in-the-loop, integration, variable-binding]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 75
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "ContractReview" for legal contract approval:
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
@@ -6,13 +6,8 @@ description: >
   even when the developer's schema description is vague or uses wrong types.
 tags: [uipath-human-in-the-loop, integration, schema-design, developer-mistake]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 75
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "ExpenseReview" for expense claim approval:
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
@@ -6,13 +6,8 @@ description: >
   correct fieldId-based outputId path, and never puts binding on an output field.
 tags: [uipath-human-in-the-loop, integration, variable-binding, developer-mistake]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 90
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "SupplierOnboarding" for supplier vetting:
 

--- a/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_11_inout_field_access.yaml
@@ -6,13 +6,8 @@ description: >
   pre-fills the value while still allowing the human to edit it.
 tags: [uipath-human-in-the-loop, integration, schema-design, inout, variable-binding]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 90
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "RCAReview" for AI-generated root cause analysis review:
 

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -12,9 +12,6 @@ description: >
   that a `report.json` self-report says "refused".
 tags: [uipath-ixp, smoke, lifecycle:execute]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 30
 

--- a/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
@@ -4,14 +4,8 @@ description: >
   joining, default routing, sequence-flow conditions, and BPMN DI.
 tags: [uipath-maestro-bpmn, smoke, mode:build, lifecycle:generate, shape:multi-node, node:gateway]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 80
-  turn_timeout: 900
-
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 

--- a/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
@@ -6,14 +6,8 @@ description: >
   manual smoke "simple approval" scenario.
 tags: [uipath-maestro-bpmn, integration, lifecycle:generate, shape:multi-node, node:gateway, node:script, node:service-task, resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 90
-  turn_timeout: 900
-
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
@@ -4,11 +4,6 @@ description: >
   Orchestrator.ExecuteApiWorkflowAsync service-task row with an eval.
 tags: [uipath-maestro-bpmn, e2e, lifecycle:generate, "node:service-task", "feature:api-workflow"]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/business_rule_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/business_rule_task.yaml
@@ -5,11 +5,6 @@ description: >
   only by static fixtures.
 tags: [uipath-maestro-bpmn, e2e, lifecycle:generate, "node:business-rule", "feature:orchestrator"]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
@@ -4,11 +4,6 @@ description: >
   local lifecycle for the Jint-backed script path with package metadata.
 tags: [uipath-maestro-bpmn, e2e, lifecycle:generate, "node:script", "feature:jint"]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
@@ -5,14 +5,8 @@ description: >
   connection metadata or running cloud-side commands.
 tags: [uipath-maestro-bpmn, integration, mode:build, lifecycle:generate, connector, feature:connections]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 80
-  turn_timeout: 900
-
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 

--- a/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
@@ -6,14 +6,8 @@ description: >
   inventing private resource metadata. Requires the `uip` CLI on PATH.
 tags: [uipath-maestro-bpmn, integration, "lifecycle:inspect", connector, "feature:connections", resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 60
-  turn_timeout: 900
-
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 

--- a/tests/tasks/uipath-maestro-bpmn/e2e/author_validate_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/author_validate_pack.yaml
@@ -6,9 +6,6 @@ description: >
   lifecycle without upload, publish, deploy, debug, or run side effects.
 tags: [uipath-maestro-bpmn, e2e, mode:build, lifecycle:generate]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 80
   turn_timeout: 1200

--- a/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
@@ -7,18 +7,13 @@ description: >
   package-file consistency without cloud-side effects.
 tags: [uipath-maestro-bpmn, e2e, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision", "node:hitl", "feature:approval-gate"]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.

--- a/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
@@ -6,14 +6,8 @@ description: >
   extension variants.
 tags: [uipath-maestro-bpmn, integration, lifecycle:generate, contract:xml, node:service-task, node:call-activity, connector]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 90
-  turn_timeout: 900
-
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
@@ -4,14 +4,8 @@ description: >
   documented non-Integration-Service UiPath activity shells.
 tags: [uipath-maestro-bpmn, integration, mode:build, lifecycle:generate, shape:multi-node, node:hitl, resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 80
-  turn_timeout: 900
-
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
@@ -4,14 +4,8 @@ description: >
   runtime boundary instead of Node.js, browser, filesystem, or network APIs.
 tags: [uipath-maestro-bpmn, smoke, mode:build, lifecycle:generate, shape:single-node, node:script]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 60
-  turn_timeout: 900
-
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 

--- a/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
@@ -6,25 +6,19 @@ description: >
   without performing lifecycle mutations.
 tags: [uipath-maestro-bpmn, smoke, "mode:diagnose", "lifecycle:execute"]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   max_turns: 20
-  turn_timeout: 900
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../skills/uipath-maestro-bpmn
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.

--- a/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
@@ -7,18 +7,13 @@ description: >
   smoke "review imported BPMN" matrix.
 tags: [uipath-maestro-bpmn, smoke, "lifecycle:inspect", "mode:inspect"]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 25
-  turn_timeout: 900
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.

--- a/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
@@ -5,14 +5,8 @@ description: >
   locally, and package it without cloud-side effects.
 tags: [uipath-maestro-bpmn, smoke, mode:build, lifecycle:generate, lifecycle:validate, lifecycle:package]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 60
-  turn_timeout: 900
-
 initial_prompt: |
   Create a UiPath Maestro BPMN Process Orchestration project named
   "ExpenseReviewBpmn".

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
@@ -7,16 +7,13 @@ description: >
   requirements without cloud-side effects.
 tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:validate", connector, "feature:connections"]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 20
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
@@ -5,18 +5,13 @@ description: >
   fixture" matrix and complements the validate-side fixture smoke.
 tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:package"]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 30
-  turn_timeout: 900
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.

--- a/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
@@ -7,13 +7,6 @@ description: >
   and writes valid JSON. Tests action-task field design (priority enum,
   recipient handling, taskTitle requirement).
 tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 90
-  turn_timeout: 900
-
 initial_prompt: |
   Create a UiPath Case Management project named "VendorPOReviewCase" with
   this shape:
@@ -275,3 +268,6 @@ success_criteria:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
     timeout: 120
+
+run_limits:
+  max_turns: 90

--- a/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
@@ -4,13 +4,6 @@ description: >
   downstream task using the `=vars.<varId>` runtime path. Tests cross-task
   binding from an action task to a follow-up task in a later stage.
 tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 110
-  turn_timeout: 900
-
 initial_prompt: |
   Create a UiPath Case Management project named "ExpenseApprovalCase" with
   this shape:
@@ -239,3 +232,6 @@ success_criteria:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
     timeout: 120
+
+run_limits:
+  max_turns: 110

--- a/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
@@ -6,13 +6,6 @@ description: >
   and that both true and false branches are wired to distinct downstream
   stages with consistent entry conditions.
 tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 130
-  turn_timeout: 900
-
 initial_prompt: |
   Create a UiPath Case Management project named "VendorApprovalCase" for
   vendor onboarding with this shape:
@@ -310,3 +303,6 @@ success_criteria:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
     timeout: 120
+
+run_limits:
+  max_turns: 130

--- a/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
@@ -9,13 +9,6 @@ description: >
   register before the skeleton can be upgraded. Replaces flow's
   brownfield-insert test (case skill regenerates from scratch).
 tags: [uipath-maestro-case, integration, lifecycle:generate, shape:multi-node, node:hitl, skeleton]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 110
-  turn_timeout: 900
-
 initial_prompt: |
   Create a UiPath Case Management project named "ContractReviewCase" with
   this shape:
@@ -291,3 +284,6 @@ success_criteria:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
     timeout: 120
+
+run_limits:
+  max_turns: 110

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
@@ -6,13 +6,6 @@ description: >
   case validates. Action-app likely unresolved in test env — skeleton task
   (empty data) is acceptable.
 tags: [uipath-maestro-case, smoke, lifecycle:generate, shape:single-node, node:hitl]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 80
-  turn_timeout: 600
-
 initial_prompt: |
   Create a UiPath Case Management project named "InvoiceApprovalCase" with a
   manual trigger and a single stage "Review" that contains one HITL action
@@ -147,3 +140,7 @@ success_criteria:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
     timeout: 120
+
+run_limits:
+  max_turns: 80
+  turn_timeout: 600

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
@@ -5,13 +5,6 @@ description: >
   to a downstream stage. Verifies the exit-condition rule type and that the
   TaskId is referenced from the rule.
 tags: [uipath-maestro-case, smoke, lifecycle:generate, shape:multi-node, node:hitl]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 105
-  turn_timeout: 600
-
 initial_prompt: |
   Create a UiPath Case Management project named "PurchaseApprovalCase" with
   this shape:
@@ -199,3 +192,7 @@ success_criteria:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
     timeout: 120
+
+run_limits:
+  max_turns: 105
+  turn_timeout: 600

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
@@ -6,13 +6,6 @@ description: >
   `IF` expressions on the same source stage, and that both downstream
   stages have correct entry conditions.
 tags: [uipath-maestro-case, lifecycle:generate, shape:multi-node, node:hitl]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 110
-  turn_timeout: 600
-
 initial_prompt: |
   Create a UiPath Case Management project named "LeaveRequestCase" with this
   shape:
@@ -234,3 +227,7 @@ success_criteria:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
     timeout: 120
+
+run_limits:
+  max_turns: 110
+  turn_timeout: 600

--- a/tests/tasks/uipath-maestro-case/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-case/init_validate.yaml
@@ -8,9 +8,6 @@ description: >
   resulting artifacts and the validate step, not on the scaffolding method.
 tags: [uipath-maestro-case, init, validate]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 80
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
@@ -17,11 +17,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:conditions, feature:edges, feature:edge-handles, feature:wait-for-user, feature:wide-fanout]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
@@ -12,11 +12,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:case-exit, feature:conditions, feature:stages, feature:wait-for-connector]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
@@ -19,11 +19,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:exception-stage, feature:multi-exception, feature:conditions, feature:sla, feature:escalation, feature:wait-for-timer]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -18,11 +18,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:edges, feature:conditions, feature:fan-in, feature:tasks, feature:skeleton-task, feature:rpa, feature:api-workflow, feature:action, feature:agent, feature:case-management-task]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
@@ -20,11 +20,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:stages, feature:edges, feature:conditions, feature:task-entry, feature:wait-for-timer, feature:parallel-tasks, feature:variables, feature:arguments]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
@@ -15,11 +15,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:trigger, feature:timer, feature:multi-trigger, feature:bounded-timer, feature:scheduled-timer]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
@@ -23,11 +23,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation, feature:conditional-sla, feature:stage-sla]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
@@ -21,11 +21,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:tasks, feature:conditions, feature:task-entry, feature:variables, feature:skeleton-task]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_discovery.yaml
@@ -6,9 +6,6 @@ description: >
   inspection at ~/.uip/case-resources/, not relying on registry search).
 tags: [uipath-maestro-case, registry]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 65
 

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -8,11 +8,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -8,11 +8,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -8,11 +8,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -9,11 +9,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -8,11 +8,6 @@ description: >
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
@@ -9,11 +9,6 @@ description: >
   branch of `upsertConnectionResourceBinding`.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, connector, bindings, regression]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 3600
   max_turns: 60

--- a/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
@@ -12,11 +12,6 @@ description: >
   https://github.com/UiPath/flow-workbench/pull/1726.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, bindings, regression]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 3600
   max_turns: 80

--- a/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
@@ -12,11 +12,6 @@ description: >
   https://uipath.atlassian.net/browse/MST-10236
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, connector, bindings, regression]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 3600
   max_turns: 50

--- a/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
@@ -8,11 +8,6 @@ description: >
   See https://github.com/UiPath/cli/pull/2197.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, connector, bindings, regression]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 3600
   max_turns: 60

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -9,11 +9,6 @@ description: >
   for routing, and pass `uip maestro flow validate`.
 tags: [uipath-maestro-flow, integration, connector, ceql, filter, uipath-microsoft-azureactivedirectory, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -4,11 +4,6 @@ description: >
   complex array field on the Act! 365 connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
@@ -5,11 +5,6 @@ description: >
   binary file flow between two IS connectors in a single Flow.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, e2e, uipath-google-drive, uipath-salesforce-slack, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -4,11 +4,6 @@ description: >
   where dropdown values load only on user interaction on the WooCommerce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-automaticc-woocommerce, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -4,11 +4,6 @@ description: >
   where a dropdown is pre-populated on the Azure connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-microsoft-azure, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -4,11 +4,6 @@ description: >
   enhanced enum field with display labels on the WooCommerce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-automaticc-woocommerce, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -5,14 +5,8 @@ description: >
   body are fixed so the test can verify the enum value wiring.
 tags: [uipath-maestro-flow, integration, lifecycle-generate, shape-multi-node, connector, uipath-google-gmail, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 3600
-  max_turns: 200
   turn_timeout: 1200
 
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/field_actions.yaml
@@ -4,11 +4,6 @@ description: >
   field action dependencies on the WooCommerce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-automaticc-woocommerce, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -6,11 +6,6 @@ description: >
   fetch, and bodyParameters carries the required fields.summary value.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -4,11 +4,6 @@ description: >
   multiselect field on the Act! 365 connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-act-act365, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -6,11 +6,6 @@ description: >
   verify the path-parameter wiring.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -4,11 +4,6 @@ description: >
   query parameter on the Google Tasks connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-google-tasks, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -4,11 +4,6 @@ description: >
   least one field from each required group must be populated on the Teams connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-microsoft-teams, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -4,11 +4,6 @@ description: >
   a join on a related object on the Salesforce connector.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-salesforce, ipe]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 1500
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -9,9 +9,6 @@ description: >
   headlessly, so correctness is enforced via the semantic checker rather than runtime.
 tags: [uipath-maestro-flow, uipath-human-in-the-loop, e2e, devcon]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 120
   turn_timeout: 1200

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
@@ -5,18 +5,13 @@ description: >
   format-summary step. Exercises inserting a node into an existing edge.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../templates/initial_flow
+    - type: template_dir
+      path: ../templates/initial_flow
 
 initial_prompt: |
   Add a script node called "convertToCelsius" between getWeather and formatSummary that converts the temp from F to C. Return both values. Also update formatSummary to include the Celsius value in its summary string.

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
@@ -4,18 +4,13 @@ description: >
   Exercises modifying node output mappings.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../templates/initial_flow
+    - type: template_dir
+      path: ../templates/initial_flow
 
 initial_prompt: |
   Add a "location" field with value "Bellevue, WA" to the summary output of both end nodes.

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -6,18 +6,13 @@ description: >
   from existing nodes.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node, node:subflow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../templates/initial_flow
+    - type: template_dir
+      path: ../templates/initial_flow
 
 initial_prompt: |
   Move getWeather and formatSummary into a subflow called "fetchAndFormat". The subflow should output the temperatureF value. The rest of the main flow (decision + end nodes) stays but reads from the subflow output.

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
@@ -4,18 +4,13 @@ description: >
   formatSummary, then a single end node. Exercises reordering nodes and merging branches.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node, node:decision]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../templates/initial_flow
+    - type: template_dir
+      path: ../templates/initial_flow
 
 initial_prompt: |
   Rearrange the flow so the decision happens right after the HTTP call. Both the true and false branches should merge back into formatSummary, which then goes to a single end node. formatSummary should pick the message ('nice day' or 'bring a jacket') based on which branch the decision took.

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
@@ -5,18 +5,13 @@ description: >
   Exercises deleting a node and reconnecting edges.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../templates/initial_flow
+    - type: template_dir
+      path: ../templates/initial_flow
 
 initial_prompt: |
   Remove the formatSummary script node. The decision and end nodes should read temperature directly from the HTTP response instead.

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
@@ -5,18 +5,13 @@ description: >
   Exercises script-node update without restructuring the flow.
 tags: [uipath-maestro-flow, e2e, lifecycle:edit, shape:multi-node, node:decision]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../templates/initial_flow
+    - type: template_dir
+      path: ../templates/initial_flow
 
 initial_prompt: |
   Update the flow to ensure if temperature is greater than 60F returns a summary with a message field 'amazing day',

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
@@ -11,9 +11,6 @@ description: >
   uipath-maestro-flow skill.
 tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:execute]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 90
   turn_timeout: 1200

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -10,9 +10,6 @@ description: >
   both pick correctly and run the CLI to pass.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:discover]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -8,9 +8,6 @@ description: >
   command.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 60
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -8,9 +8,6 @@ description: >
   `uip solution upload` and MUST record its decision in `report.json`.
 tags: [uipath-maestro-flow, smoke, mode:operate, lifecycle:execute]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -5,14 +5,8 @@ description: >
   and priority. Tests C1 (field design) and C2 (outcome design).
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 75
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "VendorPOReview" for purchase order review:
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -5,14 +5,8 @@ description: >
   the output variable path and wires it into a decision or script node.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 47
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "ExpenseApproval" that:
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -6,14 +6,8 @@ description: >
   and that both Decision branches are wired to distinct downstream nodes.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 110
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "VendorApproval" for vendor onboarding:
 

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
@@ -5,14 +5,8 @@ description: >
   remove an existing edge and re-wire it through a new HITL node.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:hitl]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 150
-  turn_timeout: 900
-
 initial_prompt: |
   You are working on an existing UiPath Flow named "ContractReview".
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -5,14 +5,8 @@ description: >
   into the .flow file as JSON and the flow validates.
 tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:hitl]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 80
-  turn_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow named "InvoiceApproval" that:
   1. Starts with a manual trigger

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -5,10 +5,6 @@ description: >
   a three-node approval flow.
 tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:hitl]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 105
   turn_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -5,10 +5,6 @@ description: >
   Verifies both true and false edges of the Decision node are wired.
 tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:hitl]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-
 run_limits:
   max_turns: 80
   turn_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/ixp/activation.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation.yaml
@@ -13,9 +13,6 @@ description: >
   do NOT relax assertions; feed findings back in.
 
 tags: [uipath-maestro-flow, smoke, activation, ixp]
-
-task_timeout: 900
-
 dataset:
   rows:
     - id: explicit
@@ -72,3 +69,4 @@ success_criteria:
 
 run_limits:
   max_turns: 40
+  task_timeout: 900

--- a/tests/tasks/uipath-maestro-flow/ixp/activation.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation.yaml
@@ -16,15 +16,6 @@ tags: [uipath-maestro-flow, smoke, activation, ixp]
 
 task_timeout: 900
 
-agent:
-  type: claude-code
-  max_turns: 40
-  turn_timeout: 900
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 dataset:
   rows:
     - id: explicit
@@ -78,3 +69,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40

--- a/tests/tasks/uipath-maestro-flow/ixp/activation_listing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation_listing.yaml
@@ -14,9 +14,6 @@ description: >
 
 tags: [uipath-maestro-flow, smoke, activation, ixp, listing]
 
-# Listing is a one-shot Q&A — no need for the full activation budget.
-task_timeout: 300
-
 dataset:
   rows:
     - id: ixp-models
@@ -59,3 +56,4 @@ success_criteria:
 run_limits:
   max_turns: 20
   turn_timeout: 300
+  task_timeout: 300

--- a/tests/tasks/uipath-maestro-flow/ixp/activation_listing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation_listing.yaml
@@ -17,15 +17,6 @@ tags: [uipath-maestro-flow, smoke, activation, ixp, listing]
 # Listing is a one-shot Q&A — no need for the full activation budget.
 task_timeout: 300
 
-agent:
-  type: claude-code
-  max_turns: 20
-  turn_timeout: 300
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 dataset:
   rows:
     - id: ixp-models
@@ -64,3 +55,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 20
+  turn_timeout: 300

--- a/tests/tasks/uipath-maestro-flow/ixp/activation_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation_negative.yaml
@@ -16,10 +16,6 @@ description: >
 
 tags: [uipath-maestro-flow, smoke, activation, ixp, negative]
 
-# Trimmed vs the positive activation suite (40 turns / 900s) — negative rows
-# do not need to drive a full registry-search → node-add → validate loop.
-task_timeout: 600
-
 dataset:
   rows:
 
@@ -62,3 +58,4 @@ success_criteria:
 run_limits:
   max_turns: 25
   turn_timeout: 600
+  task_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/ixp/activation_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation_negative.yaml
@@ -20,15 +20,6 @@ tags: [uipath-maestro-flow, smoke, activation, ixp, negative]
 # do not need to drive a full registry-search → node-add → validate loop.
 task_timeout: 600
 
-agent:
-  type: claude-code
-  max_turns: 25
-  turn_timeout: 600
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 dataset:
   rows:
 
@@ -67,3 +58,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 25
+  turn_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -14,16 +14,6 @@ tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:ixp,
 
 task_timeout: 900
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 80
-  turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   Build a UiPath Flow that monitors a SharePoint folder for new vendor PDF
   invoices, extracts the structured data (invoice number, vendor, invoice
@@ -103,3 +93,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 80
+  turn_timeout: 1200

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -12,8 +12,6 @@ description: >
 
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:ixp, connector, feature:http]
 
-task_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow that monitors a SharePoint folder for new vendor PDF
   invoices, extracts the structured data (invoice number, vendor, invoice
@@ -97,3 +95,4 @@ success_criteria:
 run_limits:
   max_turns: 80
   turn_timeout: 1200
+  task_timeout: 900

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
@@ -27,8 +27,6 @@ description: >
 
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:ixp]
 
-task_timeout: 1200
-
 dataset:
   rows:
     - id: aviation

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
@@ -29,16 +29,6 @@ tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:ixp
 
 task_timeout: 1200
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 60
-  turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 dataset:
   rows:
     - id: aviation
@@ -152,3 +142,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 60
+  turn_timeout: 1200

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -11,8 +11,6 @@ description: >
 
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:ixp, node:decision]
 
-task_timeout: 900
-
 initial_prompt: |
   Build a UiPath Flow project named "InvoiceRouter" that processes vendor
   invoices:
@@ -113,3 +111,4 @@ success_criteria:
 
 run_limits:
   max_turns: 60
+  task_timeout: 900

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -13,16 +13,6 @@ tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, n
 
 task_timeout: 900
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 60
-  turn_timeout: 900
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   Build a UiPath Flow project named "InvoiceRouter" that processes vendor
   invoices:
@@ -120,3 +110,6 @@ success_criteria:
       - '"false"'
     weight: 2.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 60

--- a/tests/tasks/uipath-maestro-flow/ixp/smoke_01_scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/smoke_01_scaffold_minimal.yaml
@@ -13,16 +13,6 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:i
 
 task_timeout: 600
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 40
-  turn_timeout: 600
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   Create a new Maestro Flow project called "Smoke" with a manual trigger, an
   extract node, and a script node that just logs "ok". Wire the extracted
@@ -87,3 +77,7 @@ success_criteria:
       - "$vars."
     weight: 1.5
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/ixp/smoke_01_scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/smoke_01_scaffold_minimal.yaml
@@ -10,9 +10,6 @@ description: >
   correctness only.
 
 tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:ixp]
-
-task_timeout: 600
-
 initial_prompt: |
   Create a new Maestro Flow project called "Smoke" with a manual trigger, an
   extract node, and a script node that just logs "ok". Wire the extracted
@@ -81,3 +78,4 @@ success_criteria:
 run_limits:
   max_turns: 40
   turn_timeout: 600
+  task_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/ixp/smoke_02_scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/smoke_02_scaffold_multinode.yaml
@@ -17,9 +17,6 @@ description: >
   Validate-only: no `uip maestro flow debug`.
 
 tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:ixp]
-
-task_timeout: 600
-
 initial_prompt: |
   Create a flow called "ReceiptIntake" with a manual trigger, an extractor
   node, and add three script nodes named `postReceipt`, `sendToValidation`,
@@ -97,3 +94,4 @@ success_criteria:
 run_limits:
   max_turns: 40
   turn_timeout: 600
+  task_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/ixp/smoke_02_scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/smoke_02_scaffold_multinode.yaml
@@ -20,16 +20,6 @@ tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:ix
 
 task_timeout: 600
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 40
-  turn_timeout: 600
-
-sandbox:
-  driver: tempdir
-  python: {}
-
 initial_prompt: |
   Create a flow called "ReceiptIntake" with a manual trigger, an extractor
   node, and add three script nodes named `postReceipt`, `sendToValidation`,
@@ -103,3 +93,7 @@ success_criteria:
       - "$vars."
     weight: 1.5
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
@@ -5,11 +5,6 @@ description: >
   'nice day', otherwise 'bring a jacket'. Exercises HTTP, script, and decision nodes.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:decision, feature:http]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -4,11 +4,6 @@ description: >
   using a script node. Exercises input variables, script logic, and output mapping.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -9,11 +9,6 @@ description: >
   notes).
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:decision, feature:trigger, connector]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 2400
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
@@ -6,11 +6,6 @@ description: >
   Script node, and validate the flow.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
@@ -5,11 +5,6 @@ description: >
   switch branching, multi-case wiring, and branch convergence on End.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:switch]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
@@ -5,11 +5,6 @@ description: >
   wiring, variable updates, and state accumulation.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:loop]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -5,11 +5,6 @@ description: >
   data flowing between nodes across iterations.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:loop, feature:http]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -6,11 +6,6 @@ description: >
   and correctly configures filter conditions and map transformations.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:transform]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -6,11 +6,6 @@ description: >
   reference resolution, node configuration, and cloud debug execution.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, connector]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -5,11 +5,6 @@ description: >
   Slack connector → Script → HTTP → Decision → End with data flowing between nodes.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:decision, connector, feature:http]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   task_timeout: 2400
   turn_timeout: 1200

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -8,9 +8,6 @@ description: >
   filter + aggregate on the response items.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:transform, feature:http]
 
-agent:
-  type: claude-code
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -14,11 +14,6 @@ description: >
   agent-side correctness without the tenant dependency (MST-9611).
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/batch_transform/batch_transform.yaml
@@ -9,11 +9,6 @@ description: >
   backend, neither of which the test sandbox can provision deterministically.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:batch-transform, context-grounding]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
@@ -5,11 +5,6 @@ description: >
   node discovery and wiring for coded (vs low-code) agents.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
@@ -6,11 +6,6 @@ description: >
   configuration, and true/false branch wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:decision]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
@@ -5,11 +5,6 @@ description: >
   node discovery and wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -13,11 +13,6 @@ description: >
   mailbox with no rules; tracked as follow-up.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, feature:trigger, connector]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -5,11 +5,6 @@ description: >
   and node wiring.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
@@ -7,11 +7,6 @@ description: >
   the parent flow and subflow.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:subflow]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/summarize/summarize.yaml
@@ -9,11 +9,6 @@ description: >
   service backend, neither of which the test sandbox can provision deterministically.
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:summarize, context-grounding]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -5,11 +5,6 @@ description: >
   multi-case routing, and per-branch Script logic.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:switch]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
@@ -7,11 +7,6 @@ description: >
   Terminate as a hard-stop that kills parallel branches.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, node:terminate]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -5,9 +5,6 @@ description: >
   the correct registry workflow (pull, list/search, get).
 tags: [uipath-maestro-flow, smoke, lifecycle:discover, feature:registry]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 28
 

--- a/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
+++ b/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
@@ -15,7 +15,6 @@ skip: true
 # subcommands. See PLT-103133.
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write", "WebFetch"]
 
 initial_prompt: |

--- a/tests/tasks/uipath-platform/orchestrator/audit_logs_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/audit_logs_e2e.yaml
@@ -6,12 +6,7 @@ description: >
 tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/orchestrator/folders_hierarchy_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_hierarchy_e2e.yaml
@@ -6,12 +6,7 @@ description: >
 tags: [uipath-platform, e2e, mode:build, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/orchestrator/job_control_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/job_control_e2e.yaml
@@ -6,13 +6,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-  turn_timeout: 600  # agent's restart/stop polling can exceed default 300s
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_LONG_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"
@@ -46,3 +40,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 600

--- a/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
@@ -8,12 +8,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/orchestrator/package_download_integration.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/package_download_integration.yaml
@@ -5,12 +5,7 @@ description: >
 tags: [uipath-platform, integration, mode:operate, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/orchestrator/role_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/role_lifecycle_e2e.yaml
@@ -7,12 +7,7 @@ description: >
 tags: [uipath-platform, e2e, mode:build, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/resources/asset_scoping_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/asset_scoping_e2e.yaml
@@ -5,12 +5,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/resources/asset_share_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/asset_share_e2e.yaml
@@ -6,12 +6,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/resources/assets_crud_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/assets_crud_e2e.yaml
@@ -6,12 +6,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/resources/bucket_files_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/bucket_files_e2e.yaml
@@ -6,12 +6,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/resources/queue_items_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/queue_items_e2e.yaml
@@ -5,12 +5,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/resources/trigger_time_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/trigger_time_e2e.yaml
@@ -7,13 +7,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-  turn_timeout: 600  # agent occasionally explores trigger CLI surface — give it room
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"
@@ -48,3 +42,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 600

--- a/tests/tasks/uipath-platform/resources/webhook_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/webhook_e2e.yaml
@@ -6,12 +6,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/resources/webhook_signed_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/webhook_signed_e2e.yaml
@@ -7,12 +7,7 @@ description: >
 tags: [uipath-platform, e2e, mode:operate, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "E2E_PROCESS_KEY=$E2E_PROCESS_KEY python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-platform, e2e, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
 
 initial_prompt: |

--- a/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
@@ -8,7 +8,6 @@ description: >
 tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
 
 initial_prompt: |

--- a/tests/tasks/uipath-review/review_multi_project_solution.yaml
+++ b/tests/tasks/uipath-review/review_multi_project_solution.yaml
@@ -16,9 +16,6 @@ description: >
   but the review skill's structural analysis is platform-independent.
 tags: [uipath-review, e2e, multi-project]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 60
 

--- a/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
@@ -13,23 +13,8 @@ description: >
   commands to succeed at runtime.
 tags: [uipath-rpa, legacy, smoke, create, validate]
 
-agent:
-  type: claude-code
-  # Historically pinned to Opus to dodge a Sonnet content-filter trip
-  # on the full legacy XAML baseline (21 namespaces + 16 assembly
-  # refs including PresentationFramework/PresentationCore/
-  # WindowsBase/System.Xaml/mscorlib + Microsoft.VisualBasic.Activities).
-  # Both Opus 4.6 and 4.1 are now invalid on the EU Bedrock inference
-  # profiles available to us (400 'invalid model identifier'), so
-  # the override was dropped. The default Sonnet from default.yaml
-  # applies; intermittent content-filter blocks are absorbed by the
-  # workflow-level 3-attempt retry on content-filter ERRORs.
-
 run_limits:
-  task_timeout: 1200
   max_turns: 40
-  turn_timeout: 900
-
 initial_prompt: |
   Create a new legacy UiPath RPA project called "HelloLegacy" with a Main.xaml
   that logs "Hello from legacy" using a LogMessage activity. Follow the skill's

--- a/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
+++ b/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
@@ -14,10 +14,7 @@ description: >
 tags: [uipath-rpa, legacy, smoke, edit, validate]
 
 run_limits:
-  task_timeout: 1200
   max_turns: 40
-  turn_timeout: 900
-
 initial_prompt: |
   A legacy UiPath RPA project already exists in this directory. Wrap the
   existing LogMessage activity in Main.xaml inside a TryCatch that logs the

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -18,13 +18,6 @@ description: >
 tags: [uipath-rpa, legacy, e2e, mode:edit-validate]
 max_iterations: 2
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  max_turns: 50
-  turn_timeout: 900
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 initial_prompt: |
   A legacy UiPath RPA project exists at `./InvoiceReader/`. It currently
   reads `invoices.xlsx` and logs each row, but Excel sometimes fails
@@ -236,3 +229,6 @@ success_criteria:
       - '"Legacy"'
     weight: 1.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 50

--- a/tests/tasks/uipath-rpa/uia_google_search.yaml
+++ b/tests/tasks/uipath-rpa/uia_google_search.yaml
@@ -9,15 +9,6 @@ description: >
   `uip rpa validate` compile gate.
 tags: [uipath-rpa, smoke, uia, xaml]
 
-# Standard XAML + UIA activities. First `uip rpa` call restores packages
-# (incl. UIAutomation) + spins up Helm — 60–90s cold start. `validate`
-# on a XAML workflow with UIA activities can run another ~45s. Budget
-# accordingly.
-agent:
-  type: claude-code
-  # Bumped from 60 → 80: evalboard runs on Linux atm so some turns are
-  # wasted since the UiPath project targets Windows.
-
 run_limits:
   task_timeout: 1800
   max_turns: 80

--- a/tests/tasks/uipath-solution/e2e_rpa_sdd/e2e_rpa_sdd.yaml
+++ b/tests/tasks/uipath-solution/e2e_rpa_sdd/e2e_rpa_sdd.yaml
@@ -7,11 +7,6 @@ description: >
 tags: [uipath-solution, e2e, lifecycle:generate]
 max_iterations: 1
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-solution/gap_detection.yaml
+++ b/tests/tasks/uipath-solution/gap_detection.yaml
@@ -6,11 +6,6 @@ description: >
   business-knowledge gaps, per Critical Rules 4 and the Gap Detection Checklist.
 tags: [uipath-solution, integration, lifecycle:generate]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-solution/operate/config_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-solution/operate/config_lifecycle_e2e.yaml
@@ -6,12 +6,7 @@ description: >
 tags: [uipath-solution, e2e, mode:build, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"

--- a/tests/tasks/uipath-solution/operate/deploy_round_trip_e2e.yaml
+++ b/tests/tasks/uipath-solution/operate/deploy_round_trip_e2e.yaml
@@ -6,13 +6,7 @@ description: >
 tags: [uipath-solution, e2e, mode:build, lifecycle:setup]
 
 agent:
-  type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
-  turn_timeout: 600  # publish + deploy + uninstall on tenant exceeds default 300s
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"
@@ -45,3 +39,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 600

--- a/tests/tasks/uipath-solution/pdd_to_sdd.yaml
+++ b/tests/tasks/uipath-solution/pdd_to_sdd.yaml
@@ -5,11 +5,6 @@ description: >
   skill teaches correct PDD extraction, product selection, and SDD structure.
 tags: [uipath-solution, integration, lifecycle:generate]
 
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-
 run_limits:
   turn_timeout: 1200
 

--- a/tests/tasks/uipath-solution/product_selection.yaml
+++ b/tests/tasks/uipath-solution/product_selection.yaml
@@ -5,13 +5,6 @@ description: >
   selection decision table correctly identifies Agents as the primary product
   instead of defaulting to RPA Process.
 tags: [uipath-solution, integration, lifecycle:generate]
-
-agent:
-  type: claude-code
-  permission_mode: acceptEdits
-  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
-
 initial_prompt: |
   Analyze the following Process Design Document and generate a Solution Design
   Document (SDD). Use Autonomous mode — do not pause for checkpoints.
@@ -119,3 +112,6 @@ success_criteria:
       - "Decisions Made"
     weight: 1.0
     pass_threshold: 1.0
+
+run_limits:
+  turn_timeout: 1200

--- a/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
+++ b/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
@@ -8,9 +8,6 @@ description: >
   complete, or otherwise mutate any task.
 tags: [uipath-tasks, e2e, discovery, fetch]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 30
 

--- a/tests/tasks/uipath-test/flaky_tests_analysis.yaml
+++ b/tests/tasks/uipath-test/flaky_tests_analysis.yaml
@@ -11,9 +11,6 @@ description: >
   and the --output json flag.
 tags: [uipath-test, integration, mode:operate, lifecycle:triage, feature:execution]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 35
 

--- a/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
+++ b/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
@@ -8,16 +8,6 @@ description: >
   (e) identifies impacted test sets based on workflow name pattern,
   (f) generates impact analysis report.
 tags: [uipath-test, integration, mode:diagnose, lifecycle:discover, feature:test-case]
-
-# Project Reference
-# Use SHIP project (Shipment Routing) for this test.
-# Fixture: 5 test cases covering shipment workflows; 1 test set
-# with 3-4 linked test cases; execution history available.
-
-agent:
-  type: claude-code
-  max_turns: 60
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 
@@ -99,3 +89,6 @@ success_criteria:
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
+
+run_limits:
+  max_turns: 60

--- a/tests/tasks/uipath-test/integration_release_readiness_qa_lead.yaml
+++ b/tests/tasks/uipath-test/integration_release_readiness_qa_lead.yaml
@@ -16,11 +16,6 @@ description: >
   coverage gap, go/no-go signoff). Requires a fixture project in the
   tenant — see references at the bottom of this file.
 tags: [uipath-test, integration, mode:diagnose, lifecycle:generate, feature:test-case, feature:compliance]
-
-agent:
-  type: claude-code
-  max_turns: 60
-
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 
@@ -160,3 +155,6 @@ success_criteria:
 #
 # The fixture is created once and persists; no pre_run/post_run cleanup.
 # ---------------------------------------------------------------------------
+
+run_limits:
+  max_turns: 60

--- a/tests/tasks/uipath-test/link_automation_and_run.yaml
+++ b/tests/tasks/uipath-test/link_automation_and_run.yaml
@@ -12,9 +12,6 @@ description: >
   folder lookup, and the UUID vs ObjKey distinction for the run command.
 tags: [uipath-test, integration, mode:operate, lifecycle:manage, feature:link-automation]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 35
 

--- a/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
+++ b/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
@@ -9,9 +9,6 @@ description: >
   the testcases add command for assigning testcases to a set.
 tags: [uipath-test, integration, mode:operate, lifecycle:manage, feature:test-set]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 35
 

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -17,9 +17,6 @@ description: >
   here; the report is expected to render the empty-data sections honestly.
 tags: [uipath-test, integration, mode:operate, lifecycle:generate, feature:test-case]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 50
 

--- a/tests/tasks/uipath-test/test_report_junit_export.yaml
+++ b/tests/tasks/uipath-test/test_report_junit_export.yaml
@@ -9,9 +9,6 @@ description: >
   it from the attachment download command.
 tags: [uipath-test, integration, mode:operate, lifecycle:report, feature:execution]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 35
 

--- a/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/testset_hierarchy_discovery.yaml
@@ -10,9 +10,6 @@ description: >
   prompt — must teach the chain commands and the `--output json` flag.
 tags: [uipath-test, smoke, mode:operate, lifecycle:discover, feature:test-case]
 
-agent:
-  type: claude-code
-
 run_limits:
   max_turns: 30
 

--- a/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, rpa, runtime-exception]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -17,14 +16,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/faulted_excel_o365/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/faulted_excel_o365/task.yaml
@@ -14,10 +14,8 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, faithful-replay, integration-serv
 # ($SKILLS_REPO_PATH), ignore_patterns. Only the fields below are overrides
 # specific to this scenario. `type` is required by the TaskDefinition schema
 # even though it could be inherited.
+
 agent:
-  type: claude-code
-  # Need Skill/Agent/AskUserQuestion/TodoWrite beyond the default's set;
-  # the troubleshooting skill orchestrates sub-agents.
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -27,14 +25,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 reference:
   file: RESOLUTION.md
 

--- a/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
@@ -13,24 +13,24 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, activity-bug-silent-failure, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
 run_limits:
   task_timeout: 1800
 
+  max_turns: 60
+  turn_timeout: 3600
+
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
@@ -1,4 +1,4 @@
-﻿task_id: skill-troubleshoot-getasset-external-vault-failure
+task_id: skill-troubleshoot-getasset-external-vault-failure
 description: >
   UiPath diagnostic agent must diagnose a Get Credential failure where
   the target asset exists in the correct folder with the right type
@@ -12,24 +12,24 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, external-vault-failure, credential-stores, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
 run_limits:
   task_timeout: 1800
 
+  max_turns: 60
+  turn_timeout: 3600
+
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, folder-scope-mismatch, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -21,14 +20,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
@@ -11,8 +11,8 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, 
 # Inherits from experiments/default.yaml: model, permission_mode, plugins
 # ($SKILLS_REPO_PATH), ignore_patterns. Only the fields below are overrides
 # specific to this scenario.
+
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -22,14 +22,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
@@ -13,24 +13,24 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, network-connectivity, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
 run_limits:
   task_timeout: 1800
 
+  max_turns: 60
+  turn_timeout: 3600
+
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
@@ -1,4 +1,4 @@
-﻿task_id: skill-troubleshoot-getasset-per-robot-no-value
+task_id: skill-troubleshoot-getasset-per-robot-no-value
 description: >
   UiPath diagnostic agent must diagnose a Get Asset failure where the
   target asset exists in the correct folder and has the right type
@@ -12,24 +12,24 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, per-robot-no-value, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
 
 run_limits:
   task_timeout: 1800
 
+  max_turns: 60
+  turn_timeout: 3600
+
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, permission-denied, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -20,14 +19,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
@@ -1,4 +1,4 @@
-﻿task_id: skill-troubleshoot-getasset-robot-not-authenticated
+task_id: skill-troubleshoot-getasset-robot-not-authenticated
 description: >
   UiPath diagnostic agent must diagnose a Get Credential failure where
   the target asset and folder are correctly configured and the robot
@@ -13,24 +13,24 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, robot-not-authenticated, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
 run_limits:
   task_timeout: 1800
 
+  max_turns: 60
+  turn_timeout: 3600
+
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
@@ -13,24 +13,24 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, get-asset, wrong-activity-type, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
 
 run_limits:
   task_timeout: 1800
 
+  max_turns: 60
+  turn_timeout: 3600
+
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/healing-agent-invalid-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-invalid-license/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, healing-agent, licensing]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -20,8 +19,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_shared/mock_template

--- a/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, healing-agent, licensing]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -22,8 +21,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_shared/mock_template

--- a/tests/tasks/uipath-troubleshoot/healing-agent-recommendation-only/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-recommendation-only/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, rpa, healing-agent]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -17,14 +16,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/maestro-stuck-rpa-job/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/maestro-stuck-rpa-job/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, maestro, bpmn]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -17,12 +16,12 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/null-reference-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/null-reference-exception/task.yaml
@@ -1,4 +1,4 @@
-﻿task_id: skill-troubleshoot-null-reference-exception
+task_id: skill-troubleshoot-null-reference-exception
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -17,14 +16,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/queue-items-failing-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/queue-items-failing-test/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -16,8 +15,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_shared/mock_template

--- a/tests/tasks/uipath-troubleshoot/rpa-foreground-already-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-foreground-already-running/task.yaml
@@ -1,4 +1,4 @@
-﻿task_id: skill-troubleshoot-rpa-foreground-already-running
+task_id: skill-troubleshoot-rpa-foreground-already-running
 description: >
   UiPath diagnostic agent must diagnose a faulted ForegroundHolder job that
   failed with System.InvalidOperationException: "A foreground process is
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, foreground-already-running, concurrency, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -22,14 +21,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/rpa-foreground-misconfigured/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-foreground-misconfigured/task.yaml
@@ -1,4 +1,4 @@
-﻿task_id: skill-troubleshoot-rpa-foreground-misconfigured
+task_id: skill-troubleshoot-rpa-foreground-misconfigured
 description: >
   UiPath diagnostic agent must diagnose a faulted MisconfiguredForeground
   job that failed with System.InvalidOperationException ("A foreground
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, foreground-already-running, misconfigured-foreground, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -27,14 +26,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, faulted-jobs, integration-service, orchestrator, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -17,14 +16,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/rpa-selector-healing-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-selector-healing-disabled/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay, faulted-jobs, ui-automation, rpa]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -17,14 +16,14 @@ run_limits:
 
 sandbox:
   template_sources:
-  - type: template_dir
-    path: ../_shared/mock_template
-  - type: template_dir
-    path: process
-  - type: template_dir
-    path: fixtures
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: process
+    - type: template_dir
+      path: fixtures
   mock_path_dirs:
-  - mocks
+    - mocks
 
 reference:
   file: RESOLUTION.md

--- a/tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml
@@ -14,8 +14,6 @@ description: >
 tags: [uipath-troubleshoot, smoke, fixture-validation]
 
 agent:
-  type: claude-code
-  permission_mode: acceptEdits
   allowed_tools: ["Bash"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, e2e, faithful-replay]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
@@ -16,8 +15,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
-  python: {}
   template_sources:
     - type: template_dir
       path: ../_shared/mock_template

--- a/tests/templates/test-task-template.yaml
+++ b/tests/templates/test-task-template.yaml
@@ -21,17 +21,14 @@ description: >
   Use a folded scalar (>) for multi-line; YAML strips the newlines.
 tags: [<uipath-skill-name>, <tier>, <feature-or-modifier>]
 
+# Inherits agent: and sandbox: defaults from tests/experiments/default.yaml.
+# Only declare fields here when overriding a default — empty blocks just add
+# noise. See scripts/prune-task-defaults.py for what counts as redundant.
+#
 # Optional — uncomment and tune for e2e tests that need longer runs:
 # max_iterations: 1
-# agent:
-#   type: claude-code
-#   permission_mode: acceptEdits
-#   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+# run_limits:
 #   turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 initial_prompt: |
   Goal-oriented prompt — describe what to build, not how. Let the skill


### PR DESCRIPTION
## Summary
- Adds `scripts/prune-task-defaults.py` — a smart pruner that compares each task's `agent:`, `run_limits:`, and `sandbox:` blocks against `tests/experiments/default.yaml` and removes redundant fields.
- Hoists deprecated `agent.max_turns` / `agent.turn_timeout` into top-level `run_limits:` (the 2026-05-20 coder_eval rename — see `coder_eval/orchestration/experiment.py:163`).
- Applied to all 429 task YAMLs; **317 updated**, net **−1181 lines** of inherited config.

## Why
Most tasks were carrying boilerplate that matches the experiment defaults verbatim — `type: claude-code`, `permission_mode: acceptEdits`, `sandbox.driver: tempdir`, empty `python: {}` / `node: {}`. Pruning makes task files focused on what actually overrides the default.

## Script behavior
1. Hoists `agent.{max_turns,turn_timeout,task_timeout}` → `run_limits.*` (conflict-safe: prefers existing `run_limits` value).
2. Drops any `agent` / `run_limits` / `sandbox` field whose value equals the default in `tests/experiments/default.yaml`.
3. Drops empty `{}` / `[]` values (no-op configs).
4. Removes top-level blocks that become empty.
5. Preserves formatting via `ruamel.yaml` (2-space sequence indent) and collapses orphaned blank lines.

Idempotent — re-running on already-pruned files is a no-op.

## Test plan
- [ ] Spot-check diffs across `uipath-admin/`, `uipath-agents/`, `uipath-maestro-flow/`, `uipath-rpa/`
- [ ] Smoke run (`tests/experiments/smoke.yaml`) — confirm overrides still take effect (smoke's `max_turns: 40` vs default's `200`)
- [ ] Nightly run — confirm docker sandbox + extra env passthrough still apply (none of those are in task files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)