### PR TITLE
test(uipath-maestro-flow): add agentic-process (uipath.core.agentic-process) e2e test

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/agentic_process/agentic_process.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/agentic_process/agentic_process.yaml
@@ -3,8 +3,10 @@ description: >
   Create a UiPath Flow that invokes a published Maestro orchestration process via
   a `uipath.core.agentic-process.{key}` resource node. Exercises agentic-process
   resource node discovery, registry lookup, and binding wiring
-  (resourceSubType=ProcessOrchestration).
-tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
+  (resourceSubType=ProcessOrchestration). Skipping `flow debug`: the test cannot
+  pin a deterministic output because the published agentic-process the agent
+  picks from the registry varies per tenant.
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:single-node, resource]
 
 agent:
   type: claude-code
@@ -16,23 +18,8 @@ run_limits:
 
 initial_prompt: |
   Create a UiPath Flow project named "RunAgenticProcess" that invokes a
-  published Maestro Process Orchestration process via a
-  `uipath.core.agentic-process.{key}` resource node.
-
-  Use the tenant registry to discover a published agentic-process (run
-  `uip maestro flow registry pull --force` then
-  `uip maestro flow registry search "uipath.core.agentic-process" --output json`)
-  and pick the first available entry. Read its full definition with
-  `uip maestro flow registry get "<nodeType>" --output json` so the
-  `typeVersion`, `resourceKey`, and `resourceSubType` come from the registry —
-  never invent them.
-
-  Wire the node with the two required top-level `bindings[]` entries
-  (`name` + `folderPath`, both with `resource: "process"` and
-  `resourceSubType: "ProcessOrchestration"`) so the runtime can resolve the
-  binding placeholders.
-
-  Validate the flow.
+  published Maestro Process Orchestration (agentic-process) from the tenant
+  registry, and validate the flow.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single
@@ -61,7 +48,7 @@ success_criteria:
   - type: command_executed
     description: "Agent searched the registry for agentic-process nodes"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+registry\s+(search|get).*agentic-process'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+(search|get).*agentic-process'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/agentic_process/agentic_process.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/agentic_process/agentic_process.yaml
