### PR TITLE
fix(uipath-agents): add missing mode:build tag to rag_langgraph task

### DIFF
--- a/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/rag_langgraph/rag_langgraph.yaml
@@ -5,7 +5,7 @@ description: >
   instantiates it inside a node body with `index_name` and
   `folder_path` set, and emits the `index` binding for the targeted
   Context Grounding index.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:rag-coded]
+tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:rag-coded]
 
 run_limits:
   turn_timeout: 1200


### PR DESCRIPTION
Adds the required `mode:build` tag flagged by the lint check on #1074. No other changes.