### PR TITLE
docs(skills): reflect login status tenant ids

### DIFF
--- a/skills/uipath-admin/references/authorization/role-management.md
+++ b/skills/uipath-admin/references/authorization/role-management.md
@@ -139,7 +139,7 @@ When Step 1a (or Step 1b's "Service level" pick on a Tenant-shape service) lands
 - **Tenant** = bound to one tenant UUID. Assignable only inside that tenant.
 - **TenantGlobal** = reusable template. Visible/assignable in every tenant.
 
-> Resolving the current tenant UUID: `uip login status --output json` gives the tenant *name*; map it to a UUID with `uip admin tenants list --filter <name> --output json`.
+> Resolving the current tenant UUID: prefer `Data.TenantId` from `uip login status --output json`. If the installed CLI is older or the status has no `TenantId`, fall back to mapping the displayed tenant name (`Data.Tenant`) with `uip admin tenants list --filter <name> --output json`.
 
 #### Step 1d — Multi-service tenant role ("Centralized Access")
 

--- a/skills/uipath-feedback/SKILL.md
+++ b/skills/uipath-feedback/SKILL.md
@@ -61,7 +61,7 @@ uip login status --output json 2>&1
 uip tools list 2>&1
 ```
 
-From login status, extract only: `tenantName`, `organizationName`, `baseUrl`. Strip everything else.
+From login status, extract only the display tenant (`Data.Tenant`), display organization (`Data.Organization`), and base URL (`Data.BaseUrl`). Strip everything else, including `Data.OrganizationId`, `Data.TenantId`, access tokens, and the raw status envelope.
 
 From tools list, extract tool `name` and `version` from each row.
 
@@ -73,7 +73,7 @@ From tools list, extract tool `name` and `version` from each row.
 | **RPA** (`.cs` or `.xaml`) | `project.json` dependencies, `uip rpa validate --output json --use-studio`, list of workflow files (`.cs` and/or `.xaml`) | File list: max 20 files; `project.json`: dependencies section only; failing workflow: first 150 lines |
 | **Agents** | `pyproject.toml`, `bindings.json` (redact connection values), directory listing | `bindings.json`: redact all values; directory: max 30 entries |
 | **Apps** | `package.json` (name, version, dependencies only), `.uipath/` listing | `package.json`: name + version + dependencies only |
-| **Platform** | `uip login status --output json` output only | Strip tokens from output |
+| **Platform** | Sanitized `uip login status --output json` summary only | Strip tokens and organization/tenant IDs from output |
 
 #### 2d. Capture the failing command
 
@@ -333,7 +333,7 @@ Apply these rules to ALL content before it is included in the description or att
 3. **Redact GUIDs** in connection/binding fields: replace values with `<REDACTED>`
 4. **Truncate long content.** Files over 150 lines: keep first 100 + `... [truncated N lines] ...` + last 30. Full description: max 4000 characters
 5. **Never include**: `~/.uipath/.auth`, `.env`, `.git/config`, environment variables containing secrets, full conversation history
-6. **Never include customer data.** Strip customer names, email addresses, and organization-specific identifiers from project files unless they are the tenant/org from `uip login status`
+6. **Never include customer data.** Strip customer names, email addresses, and organization-specific identifiers from project files unless they are the tenant/org display names from `uip login status`. Do not include `OrganizationId` or `TenantId`.
 7. **Sanitize sample prompts.** Apply rules 1-3 and 6 to every captured prompt before including it under `## Sample prompts`. Replace customer names, email addresses, project codenames, account IDs, ticket IDs, internal URLs, and file paths revealing usernames with `<REDACTED>`. If a prompt cannot be sanitized without losing its signal (the prompt is mostly customer-specific data), drop that prompt and pick another from Step 2e. Never quote a prompt verbatim if it contains a secret, even if the user typed it.
 
 ## What NOT to Do

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
@@ -2,14 +2,17 @@ task_id: skill-admin-authz-role-lifecycle-tenant-e2e
 description: >
   End-to-end test: full lifecycle of a Tenant-scope custom role bound
   to one specific tenant — discovers Tenant-shape permissions,
-  resolves the login tenant's UUID, creates with `--scope Tenant`
-  AND `--tenant-id <UUID>`, verifies, deletes.
+  resolves the login tenant's UUID from login status when available,
+  creates with `--scope Tenant` AND `--tenant-id <UUID>`,
+  verifies, deletes.
 
   Validates: `--scope Tenant`, presence of `--tenant-id` (binding to
-  one tenant), tenant resolution before create, cleanup.
+  one tenant), tenant resolution before create, cleanup. Current CLI
+  versions expose `TenantId` in `uip login status`; older CLIs may need
+  a tenant lookup fallback.
 
   Command-construction only — no live tenant available.
-tags: [uipath-admin, e2e, authz, role-lifecycle, scope:tenant]
+tags: [uipath-admin, e2e, authz, role-lifecycle, "scope:tenant"]
 
 run_limits:
   max_turns: 40
@@ -34,7 +37,7 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent resolved the current login tenant's UUID before binding the role"
+    description: "Agent resolved the current login tenant's UUID from login status or a tenant lookup before binding the role"
     tool_name: "Bash"
     command_pattern: 'uip\s+(?:login\s+status|admin\s+tenants\s+(?:list|get))'
     min_count: 1


### PR DESCRIPTION
## Summary
- Prefer `Data.TenantId` from `uip login status --output json` for tenant-bound admin authz role guidance, with an older-CLI tenant lookup fallback.
- Update the tenant authz lifecycle eval wording to match the new login-status ID shape and quote its colon tag.
- Tighten feedback sanitization so `OrganizationId` and `TenantId` exposed by UiPath/cli#1962 are not included in feedback reports.

## Validation
- `git diff --check`
- `bash hooks/validate-skill-descriptions.sh`
- `ruby -e 'require "yaml"; YAML.load_file("tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml"); puts "ok"'`