### PR TITLE
test(uipath-maestro-flow): add transform.group-by smoke test (MST-10347)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/check_transform_group_by_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/check_transform_group_by_flow.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""TransformGroupByDemo: structural check for the Group By transform node.
+
+Generation-only — does not run `uip maestro flow debug`. Verifies:
+
+  1. Exactly one node with `type == "core.action.transform.group-by"` is present
+     (exact match, not a substring — a flow built with a different transform
+     variant such as `core.action.transform.map` or the generic
+     `core.action.transform` must fail).
+  2. `inputs.collection` is a plain `$vars.<path>` string — NOT wrapped in `=js:`
+     and NOT an inline array literal (the transform runtime reads the path as-is).
+  3. `inputs.operations` is a non-empty list containing an operation with
+     `type == "groupBy"` whose:
+       - `config.groupByField` is a non-empty string, and
+       - `config.aggregations` is a non-empty list of objects, each with a
+         non-empty `operation` and a non-empty `alias`.
+  4. `outputs.output.source == "=result.response"` and
+     `outputs.error.source == "=Error"`.
+  5. `typeVersion` is present and non-empty (the value is copied from
+     `uip maestro flow registry get core.action.transform.group-by`, so it is
+     deliberately NOT pinned to a specific value here).
+"""
+
+import glob
+import json
+import sys
+from typing import NoReturn
+
+NODE_TYPE = "core.action.transform.group-by"
+EXPECTED_OUTPUT_SOURCE = "=result.response"
+EXPECTED_ERROR_SOURCE = "=Error"
+
+
+def _fail(msg: str) -> NoReturn:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/TransformGroupByDemo*.flow", recursive=True)
+    if not flows:
+        _fail("no TransformGroupByDemo*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _find_node(flow: dict) -> dict:
+    matches = [n for n in flow.get("nodes", []) if n.get("type") == NODE_TYPE]
+    if not matches:
+        types = sorted({n.get("type") for n in flow.get("nodes", [])})
+        _fail(f"no node with type == {NODE_TYPE!r}; types seen: {types}")
+    if len(matches) > 1:
+        _fail(f"expected exactly one {NODE_TYPE} node, found {len(matches)}")
+    return matches[0]
+
+
+def _check_collection(inputs: dict) -> None:
+    collection = inputs.get("collection")
+    if not isinstance(collection, str) or not collection.strip():
+        _fail("inputs.collection missing or empty — set it to a plain `$vars.<path>` string")
+    value = collection.strip()
+    if value.startswith("=js:"):
+        _fail(
+            f"inputs.collection={collection!r} is wrapped in `=js:`. Transform `collection` is a "
+            "path field, not a `=js:` expression — use a plain path like `$vars.employees.output.items`."
+        )
+    if value.startswith("[") or value.startswith("{"):
+        _fail(
+            f"inputs.collection={collection!r} looks like an inline array/object literal. "
+            "Store the static data in a variable defaultValue or upstream node and point "
+            "`collection` at that path (e.g. `$vars.employees`)."
+        )
+    if not value.startswith("$vars."):
+        _fail(
+            f"inputs.collection={collection!r} is not a plain `$vars.<path>` string. "
+            "Expected something like `$vars.employees.output.items`."
+        )
+
+
+def _check_operations(inputs: dict) -> None:
+    operations = inputs.get("operations")
+    if not isinstance(operations, list) or not operations:
+        _fail("inputs.operations must be a non-empty list")
+
+    group_by_ops = [
+        op for op in operations if isinstance(op, dict) and op.get("type") == "groupBy"
+    ]
+    if not group_by_ops:
+        types = [op.get("type") if isinstance(op, dict) else type(op).__name__ for op in operations]
+        _fail(f"inputs.operations has no operation with type == 'groupBy'; op types seen: {types}")
+
+    op = group_by_ops[0]
+    config = op.get("config")
+    if not isinstance(config, dict):
+        _fail("the groupBy operation has no `config` object")
+
+    group_by_field = config.get("groupByField")
+    if not isinstance(group_by_field, str) or not group_by_field.strip():
+        _fail("groupBy config.groupByField must be a non-empty string")
+
+    aggregations = config.get("aggregations")
+    if not isinstance(aggregations, list) or not aggregations:
+        _fail("groupBy config.aggregations must be a non-empty list")
+    for i, agg in enumerate(aggregations):
+        if not isinstance(agg, dict):
+            _fail(f"groupBy config.aggregations[{i}] is {type(agg).__name__}, expected an object")
+        for key in ("operation", "alias"):
+            val = agg.get(key)
+            if not isinstance(val, str) or not val.strip():
+                _fail(
+                    f"groupBy config.aggregations[{i}].{key} is missing or empty. "
+                    "Each aggregation needs a non-empty 'operation' and 'alias'."
+                )
+
+
+def _check_ports(node: dict) -> None:
+    outputs = node.get("outputs") or {}
+    out_src = ((outputs.get("output") or {}).get("source"))
+    if out_src != EXPECTED_OUTPUT_SOURCE:
+        _fail(
+            f"outputs.output.source={out_src!r}; must be {EXPECTED_OUTPUT_SOURCE!r}."
+        )
+    err_src = ((outputs.get("error") or {}).get("source"))
+    if err_src != EXPECTED_ERROR_SOURCE:
+        _fail(
+            f"outputs.error.source={err_src!r}; must be {EXPECTED_ERROR_SOURCE!r}."
+        )
+
+
+def _check_type_version(node: dict) -> None:
+    tv = node.get("typeVersion")
+    if not isinstance(tv, str) or not tv.strip():
+        _fail(
+            "typeVersion is missing or empty — copy it from "
+            "`uip maestro flow registry get core.action.transform.group-by --output json`."
+        )
+
+
+def main():
+    flow = _read_flow()
+    node = _find_node(flow)
+    inputs = node.get("inputs") or {}
+
+    _check_type_version(node)
+    _check_collection(inputs)
+    _check_operations(inputs)
+    _check_ports(node)
+
+    print(
+        f"OK: exactly one {NODE_TYPE} node present; typeVersion set; "
+        f"collection is a plain $vars path; groupBy op has a groupByField and "
+        f"non-empty aggregations; output source=`=result.response`, error source=`=Error`"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/test_check_transform_group_by_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/test_check_transform_group_by_flow.py
@@ -1,0 +1,208 @@
+"""Unit tests for check_transform_group_by_flow.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/single_node/transform_group_by``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CHECKER = Path(__file__).resolve().parent / "check_transform_group_by_flow.py"
+
+
+def _flow_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "TransformGroupByDemo" / "TransformGroupByDemo"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
+    d = _flow_dir(tmp_path)
+    (d / "TransformGroupByDemo.flow").write_text(json.dumps(payload))
+    # Match the canonical Flow project layout (a project.uiproj alongside the .flow).
+    (d / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _group_by_node() -> dict[str, Any]:
+    return {
+        "id": "groupByDept",
+        "type": "core.action.transform.group-by",
+        "typeVersion": "1.0",
+        "display": {"label": "Group by Department"},
+        "inputs": {
+            "collection": "$vars.employees.output.items",
+            "operations": [
+                {
+                    "id": "op1",
+                    "type": "groupBy",
+                    "config": {
+                        "groupByField": "department",
+                        "aggregations": [
+                            {"id": "a1", "field": "", "operation": "count", "alias": "headcount"},
+                            {"id": "a2", "field": "salary", "operation": "sum", "alias": "totalSalary"},
+                        ],
+                    },
+                }
+            ],
+        },
+        "outputs": {
+            "output": {
+                "type": "object",
+                "description": "The return value of the transform",
+                "source": "=result.response",
+                "var": "output",
+            },
+            "error": {
+                "type": "object",
+                "description": "Error information if the transform fails",
+                "source": "=Error",
+                "var": "error",
+            },
+        },
+    }
+
+
+def _well_formed() -> dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "core.trigger.manual"},
+            _group_by_node(),
+            {"id": "end", "type": "core.control.end"},
+        ],
+        "edges": [
+            {"sourceNodeId": "start", "targetNodeId": "groupByDept"},
+            {"sourceNodeId": "groupByDept", "targetNodeId": "end"},
+        ],
+        "variables": {
+            "globals": [
+                {
+                    "id": "employees",
+                    "direction": "in",
+                    "type": "array",
+                    "defaultValue": [
+                        {"department": "eng", "salary": 100},
+                        {"department": "eng", "salary": 120},
+                        {"department": "sales", "salary": 90},
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def test_well_formed_flow_passes(tmp_path: Path) -> None:
+    _write_flow(tmp_path, _well_formed())
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_map_variant_fails(tmp_path: Path) -> None:
+    """A core.action.transform.map node MUST fail the exact-type check."""
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["type"] = "core.action.transform.map"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "core.action.transform.group-by" in (result.stdout + result.stderr)
+
+
+def test_generic_transform_variant_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["type"] = "core.action.transform"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_collection_wrapped_in_js_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["inputs"]["collection"] = "=js:$vars.employees.output.items"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "=js:" in (result.stdout + result.stderr)
+
+
+def test_inline_array_collection_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["inputs"]["collection"] = '[{"department":"eng"}]'
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_empty_aggregations_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["inputs"]["operations"][0]["config"]["aggregations"] = []
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "aggregations" in (result.stdout + result.stderr)
+
+
+def test_aggregation_missing_alias_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["inputs"]["operations"][0]["config"]["aggregations"] = [
+                {"id": "a1", "operation": "count", "alias": ""}
+            ]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_empty_group_by_field_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["inputs"]["operations"][0]["config"]["groupByField"] = ""
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_missing_type_version_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n.pop("typeVersion", None)
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "typeVersion" in (result.stdout + result.stderr)
+
+
+def test_wrong_output_source_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.group-by":
+            n["outputs"]["output"]["source"] = "=response"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
@@ -8,7 +8,7 @@ description: >
   (never wrapped in `=js:` or an inline array literal). Pure-OOTB, validate-only:
   no tenant and no `flow debug` — the structural checker reads the `.flow` file
   directly.
-tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:transform-group-by]
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, shape:single-node, node:transform, feature:transform]
 
 run_limits:
   turn_timeout: 1200
@@ -35,9 +35,8 @@ initial_prompt: |
       `average`) and a non-empty `alias` for the output field.
     - The node's `outputs.output.source` must be `=result.response` and
       `outputs.error.source` must be `=Error`.
-    - Set the node's `typeVersion` to the `version` field returned by
-      `uip maestro flow registry get core.action.transform.group-by --output json`.
-      Do NOT hardcode a guessed version.
+    - Set the node's `typeVersion` from the node registry for
+      `core.action.transform.group-by` — do NOT hardcode a guessed version.
 
   Validate the flow. Do NOT run flow debug — just validate.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
@@ -1,0 +1,66 @@
+task_id: skill-flow-transform-group-by
+description: >
+  Create a UiPath Flow with a single Group By transform node
+  (`core.action.transform.group-by`) that groups a small static collection by a
+  field and produces at least one aggregation (e.g. a count). Exercises Group By
+  transform node discovery, the `operations`/`groupBy` op shape (`groupByField` +
+  `aggregations`), and the rule that `inputs.collection` is a plain `$vars` path
+  (never wrapped in `=js:` or an inline array literal). Pure-OOTB, validate-only:
+  no tenant and no `flow debug` — the structural checker reads the `.flow` file
+  directly.
+tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:transform-group-by]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "TransformGroupByDemo" that uses a single
+  Group By transform node (`core.action.transform.group-by`) to group a small
+  static collection of records by a field and compute at least one aggregation.
+
+  Requirements:
+
+    - Hold the static collection (a small array of objects, e.g. employees with
+      `department` and `salary` fields) in a flow variable's `defaultValue` or
+      emit it from an upstream static-data / script node. Do NOT inline the array
+      into the transform node.
+    - The Group By node's `inputs.collection` must be a PLAIN variable path such
+      as `$vars.employees.output.items` (or `$vars.employees`). NEVER wrap it in
+      `=js:` and NEVER set it to an inline array literal — the transform runtime
+      reads the path as-is, so `=js:...` resolves to an empty collection.
+    - `inputs.operations` must be a non-empty array containing one operation with
+      `type: "groupBy"` whose `config.groupByField` is the field to group on (a
+      non-empty string) and whose `config.aggregations` is a non-empty array. Each
+      aggregation must have a non-empty `operation` (e.g. `count`, `sum`,
+      `average`) and a non-empty `alias` for the output field.
+    - The node's `outputs.output.source` must be `=result.response` and
+      `outputs.error.source` must be `=Error`.
+    - Set the node's `typeVersion` to the `version` field returned by
+      `uip maestro flow registry get core.action.transform.group-by --output json`.
+      Do NOT hardcode a guessed version.
+
+  Validate the flow. Do NOT run flow debug — just validate.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its
+  workflow steps exactly — in particular, the transform plugin's Group By JSON
+  shape and the collection-input contract.
+
+success_criteria:
+  # -- Flow file validity --
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate TransformGroupByDemo/TransformGroupByDemo/TransformGroupByDemo.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # -- Structural checks (node type, collection path, groupBy op shape, ports) --
+  - type: run_command
+    description: "Flow has exactly one core.action.transform.group-by node with a plain $vars collection, a non-empty groupBy operation, and the standard output/error ports"
+    command: "python3 $TASK_DIR/check_transform_group_by_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Add a pure-OOTB, validate-only single_node smoke test for the `core.action.transform.group-by` Maestro Flow node.

