### PR TITLE
feat(coded-apps-skill): update SDK references for latest TypeScript SDK

### DIFF
--- a/skills/uipath-coded-apps/references/oauth-scopes.md
+++ b/skills/uipath-coded-apps/references/oauth-scopes.md
@@ -47,11 +47,14 @@ Use this reference to:
 
 | Method | Required Scope |
 |--------|----------------|
-| `getAll()` | `OR.Administration` or `OR.Administration.Read` |
-| `getById()` | `OR.Administration` or `OR.Administration.Read` |
-| `getFileMetaData()` | `OR.Administration` or `OR.Administration.Read` |
-| `getReadUri()` | `OR.Administration` or `OR.Administration.Read` |
-| `uploadFile()` | `OR.Administration` or `OR.Administration.Read` |
+| `getAll()` | `OR.Buckets` or `OR.Buckets.Read` |
+| `getById()` | `OR.Buckets` or `OR.Buckets.Read` |
+| `getByName()` | `OR.Buckets` or `OR.Buckets.Read` |
+| `getFiles()` | `OR.Buckets` or `OR.Buckets.Read` |
+| `getFileMetaData()` | `OR.Buckets` or `OR.Buckets.Read` |
+| `getReadUri()` | `OR.Buckets` or `OR.Buckets.Read` |
+| `uploadFile()` | `OR.Buckets` |
+| `deleteFile()` | `OR.Buckets` or `OR.Buckets.Write` |
 
 ---
 
@@ -136,6 +139,8 @@ Use this reference to:
 |--------|----------------|
 | `getAll()` | `PIMS` |
 | `getIncidents()` | `PIMS` |
+| `getInstanceStatusTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopRunCount()` / `getTopFaultedCount()` / `getTopExecutionDuration()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Maestro Process Incidents (standalone)
 
@@ -150,6 +155,8 @@ Use this reference to:
 | Method | Required Scope |
 |--------|----------------|
 | `getAll()` | `PIMS` |
+| `getInstanceStatusTimeline()` | `Insights.RealTimeData Insights OR.Folders.Read` |
+| `getTopRunCount()` / `getTopFaultedCount()` / `getTopExecutionDuration()` | `Insights.RealTimeData Insights OR.Folders.Read` |
 
 ## Case Instances
 
@@ -161,6 +168,7 @@ Use this reference to:
 | `close()` / `pause()` / `resume()` / `reopen()` | `PIMS` |
 | `getExecutionHistory()` | `PIMS` |
 | `getActionTasks()` | `OR.Tasks` or `OR.Tasks.Read` |
+| `getSlaSummary()` / `getStagesSlaSummary()` | `Insights.RealTimeData Insights OR.Folders.Read PIMS` |
 
 ---
 
@@ -198,6 +206,13 @@ Combined scopes required: `OR.Execution` · `OR.Folders` · `OR.Jobs` · `Conver
 |--------|----------------|
 | `getById()` / `getContentPartById()` | `OR.Execution.Read`, `OR.Jobs.Read` |
 
+### User Settings (`conversationalAgent.user`)
+
+| Method | Required Scope |
+|--------|----------------|
+| `getSettings()` | `OR.Users` or `OR.Users.Read` |
+| `updateSettings()` | `OR.Users` |
+
 ---
 
 ## Agent Feedback
@@ -206,6 +221,12 @@ Combined scopes required: `OR.Execution` · `OR.Folders` · `OR.Jobs` · `Conver
 |--------|----------------|
 | `getAll()` | `Traces.Api` |
 | `getById()` | `Traces.Api` |
+| `getCategories()` | `Traces.Api` |
+| `submit()` | `Traces.Api` |
+| `updateById()` | `Traces.Api` |
+| `deleteById()` | `Traces.Api` |
+| `createCategory()` | `Traces.Api` |
+| `deleteCategory()` | `Traces.Api` |
 
 ---
 
@@ -219,4 +240,5 @@ Combined scopes required: `OR.Execution` · `OR.Folders` · `OR.Jobs` · `Conver
 | Orchestrator Processes (list + start) | `OR.Execution OR.Jobs` |
 | Orchestrator Jobs (list + read output) | `OR.Jobs.Read OR.Folders.Read` (add `OR.Folders.Read` so `Jobs.getOutput()` can resolve file-type output arguments via Attachments) |
 | Maestro full access | `PIMS OR.Execution.Read` |
