### PR TITLE
feat(uipath-maestro-case): deterministic displayName for entry/exit rules; drop connector entry-condition auto-injection

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -62,6 +62,7 @@ build the case in the Case Designer without guessing.
 6. **Entry/exit conditions use WHEN + IF format:**
    - **WHEN** = the rule type (event that triggers evaluation, e.g., `selected-stage-completed("Intake")`)
    - **IF** = the optional `conditionExpression` (JavaScript expression evaluated against case variables, e.g., `applicationStatus == "Approved"`)
+   - **Display Name** (optional) = human-readable label for the condition row. Leave blank (`—`) to let the skill default it to `Entry rule {N}` (entry/task-entry conditions) or `Exit rule {N}` (stage-exit/case-exit conditions), where `N` is the 1-based index within the stage / task / case container. Set a value only to override the default.
    - **`wait-for-connector` WHEN** binds an Integration Service connector event. Name it inline in the WHEN cell (e.g. `wait-for-connector (Outlook "Email Received", Inbox)`) AND add a **Connector Rule Detail** block under the condition table. Applies to stage-entry, stage-exit, case-exit, and task-entry conditions. The IF cell is then an optional `=js:` gate on **case state** (`=js:vars.X`); the event payload is NOT directly accessible (no `event` namespace). **In-rule event-payload gating is NOT supported at runtime** — same-rule extract-then-gate (`response.X -> caseVar` on outputs + `=js:vars.caseVar` in IF) does not work; the case-backend evaluates the gate before the extract runs. To condition on the event payload, extract `response.field -> caseVar` on the connector rule and place the case-state gate on the DOWNSTREAM stage-entry / task-entry condition (where the extract has already populated the case var).
 
    **Connector Rule Detail block** — reproduce under any condition table whose WHEN is `wait-for-connector`:
@@ -206,9 +207,9 @@ DO NOT include in Configuration:
 
 > **WHEN ↔ Marks Case Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-stages-completed` (preferred) or `wait-for-connector`; `No` row MAY use `selected-stage-completed(...)` / `selected-stage-exited(...)` / `wait-for-connector`. Mixing `Yes` with a `selected-*` rule is invalid.
 
-| WHEN | IF | THEN | Marks Case Complete |
-|------|-----|------|---------------------|
-| {`required-stages-completed` for Yes; `selected-stage-completed("StageName")` or other rule for No} | {conditionExpression, or "—" if none} | Case exited | {Yes \| No} |
+| WHEN | IF | THEN | Marks Case Complete | Display Name |
+|------|-----|------|---------------------|--------------|
+| {`required-stages-completed` for Yes; `selected-stage-completed("StageName")` or other rule for No} | {conditionExpression, or "—" if none} | Case exited | {Yes \| No} | {optional label, or "—" → defaults to `Exit rule {N}`} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6) — it binds the IS connector event the rule waits for.
 
@@ -307,9 +308,9 @@ The runtime engine resolves the binding when the task completes, writing the res
 >
 > Each row is a separate entry condition. List multiple rows when a stage can be entered through more than one path (e.g., normal completion of an upstream stage AND an interrupting connector event).
 
-| WHEN | IF | Interrupting |
-|------|-----|-------------|
-| {one of: `case-entered` \| `selected-stage-completed("StageName")` \| `selected-stage-exited("StageName")` \| `user-selected-stage` \| `wait-for-connector`} | {conditionExpression, or "—" if none} | {Yes \| No} |
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| {one of: `case-entered` \| `selected-stage-completed("StageName")` \| `selected-stage-exited("StageName")` \| `user-selected-stage` \| `wait-for-connector`} | {conditionExpression, or "—" if none} | {Yes \| No} | {optional label, or "—" → defaults to `Entry rule {N}`} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
@@ -318,9 +319,9 @@ The runtime engine resolves the binding when the task completes, writing the res
 > **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed` (or `required-stages-completed`); `No` row MAY use `selected-tasks-completed(...)`. Mixing is invalid.
 > Completion (`Yes`) and routing (`No`) rows share this one table. **Stage-to-stage routing is expressed by the destination stages' Entry Conditions** (`selected-stage-completed("This Stage")` / `selected-stage-exited("This Stage")`) — one stage can fan out to N stages, each declaring it as their entry trigger. `return-to-origin` returns to the origin stage automatically.
 
