### PR TITLE
fix(tests): bindings checker — match resource: connection case-insensitively

### DIFF
--- a/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
+++ b/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
@@ -100,7 +100,11 @@ def _load_flow_bindings(pattern: str) -> tuple[str, list[dict[str, Any]]]:
 
 
 def _connection_rows(bindings: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    return [b for b in bindings if isinstance(b, dict) and b.get("resource") == "Connection"]
+    return [
+        b
+        for b in bindings
+        if isinstance(b, dict) and (b.get("resource") or "").lower() == "connection"
+    ]
 
 
 def _connection_id_rows(bindings: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -162,7 +166,9 @@ def cmd_bindings_v2_no_empty_stubs(pattern: str) -> None:
     empty = [
         x
         for x in rows
-        if isinstance(x, dict) and x.get("resource") == "Connection" and not x.get("resourceKey")
+        if isinstance(x, dict)
+        and (x.get("resource") or "").lower() == "connection"
+        and not x.get("resourceKey")
     ]
     if empty:
         _fail(f"{matches[0]}: empty-keyed Connection row(s) in derived bindings_v2.json: {empty}")
@@ -185,7 +191,9 @@ def cmd_same_connection_id(pattern_a: str, pattern_b: str) -> None:
     path_b, bindings_b = _load_flow_bindings(pattern_b)
     a_keys = {b.get("resourceKey") for b in _connection_id_rows(bindings_a)}
     b_keys = {b.get("resourceKey") for b in _connection_id_rows(bindings_b)}
-    if not a_keys or a_keys != b_keys:
+    if not a_keys or not b_keys:
+        _fail(f"no ConnectionId binding rows found: {path_a}={a_keys}, {path_b}={b_keys}")
+    if a_keys != b_keys:
         _fail(f"ConnectionId resourceKey differs across snapshots: {path_a}={a_keys} vs {path_b}={b_keys}")
     print(f"OK: ConnectionId resourceKey stable across snapshots ({a_keys})")
 


### PR DESCRIPTION
## Summary
- `_connection_rows` in `tests/tasks/uipath-maestro-flow/bindings/check_bindings.py` filtered on `resource == "Connection"`, but `uip maestro flow node configure` emits lowercase `resource: "connection"` — the filter silently returned `[]` on every produced `.flow`.
- Three connection-aware criteria were affected: `no_empty_stubs` and `matched_default` passed vacuously on empty lists; `same_connection_id` failed with a misleading "differs across snapshots" message when both sets were empty.
- Match `(resource or "").lower() == "connection"` so the checks evaluate the rows the CLI actually emits, and split `cmd_same_connection_id` so an empty result reports "no ConnectionId binding rows found" instead of a fake mismatch.

## Repro

Before the fix, `tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml` scored 4/5 (0.833) despite producing byte-identical snapshots — the `same_connection_id` criterion failed because `_connection_id_rows` returned `[]` on both files:

```
FAIL: ConnectionId resourceKey differs across snapshots:
      after_first_configure.flow=set() vs after_second_configure.flow=set()
```

The actual snapshot row:

```json
{"resource": "connection", "propertyAttribute": "ConnectionId",
 "resourceKey": "452f5ec5-9cf8-48dc-83bd-6341a8313e15", ...}
```

After the fix, the same task scores 5/5 (1.000).

## Test plan
- [x] `python3 check_bindings.py same_connection_id after_first_configure.flow after_second_configure.flow` on the prior failed run's preserved sandbox now passes
- [x] `python3 check_bindings.py no_empty_stubs after_second_configure.flow` still passes (no regression on the previously-vacuous case)
- [x] Full re-run of `skill-flow-bindings-idempotent-reconfigure` via `coder-eval`: 5/5 criteria, status SUCCESS, weighted score 1.000

🤖 Generated with [Claude Code](https://claude.com/claude-code)
