### PR TITLE
docs(skills): make connector-mode HTTP constraints explicit - HasHttpRequest + application/json-only [ENGCE-58250]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl-connector.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl-connector.md
@@ -17,6 +17,8 @@ The CLI copies the manifest into `definitions[]`, adds the node instance, regist
 
 ## Step 2 — Identify target connection
 
+**Connector mode only works if the connector supports the HTTP request activity** — verify by running `uip is connectors get "<target-connector-key>"` and checking the `HasHttpRequest` flag.
+
 ```bash
 uip is connections list "<target-connector-key>" --all-folders --output json
 ```

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl-connector.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl-connector.md
@@ -53,6 +53,8 @@ uip maestro flow node configure <ProjectName>.flow <nodeId> \
   }' --output json
 ```
 
+> **Connector mode supports `application/json` request and response bodies only.**
+
 The CLI:
 
 - Builds the full `inputs.detail` (connector, connectionId, bodyParameters, essentialConfiguration)

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl-connector.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl-connector.md
@@ -17,7 +17,7 @@ The CLI copies the manifest into `definitions[]`, adds the node instance, regist
 
 ## Step 2 — Identify target connection
 
-**Connector mode only works if the connector supports the HTTP request activity** — verify by running `uip is connectors get "<target-connector-key>"` and checking the `HasHttpRequest` flag.
+**Connector mode only works if the connector supports the HTTP request activity** — verify by running `uip is connectors get "<target-connector-key>"` and checking the `HasHttpRequest` flag. If the flag is false, **STOP** — a connection cannot help. Use the recovery `AskUserQuestion` below (switch to manual mode / skip / something else; the create-a-connection option does not apply) and do not switch modes without confirmation.
 
 ```bash
 uip is connections list "<target-connector-key>" --all-folders --output json

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/impl.md
@@ -15,7 +15,7 @@ This page is the entry point for implementing a managed HTTP node. Pick your aut
 | **Connector** | Target system has an IS connector — auth via an existing IS connection (OAuth/API key) | [impl-connector.md](impl-connector.md) |
 | **Manual** | No connector exists, public/no-auth API, or quick prototyping | [impl-manual.md](impl-manual.md) |
 
