### PR TITLE
test(uipath-maestro-flow): tighten combined-transform variant assertion (validate) (MST-10349)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -85,6 +85,36 @@ def assert_flow_has_node_type(
             )
 
 
+def assert_flow_has_exact_node_type(
+    types: Sequence[str], *, project_glob: str = "**/project.uiproj"
+) -> None:
+    """Require that the project has, for EACH type in ``types``, at least one
+    ``.flow`` node whose ``type`` equals it EXACTLY (``==``).
+
+    This is the strict counterpart to :func:`assert_flow_has_node_type`, which
+    matches by case-insensitive SUBSTRING. Use the exact helper when a family of
+    node types shares a common prefix and the task requires one specific member:
+    e.g. the generic chained ``core.action.transform`` node must be pinned so the
+    standalone variants ``core.action.transform.filter`` / ``.map`` / ``.group-by``
+    are REJECTED (the substring helper would accept all four).
+
+    On failure, exits listing the node types actually seen.
+    """
+    if not types:
+        return
+    types_seen: set[str] = set()
+    for node in _iter_flow_nodes(project_glob):
+        t = node.get("type")
+        if t:
+            types_seen.add(t)
+    for wanted in types:
+        if wanted not in types_seen:
+            _fail(
+                f"No node has exact type {wanted!r}. "
+                f"Node types seen: {sorted(types_seen)}"
+            )
+
+
 def assert_flow_uses_connector_target(
     connector_key: str, *, project_glob: str = "**/project.uiproj"
 ) -> None:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from flow_check import (  # noqa: E402
+    assert_flow_has_exact_node_type,
     assert_flow_has_node_type,
     assert_flow_uses_connector_target,
     assert_output_int_in_range,
@@ -126,6 +127,38 @@ def test_assert_flow_has_node_type_fails_when_absent(tmp_path, monkeypatch):
 def test_assert_flow_has_node_type_empty_hints_is_noop(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)  # no project needed when hints are empty
     assert_flow_has_node_type([])
+
+
+# ── assert_flow_has_exact_node_type (MST-10349) ─────────────────────────────
+
+
+def test_assert_flow_has_exact_node_type_matches_generic_transform(
+    tmp_path, monkeypatch
+):
+    """Generic chained transform node passes the exact helper."""
+    root = _write_flow(tmp_path, ["core.action.transform"])
+    monkeypatch.chdir(root)
+    assert_flow_has_exact_node_type(["core.action.transform"])
+
+
+def test_assert_flow_has_exact_node_type_rejects_filter_variant(
+    tmp_path, monkeypatch
+):
+    """A flow whose only transform node is the standalone `.filter` variant
+    FAILS the exact helper but PASSES the substring helper — this is exactly
+    the difference MST-10349 relies on to reject the variant nodes."""
+    root = _write_flow(tmp_path, ["core.action.transform.filter"])
+    monkeypatch.chdir(root)
+    # Old substring helper still accepts the variant ...
+    assert_flow_has_node_type(["core.action.transform"])
+    # ... but the exact helper rejects it.
+    with pytest.raises(SystemExit, match="exact type 'core.action.transform'"):
+        assert_flow_has_exact_node_type(["core.action.transform"])
+
+
+def test_assert_flow_has_exact_node_type_empty_is_noop(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # no project needed when types are empty
+    assert_flow_has_exact_node_type([])
 
 
 # ── assert_flow_uses_connector_target ──────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/check_reading_list.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/check_reading_list.py
@@ -11,7 +11,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
+    assert_flow_has_exact_node_type,
     assert_outputs_contain,
     run_debug,
 )
@@ -30,8 +30,10 @@ EXPECTED_AUTHORS = ["axler", "gelman", "mackay"]
 
 
 def main():
-    # Must use a transform node — substring matches all four variants
-    assert_flow_has_node_type(["core.action.transform"])
+    # Must use the GENERIC chained transform node — the prompt requires a
+    # single core.action.transform that chains filter then map. Exact match
+    # rejects the standalone .filter / .map / .group-by variants.
+    assert_flow_has_exact_node_type(["core.action.transform"])
 
     payload = run_debug(timeout=240)
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -32,7 +32,10 @@ initial_prompt: |
   2. Transform the results to show only the book title (uppercased) and author
   3. Output the curated reading list as a result variable
 
-  Use transform nodes for the data operations, not script nodes. Transform
+  Use a SINGLE generic `core.action.transform` node (the Generic Transform
+  shape) that CHAINS the filter operation and then the map operation in its
+  `operations` list — not separate `core.action.transform.filter` and
+  `core.action.transform.map` variant nodes, and not script nodes. Transform
   collection inputs must reference a variable path (e.g. `$vars.catalog`), not
   an inline `=js:[...]` array or `=js:$vars.<path>` expression.
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py
@@ -38,6 +38,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_exact_node_type,
     assert_flow_has_node_type,
     assert_output_value,
     collect_outputs,
@@ -75,10 +76,12 @@ def main():
     if case not in CASES:
         sys.exit(f"FAIL: Unknown case {case!r}; expected one of {list(CASES)}")
 
-    # Require both node types — HTTP for the API call and a Transform
-    # variant (generic/filter/map/group-by all share the `core.action.transform`
-    # prefix) for the filter step.
-    assert_flow_has_node_type(["core.action.http.v2", "core.action.transform"])
+    # Require the HTTP node (its `.v2` suffix uses substring semantics) for the
+    # API call, plus the GENERIC chained `core.action.transform` node for the
+    # filter step. Exact match on the transform rejects the standalone
+    # `.filter` / `.map` / `.group-by` variants the prompt does not ask for.
+    assert_flow_has_node_type(["core.action.http.v2"])
+    assert_flow_has_exact_node_type(["core.action.transform"])
 
     article, date1, date2 = CASES[case]
     inputs = {"article": article, "date1": date1, "date2": date2}

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -16,9 +16,11 @@ initial_prompt: |
   (string) and `date1`, `date2` (strings in `YYYYMMDD` format) as inputs.
   Call the Wikimedia pageviews API
   (`https://wikimedia.org/api/rest_v1/metrics/pageviews/per-article/en.wikipedia/all-access/user/{article}/daily/{date1}/{date2}`)
-  once to fetch the daily view counts in the range, use a Transform node to
-  filter the returned items down to days whose `views` exceed 500, then sum
-  the `views` across those matching days and return the total as an integer.
+  once to fetch the daily view counts in the range, use a generic
+  `core.action.transform` node (the chained Generic Transform shape, NOT the
+  standalone `core.action.transform.filter` variant) to filter the returned
+  items down to days whose `views` exceed 500, then sum the `views` across
+  those matching days and return the total as an integer.
   When the article does not exist and the HTTP call fails, wire the HTTP
   node's `error` output port to an End node that returns the literal string
   `Article not found` instead.


### PR DESCRIPTION
Tighten the combined-transform variant assertion so reading_list and wiki_pageviews require the generic chained `core.action.transform` node and reject the standalone `.filter` / `.map` / `.group-by` variants.

Ticket: https://uipath.atlassian.net/browse/MST-10349

What changed
- `tests/tasks/uipath-maestro-flow/_shared/flow_check.py`: add `assert_flow_has_exact_node_type` (exact `==` match, the strict counterpart to the case-insensitive substring `assert_flow_has_node_type`).
- `tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py`: add unit tests proving the generic transform passes the exact helper while the `.filter` variant is rejected by the exact helper but still accepted by the substring helper.
- `tests/tasks/uipath-maestro-flow/multi_node/reading_list/check_reading_list.py` and `reading_list.yaml`: pin to the generic `core.action.transform` node and require the Generic Transform shape in the prompt.
- `tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/check_wiki_pageviews_flow.py` and `wiki_pageviews.yaml`: same pinning and prompt update.

Testing
Ran the shared checker unit suite locally with ephemeral pytest:
```
$ uvx pytest tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py -q
................................                                         [100%]
32 passed in 0.05s
```
All 32 tests passed (exit 0). These are validate-only/structural checks; the full coder-eval gate runs in CI, not locally.

The edited `skill-flow-reading-list` and `skill-flow-wiki-pageviews` coder-eval tasks is exercised by the **Run skill smoke tests** CI job on this PR and will be confirmed green before merge (no LLM/tenant credentials are available locally, so the coder-eval run happens in CI rather than on the author's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

