### PR TITLE
test(uipath-agents): lead lowcode prompts with the artifact

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "BatchAgent" that takes a CSV upload and adds
+  Create a UiPath low-code agent "BatchAgent" that takes a CSV upload and adds
   two LLM-filled columns: a 4-digit MCC code and a confidence label.
   Enable the built-in "batch-transform" tool so the agent can produce
   one augmented row per input row. The solution should be named

--- a/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
@@ -16,11 +16,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "BatchSol" containing a low-code agent
-  "BatchAgent" that takes a CSV upload and adds two LLM-filled columns:
-  a 4-digit MCC code and a confidence label. Enable the built-in
-  "batch-transform" tool so the agent can produce one augmented row per
-  input row.
+  Build a low-code agent "BatchAgent" that takes a CSV upload and adds
+  two LLM-filled columns: a 4-digit MCC code and a confidence label.
+  Enable the built-in "batch-transform" tool so the agent can produce
+  one augmented row per input row. The solution should be named
+  "BatchSol".
 
   Use the `uip` CLI to scaffold the solution and agent — do NOT
   hand-author the solution `.uipx`, `agent.json`, `project.uiproj`,

--- a/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "DocAnalystAgent" that helps users understand
+  Create a UiPath low-code agent "DocAnalystAgent" that helps users understand
   uploaded documents. Enable the built-in "Analyze Files" tool so the
   agent can analyze PDF and image attachments. The solution should be
   named "DocsSol".

--- a/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
@@ -18,10 +18,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "DocsSol" containing a low-code agent
-  "DocAnalystAgent" that helps users understand uploaded documents.
-  Enable the built-in "Analyze Files" tool so the agent can analyze
-  PDF and image attachments.
+  Build a low-code agent "DocAnalystAgent" that helps users understand
+  uploaded documents. Enable the built-in "Analyze Files" tool so the
+  agent can analyze PDF and image attachments. The solution should be
+  named "DocsSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
@@ -17,11 +17,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "KnowledgeSol" containing a single low-code
-  agent "ProductSupportAgent". The agent accepts a required `question`
-  (string) and returns a string `answer`. It must ground its answers
-  in the existing semantic index named "UiPathAgentsProductKnowledge"
-  that is already deployed in the tenant.
+  Build a low-code agent "ProductSupportAgent" that accepts a required
+  `question` (string) and returns a string `answer`. It must ground its
+  answers in the existing semantic index named
+  "UiPathAgentsProductKnowledge" that is already deployed in the tenant.
+  The solution should be named "KnowledgeSol".
 
   Use the real folder, index name, and backing storage bucket from
   the tenant — do not hard-code or guess these values. Name the

--- a/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
@@ -17,7 +17,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "ProductSupportAgent" that accepts a required
+  Create a UiPath low-code agent "ProductSupportAgent" that accepts a required
   `question` (string) and returns a string `answer`. It must ground its
   answers in the existing semantic index named
   "UiPathAgentsProductKnowledge" that is already deployed in the tenant.

--- a/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
@@ -16,11 +16,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "DeepSol" containing a low-code agent
-  "DeepAgent" that synthesizes answers across multiple PDF or TXT
-  attachments uploaded in chat. Enable the built-in "deep-rag" tool so
-  the agent can run an iterative research-and-synthesis pass over the
-  attachments.
+  Build a low-code agent "DeepAgent" that synthesizes answers across
+  multiple PDF or TXT attachments uploaded in chat. Enable the
+  built-in "deep-rag" tool so the agent can run an iterative
+  research-and-synthesis pass over the attachments. The solution
+  should be named "DeepSol".
 
   Use the `uip` CLI to scaffold the solution and agent — do NOT
   hand-author the solution `.uipx`, `agent.json`, `project.uiproj`,

--- a/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "DeepAgent" that synthesizes answers across
+  Create a UiPath low-code agent "DeepAgent" that synthesizes answers across
   multiple PDF or TXT attachments uploaded in chat. Enable the
   built-in "deep-rag" tool so the agent can run an iterative
   research-and-synthesis pass over the attachments. The solution

--- a/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
@@ -19,11 +19,9 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "DisputeSol" containing a single low-code
-  agent "DisputeAnalystAgent".
-
-  The agent analyzes a billing dispute by synthesizing data from four
-  systems and producing a structured analysis.
+  Build a low-code agent "DisputeAnalystAgent" that analyzes a billing
+  dispute by synthesizing data from four systems and producing a
+  structured analysis. The solution should be named "DisputeSol".
 
   Inputs (all required objects):
     - invoice           — extracted invoice fields

--- a/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "DisputeAnalystAgent" that analyzes a billing
+  Create a UiPath low-code agent "DisputeAnalystAgent" that analyzes a billing
   dispute by synthesizing data from four systems and producing a
   structured analysis. The solution should be named "DisputeSol".
 

--- a/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "GreeterAgent" that accepts a required
+  Create a UiPath low-code agent "GreeterAgent" that accepts a required
   `name` (string) and returns a `greeting` (string). Validate and
   migrate it. The solution should be named "GreetSol".
 

