### PR TITLE
test(uipath-maestro-flow): add inline-agent (uipath.agent.autonomous) e2e task

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
@@ -6,6 +6,27 @@ Node type: `uipath.agent.autonomous`. The agent is bound to a local subdirectory
 
 For coded (Python) agents, use the [`agent`](../agent/impl.md) plugin (`uipath.core.agent.{key}`) — inline agents are low-code only.
 
+## Required Lifecycle — DO NOT Skip
+
+After ANY edit to `agent.json` or any `resources/*/resource.json` — and after ALL flow graph edits (nodes, edges, variables, layout) are complete — you MUST run, in this exact order, BEFORE `flow debug` / `flow upload` / `solution upload`:
+
+1. `uip agent validate "<FlowProjectDir>/<projectId>" --inline-in-flow --output json` — read-only schema check on the inline agent.
+2. `uip agent migrate "<FlowProjectDir>/<projectId>" --inline-in-flow --output json` — **writes** `.agent-builder/agent.json` and applies migrations. **For tool-bearing inline agents**, add `--bindings-target "<FlowProjectDir>/bindings_v2.json"`.
+3. `uip solution resource refresh --output json` — required only for tool-bearing inline agents; materializes solution-level resource files from `bindings_v2.json`.
+
+**`uip maestro flow validate` does NOT replace `uip agent validate --inline-in-flow`.** Flow validate checks `.flow` JSON shape only; it does not look at `agent.json`, `.agent-builder/`, or `bindings_v2.json`. Both validators are required.
+
+### Symptom of skipping migrate
+
+`flow validate` passes, `solution upload` succeeds, `flow debug` returns:
+
+```
+[170007] Failure to start the Orchestrator job (element <agentNodeId>)
+ErrorDetails: The job's associated process could not be found
+```
+
+Root cause: `.agent-builder/agent.json` was never regenerated from your edited `agent.json`, so the runtime cannot resolve the inline agent's process when the `uipath.agent.autonomous` ServiceTask fires. Fix: re-run validate + migrate, then re-upload / re-debug.
+
 ## Prerequisite — Scaffold the Inline Agent
 
 ```bash

--- a/tests/tasks/uipath-maestro-flow/single_node/inline_agent/check_inline_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/inline_agent/check_inline_agent_flow.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""InlineAgentSum: an inline-agent node executes; output holds the sum (42).
+
+Distinct from coded_agent / lowcode_agent: those exercise the published-agent
+node family (``uipath.core.agent.{key}``), whose source identity comes from
+the tenant registry. This test exercises the inline form
+(``uipath.agent.autonomous``), whose ``inputs.source`` resolves to a local
+UUID subdirectory inside the flow project — proving inputs.source hydration
+end-to-end.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
+    assert_output_value,
+    run_debug,
+)
+
+
+def main():
+    assert_flow_has_node_type(["uipath.agent.autonomous"])
+    payload = run_debug(timeout=240)
+    # 17 + 25 = 42. Default inline-agent outputSchema is content:string,
+    # so match via case-insensitive substring on the agent's text response.
+    assert_output_value(payload, "42")
+    print("OK: Inline-agent node present; output contains 42")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/inline_agent/inline_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/inline_agent/inline_agent.yaml
@@ -1,0 +1,48 @@
+task_id: skill-flow-inline-agent
+description: >
+  Create a UiPath Flow with an inline low-code agent (uipath.agent.autonomous)
+  scaffolded via `uip agent init --inline-in-flow`. Exercises the inline-agent
+  form's `inputs.source` hydration — distinct from the published-agent form
+  (uipath.core.agent.*) covered by coded_agent / lowcode_agent.
+tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource, inline-agent]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "InlineAgentSum" that embeds an inline
+  low-code agent (scaffolded inside the flow project, NOT a published tenant
+  agent). The inline agent must compute the sum of 17 and 25 and return the
+  answer (42). Reply with the digit only.
+
+  Validate the flow.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
+  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate InlineAgentSum/InlineAgentSum/InlineAgentSum.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Execution checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow has an inline-agent node and debug returns the sum"
+    command: "python3 $TASK_DIR/check_inline_agent_flow.py"
+    timeout: 300
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-flow/single_node/inline_agent/inline_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/inline_agent/inline_agent.yaml
@@ -29,7 +29,7 @@ success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
     command: "uip maestro flow validate InlineAgentSum/InlineAgentSum/InlineAgentSum.flow"
-    timeout: 30
+    timeout: 180
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/inline_agent/inline_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/inline_agent/inline_agent.yaml
@@ -4,7 +4,7 @@ description: >
   scaffolded via `uip agent init --inline-in-flow`. Exercises the inline-agent
   form's `inputs.source` hydration — distinct from the published-agent form
   (uipath.core.agent.*) covered by coded_agent / lowcode_agent.
-tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource, inline-agent]
+tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 
 agent:
   type: claude-code


### PR DESCRIPTION
## Summary
- Adds `tests/tasks/uipath-maestro-flow/single_node/inline_agent/` covering the inline-agent form (`uipath.agent.autonomous`), which had zero e2e coverage. Sibling `coded_agent` / `lowcode_agent` tasks only exercise the published-agent form (`uipath.core.agent.*`).
- Task drives the agent to scaffold an inline low-code agent via `uip agent init --inline-in-flow`, wire a `uipath.agent.autonomous` node whose `inputs.source` UUID matches the scaffolded subdirectory, and return a deterministic sum (17 + 25 = 42).
- Check script asserts node type contains `uipath.agent.autonomous` and that `flow debug` output substring-matches `"42"` — proving `inputs.source` hydration end-to-end.

Closes [MST-10353](https://uipath.atlassian.net/browse/MST-10353).

## Test plan
- [ ] Smoke runner (`smoke-skills.yml`) executes `inline_agent.yaml` against the maestro-flow skill and reports pass.
- [ ] `uip maestro flow validate InlineAgentSum/InlineAgentSum/InlineAgentSum.flow` exits 0.
- [ ] `python3 check_inline_agent_flow.py` exits 0 — confirms `uipath.agent.autonomous` node present and debug output contains "42".
- [ ] `post_run` cleanup deletes the uploaded solution (when `FLOW_E2E_CLEANUP=always`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-10353]: https://uipath.atlassian.net/browse/MST-10353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