### PR TITLE
fix(uipath-maestro-case): split complete vs exit rule displayName by marks-complete flag

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -62,7 +62,7 @@ build the case in the Case Designer without guessing.
 6. **Entry/exit conditions use WHEN + IF format:**
    - **WHEN** = the rule type (event that triggers evaluation, e.g., `selected-stage-completed("Intake")`)
    - **IF** = the optional `conditionExpression` (JavaScript expression evaluated against case variables, e.g., `applicationStatus == "Approved"`)
-   - **Display Name** (optional) = human-readable label for the condition row. Leave blank (`—`) to let the skill default it to `Entry rule {N}` (entry/task-entry conditions) or `Exit rule {N}` (stage-exit/case-exit conditions), where `N` is the 1-based index within the stage / task / case container. Set a value only to override the default.
+   - **Display Name** (optional) = human-readable label for the condition row. Leave blank (`—`) to let the skill default it: entry/task-entry conditions → `Entry Rule {N}`; stage-exit/case-exit conditions → `Complete Rule {N}` when Marks Complete is `Yes`, `Exit Rule {N}` when `No`. `N` is the 1-based index within the same label kind in the stage / task / case container. Set a value only to override the default.
    - **`wait-for-connector` WHEN** binds an Integration Service connector event. Name it inline in the WHEN cell (e.g. `wait-for-connector (Outlook "Email Received", Inbox)`) AND add a **Connector Rule Detail** block under the condition table. Applies to stage-entry, stage-exit, case-exit, and task-entry conditions. The IF cell is then an optional `=js:` gate on **case state** (`=js:vars.X`); the event payload is NOT directly accessible (no `event` namespace). **In-rule event-payload gating is NOT supported at runtime** — same-rule extract-then-gate (`response.X -> caseVar` on outputs + `=js:vars.caseVar` in IF) does not work; the case-backend evaluates the gate before the extract runs. To condition on the event payload, extract `response.field -> caseVar` on the connector rule and place the case-state gate on the DOWNSTREAM stage-entry / task-entry condition (where the extract has already populated the case var).
 
    **Connector Rule Detail block** — reproduce under any condition table whose WHEN is `wait-for-connector`:
@@ -209,7 +209,7 @@ DO NOT include in Configuration:
 
 | WHEN | IF | THEN | Marks Case Complete | Display Name |
 |------|-----|------|---------------------|--------------|
-| {`required-stages-completed` for Yes; `selected-stage-completed("StageName")` or other rule for No} | {conditionExpression, or "—" if none} | Case exited | {Yes \| No} | {optional label, or "—" → defaults to `Exit rule {N}`} |
+| {`required-stages-completed` for Yes; `selected-stage-completed("StageName")` or other rule for No} | {conditionExpression, or "—" if none} | Case exited | {Yes \| No} | {optional label, or "—" → defaults to `Complete Rule {N}` (Marks Complete = Yes) / `Exit Rule {N}` (No)} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6) — it binds the IS connector event the rule waits for.
 
@@ -310,7 +310,7 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 | WHEN | IF | Interrupting | Display Name |
 |------|-----|-------------|--------------|
-| {one of: `case-entered` \| `selected-stage-completed("StageName")` \| `selected-stage-exited("StageName")` \| `user-selected-stage` \| `wait-for-connector`} | {conditionExpression, or "—" if none} | {Yes \| No} | {optional label, or "—" → defaults to `Entry rule {N}`} |
+| {one of: `case-entered` \| `selected-stage-completed("StageName")` \| `selected-stage-exited("StageName")` \| `user-selected-stage` \| `wait-for-connector`} | {conditionExpression, or "—" if none} | {Yes \| No} | {optional label, or "—" → defaults to `Entry Rule {N}`} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
@@ -321,7 +321,7 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 | WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
 |------|-----|-----------|---------------------|--------------|
