### PR TITLE
docs(admin,governance): add reciprocal cross-redirects to descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ The repository ships skills covering authoring, platform operations, and diagnos
 | Skill | Description |
 |-------|-------------|
 | **uipath-platform** | Platform ops via `uip` CLI — auth, Orchestrator (folders, assets, queues, buckets, jobs, triggers), Integration Service, Data Fabric (entities and records), LLM Gateway, traces, licensing. |
-| **uipath-admin** | UiPath Admin — Identity Server, Authorization (custom roles, role assignments, PDP), OMS (org, tenants, services, regions), IP restriction, audit; governance policies (AOps product policies and Access ToolUsePolicy). |
+| **uipath-admin** | UiPath Admin — Identity Server, Authorization (custom roles, role assignments, PDP), OMS (org, tenants, services, regions), IP restriction, audit. |
+| **uipath-governance** | Governance via `uip gov` — author and deploy policies: AOps product policies (block/restrict/enforce features in Studio, StudioX, Assistant, Robot, AI Trust Layer, Agent Builder) and Access ToolUsePolicy (allow/deny workflow-to-workflow tool calls). |
 | **uipath-test** | Test Manager — manage projects, cases, sets, executions; generate persona-tailored test reports. |
 
 ### Diagnostics & Feedback

--- a/skills/uipath-admin/SKILL.md
+++ b/skills/uipath-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-admin
-description: "UiPath Admin via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps, secrets), Authorization (custom roles, role assignments, permission catalog, effective-access via check-access PDP), OMS (org read/update, tenant lifecycle, service provisioning, regions, async operation polling), IP Restriction (allowlist, enforcement switch, bypass rules, lockout safety), Audit (event sources, paginated queries, ZIP exports — login history, compliance dumps, who-did-what-when-where on a resource). For Orchestrator-specific roles/permissions/folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
+description: "UiPath Admin via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps, secrets), Authorization (custom roles, role assignments, permission catalog, effective-access via check-access PDP), OMS (org read/update, tenant lifecycle, service provisioning, regions, async operation polling), IP Restriction (allowlist, enforcement switch, bypass rules, lockout safety), Audit (event sources, paginated queries, ZIP exports — login history, compliance dumps, who-did-what-when-where on a resource). For policies that block/restrict/enforce product features or gate tool-use access→uipath-governance. For Orchestrator-specific roles/permissions/folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 

--- a/skills/uipath-governance/SKILL.md
+++ b/skills/uipath-governance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-governance
-description: "UiPath governance via `uip gov` — author and deploy policies on two layers. AOps product policies (`uip gov aops-policy`): block/restrict/enforce features in Studio, StudioX, Assistant, Robot, AI Trust Layer, Agent Builder; deploy to user/group/tenant. Access ToolUsePolicy (`uip gov access-policy`): allow/deny when one workflow invokes another as a tool (Agent→Agent/Maestro/Flow/RPA/API/Case), gated by tag, caller, or actor (User/Group). Skill classifies product-layer vs resource/tool-use intent before authoring. For platform ops→uipath-platform."
+description: "UiPath governance via `uip gov` — author and deploy policies on two layers. AOps product policies (`uip gov aops-policy`): block/restrict/enforce features in Studio, StudioX, Assistant, Robot, AI Trust Layer, Agent Builder; deploy to user/group/tenant. Access ToolUsePolicy (`uip gov access-policy`): allow/deny when one workflow invokes another as a tool (Agent→Agent/Maestro/Flow/RPA/API/Case), gated by tag, caller, or actor (User/Group). Skill classifies product-layer vs resource/tool-use intent before authoring. For users/groups/roles/permissions/role assignments/PATs/audit→uipath-admin. For platform ops→uipath-platform."
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
 ---
 
@@ -29,6 +29,7 @@ Activate on **any** governance / policy / rule intent — even when the user did
 - `compliance / posture / audit` framing on top of policies
 
 **Sibling redirects:**
+- Users / groups / roles / permissions / role assignments / PATs / audit (identity & authorization, not policy) → `uipath-admin`
 - Platform ops (auth, Orchestrator resources, packaging, deploy) → `uipath-platform`
 - Authoring agents / workflows / RPA themselves → `uipath-agents` / `uipath-rpa` / `uipath-maestro-flow`
 


### PR DESCRIPTION
## What

Implements **Option 1** from the decision memo [_Keep uipath-admin and uipath-governance as Separate Skills_](https://uipath.atlassian.net/wiki/spaces/CC/pages/90752352259/Decision+Memo+Keep+uipath-admin+and+uipath-governance+as+Separate+Skills): keep the two skills separate and close the discoverability gap with **sharper descriptions + reciprocal `→` cross-redirects**, rather than merging them.

This is the "single highest-leverage fix … ships in one small PR" called out in the memo's recommendation.

## Changes

- **`skills/uipath-admin/SKILL.md`** — description now redirects policy intent away from admin's `Authorization` section:
  > `For policies that block/restrict/enforce product features or gate tool-use access→uipath-governance.`
- **`skills/uipath-governance/SKILL.md`** — description now redirects identity/authorization intent to admin, plus a matching **Sibling redirects** bullet in the body:
  > `For users/groups/roles/permissions/role assignments/PATs/audit→uipath-admin.`
- **`README.md`** — corrects the skill catalog (which a recent refresh, #1112, had skewed): removed the `governance policies (AOps … Access ToolUsePolicy)` clause that had folded governance into the **uipath-admin** row, and added a proper **uipath-governance** row.

## Why

The memo's strongest concern is the `"policy"` (governance) vs `"role/permission"` (admin) mis-route. The two descriptions previously had no reciprocal pointer, so each domain's vocabulary could pull intent to the wrong skill. Reciprocal `→` redirects resolve this without the token/latency cost of a merge — the pattern the repo already uses elsewhere (e.g. admin → `uipath-platform`).

## Validation

- Both descriptions pass the 1024-char hook: **uipath-admin 725**, **uipath-governance 629** (`hooks/validate-skill-descriptions.sh`).
- No cross-skill imports introduced; skills remain self-contained.
- Branch rebased on latest `origin/main`.

## Follow-up

Measure mis-route rate before/after with the repo's `skill-compare` experiment to confirm the routing improvement, as the memo proposes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
