### PR TITLE
chore(tests): add traces and feedback tags to platform traces tasks

### DIFF
--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -4,7 +4,7 @@ description: >
   traces-smoke-agent job, wait for completion, fetch LLM trace spans, and
   confirm at least one span is returned. Unlike traces_fetch.yaml (smoke),
   this exercises the full round-trip against a real job and real traces.
-tags: [uipath-platform, e2e, lifecycle:discover, traces]
+tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover, traces]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write"]

--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -4,7 +4,7 @@ description: >
   traces-smoke-agent job, wait for completion, fetch LLM trace spans, and
   confirm at least one span is returned. Unlike traces_fetch.yaml (smoke),
   this exercises the full round-trip against a real job and real traces.
-tags: [uipath-platform, e2e, lifecycle:discover]
+tags: [uipath-platform, e2e, lifecycle:discover, traces]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write"]

--- a/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
@@ -5,7 +5,7 @@ description: >
   extracts FolderKey and TraceId from the job/spans output, creates positive
   feedback on that trace, then fetches the feedback by ID and verifies the
   round-trip. No hardcoded IDs — all values derived at runtime.
-tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover]
+tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover, traces, feedback]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write"]

--- a/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
@@ -4,7 +4,7 @@ description: >
   positive feedback. Verifies the agent knows to call
   `uip traces feedback create --trace-id ... --positive --folder-key ...` with --output json.
   Auth/404 errors are acceptable outcomes — the goal is correct command shape.
-tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover]
+tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, traces, feedback]
 
 initial_prompt: |
   I want to annotate a trace with positive feedback and then list all feedback

--- a/tests/tasks/uipath-platform/traces/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_fetch.yaml
@@ -4,7 +4,7 @@ description: >
   given job key against the live tenant. Verifies the agent knows to call
   `uip traces spans get --job-key <guid> --output json`.
   A 404 response (no traces for this job key) is an acceptable outcome.
-tags: [uipath-platform, smoke, lifecycle:discover, traces]
+tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, traces]
 
 initial_prompt: |
   Use the `uipath-platform` skill.

--- a/tests/tasks/uipath-platform/traces/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_fetch.yaml
@@ -4,7 +4,7 @@ description: >
   given job key against the live tenant. Verifies the agent knows to call
   `uip traces spans get --job-key <guid> --output json`.
   A 404 response (no traces for this job key) is an acceptable outcome.
-tags: [uipath-platform, smoke, lifecycle:discover]
+tags: [uipath-platform, smoke, lifecycle:discover, traces]
 
 initial_prompt: |
   Use the `uipath-platform` skill.


### PR DESCRIPTION
## Motivation

Adds domain-specific `traces` and `feedback` tags to the four platform traces coder-eval tasks so they can be filtered and targeted independently in CI. Without these tags, there's no way to run only traces-related or feedback-related tests as a subset.

## Summary

- `traces_e2e.yaml` — added `traces` tag
- `traces_fetch.yaml` — added `traces` tag
- `traces_feedback_e2e.yaml` — added `traces` + `feedback` tags
- `traces_feedback_smoke.yaml` — added `traces` + `feedback` tags

## Test plan

- [x] `skill-platform-traces-e2e` — passed locally
- [x] `skill-platform-traces-fetch` — passed locally
- [x] `skill-platform-traces-feedback-e2e` — passed locally
- [x] `skill-platform-traces-feedback-smoke` — passed locally

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)