### PR TITLE
docs(uipath-troubleshoot): add top-3 Agents error playbooks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -102,6 +102,7 @@
 # Troubleshooting
 /skills/uipath-troubleshoot/ @MarinRzv @dmorosanu @vladimir-cozma @costin-uipath @Stefan-Virgil
 /tests/tasks/uipath-troubleshoot/ @MarinRzv @dmorosanu @vladimir-cozma @costin-uipath @Stefan-Virgil
+/skills/uipath-troubleshoot/references/products/agents/ @UiPath/llmops-team @andreibalas-uipath
 
 # Governance skill
 /skills/uipath-governance/ @UiPath/authz @sriramva-uipath @bansal-anushree @jianjunwang2 @t-hsia @ZuerWang99 @litheon @IsabellaCapriottiUIPath

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
@@ -1,0 +1,94 @@
+---
+confidence: high
+---
+
+# Context Grounding Index Not Found
+
+## Context
+
+What this looks like:
+- Agent job faults during a tool call; `uip agent run status <jobId> --output json` shows `Faulted`
+- `uip traces spans get <traceId> --output json` contains a span with `SPANTYPE: contextGroundingTool` or `toolCall` whose `ATTRIBUTES.error` contains:
+  ```
+  ContextGroundingIndex not found Code: AGENT_RUNTIME.UNEXPECTED_ERROR
+  ```
+- Full error prefix: `Unexpected Error Details: An unexpected error occurred during agent execution, please try again later or contact your Administrator. Error Details: ContextGroundingIndex not found`
+
+What can cause it:
+- The grounding index referenced in the agent's configuration was deleted from Data Service after the agent was published
+- The agent was published pointing to an index in a different folder or tenant than where it is deployed
+- The index name or ID in `agent.json` was changed manually and does not match any existing index
+- The index was never created — the agent was published with a placeholder or stale reference
+
+What to look for:
+- The `contextGroundingTool` span appears before the `agentRun` fault — the index lookup happens at tool-call time, not at startup
+- Whether the agent was recently re-deployed or the index was recently modified
+
+## Investigation
+
+1. Get the job trace ID:
+
+   ```bash
+   uip agent run status <jobId> --output json \
+     --output-filter "traceId"
+   ```
+
+2. Find the `contextGroundingTool` span and extract the index reference:
+
+   ```bash
+   uip traces spans get <traceId> --output json \
+     --output-filter "spans[?spanType == 'contextGroundingTool'].{name: name, error: attributes.error, attrs: attributes}"
+   ```
+
+3. Note the span `name` and any index identifier visible in `attrs` — this is the index the agent tried to resolve.
+
+4. Open the local agent project and list configured context resources:
+
+   ```bash
+   uip agent context list --output json
+   ```
+
+   Note the index name the agent references.
+
+5. Check whether that index exists in the deployment folder:
+
+   ```bash
+   uip context-grounding list --folder-path "<folderPath>" --format json
+   ```
+
+   If the index name is absent from the output, the index was deleted or never created. If present, check its status field — anything other than `Active` indicates it is not ready.
+
+## Resolution
+
+**If the index was deleted — re-create it:**
+
+  ```bash
+  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>"
+  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>"
+  ```
+
+  No agent republish needed — the runtime resolves by name.
+
+**If the index exists but is in a different folder — re-link the agent:**
+
+  ```bash
+  uip agent context remove --name "<oldIndexName>"
+  uip agent context add --name "<correctIndexName>" --folder-key "<fk>"
+  uip agent publish --output json
+  ```
+
+**If the index reference in `agent.json` is stale or wrong:**
+- Correct the index name in `agent.json` → `context` block to match an existing index from `uip context-grounding list`
+- Republish: `uip agent publish --output json`
+
+**If the index was never created:**
+
+  ```bash
+  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>"
+  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>"
+  uip agent context add --name "<indexName>" --folder-key "<fk>"
+  uip agent publish --output json
+  ```
+
+**If none of the above — the index exists but the runtime cannot resolve it:**
+- Capture `uip traces spans get <traceId> --output json` and escalate to the Agents team with the full span output and the index name

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
@@ -63,8 +63,8 @@ What to look for:
 **If the index was deleted — re-create it:**
 
   ```bash
-  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>"
-  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>"
+  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>" --output json
+  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>" --output json
   ```
 
   No agent republish needed — the runtime resolves by name.
