### PR TITLE
test(uipath-maestro-flow): add transform.filter validate test (MST-10348)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/check_transform_filter_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/check_transform_filter_flow.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""TransformFilterDemo: structural check for the dedicated Transform Filter node.
+
+Generation-only — does not run `uip maestro flow debug`. Verifies:
+
+  1. Exactly one node with `type` EXACTLY `core.action.transform.filter`.
+     The match is strict (`==`), so a flow built with `.map`, `.group-by`, or
+     the generic `core.action.transform` chain FAILS — this test pins the
+     filter-only variant on purpose.
+  2. `inputs.collection` is a PLAIN `$vars` path (e.g. `$vars.items.output`).
+     A `=js:`-wrapped value, an inline array literal, or a non-`$vars` string
+     is rejected (the transform runtime reads `collection` as a literal lookup
+     path, not an expression).
+  3. `inputs.operations` is a non-empty list containing an op with
+     `type == "filter"` whose `config.filters` is a non-empty list of objects,
+     each with a non-empty `field`, a `condition` in the allowed set, and a
+     LITERAL scalar `value` (a string starting with `$vars`, `=js:`, or `{`
+     is rejected — Transform filter `value` is literal-only).
+  4. `outputs.output.source == "=result.response"` and
+     `outputs.error.source == "=Error"`.
+  5. `typeVersion` is present and non-empty (the exact value is copied from
+     `uip maestro flow registry get core.action.transform.filter`, so we do
+     NOT pin a specific version).
+"""
+
+import glob
+import json
+import sys
+from typing import NoReturn
+
+NODE_TYPE = "core.action.transform.filter"
+EXPECTED_OUTPUT_SOURCE = "=result.response"
+EXPECTED_ERROR_SOURCE = "=Error"
+
+ALLOWED_CONDITIONS = {
+    "equals",
+    "not_equals",
+    "greater_than",
+    "less_than",
+    "greater_equal",
+    "less_equal",
+    "contains",
+    "starts_with",
+    "ends_with",
+    "is_null",
+    "is_not_null",
+}
+
+# A literal filter `value` must not be an unresolved expression/template.
+_EXPR_PREFIXES = ("$vars", "=js:", "{")
+
+
+def _fail(msg: str) -> NoReturn:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/TransformFilterDemo*.flow", recursive=True)
+    if not flows:
+        _fail("no TransformFilterDemo*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _find_node(flow: dict) -> dict:
+    matches = [n for n in flow.get("nodes", []) if n.get("type") == NODE_TYPE]
+    if not matches:
+        types = sorted({n.get("type") for n in flow.get("nodes", [])})
+        _fail(
+            f"no node with type EXACTLY {NODE_TYPE!r}; types seen: {types}. "
+            "This test pins the filter-only variant — `.map`, `.group-by`, and "
+            "the generic `core.action.transform` chain do not satisfy it."
+        )
+    if len(matches) > 1:
+        _fail(f"expected exactly one {NODE_TYPE} node, found {len(matches)}")
+    return matches[0]
+
+
+def _check_collection(inputs: dict) -> None:
+    collection = inputs.get("collection")
+    if not isinstance(collection, str) or not collection.strip():
+        _fail("inputs.collection missing or empty — set it to a plain `$vars` path")
+    coll = collection.strip()
+    if coll.startswith("=js:"):
+        _fail(
+            f"inputs.collection={collection!r} is wrapped in `=js:`. Transform "
+            "`collection` is a literal lookup path, not an expression — use a "
+            "plain `$vars` path such as `$vars.items.output`."
+        )
+    if coll.startswith("[") or coll.startswith("{"):
+        _fail(
+            f"inputs.collection={collection!r} looks like an inline literal. "
+            "Store the static array in a variable default or upstream node and "
+            "point `collection` at a plain `$vars` path."
+        )
+    if not coll.startswith("$vars."):
+        _fail(
+            f"inputs.collection={collection!r} is not a plain `$vars` path. "
+            "Expected something like `$vars.items.output`."
+        )
+
+
+def _check_filter_value_literal(value, fidx: int) -> None:
+    if isinstance(value, str):
+        v = value.strip()
+        for prefix in _EXPR_PREFIXES:
+            if v.startswith(prefix):
+                _fail(
+                    f"config.filters[{fidx}].value={value!r} is an unresolved "
+                    f"expression/template (starts with {prefix!r}). Transform "
+                    "filter `value` is literal-only — use a literal scalar like "
+                    "100, \"active\", or true."
+                )
+    elif isinstance(value, (dict, list)):
+        _fail(
+            f"config.filters[{fidx}].value is a {type(value).__name__}; "
+            "filter `value` must be a literal scalar (number, string, or bool)."
+        )
+
+
+def _check_operations(inputs: dict) -> None:
+    operations = inputs.get("operations")
+    if not isinstance(operations, list) or not operations:
+        _fail("inputs.operations must be a non-empty list with a filter op")
+
+    filter_ops = [
+        op for op in operations if isinstance(op, dict) and op.get("type") == "filter"
+    ]
+    if not filter_ops:
+        op_types = [op.get("type") if isinstance(op, dict) else op for op in operations]
+        _fail(
+            f"inputs.operations has no op with type=='filter'; op types: {op_types}"
+        )
+
+    found_any_filter = False
+    for op in filter_ops:
+        config = op.get("config")
+        if not isinstance(config, dict):
+            _fail("filter operation has no `config` object")
+        filters = config.get("filters")
+        if not isinstance(filters, list) or not filters:
+            _fail("config.filters must be a non-empty list of filter objects")
+        for fidx, flt in enumerate(filters):
+            if not isinstance(flt, dict):
+                _fail(f"config.filters[{fidx}] is {type(flt).__name__}, expected object")
+            field = flt.get("field")
+            if not isinstance(field, str) or not field.strip():
+                _fail(f"config.filters[{fidx}].field is missing or empty")
+            condition = flt.get("condition")
+            if condition not in ALLOWED_CONDITIONS:
+                _fail(
+                    f"config.filters[{fidx}].condition={condition!r} not in allowed "
+                    f"set {sorted(ALLOWED_CONDITIONS)}"
+                )
+            # is_null / is_not_null take no value; everything else needs a literal.
+            if condition in ("is_null", "is_not_null"):
+                found_any_filter = True
+                continue
+            if "value" not in flt:
+                _fail(
+                    f"config.filters[{fidx}] (condition={condition!r}) has no `value`"
+                )
+            _check_filter_value_literal(flt.get("value"), fidx)
+            found_any_filter = True
+
+    if not found_any_filter:
+        _fail("no usable filter condition found in config.filters")
+
+
+def _check_output_sources(node: dict) -> None:
+    outputs = node.get("outputs") or {}
+    out_src = ((outputs.get("output")) or {}).get("source")
+    if out_src != EXPECTED_OUTPUT_SOURCE:
+        _fail(
+            f"outputs.output.source={out_src!r}; must be {EXPECTED_OUTPUT_SOURCE!r}"
+        )
+    err_src = ((outputs.get("error")) or {}).get("source")
+    if err_src != EXPECTED_ERROR_SOURCE:
+        _fail(
+            f"outputs.error.source={err_src!r}; must be {EXPECTED_ERROR_SOURCE!r}"
+        )
+
+
+def _check_type_version(node: dict) -> None:
+    tv = node.get("typeVersion")
+    if not isinstance(tv, str) or not tv.strip():
+        _fail(
+            "typeVersion is missing or empty — copy it from "
+            "`uip maestro flow registry get core.action.transform.filter`."
+        )
+
+
+def main():
+    flow = _read_flow()
+    node = _find_node(flow)
+    inputs = node.get("inputs") or {}
+
+    _check_collection(inputs)
+    _check_operations(inputs)
+    _check_output_sources(node)
+    _check_type_version(node)
+
+    print(
+        f"OK: exactly one {NODE_TYPE} node; collection is a plain `$vars` path; "
+        f"operations has a filter op with a non-empty config.filters of literal "
+        f"conditions; output source=`=result.response`, error source=`=Error`; "
+        f"typeVersion={node.get('typeVersion')!r}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/test_check_transform_filter_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/test_check_transform_filter_flow.py
@@ -1,0 +1,193 @@
+"""Unit tests for check_transform_filter_flow.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/single_node/transform_filter``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CHECKER = Path(__file__).resolve().parent / "check_transform_filter_flow.py"
+
+
+def _flow_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "TransformFilterDemo" / "TransformFilterDemo"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
+    d = _flow_dir(tmp_path)
+    (d / "TransformFilterDemo.flow").write_text(json.dumps(payload))
+    # Sibling Flow manifest, matching the api_workflow test style.
+    (d / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _filter_node(node_type: str = "core.action.transform.filter") -> dict[str, Any]:
+    return {
+        "id": "filterAmount",
+        "type": node_type,
+        "typeVersion": "1.0",
+        "display": {"label": "Filter Big Orders"},
+        "inputs": {
+            "collection": "$vars.items.output",
+            "operations": [
+                {
+                    "id": "op1",
+                    "type": "filter",
+                    "config": {
+                        "operation": "and",
+                        "filters": [
+                            {
+                                "id": "f1",
+                                "field": "amount",
+                                "condition": "greater_equal",
+                                "value": 100,
+                            }
+                        ],
+                    },
+                }
+            ],
+        },
+        "outputs": {
+            "output": {"type": "object", "source": "=result.response", "var": "output"},
+            "error": {"type": "object", "source": "=Error", "var": "error"},
+        },
+    }
+
+
+def _well_formed() -> dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "core.trigger.manual"},
+            _filter_node(),
+            {"id": "end", "type": "core.control.end"},
+        ],
+        "edges": [
+            {"sourceNodeId": "start", "targetNodeId": "filterAmount"},
+            {"sourceNodeId": "filterAmount", "targetNodeId": "end"},
+        ],
+    }
+
+
+def test_well_formed_flow_passes(tmp_path: Path) -> None:
+    _write_flow(tmp_path, _well_formed())
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ── Acceptance: wrong transform variants must FAIL ──────────────────────────
+
+
+def test_map_variant_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"] = [
+        {"id": "start", "type": "core.trigger.manual"},
+        _filter_node("core.action.transform.map"),
+        {"id": "end", "type": "core.control.end"},
+    ]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_generic_transform_variant_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"] = [
+        {"id": "start", "type": "core.trigger.manual"},
+        _filter_node("core.action.transform"),
+        {"id": "end", "type": "core.control.end"},
+    ]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_group_by_variant_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"] = [
+        {"id": "start", "type": "core.trigger.manual"},
+        _filter_node("core.action.transform.group-by"),
+        {"id": "end", "type": "core.control.end"},
+    ]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+# ── Field-level rejections ──────────────────────────────────────────────────
+
+
+def test_js_wrapped_collection_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"][1]["inputs"]["collection"] = "=js:$vars.items.output"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "=js:" in (result.stdout + result.stderr)
+
+
+def test_inline_array_collection_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"][1]["inputs"]["collection"] = '[{"amount": 100}]'
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_expression_filter_value_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    flt = payload["nodes"][1]["inputs"]["operations"][0]["config"]["filters"][0]
+    flt["value"] = "$vars.threshold"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "literal" in (result.stdout + result.stderr).lower()
+
+
+def test_bad_condition_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    flt = payload["nodes"][1]["inputs"]["operations"][0]["config"]["filters"][0]
+    flt["condition"] = "greater"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_empty_filters_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"][1]["inputs"]["operations"][0]["config"]["filters"] = []
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_missing_error_source_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    del payload["nodes"][1]["outputs"]["error"]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_empty_type_version_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["nodes"][1]["typeVersion"] = ""
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
@@ -8,7 +8,7 @@ description: >
   rule. Validate-only — no `flow debug`, no tenant: a filter over a static
   in-flow collection has no external dependency, so the test is fully
   deterministic from the flow file alone.
-tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:transform-filter]
+tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, shape:single-node, node:transform, feature:transform]
 
 run_limits:
   turn_timeout: 1200
@@ -34,9 +34,8 @@ initial_prompt: |
       templates. Use the exact condition name `greater_equal`.
     - Wire the node `outputs.output.source` to `=result.response` and
       `outputs.error.source` to `=Error`.
-    - Set `typeVersion` from the registry
-      (`uip maestro flow registry get core.action.transform.filter`) — do not
-      hardcode a guessed value.
+    - Set `typeVersion` from the node registry for
+      `core.action.transform.filter` — do not hardcode a guessed value.
 
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-transform-filter
+description: >
+  Create a UiPath Flow that uses a dedicated `core.action.transform.filter`
+  node to filter a small static collection by a real condition
+  (amount greater_equal 100). Exercises the single-variant filter node type
+  (NOT the generic `core.action.transform` chain, NOT `.map`/`.group-by`), the
+  plain `$vars` collection path contract, and the literal-only filter `value`
+  rule. Validate-only — no `flow debug`, no tenant: a filter over a static
+  in-flow collection has no external dependency, so the test is fully
+  deterministic from the flow file alone.
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:single-node, node:transform-filter]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "TransformFilterDemo" that filters a small
+  static collection using a dedicated Transform Filter node.
+
+  Requirements:
+
+    - Use a single `core.action.transform.filter` node (the filter-only variant
+      — NOT the generic `core.action.transform` chain, NOT `.map`, NOT
+      `.group-by`).
+    - Provide the data as a small static collection (e.g. a few objects each
+      with an `amount` field) held in a flow variable or emitted from an
+      upstream static-data/script node. Point the filter node's
+      `inputs.collection` at that variable as a PLAIN `$vars` path
+      (e.g. `$vars.items.output` or `$vars.items`). Do NOT wrap `collection`
+      in `=js:` and do NOT set it to an inline array literal.
+    - The filter must apply a real condition: `amount` `greater_equal` `100`.
+      The filter `value` MUST be a literal scalar (`100`) — Transform filter
+      `value` is literal-only: no `$vars`, no `=js:`, no `{...}` brace
+      templates. Use the exact condition name `greater_equal`.
+    - Wire the node `outputs.output.source` to `=result.response` and
+      `outputs.error.source` to `=Error`.
+    - Set `typeVersion` from the registry
+      (`uip maestro flow registry get core.action.transform.filter`) — do not
+      hardcode a guessed value.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single
+  pass. Before starting, load the uipath-maestro-flow skill. Read and follow
+  its workflow steps exactly — in particular the transform plugin's filter
+  node shape (`operations[].type == "filter"` with `config.filters`).
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate TransformFilterDemo/TransformFilterDemo/TransformFilterDemo.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks (exact node type, collection path, filter config) ─
+  - type: run_command
+    description: "Flow has exactly one core.action.transform.filter node with a plain $vars collection and a literal greater_equal filter"
+    command: "python3 $TASK_DIR/check_transform_filter_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Add a focused single_node validate-only task that pins `core.action.transform.filter` specifically; flows emitting a different transform variant (`.map`, `.group-by`, or the generic `core.action.transform` chain) fail the checker.

Ticket: https://uipath.atlassian.net/browse/MST-10348

What changed:
- `tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml` — validate-only integration task (`uip validate` + structural checker); no flow debug, no tenant.
- `tests/tasks/uipath-maestro-flow/single_node/transform_filter/check_transform_filter_flow.py` — exact `==` node-type pin, plain `$vars` collection path, literal-only filter value, allowed conditions, output/error sources, non-empty typeVersion.
- `tests/tasks/uipath-maestro-flow/single_node/transform_filter/test_check_transform_filter_flow.py` — positive + negative fixtures, including map and generic-transform variants that must exit non-zero.

Testing:
Ran locally via `uvx pytest tests/tasks/uipath-maestro-flow/single_node/transform_filter -q` — 11 passed in 0.29s (exit 0). This is the same pure-Python checker suite the CI test-helpers job runs; the full coder-eval gate runs in CI, not locally.

The `skill-flow-transform-filter` coder-eval task is exercised by the **Run skill smoke tests** CI job on this PR and will be confirmed green before merge (no LLM/tenant credentials are available locally, so the coder-eval run happens in CI rather than on the author's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

