### PR TITLE
docs(uipath-maestro-flow): `registry get` filters use camelCase (verbatim definition)

### DIFF
--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -356,7 +356,7 @@ uip maestro flow registry get <node-type> --output json     # get full schema fo
 - `true` — the tenant registry can return this node; it is valid to continue with `registry get <NodeType>` or `node add <NodeType>`.
 - `false` — the SDK knows about this node type, but the current tenant registry did not return it. Treat it as not enabled or not available for this tenant. Do **not** try nonexistent flags such as `--include-unavailable`; they are not supported. Choose an enabled alternative, use `--local` for in-solution resources, or report the feature/resource as unavailable.
 
-The `Data.Node` object from `registry get` is what you paste into your `.flow` file's `definitions` array.
+The `Data.Node` object from `registry get` is what you paste into your `.flow` file's `definitions` array. Unlike `registry search` (PascalCase summary), `registry get` returns the definition **verbatim** — its keys keep the manifest's own casing, predominantly **camelCase** (`nodeType`, `inputDefinition`, `supportsErrorHandling`, `form`), exactly as they must appear in the `.flow`. Filter it with that casing (`--output-filter "Node.inputDefinition"`, not `Node.InputDefinition`).
 
 Run `uip maestro flow registry <subcommand> --help` for additional options (e.g., `--force`, `--filter`, `--connection-id`).
 

--- a/skills/uipath-maestro-flow/references/shared/cli-conventions.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-conventions.md
@@ -87,7 +87,10 @@ Before reaching for an external parser, verify the JSON shape. The CLI roots `--
 - **Check whether `Data` is array or object first** — `--output-filter "type(@)"` returns `"array"` or `"object"`. `keys(@)` throws on arrays (`Filter 'keys(@)' failed to evaluate: Invalid type: keys() expected argument 1 to be type (object) but received type array instead`), so use `type(@)` as the first probe.
 - **If `type(@)` returned `"object"`:** `--output-filter "keys(@)"` lists the top-level field names at `Data`.
 - **If `type(@)` returned `"array"`:** `--output-filter "[0]"` shows the first row, or `--output-filter "[0] | keys(@)"` lists the keys of one row.
-- **Watch for silent `[]`** — when the JMESPath path doesn't match anything, the CLI returns `Data: []` with `Result: "Success"`. That's the exact silent-failure mode the docs are designed to surface. If you got `Data: []` and were expecting a value, double-check field-name casing (manifest fields are PascalCase: `Node.SupportsErrorHandling`, not `node.supportsErrorHandling`).
+- **Watch for silent `[]`** — when the JMESPath path doesn't match anything, the CLI returns `Data: []` with `Result: "Success"`. That's the exact silent-failure mode the docs are designed to surface. If you got `Data: []` and were expecting a value, double-check field-name casing — **and note casing differs by command:**
+  - `registry search` / `list` (and most `uip … --output json` commands) return **PascalCase** keys → filter `[*].NodeType`, `[*].DisplayName`.
+  - `registry get` returns the node definition **verbatim** (it is pasted straight into the `.flow`), so its keys keep the manifest's own casing — predominantly **camelCase**: `Node.nodeType`, `Node.inputDefinition`, `Node.supportsErrorHandling`, `Node.form.sections[…]`. A few nested *runtime-output* schemas are PascalCase because the engine emits them that way (e.g. Summarize's `content.Text` / `content.Citations`) — match whatever the manifest actually declares, not a normalized form.
+  - When unsure, probe before guessing: `--output-filter "keys(@)"` (object) or `--output-filter "[0] | keys(@)"` (array).
 
 Most agent-side retry loops on `uip --output json` parsing come from guessing the shape wrong; verify, then parse.
 


### PR DESCRIPTION
> **Draft — blocked on [cli#2301](https://github.com/UiPath/cli/pull/2301).** Merge only once a CLI build containing cli#2301 is live in the eval image. Until then the deployed CLI still force-PascalCases `registry get` output, so the camelCase paths documented here would (correctly) describe the *fixed* behavior but not the *deployed* one.

## Why

`--output-filter` runs a **case-sensitive** JMESPath expression over the `Data` envelope, so key casing in filter expressions is load-bearing.

cli #2266 (`normalize output keys to PascalCase`) recursively PascalCased **every** key of every `--output json` payload — including `registry get` node definitions, which the skill pastes **verbatim** into `.flow` files (camelCase by Studio Web convention). That turned `inputString`→`InputString`, broke `flow debug` at runtime (root cause of the `skill-flow-lowcode-agent` regression, run `2026-05-29_04-04-25`), and silently broke the *documented* camelCase `registry get` filter paths (`Node.inputDefinition`, the connector classifier `Node.form.sections[…].componentProps…`, the data-fabric `Data.Node.form…assemblyQualifiedName`) — they began returning `Data: []` with exit 0.

cli #2301 scopes the normalization: `registry get` is emitted **verbatim** (manifest casing preserved, predominantly camelCase); `registry search`/`list` summaries and all other commands stay PascalCase.

## What this changes (docs only)

- **`cli-conventions.md` §3** — the silent-`[]` note claimed *"manifest fields are PascalCase: `Node.SupportsErrorHandling`"* (added in #1123, adapted to #2266). That is now inverted for `registry get` and already contradicted the connector classifier doc (camelCase). Replaced with an explicit **get-vs-search casing split** plus the `keys(@)` probe reminder.
- **`cli-commands.md`** — added a matching note where `registry get`'s `Data.Node` is described: it's returned verbatim/camelCase and must be filtered with that casing (`Node.inputDefinition`, not `Node.InputDefinition`).

## What deliberately stays PascalCase (unchanged, verified correct)

`registry search`/`list` examples (`[*].{NodeType:NodeType,…}`), `connections list`, the Summarize runtime-output schema (`content.Text`/`Citations`), `objectActions.ActionType` — these describe genuine field casings on surfaces cli#2301 does not touch. The checker-side fix (#1153, case-insensitive `flow debug` payload reads) is also unaffected and still required.

## Verification

Audited every `PascalCase`/`camelCase` mention in `skills/uipath-maestro-flow`; `cli-conventions.md:90` was the only line that documented a genuinely-camelCase manifest field (`supportsErrorHandling`) as PascalCase. Confirmed `supportsErrorHandling` is camelCase in a real `.flow` definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)