### PR TITLE
feat(uipath-agents): port universal guardrail recommendation rules to low-code [AL-349]

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
@@ -84,7 +84,19 @@ For **each entry** in the catalog (`guardrails[]` array from the cached JSON):
 
 Do **not** apply predetermined knowledge about which guardrail maps to which schema field. Let the catalog entry's authored fields drive every recommendation decision.
 
-### Step 3 — Scoped or Tool-Specific Filtering (only when user requests)
+### Step 3 — De-duplicate Overlapping Validators
+
+Several catalog validators address the same threat. Recommending more than one of them at the same scope and stage is redundant — it doubles latency and cost on every call for marginal benefit (the canonical case is `prompt_injection` and `user_prompt_attacks`: both have `security_category: "adversarial_input"` and both run at Llm · PRE).
+
+After Step 2 produces the candidate list, group candidates by **(`security_category`, scope, stage)**. For any group with more than one candidate:
+
+1. **Drop deprecated or unavailable entries first.** If the catalog marks an entry deprecated (via its `status`, or a deprecation note in `notes` / `when_not_to_use`), remove it from the group. Never recommend a validator the catalog signals is being retired when an active alternative covers the same category.
+2. **Keep the single best fit** for the agent's context — the one whose `when_to_use` / `use_cases` most closely match. Recommend only that one.
+3. **Mention the alternative(s)** you dropped and why (e.g. "also recommending only User Prompt Attacks, not Prompt Injection — both cover adversarial input at Llm PRE and the catalog marks Prompt Injection deprecated").
+
+Do **not** hardcode validator names or a fixed "prefer X over Y" rule in your reasoning — derive the grouping from each entry's `security_category`, scope, and stage, and derive deprecation from the catalog's own fields. This keeps the behavior correct as the catalog evolves.
+
+### Step 4 — Scoped or Tool-Specific Filtering (only when user requests)
 
 If the user asks for recommendations for a **specific scope** (e.g., "only for Llm"):
 - After Step 2, keep only candidates where the scope name appears in `AllowedScopes` (from the guardrails list output).
