### PR TITLE
fix(tests): cleanup_solutions — handle 404 + surface real failure reason

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
@@ -50,6 +50,7 @@ def main() -> int:
     deleted: list[str] = []
     preserved: list[str] = []
     skipped: list[str] = []
+    not_uploaded: list[str] = []
     failed: list[str] = []
 
     for path in paths:
@@ -85,21 +86,41 @@ def main() -> int:
         if r.returncode == 0:
             logger.info("deleted %s (from %s)", sid, path)
             deleted.append(sid)
+            continue
+
+        # `uip solution delete` writes its envelope to stdout (including
+        # failures); stderr is empty. Parse the envelope to surface the real
+        # reason and to distinguish "never uploaded" from genuine failures.
+        envelope_msg = ""
+        try:
+            envelope = json.loads(r.stdout or "{}")
+            envelope_msg = envelope.get("Message", "") or ""
+        except json.JSONDecodeError:
+            envelope_msg = (r.stdout or "").strip()
+
+        if "404" in envelope_msg or "Not Found" in envelope_msg:
+            # Solution never registered in Studio Web — `.uipx` carries a
+            # locally-generated SolutionId from `solution init`, and tasks
+            # that don't `upload`/`flow debug` leave it unregistered.
+            # Nothing to clean up server-side.
+            logger.info("solution %s not uploaded (from %s); nothing to clean up", sid, path)
+            not_uploaded.append(sid)
         else:
             logger.warning(
                 "failed to delete %s (exit %d): %s",
                 sid,
                 r.returncode,
-                r.stderr.strip()[:300],
+                (envelope_msg or r.stderr.strip())[:300],
             )
             failed.append(sid)
 
     logger.info(
-        "summary policy=%s deleted=%d preserved=%d skipped=%d failed=%d",
+        "summary policy=%s deleted=%d preserved=%d skipped=%d not_uploaded=%d failed=%d",
         policy,
         len(deleted),
         len(preserved),
         len(skipped),
+        len(not_uploaded),
         len(failed),
     )
     return 0


### PR DESCRIPTION
## Summary
- Follow-up to #1156. Investigation of the `cleanup_solutions.py` warnings on the `skill-flow-bindings-idempotent-reconfigure` runs surfaced two bugs in the post-run cleanup script.
- **Bug 1 — stderr vs stdout:** `uip solution delete` writes its envelope (including the failure `Message`) to **stdout** and leaves stderr empty. The script logged `r.stderr.strip()` on failure, so every warning printed `exit 1:` with no context. Parse the envelope to surface the actual `Message` (and only fall back to stderr if the envelope is unparseable).
- **Bug 2 — 404 ≠ failure:** Tasks that build a solution locally but never call `solution upload` or `maestro flow debug` produce a `.uipx` carrying a locally-generated `SolutionId` from `solution init`. That ID is never registered in Studio Web, so `solution delete` returns 404. Classifying that as `failed` produced spurious noise on every offline task and would dilute the warning channel that a real cleanup failure needs. Treat 404 / "Not Found" as `not_uploaded` (info-level, distinct counter in the summary).

## Repro

From the `skill-flow-bindings-idempotent-reconfigure` runs (both passed all assertions but emitted):

```
cleanup_solutions: failed to delete 630de3cf-b3f6-4f81-bff1-da28961ee607 (exit 1):
cleanup_solutions: summary policy=always deleted=0 preserved=0 skipped=0 failed=1
```

Running `uip solution delete 630de3cf-...` directly reveals what the script was hiding:

```json
{
  "Result": "Failure",
  "Message": "Delete failed (404): {\"title\":\"Not Found\",\"status\":404,...}",
  "Instructions": "Check that the solution ID is correct and that you have permission to delete it."
}
```

…with that JSON on **stdout**, not stderr.

## After

```
cleanup_solutions: solution 630de3cf-b3f6-4f81-bff1-da28961ee607 not uploaded (from BindingsIdempotent/BindingsIdempotent.uipx); nothing to clean up
cleanup_solutions: summary policy=always deleted=0 preserved=0 skipped=0 not_uploaded=1 failed=0
```

## Test plan
- [x] Run patched `cleanup_solutions.py` in the preserved sandbox of both prior runs (`runs/2026-05-29_04-04-25/...` and `runs/2026-05-29_11-23-13/...`). Each logs `not_uploaded=1 failed=0`, no warnings.
- [ ] Genuine-failure path (non-404) — would require an uploaded solution we lack permission to delete, or a 5xx. Visually verified the new code path logs `envelope_msg or r.stderr.strip()`; left to maintainers if a fixture is desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
