### PR TITLE
fix(uipath-troubleshoot): bump getasset run_limits.task_timeout to 5400

### DIFF
--- a/tests/tasks/uipath-troubleshoot/CLAUDE.md
+++ b/tests/tasks/uipath-troubleshoot/CLAUDE.md
@@ -135,12 +135,14 @@ Every new scenario's `task.yaml` MUST satisfy the following.
 
 ```yaml
 run_limits:
-  task_timeout: 2400
+  task_timeout: 5400
   max_turns: 60
-  turn_timeout: 1800
+  turn_timeout: 3600
 ```
 
-Troubleshooting investigations span many turns and produce large intermediate outputs. Lower limits cause spurious timeouts in CI and mask real regressions.
+Troubleshooting investigations span many turns and produce large intermediate outputs. Use `task_timeout: 5400` (90 min) and `turn_timeout: 3600` (60 min) so the full triage → hypothesis → tester → depth-check → presenter chain has headroom — proxy-mode runs cluster around 25–55 min wall, so a 30-min `task_timeout` clips right before the presenter spawn on the slow end of the distribution.
+
+`task_timeout`, `max_turns`, and `turn_timeout` belong inside the `run_limits:` block (the canonical location after the c/2026-05-12-unify-run-limits migration). Top-level placement still works via a grace shim but is deprecated; setting both top-level and `run_limits:` raises `ValueError` on the validator.
 
 ### `tags`
 

--- a/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
@@ -17,7 +17,7 @@ agent:
 
 run_limits:
   expected_turns: 48
-  task_timeout: 1800
+  task_timeout: 5400
 
   max_turns: 60
   turn_timeout: 3600

--- a/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
@@ -16,7 +16,7 @@ agent:
 
 run_limits:
   expected_turns: 252
-  task_timeout: 1800
+  task_timeout: 5400
 
   max_turns: 60
   turn_timeout: 3600

--- a/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-folder-scope-mismatch/task.yaml
@@ -15,7 +15,7 @@ agent:
 
 run_limits:
   expected_turns: 46
-  task_timeout: 4500
+  task_timeout: 5400
   max_turns: 60
   turn_timeout: 3600
 

--- a/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
@@ -17,7 +17,7 @@ agent:
 
 run_limits:
   expected_turns: 40
-  task_timeout: 4500
+  task_timeout: 5400
   max_turns: 60
   turn_timeout: 3600
 

--- a/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
@@ -17,7 +17,7 @@ agent:
 
 run_limits:
   expected_turns: 47
-  task_timeout: 1800
+  task_timeout: 5400
 
   max_turns: 60
   turn_timeout: 3600

--- a/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-per-robot-no-value/task.yaml
@@ -16,7 +16,7 @@ agent:
 
 run_limits:
   expected_turns: 43
-  task_timeout: 1800
+  task_timeout: 5400
 
   max_turns: 60
   turn_timeout: 3600

--- a/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-permission-denied/task.yaml
@@ -14,7 +14,7 @@ agent:
 
 run_limits:
   expected_turns: 52
-  task_timeout: 4500
+  task_timeout: 5400
   max_turns: 60
   turn_timeout: 3600
 

--- a/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-robot-not-authenticated/task.yaml
@@ -17,7 +17,7 @@ agent:
 
 run_limits:
   expected_turns: 34
-  task_timeout: 1800
+  task_timeout: 5400
 
   max_turns: 60
   turn_timeout: 3600

--- a/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-wrong-activity-type/task.yaml
@@ -17,7 +17,7 @@ agent:
 
 run_limits:
   expected_turns: 40
-  task_timeout: 1800
+  task_timeout: 5400
 
   max_turns: 60
   turn_timeout: 3600


### PR DESCRIPTION
## Summary

- Bumps `run_limits.task_timeout` from 1800 / 4500 → **5400** (90 min) across the 9 `tests/tasks/uipath-troubleshoot/getasset-*/task.yaml` files. Six were at 1800, three at 4500; all now align at 5400.
- Updates `tests/tasks/uipath-troubleshoot/CLAUDE.md` to (a) carry the corrected recommended values and (b) note that `run_limits:` is the canonical location post c/2026-05-12-unify-run-limits.

## Why

Troubleshoot scenarios exercise the full `triage → hypothesis → tester → depth-check → presenter` chain. Proxy-mode wall times cluster in the 25–55 min range; a 30-min `task_timeout` clips right before the presenter spawn on the slow end of the distribution, and a 75-min cap is fine but inconsistent with the 30-min siblings. Memory note: prior `getasset-external-vault-failure` runs timed out at exactly 600s mid-investigation and only passed when re-run with `--task-timeout 5400` CLI override.

90 min was chosen as the headroom-with-margin value used elsewhere in the troubleshoot suite (e.g., the `invokevba-*` scenarios already at 5400).

## Context — why this is a small follow-up, not the original #1103

PR #1103 (now closed) attempted to *hoist* the timing fields **out** of `run_limits:` to top-level placement, based on a then-current reading of the coder-eval `TaskDefinition` model (no `run_limits` field; `extra` not forbidden; unknown blocks silently dropped). That reading reflected the pre-2026-05-12 model.

After upgrading the local venv (`uv pip install --upgrade "coder-eval @ git+..."`):

- `TaskDefinition.run_limits: RunLimits | None` is now a real field (`models/tasks.py:330`).
- `RunLimits` has `extra="forbid"` — unknown fields inside it raise loudly.
- The `_hoist_legacy_agent_timing` validator (lines 420-489) explicitly lifts top-level legacy form **into** `run_limits.*` with a `DeprecationWarning` (removal date 2026-05-20, kept as a grace shim).
- Setting BOTH top-level and `run_limits:` raises `ValueError`.

So `run_limits:` is the canonical location; PR #1098's bulk move into that block was correct. This follow-up keeps that structure and just bumps the value.

## Test plan

- [x] All 9 getasset task YAMLs render with `run_limits.task_timeout: 5400`.
- [x] CLAUDE.md guidance matches the bumped value.
- [ ] Smoke-run one previously-clipping scenario (e.g. `getasset-activity-silent-failure`) and confirm wall time fits under 5400s. (Local cost ≈ $14, ≈ 30 min; can be done before merge if reviewer requests.)
- [ ] Empirical evidence from PR #1106 (delete-range): three new scenarios running on the same model+plugin stack completed in 702s / 1737s / 1880s wall — well under the 5400 cap, and the 1880s case would have clipped at the old 1800s cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)