-| WHEN | IF | Exit Type | Marks Stage Complete |
-|------|-----|-----------|---------------------|
-| {`required-tasks-completed` or `wait-for-connector` for Yes; `selected-tasks-completed("TaskName")` or `wait-for-connector` for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} |
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| {`required-tasks-completed` or `wait-for-connector` for Yes; `selected-tasks-completed("TaskName")` or `wait-for-connector` for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} | {optional label, or "—" → defaults to `Exit rule {N}`} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
@@ -351,11 +352,11 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 > **Valid WHEN rule types for task entry (strict subset of Key Rule 3):** `current-stage-entered` (default — fires when the containing stage is entered; typical for first task or any task with no sibling gate), `selected-tasks-completed("TaskA", "TaskB")` (fires when specific sibling tasks in the same stage complete), `wait-for-connector` (waits for a connector event), `adhoc` (user-triggered from the case app — task does not auto-start), `runs-sequentially` (sequential ordering within the stage; parallel members of the group share a lane, solo members get their own lane). Other rule types from Key Rule 3 are NOT valid here.
 >
-> Each row is a separate entry condition. List multiple rows when a task can be entered through more than one path. Connector tasks (`execute-connector-activity`, `wait-for-connector`) receive a default `current-stage-entered` condition on creation — still author the row explicitly if it applies.
+> Each row is a separate entry condition. List multiple rows when a task can be entered through more than one path. Author a `current-stage-entered` row for any ungated task — including connector tasks (`execute-connector-activity`, `wait-for-connector`) — that should start when its stage is entered.
 
-| WHEN | IF |
-|------|-----|
-| {one of: `current-stage-entered` \| `selected-tasks-completed("TaskA", "TaskB")` \| `wait-for-connector` \| `adhoc` \| `runs-sequentially`} | {conditionExpression, or "—" if none} |
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| {one of: `current-stage-entered` \| `selected-tasks-completed("TaskA", "TaskB")` \| `wait-for-connector` \| `adhoc` \| `runs-sequentially`} | {conditionExpression, or "—" if none} | {optional label, or "—" → defaults to `Entry rule {N}`} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 

--- a/skills/uipath-maestro-case/assets/templates/sdd-viewer.html
+++ b/skills/uipath-maestro-case/assets/templates/sdd-viewer.html
@@ -505,7 +505,7 @@
         "slaEscalation": [{ "status": "At-Risk"|"Breached", "threshold": string, "action": string }],
         "variableSla": [{ "expression": string, "sla": number, "unit": string }],
         "triggers": [{ "type": string, "source": string, "config": string, "mappings": [{"from": string, "to": string}] }],