-| {`required-tasks-completed` or `wait-for-connector` for Yes; `selected-tasks-completed("TaskName")` or `wait-for-connector` for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} | {optional label, or "—" → defaults to `Exit rule {N}`} |
+| {`required-tasks-completed` or `wait-for-connector` for Yes; `selected-tasks-completed("TaskName")` or `wait-for-connector` for No} | {conditionExpression, or "—" if none} | {exit-only \| return-to-origin \| wait-for-user} | {Yes \| No} | {optional label, or "—" → defaults to `Complete Rule {N}` (Marks Complete = Yes) / `Exit Rule {N}` (No)} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 
@@ -356,7 +356,7 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 | WHEN | IF | Display Name |
 |------|-----|--------------|
-| {one of: `current-stage-entered` \| `selected-tasks-completed("TaskA", "TaskB")` \| `wait-for-connector` \| `adhoc` \| `runs-sequentially`} | {conditionExpression, or "—" if none} | {optional label, or "—" → defaults to `Entry rule {N}`} |
+| {one of: `current-stage-entered` \| `selected-tasks-completed("TaskA", "TaskB")` \| `wait-for-connector` \| `adhoc` \| `runs-sequentially`} | {conditionExpression, or "—" if none} | {optional label, or "—" → defaults to `Entry Rule {N}`} |
 
 > If `WHEN` is `wait-for-connector`, add a **Connector Rule Detail** block under this table (see Key Rule 6).
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/impl-json.md
@@ -37,7 +37,7 @@ Rules use DNF — outer array is OR, inner array is AND.
    - **v19** → locate the `root` object. Initialize `root.caseExitConditions = []` if absent.
    - **v20** → locate top-level `metadata` object (initialize `metadata: {}` if missing — should already exist from T01). Initialize `metadata.caseExitRules = []` if absent.
 4. Read `rule-type` and `marks-case-complete` from tasks.md; pick the recipe below
-5. Set `displayName`: use tasks.md `display-name` if present; else default to `Exit rule {N}`, where `N` = the 1-based index this condition takes in the schema-appropriate array (i.e. `array.length + 1` at append time). Never emit a blank or omitted `displayName`.
+5. Set `displayName`: use tasks.md `display-name` if present; else default by `marks-case-complete`: `true` → `Complete Rule {N}`, `false` → `Exit Rule {N}`. `N` = 1-based index **within the same label kind** — at append time, count existing entries in the schema-appropriate array whose `marksCaseComplete` equals this condition's value, then `N = count + 1`. FE numbers complete and exit rules with independent counters — do NOT use the array's overall length. Never emit a blank or omitted `displayName`.
 6. Append the condition object to the schema-appropriate array:
    - **v19** → `root.caseExitConditions[]`
    - **v20** → `metadata.caseExitRules[]`
@@ -86,7 +86,7 @@ Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 
 ## Post-Write Verification
 
-Confirm the schema-appropriate array contains the new object with `id`, non-empty `displayName` (SDD value or `Exit rule {N}` default), `marksCaseComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field:
+Confirm the schema-appropriate array contains the new object with `id`, non-empty `displayName` (SDD value or `Complete Rule {N}` / `Exit Rule {N}` default keyed to `marksCaseComplete`), `marksCaseComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field:
 - **v19** → `root.caseExitConditions[]`
 - **v20** → `metadata.caseExitRules[]`
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -16,7 +16,7 @@ Every case-exit condition declared in sdd.md gets its own T-task — **including
 
 | Field | Source | Notes |
 |-------|--------|-------|
-| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Exit rule {N}`. e.g., "Case resolved", "Closed — escalation path" |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Complete Rule {N}` (marks-case-complete `true`) / `Exit Rule {N}` (`false`). e.g., "Case resolved", "Closed — escalation path" |
 | `marks-case-complete` | sdd.md | `true` for normal completion, `false` for non-completing exits |
 | `rule-type` | From catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
