### PR TITLE
test(uipath-maestro-flow): add delay node smoke test (MST-10350)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/delay/check_delay_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/check_delay_flow.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""DelayDemo: structural check for the OOTB Delay node.
+
+Generation-only — does not run `uip maestro flow debug` (a delay would block
+the run for its full wait duration, and the BPMN timer fires only inside a
+live engine). Verifies:
+
+  1. Exactly one node with `type == "core.logic.delay"` is present (exact
+     ==, so a different timer/logic variant fails).
+  2. `inputs.timerType` is one of {"timeDuration", "timeDate"}.
+  3. `inputs.timerPreset` is present and non-empty.
+  4. If `timerPreset == "custom"`:
+       - `timerType == "timeDuration"` requires non-empty `inputs.timerValue`.
+       - `timerType == "timeDate"`     requires non-empty `inputs.timerDate`.
+  5. `typeVersion` is present and non-empty (value is copied from the
+     registry by the agent-under-test, so we do NOT pin a specific value).
+  6. Wiring: `flow["edges"]` contains at least one edge whose `targetNodeId`
+     is the delay node id (incoming) AND at least one edge whose
+     `sourceNodeId` is the delay node id (outgoing).
+"""
+
+import glob
+import json
+import sys
+from typing import NoReturn
+
+NODE_TYPE = "core.logic.delay"
+VALID_TIMER_TYPES = {"timeDuration", "timeDate"}
+
+
+def _fail(msg: str) -> NoReturn:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/DelayDemo*.flow", recursive=True)
+    if not flows:
+        _fail("no DelayDemo*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _find_node(flow: dict) -> dict:
+    matches = [n for n in flow.get("nodes", []) if n.get("type") == NODE_TYPE]
+    if not matches:
+        types = sorted({n.get("type") for n in flow.get("nodes", [])})
+        _fail(f"no node with type {NODE_TYPE!r}; types seen: {types}")
+    if len(matches) > 1:
+        _fail(f"expected exactly one {NODE_TYPE} node, found {len(matches)}")
+    return matches[0]
+
+
+def _check_type_version(node: dict) -> None:
+    tv = node.get("typeVersion")
+    if not isinstance(tv, str) or not tv.strip():
+        _fail(
+            "typeVersion missing or empty — copy the `version` field from "
+            "`uip maestro flow registry get core.logic.delay --output json`."
+        )
+
+
+def _check_timer_inputs(inputs: dict) -> None:
+    timer_type = inputs.get("timerType")
+    if timer_type not in VALID_TIMER_TYPES:
+        _fail(
+            f"inputs.timerType={timer_type!r}; must be one of "
+            f"{sorted(VALID_TIMER_TYPES)}."
+        )
+
+    timer_preset = inputs.get("timerPreset")
+    if not isinstance(timer_preset, str) or not timer_preset.strip():
+        _fail("inputs.timerPreset missing or empty — required for a delay node.")
+
+    if timer_preset == "custom":
+        if timer_type == "timeDuration":
+            timer_value = inputs.get("timerValue")
+            if not isinstance(timer_value, str) or not timer_value.strip():
+                _fail(
+                    "inputs.timerPreset is 'custom' with timerType 'timeDuration' "
+                    "but inputs.timerValue is missing or empty — add an ISO 8601 "
+                    "duration (e.g. P1DT5H30M)."
+                )
+        elif timer_type == "timeDate":
+            timer_date = inputs.get("timerDate")
+            if not isinstance(timer_date, str) or not timer_date.strip():
+                _fail(
+                    "inputs.timerType is 'timeDate' but inputs.timerDate is missing "
+                    "or empty — add an ISO 8601 datetime or `=js:` expression."
+                )
+
+
+def _check_wiring(flow: dict, node_id: str) -> None:
+    edges = flow.get("edges") or []
+    has_incoming = any(e.get("targetNodeId") == node_id for e in edges)
+    has_outgoing = any(e.get("sourceNodeId") == node_id for e in edges)
+    if not has_incoming:
+        _fail(
+            f"no incoming edge: flow.edges has no entry with targetNodeId={node_id!r}. "
+            "The delay node must be reached from the trigger."
+        )
+    if not has_outgoing:
+        _fail(
+            f"no outgoing edge: flow.edges has no entry with sourceNodeId={node_id!r}. "
+            "The delay node must continue to the End node."
+        )
+
+
+def main():
+    flow = _read_flow()
+    node = _find_node(flow)
+    inputs = node.get("inputs") or {}
+
+    _check_type_version(node)
+    _check_timer_inputs(inputs)
+    _check_wiring(flow, node["id"])
+
+    print(
+        f"OK: exactly one {NODE_TYPE} node present; "
+        f"timerType={inputs.get('timerType')!r}, timerPreset={inputs.get('timerPreset')!r}; "
+        f"typeVersion set; incoming and outgoing edges wired"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
@@ -1,0 +1,55 @@
+task_id: skill-flow-delay
+description: >
+  Create a UiPath Flow with a single OOTB Delay node (`core.logic.delay`)
+  that waits a fixed duration before reaching the End node. Exercises Delay
+  node discovery, the `timerType`/`timerPreset` input shape, and correct
+  incoming/outgoing edge wiring (Trigger -> Delay -> End).
+  Validate-only and pure-OOTB — no tenant, no `flow debug` (a delay node
+  would block the run for its full wait duration, and the timer fires only
+  inside a live BPMN engine the test sandbox cannot provision).
+tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:delay]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "DelayDemo" with the shape
+  Trigger -> Delay -> End. The middle node must be an OOTB Delay node of
+  type `core.logic.delay` that waits a fixed duration:
+
+    - `inputs.timerType` must be `"timeDuration"`.
+    - `inputs.timerPreset` must be a fixed ISO 8601 duration preset such as
+      `"PT15M"` (15 minutes). Do NOT use `"custom"` for this smoke test.
+    - Set `typeVersion` to the `version` field from
+      `uip maestro flow registry get core.logic.delay --output json`.
+      Do NOT hardcode a guessed version.
+
+  Wire the Delay node so that it has an incoming edge from the trigger and an
+  outgoing edge to the End node (an `edges[]` entry whose `targetNodeId` is
+  the delay node id, and one whose `sourceNodeId` is the delay node id).
+
+  Do NOT run flow debug — just validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its
+  workflow steps exactly — in particular, the delay plugin's `inputs` shape
+  (`timerType` + `timerPreset`).
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate DelayDemo/DelayDemo/DelayDemo.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks (node type, timer inputs, edge wiring) ───────────
+  - type: run_command
+    description: "Flow has exactly one core.logic.delay node with valid timer inputs and incoming/outgoing edges"
+    command: "python3 $TASK_DIR/check_delay_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
@@ -7,7 +7,7 @@ description: >
   Validate-only and pure-OOTB — no tenant, no `flow debug` (a delay node
   would block the run for its full wait duration, and the timer fires only
   inside a live BPMN engine the test sandbox cannot provision).
-tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:delay]
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, shape:single-node, node:delay]
 
 run_limits:
   turn_timeout: 1200
@@ -20,9 +20,8 @@ initial_prompt: |
     - `inputs.timerType` must be `"timeDuration"`.
     - `inputs.timerPreset` must be a fixed ISO 8601 duration preset such as
       `"PT15M"` (15 minutes). Do NOT use `"custom"` for this smoke test.
-    - Set `typeVersion` to the `version` field from
-      `uip maestro flow registry get core.logic.delay --output json`.
-      Do NOT hardcode a guessed version.
+    - Set `typeVersion` from the node registry for `core.logic.delay` —
+      do NOT hardcode a guessed version.
 
   Wire the Delay node so that it has an incoming edge from the trigger and an
   outgoing edge to the End node (an `edges[]` entry whose `targetNodeId` is

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/test_check_delay_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/test_check_delay_flow.py
@@ -1,0 +1,160 @@
+"""Unit tests for check_delay_flow.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/single_node/delay``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CHECKER = Path(__file__).resolve().parent / "check_delay_flow.py"
+
+
+def _flow_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "DelayDemo" / "DelayDemo"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
+    d = _flow_dir(tmp_path)
+    (d / "DelayDemo.flow").write_text(json.dumps(payload))
+    # A Flow project.uiproj alongside the .flow keeps the fixture realistic.
+    (d / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _well_formed() -> dict[str, Any]:
+    """Trigger -> Delay -> End, fixed-duration preset."""
+    return {
+        "version": "1.0.0",
+        "nodes": [
+            {"id": "start", "type": "core.trigger.manual"},
+            {
+                "id": "wait15min",
+                "type": "core.logic.delay",
+                "typeVersion": "1.0",
+                "display": {"label": "Wait 15 Minutes"},
+                "inputs": {
+                    "timerType": "timeDuration",
+                    "timerPreset": "PT15M",
+                },
+            },
+            {"id": "end", "type": "core.control.end"},
+        ],
+        "edges": [
+            {"sourceNodeId": "start", "targetNodeId": "wait15min"},
+            {"sourceNodeId": "wait15min", "targetNodeId": "end"},
+        ],
+    }
+
+
+def test_well_formed_flow_passes(tmp_path: Path) -> None:
+    _write_flow(tmp_path, _well_formed())
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_custom_duration_with_timer_value_passes(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n["type"] == "core.logic.delay":
+            n["inputs"] = {
+                "timerType": "timeDuration",
+                "timerPreset": "custom",
+                "timerValue": "P1DT5H30M",
+            }
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_time_date_with_timer_date_passes(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n["type"] == "core.logic.delay":
+            n["inputs"] = {
+                "timerType": "timeDate",
+                "timerPreset": "custom",
+                "timerDate": "=js:$vars.scheduledDate",
+            }
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_missing_timer_type_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n["type"] == "core.logic.delay":
+            n["inputs"] = {"timerPreset": "PT15M"}
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "timertype" in (result.stdout + result.stderr).lower()
+
+
+def test_missing_delay_node_fails(tmp_path: Path) -> None:
+    """Only non-trigger node is some other type — no core.logic.delay present."""
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n["type"] == "core.logic.delay":
+            n["type"] = "core.logic.script"
+            n["inputs"] = {}
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "core.logic.delay" in (result.stdout + result.stderr)
+
+
+def test_custom_duration_missing_timer_value_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n["type"] == "core.logic.delay":
+            n["inputs"] = {"timerType": "timeDuration", "timerPreset": "custom"}
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "timervalue" in (result.stdout + result.stderr).lower()
+
+
+def test_missing_type_version_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    for n in payload["nodes"]:
+        if n["type"] == "core.logic.delay":
+            n.pop("typeVersion", None)
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "typeversion" in (result.stdout + result.stderr).lower()
+
+
+def test_missing_outgoing_edge_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["edges"] = [{"sourceNodeId": "start", "targetNodeId": "wait15min"}]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "outgoing" in (result.stdout + result.stderr).lower()
+
+
+def test_missing_incoming_edge_fails(tmp_path: Path) -> None:
+    payload = _well_formed()
+    payload["edges"] = [{"sourceNodeId": "wait15min", "targetNodeId": "end"}]
+    _write_flow(tmp_path, payload)
+    result = _run(tmp_path)
+    assert result.returncode != 0
+    assert "incoming" in (result.stdout + result.stderr).lower()


### PR DESCRIPTION
Add a pure-OOTB, validate-only single_node smoke task exercising the `core.logic.delay` node (Trigger -> Delay -> End).

Ticket: https://uipath.atlassian.net/browse/MST-10350

What changed:
- `tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml` — the validate-only single-node smoke task.
- `tests/tasks/uipath-maestro-flow/single_node/delay/check_delay_flow.py` — structural checker: exactly one `core.logic.delay` node, valid `inputs.timerType`/`timerPreset` (with custom-preset `timerValue`/`timerDate` rules), `typeVersion` presence, and incoming/outgoing edge wiring.
- `tests/tasks/uipath-maestro-flow/single_node/delay/test_check_delay_flow.py` — dependency-free pytest unit tests with positive and negative fixtures.

Testing:
Ran locally (stdlib-only, no CLI/API/tenant needed):
`uvx pytest tests/tasks/uipath-maestro-flow/single_node/delay -q`
Result: 9 passed in 0.24s.

This is a validate-only/structural task; the full coder-eval gate runs in CI, not locally.

The `skill-flow-delay` coder-eval task is exercised by the **Run skill smoke tests** CI job on this PR and will be confirmed green before merge (no LLM/tenant credentials are available locally, so the coder-eval run happens in CI rather than on the author's machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