-| Conversational Agent | `OR.Execution OR.Folders OR.Jobs ConversationalAgents Traces.Api` |
+| Maestro analytics / insights dashboards (top run/fault/duration counts, status timelines, SLA) | add `Insights.RealTimeData Insights OR.Folders.Read` (SLA summaries also need `PIMS`) |
+| Conversational Agent | `OR.Execution OR.Folders OR.Jobs ConversationalAgents Traces.Api` (add `OR.Users` for user-settings read/write) |

--- a/skills/uipath-coded-apps/references/sdk/conversational-agent.md
+++ b/skills/uipath-coded-apps/references/sdk/conversational-agent.md
@@ -18,6 +18,8 @@ Combined scopes needed: `OR.Execution` `OR.Folders` `OR.Jobs` `ConversationalAge
 - startSession: `OR.Execution`, `OR.Jobs`, `ConversationalAgents`
 - Exchanges (read): `OR.Execution` or `OR.Execution.Read`, `OR.Jobs` or `OR.Jobs.Read`
 - Feedback: `OR.Execution`, `OR.Jobs`, `Traces.Api`
+- User Settings (getSettings): `OR.Users` or `OR.Users.Read`
+- User Settings (updateSettings): `OR.Users`
 
 ## Types to Import
 
@@ -60,6 +62,13 @@ import type {
 import type {
   MessageGetResponse,
   ContentPartGetResponse,
+} from '@uipath/uipath-typescript/conversational-agent';
+
+// User settings types
+import type {
+  UserSettingsGetResponse,
+  UserSettingsUpdateOptions,
+  UserSettingsUpdateResponse,
 } from '@uipath/uipath-typescript/conversational-agent';
 
 // Core conversation types
@@ -128,6 +137,27 @@ Registers a handler called whenever the WebSocket connection status changes. Ret
 
 Access to `ConversationService` for conversation CRUD and real-time sessions. See Conversation Service below.
 
+### user (property)
+
+Access to `UserSettingsService` — the signed-in user's agent profile. See User Settings Service below.
+
+## User Settings Service
+
+Accessed via `conversationalAgent.user`. Manages the current user's conversational-agent profile (display name, contact, locale).
+
+### getSettings()
+
+Returns `Promise<UserSettingsGetResponse>`. Includes `name`, `email`, `role`, `department`, `company`, `country`, `timezone`, plus identifiers and timestamps. **Note:** Exact fields are not fully published; check the TypeScript types. Scope: `OR.Users` or `OR.Users.Read`.
+
+### updateSettings(options: UserSettingsUpdateOptions)
+
+Returns `Promise<UserSettingsUpdateResponse>`. Partial update — send only the fields you want to change; pass `null` to clear a field. Scope: `OR.Users`.
+
+```typescript
+const settings = await conversationalAgent.user.getSettings();
+await conversationalAgent.user.updateSettings({ timezone: 'America/New_York', department: null });
+```
+
 ## Agent-Attached Methods (AgentMethods)
 
 Each agent returned by `getAll()` or `getById()` has these attached properties:
@@ -195,6 +225,10 @@ Returns `SessionStream | undefined` — the active session for the conversation,
 ### endSession(conversationId: string)
 
 Ends the active session. No-op if no session exists.
+
+### disconnect()
+
+Tears down the underlying WebSocket connection and ends **all** active sessions for this service. Use on app unmount / agent switch to release the socket; `endSession(conversationId)` ends just one conversation's session.
 
 ### sessions (getter)
 

--- a/skills/uipath-coded-apps/references/sdk/feedback.md
+++ b/skills/uipath-coded-apps/references/sdk/feedback.md
@@ -10,16 +10,24 @@ import { Feedback } from '@uipath/uipath-typescript/feedback';
 
 ## Scopes
 
-`Traces.Api` — for both `getAll()` and `getById()`.
+`Traces.Api` — for **every** method (reads, writes, and category management).
 
 ## Types to Import
 
 ```typescript
 import type {
   FeedbackGetResponse,
+  FeedbackResponse,
   FeedbackGetAllOptions,
   FeedbackOptions,
+  FeedbackSubmitOptions,
+  FeedbackUpdateOptions,
+  FeedbackGetCategoriesOptions,
+  FeedbackCreateCategoryOptions,
+  FeedbackDeleteCategoryOptions,
   FeedbackCategory,
+  FeedbackCategoryInput,
+  FeedbackCategoryResponse,
 } from '@uipath/uipath-typescript/feedback';
 ```
 
@@ -46,7 +54,31 @@ Returns `Promise<FeedbackGetResponse>`. **`options.folderKey` is required** — 
 
 `FeedbackCategory` fields: `id`, `category`, `createdAt`, `isDefault`, `isPositive`, `isNegative`. Default categories (Output, Agent Error, Agent Plan Execution) are auto-created per tenant.
 
-## Usage Example
+### submit(traceId: string, isPositive: boolean, options: FeedbackSubmitOptions)
+
+Returns `Promise<FeedbackResponse>`. Creates a new feedback entry against an agent trace. `isPositive` is the thumbs-up/down. **`options.folderKey` is required.** Other `FeedbackSubmitOptions` fields (all optional): `agentId`, `agentVersion`, `comment`, `metadata` (string), `spanId`, `spanType`, `categories: FeedbackCategoryInput[]`.
+
+### updateById(id: string, isPositive: boolean, options: FeedbackUpdateOptions)
+
+Returns `Promise<FeedbackResponse>`. Updates an existing feedback entry. **`options.folderKey` is required.** Optional fields: `comment`, `metadata`, `categories: FeedbackCategoryInput[]`.
+
+### deleteById(id: string, options: FeedbackOptions)
+
+Returns `Promise<void>`. **`options.folderKey` is required.**
+
+### getCategories(options?: FeedbackGetCategoriesOptions)
+
+Returns `NonPaginatedResponse<FeedbackCategoryResponse>` or `PaginatedResponse<FeedbackCategoryResponse>`. Lists feedback categories (default + custom). `FeedbackCategoryResponse` fields: `id`, `category`, `createdTime`, `isDefault`, `isPositive`, `isNegative`.
+
+### createCategory(category: string, options?: FeedbackCreateCategoryOptions)
+
+Returns `Promise<FeedbackCategoryResponse>`. Creates a custom category. `FeedbackCreateCategoryOptions`: `isPositive?` (defaults `true`), `isNegative?` (defaults `true`) — set the flags to scope the category to one rating direction.
+
+### deleteCategory(id: string, options?: FeedbackDeleteCategoryOptions)
+
+Returns `Promise<void>`. Deletes a custom category. Default tenant categories cannot be removed.
+
+## Usage Example — Feedback Inbox
 
 ```typescript
 import { useMemo, useEffect, useState } from 'react';