--- a/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a low-code agent "GreeterAgent" that accepts a required
+  Build a low-code agent "GreeterAgent" that accepts a required
   `name` (string) and returns a `greeting` (string). Validate and
   migrate it. The solution should be named "GreetSol".
 

--- a/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
@@ -23,7 +23,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "OutreachAgent" that accepts a required
+  Create a UiPath low-code agent "OutreachAgent" that accepts a required
   `subject` (string) and returns a string `content`. It must compose
   the content by delegating to an agent named "EmailDrafter" that is
   already deployed in the tenant — not by drafting the email itself.

--- a/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
@@ -23,12 +23,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "OutreachSol" containing a single low-code
-  agent "OutreachAgent". The agent accepts a required `subject`
-  (string) and returns a string `content`. It must compose the
-  content by delegating to an agent named "EmailDrafter"
-  that is already deployed in the tenant — not by drafting the
-  email itself.
+  Build a low-code agent "OutreachAgent" that accepts a required
+  `subject` (string) and returns a string `content`. It must compose
+  the content by delegating to an agent named "EmailDrafter" that is
+  already deployed in the tenant — not by drafting the email itself.
+  The solution should be named "OutreachSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the wrapper's tool resource

--- a/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
@@ -22,7 +22,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "WeatherAgent" that accepts a required
+  Create a UiPath low-code agent "WeatherAgent" that accepts a required
   `location` (string) and returns a number `temperature`. It must
   compute the temperature using an API workflow named "WeatherAPI"
   that is already deployed in the tenant — not by reasoning about the