-        "exitConditions": [{ "when": string, "if": string, "then": string, "marksComplete": "Yes"|"No" }],
+        "exitConditions": [{ "when": string, "if": string, "then": string, "marksComplete": "Yes"|"No", "displayName": string }],
         "variables": [{ "name": string, "type": string, "default": string, "description": string, "producedBy": string, "consumedBy": string[] }]
       },
       "stages": [
@@ -515,8 +515,8 @@
           "description": string,
           "requiredForCompletion": boolean,
           "interrupting": boolean | null,     // ExceptionStage only
-          "entryConditions": [{ "when": string, "if": string, "interrupting": "Yes"|"No" }],
-          "exitConditions":  [{ "when": string, "if": string, "exitType": string, "marksComplete": "Yes"|"No" }],
+          "entryConditions": [{ "when": string, "if": string, "interrupting": "Yes"|"No", "displayName": string }],
+          "exitConditions":  [{ "when": string, "if": string, "exitType": string, "marksComplete": "Yes"|"No", "displayName": string }],
           "sla": { "count": number, "unit": string, "atRiskPct": string, "atRiskAction": string, "breachAction": string } | null,
           "tasks": [
             {
@@ -527,7 +527,7 @@
               "persona": string | null,
               "sla": { "count": number, "unit": string } | null,
               "description": string,
-              "entryCondition": { "when": string, "if": string },
+              "entryCondition": { "when": string, "if": string, "displayName": string },
               "details": { ... }              // shape varies by type — see renderTaskDetail below
             }
           ]
@@ -735,12 +735,13 @@
         const card = el("div", { class: "card" });
         card.appendChild(el("h3", null, "Case Exit Conditions"));
         const t = el("table");
-        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF"), el("th", null, "THEN"), el("th", null, "Marks Case Complete" + schemaTag("markCaseComplete"))]));
+        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF"), el("th", null, "THEN"), el("th", null, "Marks Case Complete" + schemaTag("markCaseComplete")), el("th", null, "Display Name")]));
         c.exitConditions.forEach(r => t.appendChild(el("tr", null, [
           el("td", { html: '<code>' + escapeHtml(r.when || "—") + '</code>' }),
           el("td", { html: '<code>' + escapeHtml(r.if || "—") + '</code>' }),
           el("td", { html: renderInline(r.then) }),
-          el("td", { html: renderInline(r.marksComplete) })
+          el("td", { html: renderInline(r.marksComplete) }),
+          el("td", { html: renderInline(r.displayName) })
         ])));
         card.appendChild(t);
         mount.appendChild(card);
@@ -1111,11 +1112,12 @@
       if ((stage.entryConditions || []).length) {
         body.appendChild(el("h4", null, "Entry"));
         const t = el("table");
-        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF"), el("th", null, "Interrupting")]));
+        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF"), el("th", null, "Interrupting"), el("th", null, "Display Name")]));
         stage.entryConditions.forEach(c => t.appendChild(el("tr", null, [
           el("td", { html: '<code>' + escapeHtml(c.when || "—") + '</code>' }),
           el("td", { html: '<code>' + escapeHtml(c.if || "—") + '</code>' }),
-          el("td", { html: renderInline(c.interrupting) })
+          el("td", { html: renderInline(c.interrupting) }),
+          el("td", { html: renderInline(c.displayName) })
         ])));
         body.appendChild(t);
       }
@@ -1123,12 +1125,13 @@
       if ((stage.exitConditions || []).length) {
         body.appendChild(el("h4", null, "Exit"));
         const t = el("table");
-        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF"), el("th", null, "Exit Type"), el("th", null, "Marks Stage Complete" + schemaTag("markStageComplete"))]));
+        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF"), el("th", null, "Exit Type"), el("th", null, "Marks Stage Complete" + schemaTag("markStageComplete")), el("th", null, "Display Name")]));
         stage.exitConditions.forEach(c => t.appendChild(el("tr", null, [
           el("td", { html: '<code>' + escapeHtml(c.when || "—") + '</code>' }),
           el("td", { html: '<code>' + escapeHtml(c.if || "—") + '</code>' }),
           el("td", { html: renderInline(c.exitType) }),
-          el("td", { html: renderInline(c.marksComplete) })
+          el("td", { html: renderInline(c.marksComplete) }),
+          el("td", { html: renderInline(c.displayName) })
         ])));
         body.appendChild(t);
       }
@@ -1313,10 +1316,11 @@
       if (task.entryCondition) {
         body.appendChild(el("h4", null, "Entry condition"));
         const t = el("table");
-        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF")]));
+        t.appendChild(el("tr", null, [el("th", null, "WHEN"), el("th", null, "IF"), el("th", null, "Display Name")]));
         t.appendChild(el("tr", null, [
           el("td", { html: '<code>' + escapeHtml(task.entryCondition.when || "—") + '</code>' }),
-          el("td", { html: '<code>' + escapeHtml(task.entryCondition.if || "—") + '</code>' })
+          el("td", { html: '<code>' + escapeHtml(task.entryCondition.if || "—") + '</code>' }),
+          el("td", { html: renderInline(task.entryCondition.displayName) })
         ]));
         body.appendChild(t);
       }

--- a/skills/uipath-maestro-case/references/case-editing-operations.md
+++ b/skills/uipath-maestro-case/references/case-editing-operations.md
@@ -15,7 +15,6 @@ When editing `caseplan.json` directly, the agent is responsible for these mechan
 | Edge handles | Construct handle strings as `${nodeId}____<source\|target>____<direction>` (exactly 4 underscores on each side) |
 | Stage position | Count existing stages first; compute `{ x: 100 + existingStageCount * 500, y: 200 }`; then write |
 | Stage render fields | Emit `style`, `measured`, `width`, `zIndex`, `data.parentElement`, `data.isInvalidDropTarget`, `data.isPendingParent` on every new Stage node |
-| Connector task default entry condition | Emit the default `current-stage-entered` entry condition on every connector task |
 | Edge cleanup on stage removal | Find and remove every edge where `source` or `target` equals the removed stage's ID |
 | Root-level bindings cleanup | Prune entries from the bindings array (v19: `root.data.uipath.bindings`; v20: top-level `bindings`) no longer referenced by any task |
 | Lane array expansion | Ensure `stageNode.data.tasks` is expanded to include `laneIndex` before pushing |
@@ -69,12 +68,7 @@ Before every write to `caseplan.json`, confirm each item. These are the failure 
 
 10. **Task `elementId` = `${stageId}-${taskId}`.** Compute and write this composite string on every new task.
 
-11. **Connector task default entry condition.** Every `execute-connector-activity` or `wait-for-connector` task gets an auto-injected entry condition:
-    ```json
-    { "id": "c<8chars>", "displayName": "Entry rule 1",
-      "rules": [[{ "id": "r<8chars>", "rule": "current-stage-entered" }]] }
-    ```
-    Non-connector tasks do NOT get this default.
+11. **Entry conditions are SDD-driven — never auto-injected by task type.** A task's `entryConditions[]` are written solely by the task-entry-conditions plugin (Step 10) from the SDD's authored Entry Condition rows — including a connector task's `current-stage-entered`, which the SDD declares as an explicit first row like any ungated task. Do NOT inject a default entry condition at task-creation time based on task type: it produces a duplicate condition and breaks `displayName` indexing (the index is the 1-based position within `entryConditions[]`). Connector and non-connector tasks are treated identically here.
 
 12. **Cross-task bindings reference existing IDs.** Before writing a `var bind` entry, confirm the source stage ID and source task ID both exist in `caseplan.json`.
 
@@ -254,10 +248,9 @@ edge_   + "Qz7hVr"  → "edge_Qz7hVr"
 3. Ensure `stageNode.data.tasks` exists; ensure `stageNode.data.tasks[laneIndex]` exists (expand with empty arrays if needed).
 4. Generate a task ID.
 5. Compute `elementId = ${stageId}-${taskId}`.
-6. Build the task object per the plugin's JSON Recipe.
-7. For connector tasks, add the auto-injected default entry condition.
-8. Push onto `stageNode.data.tasks[laneIndex]`.
-9. Edit — narrow slice targeting that stage node's `data.tasks[laneIndex]`. Never whole-file Write.
+6. Build the task object per the plugin's JSON Recipe. Do NOT add `entryConditions` here — the task-entry-conditions plugin (Step 10) writes them from the SDD's authored rows, for every task type alike.
+7. Push onto `stageNode.data.tasks[laneIndex]`.
+8. Edit — narrow slice targeting that stage node's `data.tasks[laneIndex]`. Never whole-file Write.
 
 ### Bind an input
 
@@ -328,7 +321,7 @@ On failure: fix the reported issue (usually a missing field, malformed handle, o
 - **Do NOT hand-edit IDs with human-readable patterns** (e.g., `my_stage_1`). The frontend's `generateNextId` expects CLI's format.
 - **Do NOT forget `style`/`measured`/`width`/`zIndex` on stages.** Validate passes, but Studio Web renders broken.
 - **Do NOT put `entryConditions`/`exitConditions` on regular Stages.** Only ExceptionStage has them.
-- **Do NOT skip the default entry condition on connector tasks.** The frontend expects it.
+- **Do NOT auto-inject a task `entryCondition` at task-creation time based on task type.** Entry conditions come from the SDD via the task-entry-conditions plugin (Step 10), uniformly across task types. Injecting one early duplicates the Step 10 write and corrupts `displayName` indexing.
 - **Do NOT write partial JSON with Edit tool regex.** Round-trip through Read → reason → Edit per the per-section batch contract.
 - **Do NOT run validation after every single Edit.** Validate at section boundaries, not per-T-entry.
 - **Do NOT use whole-file Write mid-section.** Whole-file Write between sibling T-entries inside a section bypasses the section-entry Read snapshot and risks silently dropping fields. Use Edit per T-entry, OR collapse the entire section into one whole-section Write at section boundary when T-entry count ≥10 (per § Per-section batch write contract).

--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -507,7 +507,7 @@ All tasks inside a stage share this envelope. Per-type `data` fields live in eac
 | `type` | string | Task type — see task plugins under `plugins/tasks/` |
 | `data` | object | Type-specific configuration — see corresponding plugin's `impl-json.md`. For connector tasks, `data.bindings` references the root-level bindings array. |
 | `skipCondition` | string? | Expression — skip the task when truthy |
-| `entryConditions` | TaskEntryCondition[]? | See §3. **Connector tasks (`execute-connector-activity`, `wait-for-connector`) receive a default `current-stage-entered` entry condition on creation. Non-connector tasks do NOT.** |
+| `entryConditions` | TaskEntryCondition[]? | See §3. Written by the task-entry-conditions plugin from the SDD's authored Entry Condition rows — applied uniformly across task types (no auto-injection by task type). |
 | `shouldRunOnlyOnce` | boolean? | Run the task at most once per case, even if the stage is re-entered |
 | `shouldRunOnReEntry` | boolean? | *(deprecated — use `shouldRunOnlyOnce`)* Re-run when stage is re-entered |
 | `isRequired` | boolean? | Whether the task must complete for the stage to complete |

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -37,7 +37,8 @@ Rules use DNF — outer array is OR, inner array is AND.
    - **v19** → locate the `root` object. Initialize `root.caseExitConditions = []` if absent.
    - **v20** → locate top-level `metadata` object (initialize `metadata: {}` if missing — should already exist from T01). Initialize `metadata.caseExitRules = []` if absent.
 4. Read `rule-type` and `marks-case-complete` from tasks.md; pick the recipe below
-5. Append the condition object to the schema-appropriate array:
+5. Set `displayName`: use tasks.md `display-name` if present; else default to `Exit rule {N}`, where `N` = the 1-based index this condition takes in the schema-appropriate array (i.e. `array.length + 1` at append time). Never emit a blank or omitted `displayName`.
+6. Append the condition object to the schema-appropriate array:
    - **v19** → `root.caseExitConditions[]`
    - **v20** → `metadata.caseExitRules[]`
 
@@ -85,7 +86,7 @@ Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 
 ## Post-Write Verification
 
-Confirm the schema-appropriate array contains the new object with `id`, `marksCaseComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field:
+Confirm the schema-appropriate array contains the new object with `id`, non-empty `displayName` (SDD value or `Exit rule {N}` default), `marksCaseComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field:
 - **v19** → `root.caseExitConditions[]`
 - **v20** → `metadata.caseExitRules[]`
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -16,7 +16,7 @@ Every case-exit condition declared in sdd.md gets its own T-task — **including
 
 | Field | Source | Notes |
 |-------|--------|-------|
-| `display-name` | sdd.md (optional) | e.g., "Case resolved", "Closed — escalation path" |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Exit rule {N}`. e.g., "Case resolved", "Closed — escalation path" |
 | `marks-case-complete` | sdd.md | `true` for normal completion, `false` for non-completing exits |
 | `rule-type` | From catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
@@ -57,7 +57,7 @@ Case exit conditions are created **after** all stages exist (so `selectedStageId
 
 ```markdown
 ## T<n>: Add case-exit condition — <summary>
-- display-name: "<name>"
+- display-name: "<name>"                 # optional — omit when SDD Display Name cell is blank; impl defaults to "Exit rule {N}"
 - marks-case-complete: true
 - rule-type: required-stages-completed
 - selected-stage: "<stage-name>"        # only for selected-stage-* rule-types

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -34,7 +34,8 @@ Rules use DNF — outer array is OR, inner array is AND.
 3. Locate the target stage in `schema.nodes` by ID
 4. Initialize `stageNode.data.entryConditions = []` if absent (regular Stage is created without this key — see [`../../stages/impl-json.md`](../../stages/impl-json.md))
 5. Read `rule-type` and `is-interrupting` from tasks.md; pick the recipe below
-6. Append the condition object to `stageNode.data.entryConditions[]`
+6. Set `displayName`: use tasks.md `display-name` if present; else default to `Entry rule {N}`, where `N` = the 1-based index this condition takes in `stageNode.data.entryConditions[]` (i.e. `entryConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
+7. Append the condition object to `stageNode.data.entryConditions[]`
 
 ## Rule Types
 
@@ -86,4 +87,4 @@ Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 
 ## Post-Write Verification
 
-Confirm target stage's `data.entryConditions[]` contains the new object with `id`, `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `<stageId>-<ruleId>`, and the ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+Confirm target stage's `data.entryConditions[]` contains the new object with `id`, non-empty `displayName` (SDD value or `Entry rule {N}` default), `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `<stageId>-<ruleId>`, and the ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -17,7 +17,7 @@ Every stage with an **Entry Condition** declared in sdd.md gets its own stage-en
 | Field | Source | Notes |
 |-------|--------|-------|
 | `<stage-id>` | previously captured from the stages plugin | Target stage |
-| `display-name` | sdd.md (optional) | e.g., "Pre-check", "Interrupt on Fraud" |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Entry rule {N}`. e.g., "Pre-check", "Interrupt on Fraud" |
 | `is-interrupting` | sdd.md (default `false`) | `true` if the condition interrupts the current stage |
 | `rule-type` | Pick from the catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | ID of the referenced stage |
@@ -48,7 +48,7 @@ Stage entry conditions are created **after** all stages exist (Step 7 in impleme
 ```markdown
 ## T<n>: Add stage-entry condition for "<stage>" — <summary>
 - target-stage: "<stage-name>"
-- display-name: "<name>"
+- display-name: "<name>"   # optional — omit when SDD Display Name cell is blank; impl defaults to "Entry rule {N}"
 - is-interrupting: false
 - rule-type: selected-stage-completed
 - selected-stage: "<upstream-stage-name>"

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -31,7 +31,8 @@ Rules use DNF — outer array is OR, inner array is AND.
 3. Locate the target stage in `schema.nodes` by ID
 4. Initialize `stageNode.data.exitConditions = []` if absent (regular Stage is created without this key — see [`../../stages/impl-json.md`](../../stages/impl-json.md))
 5. Read `type`, `exit-to-stage`, `marks-stage-complete`, and `rule-type` from tasks.md; pick the recipe below
-6. Append the condition object to `stageNode.data.exitConditions[]`
+6. Set `displayName`: use tasks.md `display-name` if present; else default to `Exit rule {N}`, where `N` = the 1-based index this condition takes in `stageNode.data.exitConditions[]` (i.e. `exitConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
+7. Append the condition object to `stageNode.data.exitConditions[]`
 
 ## Exit Types
 
@@ -106,4 +107,4 @@ Routes the case back to the originating stage.
 
 ## Post-Write Verification
 
-Confirm target stage's `data.exitConditions[]` contains the new object with `id`, `type`, `exitToStageId` (if set), `marksStageComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.
+Confirm target stage's `data.exitConditions[]` contains the new object with `id`, non-empty `displayName` (SDD value or `Exit rule {N}` default), `type`, `exitToStageId` (if set), `marksStageComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -17,7 +17,7 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | Field | Source | Notes |
 |-------|--------|-------|
 | `<stage-id>` | Captured from the stages plugin | Target stage |
-| `display-name` | sdd.md (optional) | |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Exit rule {N}`. |
 | `type` | sdd.md exit style | `exit-only` / `wait-for-user` / `return-to-origin` |
 | `exit-to-stage-id` | sdd.md routing target (optional) | Required when routing to a specific stage |
 | `marks-stage-complete` | sdd.md (default depends on type) | `true` for completion exits, `false` for diverging routes |
@@ -60,7 +60,7 @@ Stage exit conditions are created **after** all tasks in the stage have been add
 ```markdown
 ## T<n>: Add stage-exit condition for "<stage>" — <summary>
 - target-stage: "<stage-name>"
-- display-name: "<name>"
+- display-name: "<name>"                        # optional — omit when SDD Display Name cell is blank; impl defaults to "Exit rule {N}"
 - type: exit-only
 - exit-to-stage: "<target-stage-name>"          # optional
 - marks-stage-complete: true

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -34,7 +34,8 @@ Rules use DNF — outer array is OR, inner array is AND.
 4. Locate the target task inside `stageNode.data.tasks[lane][index]` (search every lane until the task ID is found)
 5. Initialize `task.entryConditions = []` if absent
 6. Read `rule-type` from tasks.md; pick the recipe below
-7. Append the condition object to `task.entryConditions[]`
+7. Set `displayName`: use tasks.md `display-name` if present; else default to `Entry rule {N}`, where `N` = the 1-based index this condition takes in `task.entryConditions[]` (i.e. `entryConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
+8. Append the condition object to `task.entryConditions[]`
 
 ## Rule Types
 
@@ -100,4 +101,4 @@ Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 
 ## Post-Write Verification
 
-Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`) and `rules` with the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated, inputs/outputs `elementId` is `<stageId>-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`), non-empty `displayName` (SDD value or `Entry rule {N}` default), and `rules` with the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated, inputs/outputs `elementId` is `<stageId>-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -17,7 +17,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | Field | Source | Notes |
 |-------|--------|-------|
 | `<stage-id>`, `<task-id>` | Captured from prior steps | |
-| `display-name` | sdd.md (optional) | |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Entry rule {N}`. |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
 | `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
@@ -44,7 +44,7 @@ Task entry conditions are created **after** all tasks in the stage have been add
 ## T<n>: Add task-entry condition for "<task>" in "<stage>" — <summary>
 - target-stage: "<stage-name>"
 - target-task: "<task-name>"
-- display-name: "<name>"
+- display-name: "<name>"                  # optional — omit when SDD Display Name cell is blank; impl defaults to "Entry rule {N}"
 - rule-type: selected-tasks-completed
 - selected-tasks: "<Task A>, <Task B>"
 - condition-expression: "=js:vars.X..."   # optional gate on case state, NOT the event payload

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -254,9 +254,11 @@ Nested `{op, clauses}` groups flatten in the rendered table. Avoid `Literal: No`
 
 ≥ 1 row required. `Marks Case Complete: Yes`.
 
-| WHEN | IF | Marks Case Complete | Exit Type |
-|---|---|---|---|
-| `required-stages-completed` / `wait-for-connector` | optional `conditionExpression` | `Yes` | `exit-only` |
+| WHEN | IF | Marks Case Complete | Exit Type | Display Name |
+|---|---|---|---|---|
+| `required-stages-completed` / `wait-for-connector` | optional `conditionExpression` | `Yes` | `exit-only` | optional |
+
+> **Display Name** (optional, every condition table — entry, exit, task-entry, case-exit): human-readable label. Carry the author's value verbatim; leave blank / `—` to let the skill default it to `Entry rule {N}` (entry / task-entry) or `Exit rule {N}` (stage-exit / case-exit), `N` = 1-based index within the container. Never invent a label when the cell is blank.
 
 **Allowed WHEN:** `required-stages-completed`, `wait-for-connector`.
 **Forbidden WHEN:** `selected-stage-completed`, `selected-stage-exited` (sdd-template Key Rule 4 — `Yes` + `selected-stage-*` is a schema-pairing error → block Approve).
@@ -265,9 +267,9 @@ Nested `{op, clauses}` groups flatten in the rendered table. Avoid `Literal: No`
 
 Optional. `Marks Case Complete: No`. Used for ExceptionStage terminals (Withdrawn / Rejected / Cancelled).
 
-| WHEN | IF | Marks Case Complete | Exit Type |
-|---|---|---|---|
-| `selected-stage-completed("<Stage Name>")` / `selected-stage-exited("<Stage Name>")` / `wait-for-connector` | optional | `No` | `exit-only` / `wait-for-user` |
+| WHEN | IF | Marks Case Complete | Exit Type | Display Name |
+|---|---|---|---|---|
+| `selected-stage-completed("<Stage Name>")` / `selected-stage-exited("<Stage Name>")` / `wait-for-connector` | optional | `No` | `exit-only` / `wait-for-user` | optional |
 
 **When the case has ≥ 1 ExceptionStage AND Section 1.4a is empty** → emit a `high`-severity review item (`Alt-disposition exits missing`). The case cannot exit non-happy paths cleanly.
 
@@ -339,17 +341,17 @@ The trailing `` `{stage_id}` `` (e.g., `` `stage-intake` ``) MUST appear so read
 
 ≥ 1 row required.
 
-| WHEN | IF |
-|---|---|
-| `case-entered` (root only) / `selected-stage-completed("<Stage>")` / `selected-stage-exited("<Stage>")` / `wait-for-connector` / `user-selected-stage` | optional `conditionExpression` |
+| WHEN | IF | Display Name |
+|---|---|---|
+| `case-entered` (root only) / `selected-stage-completed("<Stage>")` / `selected-stage-exited("<Stage>")` / `wait-for-connector` / `user-selected-stage` | optional `conditionExpression` | optional |
 
 ### Stage Completion Conditions table (`Marks Stage Complete: Yes`)
 
-Completion (`Yes`) rows and the §Stage Exit Conditions (`No`) rows below render **together** as the single **Stage Exit Conditions** table in `sdd.md` (per [sdd-template.md](../assets/templates/sdd-template.md)). Shared columns, in order: `WHEN | IF | Exit Type | Marks Stage Complete`. ≥ 1 completion row required. **Stage-to-stage routing is NOT carried here** — each destination stage declares the link via its own Entry Condition (`selected-stage-completed("This Stage")` / `selected-stage-exited("This Stage")`), so one stage can fan out to N stages.
+Completion (`Yes`) rows and the §Stage Exit Conditions (`No`) rows below render **together** as the single **Stage Exit Conditions** table in `sdd.md` (per [sdd-template.md](../assets/templates/sdd-template.md)). Shared columns, in order: `WHEN | IF | Exit Type | Marks Stage Complete | Display Name`. ≥ 1 completion row required. **Stage-to-stage routing is NOT carried here** — each destination stage declares the link via its own Entry Condition (`selected-stage-completed("This Stage")` / `selected-stage-exited("This Stage")`), so one stage can fan out to N stages.
 
-| WHEN | IF | Exit Type | Marks Stage Complete |
-|---|---|---|---|
-| `required-tasks-completed` / `wait-for-connector` | optional | `exit-only` / `return-to-origin` | `Yes` |
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` / `wait-for-connector` | optional | `exit-only` / `return-to-origin` | `Yes` | optional |
 
 **Allowed WHEN:** `required-tasks-completed`, `wait-for-connector`.
 **Forbidden WHEN:** `selected-tasks-completed` (Key Rule 4 — `Yes` + `selected-tasks-completed` is a schema-pairing error → block Approve).
@@ -358,9 +360,9 @@ Completion (`Yes`) rows and the §Stage Exit Conditions (`No`) rows below render
 
 Optional. Used for early hand-offs / routing. Same columns and order as the completion rows above — one rendered table. The destination of a routing exit is set by the destination stage's Entry Condition, not here.
 
-| WHEN | IF | Exit Type | Marks Stage Complete |
-|---|---|---|---|
-| `selected-tasks-completed("<Task>")` / `wait-for-connector` | optional | `exit-only` / `wait-for-user` | `No` |
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("<Task>")` / `wait-for-connector` | optional | `exit-only` / `wait-for-user` | `No` | optional |
 
 ### Stage SLA escalation table
 
@@ -401,20 +403,20 @@ Defines per-task detail blocks. Every task opens with an **Entry Condition** blo
 ```
 **Entry Condition**
 
-| WHEN | IF |
-|---|---|
-| {rule} | {conditionExpression or "—"} |
+| WHEN | IF | Display Name |
+|---|---|---|
+| {rule} | {conditionExpression or "—"} | optional |
 ```
 
 | Rule | When to use |
 |---|---|
-| `current-stage-entered` | First task in stage (REQUIRED; emit explicitly, never imply). Connector tasks auto-inject this — render it first even when explicit rows follow. |
+| `current-stage-entered` | First task in stage, or any ungated task (including connector tasks) that should start when its stage is entered (REQUIRED for the first task; emit explicitly, never imply). When a task has multiple entry rows, render this one first. |
 | `selected-tasks-completed("<Task>")` | Sibling-gated task (e.g., after upstream task in same stage). Multiple tasks comma-separated inside the parens. |
 | `wait-for-connector` | Async connector callback. Pair with `conditionExpression` to gate on **case state** (`vars.X`); the event payload is not accessible (no `event` namespace). **In-rule extract-then-gate (extract + same-rule `=js:vars.caseVar` gate) does NOT work at runtime** — case-backend evaluates the gate before the extract populates the case var. To condition on payload content: extract `response.field -> caseVar` on the connector rule and place the case-state gate on a DOWNSTREAM stage-entry / task-entry condition. |
 | `adhoc` | Manual fire from the case app. Optional gating expression. |
 | `runs-sequentially` | Tasks in a lane that should run top-to-bottom in declaration order. |
 
-Multiple entry conditions render as multiple rows (DNF outer-OR). Connector tasks always render auto-injected `current-stage-entered` first.
+Multiple entry conditions render as multiple rows (DNF outer-OR). When `current-stage-entered` is among them, render it first.
 
 ### `action` task — required cells
 
@@ -473,7 +475,7 @@ No recipient and no role/email known → drop the cell, emit a `high`-severity r
 | Inputs | Table: `Field | Type | Binding` — `Field` MUST match IS activity schema verbatim; `Binding` per §Binding cell |
 | Outputs | Table: `Field | Binding / Value` — see §Outputs cell operators |
 
-**Auto-injected entry condition.** These two task types auto-receive `current-stage-entered` at consumer-side creation. Render explicitly as the first row; explicit additional rules APPEND, never replace.
+**Entry condition.** A connector task that should start when its stage is entered declares `current-stage-entered` as its first entry row, exactly like any other ungated task; additional rules APPEND as further rows. The skill writes these via the task-entry-conditions plugin (Step 10) — there is no task-type auto-injection.
 
 **Unresolved IDs.** Missing `connectionId` or `activityTypeId` → `high`-severity review item — Phase 1 cannot resolve the connector at build time without them.
 


### PR DESCRIPTION
## Summary

Two coupled fixes for how the **uipath-maestro-case** skill handles entry/exit **rule** behavior.

### 1. Deterministic rule `displayName`
The SDD condition tables had **no Display Name column**, and the condition plugins **never set `displayName`** — it appeared only as an example literal with no derivation rule, so the label was left to agent discretion (non-deterministic).

- `sdd-template.md` + `sdd-generation-rules.md` + `sdd-viewer.html`: add an **optional** `Display Name` column to all 4 condition tables (stage-entry, stage-exit, case-exit, task-entry) + a shared default rule.
- 4 `impl-json.md`: set `displayName` from the plan's `display-name` if present, else default to **`Entry rule {N}` / `Exit rule {N}`** (`N` = 1-based index within the container); verify non-empty.
- 4 `planning.md`: carry the SDD value verbatim, omit when blank.

### 2. Remove connector entry-condition auto-injection (stale CLI folklore)
Rule 11 auto-injected a hardcoded `{ displayName: "Entry rule 1", current-stage-entered }` onto connector tasks at creation. The `task-add` CLI that originated it is **deprecated** — tasks are now direct-edited by the skill. The injection competes with the Step 10 task-entry-conditions write (which `connector-activity/impl-json.md:260` already mandates) and **corrupts `displayName` indexing**.

Entry conditions are now **SDD-driven and uniform across task types**:
- `case-editing-operations.md`: Rule 11 rewritten to the correct principle; dropped the checklist row, the "Add a task" step, and the stale anti-pattern.
- `sdd-generation-rules.md`, `sdd-template.md`, `case-schema.md`: dropped the "auto-inject / receive a default on creation" framing.
- Kept `connector-activity/impl-json.md:260` and `connector-trigger-common.md:460` ("Step 10 handles them") — the rest of the skill now agrees with them instead of contradicting them.

## Why they're coupled
With no creation-time injection, a connector task's `current-stage-entered` is a single SDD-declared row that Step 10 writes and the index labels — one writer, `N=1` → `Entry rule 1`. No duplicate condition, no index corruption.

## Notes for reviewers
- Docs-only change; no skill code/build.
- Behavioral assumption: connector tasks still get `current-stage-entered` via the SDD (`sdd-generation-rules.md` marks it REQUIRED for the first task). An ungated connector task authored with no entry-condition row would now have empty `entryConditions[]` — previously masked by the injection. Open question in-thread: add a Phase-3 validator flag for that case, or rely on the existing "REQUIRED, emit explicitly" SDD rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)