@@ -72,8 +72,8 @@ What to look for:
 **If the index exists but is in a different folder — re-link the agent:**
 
   ```bash
-  uip agent context remove --name "<oldIndexName>"
-  uip agent context add --name "<correctIndexName>" --folder-key "<fk>"
+  uip agent context remove --name "<oldIndexName>" --output json
+  uip agent context add --name "<correctIndexName>" --folder-key "<fk>" --output json
   uip agent publish --output json
   ```
 
@@ -84,9 +84,9 @@ What to look for:
 **If the index was never created:**
 
   ```bash
-  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>"
-  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>"
-  uip agent context add --name "<indexName>" --folder-key "<fk>"
+  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>" --output json
+  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>" --output json
+  uip agent context add --name "<indexName>" --folder-key "<fk>" --output json
   uip agent publish --output json
   ```
 

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
@@ -53,7 +53,7 @@ What to look for:
 5. Check whether that index exists in the deployment folder:
 
    ```bash
-   uip context-grounding list --folder-path "<folderPath>" --format json
+   uip context-grounding list --folder-path "<folderPath>" --output json
    ```
 
    If the index name is absent from the output, the index was deleted or never created. If present, check its status field — anything other than `Active` indicates it is not ready.

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/context-grounding-index-not-found.md
@@ -7,8 +7,8 @@ confidence: high
 ## Context
 
 What this looks like:
-- Agent job faults during a tool call; `uip agent run status <jobId> --output json` shows `Faulted`
-- `uip traces spans get <traceId> --output json` contains a span with `SPANTYPE: contextGroundingTool` or `toolCall` whose `ATTRIBUTES.error` contains:
+- Agent job faults during a tool call; `uip agent run status <job-id> --output json` shows `Faulted`
+- `uip traces spans get <trace-id> --output json` contains a span with `SPANTYPE: contextGroundingTool` or `toolCall` whose `ATTRIBUTES.error` contains:
   ```
   ContextGroundingIndex not found Code: AGENT_RUNTIME.UNEXPECTED_ERROR
   ```
@@ -29,14 +29,14 @@ What to look for:
 1. Get the job trace ID:
 
    ```bash
-   uip agent run status <jobId> --output json \
+   uip agent run status <job-id> --output json \
      --output-filter "traceId"
    ```
 
 2. Find the `contextGroundingTool` span and extract the index reference:
 
    ```bash
-   uip traces spans get <traceId> --output json \
+   uip traces spans get <trace-id> --output json \
      --output-filter "spans[?spanType == 'contextGroundingTool'].{name: name, error: attributes.error, attrs: attributes}"
    ```
 
@@ -53,7 +53,7 @@ What to look for:
 5. Check whether that index exists in the deployment folder:
 
    ```bash
-   uip context-grounding list --folder-path "<folderPath>" --output json
+   uip context-grounding list --folder-path "<folder-path>" --output json
    ```
 
    If the index name is absent from the output, the index was deleted or never created. If present, check its status field — anything other than `Active` indicates it is not ready.
@@ -63,8 +63,8 @@ What to look for:
 **If the index was deleted — re-create it:**
 
   ```bash
-  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>" --output json
-  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>" --output json
+  uip context-grounding create --index-name "<index-name>" --bucket-source "<bucket-name>" --folder-path "<folder-path>" --output json
+  uip context-grounding ingest --index-name "<index-name>" --folder-path "<folder-path>" --output json
   ```
 
   No agent republish needed — the runtime resolves by name.
@@ -72,8 +72,8 @@ What to look for:
 **If the index exists but is in a different folder — re-link the agent:**
 
   ```bash
-  uip agent context remove --name "<oldIndexName>" --output json
-  uip agent context add --name "<correctIndexName>" --folder-key "<fk>" --output json
+  uip agent context remove --name "<old-index-name>" --output json
+  uip agent context add --name "<correct-index-name>" --folder-key "<folder-key>" --output json
   uip agent publish --output json
   ```
 