@@ -95,7 +107,34 @@ If the user asks for recommendations for a **specific tool** (e.g., "for the Sen
 - Set `selector.matchNames: ["<name>"]` where `<name>` is the `name` field from the tool's `resource.json` — **not** the folder name under `resources/`.
 - Note: custom guardrails (type `"Custom"` in catalog) also only support Tool scope.
 
-### Step 4 — Generate Config Blocks
+#### Block as early as possible — default scope selection
+
+When a validator supports **more than one scope** (e.g. `pii_detection` allows Agent / Llm / Tool per its `AllowedScopes`), pick the scope that stops a violation at the **outermost boundary the validator allows**, so a bad run is halted with the least wasted work:
+
+| Guardrail intent | Prefer | Why |
+|---|---|---|
+| **Input protection** (block bad/sensitive input: PII, jailbreak, injection) | broadest **PRE** scope allowed → **Agent** > Llm > Tool | Agent · PRE fires once, before the agent reaches the LLM or any tool. Catching PII or an attack at Agent · PRE blocks the whole run immediately instead of after the model has already been called. |
+| **Output protection** (block bad output the caller sees: harmful content, IP) | **Agent · POST** when allowed | Agent · POST inspects the agent's final answer — the thing the user actually receives. |
+| **Tool I/O protection** (a specific tool's input/output) | **Tool** scope on that tool | Only narrow to Tool when the concern is genuinely that one tool, or the user scoped it there. |
+
+Concretely: **PII detection meant to stop the agent handling personal data goes at `selector.scopes: ["Agent"]`, not `["Llm"]`** — both are listed in `AllowedScopes` for `pii_detection`, but Agent · PRE blocks the run earlier (before the LLM call) and covers the whole agent, not just one model invocation. Only drop to a narrower scope when the validator does not support the broader one (`prompt_injection` and `user_prompt_attacks` are Llm-only, so Llm · PRE is the earliest available for them) or when the user explicitly asks for a narrower scope.
+
+Always confirm the chosen scope is in the validator's `AllowedScopes` from the guardrails list — never assume a scope the catalog/SDK does not permit.
+
+### Step 5 — Choose the Action
+
+The action (`{"$actionType": "block"}` vs `{"$actionType": "log"}` vs `escalate` / `filter`) is **not** a free choice — default to the `action_type` in the catalog entry's representative `examples[].config`. For security-critical guardrails (`adversarial_input` — prompt injection / user prompt attacks; `content_safety` — harmful content / IP) the catalog examples use **block**, because a logged-but-allowed violation provides no actual protection.
+
+Rules:
+
+1. **Default to the catalog example's `action_type`.** If it is `block`, generate `{"$actionType": "block", "reason": "..."}`. Do not substitute `log` for a security-critical guardrail on your own initiative.
+2. **Never silently downgrade block → log.** A guardrail set to log-only when the user expected blocking is the dangerous failure mode — the agent looks protected but isn't. If you use `{"$actionType": "log"}` for any guardrail whose catalog default is `block`, you **must** state it explicitly in the report and give the reason.
+3. **Legitimate reasons to use `log` instead of `block`** (state which applies):
+   - The user explicitly asked for observe-only / audit / "log first, block later" rollout.
+   - A high false-positive risk where blocking would break normal operation (e.g. PII `Person` entity flagging ordinary words) — log so the user can tune thresholds before enforcing.
+4. **When ambiguous, ask once.** If the user gave no action preference and the guardrail is security-critical, you may apply the `block` default and report it, or ask "block on violation, or log-only to start?" — but do not quietly pick `log`.
+
+### Step 6 — Generate Config Blocks
 
 For each recommended guardrail, use the catalog `examples[].config` as the template. Map it to `agent.json` format using `guardrails.md` for the exact JSON shape (discriminators, UUID, PascalCase scopes, `$`-prefixed fields).
 
@@ -103,9 +142,11 @@ For each recommended guardrail, use the catalog `examples[].config` as the templ
 
 For parameters, use the `Parameters` array from the matching guardrails list entry to confirm correctness — see the [Correctness Check](#correctness-check) table in Validate Mode for the exact rules. Apply the same checks when generating config to avoid writing invalid parameters from the start.
 
+Use the action chosen in Step 5.
+
 Generate a fresh UUID for each guardrail `id`.
 
-### Step 5 — Apply and Validate
+### Step 7 — Apply and Validate
 
 Write the new guardrail blocks to `agent.json`'s `guardrails[]` array. Then run:
 
@@ -116,7 +157,7 @@ uip agent validate "<AgentName>" --output json
 Report to the user:
 - What was added (by name)
 - Why it was recommended (cite the catalog's `when_to_use` or a specific `use_cases` item that matched the agent's context)
-- What scope and action were chosen and why (cite `AllowedScopes` from the guardrails list or `when_not_to_use` from the catalog if relevant)
+- What scope and action were chosen and why. If you dropped an overlapping validator in Step 3, name it and the reason. If you used `{"$actionType": "log"}` for a guardrail whose catalog default is `block` (Step 5), call it out explicitly with the reason.
 - What parameters were set and their meaning
 
 ---
@@ -175,9 +216,12 @@ If the user asks to fix identified issues: apply corrections to `agent.json`, ru
 2. **If `GuardrailCatalogUnavailable`** → surface the message and stop. Do not fall back to guessing or hardcoded recommendations.
 3. **Only recommend `Available` validators**. Mention `Unauthorised` ones to the user so they can contact their administrator.
 4. **Every recommendation must cite** the catalog entry's `when_to_use` or a specific `use_cases` item that matched the agent's context. Do not recommend a guardrail without explaining why it applies.
-5. **For Tool scope**: verify the tool exists in `resources/` before writing `matchNames`. If the agent has no tool resources, do not add a Tool-scoped guardrail.
-6. **Correctness validation uses `uip agent guardrails list` output** — `Parameters[].Type`, `Options`, `KeySource`, `Min`, `Max`, `Step` are the authoritative source for all parameter rules. Do not hardcode validator-specific knowledge.
-7. **The cache file is `.guardrails-catalog-cache.json`** in the working directory. Add it to `.gitignore` if one exists.
-8. **Do not create separate guardrails per scope** — combine multiple scopes into a single guardrail's `scopes` array.
-9. **All map-enum keys must exactly match the corresponding enum-list values** — no extra or missing keys. This is the most common correctness error.
-10. **Read [guardrails.md](guardrails.md) before writing any JSON** — discriminator fields, PascalCase constraints, and parameter shapes are specified there and cannot be safely inferred.
+5. **Never recommend two validators with the same `security_category` at the same scope and stage** (e.g. `prompt_injection` + `user_prompt_attacks` at Llm PRE). De-duplicate per Step 3: drop catalog-deprecated entries, keep the best fit, mention the alternative. Derive the grouping and deprecation from the catalog's own fields — do not hardcode validator names.
+6. **Default the action to the catalog example's `action_type`; never silently downgrade `block` → `log`.** Security-critical guardrails (`adversarial_input`, `content_safety`) default to `{"$actionType": "block"}`. If you use `{"$actionType": "log"}` for a guardrail whose catalog default is `block`, state it and the reason in the report (Step 5).
+7. **Block as early as possible — pick the outermost scope the validator allows.** For input protection (PII, jailbreak, injection) prefer `selector.scopes: ["Agent"]` over `["Llm"]` over `["Tool"]`, so the run halts before the LLM call. PII meant to stop the agent handling personal data goes at **Agent**, not Llm. Only narrow when the validator is scope-restricted (e.g. `prompt_injection` / `user_prompt_attacks` are Llm-only) or the user asks for a narrower scope. See Step 4.
+8. **For Tool scope**: verify the tool exists in `resources/` before writing `matchNames`. If the agent has no tool resources, do not add a Tool-scoped guardrail.
+9. **Correctness validation uses `uip agent guardrails list` output** — `Parameters[].Type`, `Options`, `KeySource`, `Min`, `Max`, `Step` are the authoritative source for all parameter rules. Do not hardcode validator-specific knowledge.
+10. **The cache file is `.guardrails-catalog-cache.json`** in the working directory. Add it to `.gitignore` if one exists.
+11. **Do not create separate guardrails per scope** — combine multiple scopes into a single guardrail's `scopes` array.
+12. **All map-enum keys must exactly match the corresponding enum-list values** — no extra or missing keys. This is the most common correctness error.
+13. **Read [guardrails.md](guardrails.md) before writing any JSON** — discriminator fields, PascalCase constraints, and parameter shapes are specified there and cannot be safely inferred.

--- a/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/check_recommend_all.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/check_recommend_all.py
@@ -116,6 +116,20 @@ def main() -> None:
     llm_types = [get_validator_type(g) for g in llm_guards]
     print(f"OK: Llm-scoped builtInValidator guardrail(s) present: {llm_types}")
 
+    # De-dup rule: must NOT stack both prompt_injection AND user_prompt_attacks —
+    # they share security_category "adversarial_input" at Llm PRE. Recommend one.
+    has_prompt_injection = any(get_validator_type(g) == "prompt_injection" for g in guardrails)
+    has_user_prompt_attacks = any(
+        get_validator_type(g) == "user_prompt_attacks" for g in guardrails
+    )
+    if has_prompt_injection and has_user_prompt_attacks:
+        sys.exit(
+            "FAIL: both prompt_injection and user_prompt_attacks validators are present. "
+            "They cover the same security_category (adversarial_input) at Llm PRE — "
+            "the recommender must pick exactly one, not stack both."
+        )
+    print("OK: adversarial-input validators are de-duplicated (not both stacked)")
+
     # Check for content-safety guardrail
     content_guards = [
         g for g in guardrails
@@ -129,6 +143,23 @@ def main() -> None:
         )
     content_types = [get_validator_type(g) for g in content_guards]
     print(f"OK: content-safety guardrail(s) present: {content_types}")
+
+    # Default-action rule: a security-critical guardrail must block, not just log.
+    # recommend_all always yields at least one adversarial-input + one content-safety
+    # guardrail, whose catalog-default action is block — so at least one $actionType "block"
+    # must be present.
+    has_block = any(
+        (g.get("action") or {}).get("$actionType") == "block" for g in guardrails
+    )
+    if not has_block:
+        action_types = [(g.get("action") or {}).get("$actionType") for g in guardrails]
+        sys.exit(
+            "FAIL: no guardrail uses $actionType 'block'. The recommended adversarial-input "
+            "and content-safety guardrails default to block in the catalog — a security-"
+            "critical guardrail must block, not be silently downgraded to log-only. "
+            f"Action types found: {action_types}"
+        )
+    print("OK: $actionType 'block' present (security-critical guardrail blocks)")
 
     print("OK: guardrail recommendation check passed")
 


### PR DESCRIPTION
## What changed?

Brings **low-code** guardrail recommendation to parity with the coded skill for three catalog-driven, framework-agnostic decision rules (the coded equivalents shipped in #1029):

### New rules in [`lowcode/capabilities/guardrails/guardrails-recommend.md`](skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md)

| Rule | Where it lives | Why |
|---|---|---|
| **De-duplicate overlapping validators** | new Step 3 + Critical Rule 5 | Group candidates by `(security_category, scope, stage)`; drop catalog-deprecated entries; keep the single best fit and mention the rest. Stops the demo bug of recommending both `prompt_injection` and `user_prompt_attacks` at Llm PRE. Grouping + deprecation derived from catalog fields — no hardcoded validator names. |
| **Block as early as possible** | new subsection under scope/tool filtering + Critical Rule 7 | For input protection (PII, jailbreak, injection) prefer `selector.scopes: ["Agent"]` over `["Llm"]` over `["Tool"]`, so the run halts before the LLM call. PII to stop the agent handling personal data goes at **Agent**, not Llm. Narrow only when the validator is scope-restricted (e.g. `prompt_injection` / `user_prompt_attacks` are Llm-only) or the user asks. |
| **Catalog-default action; never silently downgrade Block → Log** | new Step 5 + Critical Rule 6 | Security-critical guardrails (`adversarial_input`, `content_safety`) default to `{"$actionType": "block"}` per the catalog example. `{"$actionType": "log"}` on a Block-default guardrail must be stated and justified in the report. |

The existing "Generate Config Blocks" and "Apply and Validate" steps are renumbered (6, 7). The Report bullets in "Apply and Validate" now call out dropped overlaps and any explicit Block → Log downgrade with the reason.

### Tests

[`tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/check_recommend_all.py`](tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/check_recommend_all.py) tightened with two new assertions mirroring the coded counterpart:

- **Dedup assertion** — fails if both `prompt_injection` and `user_prompt_attacks` validators are present.
- **Block-action assertion** — fails if no `$actionType: "block"` action is present (the `recommend_all` scenario always yields a security-critical guardrail whose catalog default is Block).

### Out of scope (intentionally not changed)

- [`guardrails.md`](skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md) (writer reference) — `agent.json` JSON schema is unchanged; only selection logic moves.
- Coded files — already shipped in #1029.
- Coded-only rules (adapter-registration import, `_GuardedLLM` runtime wrap) — Python/SDK mechanics that don't apply to `agent.json`.

## How has this been tested?

Live e2e via `coder-eval run` against the latest main: **3/3 SUCCESS**.

| Task | Score | Duration | Rule compliance in fresh artifact |
|---|---|---|---|
| `lowcode/guardrails/recommend_all` | 4/4 (1.000) | 187s | Single adversarial validator (`user_prompt_attacks`, no `prompt_injection`) ✓; PII at `scopes: ["Agent"]` ✓; all 4 guardrails use `$actionType: "block"` ✓ |
| `lowcode/guardrails/recommend_scoped` | 4/4 (1.000) | 127s | No-regression smoke |
| `lowcode/guardrails/validate` | 4/4 (1.000) | 90s | No-regression smoke |

Plus offline:
- `python3 -m py_compile` on the tightened check ✓
- `coder-eval plan` on all three lowcode guardrail YAMLs ✓
- Sanity tests against synthetic inputs: positive (3 dedup'd Block guardrails) → exit 0 ✓; negative (stacked `prompt_injection` + `user_prompt_attacks`) → FAIL on dedup ✓; negative (all `log` actions) → FAIL on action rule ✓.

The fresh `recommend_all` artifact's final `agent.json` (4 guardrails, all Block, PII at Agent, single adversarial):

```
pii_detection             | ["Agent"]   | block
user_prompt_attacks       | ["Llm"]     | block
harmful_content           | ["Agent"]   | block
intellectual_property     | ["Agent"]   | block
```

## Are there any breaking changes?

- [ ] Under Feature Flag
- [x] None
- [ ] DB migrations
- [ ] API removals