@@ -77,4 +109,34 @@ function FeedbackInbox({ agentId }: { agentId: string }) {
     console.log(detail.comment, detail.feedbackCategories);
   };
 }
+```
+
+## Usage Example — Submitting & Managing Feedback
+
+```typescript
+import { Feedback } from '@uipath/uipath-typescript/feedback';
+
+const feedback = new Feedback(sdk);
+
+// Submit thumbs-up on an agent trace
+const created = await feedback.submit(traceId, true, {
+  folderKey,                      // required
+  agentId,
+  comment: 'Accurate and well-structured answer',
+  categories: [{ category: 'Output', isPositive: true }],
+});
+
+// Flip it to thumbs-down and edit the comment
+await feedback.updateById(created.id, false, {
+  folderKey,
+  comment: 'On second read, the figures were wrong',
+});
+
+// Manage categories
+const categories = await feedback.getCategories({ pageSize: 50 });
+const custom = await feedback.createCategory('Tone', { isNegative: true, isPositive: false });
+await feedback.deleteCategory(custom.id);
+
+// Remove the entry
+await feedback.deleteById(created.id, { folderKey });
 ```

--- a/skills/uipath-coded-apps/references/sdk/maestro.md
+++ b/skills/uipath-coded-apps/references/sdk/maestro.md
@@ -45,9 +45,22 @@ import type {
   ProcessIncidentGetAllResponse,
 } from '@uipath/uipath-typescript/maestro-processes';
 
+// Analytics / Insights (MaestroProcesses + Cases)
+import type {
+  TimelineOptions,
+  TopQueryOptions,
+  InstanceStatusTimelineResponse,
+  ProcessGetTopRunCountResponse,
+  ProcessGetTopFaultedCountResponse,
+  ProcessGetTopDurationResponse,
+} from '@uipath/uipath-typescript/maestro-processes';
+
 // Cases
 import type {
   CaseGetAllResponse,
+  CaseGetTopRunCountResponse,
+  CaseGetTopFaultedCountResponse,
+  CaseGetTopDurationResponse,
 } from '@uipath/uipath-typescript/cases';
 
 // Case Instances
@@ -63,6 +76,9 @@ import type {
   CaseGetStageResponse,
   CaseInstanceExecutionHistoryResponse,
   StageTask,
+  SlaSummaryResponse,
+  CaseInstanceStageSLAOptions,
+  CaseInstanceStageSLAResponse,
 } from '@uipath/uipath-typescript/cases';
 ```
 