@@ -57,7 +57,7 @@ Case exit conditions are created **after** all stages exist (so `selectedStageId
 
 ```markdown
 ## T<n>: Add case-exit condition — <summary>
-- display-name: "<name>"                 # optional — omit when SDD Display Name cell is blank; impl defaults to "Exit rule {N}"
+- display-name: "<name>"                 # optional — omit when blank; impl defaults to "Complete Rule {N}"/"Exit Rule {N}" per marks-case-complete
 - marks-case-complete: true
 - rule-type: required-stages-completed
 - selected-stage: "<stage-name>"        # only for selected-stage-* rule-types

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/impl-json.md
@@ -34,7 +34,7 @@ Rules use DNF — outer array is OR, inner array is AND.
 3. Locate the target stage in `schema.nodes` by ID
 4. Initialize `stageNode.data.entryConditions = []` if absent (regular Stage is created without this key — see [`../../stages/impl-json.md`](../../stages/impl-json.md))
 5. Read `rule-type` and `is-interrupting` from tasks.md; pick the recipe below
-6. Set `displayName`: use tasks.md `display-name` if present; else default to `Entry rule {N}`, where `N` = the 1-based index this condition takes in `stageNode.data.entryConditions[]` (i.e. `entryConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
+6. Set `displayName`: use tasks.md `display-name` if present; else default to `Entry Rule {N}`, where `N` = the 1-based index this condition takes in `stageNode.data.entryConditions[]` (i.e. `entryConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
 7. Append the condition object to `stageNode.data.entryConditions[]`
 
 ## Rule Types
@@ -87,4 +87,4 @@ Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 
 ## Post-Write Verification
 
-Confirm target stage's `data.entryConditions[]` contains the new object with `id`, non-empty `displayName` (SDD value or `Entry rule {N}` default), `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `<stageId>-<ruleId>`, and the ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+Confirm target stage's `data.entryConditions[]` contains the new object with `id`, non-empty `displayName` (SDD value or `Entry Rule {N}` default), `isInterrupting` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated (placeholders substituted), inputs/outputs `elementId` is `<stageId>-<ruleId>`, and the ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -17,7 +17,7 @@ Every stage with an **Entry Condition** declared in sdd.md gets its own stage-en
 | Field | Source | Notes |
 |-------|--------|-------|
 | `<stage-id>` | previously captured from the stages plugin | Target stage |
-| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Entry rule {N}`. e.g., "Pre-check", "Interrupt on Fraud" |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Entry Rule {N}`. e.g., "Pre-check", "Interrupt on Fraud" |
 | `is-interrupting` | sdd.md (default `false`) | `true` if the condition interrupts the current stage |
 | `rule-type` | Pick from the catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | ID of the referenced stage |
@@ -48,7 +48,7 @@ Stage entry conditions are created **after** all stages exist (Step 7 in impleme
 ```markdown
 ## T<n>: Add stage-entry condition for "<stage>" — <summary>
 - target-stage: "<stage-name>"
-- display-name: "<name>"   # optional — omit when SDD Display Name cell is blank; impl defaults to "Entry rule {N}"
+- display-name: "<name>"   # optional — omit when SDD Display Name cell is blank; impl defaults to "Entry Rule {N}"
 - is-interrupting: false
 - rule-type: selected-stage-completed
 - selected-stage: "<upstream-stage-name>"

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -31,7 +31,7 @@ Rules use DNF — outer array is OR, inner array is AND.
 3. Locate the target stage in `schema.nodes` by ID
 4. Initialize `stageNode.data.exitConditions = []` if absent (regular Stage is created without this key — see [`../../stages/impl-json.md`](../../stages/impl-json.md))
 5. Read `type`, `exit-to-stage`, `marks-stage-complete`, and `rule-type` from tasks.md; pick the recipe below
-6. Set `displayName`: use tasks.md `display-name` if present; else default to `Exit rule {N}`, where `N` = the 1-based index this condition takes in `stageNode.data.exitConditions[]` (i.e. `exitConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
+6. Set `displayName`: use tasks.md `display-name` if present; else default by `marks-stage-complete`: `true` → `Complete Rule {N}`, `false` → `Exit Rule {N}`. `N` = 1-based index **within the same label kind** — at append time, count existing entries in `stageNode.data.exitConditions[]` whose `marksStageComplete` equals this condition's value, then `N = count + 1`. FE numbers complete and exit rules with independent counters — do NOT use the array's overall length. Never emit a blank or omitted `displayName`.
 7. Append the condition object to `stageNode.data.exitConditions[]`
 
 ## Exit Types
@@ -107,4 +107,4 @@ Routes the case back to the originating stage.
 
 ## Post-Write Verification
 
-Confirm target stage's `data.exitConditions[]` contains the new object with `id`, non-empty `displayName` (SDD value or `Exit rule {N}` default), `type`, `exitToStageId` (if set), `marksStageComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.
+Confirm target stage's `data.exitConditions[]` contains the new object with `id`, non-empty `displayName` (SDD value or `Complete Rule {N}` / `Exit Rule {N}` default keyed to `marksStageComplete`), `type`, `exitToStageId` (if set), `marksStageComplete` matching the T-entry, and `rules` carrying the expected `rule` value plus any required side field.

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -17,7 +17,7 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | Field | Source | Notes |
 |-------|--------|-------|
 | `<stage-id>` | Captured from the stages plugin | Target stage |
-| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Exit rule {N}`. |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Complete Rule {N}` (marks-stage-complete `true`) / `Exit Rule {N}` (`false`). |
 | `type` | sdd.md exit style | `exit-only` / `wait-for-user` / `return-to-origin` |
 | `exit-to-stage-id` | sdd.md routing target (optional) | Required when routing to a specific stage |
 | `marks-stage-complete` | sdd.md (default depends on type) | `true` for completion exits, `false` for diverging routes |
@@ -60,7 +60,7 @@ Stage exit conditions are created **after** all tasks in the stage have been add
 ```markdown
 ## T<n>: Add stage-exit condition for "<stage>" — <summary>
 - target-stage: "<stage-name>"
-- display-name: "<name>"                        # optional — omit when SDD Display Name cell is blank; impl defaults to "Exit rule {N}"
+- display-name: "<name>"                        # optional — omit when blank; impl defaults to "Complete Rule {N}"/"Exit Rule {N}" per marks-stage-complete
 - type: exit-only
 - exit-to-stage: "<target-stage-name>"          # optional
 - marks-stage-complete: true

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/impl-json.md
@@ -34,7 +34,7 @@ Rules use DNF — outer array is OR, inner array is AND.
 4. Locate the target task inside `stageNode.data.tasks[lane][index]` (search every lane until the task ID is found)
 5. Initialize `task.entryConditions = []` if absent
 6. Read `rule-type` from tasks.md; pick the recipe below
-7. Set `displayName`: use tasks.md `display-name` if present; else default to `Entry rule {N}`, where `N` = the 1-based index this condition takes in `task.entryConditions[]` (i.e. `entryConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
+7. Set `displayName`: use tasks.md `display-name` if present; else default to `Entry Rule {N}`, where `N` = the 1-based index this condition takes in `task.entryConditions[]` (i.e. `entryConditions.length + 1` at append time). Never emit a blank or omitted `displayName`.
 8. Append the condition object to `task.entryConditions[]`
 
 ## Rule Types
@@ -101,4 +101,4 @@ Write `rule.uipath` per [connector-trigger-common.md § Target: connector-bound 
 
 ## Post-Write Verification
 
-Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`), non-empty `displayName` (SDD value or `Entry rule {N}` default), and `rules` with the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated, inputs/outputs `elementId` is `<stageId>-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.
+Confirm target task's `entryConditions[]` length equals the number of task-entry T-tasks tasks.md wrote for this task. Each entry carries `id` (prefix `c`), non-empty `displayName` (SDD value or `Entry Rule {N}` default), and `rules` with the expected `rule` value plus any required side field. For `wait-for-connector`: verify `rule.uipath.serviceType` is `"Intsvc.WaitForEvent"`, `rule.uipath.context[]` is populated, inputs/outputs `elementId` is `<stageId>-<ruleId>`, and ConnectionId + FolderKey root bindings exist. CLI `validate` does NOT check `rule.uipath` — confirm via Studio Web.

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -17,7 +17,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | Field | Source | Notes |
 |-------|--------|-------|
 | `<stage-id>`, `<task-id>` | Captured from prior steps | |
-| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Entry rule {N}`. |
+| `display-name` | sdd.md Display Name column (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one; impl defaults it to `Entry Rule {N}`. |
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs |
 | `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-common.md § Planning Pipeline](../../../connector-trigger-common.md#planning-pipeline) |
@@ -44,7 +44,7 @@ Task entry conditions are created **after** all tasks in the stage have been add
 ## T<n>: Add task-entry condition for "<task>" in "<stage>" — <summary>
 - target-stage: "<stage-name>"
 - target-task: "<task-name>"
-- display-name: "<name>"                  # optional — omit when SDD Display Name cell is blank; impl defaults to "Entry rule {N}"
+- display-name: "<name>"                  # optional — omit when SDD Display Name cell is blank; impl defaults to "Entry Rule {N}"
 - rule-type: selected-tasks-completed
 - selected-tasks: "<Task A>, <Task B>"
 - condition-expression: "=js:vars.X..."   # optional gate on case state, NOT the event payload

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -258,7 +258,7 @@ Nested `{op, clauses}` groups flatten in the rendered table. Avoid `Literal: No`
 |---|---|---|---|---|
 | `required-stages-completed` / `wait-for-connector` | optional `conditionExpression` | `Yes` | `exit-only` | optional |
 
-> **Display Name** (optional, every condition table — entry, exit, task-entry, case-exit): human-readable label. Carry the author's value verbatim; leave blank / `—` to let the skill default it to `Entry rule {N}` (entry / task-entry) or `Exit rule {N}` (stage-exit / case-exit), `N` = 1-based index within the container. Never invent a label when the cell is blank.
+> **Display Name** (optional, every condition table — entry, exit, task-entry, case-exit): human-readable label. Carry the author's value verbatim; leave blank / `—` to let the skill default it: entry / task-entry → `Entry Rule {N}`; stage-exit / case-exit → `Complete Rule {N}` (Marks Complete `Yes`) / `Exit Rule {N}` (`No`). `N` = 1-based index within the same label kind in the container. Never invent a label when the cell is blank.
 
 **Allowed WHEN:** `required-stages-completed`, `wait-for-connector`.
 **Forbidden WHEN:** `selected-stage-completed`, `selected-stage-exited` (sdd-template Key Rule 4 — `Yes` + `selected-stage-*` is a schema-pairing error → block Approve).


### PR DESCRIPTION
## Summary

Bug fix for exit-rule `displayName` defaulting introduced by #1164.

#1164 made exit-rule `displayName` deterministic but hardcoded the default to `Exit rule {N}` for **every** exit condition, ignoring the marks-complete flag that the FE uses to split **complete rules** from **exit rules**. A condition with `marksCaseComplete` / `marksStageComplete: true` was mislabeled `Exit rule` instead of `Complete Rule`.

## Fix

The default now keys on the marks-complete flag, mirroring FE:

| Flag | Default label |
|---|---|
| `true`  | `Complete Rule {N}` |
| `false` | `Exit Rule {N}` |

- **case-exit + stage-exit** (`impl-json.md` + `planning.md`): default keyed on `marks-case-complete` / `marks-stage-complete`. `N` counts **within the same label kind** (independent per-prefix counters) at append time — explicitly *not* the array's overall length. So `[complete, exit, complete]` → `Complete Rule 1`, `Exit Rule 1`, `Complete Rule 2`.
- **stage-entry + task-entry**: `Entry rule {N}` → `Entry Rule {N}` for casing parity (capital R) with the exit/complete labels.
- **`sdd-template.md` + `sdd-generation-rules.md`**: shared default-rule text and the four condition-table footers updated to match.

## Scope / notes

- Docs-only change; no skill code or build.
- `sdd-viewer.html` unchanged — it only renders authored values, never computes defaults.
- No tests assert these label literals (verified via grep), so no eval-task changes.
- **Reviewer check:** assumes FE numbers complete and exit rules with **independent** counters. If FE uses a single array-position counter instead, only the `N` rule in the two exit `impl-json.md` files needs flipping back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)