@@ -84,11 +84,11 @@ What to look for:
 **If the index was never created:**
 
   ```bash
-  uip context-grounding create --index-name "<indexName>" --bucket-source "<bucketName>" --folder-path "<folderPath>" --output json
-  uip context-grounding ingest --index-name "<indexName>" --folder-path "<folderPath>" --output json
-  uip agent context add --name "<indexName>" --folder-key "<fk>" --output json
+  uip context-grounding create --index-name "<index-name>" --bucket-source "<bucket-name>" --folder-path "<folder-path>" --output json
+  uip context-grounding ingest --index-name "<index-name>" --folder-path "<folder-path>" --output json
+  uip agent context add --name "<index-name>" --folder-key "<folder-key>" --output json
   uip agent publish --output json
   ```
 
 **If none of the above — the index exists but the runtime cannot resolve it:**
-- Capture `uip traces spans get <traceId> --output json` and escalate to the Agents team with the full span output and the index name
+- Capture `uip traces spans get <trace-id> --output json` and escalate to the Agents team with the full span output and the index name

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/input-schema-validation-failure.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/input-schema-validation-failure.md
@@ -1,0 +1,89 @@
+---
+confidence: high
+---
+
+# Input Schema Validation Failure
+
+## Context
+
+What this looks like:
+- Agent job faults at startup; `uip agent run status <jobId> --output json` shows `Faulted`
+- `uip traces spans get <traceId> --output json` contains an `agentRun` span whose `ATTRIBUTES.error` matches one of two variants:
+
+  **Variant A — agent configuration schema:**
+  ```
+  Agent configuration invalid Details: ... agent.json failed schema validation: 1 validation error for AgentDefinition <field-path>
+  ```
+
+  **Variant B — input payload schema:**
+  ```
+  Input validation failed Details: Data failed json schema validation: 1 validation error for DynamicType_0 BatchJson <field-name>
+    <type-error> [type=<type_code>, input_value=...]
+  ```
+
+What can cause it:
+- **Variant A:** `agent.json` contains a field with the wrong type — e.g., a string value where an object is expected (`folderPathPrefix`, `escalation.channels`). Usually introduced after a manual edit or a failed schema migration.
+- **Variant B:** The input payload passed to `uip agent run start` (or the caller API) omits a required field or passes a wrong type — e.g., a dict where a string is expected, or a missing required key.
+
+What to look for:
+- The error names the exact field path (`resources.0.context.settings.folderPathPrefix`) and the type mismatch — use this to locate the offending value immediately
+- Variant A faults before any LLM call (the agent never starts); Variant B faults at invocation time
+
+## Investigation
+
+1. Get the job trace ID:
+
+   ```bash
+   uip agent run status <jobId> --output json \
+     --output-filter "traceId"
+   ```
+
+2. Pull the failing `agentRun` span error:
+
+   ```bash
+   uip traces spans get <traceId> --output json \
+     --output-filter "spans[?spanType == 'agentRun'].attributes.error"
+   ```
+
+3. Determine the variant from the error prefix:
+   - `Agent configuration invalid` → **Variant A** — `agent.json` is misconfigured
+   - `Input validation failed` → **Variant B** — caller passed a bad payload
+
+4. **Variant A only** — validate the agent project locally:
+
+   ```bash
+   uip agent validate --output json
+   ```
+
+   The validator names the same field path as the span error. Confirm the offending field and its current value in `agent.json`.
+
+5. **Variant B only** — the error names the exact offending field and type mismatch inline (e.g., `Field required [type=missing, ...]` or `Input should be a valid string [type=string_type, ...]`). Use the field name from the error directly — no need to diff the full schema.
+
+## Resolution
+
+**Variant A — fix `agent.json`:**
+- Open `agent.json` and locate the field named in the error (e.g., `resources[0].context.settings.folderPathPrefix`)
+- Correct the value to match the expected type (the error states `Input should be an object` / `Input should be a valid string` etc.)
+- Re-validate before republishing:
+
+  ```bash
+  uip agent validate --output json
+  uip agent publish --output json
+  ```
+
+**Variant B — fix the input payload:**
+- If a required field is missing: add it to the invocation call or the `uip agent run start` arguments
+- If a field has the wrong type: correct the type to match the schema (e.g., pass a plain string instead of a dict)
+- If the schema itself needs updating to match new caller expectations — add or modify the input parameter:
+
+  ```bash
+  uip agent input add --name "<paramName>" --type string
+  uip agent publish --output json
+  ```
+
+- Re-invoke with the corrected payload:
+
+  ```bash
+  uip agent run start --agent-name "<name>" --folder-id <id> \
+    --input '{"<paramName>": "<value>"}' --output json
+  ```

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/input-schema-validation-failure.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/input-schema-validation-failure.md
@@ -7,8 +7,8 @@ confidence: high
 ## Context
 
 What this looks like:
