### PR TITLE
chore: refresh uip CLI catalog (1.2.0-alpha.20260602.7374)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-02T16:13:20Z",
-  "cli_version": "1.2.0-alpha.20260602.7371",
+  "generated_at": "2026-06-02T16:43:43Z",
+  "cli_version": "1.2.0-alpha.20260602.7374",
   "verbs": [
     "completion",
     "config",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.2.0-alpha.20260602.7374`. The catalog has 31 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.