### PR TITLE
test(uipath-maestro-flow): bump subflow debug-criterion timeout above run_debug subprocess timeout

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
@@ -35,7 +35,10 @@ success_criteria:
   - type: run_command
     description: "Flow has correct subflow structure and debug reverses 'hello' to 'olleh'"
     command: "python3 $TASK_DIR/check_subflow_flow.py"
-    timeout: 120
+    # Must exceed flow_check.run_debug's 240s subprocess timeout so a slow/hung
+    # `flow debug` surfaces the real CLI error (exit 1 + traceback) instead of an
+    # opaque sandbox kill (exit -1, empty output). Guarded by test_check_subflow_flow.py.
+    timeout: 300
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/test_check_subflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/test_check_subflow_flow.py
@@ -26,8 +26,6 @@ import inspect
 import re
 from pathlib import Path
 
-import yaml
-
 TASK_DIR = Path(__file__).resolve().parent
 TASK_YAML = TASK_DIR / "subflow.yaml"
 CHECKER = TASK_DIR / "check_subflow_flow.py"
@@ -35,20 +33,26 @@ SHARED = TASK_DIR.parents[1] / "_shared" / "flow_check.py"
 
 
 def _debug_criterion_timeout() -> int:
-    """The ``timeout`` of the run_command criterion that runs check_subflow_flow.py."""
-    config = yaml.safe_load(TASK_YAML.read_text())
-    matches = [
-        c
-        for c in config.get("success_criteria", [])
-        if c.get("type") == "run_command"
-        and CHECKER.name in str(c.get("command", ""))
-    ]
+    """The ``timeout`` of the run_command criterion that runs check_subflow_flow.py.
+
+    Parsed with a scoped regex rather than a YAML library: CI installs only
+    pytest (no PyYAML), and a module-level ``import yaml`` would error at
+    collection and interrupt the whole maestro-flow suite. We isolate the
+    criterion entry that invokes the checker (from its ``command:`` line to the
+    next list item / top-level section) and read the first ``timeout:`` key in
+    that block.
+    """
+    text = TASK_YAML.read_text()
+    assert CHECKER.name in text, f"{CHECKER.name} not referenced in {TASK_YAML.name}"
+    rest = text[text.index(CHECKER.name):]
+    boundary = re.search(r"\n\s*-\s+type:|\npost_run:|\Z", rest)
+    block = rest[: boundary.start()]
+    matches = re.findall(r"^\s*timeout:\s*(\d+)\b", block, re.MULTILINE)
     assert len(matches) == 1, (
-        f"Expected exactly one criterion invoking {CHECKER.name}, found {len(matches)}"
+        f"Expected exactly one timeout in the {CHECKER.name} criterion block, "
+        f"found {matches}"
     )
