### PR TITLE
fix(uipath-agents): unblock 3 failing guardrail smoke tests [AL-450]

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
@@ -24,17 +24,17 @@ Add guardrails to a Python coded agent (LangChain/LangGraph) in two styles: **mi
 
 ---
 
-## Optional: Check Tenant Availability
+## Check Tenant Availability (mandatory for built-in AI validators)
 
-For built-in AI validators (PII, harmful content, user prompt attacks, IP), optionally confirm the validator is enabled on this tenant:
+For built-in AI validators (PII, harmful content, user prompt attacks, IP), confirm the validator is enabled on this tenant **before authoring** — run:
 
 ```bash
 uip agent guardrails list --output json
 ```
 
-If the requested validator has `Status != "Available"` → tell the user and stop.
+If the requested validator has `Status != "Available"` → tell the user and stop. This is not optional for AI validators: they depend on a tenant-side service, and adding one that is not entitled produces a guardrail that never fires.
 
-**Skip this step for deterministic guardrails** — they run locally with no backend dependency.
+**Skip this step only for deterministic guardrails** — they run locally with no backend dependency.
 
 ---
 
@@ -247,3 +247,4 @@ For non-LangChain frameworks, there is no published adapter yet, so the decorato
 10. **Entity/threshold values must match the docs exactly** — use enum member names, not raw strings; use only allowed threshold values.
 11. **Deterministic guardrails run locally** — no backend API call, no tenant availability check needed.
 12. **Do not duplicate existing guardrails** — read the agent code first and skip if the same guardrail is already configured.
+13. **Do not delegate the import-source decision (or guardrail authoring) to a subagent.** A dispatched subagent does not carry this skill's context and will report the module where the symbols physically live (`uipath.platform.guardrails`) — the no-op path for LangChain agents (Rule 8). It looks authoritative and silently overrides the correct `uipath_langchain.guardrails` choice. Fetch the docs and write the imports inline, where this skill's import rule still applies.

--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
@@ -32,7 +32,7 @@ For built-in AI validators (PII, harmful content, user prompt attacks, IP), conf
 uip agent guardrails list --output json
 ```
 
-If the requested validator has `Status != "Available"` → tell the user and stop. This is not optional for AI validators: they depend on a tenant-side service, and adding one that is not entitled produces a guardrail that never fires.
+If the requested validator has `Status != "Available"` → tell the user and stop. Actually adding one that is not entitled produces a guardrail that always fails.
 
 **Skip this step only for deterministic guardrails** — they run locally with no backend dependency.
 

--- a/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
@@ -9,6 +9,14 @@ tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+  # Disallow the subagent-dispatch tool. It is NOT gated by allowed_tools, and in
+  # the failing run the agent (which had already reasoned its way to the correct
+  # `uipath_langchain.guardrails` import) dispatched a research subagent that came
+  # back recommending `uipath.platform.guardrails` — the no-op import path that
+  # bypasses the LangChain adapter. The subagent has no skill context, so it can't
+  # see the import-source rule; trusting it silently regressed the answer. Force
+  # inline research where the loaded skill's import rule still applies.
+  disallowed_tools: ["Task"]
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -118,6 +118,12 @@ success_criteria:
 
 run_limits:
   expected_turns: 41
-  max_turns: 40
+  # This is the heaviest guardrail task (scaffold solution + agent, discover
+  # validators, look up the escalation app, author the escalate guardrail, then
+  # validate). expected_turns is 41, so a 40-turn cap guaranteed
+  # MAX_TURNS_EXHAUSTED before validate could run. Give headroom above the
+  # expected length. task_timeout (1800s) is not the bottleneck — runs finish
+  # in ~500s; turns are the cap.
+  max_turns: 55
   turn_timeout: 1200
   task_timeout: 1800


### PR DESCRIPTION
## Summary

Fixes the 3 failing guardrail tasks from run `2026-06-01_04-04-22`. Each was investigated to root cause (logs + artifacts on coder-evalboard), then fixed and verified locally.

| Task | Before | Root cause | Fix |
|------|--------|-----------|-----|
| `recommend-scoped` | FAILURE · 0.81 (3/4) | Agent skipped `uip agent guardrails list`. `guardrails.md` framed it "Optional", contradicting the recommend flow which mandates it. | Made the tenant-availability `list` **mandatory for built-in AI validators** (skippable only for deterministic guardrails). |
| `user-prompt-attacks-decorator` | FAILURE · 0.00 (0/1) | Agent reasoned to the correct `uipath_langchain.guardrails` import, then dispatched a research **subagent** that returned `uipath.platform.guardrails` — the no-op path that bypasses the LangChain adapter — and trusted it. | `disallowed_tools: ["Task"]` so import research stays inline where the skill's rule applies; + Critical Rule 13 ("don't delegate the import-source decision to a subagent"). |
| `escalation-app` | MAX_TURNS_EXHAUSTED · 0.67 (8/11) | `expected_turns: 41` with `max_turns: 40` — the hard cap sat **below** the expected run length. | Raised `max_turns` 40 → 55. |

## Verification

Ran locally with coder-eval (`experiments/default.yaml`, `claude-sonnet-4-6`, against an authenticated tenant), **twice**, to confirm not flaky:

| Task | Run 1 | Run 2 |
|------|-------|-------|
| recommend-scoped | ✅ 4/4 · 1.000 | ✅ 4/4 · 1.000 |
| user-prompt-attacks-decorator | ✅ 1/1 · 1.000 | ✅ 1/1 · 1.000 |
| escalation-app | ✅ 11/11 · 1.000 | ✅ 11/11 · 1.000 |

The `user_prompt_attacks_decorator` check script was also confirmed correct in isolation: the agent's original output → FAIL, the same file with only the import module swapped → full PASS.

## Files changed

- `skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md`
- `tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml`
- `tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)