@@ -1,0 +1,71 @@
+task_id: skill-flow-agentic-process
+description: >
+  Create a UiPath Flow that invokes a published Maestro orchestration process via
+  a `uipath.core.agentic-process.{key}` resource node. Exercises agentic-process
+  resource node discovery, registry lookup, and binding wiring
+  (resourceSubType=ProcessOrchestration).
+tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "RunAgenticProcess" that invokes a
+  published Maestro Process Orchestration process via a
+  `uipath.core.agentic-process.{key}` resource node.
+
+  Use the tenant registry to discover a published agentic-process (run
+  `uip maestro flow registry pull --force` then
+  `uip maestro flow registry search "uipath.core.agentic-process" --output json`)
+  and pick the first available entry. Read its full definition with
+  `uip maestro flow registry get "<nodeType>" --output json` so the
+  `typeVersion`, `resourceKey`, and `resourceSubType` come from the registry —
+  never invent them.
+
+  Wire the node with the two required top-level `bindings[]` entries
+  (`name` + `folderPath`, both with `resource: "process"` and
+  `resourceSubType: "ProcessOrchestration"`) so the runtime can resolve the
+  binding placeholders.
+
+  Validate the flow.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single
+  pass. Before starting, load the uipath-maestro-flow skill. Read and follow
+  its workflow steps exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate RunAgenticProcess/RunAgenticProcess/RunAgenticProcess.flow --output json"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks ──────────────────────────────────────────────────
+  - type: run_command
+    description: "Flow has an agentic-process node and ProcessOrchestration bindings"
+    command: "python3 $TASK_DIR/check_agentic_process_flow.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the registry for agentic-process nodes"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+registry\s+(search|get).*agentic-process'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-flow/single_node/agentic_process/check_agentic_process_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/agentic_process/check_agentic_process_flow.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""RunAgenticProcess: a uipath.core.agentic-process node is present with the
+two required ProcessOrchestration bindings (name + folderPath).
+
+Structural-only check — we deliberately do NOT run ``flow debug`` here because
+the test does not control which published agentic-process the agent picks
+from the tenant registry, so we cannot pin a deterministic output to assert.
+A debug-execution variant is tracked as follow-up work (needs a dedicated
+stable test fixture on the tenant, similar to ``E2E_PROCESS_KEY``).
+"""
+
+import glob
+import json
+import os
+import sys
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _find_flow():
+    flows = glob.glob("**/RunAgenticProcess.flow", recursive=True)
+    if not flows:
+        _fail("No RunAgenticProcess.flow found under cwd")
+    return flows[0]
+
+
+def main():
+    flow_path = _find_flow()
+    with open(flow_path) as f:
+        flow = json.load(f)
+
+    # 1. At least one node with type prefix uipath.core.agentic-process.
+    nodes = flow.get("nodes") or []
+    ap_nodes = [
+        n for n in nodes if str(n.get("type", "")).startswith("uipath.core.agentic-process.")
+    ]
+    if not ap_nodes:
+        types_seen = sorted({n.get("type", "") for n in nodes})
+        _fail(f"No uipath.core.agentic-process.* node found. Types: {types_seen}")
+
+    # 2. Bindings must include 'name' and 'folderPath' entries with
+    #    resource=process and resourceSubType=ProcessOrchestration.
+    bindings = flow.get("bindings") or []
+    by_attr = {b.get("propertyAttribute"): b for b in bindings}
+    for attr in ("name", "folderPath"):
+        b = by_attr.get(attr)
+        if not b:
+            _fail(
+                f"Missing top-level bindings[] entry with propertyAttribute={attr!r}. "
+                f"Bindings: {json.dumps(bindings, indent=2)[:1000]}"
+            )
+        if b.get("resource") != "process":
+            _fail(f"binding {attr!r}: expected resource='process', got {b.get('resource')!r}")
+        if b.get("resourceSubType") != "ProcessOrchestration":
+            _fail(
+                f"binding {attr!r}: expected resourceSubType='ProcessOrchestration', "
+                f"got {b.get('resourceSubType')!r}"
+            )
+        if not b.get("resourceKey"):
+            _fail(f"binding {attr!r}: resourceKey is empty")
+
+    # 3. The agentic-process node has an `error` output mapping (implicit error
+    #    port shared with all action nodes — see action-nodes shared doc).
+    n = ap_nodes[0]
+    outputs = n.get("outputs") or {}
+    if "error" not in outputs:
+        _fail(
+            f"Agentic-process node {n.get('id')!r} missing 'error' output port. "
+            f"Outputs: {list(outputs)}"
+        )
+
+    print(
+        f"OK: agentic-process node {n.get('id')!r} present with "
+        f"ProcessOrchestration bindings (name + folderPath)"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `tests/tasks/uipath-maestro-flow/single_node/agentic_process/` covering the `uipath.core.agentic-process.{key}` resource node — previously zero coverage.
- The agent discovers a published Maestro Process Orchestration process via `uip maestro flow registry search`, reads its definition via `registry get`, and wires the node with the two required `ProcessOrchestration` bindings (`name` + `folderPath`).
- Check script (`check_agentic_process_flow.py`) asserts node type, binding shape (`resource: "process"`, `resourceSubType: "ProcessOrchestration"`, non-empty `resourceKey`), and the implicit `error` output port.

Closes [MST-10355](https://uipath.atlassian.net/browse/MST-10355).

## Test plan
- [x] Ran `skill-flow-agentic-process` end-to-end via the `Run Coder Eval` GitHub Action on this branch (docker sandbox, `experiments/nightly.yaml`, Bedrock): **1/1 PASS** — [run 26834177506](https://github.com/UiPath/skills/actions/runs/26834177506).
- [x] Ran locally against `experiments/default.yaml` — agent built a valid `.flow` file with the agentic-process node and correct `ProcessOrchestration` bindings; structural check + `uip maestro flow validate` both pass against the preserved artifact.

## Notes
- Flow debug execution against a deterministic output is intentionally **not** in this PR. The tenant registry returns user-uploaded agentic-processes whose input/output schemas cannot be pinned for assertion. A follow-up should add an `E2E_AGENTIC_PROCESS_KEY`-style stable test fixture (similar to `E2E_PROCESS_KEY` in `tests/fixtures/packages/README.md`) so the debug branch can assert specific output.
- The `uip maestro flow validate` timeout is set to 120s — first-run validation needs to fetch ~7900 registry node manifests and can exceed the default 30s used by other single_node tests.

[MST-10355]: https://uipath.atlassian.net/browse/MST-10355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
