### PR TITLE
docs(uipath-ixp): align deployments get-taxonomy with new project + version surface

### DIFF
--- a/skills/uipath-ixp/SKILL.md
+++ b/skills/uipath-ixp/SKILL.md
@@ -14,7 +14,7 @@ Skill for working with UiPath IXP (Intelligent eXtraction Platform) projects —
 - User asks to improve extraction scores, prompts, or field instructions
 - User asks to publish or manage IXP model versions
 - User provides a taxonomy file to import into a project
-- User asks for the schema of a deployed (runtime) IXP model (use `deployments get-taxonomy`)
+- User asks for the project taxonomy at a specific trained model version — what the schema looked like when version N was published (use `deployments get-taxonomy <project-name> --version <N>`)
 
 ## Critical Rules
 

--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -110,4 +110,4 @@ For working with runtime (deployed) IXP models — separate from the training wo
 
 | Command | Description |
 |---------|-------------|
-| `uip ixp deployments get-taxonomy <model-name> --folder-key <key> --output json` | Get the taxonomy (field names) of a deployed model. Pairs with `uip maestro flow registry get` — use `inputDefaults.modelName` and `inputDefaults.folderKey` from that output. |
+| `uip ixp deployments get-taxonomy <project-name> --version <N> --output json` | Get the project taxonomy (data types + field groups) at a specific trained model version. `--version` is the model version number from `projects list-models`. Output mirrors `projects get-taxonomy` — `EntityDefs[]` + `LabelGroups[]` — pinned to the snapshot the version was trained on. |


### PR DESCRIPTION
## Summary

Paired with [cli#2324](https://github.com/UiPath/cli/pull/2324). The `deployments get-taxonomy` command no longer takes `folderKey + modelName` (which was for inspecting a deployed model's runtime field schema via the DU framework). It now takes `project-name + --version` and returns the project taxonomy snapshot pinned to a published model version — same shape as `projects get-taxonomy`.