### PR TITLE
test(uipath-rpa): route windows-tagged coder-eval tasks to windows-latest

### DIFF
--- a/.claude/commands/generate-task.md
+++ b/.claude/commands/generate-task.md
@@ -54,7 +54,7 @@ Per the tier table in `tests/README.md`:
 
 ### 2b. Tags
 
-Required, in this order: `<skill-name>` first, then `<tier>`, then `mode:<X>`. Optional dimensions (`shape:*`, `node:*`, `resource`, `connector`, `feature:*`) follow per `tests/README.md#tag-taxonomy`.
+Required, in this order: `<skill-name>` first, then `<tier>`, then `mode:<X>`. Optional dimensions (`shape:*`, `node:*`, `resource`, `connector`, `windows`, `feature:*`) follow per `tests/README.md#tag-taxonomy`.
 
 - **`<skill-name>`** — always the first tag. Must match the `skills/<name>/` folder exactly (e.g. `uipath-maestro-flow`, `uipath-agents`). Never abbreviate or drop the `uipath-` prefix.
 - **`<tier>`** — `smoke`, `integration`, or `e2e`.
@@ -65,7 +65,7 @@ Required, in this order: `<skill-name>` first, then `<tier>`, then `mode:<X>`. O
 
 **Use only the closed-vocabulary values listed in `tests/README.md`.** If no value fits an optional dimension, omit it and surface it in the Phase 4 summary so the taxonomy can be extended deliberately. Never invent tag values inline.
 
-Final tag order: `[<skill-name>, <tier>, mode:X, shape:X, node:..., resource, connector, feature:...]`.
+Final tag order: `[<skill-name>, <tier>, mode:X, shape:X, node:..., resource, connector, windows, feature:...]`.
 
 Example:
 

--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -108,7 +108,7 @@ task_id         — unique test identifier (e.g., "skill-flow-calculator")
 description     — what the test validates
 tags            — array carrying values from the Tag Taxonomy dimensions
                   documented in tests/README.md. Form:
-                  [skill, tier, mode:X, shape:X, node:..., resource, connector, feature:...]
+                  [skill, tier, mode:X, shape:X, node:..., resource, connector, windows, feature:...]
                     skill      — uipath-<name>                                (required, flat)
                     tier       — smoke | integration | e2e                    (required, flat)
                     mode       — mode:{build|operate|troubleshoot}                (required)
@@ -116,6 +116,7 @@ tags            — array carrying values from the Tag Taxonomy dimensions
                     node       — node:{decision|switch|subflow|terminate|loop|transform|hitl} (0..n)
                     resource   — flat boolean marker (present iff task uses a resource node) (0..1)
                     connector  — flat boolean marker (present iff task uses any connector)   (0..1)
+                    windows    — flat boolean marker (present iff task requires a Windows host) (0..1)
                     feature    — feature:{http|trigger|registry|transform|approval-gate|
                                  write-back|escalation|…}                     (0..n)
                   Record every dimension; Phase 4f keys off all of them, not just tier.
@@ -235,7 +236,7 @@ For each skill that has at least one test, compute which values from the Tag Tax
 - **Mode** — tick each of `mode:build`, `mode:operate`, `mode:diagnose` if any test carries that tag. All three are expected eventually for most skills; missing modes surface as gaps.
 - **Shape** — tick each of `shape:single-node`, `shape:multi-node` (applies to flow-building skills only).
 - **Node** — list values present under `node:*` for skills where that axis applies.
-- **Resource / Connector** — flat boolean markers; report count of tasks carrying each (`resource`, `connector`) for skills where they apply.
+- **Resource / Connector / Windows** — flat boolean markers; report count of tasks carrying each (`resource`, `connector`, `windows`) for skills where they apply.
 - **Feature** — list `feature:*` tags present vs a reasonable "expected" set for this skill (derived from SKILL.md — e.g. `uipath-human-in-the-loop` should exercise `feature:approval-gate`, `feature:write-back`, `feature:escalation`; `uipath-maestro-flow` should exercise `feature:registry`, `feature:transform`, `feature:http`, …). If the skill's vocabulary is open, list what's present without the ✗ column.
 
 This is structured data for the per-skill report (see template below). It is NOT folded into the weighted overall score — adding it on top of Components/Steps would double-count (a missing edit-scenario test already shows up as a workflow-step gap).

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -4,6 +4,12 @@ name: Run Coder Eval
 # single task ad-hoc, a folder, or (with explicit confirmation) the full
 # suite that the VM cron runs nightly. Long-term replacement for the
 # coder-eval-runner VM.
+#
+# Tasks are split by the `windows` tag (see tests/README.md#tag-taxonomy):
+# windows-tagged tasks run on `windows-latest` (Helm/Studio is Windows-only,
+# tempdir driver), everything else runs on `ubuntu-latest` (Docker driver
+# + experiments/nightly.yaml). Both jobs receive the resolved file list
+# from the `partition` job — never the raw glob.
 
 on:
   workflow_dispatch:
