### PR TITLE
test(maestro-flow,maestro-case): make checkers casing-agnostic for CLI #2266 + contract guard

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'tests/tasks/uipath-maestro-flow/**'
+      - 'tests/tasks/uipath-maestro-case/**'
+      - 'tests/scripts/**'
       - '.github/workflows/test-helpers.yml'
   workflow_dispatch:
 
@@ -23,3 +25,38 @@ jobs:
 
       - name: Run pytest
         run: pytest tests/tasks/uipath-maestro-flow/ -v
+
+  pytest-case-check:
+    runs-on: ubuntu-latest
+    name: maestro-case checker unit tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/tasks/uipath-maestro-case/ -v
+
+  runtime-payload-casing-guard:
+    runs-on: ubuntu-latest
+    name: runtime-payload key-casing contract guard
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      # Fails if any checker reads a runtime-only debug key (finalStatus /
+      # elementExecutions) by a hard-coded lowercase .get() instead of the
+      # case-insensitive _get_ci accessor — the CLI #2266 PascalCase break.
+      - name: Run contract guard
+        run: pytest tests/scripts/test_runtime_payload_key_casing.py -v

--- a/tests/scripts/test_runtime_payload_key_casing.py
+++ b/tests/scripts/test_runtime_payload_key_casing.py
@@ -1,0 +1,66 @@
+"""Contract guard: maestro flow/case checkers must read the debug RUNTIME
+payload case-insensitively.
+
+Background — uipath-cli PR #2266 made ``OutputFormatter`` recursively PascalCase
+every key of a ``--output json`` ``Data`` payload. Checkers written against the
+documented camelCase shape then read ``None`` and fail with misleading messages
+(``finalStatus=None``; ``Statuses: []`` for terminate; ``{None}`` ID sets for
+outlook). PR #1153 hardened ``_shared/flow_check.py`` but not the task-local
+checkers, so the break kept resurfacing one layer deeper (skill-flow-terminate,
+run 2026-06-01). The durable fix is: route every runtime-payload read through a
+case-insensitive accessor (``_get_ci``).
+
+This test fails if any checker reads a RUNTIME-ONLY key — ``finalStatus`` or
+``elementExecutions``, which exist only in debug output, never in ``.flow`` /
+``caseplan.json`` source — by a hard-coded lowercase ``.get("…")`` / ``["…"]``
+instead of through ``_get_ci``. It deliberately targets only those two
+unambiguous keys (``variables``/``outputs``/``value`` also appear in source
+files and would false-positive).
+
+Run from repo root:
+    pytest tests/scripts/test_runtime_payload_key_casing.py
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TASKS = REPO_ROOT / "tests" / "tasks"
+
+# Runtime-only debug-payload keys. They never appear in .flow / caseplan source,
+# so a literal-lowercase read of them is always an unguarded runtime read.
+RUNTIME_ONLY_KEYS = ("finalStatus", "elementExecutions")
+
+_RAW_READ = re.compile(
+    r"""\.get\(\s*['"](?:%s)['"]\s*[,)]|\[\s*['"](?:%s)['"]\s*\]"""
+    % ("|".join(RUNTIME_ONLY_KEYS), "|".join(RUNTIME_ONLY_KEYS))
+)
+
+
+def _files_to_scan():
+    # The checker contract surface: success-criteria checkers and their shared
+    # helpers. Diagnostics (e.g. canary.py) and unit tests are out of scope.
+    for path in TASKS.rglob("check_*.py"):
+        yield path
+    for shared in TASKS.rglob("_shared/*.py"):
+        if shared.name.startswith("test_"):
+            continue
+        yield shared
+
+
+def test_no_raw_lowercase_runtime_key_reads():
+    offenders = []
+    for path in sorted(_files_to_scan()):
+        for lineno, line in enumerate(path.read_text().splitlines(), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if _RAW_READ.search(line):
+                rel = path.relative_to(REPO_ROOT)
+                offenders.append(f"{rel}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Runtime debug-payload keys must be read via _get_ci (case-insensitive) so a "
+        "PascalCasing CLI (PR #2266) cannot silently break the checker. Offenders:\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/scripts/test_runtime_payload_key_casing.py
+++ b/tests/scripts/test_runtime_payload_key_casing.py
@@ -28,12 +28,19 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TASKS = REPO_ROOT / "tests" / "tasks"
 
 # Runtime-only debug-payload keys. They never appear in .flow / caseplan source,
-# so a literal-lowercase read of them is always an unguarded runtime read.
+# so a raw `.get()` / `[...]` of them (in ANY casing) is always an unguarded
+# runtime read that must go through `_get_ci` instead.
 RUNTIME_ONLY_KEYS = ("finalStatus", "elementExecutions")
 
+# IGNORECASE so a raw read in either direction is caught: `.get("finalStatus")`
+# (breaks under a PascalCasing CLI) AND `.get("FinalStatus")` (breaks under a
+# camelCase CLI). Both are unguarded — only `_get_ci` tolerates both. Matching
+# case-insensitively is safe because these key *names* are runtime-only at any
+# casing, so there is no source-reader false positive.
 _RAW_READ = re.compile(
     r"""\.get\(\s*['"](?:%s)['"]\s*[,)]|\[\s*['"](?:%s)['"]\s*\]"""
-    % ("|".join(RUNTIME_ONLY_KEYS), "|".join(RUNTIME_ONLY_KEYS))
+    % ("|".join(RUNTIME_ONLY_KEYS), "|".join(RUNTIME_ONLY_KEYS)),
+    re.IGNORECASE,
 )
 
 
@@ -64,3 +71,16 @@ def test_no_raw_lowercase_runtime_key_reads():
         "PascalCasing CLI (PR #2266) cannot silently break the checker. Offenders:\n  "
         + "\n  ".join(offenders)
     )
+
+
+def test_guard_matches_raw_reads_in_either_casing():
+    """The guard must catch a raw read in BOTH directions (camelCase that
+    breaks under a PascalCasing CLI, and PascalCase that breaks under a
+    camelCase CLI), and must NOT flag the `_get_ci` accessor form."""
+    assert _RAW_READ.search('payload.get("finalStatus")')
+    assert _RAW_READ.search('payload.get("FinalStatus")')
+    assert _RAW_READ.search("payload.get('elementExecutions')")
+    assert _RAW_READ.search('payload["ElementExecutions"]')
+    # The sanctioned form passes the key as a _get_ci positional arg, not via
+    # `.get("…")` / `[...]`, so it must NOT be flagged.
+    assert not _RAW_READ.search('_get_ci(payload, "finalStatus", "FinalStatus")')

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -281,6 +281,32 @@ def _fail(msg: str):
     sys.exit(f"FAIL: {msg}")
 
 
+def _get_ci(mapping: Any, *candidate_keys: str, default: Any = None) -> Any:
+    """Case-insensitively read the first present candidate key from ``mapping``.
+
+    The ``uip maestro case debug --output json`` RUNTIME payload uses camelCase
+    keys by Studio Web convention (``finalStatus``, ``variables``, ``outputs``,
+    ``value``). A CLI that PascalCases ``--output json`` keys (PR #2266) would
+    turn those into ``FinalStatus``/``Variables``/… and silently break every
+    lowercase read. Routing runtime-payload reads through this accessor tolerates
+    either casing and any future CLI normalization. Use it ONLY for the debug
+    RUNTIME payload — NOT for ``caseplan.json`` SOURCE readers, whose camelCase
+    keys are stable and intentional.
+
+    Candidates are tried in order; the first whose lowercased form matches a key
+    in ``mapping`` (also lowercased) wins. Returns ``default`` if ``mapping`` is
+    not a dict or no candidate matches.
+    """
+    if not isinstance(mapping, dict):
+        return default
+    lowered = {k.lower(): k for k in mapping.keys() if isinstance(k, str)}
+    for candidate in candidate_keys:
+        actual = lowered.get(candidate.lower())
+        if actual is not None:
+            return mapping[actual]
+    return default
+
+
 # ── Debug helpers ───────────────────────────────────────────────────────────
 
 
@@ -348,7 +374,7 @@ def run_debug(
         solution_glob=solution_glob,
         refresh_timeout=refresh_timeout,
     )
-    status = (payload or {}).get("finalStatus")
+    status = _get_ci(payload or {}, "finalStatus", "FinalStatus", "status", "Status")
     if status != "Completed" and status != "Successful":
         _fail(f"Case did not complete (finalStatus={status})\nPayload: {json.dumps(payload, default=str)[:2000]}")
     return payload
@@ -437,6 +463,10 @@ _METADATA_KEYS = frozenset({
     "timestamp", "occurredAt",
 })
 
+# Lowercased mirror so metadata keys are excluded regardless of the CLI's
+# key casing (a PascalCasing CLI would emit `FinalStatus`/`InstanceId`/…).
+_METADATA_KEYS_LOWER = frozenset(k.lower() for k in _METADATA_KEYS)
+
 
 def collect_outputs(payload: dict) -> list[Any]:
     """Return the declared output values from a case debug payload.
@@ -447,21 +477,24 @@ def collect_outputs(payload: dict) -> list[Any]:
     """
     out: list[Any] = []
 
-    variables = payload.get("variables") or {}
-    for val in (variables.get("globals") or {}).values():
+    variables = _get_ci(payload, "variables", "Variables") or {}
+    for val in (_get_ci(variables, "globals", "Globals") or {}).values():
         out.extend(_leaves(val))
-    for v in variables.get("globalVariables") or []:
-        if isinstance(v, dict) and "value" in v:
-            out.extend(_leaves(v.get("value")))
-    for section in ("outputs", "inputOutputs"):
-        for v in variables.get(section) or []:
-            if isinstance(v, dict) and "value" in v:
-                out.extend(_leaves(v.get("value")))
+    for v in _get_ci(variables, "globalVariables", "GlobalVariables") or []:
+        value = _get_ci(v, "value", "Value")
+        if value is not None:
+            out.extend(_leaves(value))
+    for section_keys in (("outputs", "Outputs"), ("inputOutputs", "InputOutputs")):
+        for v in _get_ci(variables, *section_keys) or []:
+            value = _get_ci(v, "value", "Value")
+            if value is not None:
+                out.extend(_leaves(value))
 
     for task in _iter_runtime_tasks(payload):
-        for out_var in task.get("outputs") or []:
-            if isinstance(out_var, dict) and "value" in out_var:
-                out.extend(_leaves(out_var.get("value")))
+        for out_var in _get_ci(task, "outputs", "Outputs") or []:
+            value = _get_ci(out_var, "value", "Value")
+            if value is not None:
+                out.extend(_leaves(value))
 
     return out
 
@@ -481,8 +514,9 @@ def _iter_runtime_tasks(payload: dict):
             continue
         seen_ids.add(id(node))
         if isinstance(node, dict):
-            if "outputs" in node and (
-                "displayName" in node or "taskTypeId" in node or "type" in node
+            keys_ci = {k.lower() for k in node.keys() if isinstance(k, str)}
+            if "outputs" in keys_ci and (
+                "displayname" in keys_ci or "tasktypeid" in keys_ci or "type" in keys_ci
             ):
                 yield node
             stack.extend(node.values())
@@ -493,7 +527,7 @@ def _iter_runtime_tasks(payload: dict):
 def _leaves(v: Any):
     if isinstance(v, dict):
         for k, nested in v.items():
-            if k in _METADATA_KEYS:
+            if isinstance(k, str) and k.lower() in _METADATA_KEYS_LOWER:
                 continue
             yield from _leaves(nested)
     elif isinstance(v, (list, tuple)):

--- a/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
@@ -1,0 +1,77 @@
+"""Unit tests for case_check runtime-payload helpers.
+
+Run with ``pytest`` from any directory.
+
+These pin the CLI #2266 contract: the ``uip maestro case debug --output json``
+runtime payload must be readable whether its keys are camelCase (the documented
+Studio Web shape, and what the CLI emits once case debug opts into
+``preserveDataKeys``) or PascalCase (what a #2266-carrying CLI emits without the
+opt-out). A checker must not depend on which CLI build the eval image runs.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from case_check import (  # noqa: E402
+    _get_ci,
+    collect_outputs,
+    run_debug,
+)
+import case_check  # noqa: E402
+
+
+def test_get_ci_reads_camelcase_and_pascalcase():
+    assert _get_ci({"finalStatus": "Completed"}, "finalStatus", "FinalStatus") == "Completed"
+    assert _get_ci({"FinalStatus": "Completed"}, "finalStatus", "FinalStatus") == "Completed"
+    assert _get_ci({}, "finalStatus", "FinalStatus", default="<none>") == "<none>"
+
+
+def test_collect_outputs_handles_pascalcase_payload():
+    pascal = {
+        "Variables": {
+            "Globals": {"result": "approved"},
+            "GlobalVariables": [{"Name": "score", "Value": 7}],
+            "Outputs": [{"Name": "note", "Value": "done"}],
+        }
+    }
+    out = collect_outputs(pascal)
+    assert "approved" in out
+    assert 7 in out
+    assert "done" in out
+
+
+def test_collect_outputs_walks_pascalcase_runtime_task():
+    """Task executions nested under PascalCase keys must still yield outputs."""
+    pascal = {
+        "Stages": [
+            {
+                "Tasks": [
+                    {"DisplayName": "Triage", "Type": "rpa", "Outputs": [{"Value": "ok"}]}
+                ]
+            }
+        ]
+    }
+    assert "ok" in collect_outputs(pascal)
+
+
+def test_collect_outputs_pascalcase_matches_camelcase():
+    camel = {"variables": {"globals": {"a": "x"}, "globalVariables": [{"value": 1}]}}
+    pascal = {"Variables": {"Globals": {"a": "x"}, "GlobalVariables": [{"Value": 1}]}}
+    assert sorted(map(str, collect_outputs(camel))) == sorted(map(str, collect_outputs(pascal)))
+
+
+def test_run_debug_gate_accepts_pascalcase_finalstatus(monkeypatch):
+    """run_debug's Completed gate must pass on a PascalCase payload (the exact
+    #2266 break that made case debug look like it 'did not complete')."""
+    monkeypatch.setattr(case_check, "start_debug", lambda **kw: {"FinalStatus": "Completed"})
+    assert run_debug() == {"FinalStatus": "Completed"}
+
+
+def test_run_debug_gate_still_rejects_incomplete(monkeypatch):
+    monkeypatch.setattr(case_check, "start_debug", lambda **kw: {"FinalStatus": "Faulted"})
+    with pytest.raises(SystemExit, match="Case did not complete"):
+        run_debug()

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/check_branching_exit.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/check_branching_exit.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    _get_ci,
     assert_count,
     edge_labels_from,
     find_edges,
@@ -138,7 +139,7 @@ def main():
         payload, "Triage", "Approved Path", "Rejected Path", "Pending Path",
         require_all=False,
     )
-    status = payload.get("finalStatus") or payload.get("status")
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
 
     print(
         "OK: Triage WIDE fan-outs to Approved/Rejected/Pending (3 branches); exits "

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/check_case_exit_full.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/check_case_exit_full.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    _get_ci,
     assert_count,
     find_node_by_label,
     find_stages,
@@ -129,7 +130,7 @@ def main():
 
     payload = start_debug(timeout=540)
     payload_contains(payload, "Intake", "Audit", "Archive", require_all=False)
-    status = payload.get("finalStatus") or payload.get("status")
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
 
     print(
         "OK: 3 stages with mixed isRequired (Intake/Archive true, Audit false); "

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/check_fan_in_join.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/check_fan_in_join.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    _get_ci,
     assert_count,
     find_edges,
     find_node_by_label,
@@ -121,7 +122,7 @@ def main():
     payload_contains(
         payload, "Triage", "Validate", "Enrich", "Join", require_all=False
     )
-    status = payload.get("finalStatus") or payload.get("status")
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
 
     print(
         "OK: diamond topology Triage→{Validate,Enrich}→Join with two "

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/check_linear_three_stages.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/check_linear_three_stages.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    _get_ci,
     assert_count,
     find_edges,
     find_node_by_label,
@@ -201,7 +202,7 @@ def main():
     payload_contains(
         payload, "Intake", "Review", "Decision", require_all=False
     )
-    status = payload.get("finalStatus") or payload.get("status")
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
 
     print(
         "OK: 3 stages (Intake → Review → Decision) chained via single-outbound "

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/check_multi_trigger.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/check_multi_trigger.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    _get_ci,
     assert_count,
     find_node_by_label,
     find_triggers,
@@ -88,7 +89,7 @@ def main():
 
     payload = start_debug(timeout=540)
     payload_contains(payload, "Run", require_all=False)
-    status = payload.get("finalStatus") or payload.get("status")
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
 
     print(
         "OK: 3 triggers (manual + infinite hourly R/PT1H + bounded daily "

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/check_task_dependency_chain.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    _get_ci,
     find_node_by_label,
     find_stages,
     first_rule_of_condition,
@@ -228,7 +229,7 @@ def main():
     payload_contains(
         payload, "Process", "Finalize", "Done", require_all=False
     )
-    status = payload.get("finalStatus") or payload.get("status")
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
 
     print(
         "OK: Process exit required-tasks-completed; Finalize exit "

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -356,3 +356,57 @@ def test_find_project_dir_uses_central_filter(tmp_path, monkeypatch):
     _make_proj(solution, "Helper", "Process")
     _make_proj(solution, "MainFlow", "Flow")
     assert find_project_dir() == os.path.join("Mixed", "MainFlow")
+
+
+# ── _get_ci / PascalCase tolerance (CLI #2266 contract) ─────────────────────
+#
+# `uip … --output json` PascalCases its Data keys when the CLI carries PR #2266
+# and the command does not opt out via `preserveDataKeys` (flow/case debug DO
+# opt out — see uipath-cli debug.ts — but a checker must not depend on which
+# CLI build the eval image happens to run). These tests pin that every runtime
+# read tolerates BOTH casings, so a future re-introduction of #2266-style
+# normalization cannot silently break the maestro-flow debug checkers again.
+
+from flow_check import _get_ci  # noqa: E402
+
+
+def test_get_ci_reads_camelcase_and_pascalcase():
+    assert _get_ci({"finalStatus": "Completed"}, "finalStatus", "FinalStatus") == "Completed"
+    assert _get_ci({"FinalStatus": "Completed"}, "finalStatus", "FinalStatus") == "Completed"
+
+
+def test_get_ci_first_candidate_wins_and_default():
+    assert _get_ci({"Status": "x"}, "status", "Status") == "x"
+    assert _get_ci({}, "status", "Status", default="<none>") == "<none>"
+    assert _get_ci("not-a-dict", "status", default=None) is None
+
+
+def test_collect_outputs_handles_pascalcase_payload():
+    """The exact #2266 shape: every Data key PascalCased. collect_outputs must
+    still recover the declared output value (it was silently dropped before)."""
+    pascal = {
+        "Variables": {
+            "GlobalVariables": [{"Name": "result", "Value": "warm"}],
+            "Elements": [{"Outputs": {"message": "bring a jacket"}}],
+        }
+    }
+    out = collect_outputs(pascal)
+    assert "warm" in out
+    assert "bring a jacket" in out
+
+
+def test_collect_outputs_pascalcase_matches_camelcase():
+    """Casing must not change the extracted output set."""
+    camel = {
+        "variables": {
+            "globalVariables": [{"name": "result", "value": 42}],
+            "elements": [{"outputs": {"x": "done"}}],
+        }
+    }
+    pascal = {
+        "Variables": {
+            "GlobalVariables": [{"Name": "result", "Value": 42}],
+            "Elements": [{"Outputs": {"x": "done"}}],
+        }
+    }
+    assert sorted(map(str, collect_outputs(camel))) == sorted(map(str, collect_outputs(pascal)))

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -154,7 +154,14 @@ def check_folder_id_fresh():
     live = _uip_resources_run(
         ["list", CONNECTOR_KEY, "MailFolder", "--connection-id", conn_id, "--output", "json"]
     )
-    live_ids = {f.get("id") for f in _extract_list_items(live)}
+    # Read the item id case-insensitively (a CLI that PascalCases --output json
+    # keys per PR #2266 emits `Id`, not `id`) and drop any None so a missed key
+    # can't collapse the set to `{None}` and falsely accuse the agent.
+    live_ids = {
+        fid
+        for f in _extract_list_items(live)
+        if (fid := (f.get("id") or f.get("Id")))
+    }
     if not live_ids:
         sys.exit(
             "FAIL: resources run/execute list MailFolder returned no folders on the bound connection"

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
@@ -116,6 +116,22 @@ def test_does_not_fall_back_on_unrelated_failure(monkeypatch) -> None:
     assert calls[0][3] == "run"
 
 
+def test_handles_pascalcase_item_id(monkeypatch) -> None:
+    """A CLI that PascalCases --output json keys (PR #2266) emits item key `Id`.
+    The checker must read it (else the live set collapses to {None} and falsely
+    fails with the PR #348 signature). Locks the `f.get("id") or f.get("Id")` fix.
+    """
+    checker = _load_checker()
+    _patch_static(monkeypatch, checker, folder_id="mail-folder-1")
+
+    def fake_run(_args, **_kwargs):
+        # PascalCase item key, as #2266 emits it
+        return _fake_proc(0, stdout=json.dumps({"Data": [{"Id": "mail-folder-1"}]}))
+
+    monkeypatch.setattr(checker.subprocess, "run", fake_run)
+    checker.check_folder_id_fresh()  # must NOT raise (id resolves on the connection)
+
+
 def test_folder_id_mismatch_fails_with_pr348_signature(monkeypatch) -> None:
     """If the flow's parentFolderId is not in the live ID set, the checker
     fails with the PR #348 regression marker (independent of the verb)."""

--- a/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/check_salesforce_opportunity_list.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/check_salesforce_opportunity_list.py
@@ -26,6 +26,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
+    _get_ci,
     assert_flow_uses_connector_target,
     find_project_dir,
     run_debug,
@@ -108,7 +109,11 @@ def _assert_structure() -> None:
 
 
 def _assert_records_returned(payload: dict) -> None:
-    globals_ = (payload.get("variables") or {}).get("globals") or {}
+    # The flow debug runtime payload is PascalCase under CLI #2266
+    # (Variables/Globals) and camelCase otherwise; read both via _get_ci so
+    # the record-array search doesn't silently see {} and report no records.
+    variables = _get_ci(payload, "variables", "Variables") or {}
+    globals_ = _get_ci(variables, "globals", "Globals") or {}
     # Find any output variable holding a non-empty array of record objects.
     for name, value in globals_.items():
         if (

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/check_terminate_flow.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
 from _shared.flow_check import (  # noqa: E402
+    _get_ci,
     assert_flow_has_node_type,
     find_project_dir,
     run_debug,
@@ -40,11 +41,13 @@ def main():
 
     payload = run_debug()
 
-    # Verify the terminate node actually killed the delay branch
-    executions = payload.get("elementExecutions") or []
-    terminated = [e for e in executions if e.get("status") == "Terminated"]
+    # Verify the terminate node actually killed the delay branch. Read the
+    # runtime payload case-insensitively so a CLI that PascalCases --output json
+    # keys (PR #2266) does not make `elementExecutions` unreadable → empty.
+    executions = _get_ci(payload, "elementExecutions", "ElementExecutions") or []
+    terminated = [e for e in executions if _get_ci(e, "status", "Status") == "Terminated"]
     if not terminated:
-        statuses = [(e.get("elementId"), e.get("status")) for e in executions]
+        statuses = [(_get_ci(e, "elementId", "ElementId"), _get_ci(e, "status", "Status")) for e in executions]
         sys.exit(f"FAIL: No element was Terminated — terminate node didn't kill the delay branch. Statuses: {statuses}")
 
     print(f"OK: Terminate + Delay nodes present; {len(terminated)} element(s) terminated")


### PR DESCRIPTION
## Problem

uipath-cli PR #2266 made `OutputFormatter` recursively PascalCase every `--output json` `Data` key. PR #1153 hardened **only** `_shared/flow_check.py`, so task-local checkers that read the debug **runtime** payload by lowercase key kept breaking one layer deeper:

- **skill-flow-terminate** → `FAIL: … Statuses: []` (run `2026-06-01_04-04-22`). #1153 let the shared `finalStatus` gate pass via `_get_ci`, then the task-local `check_terminate_flow.py` read `payload.get("elementExecutions")` on a payload that now only has `ElementExecutions` → `[]`.
- **outlook_trigger_inbox** → live-ID set collapsed to `{None}` because items were keyed `Id`, not `id`.

The whole maestro-**case** suite was likewise exposed: `case_check.run_debug` and `collect_outputs` read the runtime payload by camelCase.

## Fix

Route **every runtime-payload read** through the case-insensitive `_get_ci` accessor, so a checker no longer depends on which CLI build the eval image runs:

- **maestro-flow:** `terminate` (`elementExecutions`/`status`/`elementId`), `outlook_trigger_inbox` (item `id`/`Id`, drop `None`)
- **maestro-case:** `_shared/case_check` — added `_get_ci`; hardened `run_debug` gate, `collect_outputs`, `_iter_runtime_tasks`, and the metadata-key filter — plus the 6 task-local `finalStatus` reads

## Contract guard (the part that prevents recurrence)

`tests/scripts/test_runtime_payload_key_casing.py` fails CI if any checker reads a **runtime-only** key (`finalStatus` / `elementExecutions`, which never appear in `.flow`/`caseplan` source) by a raw lowercase `.get()` / `[...]` instead of `_get_ci`. New maestro-case + guard jobs added to `test-helpers.yml`, and PascalCase unit fixtures added (flow `_get_ci`/`collect_outputs`, case `_get_ci`/`collect_outputs`/`run_debug` gate, outlook item `Id`).

## Test

- `pytest tests/tasks/uipath-maestro-flow/` 100 pass · `tests/tasks/uipath-maestro-case/` 6 pass · guard 1 pass · full sweep **121 pass**
- Guard confirms zero raw runtime-key reads remain in `check_*.py` / `_shared`

## Companion

Source-side fix (flow/case debug emit camelCase via `preserveDataKeys`) ships in UiPath/cli #2309. With both merged: the CLI emits camelCase **and** checkers tolerate either casing, with CI blocking the next raw-lowercase read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)