-    timeout = matches[0].get("timeout")
-    assert isinstance(timeout, int), f"criterion timeout must be an int, got {timeout!r}"
-    return timeout
+    return int(matches[0])
 
 
 def _run_debug_subprocess_timeout() -> int:

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/test_check_subflow_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/test_check_subflow_flow.py
@@ -1,0 +1,83 @@
+"""Regression guard for the subflow task's debug-criterion timeout budget.
+
+Context (RCA 2026-05-29, run 2026-05-29_04-04-25): skill-flow-subflow failed
+because its ``check_subflow_flow.py`` criterion was killed by the sandbox after
+exceeding the criterion ``timeout`` while ``uip maestro flow debug`` (a live
+cloud round-trip) was still running. The criterion budget (120s) was *below*
+``flow_check.run_debug``'s own ``subprocess.run`` timeout (240s default, since
+the checker calls ``run_debug(inputs=...)`` with no explicit timeout). That
+inversion means the checker can NEVER surface the underlying CLI error: the
+sandbox kills the whole process first, yielding exit ``-1`` with empty output
+("Command ... timed out after N seconds") instead of the informative exit ``1``
++ traceback that the inner ``subprocess.TimeoutExpired`` would produce.
+
+This test locks the ordering for the subflow task: the debug criterion's
+``timeout`` must be strictly greater than the subprocess timeout the checker
+hands to ``run_debug``. It FAILS on the pre-fix value (120 <= 240) and PASSES
+on the fixed value (300 > 240).
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/single_node/subflow``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import re
+from pathlib import Path
+
+import yaml
+
+TASK_DIR = Path(__file__).resolve().parent
+TASK_YAML = TASK_DIR / "subflow.yaml"
+CHECKER = TASK_DIR / "check_subflow_flow.py"
+SHARED = TASK_DIR.parents[1] / "_shared" / "flow_check.py"
+
+
+def _debug_criterion_timeout() -> int:
+    """The ``timeout`` of the run_command criterion that runs check_subflow_flow.py."""
+    config = yaml.safe_load(TASK_YAML.read_text())
+    matches = [
+        c
+        for c in config.get("success_criteria", [])
+        if c.get("type") == "run_command"
+        and CHECKER.name in str(c.get("command", ""))
+    ]
+    assert len(matches) == 1, (
+        f"Expected exactly one criterion invoking {CHECKER.name}, found {len(matches)}"
+    )
+    timeout = matches[0].get("timeout")
+    assert isinstance(timeout, int), f"criterion timeout must be an int, got {timeout!r}"
+    return timeout
+
+
+def _run_debug_subprocess_timeout() -> int:
+    """The subprocess timeout check_subflow_flow.py effectively gives run_debug.
+
+    The checker calls ``run_debug(inputs=...)`` with no explicit ``timeout``, so
+    the value that governs ``subprocess.run`` is ``run_debug``'s signature
+    default. If the checker is ever changed to pass ``timeout=N`` explicitly,
+    prefer that literal so this guard tracks the real budget.
+    """
+    explicit = re.findall(r"run_debug\([^)]*timeout\s*=\s*(\d+)", CHECKER.read_text())
+    if explicit:
+        return max(int(n) for n in explicit)
+
+    spec = importlib.util.spec_from_file_location("flow_check", SHARED)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    default = inspect.signature(module.run_debug).parameters["timeout"].default
+    assert isinstance(default, int), "run_debug.timeout default must be an int"
+    return default
+
+
+def test_debug_criterion_timeout_exceeds_run_debug_subprocess_timeout():
+    criterion = _debug_criterion_timeout()
+    subprocess_timeout = _run_debug_subprocess_timeout()
+    assert criterion > subprocess_timeout, (
+        f"subflow debug criterion timeout ({criterion}s) must be greater than "
+        f"flow_check.run_debug's subprocess timeout ({subprocess_timeout}s); "
+        "otherwise the sandbox kills the checker first (exit -1, empty output) "
+        "and the real `uip maestro flow debug` error never surfaces. "
+        "See the RCA: docs/uipath-skills/2026-05-29-skill-flow-subflow-root-cause.md."
+    )


### PR DESCRIPTION
## Why

`skill-flow-subflow` failed in run `2026-05-29_04-04-25` (weighted **0.375**). The agent built a valid subflow and `uip maestro flow validate` **passed** (weight 3). The second criterion — `check_subflow_flow.py` (weight 5) — was **killed by the sandbox after 120s** (exit `-1`, empty output, `"timed out after 120 seconds"`) while `uip maestro flow debug` (a live Studio Web cloud round-trip) was still running. Nothing was wrong with the flow; only the latency-bound debug step ran long.

## Root cause — a timeout-budget inversion

`check_subflow_flow.py` calls `run_debug(inputs=...)` **with no explicit timeout**, so `flow_check.run_debug` uses its default `subprocess.run(timeout=240)`. But the criterion's own `timeout:` was **120s** — *below* the subprocess timeout.

With `criterion (120) < subprocess (240)`:
- the sandbox always kills the whole checker first → opaque exit `-1`, empty output (the real `flow debug` error can never surface);
- and 120s leaves little headroom over the cloud round-trip, so normal latency variance trips it.

For comparison, the 19 maestro-flow tasks that order this correctly use **criterion 300 / run_debug 240** (e.g. `lowcode_agent`), or 600/300 (`wiki_pageviews`).

## Fix

- Raise the subflow debug criterion `timeout` **120 → 300** (validate stays 30; post_run cleanup stays 120). This gives the round-trip headroom **and** restores `criterion > subprocess`, so a genuinely slow/hung debug now surfaces as the informative exit-1 + `TimeoutExpired` traceback instead of an opaque exit `-1`.
- Add `test_check_subflow_flow.py` locking the invariant *(debug-criterion timeout > the checker's `run_debug` subprocess timeout)*. It **fails on the old 120** and **passes on 300**, and reads both values dynamically so it tracks future changes.

## Verification

```
$ pytest tests/tasks/uipath-maestro-flow/ -q
95 passed in 1.70s        # 94 existing + the new guard
```
Confirmed the new test fails at the pre-fix value (`assert 120 > 240`) and passes at 300.

## Scope

Scoped to `subflow` per request. **6 sibling tasks share the identical inversion** (`calculator`, `reading_list`, `decision`, `file_attachment`, `switch`, `terminate` — all criterion ≤ 240 vs run_debug 240) and will be addressed separately.

Full root-cause analysis: `docs/uipath-skills/2026-05-29-skill-flow-subflow-root-cause.md` (workspace).

> Note: this is independent of the PascalCase output break (#1153, already merged), which fixed the checker's key-casing reads but did not touch this timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)