### PR TITLE
fix(uipath-troubleshoot): hoist getasset task timing fields to top level

### DIFF
--- a/tests/tasks/uipath-troubleshoot/CLAUDE.md
+++ b/tests/tasks/uipath-troubleshoot/CLAUDE.md
@@ -131,16 +131,17 @@ Test runs require valid `uip` auth on the host (set via `.env` or environment) f
 
 Every new scenario's `task.yaml` MUST satisfy the following.
 
-### `run_limits`
+### Timing limits
 
 ```yaml
-run_limits:
-  task_timeout: 2400
-  max_turns: 60
-  turn_timeout: 1800
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 ```
 
-Troubleshooting investigations span many turns and produce large intermediate outputs. Lower limits cause spurious timeouts in CI and mask real regressions.
+`task_timeout`, `max_turns`, and `turn_timeout` MUST be top-level scalars on the task — NOT nested under a `run_limits:` block. The coder-eval task Pydantic model has no `run_limits` field; any block by that name is silently dropped and the task falls back to the experiment / agent defaults (typically `task_timeout: 600`, `turn_timeout: 300`, `max_turns: 20`), which clip troubleshoot investigations mid-chain.
+
+Troubleshooting investigations span many turns and produce large intermediate outputs. Use 90-min `task_timeout` (5400s) and 60-min `turn_timeout` (3600s) so the full triage → hypothesis → tester → depth-check → presenter cycle has headroom; observed wall time for proxy-mode runs is 25–55 min.
 
 ### `tags`
 

--- a/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
@@ -15,11 +15,10 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, 
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
-run_limits:
-  task_timeout: 1800
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
@@ -14,11 +14,10 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, 
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
-run_limits:
-  task_timeout: 1800
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
@@ -14,10 +14,9 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-run_limits:
-  task_timeout: 4500
-  max_turns: 60
-  turn_timeout: 3600
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
@@ -15,10 +15,9 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-run_limits:
-  task_timeout: 4500
-  max_turns: 60
-  turn_timeout: 3600
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
@@ -15,11 +15,10 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, 
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
-run_limits:
-  task_timeout: 1800
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
@@ -14,11 +14,10 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, 
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
 
-run_limits:
-  task_timeout: 1800
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
@@ -13,10 +13,9 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-run_limits:
-  task_timeout: 4500
-  max_turns: 60
-  turn_timeout: 3600
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
@@ -15,11 +15,10 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, 
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600
 
-run_limits:
-  task_timeout: 1800
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
@@ -15,11 +15,10 @@ tags: [uipath-troubleshoot, e2e, faulted-jobs, orchestrator, system-activities, 
 agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
-  max_turns: 60
-  turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
 
-run_limits:
-  task_timeout: 1800
+task_timeout: 5400
+max_turns: 60
+turn_timeout: 3600   # 60 min per turn — LLMGW-proxied diagnostic runs observe up to ~30 min per turn
 
 sandbox:
   template_sources:


### PR DESCRIPTION
## Summary

- 9 `tests/tasks/uipath-troubleshoot/getasset-*/task.yaml` files placed `task_timeout` (and in some cases `max_turns` / `turn_timeout`) under a `run_limits:` block. The coder-eval task Pydantic model has no such field, so Pydantic silently drops it and the run falls back to the experiment-default cap (600s `task_timeout`, 300s `turn_timeout`, 20 `max_turns`).
- Move `task_timeout`, `max_turns`, and `turn_timeout` to top-level scalars on each task. Set `task_timeout: 5400` (90 min) — the headroom uipath-troubleshoot scenarios need for the full triage → hypothesis → tester → depth-check → presenter chain.
- Update `tests/tasks/uipath-troubleshoot/CLAUDE.md` so the local scenario-authoring guidance no longer recommends the broken `run_limits:` block. New scenarios authored from that template will now use the correct top-level placement.
- Inline timing comments on `per-robot-no-value` and `wrong-activity-type` preserved.

## Scope

Intentionally narrow: only the 9 `getasset-*` troubleshoot tasks plus the local CLAUDE.md. Two reasons:

1. **These are the tasks I'm actively running.** Memory from prior sessions confirms the troubleshoot suite was clipping at the silently-dropped defaults; the `getasset-external-vault-failure` scenario specifically timed out at exactly 600s mid-investigation and only passed when re-run with the CLI `--task-timeout 5400` override.
2. **Repo-wide scope is a separate effort.** The reviewer correctly notes ~233 other task files repo-wide use `run_limits:` at the task level (under `uipath-test`, `uipath-maestro-flow`, others). Whether each of those is actually clipping vs. passing on the implicit fallback requires per-suite verification. That audit belongs in a follow-up PR with its own per-suite owners reviewing — bundling it here would mix unrelated concerns and balloon the diff.

`tests/experiments/default.yaml` uses a different structural path (`defaults.run_limits:` under `ExperimentDefaults`); that's a separate Pydantic model and is also broken, but again, out of scope for this PR.

## Evidence the new format works

Three brand-new coder-eval scenarios on PR #1106 (`docs/troubleshoot-excel-delete-range`) were authored using the exact same top-level timing fields this PR introduces (`task_timeout: 4500`, `max_turns: 30`, `turn_timeout: 3600`). All three ran to completion against the uipath-troubleshoot skill on 2026-05-28 with **3/3 success, score 1.000 across all replicates, wall times 702s / 1737s / 1880s**. None were clipped by the previously-dropped `task_timeout`. This validates that the structural pattern flows through the experiment-resolution chain correctly. See `tests/runs/2026-05-28_15-47-21/` for the rendered task.json + experiment artifacts.

## Test plan

- [x] All 9 task.yamls re-render with top-level `task_timeout: 5400` (visual diff verified).
- [x] CLAUDE.md updated to match.
- [x] Empirical validation via PR #1106's delete-range scenarios (same format, 3/3 passed on 2026-05-28).
- [ ] Follow-up: audit the ~233 other tasks repo-wide that use `run_limits:` (separate PR, separate owners).
- [ ] Follow-up: fix `tests/experiments/default.yaml`'s `defaults.run_limits:` nesting (separate PR — touches the `ExperimentDefaults` model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)