### PR TITLE
fix(automerge): set GH_REPO so catalog-refresh auto-merge can run

### DIFF
--- a/.github/workflows/automerge-catalog-refresh.yml
+++ b/.github/workflows/automerge-catalog-refresh.yml
@@ -34,6 +34,10 @@ jobs:
           # post-merge job that depends on the new catalog landing on main).
           # Same PAT used elsewhere — see activation-gate.yml.
           GH_TOKEN: ${{ secrets.GH_PAT }}
+          # `gh pr {list,view,merge}` resolve the repo from a local git
+          # remote; this job has no actions/checkout step, so GH_REPO is
+          # required or every gh pr call dies with "not a git repository".
+          GH_REPO: ${{ github.repository }}
           MANUAL_PR: ${{ github.event.inputs.pr_number }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Problem

The catalog-refresh auto-merger (`automerge-catalog-refresh.yml`) **has never successfully run**. Every one of the last 30+ runs failed with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job has no `actions/checkout` step, so `gh pr list` / `gh pr view` / `gh pr merge` — which resolve the repo from a local git remote — crash at the **first `gh pr` call**, before any check-gating logic executes. As a result no nightly refresh PR was ever auto-merged; they were all closed by hand (#1048, #1099, #1189).

This means the required-checks gating added in #1081 was **correct but unreachable** — the workflow died long before evaluating checks.

## Fix

Set `GH_REPO: ${{ github.repository }}` in the step's `env:` block so `gh` resolves the repo without a checkout. One line.

`gh api "repos/$GITHUB_REPOSITORY/..."` already worked (explicit path); only the `gh pr` subcommands needed this.

## Validation plan

`workflow_dispatch` and `check_suite` triggers run the workflow definition from the default branch, so this only takes effect once merged. After merge, dispatch the automerger against the still-open refresh PR #1203 to confirm it:
- reaches the gating logic (no more "not a git repository"),
- merges on the green/skipped **required** smoke checks,
- ignores the failing non-required `uipath-*` CLI Verb Gate checks (the #1081 behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)