-> **Mode fallback — auto-try, then confirm.** Prefer a curated connector activity first; if none, use connector mode; if connector mode cannot be configured (no usable IS connection), fall through to manual mode automatically. Manual changes the auth model (you supply auth yourself), so confirm the switched mode with the user via `AskUserQuestion` before finalizing. See [impl-connector.md — Step 2](impl-connector.md#step-2--identify-target-connection).
+> **Mode fallback — auto-try, then confirm.** Prefer a curated connector activity first; if none, use connector mode; if connector mode cannot be configured (connector lacks HTTP request support — `HasHttpRequest` false — or no usable IS connection), fall through to manual mode automatically. Manual changes the auth model (you supply auth yourself), so confirm the switched mode with the user via `AskUserQuestion` before finalizing. See [impl-connector.md — Step 2](impl-connector.md#step-2--identify-target-connection).
 
 The `--detail` payload differs in two places between modes: `authentication` (`"connector"` vs `"manual"`), and the connector-binding fields `targetConnector` / `connectionId` / `folderKey` (connector mode only; `url` is then relative to the connector base, vs. an absolute URL in manual mode). Everything else (node add, dynamic values, branches, edges, debug) is shared.
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
@@ -12,7 +12,7 @@
 
 | Situation | Use Managed HTTP? |
 | --- | --- |
-| Connector exists but lacks the specific curated activity | Yes — connector mode ([impl-connector.md](impl-connector.md)) |
+| Connector exists but lacks the specific curated activity | Yes — connector mode ([impl-connector.md](impl-connector.md)), **if the connector supports HTTP request activity** (verify `HasHttpRequest` — see [Prerequisites](#prerequisites)) |
 | No connector exists, but service has a REST API | Yes — manual mode ([impl-manual.md](impl-manual.md)) |
 | Quick prototyping against any REST API | Yes — manual mode ([impl-manual.md](impl-manual.md)) |
 | Connector exists and covers the use case | No — use [Connector Activity](../connector/planning.md) |
@@ -92,6 +92,7 @@ Run `uip maestro flow node configure` with a `--detail` JSON. The CLI builds the
 ## Prerequisites
 
 - `uip login` required (for both modes — node type comes from registry)
+- For connector mode: connector must support the HTTP request activity — verify the `HasHttpRequest` flag via `uip is connectors get "<connector-key>"`. See [impl-connector.md Step 2](impl-connector.md#step-2--identify-target-connection).
 - For connector mode: a healthy IS connection must exist for the **target connector**. If none exists, auto-fall-through to manual mode is the recommended fallback — but confirm the mode switch with the user before finalizing. See [impl-connector.md Step 2 — HTTP-specific recovery](impl-connector.md#step-2--identify-target-connection) for the `AskUserQuestion` flow (switch-to-manual / create-now / skip).
 - `uip maestro flow registry pull` to cache the `core.action.http.v2` definition
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
@@ -1,6 +1,6 @@
 # HTTP Request Node — Planning
 
-> **MUST READ FIRST:** [/uipath:uipath-platform — http-request.md](../../../../../../uipath-platform/references/integration-service/http-request.md). This file is the flow-specific authoring layer on top.
+> **MUST READ FIRST — confirm Managed HTTP Request fits your use case before authoring:** [/uipath:uipath-platform — http-request.md](../../../../../../uipath-platform/references/integration-service/http-request.md). This planning doc is the flow-specific layer on top of it.
 
 ## Node Type
 
@@ -76,7 +76,7 @@ Run `uip maestro flow node configure` with a `--detail` JSON. The CLI builds the
 | `url` | No | API endpoint URL/path (e.g., `"/conversations.replies"`). Auto-fills both `bodyParameters.path` and `bodyParameters.url`. |
 | `query` | No | Query parameters as key-value object |
 | `headers` | No | Additional headers as key-value object |
-| `body` | No | Request body (for POST/PUT/PATCH) |
+| `body` | No | Request body (for POST/PUT/PATCH). Connector mode is **`application/json` only** (request and response) — no other content type. |
 
 **Manual mode** (no connector auth):
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/http/planning.md
@@ -92,7 +92,7 @@ Run `uip maestro flow node configure` with a `--detail` JSON. The CLI builds the
 ## Prerequisites
 
 - `uip login` required (for both modes — node type comes from registry)
-- For connector mode: connector must support the HTTP request activity — verify the `HasHttpRequest` flag via `uip is connectors get "<connector-key>"`. See [impl-connector.md Step 2](impl-connector.md#step-2--identify-target-connection).
+- For connector mode: connector must support the HTTP request activity — verify the `HasHttpRequest` flag via `uip is connectors get "<connector-key>"`. If false, fall back to manual mode — confirm the switch with the user before finalizing. See [impl-connector.md Step 2](impl-connector.md#step-2--identify-target-connection).
 - For connector mode: a healthy IS connection must exist for the **target connector**. If none exists, auto-fall-through to manual mode is the recommended fallback — but confirm the mode switch with the user before finalizing. See [impl-connector.md Step 2 — HTTP-specific recovery](impl-connector.md#step-2--identify-target-connection) for the `AskUserQuestion` flow (switch-to-manual / create-now / skip).
 - `uip maestro flow registry pull` to cache the `core.action.http.v2` definition
 

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -17,6 +17,7 @@ A built-in way to make an HTTP call from a UiPath automation. Runs in two modes 
 
 ## Connector-Mode Rules
 
+- **Connector mode only works if the connector supports HTTP request activity** — verify by running `uip is connectors get "<connector-key>"` and checking the `HasHttpRequest` flag.
 - `url` must be **relative**. Wrong: `"url": "https://example.atlassian.net/rest/api/2/issue"`. Right: `"url": "/issue"`.
 - The connection's base URL is prepended automatically.
 - The auth header is applied automatically - do not set `Authorization`.

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -21,7 +21,7 @@ A built-in way to make an HTTP call from a UiPath automation. Runs in two modes 
 - `url` must be **relative**. Wrong: `"url": "https://example.atlassian.net/rest/api/2/issue"`. Right: `"url": "/issue"`.
 - The connection's base URL is prepended automatically.
 - The auth header is applied automatically - do not set `Authorization`.
-- **`application/json` only - request and response.** No other content type is supported. If the operation requires or returns a non-JSON body, connector mode cannot call it - use a curated connector activity.
+- **`application/json` only - request and response.** No other content type is supported. File upload/download operations are the most common violation (`multipart/form-data`, `application/octet-stream`, binary/stream responses) - check the operation's request and response content types before authoring. If non-JSON, connector mode cannot call it - use a curated connector activity; if none exists, surface to the user.
 - Get the exact vendor base URL for a connection via (so you can compose the relative `url` correctly):
 
 ```bash

--- a/skills/uipath-platform/references/integration-service/http-request.md
+++ b/skills/uipath-platform/references/integration-service/http-request.md
@@ -8,7 +8,7 @@ Consumers: Maestro Flow, Maestro BPMN, API Workflows, Case Management, etc. Each
 
 ## What is Managed HTTP Request?
 
-A built-in way to make an HTTP call from a UiPath automation when there's no curated activity for it. Runs in two modes - **connector mode** and **manual mode**:
+A built-in way to make an HTTP call from a UiPath automation. Runs in two modes - **connector mode** and **manual mode**:
 
 | Mode | When | `url` | Auth |
 |---|---|---|---|
@@ -20,6 +20,7 @@ A built-in way to make an HTTP call from a UiPath automation when there's no cur
 - `url` must be **relative**. Wrong: `"url": "https://example.atlassian.net/rest/api/2/issue"`. Right: `"url": "/issue"`.
 - The connection's base URL is prepended automatically.
 - The auth header is applied automatically - do not set `Authorization`.
+- **`application/json` only - request and response.** No other content type is supported. If the operation requires or returns a non-JSON body, connector mode cannot call it - use a curated connector activity.
 - Get the exact vendor base URL for a connection via (so you can compose the relative `url` correctly):
 
 ```bash
@@ -58,7 +59,7 @@ uip is resources run create "<connector-key>" http-request \
 | `method` | Yes | Uppercase HTTP verb |
 | `url` | Yes | **Relative** to the connection's vendor base URL (same convention as Managed HTTP Request connector mode) |
 | `headers` | No | Extra headers. Do NOT set `Authorization`. |
-| `body` | For POST/PUT/PATCH | **Stringified** JSON. Only `application/json` is supported today - non-JSON content types (form-urlencoded, XML, multipart, plain text) are not. |
+| `body` | For POST/PUT/PATCH | **Stringified** JSON. Only `application/json` is supported today — no other content type. |
 
 `http-request` command uses the same connection that Managed HTTP Request will use at runtime, so auth + base URL are applied automatically - same convention as Managed HTTP Request itself.
 
@@ -114,3 +115,4 @@ All steps 1-2 are GETs because we are in the authoring phase. The POST to `/issu
 2. **Do NOT use an absolute URL in connector-mode `url`.** Wrong: `"url": "https://example.atlassian.net/rest/api/2/project"`. Right: `"url": "/project"`.
 3. **Do NOT issue writes via CLI during authoring.** See "Read-Only During Authoring" above.
 4. **Do NOT guess the base URL.** Use `uip is connections base-url <connection-id>`.
+5. **In connector mode, request and response bodies are `application/json` only.** No other content type is supported; do NOT set `Content-Type` to anything else. Same rule applies to the `http-request` helper command body (it runs through a connection). Manual mode has no such limit — you supply your own `Content-Type` and body.


### PR DESCRIPTION
## Summary

Make two connector-mode limits of Managed HTTP Request explicit where agents read and write:

1. **Connector mode needs HTTP support** - it only works if the connector exposes the HTTP request activity (`HasHttpRequest`).
2. **Connector mode is JSON-only** - it sends and accepts `application/json` only, for both request and response.

Manual mode has neither limit.

## Why

Both rules were easy to miss. The JSON-only limit lived in a single table cell scoped to the `http-request` helper, not the node itself, and was absent from the Flow node-authoring docs. Nothing told an agent to check `HasHttpRequest` before picking connector mode, or that a non-JSON body won't work - so it would author one anyway and fail at runtime.

## What changed

Stated both rules in the spots an agent hits while building an HTTP node:

- **platform `http-request.md`** - Connector-Mode Rules: added the `HasHttpRequest` check and the JSON-only rule; new Critical Rule #5; small wording fix to the "What is Managed HTTP Request?" definition.
- **`http/impl.md`** - `HasHttpRequest` verification at the connector step + JSON-only note at the configure step.
- **`http/planning.md`** - `HasHttpRequest` condition on the connector-mode row and a new Prerequisites bullet; JSON-only on the `body` row; sharper MUST-READ-FIRST pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)