--- a/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
@@ -22,12 +22,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "WeatherSol" containing a single low-code
-  agent "WeatherAgent". The agent accepts a required `location`
-  (string) and returns a number `temperature`. It must compute the
-  temperature using an API workflow named "WeatherAPI" that is
-  already deployed in the tenant — not by reasoning about the answer
-  itself.
+  Build a low-code agent "WeatherAgent" that accepts a required
+  `location` (string) and returns a number `temperature`. It must
+  compute the temperature using an API workflow named "WeatherAPI"
+  that is already deployed in the tenant — not by reasoning about the
+  answer itself. The solution should be named "WeatherSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "FraudTriageAgent" that accepts a required
+  Create a UiPath low-code agent "FraudTriageAgent" that accepts a required
   `transaction` (object) and returns a `verdict` (string). When the
   agent is uncertain, it must escalate to a human reviewer via an
   EXISTING EXTERNAL ActionCenter app named "FraudEscalationQueue" that

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
@@ -18,13 +18,13 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "FraudSol" containing a low-code agent
-  "FraudTriageAgent". The agent accepts a required `transaction`
-  (object) and returns a `verdict` (string). When the agent is
-  uncertain, it must escalate to a human reviewer via an EXISTING
-  EXTERNAL ActionCenter app named "FraudEscalationQueue" that is
-  already deployed to the Orchestrator "Shared" folder (not inside
+  Build a low-code agent "FraudTriageAgent" that accepts a required
+  `transaction` (object) and returns a `verdict` (string). When the
+  agent is uncertain, it must escalate to a human reviewer via an
+  EXISTING EXTERNAL ActionCenter app named "FraudEscalationQueue" that
+  is already deployed to the Orchestrator "Shared" folder (not inside
   this solution). Model this as an escalation resource on the agent.
+  The solution should be named "FraudSol".
 
   When writing the escalation resource.json, set `isEnabled` to true so
   the escalation is active for the agent. Set `properties.folderPath`

--- a/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
@@ -22,7 +22,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "ProcurementAgent" that accepts a required
+  Create a UiPath low-code agent "ProcurementAgent" that accepts a required
   `productId` (number) and returns a boolean `status`. It must
   determine the status by delegating to an Agentic process named
   "ProcurementProcess" that is already deployed in the tenant — not by

--- a/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
@@ -22,12 +22,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ProcurementSol" containing a single
-  low-code agent "ProcurementAgent". The agent accepts a required
+  Build a low-code agent "ProcurementAgent" that accepts a required
   `productId` (number) and returns a boolean `status`. It must
-  determine the status by delegating to an Agentic process
-  named "ProcurementProcess" that is already deployed in the
-  tenant — not by reasoning about the answer itself.
+  determine the status by delegating to an Agentic process named
+  "ProcurementProcess" that is already deployed in the tenant — not by
+  reasoning about the answer itself. The solution should be named
+  "ProcurementSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
@@ -22,11 +22,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "FibonacciSol" containing a single low-code
-  agent "FibonacciAgent". The agent accepts a required `index`
-  (number) and returns a number `value`. It must compute the value
-  using an process named "FibonacciRPA" that is already deployed in
-  the tenant — not by reasoning about the answer itself.
+  Build a low-code agent "FibonacciAgent" that accepts a required
+  `index` (number) and returns a number `value`. It must compute the
+  value using an process named "FibonacciRPA" that is already deployed
+  in the tenant — not by reasoning about the answer itself. The
+  solution should be named "FibonacciSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
@@ -22,7 +22,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "FibonacciAgent" that accepts a required
+  Create a UiPath low-code agent "FibonacciAgent" that accepts a required
   `index` (number) and returns a number `value`. It must compute the
   value using an process named "FibonacciRPA" that is already deployed
   in the tenant — not by reasoning about the answer itself. The

--- a/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
@@ -24,7 +24,7 @@ run_limits:
 initial_prompt: |
   Create a UiPath low-code agent "FibonacciAgent" that accepts a required
   `index` (number) and returns a number `value`. It must compute the
-  value using an process named "FibonacciRPA" that is already deployed
+  value using a process named "FibonacciRPA" that is already deployed
   in the tenant — not by reasoning about the answer itself. The
   solution should be named "FibonacciSol".
 

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
@@ -15,7 +15,7 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "SafeAgent" that answers user questions. Add
+  Create a UiPath low-code agent "SafeAgent" that answers user questions. Add
   a custom guardrail that blocks the word "CONFIDENTIAL" from appearing
   in any agent or LLM output. The guardrail should use a word rule with
   the "contains" operator and a block action with the reason "Forbidden

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
@@ -15,11 +15,11 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "GuardSol" containing a low-code agent
-  "SafeAgent" that answers user questions. Then add a custom guardrail
-  that blocks the word "CONFIDENTIAL" from appearing in any agent or
-  LLM output. The guardrail should use a word rule with the "contains"
-  operator and a block action with the reason "Forbidden term detected."
+  Build a low-code agent "SafeAgent" that answers user questions. Add
+  a custom guardrail that blocks the word "CONFIDENTIAL" from appearing
+  in any agent or LLM output. The guardrail should use a word rule with
+  the "contains" operator and a block action with the reason "Forbidden
+  term detected." The solution should be named "GuardSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
@@ -18,7 +18,7 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "DiscoverAgent". Discover what guardrail
+  Create a UiPath low-code agent "DiscoverAgent". Discover what guardrail
   validators are available using the CLI and add any built-in validator
   guardrail to the agent based on the discovery results. Use a block
   action. The solution should be named "DiscoverSol".

--- a/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
@@ -18,10 +18,10 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "DiscoverSol" containing a low-code agent
-  "DiscoverAgent". Then discover what guardrail validators are available
-  using the CLI and add any built-in validator guardrail to the agent
-  based on the discovery results. Use a block action.
+  Build a low-code agent "DiscoverAgent". Discover what guardrail
+  validators are available using the CLI and add any built-in validator
+  guardrail to the agent based on the discovery results. Use a block
+  action. The solution should be named "DiscoverSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -31,6 +31,7 @@ initial_prompt: |
   violations to a human reviewer via the
   "Tool.Guardrail.Escalation.Action.App" app, notifying
   reviewer@example.com. The solution should be named "EscalateSol".
+
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
   implementation. Complete the entire task end-to-end in a single pass.

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -25,7 +25,7 @@ agent:
 task_timeout: 1800
 
 initial_prompt: |
-  Build a low-code agent "ComplianceAgent" for handling user requests
+  Create a UiPath low-code agent "ComplianceAgent" for handling user requests
   about financial data. Add a guardrail that detects PII — specifically
   email addresses and phone numbers — and instead of blocking, escalates
   violations to a human reviewer via the

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -25,11 +25,12 @@ agent:
 task_timeout: 1800
 
 initial_prompt: |
-  Create a UiPath solution "EscalateSol" with an agent "ComplianceAgent" for
-  handling user requests about financial data. Add a guardrail that detects PII
-  — specifically email addresses and phone numbers — and instead of blocking,
-  escalates violations to a human reviewer via the
-  "Tool.Guardrail.Escalation.Action.App" app, notifying reviewer@example.com.
+  Build a low-code agent "ComplianceAgent" for handling user requests
+  about financial data. Add a guardrail that detects PII — specifically
+  email addresses and phone numbers — and instead of blocking, escalates
+  violations to a human reviewer via the
+  "Tool.Guardrail.Escalation.Action.App" app, notifying
+  reviewer@example.com. The solution should be named "EscalateSol".
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
   implementation. Complete the entire task end-to-end in a single pass.

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
@@ -16,7 +16,7 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "ReviewAgent" that handles compliance review
+  Create a UiPath low-code agent "ReviewAgent" that handles compliance review
   requests. Add a built-in PII detection guardrail that escalates
   violations to a human reviewer instead of blocking. The solution
   should be named "ValidationSol".

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
@@ -16,10 +16,10 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ValidationSol" containing a low-code agent
-  "ReviewAgent" that handles compliance review requests.
-  Then add a built-in PII detection guardrail that escalates violations
-  to a human reviewer instead of blocking.
+  Build a low-code agent "ReviewAgent" that handles compliance review
+  requests. Add a built-in PII detection guardrail that escalates
+  violations to a human reviewer instead of blocking. The solution
+  should be named "ValidationSol".
 
   Guardrail requirements:
   - validatorType: pii_detection

--- a/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
@@ -16,11 +16,11 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "PiiGuardSol" containing a low-code agent
-  "PiiSafeAgent" that answers user questions about their accounts.
-  Then add a built-in PII detection guardrail that blocks Email and
-  PhoneNumber entities in agent-level output. Use a block action with
-  reason "PII detected in output."
+  Build a low-code agent "PiiSafeAgent" that answers user questions
+  about their accounts. Add a built-in PII detection guardrail that
+  blocks Email and PhoneNumber entities in agent-level output. Use a
+  block action with reason "PII detected in output." The solution
+  should be named "PiiGuardSol".
 
   Include entity thresholds of 0.5 for both Email and PhoneNumber.
 

--- a/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
@@ -16,7 +16,7 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "PiiSafeAgent" that answers user questions
+  Create a UiPath low-code agent "PiiSafeAgent" that answers user questions
   about their accounts. Add a built-in PII detection guardrail that
   blocks Email and PhoneNumber entities in agent-level output. Use a
   block action with reason "PII detected in output." The solution

--- a/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
@@ -15,7 +15,7 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "InjSafeAgent" that answers user questions.
+  Create a UiPath low-code agent "InjSafeAgent" that answers user questions.
   Add a built-in prompt injection detection guardrail with a threshold
   of 0.5. Use a block action with reason "Prompt injection detected."
   The solution should be named "InjGuardSol".

--- a/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
@@ -15,10 +15,10 @@ agent:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "InjGuardSol" containing a low-code agent
-  "InjSafeAgent" that answers user questions. Then add a built-in
-  prompt injection detection guardrail with a threshold of 0.5. Use a
-  block action with reason "Prompt injection detected."
+  Build a low-code agent "InjSafeAgent" that answers user questions.
+  Add a built-in prompt injection detection guardrail with a threshold
+  of 0.5. Use a block action with reason "Prompt injection detected."
+  The solution should be named "InjGuardSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/init_validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/init_validate.yaml
@@ -14,7 +14,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a low-code agent "GreeterAgent" that accepts a required
+  Build a low-code agent "GreeterAgent" that accepts a required
   `name` (string) and returns a `greeting` (string). Make sure it
   validates successfully. The solution should be named "GreetSol".
 

--- a/tests/tasks/uipath-agents/lowcode/init_validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/init_validate.yaml
@@ -14,7 +14,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "GreeterAgent" that accepts a required
+  Create a UiPath low-code agent "GreeterAgent" that accepts a required
   `name` (string) and returns a `greeting` (string). Make sure it
   validates successfully. The solution should be named "GreetSol".
 

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
@@ -19,11 +19,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "DocsFlowSol" containing a flow project
-  "DocsFlow". The flow should use an inline low-code agent that helps
-  users understand uploaded documents. Enable the built-in "Analyze
-  Files" tool on the inline agent so it can analyze PDF and image
-  attachments, and wire that tool in the flow.
+  Build a flow project "DocsFlow" that uses an inline low-code agent
+  to help users understand uploaded documents. Enable the built-in
+  "Analyze Files" tool on the inline agent so it can analyze PDF and
+  image attachments, and wire that tool in the flow. The solution
+  should be named "DocsFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "DocsFlow" that uses an inline low-code agent
+  Create a UiPath Flow project "DocsFlow" that uses an inline low-code agent
   to help users understand uploaded documents. Enable the built-in
   "Analyze Files" tool on the inline agent so it can analyze PDF and
   image attachments, and wire that tool in the flow. The solution

--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
@@ -19,12 +19,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "KnowledgeFlowSol" containing a flow project
-  "KnowledgeFlow" with an inline low-code agent. The agent accepts a
-  required `question` (string) and returns a string `answer`. It must
-  ground its answers in the existing semantic index named
-  "UiPathAgentsProductKnowledge" that is already deployed in the
-  tenant (indexes always live outside the solution).
+  Build a flow project "KnowledgeFlow" with an inline low-code agent
+  that accepts a required `question` (string) and returns a string
+  `answer`. It must ground its answers in the existing semantic index
+  named "UiPathAgentsProductKnowledge" that is already deployed in the
+  tenant (indexes always live outside the solution). The solution
+  should be named "KnowledgeFlowSol".
 
   Use the real folder and index name from the tenant — do not
   hard-code or guess these values. Name the agent's context resource

--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "KnowledgeFlow" with an inline low-code agent
+  Create a UiPath Flow project "KnowledgeFlow" with an inline low-code agent
   that accepts a required `question` (string) and returns a string
   `answer`. It must ground its answers in the existing semantic index
   named "UiPathAgentsProductKnowledge" that is already deployed in the

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "OutreachFlow" with an inline low-code agent
+  Create a UiPath Flow project "OutreachFlow" with an inline low-code agent
   that accepts a required `subject` (string) and returns a string
   `content`. It must compose the content by delegating to an agent
   named "EmailDrafter" that is already deployed in the tenant — not by

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -19,12 +19,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "OutreachFlowSol" containing a flow project
-  "OutreachFlow" with an inline low-code agent. The agent accepts a
-  required `subject` (string) and returns a string `content`. It must
-  compose the content by delegating to an agent named "EmailDrafter"
-  that is already deployed in the tenant — not by drafting the email
-  itself.
+  Build a flow project "OutreachFlow" with an inline low-code agent
+  that accepts a required `subject` (string) and returns a string
+  `content`. It must compose the content by delegating to an agent
+  named "EmailDrafter" that is already deployed in the tenant — not by
+  drafting the email itself. The solution should be named
+  "OutreachFlowSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -18,12 +18,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "WeatherFlowSol" containing a flow project
-  "WeatherFlow" with an inline low-code agent. The agent accepts a
-  required `location` (string) and returns a number `temperature`. It
-  must compute the temperature using an API workflow named "WeatherAPI"
-  that is already deployed in the tenant — not by reasoning about the
-  answer itself.
+  Build a flow project "WeatherFlow" with an inline low-code agent
+  that accepts a required `location` (string) and returns a number
+  `temperature`. It must compute the temperature using an API workflow
+  named "WeatherAPI" that is already deployed in the tenant — not by
+  reasoning about the answer itself. The solution should be named
+  "WeatherFlowSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "WeatherFlow" with an inline low-code agent
+  Create a UiPath Flow project "WeatherFlow" with an inline low-code agent
   that accepts a required `location` (string) and returns a number
   `temperature`. It must compute the temperature using an API workflow
   named "WeatherAPI" that is already deployed in the tenant — not by

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -18,12 +18,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "FraudFlowSol" containing a flow project
-  "FraudFlow". The flow should use an inline low-code agent that
-  triages transactions and escalates uncertain cases to an EXISTING
+  Build a flow project "FraudFlow" that uses an inline low-code agent
+  to triage transactions and escalate uncertain cases to an EXISTING
   EXTERNAL ActionCenter app named "FraudEscalationQueue" already
   deployed to the Orchestrator "Shared" folder (not inside this
   solution). Wire the escalation as a resource on the inline agent.
+  The solution should be named "FraudFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "FraudFlow" that uses an inline low-code agent
+  Create a UiPath Flow project "FraudFlow" that uses an inline low-code agent
   to triage transactions and escalate uncertain cases to an EXISTING
   EXTERNAL ActionCenter app named "FraudEscalationQueue" already
   deployed to the Orchestrator "Shared" folder (not inside this

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "ProcurementFlow" with an inline low-code agent
+  Create a UiPath Flow project "ProcurementFlow" with an inline low-code agent
   that accepts a required `productId` (number) and returns a boolean
   `status`. It must determine the status by delegating to an Agentic
   process named "ProcurementProcess" that is already deployed in the

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -19,12 +19,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ProcurementFlowSol" containing a flow
-  project "ProcurementFlow" with an inline low-code agent. The agent
-  accepts a required `productId` (number) and returns a boolean
+  Build a flow project "ProcurementFlow" with an inline low-code agent
+  that accepts a required `productId` (number) and returns a boolean
   `status`. It must determine the status by delegating to an Agentic
   process named "ProcurementProcess" that is already deployed in the
-  tenant — not by reasoning about the answer itself.
+  tenant — not by reasoning about the answer itself. The solution
+  should be named "ProcurementFlowSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "FibonacciFlow" with an inline low-code agent
+  Create a UiPath Flow project "FibonacciFlow" with an inline low-code agent
   that accepts a required `index` (number) and returns a number
   `value`. It must compute the value using an process named
   "FibonacciRPA" that is already deployed in the tenant — not by

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -18,12 +18,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "FibonacciFlowSol" containing a flow project
-  "FibonacciFlow" with an inline low-code agent. The agent accepts a
-  required `index` (number) and returns a number `value`. It must
-  compute the value using an process named "FibonacciRPA" that is
-  already deployed in the tenant — not by reasoning about the answer
-  itself.
+  Build a flow project "FibonacciFlow" with an inline low-code agent
+  that accepts a required `index` (number) and returns a number
+  `value`. It must compute the value using an process named
+  "FibonacciRPA" that is already deployed in the tenant — not by
+  reasoning about the answer itself. The solution should be named
+  "FibonacciFlowSol".
 
   Use the real folder and process name from the tenant — do not
   hard-code or guess these values. Name the agent's tool resource

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -20,7 +20,7 @@ run_limits:
 initial_prompt: |
   Create a UiPath Flow project "FibonacciFlow" with an inline low-code agent
   that accepts a required `index` (number) and returns a number
-  `value`. It must compute the value using an process named
+  `value`. It must compute the value using a process named
   "FibonacciRPA" that is already deployed in the tenant — not by
   reasoning about the answer itself. The solution should be named
   "FibonacciFlowSol".

--- a/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "GreetingFlow" that uses a single low-code agent
+  Create a UiPath Flow project "GreetingFlow" that uses a single low-code agent
   embedded inside the flow project to generate a greeting. The solution
   should be named "GreetingSol".
 

--- a/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
@@ -19,9 +19,9 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "GreetingSol" containing a flow project
-  "GreetingFlow". The flow uses a single low-code agent embedded
-  inside the flow project to generate a greeting.
+  Build a flow project "GreetingFlow" that uses a single low-code agent
+  embedded inside the flow project to generate a greeting. The solution
+  should be named "GreetingSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -23,14 +23,14 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ResearchFlowSol" containing a flow project
-  "ResearchFlow". The flow should use an inline low-code agent that
-  searches the web using the "WebSearch" activity from the UiPath
-  GenAI Activities Integration Service connector (connector key
+  Build a flow project "ResearchFlow" that uses an inline low-code
+  agent to search the web using the "WebSearch" activity from the
+  UiPath GenAI Activities Integration Service connector (connector key
   `uipath-uipath-airdk`). Wire the Integration Service activity as a
   tool on the inline agent via the flow canvas, update the agent
   bindings, and refresh the solution so the connection resource is
-  provisioned. Validate the inline agent.
+  provisioned. Validate the inline agent. The solution should be named
+  "ResearchFlowSol".
 
   Do NOT invoke the connector at runtime.
 

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -23,7 +23,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "ResearchFlow" that uses an inline low-code
+  Create a UiPath Flow project "ResearchFlow" that uses an inline low-code
   agent to search the web using the "WebSearch" activity from the
   UiPath GenAI Activities Integration Service connector (connector key
   `uipath-uipath-airdk`). Wire the Integration Service activity as a

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -18,11 +18,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "DevToolsFlowSol" containing a flow project
-  "DevToolsFlow". The flow should use an inline low-code agent that
-  connects to an MCP server named "GitHubMcp" exposing GitHub-related
-  tools. Declare the MCP server as a resource on the inline agent and
-  wire it into the flow.
+  Build a flow project "DevToolsFlow" that uses an inline low-code
+  agent connecting to an MCP server named "GitHubMcp" exposing
+  GitHub-related tools. Declare the MCP server as a resource on the
+  inline agent and wire it into the flow. The solution should be named
+  "DevToolsFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "DevToolsFlow" that uses an inline low-code
+  Create a UiPath Flow project "DevToolsFlow" that uses an inline low-code
   agent connecting to an MCP server named "GitHubMcp" exposing
   GitHub-related tools. Declare the MCP server as a resource on the
   inline agent and wire it into the flow. The solution should be named

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -19,10 +19,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "OrchestratorFlowSol" containing a flow
-  project "OrchestratorFlow" and a low-code agent "ToolAgent" that
-  echoes back any string it receives. The flow should use an inline
-  low-code agent that delegates to "ToolAgent" as a tool.
+  Build a flow project "OrchestratorFlow" and a low-code agent
+  "ToolAgent" that echoes back any string it receives. The flow should
+  use an inline low-code agent that delegates to "ToolAgent" as a tool.
+  The solution should be named "OrchestratorFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "OrchestratorFlow" and a low-code agent
+  Create a UiPath Flow project "OrchestratorFlow" and a low-code agent
   "ToolAgent" that echoes back any string it receives. The flow should
   use an inline low-code agent that delegates to "ToolAgent" as a tool.
   The solution should be named "OrchestratorFlowSol".

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "ShippingFlow" that uses an inline low-code
+  Create a UiPath Flow project "ShippingFlow" that uses an inline low-code
   agent to call an API workflow called "CalculateShippingRate" living
   inside this same solution as a separate project. Wire the API
   workflow as a tool on the inline agent. The solution should be named

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -18,11 +18,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ShippingFlowSol" containing a flow project
-  "ShippingFlow". The flow should use an inline low-code agent that
-  calls an API workflow called "CalculateShippingRate" living inside
-  this same solution as a separate project. Wire the API workflow as
-  a tool on the inline agent.
+  Build a flow project "ShippingFlow" that uses an inline low-code
+  agent to call an API workflow called "CalculateShippingRate" living
+  inside this same solution as a separate project. Wire the API
+  workflow as a tool on the inline agent. The solution should be named
+  "ShippingFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
@@ -18,11 +18,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ReviewFlowSol" containing a flow project
-  "ReviewFlow". The flow should use an inline low-code agent that
-  moderates user content and escalates uncertain cases to a human
+  Build a flow project "ReviewFlow" that uses an inline low-code agent
+  to moderate user content and escalate uncertain cases to a human
   reviewer via a UiPath ActionCenter app provisioned INSIDE this same
   solution. Wire the escalation as a resource on the inline agent.
+  The solution should be named "ReviewFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "ReviewFlow" that uses an inline low-code agent
+  Create a UiPath Flow project "ReviewFlow" that uses an inline low-code agent
   to moderate user content and escalate uncertain cases to a human
   reviewer via a UiPath ActionCenter app provisioned INSIDE this same
   solution. Wire the escalation as a resource on the inline agent.

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -18,11 +18,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "OnboardingFlowSol" containing a flow
-  project "OnboardingFlow". The flow should use an inline low-code
-  agent that calls an Agentic process called "EmployeeOnboarding" living
+  Build a flow project "OnboardingFlow" that uses an inline low-code
+  agent to call an Agentic process called "EmployeeOnboarding" living
   inside this same solution as a separate project. Wire the Agentic
-  process as a tool on the inline agent.
+  process as a tool on the inline agent. The solution should be named
+  "OnboardingFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "OnboardingFlow" that uses an inline low-code
+  Create a UiPath Flow project "OnboardingFlow" that uses an inline low-code
   agent to call an Agentic process called "EmployeeOnboarding" living
   inside this same solution as a separate project. Wire the Agentic
   process as a tool on the inline agent. The solution should be named

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow project "PayrollFlow" that uses an inline low-code
+  Create a UiPath Flow project "PayrollFlow" that uses an inline low-code
   agent to call an RPA process called "CalculatePay" living inside
   this same solution as a separate project. Wire the RPA process as a
   tool on the inline agent. The solution should be named

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -19,11 +19,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "PayrollFlowSol" containing a flow project
-  "PayrollFlow". The flow should use an inline low-code agent that
-  calls an RPA process called "CalculatePay" living inside this same
-  solution as a separate project. Wire the RPA process as a tool on
-  the inline agent.
+  Build a flow project "PayrollFlow" that uses an inline low-code
+  agent to call an RPA process called "CalculatePay" living inside
+  this same solution as a separate project. Wire the RPA process as a
+  tool on the inline agent. The solution should be named
+  "PayrollFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
@@ -21,7 +21,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "ResearchAgent" that can search the web using
+  Create a UiPath low-code agent "ResearchAgent" that can search the web using
   the "WebSearch" activity from the UiPath GenAI Activities Integration
   Service connector (connector key `uipath-uipath-airdk`). Expose the
   activity to the agent as an Integration Service tool. Update the

--- a/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
@@ -21,14 +21,13 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ResearchSol" containing a single low-code
-  agent "ResearchAgent". The agent should be able to search the web
-  using the "WebSearch" activity from the UiPath GenAI Activities
-  Integration Service connector (connector key
-  `uipath-uipath-airdk`). Expose the activity to the agent as an
-  Integration Service tool. Update the agent's bindings and refresh
-  the solution so the connection resource is provisioned. Validate
-  the agent project.
+  Build a low-code agent "ResearchAgent" that can search the web using
+  the "WebSearch" activity from the UiPath GenAI Activities Integration
+  Service connector (connector key `uipath-uipath-airdk`). Expose the
+  activity to the agent as an Integration Service tool. Update the
+  agent's bindings and refresh the solution so the connection resource
+  is provisioned. Validate the agent project. The solution should be
+  named "ResearchSol".
 
   Do NOT invoke the connector at runtime.
 

--- a/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "DevAssistantAgent" that connects to an MCP
+  Create a UiPath low-code agent "DevAssistantAgent" that connects to an MCP
   server named "GitHubMcp" exposing GitHub-related tools. Declare the
   MCP server as a resource on the agent. The solution should be named
   "DevToolsSol".

--- a/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
@@ -16,10 +16,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "DevToolsSol" containing a low-code agent
-  "DevAssistantAgent". The agent should connect to an MCP server
-  named "GitHubMcp" that exposes GitHub-related tools. Declare the
-  MCP server as a resource on the agent.
+  Build a low-code agent "DevAssistantAgent" that connects to an MCP
+  server named "GitHubMcp" exposing GitHub-related tools. Declare the
+  MCP server as a resource on the agent. The solution should be named
+  "DevToolsSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "ResolutionDrafterAgent" that composes a
+  Create a UiPath low-code agent "ResolutionDrafterAgent" that composes a
   professional customer-facing resolution email after a billing dispute
   has been adjusted. The solution should be named "ResolutionSol".
 

--- a/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
@@ -19,11 +19,9 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ResolutionSol" containing a single low-code
-  agent "ResolutionDrafterAgent".
-
-  The agent composes a professional customer-facing resolution email
-  after a billing dispute has been adjusted.
+  Build a low-code agent "ResolutionDrafterAgent" that composes a
+  professional customer-facing resolution email after a billing dispute
+  has been adjusted. The solution should be named "ResolutionSol".
 
   Inputs (all required objects):
     - customer         — { name, email, tier }

--- a/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
+++ b/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
@@ -17,7 +17,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a low-code agent "QueryAgent" that accepts a required
+  Build a low-code agent "QueryAgent" that accepts a required
   `userQuery` (string) and returns a `reply` (string). Validate the
   agent. The solution should be named "QuerySol".
 

--- a/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
+++ b/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
@@ -17,7 +17,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "QueryAgent" that accepts a required
+  Create a UiPath low-code agent "QueryAgent" that accepts a required
   `userQuery` (string) and returns a `reply` (string). Validate the
   agent. The solution should be named "QuerySol".
 

--- a/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
@@ -18,7 +18,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build two low-code agents, "ParentAgent" and "ToolAgent". ToolAgent
+  Create two UiPath low-code agents, "ParentAgent" and "ToolAgent". ToolAgent
   echoes back the string it receives. ParentAgent should use ToolAgent
   as a tool. The solution should be named "OrchestratorSol".
 

--- a/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
@@ -18,9 +18,9 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "OrchestratorSol" with two low-code
-  agents, "ParentAgent" and "ToolAgent". ToolAgent echoes back the
-  string it receives. ParentAgent should use ToolAgent as a tool.
+  Build two low-code agents, "ParentAgent" and "ToolAgent". ToolAgent
+  echoes back the string it receives. ParentAgent should use ToolAgent
+  as a tool. The solution should be named "OrchestratorSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
@@ -16,10 +16,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ShippingSol" containing a low-code agent
-  "ShippingAgent". The agent should call an API workflow called
-  "CalculateShippingRate" that lives INSIDE this same solution as a
-  separate project. Expose it to the agent as a tool resource.
+  Build a low-code agent "ShippingAgent" that calls an API workflow
+  called "CalculateShippingRate" living INSIDE this same solution as a
+  separate project. Expose it to the agent as a tool resource. The
+  solution should be named "ShippingSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "ShippingAgent" that calls an API workflow
+  Create a UiPath low-code agent "ShippingAgent" that calls an API workflow
   called "CalculateShippingRate" living INSIDE this same solution as a
   separate project. Expose it to the agent as a tool resource. The
   solution should be named "ShippingSol".

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
@@ -19,7 +19,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "ModerationAgent" that accepts a required
+  Create a UiPath low-code agent "ModerationAgent" that accepts a required
   `content` (string) and returns a `decision` (string). When the agent
   is uncertain, it must be able to escalate to a human reviewer via
   UiPath ActionCenter — model this as an escalation resource called

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
@@ -19,12 +19,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "ReviewSol" containing a single low-code
-  agent "ModerationAgent". The agent accepts a required `content`
-  (string) and returns a `decision` (string). When the agent is
-  uncertain, it must be able to escalate to a human reviewer via
+  Build a low-code agent "ModerationAgent" that accepts a required
+  `content` (string) and returns a `decision` (string). When the agent
+  is uncertain, it must be able to escalate to a human reviewer via
   UiPath ActionCenter — model this as an escalation resource called
-  "HumanReview" on the agent.
+  "HumanReview" on the agent. The solution should be named "ReviewSol".
 
   When writing the escalation resource.json, set `isEnabled` to true so
   the escalation is active for the agent.

--- a/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
@@ -16,10 +16,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "OnboardingSol" containing a low-code agent
-  "OnboardingAgent". The agent should call an Agentic process called
-  "EmployeeOnboarding" that lives INSIDE this same solution as a
-  separate project. Expose it to the agent as a tool resource.
+  Build a low-code agent "OnboardingAgent" that calls an Agentic
+  process called "EmployeeOnboarding" living INSIDE this same solution
+  as a separate project. Expose it to the agent as a tool resource.
+  The solution should be named "OnboardingSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "OnboardingAgent" that calls an Agentic
+  Create a UiPath low-code agent "OnboardingAgent" that calls an Agentic
   process called "EmployeeOnboarding" living INSIDE this same solution
   as a separate project. Expose it to the agent as a tool resource.
   The solution should be named "OnboardingSol".

--- a/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
@@ -16,10 +16,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "PayrollSol" containing a low-code agent
-  "PayrollAgent". The agent should call an RPA process called
-  "CalculatePay" that lives INSIDE this same solution as a separate
-  project. Expose it to the agent as a tool resource.
+  Build a low-code agent "PayrollAgent" that calls an RPA process
+  called "CalculatePay" living INSIDE this same solution as a separate
+  project. Expose it to the agent as a tool resource. The solution
+  should be named "PayrollSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a low-code agent "PayrollAgent" that calls an RPA process
+  Create a UiPath low-code agent "PayrollAgent" that calls an RPA process
   called "CalculatePay" living INSIDE this same solution as a separate
   project. Expose it to the agent as a tool resource. The solution
   should be named "PayrollSol".


### PR DESCRIPTION
## Summary

- Consolidates the `initial_prompt` wording across every uipath-agents lowcode build task so it opens with the artifact being built (`Build a low-code agent "<name>" ...` or `Build a flow project "<name>" ...`) instead of `Create a UiPath solution "<sol>" containing ...`.
- The solution name moves to a trailing `The solution should be named "<sol>".` sentence so it no longer buries the lede.
- Aligns the three pre-existing artifact-first prompts (`init_validate.yaml`, `edit_roundtrip.yaml`, `schema_update.yaml`) on the same `Build` verb the rest of the suite now uses.

Scope: 42 task YAMLs under `tests/tasks/uipath-agents/lowcode/`. Smoke-trigger inquiry tasks and the guardrail-recommend/validate tasks that operate on pre-seeded fixtures are intentionally untouched — they don't share this pattern.

## Test plan

- [x] Re-run a representative sample of the modified tasks via `coder-eval` (e.g. `solution_rpa_tool`, `inline_external_apiworkflow_tool`, `guardrail_pii_detection`) and confirm they still grade pass on the new prompt.
- [x] `/lint-task` on a couple of the updated YAMLs to confirm no lint regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)