### PR TITLE
fix(agents): hint for agents to provide example calls on mocking eval

### DIFF
--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -95,6 +95,9 @@ initial_prompt: |
   about the shape of `{"masked_key": ..., "label": ...}. Those
   should be as similar as possible to what we expect.
 
+  I also want to be able (in the future) to have an llm deciding
+  what mocking values should be substituted at runtime.
+  
   Do NOT publish, upload, or deploy. Complete it in a single pass.
 
 success_criteria:


### PR DESCRIPTION

hint for agents to provide example calls on mocking eval

## ToDo:

- [x] revert to e2e instead of smoke tag