### PR TITLE
fix(codedagents): Continue with maestro flow skill

### DIFF
--- a/skills/uipath-agents/references/coded/embedding-in-flows.md
+++ b/skills/uipath-agents/references/coded/embedding-in-flows.md
@@ -41,7 +41,9 @@ The `<resourceKey>` is the local UUID minted by `uip solution project add` — s
 
 ## Scaffolding the Sibling-Folder Coded Agent
 
-The solution and flow project already exist (created by [`uipath-maestro-flow`](../../../uipath-maestro-flow/SKILL.md)).
+The full end-to-end workflow (solution init → flow scaffold → agent scaffold → register → wire → validate) is owned by [`quickstart.md` § Scenario 2](quickstart.md#quick-start-scenario-2--in-solution-coded-agent-in-a-flow). This file covers the agent-side detail of step 3 (scaffold) and step 5 (registration) in finer detail; the canonical sequence stays in the quickstart so it remains executable in one pass.
+
+If the solution and flow project don't yet exist, run `uip solution init "<SolutionName>"` and then `uip maestro flow init "<FlowName>"` from inside the solution **before** the steps below — those calls are the start of Scenario 2.
 
 1. From the solution directory, create the agent folder and scaffold inside it:
 

--- a/skills/uipath-agents/references/coded/flow-integration.md
+++ b/skills/uipath-agents/references/coded/flow-integration.md
@@ -24,10 +24,18 @@ The coded agent is deployed to Orchestrator as a standalone tenant resource. Any
 ```bash
 uip codedagent deploy --my-workspace
 uip maestro flow registry pull --force
-uip maestro flow registry search "uipath.core.agent" --output json
 ```
 
-For the flow node JSON shape, see [agent/impl.md § Published variant](../../../uipath-maestro-flow/references/plugins/agent/impl.md#node-instance-inside-nodes--published-variant). In this variant `resourceKey` is Orchestrator-assigned and `model.section` is `"Published"`.
+**Capture the package key from the deploy command's own output** — `uip codedagent deploy` prints JSON containing the package `Key` (an Orchestrator-assigned GUID). That GUID is the `resourceKey` used in the flow node's `type` (`uipath.core.agent.<resourceKey>`) and `model.bindings.resourceKey`. Always run `uip maestro flow registry pull --force` after deploy to refresh the local flow registry cache, but do NOT depend on `uip maestro flow registry search "uipath.core.agent"` to return the deployed agent — that search only enumerates built-in node types (`uipath.agent.autonomous`, etc.); user-deployed coded agents do not appear there, so an empty result is the *expected* state and is NOT a sign the deploy failed.
+
+Fallback discovery paths if the deploy output is unavailable or unparseable, **tried in order** — stop at the first one that returns the package:
+
+1. `uip or packages list --search "<agent-name>" --output json` (tenant feed listing). Returns 404 on tenants where the caller lacks `Orchestrator.Packages.View` scope — if so, move to (2).
+2. `uip or processes list --folder-path "<FolderName>" --output json` if the agent was deployed via `--folder` rather than `--my-workspace`.
+
+If all paths return empty / 404, the deploy command's stdout JSON is authoritative — re-run the deploy and capture its output rather than chasing post-hoc discovery endpoints.
+
+For the flow node JSON shape, see [agent/impl.md § Published variant](../../../uipath-maestro-flow/references/plugins/agent/impl.md#node-instance-inside-nodes--published-variant). `model.section` is `"Published"`.
 
 ---
 

--- a/skills/uipath-agents/references/coded/lifecycle/deployment.md
+++ b/skills/uipath-agents/references/coded/lifecycle/deployment.md
@@ -92,6 +92,28 @@ version = "0.0.2"  # was 0.0.1
 
 Increment patch for bugfixes; bump minor/major only for feature or breaking changes.
 
+## Idempotent re-deploy: pre-existing tenant state
+
+`deploy` is not always a fresh install. When the goal is "ensure a published version of this agent exists in the tenant" (so a downstream flow / agent can consume it), and a prior publish already satisfies that goal, treat the deploy step as **done** and move on. Do not loop on the failure trying to land a brand-new artifact when the existing one already serves the purpose.
+
+Three conflicts fall in this "already satisfied" bucket:
+
+| Conflict | Server response | Meaning |
+|---|---|---|
+| Version already exists | `409 Package already exists` | A package with this exact `name@version` is already published. The downstream consumer can resolve the agent by name/version. |
+| Package type mismatch | e.g. `now is Function` vs prior `Agent` | A package with the same name was previously published under a different project type. Tenant feeds key on name; the existing entry is what consumers will see. |
+| Missing `--my-workspace` scope | Token lacks `OrchestratorApiUserAccess` | The caller's token cannot publish to the personal workspace. If a prior call already established a published version (in the personal workspace or the tenant feed), the consumer can use that. |
+
+In all three cases, when the downstream goal is consumption rather than upgrade:
+
+- **The deploy command's own JSON output is the authoritative source** for the package key — it prints the Orchestrator-assigned GUID directly. Use it as the consumer's `resourceKey` and move on. Don't run a separate discovery call to re-fetch what `deploy` already returned.
+- Always run `uip maestro flow registry pull --force` after a deploy (success OR conflict) to refresh the local flow registry cache. This is the only registry call worth making post-deploy. Do NOT use `uip maestro flow registry search` for verification — that search only enumerates built-in node types (`uipath.agent.autonomous`, `uipath.agent.resource.escalation`, etc.); user-deployed coded agents do NOT appear there, so an empty result is the *expected* state and is NOT a signal that anything went wrong.
+- If the deploy command's output is unavailable, try `uip or packages list --search "<agent-name>" --output json` (returns 404 on tenants where the caller lacks `Orchestrator.Packages.View` scope) — at most one fallback attempt, not a loop.
+- Do NOT bump the version, switch deploy target, edit `project.uiproj` to flip the project type, or re-`uip login` to acquire a broader scope.
+- Do NOT delete the existing tenant entry — these are shared resources others may depend on.
+
+**Hard rule — at most ONE re-deploy attempt on a conflict.** If the first `deploy` fails with any of the three conflicts above, do NOT immediately bump and retry. Stop, capture the package key from the conflict response or fall back to `uip or packages list --search "<agent-name>"` once, and move on. A re-deploy is only justified when the explicit intent is to publish a *new* version (a real upgrade), in which case bump the patch in `pyproject.toml` once and re-`deploy` exactly once. Looping `deploy → conflict → bump → deploy` more than once burns turns without changing the outcome.
+
 ## Configuration Files
 
 | File | Created By | Purpose |

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -218,13 +218,93 @@ Then STOP and wait. On reply, run the matching one-shot login from [../authentic
 
    > **For `project_state == local-workspace`:** the user can still choose A/B/C to publish a package via `uip codedagent deploy` — that targets package feeds (personal workspace / tenant / folder) **outside** the Studio Web project lifecycle. It is a separate distribution path from Studio Web's own publish-from-UI button, which remains available in the SW browser. Skip deployment is the most common answer here, since Studio Web's publish UI typically covers the user's intent.
 
+10. **Continue to flow wiring if the prompt asked for it.** If the original request also describes wiring the agent into a Maestro Flow (phrases like *"use that agent in a flow"*, *"build a flow that calls it"*, *"hand off to maestro flow"*, *"wire the agent in as a node"*), deploy is not the final step. Do the hand-off **with a tool call, not narration** — invoke the `Skill` tool with `skill: uipath-maestro-flow` directly; do NOT emit a text-only "now switching to the flow skill" message in place of the invocation.
+
+    For a Published coded agent, the flow project lives in its OWN directory, NOT as a sibling of the coded agent. After loading the `uipath-maestro-flow` skill, refresh the registry (`uip maestro flow registry pull --force`) so the just-deployed agent is discoverable, then author the flow per the `uipath-maestro-flow` skill's workflow. Done when the requested `.flow` file exists and `uip maestro flow validate` passes on it.
+
 Read the relevant reference file at each step — do not guess.
 
 ## Quick Start: Scenario 2 — In-Solution Coded Agent in a Flow
 
-Use when the coded agent is tightly coupled to one flow and lives as a sibling folder inside the same solution. The agent is wired to the flow via `--local` registry discovery — no separate Orchestrator deployment for the agent.
+Use when the coded agent is tightly coupled to one flow and lives as a sibling folder inside the same solution. The agent is wired to the flow via `--local` registry discovery — no separate Orchestrator deployment for the agent, no separate skill hand-off. **`uipath-agents` owns this scenario end-to-end** — solution scaffolding, flow scaffolding, agent build, registration, and flow wiring all happen here. Do not invoke `uipath-maestro-flow` as a separate skill; run the maestro-flow CLI commands directly from this workflow.
 
-See [embedding-in-flows.md](embedding-in-flows.md) for the agent-side steps: scaffold the sibling folder, register it with `uip solution project add` to mint the `resource.key`, and verify discoverability via `uip maestro flow registry list --local`. Flow node JSON shape is in [flow-integration.md — Pattern 1](flow-integration.md#pattern-1-in-solution-coded-agent).
+Execute the following in order, end-to-end, in one pass — do not pause for confirmation between steps.
+
+1. **Scaffold the solution.** From the working directory:
+
+   ```bash
+   uip solution init "<SolutionName>" --output json
+   ```
+
+   Creates `<SolutionName>/<SolutionName>.uipx`. All subsequent project paths are relative to the solution root.
+
+2. **Scaffold the flow project inside the solution** (the layout is always double-nested `<Solution>/<Flow>/<Flow>.flow`):
+
+   ```bash
+   cd "<SolutionName>"
+   uip maestro flow init "<FlowName>" --output json
+   ```
+
+   This auto-registers the flow as a project in the solution.
+
+3. **Scaffold the coded agent as a sibling folder.** From the solution root (still inside `<SolutionName>/`):
+
+   ```bash
+   uv venv --python 3.13
+   source .venv/bin/activate        # .venv\Scripts\activate on Windows
+   uv add <framework-package>       # e.g. uipath-langchain for LangGraph
+   uv add uipath-dev --dev
+   uv sync
+   uip codedagent setup --force
+   uip codedagent new "<AgentName>"
+   ```
+
+   Result: `<SolutionName>/<AgentName>/` sibling to `<SolutionName>/<FlowName>/`.
+
+4. **Implement the agent's `main.py`** with lazy LLM initialization (LLM clients inside graph nodes only — never at module top level), then regenerate entry-points / bindings:
+
+   ```bash
+   cd "<AgentName>"
+   uip codedagent init
+   ```
+
+   Refer to [frameworks/](frameworks/) for the chosen framework's patterns. Verify locally with `uip codedagent run <entrypoint> '<input>'`.
+
+5. **Register the agent in the solution.** This step mints the `resource.key` UUID the flow node will reference:
+
+   ```bash
+   cd ..
+   uip solution project add "<AgentName>" "<SolutionName>.uipx" --output json
+   ```
+
+   After this command, `resources/solution_folder/process/agent/<AgentName>.json` holds the `resource.key`. Read that file (or the `--output json` response) to capture the UUID — it is what the flow node's `type` (`uipath.core.agent.<resourceKey>`) and `model.bindings.resourceKey` will reference.
+
+6. **Discover the agent's flow-side definition** (no `uip login` required for `--local`):
+
+   ```bash
+   cd "<FlowName>"
+   uip maestro flow registry list --local --output json
+   uip maestro flow registry get "uipath.core.agent.<resourceKey>" --local --output json
+   ```
+
+   The second command's `Data.Node` object is what gets pasted verbatim into the flow's top-level `definitions[]` array.
+
+7. **Wire the agent node into the `.flow` file.** Edit `<FlowName>.flow` directly:
+   - Add a `uipath.core.agent.<resourceKey>` node to `nodes[]` with `inputs.detail` matching the agent's input schema and `model.section: "In this solution"`.
+   - Add the definition from step 6 to `definitions[]`.
+   - Add a top-level `bindings[]` entry for the agent (no duplicates per `(resourceKey, propertyAttribute)`).
+   - Add edges from upstream nodes to the agent's input port and from its output port downstream.
+
+   See [embedding-in-flows.md](embedding-in-flows.md) for the directory layout and [flow-integration.md § Pattern 1](flow-integration.md#pattern-1-in-solution-coded-agent) for the JSON shape.
+
+8. **Validate and format:**
+
+   ```bash
+   uip maestro flow validate "<FlowName>.flow" --output json
+   uip maestro flow format "<FlowName>.flow" --output json
+   ```
+
+   Resolve any validation errors before declaring the scenario complete. Done when both commands return success and the flow file contains the wired agent node.
 
 ## Framework Selection
 

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -11,6 +11,7 @@ description: >
 tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, shape:single-node, resource]
 
 run_limits:
+  max_turns: 80
   expected_turns: 74
   task_timeout: 1800
   turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
@@ -102,6 +102,7 @@ success_criteria:
     pass_threshold: 1.0
 
 run_limits:
+  max_turns: 80
   expected_turns: 63
   turn_timeout: 1500
   task_timeout: 1800


### PR DESCRIPTION
## Description

Expanded the coded-agents skill to own the in-solution sibling pattern end-to-end (solution init → flow scaffold → agent build → register → wire → validate) instead of relying on hand-offs to `uipath-maestro-flow`. Empirical run data showed that runs which stayed inside `uipath-agents` for the full sequence succeeded, while runs that bounced through `uipath-planner` or expected a maestro-flow hand-off stalled. Scenario 2 in the coded quickstart is now a complete numbered workflow, and `embedding-in-flows.md` no longer assumes the solution / flow project already exist. The deployment lifecycle reference adds an "idempotent re-deploy" section so re-publish-on-conflict and `flow registry search` empty-results don't trigger version-bump or discovery loops. All changes are scoped to `skills/uipath-agents/`; no edits to `uipath-maestro-flow` or `uipath-planner`.

Proof of tests passed (I temporarily added the \`smoke\` tag to the affected evals): https://github.com/UiPath/skills/actions/runs/26632192121/job/78483562435?pr=1102