### PR TITLE
test(uipath-maestro-flow): address PascalCase issue in flow check

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -13,6 +13,22 @@ Runs ``uip maestro flow debug --output json`` and asserts:
    timestamps, GUIDs, and status strings whose digits/chars can falsely match
    tiny expected values (e.g. ``"3" in json.dumps(data)`` is almost always
    true whenever a debug run completes).
+
+Payload key casing
+------------------
+Two distinct sources with two casings:
+
+- The ``flow debug --output json`` RUNTIME payload uses **PascalCase** keys
+  (``Data``, ``FinalStatus``, ``Variables``, ``Globals``, ``Elements``,
+  ``Outputs``, and the file-attachment object's ``Id``/``FullName``/``MimeType``/
+  ``Metadata``). Every runtime-payload read goes through :func:`_get_ci`, a
+  case-insensitive accessor — so the conceptual camelCase key names used in this
+  docstring resolve regardless of the CLI's serialization casing or any future
+  normalization.
+- The ``.flow`` SOURCE file uses **camelCase** keys (``variables``, ``globals``,
+  ``direction``, ``type``, ``nodes``). Source readers (``read_flow_*_vars``,
+  ``_iter_flow_nodes``, the node-type asserts) keep their literal camelCase keys
+  — do NOT route them through :func:`_get_ci`.
 """
 
 from __future__ import annotations
@@ -55,8 +71,8 @@ def run_debug(
     data = _parse_json(r.stdout)
     if data is None:
         _fail(f"Could not parse JSON from flow debug\n{r.stdout}")
-    payload = data.get("Data") or {}
-    status = payload.get("finalStatus")
+    payload = _get_ci(data, "Data") or {}
+    status = _get_ci(payload, "finalStatus", "FinalStatus")
     if status != "Completed":
         _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}")
     return payload
@@ -184,14 +200,15 @@ def collect_outputs(payload: dict) -> list[Any]:
     Both are walked to be safe.
     """
     out: list[Any] = []
-    variables = payload.get("variables") or {}
-    for val in (variables.get("globals") or {}).values():
+    variables = _get_ci(payload, "variables", "Variables") or {}
+    for val in (_get_ci(variables, "globals", "Globals") or {}).values():
         out.extend(_leaves(val))
-    for v in variables.get("globalVariables") or []:
-        if "value" in v:
-            out.extend(_leaves(v.get("value")))
-    for e in variables.get("elements") or []:
-        out.extend(_leaves(e.get("outputs") or {}))
+    for v in _get_ci(variables, "globalVariables", "GlobalVariables") or []:
+        value = _get_ci(v, "value", "Value")
+        if value is not None:
+            out.extend(_leaves(value))
+    for e in _get_ci(variables, "elements", "Elements") or []:
+        out.extend(_leaves(_get_ci(e, "outputs", "Outputs") or {}))
     return out
 
 
@@ -311,6 +328,30 @@ def _parse_json(stdout: str) -> dict | None:
     return None
 
 
+def _get_ci(mapping: Any, *candidate_keys: str, default: Any = None) -> Any:
+    """Case-insensitively read the first present candidate key from ``mapping``.
+
+    The ``uip maestro flow debug --output json`` runtime payload uses PascalCase
+    keys (``FinalStatus``, ``Variables``, ``Globals``, ``Elements``, ``Outputs``)
+    while this module's docstring and the ``.flow`` source files use camelCase.
+    Reading the runtime payload through this accessor tolerates either casing and
+    any future CLI normalization. Use it ONLY for the debug RUNTIME payload — NOT
+    for ``.flow`` SOURCE readers, whose camelCase keys are stable and intentional.
+
+    Candidates are tried in order; the first whose lowercased form matches a key
+    in ``mapping`` (also lowercased) wins. Returns ``default`` if ``mapping`` is
+    not a dict or no candidate matches.
+    """
+    if not isinstance(mapping, dict):
+        return default
+    lowered = {k.lower(): k for k in mapping.keys() if isinstance(k, str)}
+    for candidate in candidate_keys:
+        actual = lowered.get(candidate.lower())
+        if actual is not None:
+            return mapping[actual]
+    return default
+
+
 def _iter_flow_nodes(project_glob: str):
     project_dir = _find_project(project_glob)
     for path in glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
@@ -320,7 +361,9 @@ def _iter_flow_nodes(project_glob: str):
 
 
 def _non_empty_binding_value(value: Any) -> bool:
-    return isinstance(value, str) and bool(value.strip()) and value != "ImplicitConnection"
+    return (
+        isinstance(value, str) and bool(value.strip()) and value != "ImplicitConnection"
+    )
 
 
 def _find_project(pattern: str) -> str:
@@ -343,7 +386,7 @@ def _find_project(pattern: str) -> str:
         joined = "\n  - ".join(candidates)
         _fail(
             f"No Flow project.uiproj found matching {pattern} — "
-            f"candidates exist but none declare ProjectType=\"Flow\":\n  - {joined}"
+            f'candidates exist but none declare ProjectType="Flow":\n  - {joined}'
         )
     if len(flow_projects) > 1:
         joined = "\n  - ".join(flow_projects)


### PR DESCRIPTION
## Fix: `flow_check.py` reads PascalCase debug payload

### Problem
`tests/tasks/uipath-maestro-flow/_shared/flow_check.py` read the `uip maestro flow debug --output json` payload with **camelCase** keys (`finalStatus`, `variables`, `globals`, `elements`, `outputs`), but the CLI emits **PascalCase** (`FinalStatus`, `Variables`, `Globals`, `Elements`, `Outputs`).

A flow that runs correctly and completes was graded as a failure: `payload.get("finalStatus")` returned `None`, so `run_debug` raised `FAIL: Flow did not complete (finalStatus=None)` even though the payload contained `"FinalStatus": "Completed"`. The `file_attachment` e2e task scored 0.500 / FAILURE despite a correct, completed flow.

### Root cause
Key-casing mismatch in the test checker only. The CLI, the skill, and the agent's flow were all correct — `flow_check.py`'s nested payload reads had drifted to camelCase while the top-level `Data` read was already PascalCase. Both symptoms stemmed from this:
1. `run_debug` misread the completion status → `finalStatus=None` failure.
2. `collect_outputs` read camelCase `variables` → returned `[]`, so `assert_outputs_contain` found nothing even when the basename was present under `Variables.Globals.FileName`.

### Fix
Added `_get_ci(mapping, *candidate_keys, default=None)` — a case-insensitive key accessor — and routed every **runtime-payload** read through it (`run_debug`, `collect_outputs`). Chose case-insensitive over hardcoded PascalCase so the reader tolerates either casing and any future CLI normalization.

`.flow`-**source** readers (`read_flow_*_vars`, `_iter_flow_nodes`, node-type asserts) deliberately keep their camelCase literals — the source schema is camelCase and matches the skill docs. The `_is_flow_project` manifest read (`ProjectType`) is unchanged.

Module docstring updated with a "Payload key casing" section documenting the two sources/casings.

### Verification
- All existing canonical unit tests in `_shared/test_flow_check.py` pass (they use camelCase payloads) — confirms backward compatibility.
- The previously-failing `check_file_attachment_flow.py` passes end-to-end against the recorded PascalCase payload, including with a randomly-generated basename it never saw.