@@ -74,6 +90,8 @@ import {
   ProcessIncidentType,      // System, User, Deployment
   ProcessIncidentSeverity,  // Error, Warning
   DebugMode,                // None, Default, StepByStep, SingleStep
+  TimeInterval,             // Hour = 'HOUR', Day = 'DAY', Week = 'WEEK' (analytics time-axis grouping)
+  InstanceFinalStatus,      // status value in getInstanceStatusTimeline() entries
 } from '@uipath/uipath-typescript/maestro-processes';
 
 import {
@@ -107,6 +125,39 @@ const instances = await processInstances.getAll({ processKey: target.processKey,
 ### getIncidents(processKey: string, folderKey: string)
 
 Returns `Promise<ProcessIncidentGetResponse[]>`. Each incident has: `instanceId`, `elementId`, `folderKey`, `processKey`, `incidentId`, `incidentStatus`, `incidentType`, `errorCode`, `errorMessage`, `errorTime`, `errorDetails`, `debugMode`, `incidentSeverity`, `incidentElementActivityType`, `incidentElementActivityName`.
+
+### Analytics / Insights methods
+
+Tenant-wide, time-ranged aggregates for dashboards. **All require `Insights.RealTimeData Insights OR.Folders.Read` scope** (not `PIMS`) — a separate scope bundle from the rest of Maestro. `startTime`/`endTime` are `Date` objects. Use these instead of fetching raw instances and aggregating client-side (which only sees one page — see [pagination.md](pagination.md)).
+
+#### getInstanceStatusTimeline(startTime: Date, endTime: Date, options?: TimelineOptions)
+
+Returns `Promise<InstanceStatusTimelineResponse[]>` — instance counts bucketed across the time axis. `TimelineOptions` supports `groupBy` and a `TimeInterval` (`Hour` / `Day` / `Week`) controlling bucket size. Use for "instances over time" charts. Each entry: `startTime: string` (bucket start, local tz, e.g. `"5/8/2026 12:00:00 AM"`), `status: InstanceFinalStatus`, `count: number`.
+
+#### getTopRunCount(startTime: Date, endTime: Date, options?: TopQueryOptions)
+
+Returns `Promise<ProcessGetTopRunCountResponse[]>` — processes ranked by run count. `TopQueryOptions` supports optional filters `packageId`, `processKey`, `version`. Each entry: `name: string`, `packageId: string`, `processKey: string`, `runCount: number`.
+
+#### getTopFaultedCount(startTime: Date, endTime: Date, options?: TopQueryOptions)
+
+Returns `Promise<ProcessGetTopFaultedCountResponse[]>` — processes ranked by faulted-instance count. Each entry: `name`, `packageId`, `processKey`, `faultedCount: number`.
+
+#### getTopExecutionDuration(startTime: Date, endTime: Date, options?: TopQueryOptions)
+
+Returns `Promise<ProcessGetTopDurationResponse[]>` — processes ranked by execution duration. Each entry: `name`, `packageId`, `processKey`, `duration: number`.
+
+```typescript
+import { MaestroProcesses, TimeInterval } from '@uipath/uipath-typescript/maestro-processes';
+
+const maestro = new MaestroProcesses(sdk);
+const end = new Date();
+const start = new Date(end.getTime() - 7 * 24 * 60 * 60 * 1000); // last 7 days
+
+const timeline = await maestro.getInstanceStatusTimeline(start, end, { groupBy: TimeInterval.Day });
+const busiest = await maestro.getTopRunCount(start, end);
+const flakiest = await maestro.getTopFaultedCount(start, end);
+const slowest = await maestro.getTopExecutionDuration(start, end);
+```
 
 ## Process-Attached Methods (ProcessMethods)
 
@@ -221,6 +272,15 @@ Returned by `getAll()` and `getById()` on each `ProcessInstanceGetResponse`:
 
 Returns `Promise<CaseGetAllResponse[]>`. Each case has: `processKey`, `packageId`, `name`, `folderKey`, `folderName`, `packageVersions`, `versionCount`, plus instance count fields (same as MaestroProcesses).
 
+### Analytics / Insights methods
+
+Same signatures and scope as the MaestroProcesses analytics methods above (`Insights.RealTimeData Insights OR.Folders.Read`), but scoped to cases:
+
+- `getInstanceStatusTimeline(startTime: Date, endTime: Date, options?: TimelineOptions)` → `Promise<InstanceStatusTimelineResponse[]>`
+- `getTopRunCount(startTime: Date, endTime: Date, options?: TopQueryOptions)` → `Promise<CaseGetTopRunCountResponse[]>`
+- `getTopFaultedCount(startTime: Date, endTime: Date, options?: TopQueryOptions)` → `Promise<CaseGetTopFaultedCountResponse[]>`
+- `getTopExecutionDuration(startTime: Date, endTime: Date, options?: TopQueryOptions)` → `Promise<CaseGetTopDurationResponse[]>`
+
 ## CaseInstanceGetResponse Fields
 
 `instanceId: string`, `packageKey: string`, `packageId: string`, `packageVersion: string`, `latestRunId: string`, `latestRunStatus: string`, `processKey: string`, `folderKey: string`, `userId: number`, `instanceDisplayName: string`, `startedByUser: string`, `source: string`, `creatorUserKey: string`, `startedTime: string`, `completedTime: string`, `instanceRuns: CaseInstanceRun[]`, `caseAppConfig?: CaseAppConfig`, `caseType?: string`, `caseTitle?: string`. Plus all `CaseInstanceMethods`.
@@ -270,6 +330,14 @@ Returns `Promise<CaseInstanceExecutionHistoryResponse>` with `{ elementExecution
 ### getActionTasks(caseInstanceId: string, options?: TaskGetAllOptions)
 
 Returns `NonPaginatedResponse<TaskGetResponse>` or `PaginatedResponse<TaskGetResponse>`. Requires `OR.Tasks` scope.
+
+### getSlaSummary(options?)
+
+Returns `NonPaginatedResponse<SlaSummaryResponse>` or `PaginatedResponse<SlaSummaryResponse>` (pass pagination options to get the paginated shape). Tenant-wide SLA rollup across case instances. **Requires `Insights.RealTimeData Insights OR.Folders.Read PIMS` scope.**
+
+### getStagesSlaSummary(options?: CaseInstanceStageSLAOptions)
+
+Returns `Promise<CaseInstanceStageSLAResponse[]>` — per-stage SLA breakdown. Same scope as `getSlaSummary`. **Note:** Exact response fields are not fully published; check the TypeScript types.
 
 ## CaseInstance-Attached Methods (CaseInstanceMethods)
 

--- a/skills/uipath-coded-apps/references/sdk/orchestrator.md
+++ b/skills/uipath-coded-apps/references/sdk/orchestrator.md
@@ -45,12 +45,16 @@ import type {
   BucketGetResponse,
   BucketGetAllOptions,
   BucketGetByIdOptions,
+  BucketGetByNameOptions,
+  BucketGetFilesOptions,
+  BucketFile,
   BucketGetFileMetaDataWithPaginationOptions,
   BucketGetFileMetaDataOptions,
   BucketGetReadUriOptions,
   BucketGetUriResponse,
   BucketUploadFileOptions,
   BucketUploadResponse,
+  BucketDeleteFileOptions,
   BlobItem,
 } from '@uipath/uipath-typescript/buckets';
 
@@ -141,7 +145,7 @@ Returns `Promise<QueueGetResponse>`. The `folderId` is required.
 
 `QueueGetResponse` fields: `key`, `name`, `id`, `description`, `maxNumberOfRetries`, `acceptAutomaticallyRetry`, `retryAbandonedItems`, `enforceUniqueReference`, `encrypted`, `createdTime`, `slaInMinutes`, `riskSlaInMinutes`, `folderId`, `folderName`.
 
-## Buckets Service (Scopes: `OR.Administration` or `OR.Administration.Read`)
+## Buckets Service (Scopes: `OR.Buckets` or `OR.Buckets.Read`; `OR.Buckets.Write` for `deleteFile`)
 
 ### getAll(options?: BucketGetAllOptions)
 
@@ -152,6 +156,16 @@ Returns `NonPaginatedResponse<BucketGetResponse>` or `PaginatedResponse<BucketGe
 Returns `Promise<BucketGetResponse>`.
 
 `BucketGetResponse` fields: `id`, `name`, `description`, `identifier`, `storageProvider`, `storageContainer`, `options`, `foldersCount`.
+
+### getByName(name: string, options?: BucketGetByNameOptions)
+
+Returns `Promise<BucketGetResponse>`. Resolves a bucket by name within a folder. `BucketGetByNameOptions` is `FolderScopedOptions` — supply one of `folderId`, `folderKey`, or `folderPath` (same precedence as Assets/Processes) plus optional `expand` / `select`. Throws `NotFoundError` if no bucket matches.
+
+### getFiles(bucketId: number, options?: BucketGetFilesOptions)
+
+Returns `NonPaginatedResponse<BucketFile>` or `PaginatedResponse<BucketFile>`. Folder-scoped (`folderId` / `folderKey` / `folderPath`); supports regex filtering, query options, and pagination. Each `BucketFile` includes `isDirectory` so callers can distinguish folders from files. **Note:** Additional fields may be available — check the TypeScript types.
+
+> **`getFiles` vs `getFileMetaData`.** `getFiles` returns `BucketFile` items (folder-aware, supports regex filtering) and is folder-scoped via `FolderScopedOptions`. `getFileMetaData` returns flat `BlobItem` items by `prefix` and takes a positional `folderId`. Prefer `getFiles` for directory-style browsing.
 
 ### getFileMetaData(bucketId: number, folderId: number, options?: BucketGetFileMetaDataWithPaginationOptions)
 
@@ -164,6 +178,10 @@ Returns `Promise<BucketUploadResponse>` with `{ success, statusCode }`. Options:
 ### getReadUri(options: BucketGetReadUriOptions)
 
 Returns `Promise<BucketGetUriResponse>` with `{ uri, httpMethod, requiresAuth, headers }`. Options: `{ bucketId, folderId, path, expiryInMinutes? }`.
+
+### deleteFile(bucketId: number, path: string, options?: BucketDeleteFileOptions)
+
+Returns `Promise<void>`. Deletes a single file from the bucket by `path`. `BucketDeleteFileOptions` is folder-scoped (`folderId` / `folderKey` / `folderPath`). Requires `OR.Buckets` or `OR.Buckets.Write`.
 
 ## Processes Service (Scopes: `OR.Execution` / `OR.Execution.Read`, `OR.Jobs` / `OR.Jobs.Write` for start)
 


### PR DESCRIPTION
Brings the `uipath-coded-apps` skill's SDK references in line with the current `@uipath/uipath-typescript` docs (uipath.github.io/uipath-typescript).

## Correctness fix
- **Buckets OAuth scope was wrong** (`OR.Administration` → `OR.Buckets` / `.Read` / `.Write`). Apps following the old doc requested the wrong scope and hit silent 401/403.

## New feature coverage
- **Maestro analytics / insights** — `getInstanceStatusTimeline`, `getTopRunCount`, `getTopFaultedCount`, `getTopExecutionDuration` (MaestroProcesses + Cases), `getSlaSummary` / `getStagesSlaSummary` (CaseInstances), `TimeInterval` / `InstanceFinalStatus` enums, `Insights.*` scopes.
- **Feedback writes** — `submit`, `updateById`, `deleteById`, `getCategories`, `createCategory`, `deleteCategory` (was read-only).
- **Buckets** — `getByName`, `getFiles`, `deleteFile`.
- **Conversational Agent** — `conversationalAgent.user` user-settings sub-service, `disconnect()`, `OR.Users` scopes.

Scope tables in `oauth-scopes.md` updated to match. Method signatures and response fields verified against the official API reference pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)