**Ticket:** https://uipath.atlassian.net/browse/MST-10347

**What changed**
- `tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml` — task definition (group a static collection by a field, compute an aggregation; no tenant, no flow debug).
- `tests/tasks/uipath-maestro-flow/single_node/transform_group_by/check_transform_group_by_flow.py` — structural checker: reads the `.flow` (glob + `json.load`), asserts exactly one exact-typed group-by node, a plain `$vars` collection path (no `=js:`/inline literal), a non-empty `groupBy` op with `groupByField` + `aggregations`, standard `=result.response`/`=Error` ports, and a non-empty `typeVersion`.
- `tests/tasks/uipath-maestro-flow/single_node/transform_group_by/test_check_transform_group_by_flow.py` — unit test covering the well-formed case and negative fixtures (map/generic variant, `=js:` collection, empty aggregations, etc.).

**Testing**
Ran the same suite the CI test-helpers job runs, locally via `uvx pytest`:

```
$ uvx pytest tests/tasks/uipath-maestro-flow/single_node/transform_group_by -q
..........                                                               [100%]
10 passed in 0.26s
```

Exit 0, 10 tests passed. These are validate-only/structural tasks; the full coder-eval gate runs in CI, not locally.

The `skill-flow-transform-group-by` coder-eval task is exercised by the **Run skill smoke tests** CI job on this PR and will be confirmed green before merge (no LLM/tenant credentials are available locally, so the coder-eval run happens in CI rather than on the author's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