@@ -30,7 +36,66 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  run:
+  partition:
+    runs-on: ubuntu-latest
+    name: Partition globs by `windows` tag
+    outputs:
+      linux_globs:   ${{ steps.split.outputs.linux_globs }}
+      windows_globs: ${{ steps.split.outputs.windows_globs }}
+      linux_count:   ${{ steps.split.outputs.linux_count }}
+      windows_count: ${{ steps.split.outputs.windows_count }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve globs, split by tag, enforce large-run gate
+        id: split
+        env:
+          INPUT_GLOBS: ${{ inputs.task_globs }}
+          CONFIRMED:   ${{ inputs.confirm_large_run }}
+        run: |
+          set -euo pipefail
+          if [ -z "$INPUT_GLOBS" ]; then
+            echo "::error::task_globs is required"
+            exit 1
+          fi
+          shopt -s globstar nullglob
+          cd tests
+          LINUX=()
+          WINDOWS=()
+          for pat in $INPUT_GLOBS; do
+            for f in $pat; do
+              [ -f "$f" ] || continue
+              # Tag is the literal token `windows` on the `tags:` line.
+              # Word boundary keeps `feature:windows-foo` (hypothetical)
+              # from matching.
+              if grep -qE '^tags:.*\bwindows\b' "$f"; then
+                WINDOWS+=("$f")
+              else
+                LINUX+=("$f")
+              fi
+            done
+          done
+          LCOUNT=${#LINUX[@]}
+          WCOUNT=${#WINDOWS[@]}
+          TOTAL=$((LCOUNT + WCOUNT))
+          echo "Matched $TOTAL task file(s): $LCOUNT linux + $WCOUNT windows"
+          if [ "$TOTAL" -eq 0 ]; then
+            echo "::error::No task files matched the provided globs"
+            exit 1
+          fi
+          if [ "$TOTAL" -gt 50 ] && [ "$CONFIRMED" != "true" ]; then
+            echo "::error::Glob matches $TOTAL tasks (> 50). Tick confirm_large_run to authorize."
+            exit 1
+          fi
+          # Space-separated; downstream jobs word-split on consumption.
+          echo "linux_globs=${LINUX[*]:-}"     >> "$GITHUB_OUTPUT"
+          echo "windows_globs=${WINDOWS[*]:-}" >> "$GITHUB_OUTPUT"
+          echo "linux_count=$LCOUNT"            >> "$GITHUB_OUTPUT"
+          echo "windows_count=$WCOUNT"          >> "$GITHUB_OUTPUT"
+
+  run-linux:
+    needs: partition
+    if: needs.partition.outputs.linux_count != '0'
     # TODO: switch to `ubuntu-latest-16-cores` (16 vCPU / 64 GB RAM) once
     # the UiPath/skills repo is allowlisted for that runner group. Standard
     # ubuntu-latest is fine for ad-hoc single-task / small-folder runs at
@@ -41,7 +106,7 @@ jobs:
     # covers worst-case stalls (one slow task pinning a slot, network
     # hiccups, etc.) on ubuntu-latest at j=20.
     timeout-minutes: 330
-    name: Run coder-eval
+    name: Run coder-eval (Linux)
     steps:
       - uses: actions/checkout@v4
 
@@ -57,40 +122,6 @@ jobs:
           python-version: '3.13'
 
       - uses: astral-sh/setup-uv@v4
-
-      - name: Resolve task globs + enforce large-run gate
-        id: globs
-        env:
-          INPUT_GLOBS: ${{ inputs.task_globs }}
-          CONFIRMED:   ${{ inputs.confirm_large_run }}
-        run: |
-          set -euo pipefail
-          if [ -z "$INPUT_GLOBS" ]; then
-            echo "::error::task_globs is required"
-            exit 1
-          fi
-          # Expand globs against the skills checkout to count matches.
-          # Run from tests/ so the glob syntax matches what coder-eval consumes.
-          shopt -s globstar nullglob
-          cd tests
-          MATCHES=()
-          for pat in $INPUT_GLOBS; do
-            for f in $pat; do
-              [ -f "$f" ] && MATCHES+=("$f")
-            done
-          done
-          COUNT=${#MATCHES[@]}
-          echo "Matched $COUNT task file(s) for: $INPUT_GLOBS"
-          if [ "$COUNT" -eq 0 ]; then
-            echo "::error::No task files matched the provided globs"
-            exit 1
-          fi
-          if [ "$COUNT" -gt 50 ] && [ "$CONFIRMED" != "true" ]; then
-            echo "::error::Glob matches $COUNT tasks (> 50). Tick confirm_large_run to authorize."
-            exit 1
-          fi
-          echo "globs=$INPUT_GLOBS" >> "$GITHUB_OUTPUT"
-          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
 
       - name: Install coder-eval
         working-directory: .coder_eval
@@ -134,8 +165,8 @@ jobs:
           CE_PASSWORD:              ${{ secrets.UIPATH_BOT_PASSWORD }}
         run: bash .coder_eval/dashboard/scripts/ci/refresh-auth.sh
 
-      # Pass globs / count via env to avoid `${{ }}` shell injection — the
-      # value of task_globs is user-supplied and flows through this step.
+      # TASK_GLOBS here is the partition-resolved list of *file paths* (not
+      # globs). Word-splitting is intentional — do not quote.
       - name: Run coder-eval
         env:
           SKILLS_REPO_PATH:         ${{ github.workspace }}
@@ -145,13 +176,12 @@ jobs:
           BEDROCK_MODEL:            ${{ secrets.BEDROCK_MODEL }}
           ANTHROPIC_API_KEY:        ${{ secrets.ANTHROPIC_API_KEY }}
           TRACES_SMOKE_PROCESS_KEY: ${{ secrets.TRACES_SMOKE_PROCESS_KEY }}
-          TASK_GLOBS:               ${{ steps.globs.outputs.globs }}
-          TASK_COUNT:               ${{ steps.globs.outputs.count }}
+          TASK_GLOBS:               ${{ needs.partition.outputs.linux_globs }}
+          TASK_COUNT:               ${{ needs.partition.outputs.linux_count }}
         working-directory: tests
         id: eval
         run: |
           echo "Running: coder-eval run $TASK_GLOBS -e experiments/nightly.yaml -j 20 ($TASK_COUNT task files)"
-          # TASK_GLOBS must word-split into multiple glob args; do not quote.
           coder-eval run $TASK_GLOBS \
             -e experiments/nightly.yaml \
             -j 20 -v \
@@ -172,7 +202,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coder-eval-${{ github.run_id }}
+          name: coder-eval-linux-${{ github.run_id }}
           # ** so the pattern matches the replicate-index segment that
           # coder_eval adds to per-task run dirs (/tmp/runs/<ts>/<variant>/<task>/<NN>/).
           path: |
@@ -205,6 +235,217 @@ jobs:
           for r in rows:
               print(f"{r.get('task_id','?')}: {r.get('final_status','?')}")
           ok = sum(1 for r in rows if r.get('final_status') == 'SUCCESS')
-          print(f"\n{ok}/{len(rows)} PASS")
+          print(f"\n{ok}/{len(rows)} PASS (linux)")
+          sys.exit(0 if rows and ok == len(rows) else 1)
+          PY
+
+  run-windows:
+    needs: partition
+    if: needs.partition.outputs.windows_count != '0'
+    runs-on: windows-latest
+    # Windows RPA tasks spin up Helm on each `uip rpa` call (30–60s each)
+    # and run j=1 (Helm state leaks between concurrent tasks). Budget
+    # mirrors smoke-rpa-skills.yml plus headroom for ad-hoc / e2e runs.
+    timeout-minutes: 240
+    name: Run coder-eval (Windows)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@v4
+        with:
+          repository: UiPath/coder_eval
+          ref: ${{ inputs.coder_eval_ref }}
+          token: ${{ secrets.GH_PAT }}
+          path: .coder_eval
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - uses: astral-sh/setup-uv@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install coder-eval
+        working-directory: .coder_eval
+        env:
+          UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
+        run: uv pip install --system .
+
+      - name: Configure NuGet feed for Helm packages
+        shell: bash
+        run: |
+          dotnet nuget add source \
+            "https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Internal/nuget/v3/index.json" \
+            --name UiPath-Internal \
+            --username az \
+            --password "${{ secrets.UV_INDEX_UIPATH_PASSWORD }}" \
+            --store-password-in-clear-text
+
+      # Install from public npm; force the `@uipath` scope to public npm
+      # to bypass any internal scope mappings carrying divergent prereleases.
+      # See smoke-rpa-skills.yml for the full rationale.
+      - name: Install uip CLI + RPA tools (public npm, rpa-tool >=0.9)
+        shell: bash
+        env:
+          CLI_VERSION: ${{ inputs.cli_version }}
+        run: |
+          set -e
+          install_dir="$(mktemp -d)"
+          cd "$install_dir"
+          npm config get registry
+          npm install -g \
+            --@uipath:registry=https://registry.npmjs.org/ \
+            "@uipath/cli@${CLI_VERSION}" \
+            "@uipath/rpa-tool@>=0.9" \
+            @uipath/rpa-legacy-tool@latest
+          uip --version
+          echo "--- Installed @uipath/* packages ---"
+          npm ls -g --depth=0 2>/dev/null | grep '@uipath/' || true
+          echo "--- uip tools list ---"
+          uip tools list --output json
+
+      # Pre-auth uip as a real licensed Studio user via Studio's e2e helper.
+      # Required for Helm's HelmLicenseSkuFeatureSourceService gate, which
+      # client_credentials principals don't clear. See smoke-rpa-skills.yml
+      # for the full rationale.
+      - name: Install Puppeteer (auth helper dep)
+        shell: bash
+        run: npm install --no-save puppeteer
+
+      - name: Authenticate uip as licensed Studio user
+        id: auth
+        shell: bash
+        env:
+          AUTHORITY: https://alpha.uipath.com
+          EMAIL:    ${{ secrets.UIPATH_EMAIL }}
+          PASSWORD: ${{ secrets.UIPATH_PASSWORD }}
+          TENANT:   ${{ secrets.UIPATH_TENANT }}
+          ORG:      ${{ secrets.UIPATH_ORG }}
+          AUTH_DEBUG_DIR: ${{ github.workspace }}/auth-debug
+        run: |
+          set -euo pipefail
+          mkdir -p "$AUTH_DEBUG_DIR"
+          for attempt in 1 2 3; do
+            echo "--- Auth attempt $attempt ---"
+            if node .github/scripts/uipath-oauth-login.mjs; then
+              break
+            fi
+            if [ "$attempt" = "3" ]; then
+              echo "::error::Auth failed after 3 attempts"
+              exit 1
+            fi
+            sleep 5
+          done
+          uip login status --output json
+
+      - name: Upload auth-debug artifacts
+        if: always() && steps.auth.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: auth-debug-windows-${{ github.run_id }}
+          path: ${{ github.workspace }}/auth-debug
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Pre-warm Helm (download NuGet package before tests)
+        shell: bash
+        run: |
+          mkdir -p /tmp/helm-warmup && cd /tmp/helm-warmup
+          uip rpa list-instances --output json 2>&1 || true
+          taskkill //F //IM UiPath.Studio.Helm.exe 2>/dev/null || true
+
+      # Run tasks one at a time on Windows: Helm state leaks between tasks
+      # (stale Studio session, locked NuGet cache), so the loop kills Helm
+      # between tasks. j=1 by construction.
+      #
+      # Uses experiments/smoke-windows.yaml (the only existing Windows
+      # tempdir experiment); per-task `run_limits` in the YAML extend the
+      # smoke budget where needed (e.g. legacy/refactor_with_retry_scope_e2e
+      # sets max_turns: 50).
+      - name: Run coder-eval (Windows)
+        env:
+          SKILLS_REPO_PATH:         ${{ github.workspace }}
+          API_BACKEND:              bedrock
+          AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
+          AWS_REGION:               ${{ secrets.AWS_REGION }}
+          BEDROCK_MODEL:            ${{ secrets.BEDROCK_MODEL }}
+          ANTHROPIC_API_KEY:        ${{ secrets.ANTHROPIC_API_KEY }}
+          TASK_GLOBS:               ${{ needs.partition.outputs.windows_globs }}
+        working-directory: tests
+        id: eval
+        shell: bash
+        run: |
+          shopt -s globstar nullglob
+          overall_exit=0
+          for task in $TASK_GLOBS; do
+            echo "--- Killing leftover Helm/Studio processes ---"
+            taskkill //F //IM UiPath.Studio.Helm.exe 2>/dev/null || true
+            echo "--- Running: $task ---"
+            for attempt in 1 2 3; do
+              echo "--- $task attempt $attempt ---"
+              if coder-eval run "$task" \
+                  -e experiments/smoke-windows.yaml -j 1 -v; then
+                break
+              fi
+              # Only retry on Bedrock content-filter ERRORs. Real task
+              # failures are real signal — don't burn retries on them.
+              latest_json="$(ls -t runs/*/default/*/00/task.json 2>/dev/null | head -n 1 || true)"
+              if [ -n "$latest_json" ] && LATEST_JSON="$latest_json" python -c "import json,os,sys; d=json.load(open(os.environ['LATEST_JSON'])); det=d.get('error_details') or {}; msg=json.dumps(det)+(d.get('error_message') or ''); sys.exit(0 if d.get('final_status')=='ERROR' and 'content filter' in msg.lower() else 2)"; then
+                echo "::warning::$task: content-filter error on attempt $attempt — retrying"
+                if [ "$attempt" = "3" ]; then
+                  overall_exit=1
+                fi
+                continue
+              fi
+              overall_exit=1
+              break
+            done
+          done
+          exit $overall_exit
+
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coder-eval-windows-${{ github.run_id }}
+          path: |
+            tests/runs/*/experiment.html
+            tests/runs/*/experiment.md
+            tests/runs/*/experiment.json
+            tests/runs/*/experiment.log
+            tests/runs/*/*/variant.html
+            tests/runs/*/*/variant.md
+            tests/runs/*/*/variant.json
+            tests/runs/**/task.html
+            tests/runs/**/task.json
+            tests/runs/**/task.log
+            tests/runs/**/artifacts
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Plaintext summary + verdict
+        if: always()
+        shell: bash
+        run: |
+          set -uo pipefail
+          run_dir=$(ls -td tests/runs/*/ 2>/dev/null | head -n 1 || true)
+          if [ -z "$run_dir" ]; then
+            echo "FAIL — no run directory produced" | tee -a "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          python - "$run_dir" <<'PY' | tee -a "$GITHUB_STEP_SUMMARY"
+          import json, pathlib, sys
+          rows = [json.loads(p.read_text()) for p in sorted(pathlib.Path(sys.argv[1]).rglob('task.json'))]
+          for r in rows:
+              print(f"{r.get('task_id','?')}: {r.get('final_status','?')}")
+          ok = sum(1 for r in rows if r.get('final_status') == 'SUCCESS')
+          print(f"\n{ok}/{len(rows)} PASS (windows)")
           sys.exit(0 if rows and ok == len(rows) else 1)
           PY

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -278,7 +278,19 @@ jobs:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
         run: uv pip install --system .
 
-      - name: Configure NuGet feed for Helm packages
+      # Two-feed config. UiPath-Internal is required for Helm itself
+      # (`UiPath.Studio.Helm.*` only lives there) and carries the
+      # newer .NET-6 activity line. UiPath-Official is the public
+      # stable feed Studio Desktop uses by default and is the only
+      # source of net461-compatible legacy activity package versions
+      # (e.g. `UiPath.System.Activities@23.4.4`,
+      # `UiPath.Excel.Activities@2.21.4`) that the legacy RPA tasks
+      # pin in their `initial_prompt` project.json fixtures. Without
+      # Official configured, `find-package` only returns the newer
+      # line and `find-activities` returns empty for net461 projects,
+      # which burns the legacy refactor task's turn budget before any
+      # edit lands.
+      - name: Configure NuGet feeds (Helm + legacy activity packages)
         shell: bash
         run: |
           dotnet nuget add source \
@@ -287,6 +299,9 @@ jobs:
             --username az \
             --password "${{ secrets.UV_INDEX_UIPATH_PASSWORD }}" \
             --store-password-in-clear-text
+          dotnet nuget add source \
+            "https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json" \
+            --name UiPath-Official
 
       # Two-feed install: `@uipath/cli` comes from the internal GitHub
       # Packages feed (so the `cli_version` input — e.g. `alpha`, pinned

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -288,26 +288,45 @@ jobs:
             --password "${{ secrets.UV_INDEX_UIPATH_PASSWORD }}" \
             --store-password-in-clear-text
 
-      # Install from public npm; force the `@uipath` scope to public npm
-      # to bypass any internal scope mappings carrying divergent prereleases.
-      # Pin `@uipath/cli@latest` here — the `cli_version` input refers to
-      # GitHub Packages tags (e.g. `alpha`), which only the Linux Docker
-      # build can resolve (it carries GH_PAT). Public npm doesn't publish
-      # those prerelease tags. See smoke-rpa-skills.yml for the full
-      # rationale (rpa-tool pin, install-from-tempdir, ToolManager paths).
-      - name: Install uip CLI + RPA tools (public npm, rpa-tool >=0.9)
+      # Two-feed install: `@uipath/cli` comes from the internal GitHub
+      # Packages feed (so the `cli_version` input — e.g. `alpha`, pinned
+      # prereleases — resolves the same way as the Linux Docker build).
+      # `@uipath/rpa-tool` + `@uipath/rpa-legacy-tool` come from public npm
+      # because the internal feed carries a divergent `1.0.0-alpha.*`
+      # rpa-tool line under the same scope; pulling those from the public
+      # feed (with the `^0.9` pin) keeps Helm on the known-good 0.9.x
+      # line. See smoke-rpa-skills.yml for the full rationale.
+      - name: Install uip CLI + RPA tools (GH Packages cli, public-npm tools)
         shell: bash
+        env:
+          CLI_VERSION:    ${{ inputs.cli_version }}
+          NPM_AUTH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
           set -e
           install_dir="$(mktemp -d)"
           cd "$install_dir"
           npm config get registry
+
+          # Step 1: install the CLI from GH Packages. Use a scratch
+          # NPM_CONFIG_USERCONFIG so the @uipath→npm.pkg.github.com mapping
+          # and auth token don't leak into other steps. Mirrors the
+          # tests/docker/Dockerfile config (line 14-17).
+          tmp_npmrc="$(mktemp)"
+          cat > "$tmp_npmrc" <<EOF
+          @uipath:registry=https://npm.pkg.github.com/
+          //npm.pkg.github.com/:_authToken=${NPM_AUTH_TOKEN}
+          EOF
+          NPM_CONFIG_USERCONFIG="$tmp_npmrc" npm install -g "@uipath/cli@${CLI_VERSION}"
+          rm -f "$tmp_npmrc"
+          uip --version
+
+          # Step 2: install the RPA tools from public npm. CLI-flag scope
+          # override beats any lingering global config, so this stays on
+          # the public registry regardless of runner image defaults.
           npm install -g \
             --@uipath:registry=https://registry.npmjs.org/ \
-            @uipath/cli@latest \
             "@uipath/rpa-tool@>=0.9" \
             @uipath/rpa-legacy-tool@latest
-          uip --version
           echo "--- Installed @uipath/* packages ---"
           npm ls -g --depth=0 2>/dev/null | grep '@uipath/' || true
           echo "--- uip tools list ---"

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -290,11 +290,13 @@ jobs:
 
       # Install from public npm; force the `@uipath` scope to public npm
       # to bypass any internal scope mappings carrying divergent prereleases.
-      # See smoke-rpa-skills.yml for the full rationale.
+      # Pin `@uipath/cli@latest` here — the `cli_version` input refers to
+      # GitHub Packages tags (e.g. `alpha`), which only the Linux Docker
+      # build can resolve (it carries GH_PAT). Public npm doesn't publish
+      # those prerelease tags. See smoke-rpa-skills.yml for the full
+      # rationale (rpa-tool pin, install-from-tempdir, ToolManager paths).
       - name: Install uip CLI + RPA tools (public npm, rpa-tool >=0.9)
         shell: bash
-        env:
-          CLI_VERSION: ${{ inputs.cli_version }}
         run: |
           set -e
           install_dir="$(mktemp -d)"
@@ -302,7 +304,7 @@ jobs:
           npm config get registry
           npm install -g \
             --@uipath:registry=https://registry.npmjs.org/ \
-            "@uipath/cli@${CLI_VERSION}" \
+            @uipath/cli@latest \
             "@uipath/rpa-tool@>=0.9" \
             @uipath/rpa-legacy-tool@latest
           uip --version

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -278,19 +278,7 @@ jobs:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
         run: uv pip install --system .
 
-      # Two-feed config. UiPath-Internal is required for Helm itself
-      # (`UiPath.Studio.Helm.*` only lives there) and carries the
-      # newer .NET-6 activity line. UiPath-Official is the public
-      # stable feed Studio Desktop uses by default and is the only
-      # source of net461-compatible legacy activity package versions
-      # (e.g. `UiPath.System.Activities@23.4.4`,
-      # `UiPath.Excel.Activities@2.21.4`) that the legacy RPA tasks
-      # pin in their `initial_prompt` project.json fixtures. Without
-      # Official configured, `find-package` only returns the newer
-      # line and `find-activities` returns empty for net461 projects,
-      # which burns the legacy refactor task's turn budget before any
-      # edit lands.
-      - name: Configure NuGet feeds (Helm + legacy activity packages)
+      - name: Configure NuGet feed for Helm packages
         shell: bash
         run: |
           dotnet nuget add source \
@@ -299,9 +287,6 @@ jobs:
             --username az \
             --password "${{ secrets.UV_INDEX_UIPATH_PASSWORD }}" \
             --store-password-in-clear-text
-          dotnet nuget add source \
-            "https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json" \
-            --name UiPath-Official
 
       # Two-feed install: `@uipath/cli` comes from the internal GitHub
       # Packages feed (so the `cli_version` input — e.g. `alpha`, pinned

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -26,28 +26,53 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Detect changed RPA skills and map to test tasks
+      - name: Detect changed Windows-tagged skills and map to test tasks
         id: detect
         run: |
           BASE_REF="${{ github.base_ref }}"
           if [ -z "$BASE_REF" ]; then BASE_REF="main"; fi
           CHANGED=$(git diff --name-only origin/$BASE_REF...HEAD)
 
-          # Infra change → run all RPA smoke tasks (modern + legacy)
-          if echo "$CHANGED" | grep -qE '^tests/(experiments|_shared)/|^tests/[^/]+\.(py|yaml|toml)$|^\.github/workflows/smoke-rpa-skills\.yml$'; then
-            echo "task_globs=tasks/uipath-rpa/**/*.yaml" >> "$GITHUB_OUTPUT"
-            echo "Running all RPA smoke tests (test infrastructure changed)"
+          # Discover the set of Windows-tagged task files (tag = `windows` in the
+          # `tags:` line). Source of truth for "what runs on this Windows
+          # workflow" — adding/removing a `windows` tag is the opt-in/out.
+          WINDOWS_TASKS=$(grep -rEl '^tags:.*\bwindows\b' tests/tasks/ 2>/dev/null | sort -u)
+          if [ -z "$WINDOWS_TASKS" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "No tasks tagged 'windows' found — skipping"
             exit 0
           fi
 
-          GLOBS=""
-          if echo "$CHANGED" | grep -qE '^(skills/uipath-rpa/|tests/tasks/uipath-rpa/)'; then
-            [ -d "tests/tasks/uipath-rpa" ] && GLOBS="tasks/uipath-rpa/**/*.yaml"
+          # Skills that own at least one windows-tagged task. Used to map
+          # `skills/<X>/` changes to the right test set.
+          WINDOWS_SKILLS=$(echo "$WINDOWS_TASKS" | sed -nE 's|^tests/tasks/([^/]+)/.*|\1|p' | sort -u)
+
+          # Globs are relative to the `tests/` working dir of the smoke job.
+          ALL_GLOBS=$(echo "$WINDOWS_TASKS" | sed 's|^tests/||' | tr '\n' ' ' | xargs)
+
+          # Infra change → run every windows-tagged task.
+          if echo "$CHANGED" | grep -qE '^tests/(experiments|_shared)/|^tests/[^/]+\.(py|yaml|toml)$|^\.github/workflows/smoke-rpa-skills\.yml$'; then
+            echo "task_globs=$ALL_GLOBS" >> "$GITHUB_OUTPUT"
+            echo "Running all Windows smoke tasks (test infrastructure changed)"
+            exit 0
           fi
+
+          # Skill-scoped change → run only that skill's windows-tagged tasks.
+          GLOBS=""
+          for skill in $WINDOWS_SKILLS; do
+            if echo "$CHANGED" | grep -qE "^(skills/${skill}/|tests/tasks/${skill}/)"; then
+              for t in $WINDOWS_TASKS; do
+                case "$t" in
+                  "tests/tasks/${skill}/"*) GLOBS="$GLOBS ${t#tests/}";;
+                esac
+              done
+            fi
+          done
+          GLOBS=$(echo "$GLOBS" | xargs)
 
           if [ -z "$GLOBS" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "No RPA skill changes detected — skipping"
+            echo "No Windows-tagged skill changes detected — skipping"
           else
             echo "task_globs=$GLOBS" >> "$GITHUB_OUTPUT"
             echo "Will test: $GLOBS"

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -116,19 +116,7 @@ jobs:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
         run: uv pip install --system .
 
-      # Two-feed config. UiPath-Internal is required for Helm itself
-      # (`UiPath.Studio.Helm.*` only lives there) and carries the
-      # newer .NET-6 activity line. UiPath-Official is the public
-      # stable feed Studio Desktop uses by default and is the only
-      # source of net461-compatible legacy activity package versions
-      # (e.g. `UiPath.System.Activities@23.4.4`,
-      # `UiPath.Excel.Activities@2.21.4`) that the legacy RPA tasks
-      # pin in their `initial_prompt` project.json fixtures. Without
-      # Official configured, `find-package` only returns the newer
-      # line and `find-activities` returns empty for net461 projects,
-      # which burns the legacy refactor task's turn budget before any
-      # edit lands.
-      - name: Configure NuGet feeds (Helm + legacy activity packages)
+      - name: Configure NuGet feed for Helm packages
         shell: bash
         run: |
           dotnet nuget add source \
@@ -137,9 +125,6 @@ jobs:
             --username az \
             --password "${{ secrets.UV_INDEX_UIPATH_PASSWORD }}" \
             --store-password-in-clear-text
-          dotnet nuget add source \
-            "https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json" \
-            --name UiPath-Official
 
       # Install from public npm. The `--@uipath:registry=` flag forces
       # the `@uipath` scope to public npm even if some `.npmrc` (runner

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -116,7 +116,19 @@ jobs:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
         run: uv pip install --system .
 
-      - name: Configure NuGet feed for Helm packages
+      # Two-feed config. UiPath-Internal is required for Helm itself
+      # (`UiPath.Studio.Helm.*` only lives there) and carries the
+      # newer .NET-6 activity line. UiPath-Official is the public
+      # stable feed Studio Desktop uses by default and is the only
+      # source of net461-compatible legacy activity package versions
+      # (e.g. `UiPath.System.Activities@23.4.4`,
+      # `UiPath.Excel.Activities@2.21.4`) that the legacy RPA tasks
+      # pin in their `initial_prompt` project.json fixtures. Without
+      # Official configured, `find-package` only returns the newer
+      # line and `find-activities` returns empty for net461 projects,
+      # which burns the legacy refactor task's turn budget before any
+      # edit lands.
+      - name: Configure NuGet feeds (Helm + legacy activity packages)
         shell: bash
         run: |
           dotnet nuget add source \
@@ -125,6 +137,9 @@ jobs:
             --username az \
             --password "${{ secrets.UV_INDEX_UIPATH_PASSWORD }}" \
             --store-password-in-clear-text
+          dotnet nuget add source \
+            "https://uipath.pkgs.visualstudio.com/Public.Feeds/_packaging/UiPath-Official/nuget/v3/index.json" \
+            --name UiPath-Official
 
       # Install from public npm. The `--@uipath:registry=` flag forces
       # the `@uipath` scope to public npm even if some `.npmrc` (runner

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -34,23 +34,35 @@ jobs:
           BASE_REF="${BASE_REF:-main}"
           CHANGED=$(git diff --name-only "origin/${BASE_REF}...HEAD")
 
-          # RPA skill (modern + legacy) runs on the Windows workflow
+          # Windows-tagged tasks run on the Windows workflow
           # (smoke-rpa-skills.yml). Helm/Studio only exists there, and
           # the full lifecycle (`uip rpa` / `uip rpa-legacy` CLI) is
           # what's being exercised — so we skip those tasks here.
-          WINDOWS_SKILLS="uipath-rpa"
+          # Source of truth: the `windows` tag in each task YAML, so adding
+          # a new Windows-only skill is just a tag, not a workflow edit.
+          WINDOWS_TASKS=$(grep -rEl '^tags:.*\bwindows\b' tests/tasks/ 2>/dev/null | sort -u)
+          WINDOWS_SKILLS=$(echo "$WINDOWS_TASKS" | sed -nE 's|^tests/tasks/([^/]+)/.*|\1|p' | sort -u)
 
           # Opt-in benchmarks live alongside skill tests but are NOT smoke
           # tests — they're large/expensive and run via the dashboard
           # (`dashboard run --suite <name>`). Skip here so smoke stays cheap.
           BENCHMARK_DIRS="activation"
 
-          # Single source of truth for "skill dirs not smoke-eligible".
+          # Single source of truth for "task file not smoke-eligible on Linux".
           # Used by both the test-infra fan-out and the per-skill loop below.
+          # Accepts either a task-file path (matches the windows-task list
+          # exactly) or a `tests/tasks/<skill>/` directory prefix (matches the
+          # derived windows-skills / benchmark dirs).
           is_excluded_path() {
-            local dir="$1"
-            for skill in $WINDOWS_SKILLS $BENCHMARK_DIRS; do
-              [[ "$dir" == "tests/tasks/$skill/"* ]] && return 0
+            local path="$1"
+            for skill in $BENCHMARK_DIRS; do
+              [[ "$path" == "tests/tasks/$skill/"* ]] && return 0
+            done
+            for skill in $WINDOWS_SKILLS; do
+              [[ "$path" == "tests/tasks/$skill/"* ]] && return 0
+            done
+            for t in $WINDOWS_TASKS; do
+              [[ "$path" == "$t" ]] && return 0
             done
             return 1
           }
@@ -94,7 +106,10 @@ jobs:
           fi
 
           # Build task glob pattern for changed skills that have tests.
-          # Skip the Windows-only RPA skills — they run on smoke-rpa-skills.yml.
+          # Skip skills whose tasks are all `windows`-tagged (they run on
+          # smoke-rpa-skills.yml). If a skill ever mixes windows-tagged and
+          # non-windows tasks, switch this to per-task filtering against
+          # $WINDOWS_TASKS instead of skipping the whole skill.
           GLOBS=""
           UNTESTED=""
           for skill in $SKILLS; do

--- a/tests/README.md
+++ b/tests/README.md
@@ -105,6 +105,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 | **node** | `node:X`, repeatable | Node type(s) under test | `decision`, `switch`, `subflow`, `terminate`, `loop`, `transform`, `hitl` (omit `script`/`http` — ubiquitous) |
 | **resource** | flat, present iff applicable | Marks tasks that exercise any resource-node type (`coded-agent`, `lowcode-agent`, `api-workflow`, `rpa`). The specific resource is implied by the file path / `task_id`. |
 | **connector** | flat, present iff applicable | Marks tasks that use any IS connector. The specific connector is in the YAML body / file path. |
+| **windows** | flat, present iff applicable | Marks tasks that require a Windows host (e.g. RPA `.xaml`/`.cs` projects that need Studio Helm). Used by `smoke-rpa-skills.yml` to route the task to a `windows-latest` runner; Linux/macOS smoke runs skip it. |
 | **feature** | `feature:X`, repeatable | Cross-cutting capability orthogonal to node/resource/connector. Closed vocabulary: `http`, `trigger`, `registry`, `transform`, `approval-gate`, `write-back`, `escalation`, `connections`, `activities`, `records`, `entities`, `api-workflow`, `compliance`, `test-case`, `hooks`. Do not invent leaf names like `feature:ceql-where` or directory-name markers like `feature:connector-feature` — those duplicate the file path. |
 
 ### Rules
@@ -112,7 +113,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 1. **Required on every task: `skill` + `tier` + `mode:*` + `lifecycle:*`.** These drive `make` targets, coverage, and evalboard dashboards.
 2. **One value per singular dimension** (`tier`, `mode`, `shape`). A task doesn't have two tiers.
 3. **`node:` and `feature:` are repeatable.** A flow exercising decision and switch nodes gets both `node:decision` and `node:switch`.
-4. **`connector` and `resource` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
+4. **`connector`, `resource`, and `windows` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
 5. **Use only the vocabularies above.** Propose new values in the PR — do not invent tags inline. New values should apply to at least two tasks in practice.
 6. **Don't repeat the skill name as a feature tag.** Don't tag a flow task with `rpa` (bare) or `uipath-rpa` as a feature.
 
@@ -125,6 +126,7 @@ tags: [uipath-maestro-flow, e2e, mode:build, shape:multi-node, node:decision, co
 ### Useful slices this enables
 
 - `make tags TAGS="smoke"` → every skill's entry-gate checks.
+- `make tags TAGS="smoke windows"` → Windows-only smoke tasks (the slice `smoke-rpa-skills.yml` runs on `windows-latest`).
 - `make tags TAGS="integration connector"` → connector coverage across skills.
 - `make tags TAGS="e2e mode:build"` → end-to-end build tasks across skills.
 - `make tags TAGS="mode:diagnose"` → diagnosis-mode coverage across skills.

--- a/tests/tasks/uipath-rpa/coded_test_case.yaml
+++ b/tests/tasks/uipath-rpa/coded_test_case.yaml
@@ -5,7 +5,7 @@ description: >
   hooks plus a coded test case with Given-When-Then structure, testing-service
   assertions, and a project.json fileInfoCollection entry. Covers both the
   hooks pattern and the coded test case workflow in one task.
-tags: [uipath-rpa, smoke, coded, hooks, test-case]
+tags: [uipath-rpa, windows, smoke, coded, hooks, test-case]
 
 run_limits:
   max_turns: 70

--- a/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
@@ -11,7 +11,7 @@ description: >
   This smoke test verifies the skill guides the agent to produce correct
   artifacts and invoke the right commands — it does not require the CLI
   commands to succeed at runtime.
-tags: [uipath-rpa, legacy, smoke, create, validate]
+tags: [uipath-rpa, windows, legacy, smoke, create, validate]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
+++ b/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
@@ -35,7 +35,7 @@ initial_prompt: |
     "description": "Legacy project for edit smoke test",
     "main": "Main.xaml",
     "dependencies": {
-      "UiPath.System.Activities": "[23.4.4]"
+      "UiPath.System.Activities": "[24.10.8]"
     },
     "webServices": [],
     "entitiesStores": [],

--- a/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
+++ b/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
@@ -11,7 +11,7 @@ description: >
   test verifies the skill guides the agent to invoke the right commands and
   preserve the legacy XAML baseline — it does not require the CLI calls to
   succeed at runtime.
-tags: [uipath-rpa, legacy, smoke, edit, validate]
+tags: [uipath-rpa, windows, legacy, smoke, edit, validate]
 
 run_limits:
   task_timeout: 1200

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -190,7 +190,7 @@ success_criteria:
   # Edit shape: Retry Scope correctly wraps the Excel read
   - type: run_command
     description: "Main.xaml has a Retry Scope that nests the Excel read inside its body"
-    command: "python -c \"import re,sys; s=open('InvoiceReader/Main.xaml',encoding='utf-8').read(); sys.exit(0 if re.search(r'<RetryScope\\b[^>]*>[\\s\\S]*?(?:ExcelApplicationScope|ExcelReadRange|<ui:ExcelReadRange|<ui:ExcelApplicationScope)[\\s\\S]*?</RetryScope>', s) else 1)\""
+    command: "python -c \"import re,sys; s=open('InvoiceReader/Main.xaml',encoding='utf-8').read(); sys.exit(0 if re.search(r'<(?:ui:|uca:|uic:)?RetryScope\\b[^>]*>[\\s\\S]*?<(?:ui:|uea:|ueab:)?(?:ExcelApplicationScope|ExcelReadRange)\\b[\\s\\S]*?</(?:ui:|uca:|uic:)?RetryScope>', s) else 1)\""
     timeout: 5
     expected_exit_code: 0
     weight: 2.5

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -15,7 +15,7 @@ description: >
   and edit shape — the agent must produce the right command sequence,
   preserve baseline assemblies, and emit XAML that matches the legacy
   schema.
-tags: [uipath-rpa, legacy, e2e, mode:edit-validate]
+tags: [uipath-rpa, windows, legacy, e2e, mode:edit-validate]
 max_iterations: 2
 
 agent:

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -200,7 +200,7 @@ success_criteria:
   # value "00:00:05" or numeric 5).
   - type: run_command
     description: "Retry Scope is configured with NumberOfRetries=3 and a 5-second RetryInterval"
-    command: "python -c \"import re,sys; s=open('InvoiceReader/Main.xaml',encoding='utf-8').read(); ok = re.search(r'NumberOfRetries=\\\"[\\[\\(]?\\s*3\\s*[\\]\\)]?\\\"', s) and re.search(r'RetryInterval=\\\"[\\[\\(]?\\s*(?:00:00:05|TimeSpan\\.FromSeconds\\(5\\)|New TimeSpan\\(0,\\s*0,\\s*5\\))[\\]\\)]?\\\"', s); sys.exit(0 if ok else 1)\""
+    command: "python -c \"import re,sys; s=open('InvoiceReader/Main.xaml',encoding='utf-8').read(); ok = re.search(r'NumberOfRetries=\\W?[\\[\\(]?\\s*3\\s*[\\]\\)]?\\W', s) and re.search(r'RetryInterval=\\W?[\\[\\(]?\\s*(?:00:00:05|TimeSpan\\.FromSeconds\\(5\\)|New TimeSpan\\(0,\\s*0,\\s*5\\))[\\]\\)]?\\W', s); sys.exit(0 if ok else 1)\""
     timeout: 5
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -48,8 +48,8 @@ initial_prompt: |
     "description": "Legacy invoice reader for refactor smoke test",
     "main": "Main.xaml",
     "dependencies": {
-      "UiPath.System.Activities": "[23.4.4]",
-      "UiPath.Excel.Activities": "[2.21.4]"
+      "UiPath.System.Activities": "[24.10.8]",
+      "UiPath.Excel.Activities": "[2.24.4]"
     },
     "webServices": [],
     "entitiesStores": [],

--- a/tests/tasks/uipath-rpa/template_aware_create.yaml
+++ b/tests/tasks/uipath-rpa/template_aware_create.yaml
@@ -5,7 +5,7 @@ description: >
   with `--template-package-id UiPath.Template.REFramework`, not with
   `--template-id BlankTemplate`. Tests whether the skill teaches the
   template-detection decision before `init`.
-tags: [uipath-rpa, smoke, lifecycle:generate]
+tags: [uipath-rpa, windows, smoke, lifecycle:generate]
 
 initial_prompt: |
   I want to create a new UiPath REFramework project called "InvoiceREF"

--- a/tests/tasks/uipath-rpa/uia_google_search.yaml
+++ b/tests/tasks/uipath-rpa/uia_google_search.yaml
@@ -7,7 +7,7 @@ description: >
   full XAML surface the skill teaches: project.json with VisualBasic expression
   language, ApplicationCard / TypeInto / Click activity XML, and the
   `uip rpa validate` compile gate.
-tags: [uipath-rpa, smoke, uia, xaml]
+tags: [uipath-rpa, windows, smoke, uia, xaml]
 
 # Standard XAML + UIA activities. First `uip rpa` call restores packages
 # (incl. UIAutomation) + spins up Helm — 60–90s cold start. `validate`

--- a/tests/tasks/uipath-rpa/xaml_test_case.yaml
+++ b/tests/tasks/uipath-rpa/xaml_test_case.yaml
@@ -6,7 +6,7 @@ description: >
   fileInfoCollection entry in project.json (NOT entryPoints). Mirrors
   coded_test_case.yaml for the XAML mode that the skill historically
   under-served. See PILOT-5327.
-tags: [uipath-rpa, integration, mode:build, feature:test-case]
+tags: [uipath-rpa, windows, integration, mode:build, feature:test-case]
 
 initial_prompt: |
   I need a UiPath XAML test project called "LoginTests" with a first XAML


### PR DESCRIPTION
## Summary

- Add a `windows` boolean tag to all 7 `uipath-rpa` tasks; document the tag in the taxonomy (`tests/README.md`) and propagate to `/generate-task` + `/test-coverage` schemas
- Split `run-coder-eval.yml` into `partition` → `run-linux` (existing Docker flow) + `run-windows` (mirrors `smoke-rpa-skills.yml`: `setup-dotnet`, npm-based CLI install, Puppeteer OAuth, Helm prewarm, per-task loop with 3× content-filter retries, `experiments/smoke-windows.yaml -j 1`)
- Make tag-based routing self-maintaining: `smoke-skills.yml` (Linux) and `smoke-rpa-skills.yml` (Windows) both derive the windows-skill set from the `windows` tag instead of hardcoding `uipath-rpa`. Future Windows-only skills opt in via tag, not workflow edits.
- Install `@uipath/cli@${{ inputs.cli_version }}` from internal GitHub Packages on the Windows runner (`NPM_CONFIG_USERCONFIG`-scoped, doesn't leak runner state). RPA tools (`rpa-tool`, `rpa-legacy-tool`) stay on public npm to avoid the `1.0.0-alpha.*` divergence on the internal feed.
- Repin legacy task fixtures (`refactor_with_retry_scope_e2e.yaml`, `edit_existing_xaml.yaml`) to `UiPath.System.Activities@[24.10.8]` and `UiPath.Excel.Activities@[2.24.4]` — both confirmed on `UiPath-Internal`. The previous `[23.4.4]`/`[2.21.4]` pin was unpublished on every reachable feed and `NU1102` from `uip rpa-legacy validate` was diverting the agent into package-version archaeology.
- Fix two latent regex bugs in the legacy refactor task's success criteria — `RetryScope`/`Excel` element matching now accepts `ui:`/`uca:`/`uic:` (docs-documented xmlns prefixes) and the `NumberOfRetries`/`RetryInterval` criterion uses `\W?…\W` boundaries instead of literal `\"` so cmd.exe quote-toggle parsing under `subprocess.Popen(shell=True)` no longer mangles the command (exit 255 → 0)

## Test plan

- [x] Run `gh workflow run "Run Coder Eval" -f task_globs='tasks/uipath-rpa/**/*.yaml' --ref nightly/win-support`; verify `partition` job emits the `windows` task set, `run-linux` is skipped, `run-windows` lands on `windows-latest`
- [x] Confirm the 7 `uipath-rpa` tasks all execute on the Windows runner; expect 7/7 PASS after the criterion-regex fix lands
- [x] Trigger `Smoke Skill Tests` (Linux) on a branch that touches a non-RPA skill; verify `uipath-rpa` tasks stay excluded via the `windows`-tag derivation

🤖 Generated with [Claude Code](https://claude.com/claude-code)