### PR TITLE
test(uipath-maestro-flow): tolerate CLI PascalCase output in task-local checkers (#2266)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -13,6 +13,7 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from flow_check import (  # noqa: E402
+    _get_ci,
     assert_flow_has_exact_node_type,
     assert_flow_has_node_type,
     assert_flow_uses_connector_target,
@@ -346,6 +347,21 @@ def test_is_flow_project_handles_malformed_manifest(tmp_path):
 def test_is_flow_project_handles_missing_file(tmp_path):
     missing = tmp_path / "does-not-exist.uiproj"
     assert _is_flow_project(str(missing)) is False
+
+
+def test_get_ci_tolerates_camel_and_pascal_case():
+    """_get_ci backs the debug-payload reads in the terminate/salesforce
+    checkers; it must resolve a key regardless of the CLI's output casing
+    (camelCase pre-#2266 / restored by cli #2308, PascalCase under #2266)."""
+    assert _get_ci({"finalStatus": "Completed"}, "finalStatus", "FinalStatus") == "Completed"
+    assert _get_ci({"FinalStatus": "Completed"}, "finalStatus", "FinalStatus") == "Completed"
+    # First lowercased candidate to match wins; order of args is the preference.
+    assert _get_ci({"Status": "Terminated"}, "status", "Status") == "Terminated"
+    # Missing key -> default; non-dict input -> default (never raises).
+    assert _get_ci({"Other": 1}, "status", "Status") is None
+    assert _get_ci({"Other": 1}, "status", default="x") == "x"
+    assert _get_ci(None, "status") is None
+    assert _get_ci(["not", "a", "dict"], "status") is None
 
 
 def test_find_project_dir_uses_central_filter(tmp_path, monkeypatch):

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -154,7 +154,14 @@ def check_folder_id_fresh():
     live = _uip_resources_run(
         ["list", CONNECTOR_KEY, "MailFolder", "--connection-id", conn_id, "--output", "json"]
     )
-    live_ids = {f.get("id") for f in _extract_list_items(live)}
+    # A MailFolder item exposes its id under `id` (camelCase — the connector's
+    # native shape, restored for `resources run` by uipath-cli #2308) or `Id`
+    # (PascalCase — CLI #2266 output normalization). Read both, then drop None
+    # so the set can never collapse to {None}: that previously masqueraded as
+    # "1 MailFolder IDs" and tripped a FALSE PR #348 regression even when the
+    # agent had freshly resolved the folder.
+    live_ids = {(f.get("id") or f.get("Id")) for f in _extract_list_items(live)}
+    live_ids.discard(None)
     if not live_ids:
         sys.exit(
             "FAIL: resources run/execute list MailFolder returned no folders on the bound connection"

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
@@ -52,6 +52,12 @@ def _success_payload(folder_id: str = "mail-folder-1") -> str:
     return json.dumps({"Data": [{"id": folder_id}]})
 
 
+def _success_payload_pascal(folder_id: str = "mail-folder-1") -> str:
+    """`resources run list` output under CLI #2266 PascalCase normalization:
+    the item id key is `Id`, not `id`."""
+    return json.dumps({"Data": [{"Id": folder_id}]})
+
+
 def test_uses_run_verb_when_cli_supports_it(monkeypatch) -> None:
     """Happy path: post-rename CLI accepts `run`; no fallback issued."""
     checker = _load_checker()
@@ -133,3 +139,41 @@ def test_folder_id_mismatch_fails_with_pr348_signature(monkeypatch) -> None:
         assert "PR #348 regression" in str(message)
     else:
         raise AssertionError("expected SystemExit on a stale folder id")
+
+
+def test_pascalcase_item_id_resolves(monkeypatch) -> None:
+    """CLI #2266 regression: when `resources run list` returns PascalCase
+    item keys (`Id`), a freshly-resolved folder must still resolve.
+
+    On the pre-fix checker every `f.get("id")` was None, so `live_ids`
+    collapsed to {None} (cardinality 1) and a correct flow failed with a
+    bogus "1 MailFolder IDs" PR #348 regression. This locks the camelCase/
+    PascalCase tolerance."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="mail-folder-1")
+
+    def fake_run(_args, **_kwargs):
+        return _fake_proc(0, stdout=_success_payload_pascal(folder_id="mail-folder-1"))
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    # Must NOT raise: the agent's folder id is present under the PascalCase key.
+    checker.check_folder_id_fresh()
+
+
+def test_pascalcase_genuine_mismatch_still_fails(monkeypatch) -> None:
+    """Tolerating PascalCase must not weaken the check: a genuinely stale
+    id under PascalCase output still trips the PR #348 marker (not a silent
+    pass via {None})."""
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="stale-id-from-old-connection")
+
+    def fake_run(_args, **_kwargs):
+        return _fake_proc(0, stdout=_success_payload_pascal(folder_id="fresh-id"))
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    try:
+        checker.check_folder_id_fresh()
+    except SystemExit as exc:
+        assert "PR #348 regression" in str(exc.code)
+    else:
+        raise AssertionError("expected SystemExit on a stale folder id (PascalCase)")

--- a/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/check_salesforce_opportunity_list.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/check_salesforce_opportunity_list.py
@@ -26,6 +26,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
+    _get_ci,
     assert_flow_uses_connector_target,
     find_project_dir,
     run_debug,
@@ -108,7 +109,11 @@ def _assert_structure() -> None:
 
 
 def _assert_records_returned(payload: dict) -> None:
-    globals_ = (payload.get("variables") or {}).get("globals") or {}
+    # The flow debug runtime payload is PascalCase under CLI #2266
+    # (Variables/Globals) and camelCase otherwise; read both via _get_ci so
+    # the record-array search doesn't silently see {} and report no records.
+    variables = _get_ci(payload, "variables", "Variables") or {}
+    globals_ = _get_ci(variables, "globals", "Globals") or {}
     # Find any output variable holding a non-empty array of record objects.
     for name, value in globals_.items():
         if (

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
 from _shared.flow_check import (  # noqa: E402
+    _get_ci,
     assert_flow_has_node_type,
     find_project_dir,
     run_debug,
@@ -40,11 +41,21 @@ def main():
 
     payload = run_debug()
 
-    # Verify the terminate node actually killed the delay branch
-    executions = payload.get("elementExecutions") or []
-    terminated = [e for e in executions if e.get("status") == "Terminated"]
+    # Verify the terminate node actually killed the delay branch. The flow
+    # debug runtime payload is PascalCase under CLI #2266
+    # (ElementExecutions/Status/ElementId) and camelCase otherwise (and once
+    # uipath-cli #2308 restores camelCase for debug); read both via _get_ci so
+    # the detection holds across CLI versions instead of seeing [] and falsely
+    # reporting "No element was Terminated".
+    executions = _get_ci(payload, "elementExecutions", "ElementExecutions") or []
+    terminated = [
+        e for e in executions if _get_ci(e, "status", "Status") == "Terminated"
+    ]
     if not terminated:
-        statuses = [(e.get("elementId"), e.get("status")) for e in executions]
+        statuses = [
+            (_get_ci(e, "elementId", "ElementId"), _get_ci(e, "status", "Status"))
+            for e in executions
+        ]
         sys.exit(f"FAIL: No element was Terminated — terminate node didn't kill the delay branch. Statuses: {statuses}")
 
     print(f"OK: Terminate + Delay nodes present; {len(terminated)} element(s) terminated")


### PR DESCRIPTION
## Problem

`#1153` made `_shared/flow_check.py` case-insensitive (`_get_ci`), fixing the shared runtime-payload reads after `uipath-cli #2266` started PascalCasing all `--output json` `Data` keys (cli ≥ `1.2.0-alpha.20260528`). But **task-local** checkers that parse CLI json directly were never swept, so the break just resurfaced one layer deeper:

| Checker | Lowercase read on CLI output | Symptom under #2266 |
|---|---|---|
| `outlook_trigger_inbox` | `f.get("id")` on `resources run list MailFolder` | every id → `None` → `live_ids == {None}` (cardinality **1**) → false *"… NOT among the 1 MailFolder IDs … reused a reference ID"* PR #348 regression, even though the agent freshly resolved the folder |
| `terminate` | `elementExecutions` / `status` / `elementId` on `flow debug` | `[]` → *"No element was Terminated. Statuses: []"* |
| `salesforce_opportunity_list` | `variables` / `globals` on `flow debug` | `{}` → "no records returned" |

(`terminate` actually *migrated* across #1153: the 05-29 run died at the `_shared` `finalStatus` gate; once #1153 fixed that, 06-01 cleared it and died at the task-local `elementExecutions` read.)

## Fix

- Route the `flow debug` payload reads in `terminate` and `salesforce_opportunity_list` through the existing `_get_ci(...)` helper.
- In `outlook_trigger_inbox`, read the MailFolder id under both `id`/`Id` and `discard(None)` so the live set can never collapse to `{None}`.

All reads stay **tolerant of both casings**, so the suite is green whether the sandbox runs the PascalCase CLI today or a camelCase one — including after `uipath-cli #2308` restores camelCase for `flow debug` + `resources run`. Defense-in-depth paired with that CLI fix.

Scope note: only the three checkers that read CLI json by lowercase key are touched. `.flow` *source* readers (e.g. `subflow`) intentionally keep camelCase and are left alone, per the `_get_ci` docstring.

## Tests

- New PascalCase fixtures lock `check_folder_id_fresh`: a matching id under `Id` now **passes** (fails on the pre-fix `f.get("id")` code), and a genuinely stale id under PascalCase **still fails** with the PR #348 marker (the `discard(None)` fix doesn't weaken the check).
- New `_get_ci` camel/Pascal test locks the shared helper.
- Full `tests/tasks/uipath-maestro-flow/` suite: **98 passed**.

Root-cause writeup: `docs/uipath-skills/2026-06-01-skill-flow-outlook-trigger-inbox-root-cause.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)