### PR TITLE
fix(agents): focused mocking eval

### DIFF
--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/check_eval_mocking_mockito.py
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/check_eval_mocking_mockito.py
@@ -18,16 +18,16 @@ is structured JSON, so JsonSimilarity is the natural fit and it
 exercises a separate evaluator type from `eval_exact_match`.
 
 Checks:
-  1. `secret-peek/pyproject.toml` exists with no `[build-system]`.
-  2. `secret-peek/main.py` imports `mockable` and `ExampleCall` from
+  1. `asset-retriever/pyproject.toml` exists with no `[build-system]`.
+  2. `asset-retriever/main.py` imports `mockable` and `ExampleCall` from
      `uipath.eval.mocks` AND has at least one `@mockable(...)`
      decorator.
-  3. `secret-peek/evaluations/evaluators/*.json` contains an
+  3. `asset-retriever/evaluations/evaluators/*.json` contains an
      evaluator with `evaluatorTypeId == "uipath-json-similarity"`.
-  4. `secret-peek/evaluations/eval-sets/*.json` is v1.0; at least
+  4. `asset-retriever/evaluations/eval-sets/*.json` is v1.0; at least
      one test case carries `mockingStrategy.type == "mockito"` with
      a non-empty return behavior.
-  5. `secret-peek/eval-results.json` has the documented shape and
+  5. `asset-retriever/eval-results.json` has the documented shape and
      every recorded evaluator run scored >= 0.5.
 """
 
@@ -41,7 +41,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.project_root import find_project_root  # noqa: E402
 
-ROOT = find_project_root("secret-peek")
+ROOT = find_project_root("asset-retriever")
 
 
 def _read_text(path: Path) -> str:

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -20,19 +20,78 @@ agent:
   turn_timeout: 1800
 
 initial_prompt: |
-  Build a Simple Function UiPath coded agent named `secret-peek` that
-  returns a structured summary of a UiPath asset: the first 4
-  characters followed by stars to pad out to the original length,
-  alongside a human-readable label looked up from a remote registry.
+  Recreate the coded agent project under `asset-retriever/`
+  exactly as below.
 
-  The agent has two external calls:
-    1. Reads the asset `api_key` from the `Shared` folder via the
-       UiPath SDK.
-    2. Calls a helper `fetch_label(key_id: str) -> str` that talks
-       to a remote registry (just `requests.get` against a URL).
+  **asset-retriever/pyproject.toml**:
+  [project]
+  name = "asset-retriever"
+  version = "0.0.1"
+  description = "UiPath agent that returns a structured summary of an asset with masked value and remote label"
+  authors = [{ name = "john doe", email = "john.doe@example.com" }]
+  dependencies = [
+      "requests>=2.34.2",
+      "uipath>=2.10.0, <2.11.0",
+  ]
+  requires-python = ">=3.11"
 
-  Output shape (Pydantic):
-    `{"masked_key": "abcd******", "label": "production-stripe"}`
+  [dependency-groups]
+  dev = [
+      "uipath-dev>=0.0.79",
+  ]
+
+  **asset-retriever/main.py**:
+  from dataclasses import dataclass
+  import requests
+  from uipath.platform import UiPath
+
+  @dataclass
+  class SecretPeekInput:
+      asset_name: str
+
+  @dataclass
+  class SecretPeekOutput:
+      masked_key: str
+      label: str
+
+  def fetch_label(key_id: str) -> str:
+      """Fetch human-readable label from remote registry."""
+      url = f"https://registry.example.com/labels/{key_id}"
+      try:
+          response = requests.get(url, timeout=5)
+          response.raise_for_status()
+          data = response.json()
+          return data.get("label", "unknown")
+      except Exception:
+          return "unknown"
+
+  def mask_secret(secret: str) -> str:
+      """Mask secret: first 4 chars + stars padded to original length."""
+      if len(secret) < 4:
+          return "*" * len(secret)
+      return secret[:4] + "*" * (len(secret) - 4)
+
+  def main(input: SecretPeekInput) -> SecretPeekOutput:
+      sdk = UiPath()
+
+      # Read asset from Shared folder
+      asset = sdk.assets.retrieve(input.asset_name, folder_name="Shared")
+      secret_value = asset.value
+
+      # Mask the secret
+      masked = mask_secret(secret_value)
+
+      # Fetch label from registry
+      label = fetch_label(input.asset_name)
+
+      return SecretPeekOutput(masked_key=masked, label=label)
+
+    **asset-retriever/uipath.json**:
+      {
+    "functions": {
+      "main": "main.py:main"
+      }
+    }
 
   Add a smoke evaluation suite with 2–3 cases covering different
   asset values and run it locally. The evals must pass without
@@ -40,34 +99,13 @@ initial_prompt: |
   remote registry being reachable. Save the eval output to
   `eval-results.json` in the project root.
 
-  Two constraints on how the mocking is wired (both matter — we use
-  this project as a reference for new joiners learning the eval
-  framework, so it has to demonstrate both approaches):
-    - For the `fetch_label` helper, bake the mock outputs **into the
-      Python code** so reviewers can see the example values right
-      next to the function definition. The mock data should travel
-      with `main.py`.
-    - For the asset retrieval, supply the mock value **from the
-      eval-set definitions** so each test case can use a different
-      asset value without code changes.
-
   For scoring, use a **structured-output evaluator** — we care
-  about the shape of `{"masked_key": ..., "label": ...}` matching
-  the expected JSON per case, not character-for-character string
-  equality. We want the eval to flag a case where one field is
-  right but the other is subtly wrong.
+  about the shape of `{"masked_key": ..., "label": ...}. Those
+  should be as similar as possible to what we expect.
 
-  Take the agent through scaffold → init → run the eval suite. Do
-  NOT publish, upload, or deploy. Complete it in a single pass.
+  Do NOT publish, upload, or deploy. Complete it in a single pass.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent scaffolded the project with uip codedagent new"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+codedagent\s+new'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent ran uip codedagent init to generate entry-points.json"


### PR DESCRIPTION
fix(agents): focused mocking eval

## Why

Evaluation was failing with `MAX_TURNS_EXHAUSTED` because the agent had to do multiple tasks in the same session:

- scaffold project
- apply 2 types of mocking
- define custom evaluators
- run evaluations

The current changes scope the eval to test the mocking behaviour, not the entire suite