### PR TITLE
test(uipath-maestro-flow): add transform.map smoke test (MST-10346)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/check_transform_map_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/check_transform_map_flow.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""TransformMapDemo: structural check for the Transform Map node (smoke).
+
+Generation-only — does not run `uip maestro flow debug`. Verifies:
+
+  1. Exactly one node whose `type` is EXACTLY `core.action.transform.map`
+     (strict `==`, NOT a substring) — a flow built with the generic
+     `core.action.transform` or any other variant (`.filter`, `.group-by`)
+     must fail, since the whole point of this smoke test is pinning the
+     exact `map` variant.
+  2. `inputs.collection` is a string that starts with `$vars.` and does NOT
+     start with `=js:` — the transform `collection` is a plain variable path,
+     never an `=js:` expression and never an inline array literal.
+  3. `inputs.operations` is a non-empty list containing an operation with
+     `type == "map"` whose `config.mappings` is a non-empty list of objects,
+     each having a non-empty `field` and a non-empty `transformation`.
+  4. `outputs.output.source == "=result.response"` and
+     `outputs.error.source == "=Error"`.
+  5. `typeVersion` is present and non-empty (the exact value is copied from
+     `uip maestro flow registry get core.action.transform.map`, so we do NOT
+     pin a specific version string here).
+"""
+
+import glob
+import json
+import sys
+from typing import NoReturn
+
+NODE_TYPE = "core.action.transform.map"
+EXPECTED_OUTPUT_SOURCE = "=result.response"
+EXPECTED_ERROR_SOURCE = "=Error"
+
+
+def _fail(msg: str) -> NoReturn:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/TransformMapDemo*.flow", recursive=True)
+    if not flows:
+        _fail("no TransformMapDemo*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _find_node(flow: dict) -> dict:
+    # Strict equality on type — NOT a substring match. The generic
+    # `core.action.transform` node and the `.filter` / `.group-by` variants
+    # must NOT satisfy this smoke test.
+    matches = [n for n in flow.get("nodes", []) if n.get("type") == NODE_TYPE]
+    if not matches:
+        types = sorted({n.get("type") for n in flow.get("nodes", [])})
+        _fail(f"no node with type == {NODE_TYPE!r}; types seen: {types}")
+    if len(matches) > 1:
+        _fail(f"expected exactly one {NODE_TYPE} node, found {len(matches)}")
+    return matches[0]
+
+
+def _check_collection(inputs: dict) -> None:
+    collection = inputs.get("collection")
+    if not isinstance(collection, str) or not collection.strip():
+        _fail("inputs.collection missing or empty — set it to a plain `$vars.<...>` path")
+    c = collection.strip()
+    if c.startswith("=js:"):
+        _fail(
+            f"inputs.collection={collection!r} starts with `=js:`. The transform "
+            "`collection` is a plain variable path, never an `=js:` expression. "
+            "Use e.g. `$vars.people.output`."
+        )
+    if not c.startswith("$vars."):
+        _fail(
+            f"inputs.collection={collection!r} must start with `$vars.` (a plain "
+            "variable path). Inline array literals and other shapes are rejected."
+        )
+
+
+def _check_operations(inputs: dict) -> None:
+    operations = inputs.get("operations")
+    if not isinstance(operations, list) or not operations:
+        _fail("inputs.operations must be a non-empty list with a `map` operation")
+    map_ops = [op for op in operations if isinstance(op, dict) and op.get("type") == "map"]
+    if not map_ops:
+        _fail(
+            "inputs.operations has no operation with type == 'map'. "
+            f"operations seen: {[op.get('type') for op in operations if isinstance(op, dict)]}"
+        )
+    for op in map_ops:
+        config = op.get("config")
+        if not isinstance(config, dict):
+            _fail("map operation has no `config` object")
+        mappings = config.get("mappings")
+        if not isinstance(mappings, list) or not mappings:
+            _fail("map operation config.mappings must be a non-empty list")
+        for i, m in enumerate(mappings):
+            if not isinstance(m, dict):
+                _fail(f"config.mappings[{i}] is {type(m).__name__}, expected an object")
+            for key in ("field", "transformation"):
+                val = m.get(key)
+                if not isinstance(val, str) or not val.strip():
+                    _fail(
+                        f"config.mappings[{i}].{key} is missing or empty. "
+                        "Each mapping needs a non-empty 'field' and 'transformation'."
+                    )
+
+
+def _check_output_sources(node: dict) -> None:
+    outputs = node.get("outputs") or {}
+    out_src = ((outputs.get("output")) or {}).get("source")
+    if out_src != EXPECTED_OUTPUT_SOURCE:
+        _fail(
+            f"outputs.output.source={out_src!r}; must be {EXPECTED_OUTPUT_SOURCE!r}."
+        )
+    err_src = ((outputs.get("error")) or {}).get("source")
+    if err_src != EXPECTED_ERROR_SOURCE:
+        _fail(
+            f"outputs.error.source={err_src!r}; must be {EXPECTED_ERROR_SOURCE!r}."
+        )
+
+
+def _check_type_version(node: dict) -> None:
+    tv = node.get("typeVersion")
+    if not isinstance(tv, str) or not tv.strip():
+        _fail(
+            "typeVersion missing or empty — copy it from "
+            "`uip maestro flow registry get core.action.transform.map`."
+        )
+
+
+def main():
+    flow = _read_flow()
+    node = _find_node(flow)
+    inputs = node.get("inputs") or {}
+
+    _check_type_version(node)
+    _check_collection(inputs)
+    _check_operations(inputs)
+    _check_output_sources(node)
+
+    print(
+        f"OK: exactly one {NODE_TYPE} node; collection is a plain `$vars.` path; "
+        f"a `map` operation with non-empty mappings (field+transformation); "
+        f"output source=`{EXPECTED_OUTPUT_SOURCE}`, error source=`{EXPECTED_ERROR_SOURCE}`; "
+        f"typeVersion present"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/test_check_transform_map_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/test_check_transform_map_flow.py
@@ -1,0 +1,188 @@
+"""Unit tests for check_transform_map_flow.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/single_node/transform_map``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CHECKER = Path(__file__).resolve().parent / "check_transform_map_flow.py"
+
+
+def _flow_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "TransformMapDemo" / "TransformMapDemo"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
+    d = _flow_dir(tmp_path)
+    (d / "TransformMapDemo.flow").write_text(json.dumps(payload))
+    # A Flow project.uiproj alongside the .flow keeps the fixture realistic.
+    (d / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _map_node(node_type: str = "core.action.transform.map") -> dict[str, Any]:
+    return {
+        "id": "mapNames",
+        "type": node_type,
+        "typeVersion": "1.0",
+        "display": {"label": "Uppercase Names"},
+        "inputs": {
+            "collection": "$vars.people.output",
+            "operations": [
+                {
+                    "id": "op1",
+                    "type": "map",
+                    "config": {
+                        "keepOriginalFields": False,
+                        "mappings": [
+                            {
+                                "id": "m1",
+                                "field": "name",
+                                "transformation": "uppercase",
+                                "renameTo": "",
+                            }
+                        ],
+                    },
+                }
+            ],
+        },
+        "outputs": {
+            "output": {
+                "type": "object",
+                "description": "The return value of the transform",
+                "source": "=result.response",
+                "var": "output",
+            },
+            "error": {
+                "type": "object",
+                "description": "Error information if the transform fails",
+                "source": "=Error",
+                "var": "error",
+            },
+        },
+    }
+
+
+def _well_formed() -> dict[str, Any]:
+    return {
+        "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "core.trigger.manual"},
+            _map_node(),
+            {"id": "end", "type": "core.control.end"},
+        ],
+        "edges": [
+            {"sourceNodeId": "start", "targetNodeId": "mapNames"},
+            {"sourceNodeId": "mapNames", "targetNodeId": "end"},
+        ],
+    }
+
+
+def test_well_formed_flow_passes(tmp_path: Path) -> None:
+    _write_flow(tmp_path, _well_formed())
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_filter_variant_fails(tmp_path: Path) -> None:
+    # Negative fixture: the .filter variant must NOT satisfy the exact-map pin.
+    payload = _well_formed()
+    payload["nodes"] = [
+        n for n in payload["nodes"] if n.get("type") != "core.action.transform.map"
+    ]
+    payload["nodes"].insert(1, _map_node(node_type="core.action.transform.filter"))
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_generic_transform_variant_fails(tmp_path: Path) -> None:
+    # Negative fixture: the generic core.action.transform must also fail —
+    # substring matching would wrongly accept it, exact == must reject it.
+    payload = _well_formed()
+    payload["nodes"] = [
+        n for n in payload["nodes"] if n.get("type") != "core.action.transform.map"
+    ]
+    payload["nodes"].insert(1, _map_node(node_type="core.action.transform"))
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_js_collection_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.map":
+            n["inputs"]["collection"] = "=js:$vars.people.output"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_inline_array_collection_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.map":
+            n["inputs"]["collection"] = '[{"name": "alice"}]'
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_empty_mappings_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.map":
+            n["inputs"]["operations"][0]["config"]["mappings"] = []
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_mapping_missing_field_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.map":
+            n["inputs"]["operations"][0]["config"]["mappings"] = [
+                {"id": "m1", "transformation": "uppercase"}
+            ]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_wrong_output_source_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.map":
+            n["outputs"]["output"]["source"] = "=response"
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+
+
+def test_missing_type_version_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n.get("type") == "core.action.transform.map":
+            n.pop("typeVersion", None)
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
@@ -1,0 +1,65 @@
+task_id: skill-flow-transform-map
+description: >
+  Smoke test: agent builds a pure-OOTB UiPath Flow with a single
+  `core.action.transform.map` node that maps a small static collection
+  (uppercasing a name field). Exercises Transform Map node discovery, the
+  plain-`$vars` `collection` path contract, and the map operation's
+  `config.mappings` shape. Validate-only — no tenant, no `flow debug`.
+tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:transform-map]
+
+run_limits:
+  max_turns: 80
+
+initial_prompt: |
+  Create a UiPath Flow project named "TransformMapDemo" that contains a single
+  Transform Map node which uppercases a `name` field over a small static
+  collection of people.
+
+  Requirements:
+
+    - Use a manual trigger -> the Transform Map node -> an End node.
+    - The transform node MUST be the dedicated map variant: its `type` must be
+      exactly `core.action.transform.map` (NOT the generic
+      `core.action.transform`, and NOT `.filter` or `.group-by`).
+    - Hold the static collection in a flow variable (or an upstream
+      static-data / script node). Example rows:
+      `[{ "name": "alice" }, { "name": "bob" }]`.
+    - The node's `inputs.collection` MUST be a plain `$vars.<...>` variable
+      path (e.g. `$vars.people.output` or `$vars.people`). Do NOT wrap it in
+      `=js:` and do NOT set it to an inline array literal — the transform
+      runtime treats `collection` as a path string, so `=js:` or a literal
+      array resolves to an empty collection.
+    - `inputs.operations` must contain one operation with `type: "map"` whose
+      `config.mappings` includes a mapping with `field: "name"` and
+      `transformation: "uppercase"`.
+    - The node `outputs.output.source` must be `=result.response` and
+      `outputs.error.source` must be `=Error`.
+    - Set the node's `typeVersion` to the `version` field returned by
+      `uip maestro flow registry get core.action.transform.map` — do NOT
+      hardcode a guessed version.
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its
+  workflow steps exactly — in particular, the transform plugin's Map JSON
+  shape and the `collection` path contract.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate TransformMapDemo/TransformMapDemo/TransformMapDemo.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks (exact map variant, collection path, mappings) ────
+  - type: run_command
+    description: "Flow has exactly one core.action.transform.map node with a $vars collection and a uppercase name mapping"
+    command: "python3 $TASK_DIR/check_transform_map_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
@@ -5,10 +5,10 @@ description: >
   (uppercasing a name field). Exercises Transform Map node discovery, the
   plain-`$vars` `collection` path contract, and the map operation's
   `config.mappings` shape. Validate-only — no tenant, no `flow debug`.
-tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:transform-map]
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, shape:single-node, node:transform, feature:transform]
 
 run_limits:
-  max_turns: 80
+  turn_timeout: 1200
 
 initial_prompt: |
   Create a UiPath Flow project named "TransformMapDemo" that contains a single
@@ -26,17 +26,15 @@ initial_prompt: |
       `[{ "name": "alice" }, { "name": "bob" }]`.
     - The node's `inputs.collection` MUST be a plain `$vars.<...>` variable
       path (e.g. `$vars.people.output` or `$vars.people`). Do NOT wrap it in
-      `=js:` and do NOT set it to an inline array literal — the transform
-      runtime treats `collection` as a path string, so `=js:` or a literal
-      array resolves to an empty collection.
+      `=js:` and do NOT set it to an inline array literal.
     - `inputs.operations` must contain one operation with `type: "map"` whose
       `config.mappings` includes a mapping with `field: "name"` and
       `transformation: "uppercase"`.
     - The node `outputs.output.source` must be `=result.response` and
       `outputs.error.source` must be `=Error`.
-    - Set the node's `typeVersion` to the `version` field returned by
-      `uip maestro flow registry get core.action.transform.map` — do NOT
-      hardcode a guessed version.
+    - Set the node's `typeVersion` from the node registry for
+      `core.action.transform.map` — do NOT hardcode a guessed version (the
+      skill's workflow teaches how to read the registry).
 
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between


### PR DESCRIPTION
Add a pure-OOTB, validate-only single_node smoke test exercising a `core.action.transform.map` node that uppercases a name field over a small static collection.

Ticket: https://uipath.atlassian.net/browse/MST-10346

What changed
- `tests/tasks/uipath-maestro-flow/single_node/transform_map/check_transform_map_flow.py` — structural checker (exact `==` on the `core.action.transform.map` variant, plain `$vars.` collection path, non-empty `map` mappings with field+transformation, output/error sources, present typeVersion)
- `tests/tasks/uipath-maestro-flow/single_node/transform_map/test_check_transform_map_flow.py` — dependency-free pytest unit test with positive + negative fixtures (`.filter` and generic `transform` variants confirm the exact-variant pin)
- `tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml` — task definition

Testing
Ran locally from the worktree root:

```
uvx pytest tests/tasks/uipath-maestro-flow/single_node/transform_map -q
.........                                                                [100%]
9 passed in 0.24s
```

These are validate-only/structural checks; the full coder-eval gate runs in CI, not locally.

The `skill-flow-transform-map` coder-eval task is exercised by the **Run skill smoke tests** CI job on this PR and will be confirmed green before merge (no LLM/tenant credentials are available locally, so the coder-eval run happens in CI rather than on the author's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