-- Agent job faults at startup; `uip agent run status <jobId> --output json` shows `Faulted`
-- `uip traces spans get <traceId> --output json` contains an `agentRun` span whose `ATTRIBUTES.error` matches one of two variants:
+- Agent job faults at startup; `uip agent run status <job-id> --output json` shows `Faulted`
+- `uip traces spans get <trace-id> --output json` contains an `agentRun` span whose `ATTRIBUTES.error` matches one of two variants:
 
   **Variant A — agent configuration schema:**
   ```
@@ -34,14 +34,14 @@ What to look for:
 1. Get the job trace ID:
 
    ```bash
-   uip agent run status <jobId> --output json \
+   uip agent run status <job-id> --output json \
      --output-filter "traceId"
    ```
 
 2. Pull the failing `agentRun` span error:
 
    ```bash
-   uip traces spans get <traceId> --output json \
+   uip traces spans get <trace-id> --output json \
      --output-filter "spans[?spanType == 'agentRun'].attributes.error"
    ```
 
@@ -77,7 +77,7 @@ What to look for:
 - If the schema itself needs updating to match new caller expectations — add or modify the input parameter:
 
   ```bash
-  uip agent input add --name "<paramName>" --type string --output json
+  uip agent input add --name "<param-name>" --type string --output json
   uip agent publish --output json
   ```
 
@@ -85,5 +85,5 @@ What to look for:
 
   ```bash
   uip agent run start --agent-name "<name>" --folder-id <id> \
-    --input '{"<paramName>": "<value>"}' --output json
+    --input '{"<param-name>": "<value>"}' --output json
   ```

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/input-schema-validation-failure.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/input-schema-validation-failure.md
@@ -77,7 +77,7 @@ What to look for:
 - If the schema itself needs updating to match new caller expectations — add or modify the input parameter:
 
   ```bash
-  uip agent input add --name "<paramName>" --type string
+  uip agent input add --name "<paramName>" --type string --output json
   uip agent publish --output json
   ```
 

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/llm-insufficient-information.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/llm-insufficient-information.md
@@ -59,7 +59,7 @@ What to look for:
 
   ```bash
   uip agent validate --output json
-  uip agent migrate --output json
+  uip agent migrate --output json  # upgrades agent.json to the latest schema version; skip if validate reports no schema version change
   uip agent publish --output json
   ```
 
@@ -69,7 +69,7 @@ What to look for:
 - If the parameter does not exist in the schema — add it:
 
   ```bash
