### PR TITLE
fix(uipath-maestro-flow): document runtime shape of file-typed variables

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
@@ -67,6 +67,17 @@ if (error) {
 return { hasError: false, data: $vars.httpCall.output.body };
 ```
 
+### Reading a file-typed variable
+
+A `file` variable (bound via `uip maestro flow debug --attachment <id>=<path>`) hydrates as an **object**, not a string. Read the uploaded file's name from `.FullName`:
+
+```javascript
+const doc = $vars.start.output.inputDoc; // file variable → object
+return { fileName: doc.FullName };        // .FullName, not .name/.fileName
+```
+
+Property access is **case-sensitive** — these casings resolve: `.FullName`, `.ID` (uppercase, not `.Id`), `.MimeType`, `.Metadata.size` (nested, lowercase `size`). `.name` / `.fileName` do not exist. See [variables-and-expressions.md — Runtime shape of a `file` variable](../../../../shared/variables-and-expressions.md#file-input).
+
 ## Debug
 
 | Error | Cause | Fix |

--- a/skills/uipath-maestro-flow/references/operate/references/run.md
+++ b/skills/uipath-maestro-flow/references/operate/references/run.md
@@ -39,6 +39,8 @@ UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
 
 > **Pre-flight.** Confirm each `<variableId>` exists in the flow's `variables.globals[]` with `direction:"in"` and `type:"file"`. See [shared/cli-commands.md — Pre-flight](../../shared/cli-commands.md#pre-flight---attachment-binding).
 
+> **Reading the bound file.** At runtime a `file` variable is an object — a Script node reads the uploaded name via `$vars.{triggerNodeId}.output.{id}.FullName`. See [shared/variables-and-expressions.md — Runtime shape of a `file` variable](../../shared/variables-and-expressions.md#file-input).
+
 ### Reporting debug runs to the user
 
 The CLI response includes a **Studio Web URL** (where the user inspects the run) and an **instanceId** (for log/trace correlation). Parse both from the JSON output — typically `Data.studioWebUrl` and `Data.instanceId` — and **always show them as the first two lines of the summary**:

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -168,6 +168,8 @@ The CLI does not validate `<variableId>` — a mismatch uploads successfully the
 2. Confirm each `<variableId>` passed to `--attachment` appears in that list.
 3. If none exist, add one to `variables.globals[]`: `{ "id": "<variableId>", "direction": "in", "type": "file", "triggerNodeId": "<triggerId>" }`.
 
+> **Reading the bound file in a Script node.** A `file` variable hydrates at runtime as an object; read the uploaded name via `$vars.{triggerNodeId}.output.{id}.FullName`. See [variables-and-expressions.md — Runtime shape of a `file` variable](variables-and-expressions.md#file-input).
+
 Run `uip maestro flow debug --help` for other options.
 
 ### Reporting the run back to the user

--- a/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
+++ b/skills/uipath-maestro-flow/references/shared/variables-and-expressions.md
@@ -72,7 +72,7 @@ Workflow variables are declared in `variables.globals`. Each has a **direction**
 {
   id: string              // Unique identifier, used in expressions as $vars.{id}
   direction: "in" | "out" | "inout"
-  type?: string           // "string" (default), "number", "boolean", "object", "array"
+  type?: string           // "string" (default), "number", "boolean", "object", "array", "file"
   subType?: string        // Item type for arrays (e.g., "object", "string")
   schema?: object         // JSON Schema (draft-07) for complex types
   defaultValue?: unknown  // Initial value (must match type)
@@ -158,6 +158,26 @@ Workflow variables are declared in `variables.globals`. Each has a **direction**
 ```
 Accessed in expressions as `$vars.{triggerNodeId}.output.{id}` (the variable is nested under the trigger node's output — NOT `$vars.{id}`).
 
+<a id="file-input"></a>
+**File input (`type: "file"`):**
+```json
+{
+  "id": "inputDoc",
+  "direction": "in",
+  "type": "file",
+  "description": "Document uploaded at trigger / bound via --attachment",
+  "triggerNodeId": "start"
+}
+```
+
+> **Runtime shape of a `file` variable.** At runtime a `file` variable is an **object** (the *Flow Attachment* object), not a string. A Script node reading `$vars.start.output.inputDoc` receives:
+>
+> ```json
+> { "ID": "<uuid>", "FullName": "report.pdf", "MimeType": "application/pdf", "Metadata": { "size": "1024" } }
+> ```
+>
+> The uploaded file's name is **`.FullName`**. Property access is **case-sensitive** at runtime — these exact casings resolve, others return `undefined`/`null`: `.ID` (uppercase, not `.Id`), `.FullName`, `.MimeType`, and the **nested `.Metadata.size`** (lowercase `size`, NOT `.Size`). `.name` / `.fileName` do **not** exist. Two layers: the `.flow` *declaration* is camelCase (`type`, `direction`); the *runtime* object carries the casing above. Do NOT write `"FullName"` into the `.flow` source. Bind the file with `uip maestro flow debug --attachment <id>=<path>` — see [cli-commands.md — Pre-flight](cli-commands.md#attachment-preflight).
+
 ### Type Reference
 
 | Type | Default Value | Notes |
@@ -167,6 +187,7 @@ Accessed in expressions as `$vars.{triggerNodeId}.output.{id}` (the variable is 
 | `boolean` | `false` | |
 | `object` | `{}` | Use `schema` for structured objects |
 | `array` | `[]` | Use `subType` for typed arrays |
+| `file` | — | Bound at runtime via `--attachment`; hydrates as an object — read `.FullName` (see [File input](#file-input) above) |
 
 ---
 
@@ -389,6 +410,9 @@ $vars.counter
 
 // Trigger-associated flow input (triggerNodeId set)
 $vars.{triggerNodeId}.output.{id}
+
+// File input (type: "file") → object, read .FullName for the name
+$vars.start.output.inputDoc.FullName
 
 // Node output (script node)
 $vars.script1.output


### PR DESCRIPTION
## What

Documents the **runtime shape of `file`-typed variables** in the Maestro Flow skill. A `file` variable hydrates at runtime as an object (the *Flow Attachment* object); a Script node reads the uploaded file's name from `.FullName`. None of this was documented — the skill covered how to **declare** a `file` variable and how to **bind** one (`--attachment`), but never how to **read** it.

## Why

In the `file_attachment` eval (`ISSUE.md`) the agent guessed `doc.name` / `doc.fileName`, got back the `String(doc)` fallback, inspected the debug output, discovered `FullName`, fixed the script, and re-ran. That failed-debug round-trip is the cost of the undocumented shape. This is an **efficiency gap** — not the cause of the task's FAILURE (that was a separate test-checker casing bug, tracked elsewhere).

## Empirically verified, not assumed

The runtime shape and **case-sensitive** property access were confirmed with live `uip maestro flow debug --attachment` runs (`FinalStatus: "Completed"`), not copied from the serialized payload. This mattered — the debug-output **serializer re-cases keys**, so the ISSUE.md payload was misleading. The live JS object is:

```json
{ "ID": "<uuid>", "FullName": "report.pdf", "MimeType": "application/pdf", "Metadata": { "size": "1024" } }
```

A probe accessed every property explicitly and recorded what resolves vs. returns `null`:

| Access | Result |
|---|---|
| `.FullName` | ✅ resolves |
| `.ID` (uppercase) | ✅ resolves |
| `.Id` / `.id` | ❌ `null` — access is case-sensitive |
| `.MimeType` | ✅ resolves |
| `.Metadata.size` (lowercase) | ✅ resolves |
| `.Metadata.Size` (capital) | ❌ `null` |
| `.name` / `.fileName` | ❌ do not exist |

Top-level keys are uppercase/PascalCase; the nested `Metadata` key is **lowercase `size`**. Wrong casing fails **silently** (`null`/`undefined`, no throw) — the trap worth knowing.

> ⚠️ The verification corrected two property names the first draft got wrong (`.Id` → `.ID`, `.Metadata.Size` → `.Metadata.size`), both traceable to trusting the serializer over the runtime object.

## Changes

| File | Change |
|---|---|
| `references/shared/variables-and-expressions.md` | Added `"file"` to the variable-type vocabulary (schema comment + Type Reference row); File-input example; **Runtime shape** callout; `$vars` access-pattern line |
| `references/author/references/plugins/script/impl.md` | **Reading a file-typed variable** snippet + case-sensitive property guidance |
| `references/operate/references/run.md` | Pointer from `--attachment` binding docs → reading callout |
| `references/shared/cli-commands.md` | Pointer from `--attachment` pre-flight → reading callout |

## Decisions

- **Canonical access form only.** Docs use `$vars.{triggerNodeId}.output.{id}` exclusively. The bare `$vars.{id}` shorthand resolves at runtime (verified) but is intentionally **not documented**, keeping `variables-and-expressions.md` internally consistent.
- **Positive-path only.** The `"System.Dynamic.ExpandoObject"` failure-string is deliberately **not** documented (no troubleshooting row, no prose) — the three reading pointers prevent the wrong-property mistake up front. Trade-off: an agent that does hit the string can't grep the skill for it.

## Consistency

Aligns with the existing `summarize` / `batch-transform` plugin docs, which already enumerate the top-level `{ ID, FullName, MimeType, Metadata }` shape and warn `ID` is uppercase. Those docs pass the whole object and never reach into `Metadata`, so they stay consistent — no sibling edits needed. This PR is now the only place documenting the nested `Metadata.size` field.

## Scope

Docs-only. No CLI, schema, or test changes. All Phase-4 cross-link anchors resolve.