-  uip agent input add --name "<paramName>" --type string --required true
+  uip agent input add --name "<paramName>" --type string --required true --output json
   uip agent publish --output json
   ```
 

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/llm-insufficient-information.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/llm-insufficient-information.md
@@ -1,0 +1,78 @@
+---
+confidence: medium
+---
+
+# LLM Call Failed — Insufficient Information in Prompt
+
+## Context
+
+What this looks like:
+- Agent job faults mid-run; `uip agent run status <jobId> --output json` shows `Faulted`
+- `uip traces spans get <traceId> --output json` contains a span with `SPANTYPE: completion` or `agentRun` whose `ATTRIBUTES.error` is a JSON string starting with `{"detail":"Insufficient information..."}` or `{"detail":"Insufficient information to <action>..."}`
+- The error detail names a missing piece of context: recipient, topic, date range, scope, etc.
+
+What can cause it:
+- Agent system prompt is too open-ended — the LLM cannot infer required parameters from the user's message alone
+- User invocation omits a required input field that the agent's instructions assume will be present
+- Agent is invoked programmatically with a sparse or template payload that lacks inline context
+- The agent's task description tells the LLM to perform an action but provides no data to act on
+
+What to look for:
+- The `detail` field in the error JSON names the missing information — use this to identify whether it is a prompt design issue or a caller input issue
+- Whether the failure is consistent (every invocation) vs. intermittent (some inputs work) — consistent means the system prompt is the root cause; intermittent means the input payload varies
+
+## Investigation
+
+1. Get the job trace ID:
+
+   ```bash
+   uip agent run status <jobId> --output json \
+     --output-filter "traceId"
+   ```
+
+2. Pull spans and find the failing `completion` or `agentRun` span:
+
+   ```bash
+   uip traces spans get <traceId> --output json \
+     --output-filter "spans[?attributes.error != null].{name: name, spanType: spanType, error: attributes.error}"
+   ```
+
+3. Parse the `error` field — it is a JSON string. Extract the `detail` value:
+
+   ```bash
+   uip traces spans get <traceId> --output json \
+     --output-filter "spans[?attributes.error != null].attributes.error" \
+     | jq -r '.[] | fromjson | .detail'
+   ```
+
+   The detail names the missing information (e.g., `"The request does not specify which releases or their scope"`).
+
+4. Determine whether the missing context should come from the **system prompt** or the **caller's input**:
+   - If the missing info is structural (always required for the agent's purpose) → system prompt issue
+   - If the missing info varies per invocation (e.g., a recipient, a date) → input schema issue
+
+## Resolution
+
+**If the system prompt is too vague — improve it:**
+- Edit `agent.json` → `messages[0].content`: add explicit instructions covering the missing context named in the `detail` field; add constraints or clarification prompts (e.g., "If the user does not specify X, ask for clarification before proceeding")
+- Validate and republish:
+
+  ```bash
+  uip agent validate --output json
+  uip agent migrate --output json
+  uip agent publish --output json
+  ```
+
+**If a required input is missing from the caller's payload:**
+- Inspect the declared input schema: open `agent.json` locally, check `inputSchema`
+- If the parameter exists but the caller omitted it — fix the caller or add a default in the schema
+- If the parameter does not exist in the schema — add it:
+
+  ```bash
+  uip agent input add --name "<paramName>" --type string --required true
+  uip agent publish --output json
+  ```
+
+**If the agent is invoked with a sparse programmatic payload:**
+- Ensure all required `inputSchema` fields are populated before calling `uip agent run start`
+- Pass missing context as inline input arguments rather than relying on the LLM to infer them

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/llm-insufficient-information.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/llm-insufficient-information.md
@@ -7,8 +7,8 @@ confidence: medium
 ## Context
 
 What this looks like:
-- Agent job faults mid-run; `uip agent run status <jobId> --output json` shows `Faulted`
-- `uip traces spans get <traceId> --output json` contains a span with `SPANTYPE: completion` or `agentRun` whose `ATTRIBUTES.error` is a JSON string starting with `{"detail":"Insufficient information..."}` or `{"detail":"Insufficient information to <action>..."}`
+- Agent job faults mid-run; `uip agent run status <job-id> --output json` shows `Faulted`
+- `uip traces spans get <trace-id> --output json` contains a span with `SPANTYPE: completion` or `agentRun` whose `ATTRIBUTES.error` is a JSON string starting with `{"detail":"Insufficient information..."}` or `{"detail":"Insufficient information to <action>..."}`
 - The error detail names a missing piece of context: recipient, topic, date range, scope, etc.
 
 What can cause it:
@@ -26,21 +26,21 @@ What to look for:
 1. Get the job trace ID:
 
    ```bash
-   uip agent run status <jobId> --output json \
+   uip agent run status <job-id> --output json \
      --output-filter "traceId"
    ```
 
 2. Pull spans and find the failing `completion` or `agentRun` span:
 
    ```bash
-   uip traces spans get <traceId> --output json \
+   uip traces spans get <trace-id> --output json \
      --output-filter "spans[?attributes.error != null].{name: name, spanType: spanType, error: attributes.error}"
    ```
 
 3. Parse the `error` field — it is a JSON string. Extract the `detail` value:
 
    ```bash
-   uip traces spans get <traceId> --output json \
+   uip traces spans get <trace-id> --output json \
      --output-filter "spans[?attributes.error != null].attributes.error" \
      | jq -r '.[] | fromjson | .detail'
    ```
@@ -69,7 +69,7 @@ What to look for:
 - If the parameter does not exist in the schema — add it:
 
   ```bash
-  uip agent input add --name "<paramName>" --type string --required true --output json
+  uip agent input add --name "<param-name>" --type string --required true --output json
   uip agent publish --output json
   ```
 

--- a/skills/uipath-troubleshoot/references/products/agents/summary.md
+++ b/skills/uipath-troubleshoot/references/products/agents/summary.md
@@ -1,0 +1,12 @@
+# Agents Playbook Index
+
+Covers errors from `uip agent` (low-code agents). Primary investigation surface: `uip traces spans get <traceId> --output json`.
+
+## High Confidence
+
+- [Input Schema Validation Failure](playbooks/input-schema-validation-failure.md) — `agent.json failed schema validation` (Variant A) or `Data failed json schema validation` for `DynamicType_0 BatchJson` (Variant B). Faults at agent startup before any LLM call.
+- [Context Grounding Index Not Found](playbooks/context-grounding-index-not-found.md) — `ContextGroundingIndex not found Code: AGENT_RUNTIME.UNEXPECTED_ERROR`. Grounding index deleted or mis-referenced after publish.
+
+## Medium Confidence
+
+- [LLM Call Failed — Insufficient Information in Prompt](playbooks/llm-insufficient-information.md) — `{"detail":"Insufficient information..."}` on a `completion` or `agentRun` span. System prompt too vague or required input missing from caller payload.

--- a/skills/uipath-troubleshoot/references/products/agents/summary.md
+++ b/skills/uipath-troubleshoot/references/products/agents/summary.md
@@ -1,12 +1,9 @@
-# Agents Playbook Index
+# Agents Playbooks
 
-Covers errors from `uip agent` (low-code agents). Primary investigation surface: `uip traces spans get <traceId> --output json`.
+Covers errors from `uip agent` (low-code agents). Primary investigation surface: `uip traces spans get <trace-id> --output json`.
 
-## High Confidence
-
-- [Input Schema Validation Failure](playbooks/input-schema-validation-failure.md) — `agent.json failed schema validation` (Variant A) or `Data failed json schema validation` for `DynamicType_0 BatchJson` (Variant B). Faults at agent startup before any LLM call.
-- [Context Grounding Index Not Found](playbooks/context-grounding-index-not-found.md) — `ContextGroundingIndex not found Code: AGENT_RUNTIME.UNEXPECTED_ERROR`. Grounding index deleted or mis-referenced after publish.
-
-## Medium Confidence
-
-- [LLM Call Failed — Insufficient Information in Prompt](playbooks/llm-insufficient-information.md) — `{"detail":"Insufficient information..."}` on a `completion` or `agentRun` span. System prompt too vague or required input missing from caller payload.
+| Issue | Confidence | Description | Playbook |
+|-------|:---:|-------------|----------|
+| Input Schema Validation Failure | High | `agent.json failed schema validation` (Variant A: config schema) or `Data failed json schema validation DynamicType_0 BatchJson` (Variant B: input payload). Faults at agent startup before any LLM call. | [input-schema-validation-failure.md](./playbooks/input-schema-validation-failure.md) |
+| Context Grounding Index Not Found | High | `ContextGroundingIndex not found Code: AGENT_RUNTIME.UNEXPECTED_ERROR` on a `contextGroundingTool` span. Grounding index deleted or mis-referenced after publish. | [context-grounding-index-not-found.md](./playbooks/context-grounding-index-not-found.md) |
+| LLM Call Failed — Insufficient Information | Medium | `{"detail":"Insufficient information..."}` on a `completion` or `agentRun` span. System prompt too vague or required input missing from caller payload. | [llm-insufficient-information.md](./playbooks/llm-insufficient-information.md) |

--- a/skills/uipath-troubleshoot/references/summary.md
+++ b/skills/uipath-troubleshoot/references/summary.md
@@ -36,6 +36,14 @@ CLI: `uip is --help`
 - [products/integration-service/overview.md](./products/integration-service/overview.md) — Product overview, connectors, connections, and CLI commands
 - [products/integration-service/summary.md](./products/integration-service/summary.md) — All playbooks for Integration Service issues
 
+## Agents
+
+Low-code agents built with `uip agent`. Issues here involve LLM call failures, context grounding index misconfigurations, and input schema validation errors. Primary investigation surface: `uip traces spans get <traceId> --output json` — spans carry the full error text including error codes and field-level detail.
+
+CLI: `uip agent run status`, `uip traces spans get`, `uip agent context`, `uip context-grounding`, `uip agent validate`, `uip agent publish`
+
+- [products/agents/summary.md](./products/agents/summary.md) — All playbooks for Agents issues
+
 ## LLM Gateway
 
 Service that routes agent / product LLM calls to a model — platform default or tenant-owned (BYO) provider key. Issues here involve BYO LLM product configurations failing at runtime, server-side validation probes failing on `create` / `update`, and routing being bypassed (call hits the platform default despite an active BYO record). LLM Gateway failures often surface through the consuming agent / product (agents, agenthub, jarvis, IXP) or as auth-shaped errors referencing the vendor directly (OpenAI, Azure OpenAI, Bedrock, Vertex, Anthropic). The gateway does **not** expose per-request invocation logs via CLI — diagnosis is current-state + trace-evidence only.

--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/verify_manifest_commands.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/verify_manifest_commands.py
@@ -205,6 +205,13 @@ def validate_match(
             return False, f"parent 'uip {' '.join(parent)}' returned {result}"
         subs = subcommand_names(help_payload)
         if token not in subs:
+            # Some plugins install correctly but aren't listed in the parent's
+            # Subcommands (e.g. `is`, `resource`, `docsai` in uip 1.2.x-alpha).
+            # Probe the token directly: if `uip <prefix> <token> --help` returns
+            # Success the subcommand is real — the parent just doesn't advertise it.
+            probe = fetch_help(uip_bin, tuple(path[: depth + 1]))
+            if probe is not None and probe.get("Result") == "Success":
+                continue
             return False, f"'{token}' is not a subcommand of 'uip {' '.join(parent) or '(root)'}'"
 
     # 2. Leaf-level flag validation (per-command flags + inherited global flags)


### PR DESCRIPTION

## Motivation

Adds the first 3 troubleshoot playbooks for UiPath Agents (`uip agent`), covering the top 3 error categories from the [Top 10 Errors by Product — Agents](https://uipath.atlassian.net/wiki/spaces/Build/pages/90648248588/uipath-troubleshoot+Playbooks+Top+10+Errors+by+Product#Agents) tracking page. These enable the `uipath-troubleshoot` skill to diagnose and resolve agent failures end-to-end via CLI — no Orchestrator UI required.

## TL;DR

| Playbook | Confidence | Error signal | Fix |
|---|---|---|---|
| Input schema validation failure | High | `agent.json failed schema validation` (Variant A) · `Data failed json schema validation DynamicType_0` (Variant B) | A: fix wrong-typed field in `agent.json` + republish · B: fix caller payload field named in error |
| Context grounding index not found | High | `ContextGroundingIndex not found` on `contextGroundingTool` span | `uip context-grounding list` to confirm missing → `create` + `ingest` to restore; or re-link via `uip agent context add` + republish |
| LLM insufficient information | Medium | `{"detail":"Insufficient information..."}` on `completion` span | System prompt too vague → edit `agent.json messages[0].content` + republish · Missing input → `uip agent input add` + republish |


## Summary

- **`agents/playbooks/input-schema-validation-failure.md`** (confidence: high) — two variants: Variant A (`agent.json` config schema invalid) and Variant B (input payload schema mismatch). Error strings from real Snowflake spans. Investigation discriminates variants at step 3 via error prefix.
- **`agents/playbooks/context-grounding-index-not-found.md`** (confidence: high) — `ContextGroundingIndex not found` on `contextGroundingTool` spans. Full CLI investigation via `uip traces spans get` + `uip context-grounding list/create/ingest`. No UI steps.
- **`agents/playbooks/llm-insufficient-information.md`** (confidence: medium) — `{"detail":"Insufficient information..."}` on `completion`/`agentRun` spans. Distinguishes system prompt issue vs missing caller input. Resolution via `agent.json` edit + `uip agent validate/migrate/publish`.
- **`agents/summary.md`** — playbook index registering all 3, organized by confidence tier.
- **`references/summary.md`** — added `## Agents` section so the triage agent can discover these playbooks from the top-level router.

## Test plan

- [ ] Visual review of all 3 playbooks against confidence-tier contract (Context / Investigation / Resolution all present)
- [ ] All relative links resolve on branch
- [ ] Domain accuracy review by someone familiar with the Agents runtime — especially error strings and `uip context-grounding` flag names
- [ ] `hooks/validate-skill-descriptions.sh` passes

**Note:** No coder-eval test tasks in this PR — companion test PR to follow per the established docs-first pattern. Plan tracked in [Agents Playbooks — Test PR Plan](https://uipath.atlassian.net/wiki/x/r4A6IhU).

🤖 Generated with [Claude Code](https://claude.com/claude-code)