### PR TITLE
fix(uipath-maestro-flow): migrate edit template + bump eval-run turn_timeout

### DIFF
--- a/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/BellevueWeather.flow
+++ b/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/BellevueWeather.flow
@@ -1,15 +1,13 @@
 {
   "id": "51e93e69-8d7b-4543-b079-cec6c73673ff",
-  "version": "1.2",
+  "version": "1.0.0",
   "name": "BellevueWeather",
   "nodes": [
     {
       "id": "start",
       "type": "core.trigger.manual",
-      "typeVersion": "1.0",
-      "display": {
-        "label": "Manual trigger"
-      },
+      "typeVersion": "1.0.0",
+      "display": { "label": "Manual trigger" },
       "inputs": {},
       "outputs": {
         "output": {
@@ -27,10 +25,8 @@
     {
       "id": "getWeather",
       "type": "core.action.http",
-      "typeVersion": "1.1",
-      "display": {
-        "label": "Get Bellevue Weather"
-      },
+      "typeVersion": "1.0.0",
+      "display": { "label": "Get Bellevue Weather" },
       "inputs": {
         "mode": "manual",
         "method": "GET",
@@ -57,17 +53,13 @@
           "var": "error"
         }
       },
-      "model": {
-        "type": "bpmn:ServiceTask"
-      }
+      "model": { "type": "bpmn:ServiceTask" }
     },
     {
       "id": "formatSummary",
       "type": "core.action.script",
-      "typeVersion": "1.0",
-      "display": {
-        "label": "Format Weather Summary"
-      },
+      "typeVersion": "1.0.0",
+      "display": { "label": "Format Weather Summary" },
       "inputs": {
         "script": "const tempF = $vars.getWeather.output.body.current.temperature_2m;\nconst time = $vars.getWeather.output.body.current.time;\nreturn {\n  temperatureF: tempF,\n  summary: 'Bellevue weather today: ' + tempF + 'F at ' + time\n};"
       },
@@ -85,59 +77,45 @@
           "var": "error"
         }
       },
-      "model": {
-        "type": "bpmn:ScriptTask"
-      }
+      "model": { "type": "bpmn:ScriptTask" }
     },
     {
       "id": "checkTemperature",
       "type": "core.logic.decision",
-      "typeVersion": "1.0",
-      "display": {
-        "label": "Temp > 60F?"
-      },
+      "typeVersion": "1.0.0",
+      "display": { "label": "Temp > 60F?" },
       "inputs": {
         "expression": "$vars.formatSummary.output.temperatureF > 60",
         "trueLabel": "Nice Day",
         "falseLabel": "Bring a Jacket"
       },
-      "model": {
-        "type": "bpmn:InclusiveGateway"
-      }
+      "model": { "type": "bpmn:InclusiveGateway" }
     },
     {
       "id": "endNiceDay",
       "type": "core.control.end",
-      "typeVersion": "1.0",
-      "display": {
-        "label": "Nice Day"
-      },
+      "typeVersion": "1.0.0",
+      "display": { "label": "Nice Day" },
       "inputs": {},
       "outputs": {
         "summary": {
           "source": "=js:({ message: 'nice day', temperatureF: $vars.formatSummary.output.temperatureF, description: $vars.formatSummary.output.summary })"
         }
       },
-      "model": {
-        "type": "bpmn:EndEvent"
-      }
+      "model": { "type": "bpmn:EndEvent" }
     },
     {
       "id": "endBringJacket",
       "type": "core.control.end",
-      "typeVersion": "1.0",
-      "display": {
-        "label": "Bring a Jacket"
-      },
+      "typeVersion": "1.0.0",
+      "display": { "label": "Bring a Jacket" },
       "inputs": {},
       "outputs": {
         "summary": {
           "source": "=js:({ message: 'bring a jacket', temperatureF: $vars.formatSummary.output.temperatureF, description: $vars.formatSummary.output.summary })"
         }
       },
-      "model": {
-        "type": "bpmn:EndEvent"
-      }
+      "model": { "type": "bpmn:EndEvent" }
     }
   ],
   "edges": [
@@ -181,13 +159,9 @@
     {
       "nodeType": "core.trigger.manual",
       "version": "1.0.0",
-      "description": "Start workflow manually",
       "category": "trigger",
-      "tags": [
-        "trigger",
-        "start",
-        "manual"
-      ],
+      "description": "Start workflow manually",
+      "tags": ["trigger", "start", "manual"],
       "sortOrder": 40,
       "display": {
         "label": "Manual trigger",
@@ -206,15 +180,25 @@
               "handleType": "output",
               "showButton": true,
               "constraints": {
-                "forbiddenTargetCategories": [
-                  "trigger"
-                ]
+                "forbiddenTargetCategories": ["trigger"]
               }
             }
           ],
           "visible": true
         }
       ],
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": true
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "Data passed when manually triggering the workflow.",
+          "source": "null",
+          "var": "output"
+        }
+      },
       "toolbarExtensions": {
         "design": {
           "actions": [
@@ -225,33 +209,16 @@
             }
           ]
         }
-      },
-      "outputDefinition": {
-        "output": {
-          "type": "object",
-          "description": "Data passed when manually triggering the workflow.",
-          "source": "null",
-          "var": "output"
-        }
-      },
-      "model": {
-        "type": "bpmn:StartEvent",
-        "entryPointId": true
       }
     },
     {
       "nodeType": "core.action.http",
       "version": "1.0.0",
-      "description": "Make API calls with branching and retry",
       "category": "data-operations",
-      "tags": [
-        "connector",
-        "http",
-        "api",
-        "rest",
-        "request"
-      ],
+      "description": "Make API calls with branching and retry",
+      "tags": ["connector", "http", "api", "rest", "request"],
       "sortOrder": 35,
+      "supportsErrorHandling": true,
       "display": {
         "label": "HTTP Request",
         "icon": "app-window",
@@ -290,168 +257,6 @@
           "visible": true
         }
       ],
-      "inputDefaults": {
-        "mode": "manual",
-        "method": "GET",
-        "url": "",
-        "swaggerDefinition": null,
-        "authenticationType": "manual",
-        "application": "",
-        "connection": "",
-        "headers": {},
-        "queryParams": {},
-        "body": "",
-        "contentType": "application/json",
-        "timeout": "PT15M",
-        "retryCount": 0,
-        "branches": []
-      },
-      "inputDefinition": {
-        "type": "object",
-        "properties": {
-          "mode": {
-            "type": "string"
-          },
-          "method": {
-            "type": "string",
-            "minLength": 1,
-            "errorMessage": "Method is required"
-          },
-          "url": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^(.*\\.\\S.*|.*\\$vars.*)$",
-            "errorMessage": {
-              "minLength": "URL is required",
-              "pattern": "URL must be a valid URL or variable expression"
-            }
-          },
-          "swaggerDefinition": {
-            "type": [
-              "object",
-              "null"
-            ]
-          },
-          "authenticationType": {
-            "type": "string"
-          },
-          "application": {
-            "type": "string"
-          },
-          "connection": {
-            "type": "string"
-          },
-          "headers": {
-            "type": "object"
-          },
-          "queryParams": {
-            "type": "object"
-          },
-          "body": {
-            "type": "string"
-          },
-          "contentType": {
-            "type": "string"
-          },
-          "timeout": {
-            "type": "string",
-            "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$",
-            "errorMessage": {
-              "pattern": "Timeout must be in ISO 8601 duration format (e.g., PT15M, PT1H, P1D)"
-            }
-          },
-          "retryCount": {
-            "type": "number"
-          },
-          "branches": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "conditionExpression": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "required": [
-          "method",
-          "url"
-        ]
-      },
-      "outputDefinition": {
-        "output": {
-          "type": "object",
-          "description": "HTTP response object",
-          "source": "=response",
-          "var": "output",
-          "properties": {
-            "body": {
-              "type": "object",
-              "description": "Response body content",
-              "additionalProperties": true
-            },
-            "statusCode": {
-              "type": "number",
-              "description": "HTTP status code"
-            },
-            "headers": {
-              "type": "object",
-              "description": "Response headers",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "error": {
-          "type": "object",
-          "description": "Error information if the node fails",
-          "source": "=Error",
-          "var": "error",
-          "schema": {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "required": [
-              "code",
-              "message",
-              "detail",
-              "category",
-              "status"
-            ],
-            "properties": {
-              "code": {
-                "type": "string",
-                "description": "Error code as a string"
-              },
-              "message": {
-                "type": "string",
-                "description": "High-level error message"
-              },
-              "detail": {
-                "type": "string",
-                "description": "Detailed error description"
-              },
-              "category": {
-                "type": "string",
-                "description": "Error category"
-              },
-              "status": {
-                "type": "integer",
-                "description": "HTTP status code"
-              }
-            },
-            "additionalProperties": false
-          }
-        }
-      },
       "debug": {
         "runtime": "bpmnEngine"
       },
@@ -531,22 +336,14 @@
                   "id": "_Implicit_StartEvent_{nodeId}",
                   "type": "bpmn:StartEvent",
                   "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "data": {
-                    "label": "HTTP Request Start"
-                  }
+                  "position": { "x": 0, "y": 0 },
+                  "data": { "label": "HTTP Request Start" }
                 },
                 {
                   "id": "_Implicit_HttpTask_{nodeId}",
                   "type": "bpmn:SendTask",
                   "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
+                  "position": { "x": 0, "y": 0 },
                   "propagate": {
                     "retry": {
                       "condition": "node.data.inputs.retryCount > 0",
@@ -563,48 +360,15 @@
                       "serviceType": "Intsvc.HttpExecution",
                       "version": "v1",
                       "context": [
-                        {
-                          "name": "mode",
-                          "type": "string",
-                          "source": "node.data.inputs.mode"
-                        },
-                        {
-                          "name": "method",
-                          "type": "string",
-                          "source": "node.data.inputs.method"
-                        },
-                        {
-                          "name": "url",
-                          "type": "string",
-                          "source": "node.data.inputs.url"
-                        },
-                        {
-                          "name": "headers",
-                          "type": "json",
-                          "source": "node.data.inputs.headers",
-                          "format": "json"
-                        },
-                        {
-                          "name": "parameters",
-                          "type": "json",
-                          "source": "node.data.inputs.queryParams",
-                          "format": "json"
-                        },
-                        {
-                          "name": "body",
-                          "type": "json",
-                          "source": "node.data.inputs.body",
-                          "format": "json"
-                        }
+                        { "name": "mode", "type": "string", "source": "node.data.inputs.mode" },
+                        { "name": "method", "type": "string", "source": "node.data.inputs.method" },
+                        { "name": "url", "type": "string", "source": "node.data.inputs.url" },
+                        { "name": "headers", "type": "json", "source": "node.data.inputs.headers", "format": "json" },
+                        { "name": "parameters", "type": "json", "source": "node.data.inputs.queryParams", "format": "json" },
+                        { "name": "body", "type": "json", "source": "node.data.inputs.body", "format": "json" }
                       ],
                       "outputs": [
-                        {
-                          "name": "response",
-                          "type": "json",
-                          "source": "=response",
-                          "var": "response",
-                          "internal": true
-                        }
+                        { "name": "response", "type": "json", "source": "=response", "var": "response", "internal": true }
                       ]
                     }
                   }
@@ -613,36 +377,23 @@
                   "id": "_Implicit_EndEvent_Default_{nodeId}",
                   "type": "bpmn:EndEvent",
                   "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "data": {
-                    "label": "Default"
-                  }
+                  "position": { "x": 0, "y": 0 },
+                  "data": { "label": "Default" }
                 },
                 {
                   "condition": "hasEdgeFromHandle('error')",
                   "id": "_Implicit_EndEvent_Failure_{nodeId}",
                   "type": "bpmn:EndEvent",
                   "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "data": {
-                    "label": "Failure"
-                  }
+                  "position": { "x": 0, "y": 0 },
+                  "data": { "label": "Failure" }
                 },
                 {
                   "condition": "hasEdgeFromHandle('error')",
                   "id": "_Implicit_BoundaryError_{nodeId}",
                   "type": "bpmn:BoundaryEvent",
                   "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
+                  "position": { "x": 0, "y": 0 },
                   "data": {
                     "label": "Error",
                     "attachedToId": "_Implicit_HttpTask_{nodeId}",
@@ -652,13 +403,7 @@
                     },
                     "model": {
                       "outputs": [
-                        {
-                          "name": "Error",
-                          "type": "jsonSchema",
-                          "source": "=Error",
-                          "var": "error",
-                          "internal": true
-                        }
+                        { "name": "Error", "type": "jsonSchema", "source": "=Error", "var": "error", "internal": true }
                       ]
                     }
                   }
@@ -694,10 +439,7 @@
               "id": "_Implicit_SubprocessBoundaryError_{nodeId}",
               "type": "bpmn:BoundaryEvent",
               "parentId": null,
-              "position": {
-                "x": 0,
-                "y": 0
-              },
+              "position": { "x": 0, "y": 0 },
               "data": {
                 "label": "",
                 "attachedToId": "{nodeId}",
@@ -707,12 +449,7 @@
                 },
                 "model": {
                   "outputs": [
-                    {
-                      "name": "Error",
-                      "type": "jsonSchema",
-                      "source": "=Error",
-                      "var": "{nodeId}.boundaryError"
-                    }
+                    { "name": "Error", "type": "jsonSchema", "source": "=Error", "var": "{nodeId}.boundaryError" }
                   ]
                 }
               }
@@ -722,13 +459,8 @@
               "type": "bpmn:ExclusiveGateway",
               "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
               "parentId": null,
-              "position": {
-                "x": 0,
-                "y": 0
-              },
-              "data": {
-                "label": "Post-Subprocess Branch"
-              }
+              "position": { "x": 0, "y": 0 },
+              "data": { "label": "Post-Subprocess Branch" }
             }
           ],
           "edges": [
@@ -758,9 +490,7 @@
               "preserveEdgeId": true,
               "source": "_Implicit_PostSubprocessGateway_{nodeId}",
               "type": "bpmn:SequenceFlow",
-              "data": {
-                "label": "Default"
-              }
+              "data": { "label": "Default" }
             },
             {
               "condition": "hasEdgeFromHandle('error')",
@@ -782,361 +512,49 @@
             }
           ]
         }
-      }
-    },
-    {
-      "nodeType": "core.action.script",
-      "version": "1.0.0",
-      "description": "Run custom JavaScript code",
-      "category": "data-operations",
-      "tags": [
-        "code",
-        "javascript",
-        "python"
-      ],
-      "sortOrder": 35,
-      "display": {
-        "label": "Script",
-        "icon": "code",
-        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
-        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
-      },
-      "handleConfiguration": [
-        {
-          "position": "left",
-          "handles": [
-            {
-              "id": "input",
-              "type": "target",
-              "handleType": "input"
-            }
-          ]
-        },
-        {
-          "position": "right",
-          "handles": [
-            {
-              "id": "success",
-              "type": "source",
-              "handleType": "output"
-            }
-          ]
-        }
-      ],
-      "inputDefaults": {
-        "script": ""
       },
       "inputDefinition": {
         "type": "object",
         "properties": {
-          "script": {
+          "mode": { "type": "string" },
+          "method": { "type": "string", "minLength": 1, "errorMessage": "Method is required" },
+          "url": {
             "type": "string",
             "minLength": 1,
-            "errorMessage": "A script function is required",
-            "validationSeverity": "warning"
-          }
-        },
-        "required": [
-          "script"
-        ]
-      },
-      "outputDefinition": {
-        "output": {
-          "type": "object",
-          "description": "The return value of the script",
-          "source": "=result.response",
-          "var": "output"
-        },
-        "error": {
-          "type": "object",
-          "description": "Error information if the script fails",
-          "source": "=result.Error",
-          "var": "error",
-          "schema": {
-            "$schema": "http://json-schema.org/draft-07/schema#",
-            "type": "object",
-            "required": [
-              "code",
-              "message",
-              "detail",
-              "category",
-              "status"
-            ],
-            "properties": {
-              "code": {
-                "type": "string",
-                "description": "Error code as a string"
-              },
-              "message": {
-                "type": "string",
-                "description": "High-level error message"
-              },
-              "detail": {
-                "type": "string",
-                "description": "Detailed error description"
-              },
-              "category": {
-                "type": "string",
-                "description": "Error category"
-              },
-              "status": {
-                "type": "integer",
-                "description": "HTTP status code"
-              }
-            },
-            "additionalProperties": false
-          }
-        }
-      },
-      "debug": {
-        "runtime": "clientScript"
-      },
-      "model": {
-        "type": "bpmn:ScriptTask"
-      }
-    },
-    {
-      "nodeType": "core.logic.decision",
-      "version": "1.0.0",
-      "description": "Branch based on a true/false condition",
-      "category": "control-flow",
-      "tags": [
-        "control-flow",
-        "if",
-        "loop",
-        "switch"
-      ],
-      "sortOrder": 20,
-      "display": {
-        "label": "Decision",
-        "icon": "trending-up-down",
-        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
-        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
-      },
-      "handleConfiguration": [
-        {
-          "position": "left",
-          "handles": [
-            {
-              "id": "input",
-              "type": "target",
-              "handleType": "input"
+            "pattern": "^(.*\\.\\S.*|.*\\$vars.*)$",
+            "errorMessage": {
+              "minLength": "URL is required",
+              "pattern": "URL must be a valid URL or variable expression"
             }
-          ],
-          "visible": true
-        },
-        {
-          "position": "right",
-          "handles": [
-            {
-              "id": "true",
-              "type": "source",
-              "handleType": "output",
-              "label": "{inputs.trueLabel}",
-              "constraints": {
-                "minConnections": 1
-              }
-            },
-            {
-              "id": "false",
-              "type": "source",
-              "handleType": "output",
-              "label": "{inputs.falseLabel}",
-              "constraints": {
-                "minConnections": 1
-              }
-            }
-          ],
-          "visible": true
-        }
-      ],
-      "inputDefaults": {
-        "trueLabel": "True",
-        "falseLabel": "False"
-      },
-      "inputDefinition": {
-        "type": "object",
-        "properties": {
-          "expression": {
+          },
+          "swaggerDefinition": { "type": ["object", "null"] },
+          "authenticationType": { "type": "string" },
+          "application": { "type": "string" },
+          "connection": { "type": "string" },
+          "headers": { "type": "object" },
+          "queryParams": { "type": "object" },
+          "body": { "type": "string" },
+          "contentType": { "type": "string" },
+          "timeout": {
             "type": "string",
-            "minLength": 1,
-            "errorMessage": "A condition expression is required"
+            "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$",
+            "errorMessage": { "pattern": "Timeout must be in ISO 8601 duration format (e.g., PT15M, PT1H, P1D)" }
           },
-          "trueLabel": {
-            "type": "string"
-          },
-          "falseLabel": {
-            "type": "string"
-          }
-        },
-        "required": [
-          "expression"
-        ]
-      },
-      "outputDefinition": {
-        "matchedCase": {
-          "type": "string",
-          "description": "The label of the matched branch (true/false label)",
-          "var": "matchedCase"
-        },
-        "matchedCaseId": {
-          "type": "string",
-          "description": "The branch that was taken (true or false)",
-          "var": "matchedCaseId"
-        }
-      },
-      "debug": {
-        "runtime": "clientScript"
-      },
-      "model": {
-        "type": "bpmn:InclusiveGateway"
-      }
-    },
-    {
-      "nodeType": "core.control.end",
-      "version": "1.0.0",
-      "description": "Mark the end of a workflow path",
-      "category": "control-flow",
-      "tags": [
-        "control-flow",
-        "end",
-        "finish",
-        "complete"
-      ],
-      "sortOrder": 20,
-      "display": {
-        "label": "End",
-        "icon": "circle-check",
-        "shape": "circle"
-      },
-      "handleConfiguration": [
-        {
-          "position": "left",
-          "handles": [
-            {
-              "id": "input",
-              "type": "target",
-              "handleType": "input"
-            }
-          ]
-        }
-      ],
-      "model": {
-        "type": "bpmn:EndEvent"
-      }
-    },
-    {
-      "nodeType": "core.trigger.manual",
-      "version": "1.0",
-      "description": "Start workflow manually",
-      "category": "trigger",
-      "tags": [
-        "trigger",
-        "start",
-        "manual"
-      ],
-      "sortOrder": 40,
-      "display": {
-        "label": "Manual trigger",
-        "icon": "play",
-        "shape": "circle",
-        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
-        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
-      },
-      "handleConfiguration": [
-        {
-          "position": "right",
-          "handles": [
-            {
-              "id": "output",
-              "type": "source",
-              "handleType": "output",
-              "showButton": true,
-              "constraints": {
-                "forbiddenTargetCategories": [
-                  "trigger"
-                ]
+          "retryCount": { "type": "number" },
+          "branches": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "conditionExpression": { "type": "string" }
               }
             }
-          ],
-          "visible": true
-        }
-      ],
-      "toolbarExtensions": {
-        "design": {
-          "actions": [
-            {
-              "id": "change-trigger-type",
-              "icon": "replace",
-              "label": "Change trigger type"
-            }
-          ]
-        }
-      },
-      "outputDefinition": {
-        "output": {
-          "type": "object",
-          "description": "Data passed when manually triggering the workflow.",
-          "source": "null",
-          "var": "output"
-        }
-      },
-      "model": {
-        "type": "bpmn:StartEvent",
-        "entryPointId": true
-      }
-    },
-    {
-      "nodeType": "core.action.http",
-      "version": "1.1",
-      "description": "Make API calls with branching and retry",
-      "category": "data-operations",
-      "tags": [
-        "connector",
-        "http",
-        "api",
-        "rest",
-        "request"
-      ],
-      "sortOrder": 35,
-      "display": {
-        "label": "HTTP Request",
-        "icon": "app-window",
-        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
-        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
-      },
-      "handleConfiguration": [
-        {
-          "position": "left",
-          "handles": [
-            {
-              "id": "input",
-              "type": "target",
-              "handleType": "input"
-            }
-          ],
-          "visible": true
+          }
         },
-        {
-          "position": "right",
-          "handles": [
-            {
-              "id": "branch-{item.id}",
-              "type": "source",
-              "handleType": "output",
-              "label": "{item.name}",
-              "repeat": "inputs.branches"
-            },
-            {
-              "id": "default",
-              "type": "source",
-              "handleType": "output",
-              "label": "Default"
-            }
-          ],
-          "visible": true
-        }
-      ],
+        "required": ["method", "url"]
+      },
       "inputDefaults": {
         "mode": "manual",
         "method": "GET",
@@ -1153,86 +571,6 @@
         "retryCount": 0,
         "branches": []
       },
-      "inputDefinition": {
-        "type": "object",
-        "properties": {
-          "mode": {
-            "type": "string"
-          },
-          "method": {
-            "type": "string",
-            "minLength": 1,
-            "errorMessage": "Method is required"
-          },
-          "url": {
-            "type": "string",
-            "minLength": 1,
-            "pattern": "^(.*\\.\\S.*|.*\\$vars.*)$",
-            "errorMessage": {
-              "minLength": "URL is required",
-              "pattern": "URL must be a valid URL or variable expression"
-            }
-          },
-          "swaggerDefinition": {
-            "type": [
-              "object",
-              "null"
-            ]
-          },
-          "authenticationType": {
-            "type": "string"
-          },
-          "application": {
-            "type": "string"
-          },
-          "connection": {
-            "type": "string"
-          },
-          "headers": {
-            "type": "object"
-          },
-          "queryParams": {
-            "type": "object"
-          },
-          "body": {
-            "type": "string"
-          },
-          "contentType": {
-            "type": "string"
-          },
-          "timeout": {
-            "type": "string",
-            "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$",
-            "errorMessage": {
-              "pattern": "Timeout must be in ISO 8601 duration format (e.g., PT15M, PT1H, P1D)"
-            }
-          },
-          "retryCount": {
-            "type": "number"
-          },
-          "branches": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                },
-                "conditionExpression": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "required": [
-          "method",
-          "url"
-        ]
-      },
       "outputDefinition": {
         "output": {
           "type": "object",
@@ -1240,22 +578,9 @@
           "source": "=response",
           "var": "output",
           "properties": {
-            "body": {
-              "type": "object",
-              "description": "Response body content",
-              "additionalProperties": true
-            },
-            "statusCode": {
-              "type": "number",
-              "description": "HTTP status code"
-            },
-            "headers": {
-              "type": "object",
-              "description": "Response headers",
-              "additionalProperties": {
-                "type": "string"
-              }
-            }
+            "body": { "type": "object", "description": "Response body content", "additionalProperties": true },
+            "statusCode": { "type": "number", "description": "HTTP status code" },
+            "headers": { "type": "object", "description": "Response headers", "additionalProperties": { "type": "string" } }
           }
         },
         "error": {
@@ -1266,382 +591,27 @@
           "schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
-            "required": [
-              "code",
-              "message",
-              "detail",
-              "category",
-              "status"
-            ],
+            "required": ["code", "message", "detail", "category", "status"],
             "properties": {
-              "code": {
-                "type": "string",
-                "description": "Error code as a string"
-              },
-              "message": {
-                "type": "string",
-                "description": "High-level error message"
-              },
-              "detail": {
-                "type": "string",
-                "description": "Detailed error description"
-              },
-              "category": {
-                "type": "string",
-                "description": "Error category"
-              },
-              "status": {
-                "type": "integer",
-                "description": "HTTP status code"
-              }
+              "code": { "type": "string", "description": "Error code as a string" },
+              "message": { "type": "string", "description": "High-level error message" },
+              "detail": { "type": "string", "description": "Detailed error description" },
+              "category": { "type": "string", "description": "Error category" },
+              "status": { "type": "integer", "description": "HTTP status code" }
             },
             "additionalProperties": false
           }
-        }
-      },
-      "debug": {
-        "runtime": "bpmnEngine"
-      },
-      "model": {
-        "type": "bpmn:ServiceTask",
-        "expansion": {
-          "processLevelVariables": [
-            {
-              "id": "{nodeId}.output",
-              "name": "output",
-              "type": "jsonSchema",
-              "elementId": "{nodeId}",
-              "custom": true
-            },
-            {
-              "condition": "hasEdgeFromHandle('error')",
-              "id": "{nodeId}.error",
-              "name": "error",
-              "type": "jsonSchema",
-              "elementId": "{nodeId}",
-              "custom": true
-            },
-            {
-              "condition": "!hasEdgeFromHandle('error')",
-              "id": "{nodeId}.boundaryError",
-              "name": "Error",
-              "type": "jsonSchema",
-              "elementId": "_Implicit_SubprocessBoundaryError_{nodeId}"
-            }
-          ],
-          "nodes": [
-            {
-              "id": "{nodeId}",
-              "type": "bpmn:SubProcess",
-              "replaceOriginal": true,
-              "data": {
-                "label": "{node.data.label}",
-                "isExpanded": true,
-                "model": {
-                  "serviceType": "BPMN.Variables",
-                  "subprocessVariables": {
-                    "inputOutputs": [
-                      {
-                        "id": "response",
-                        "name": "response",
-                        "type": "jsonSchema",
-                        "variableType": "inputOutput"
-                      },
-                      {
-                        "id": "error",
-                        "name": "error",
-                        "type": "jsonSchema",
-                        "variableType": "inputOutput"
-                      }
-                    ]
-                  },
-                  "outputs": [
-                    {
-                      "name": "output",
-                      "type": "jsonSchema",
-                      "source": "=vars.response",
-                      "var": "{nodeId}.output",
-                      "custom": true
-                    },
-                    {
-                      "name": "Error",
-                      "type": "jsonSchema",
-                      "source": "=vars.error",
-                      "var": "{nodeId}.error",
-                      "custom": true
-                    }
-                  ]
-                }
-              },
-              "nodes": [
-                {
-                  "id": "_Implicit_StartEvent_{nodeId}",
-                  "type": "bpmn:StartEvent",
-                  "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "data": {
-                    "label": "HTTP Request Start"
-                  }
-                },
-                {
-                  "id": "_Implicit_HttpTask_{nodeId}",
-                  "type": "bpmn:SendTask",
-                  "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "propagate": {
-                    "retry": {
-                      "condition": "node.data.inputs.retryCount > 0",
-                      "maxRetryCount": "node.data.inputs.retryCount",
-                      "retryBackoff": "node.data.inputs.timeout",
-                      "retryBackoffDefault": "PT1S",
-                      "retryAllErrors": "true",
-                      "retryBackoffType": "Static"
-                    }
-                  },
-                  "data": {
-                    "label": "{node.data.label}",
-                    "model": {
-                      "serviceType": "Intsvc.HttpExecution",
-                      "version": "v1",
-                      "context": [
-                        {
-                          "name": "mode",
-                          "type": "string",
-                          "source": "node.data.inputs.mode"
-                        },
-                        {
-                          "name": "method",
-                          "type": "string",
-                          "source": "node.data.inputs.method"
-                        },
-                        {
-                          "name": "url",
-                          "type": "string",
-                          "source": "node.data.inputs.url"
-                        },
-                        {
-                          "name": "headers",
-                          "type": "json",
-                          "source": "node.data.inputs.headers",
-                          "format": "json"
-                        },
-                        {
-                          "name": "parameters",
-                          "type": "json",
-                          "source": "node.data.inputs.queryParams",
-                          "format": "json"
-                        },
-                        {
-                          "name": "body",
-                          "type": "json",
-                          "source": "node.data.inputs.body",
-                          "format": "json"
-                        }
-                      ],
-                      "outputs": [
-                        {
-                          "name": "response",
-                          "type": "json",
-                          "source": "=response",
-                          "var": "response",
-                          "internal": true
-                        }
-                      ]
-                    }
-                  }
-                },
-                {
-                  "id": "_Implicit_EndEvent_Default_{nodeId}",
-                  "type": "bpmn:EndEvent",
-                  "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "data": {
-                    "label": "Default"
-                  }
-                },
-                {
-                  "condition": "hasEdgeFromHandle('error')",
-                  "id": "_Implicit_EndEvent_Failure_{nodeId}",
-                  "type": "bpmn:EndEvent",
-                  "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "data": {
-                    "label": "Failure"
-                  }
-                },
-                {
-                  "condition": "hasEdgeFromHandle('error')",
-                  "id": "_Implicit_BoundaryError_{nodeId}",
-                  "type": "bpmn:BoundaryEvent",
-                  "parentId": "{nodeId}",
-                  "position": {
-                    "x": 0,
-                    "y": 0
-                  },
-                  "data": {
-                    "label": "Error",
-                    "attachedToId": "_Implicit_HttpTask_{nodeId}",
-                    "eventDefinition": {
-                      "type": "bpmn:ErrorEventDefinition",
-                      "id": "_Implicit_BoundaryError_{nodeId}_Error"
-                    },
-                    "model": {
-                      "outputs": [
-                        {
-                          "name": "Error",
-                          "type": "jsonSchema",
-                          "source": "=Error",
-                          "var": "error",
-                          "internal": true
-                        }
-                      ]
-                    }
-                  }
-                }
-              ],
-              "edges": [
-                {
-                  "id": "_Implicit_Edge__Implicit_StartEvent_{nodeId}__Implicit_HttpTask_{nodeId}",
-                  "source": "_Implicit_StartEvent_{nodeId}",
-                  "target": "_Implicit_HttpTask_{nodeId}",
-                  "type": "bpmn:SequenceFlow",
-                  "data": {}
-                },
-                {
-                  "id": "_Implicit_Edge__Implicit_HttpTask_{nodeId}__Implicit_EndEvent_Default_{nodeId}",
-                  "source": "_Implicit_HttpTask_{nodeId}",
-                  "target": "_Implicit_EndEvent_Default_{nodeId}",
-                  "type": "bpmn:SequenceFlow",
-                  "data": {}
-                },
-                {
-                  "condition": "hasEdgeFromHandle('error')",
-                  "id": "_Implicit_Edge__Implicit_BoundaryError_{nodeId}__Implicit_EndEvent_Failure_{nodeId}",
-                  "source": "_Implicit_BoundaryError_{nodeId}",
-                  "target": "_Implicit_EndEvent_Failure_{nodeId}",
-                  "type": "bpmn:SequenceFlow",
-                  "data": {}
-                }
-              ]
-            },
-            {
-              "condition": "!hasEdgeFromHandle('error')",
-              "id": "_Implicit_SubprocessBoundaryError_{nodeId}",
-              "type": "bpmn:BoundaryEvent",
-              "parentId": null,
-              "position": {
-                "x": 0,
-                "y": 0
-              },
-              "data": {
-                "label": "",
-                "attachedToId": "{nodeId}",
-                "eventDefinition": {
-                  "type": "bpmn:ErrorEventDefinition",
-                  "id": "_Implicit_SubprocessBoundaryError_{nodeId}_Error"
-                },
-                "model": {
-                  "outputs": [
-                    {
-                      "name": "Error",
-                      "type": "jsonSchema",
-                      "source": "=Error",
-                      "var": "{nodeId}.boundaryError"
-                    }
-                  ]
-                }
-              }
-            },
-            {
-              "id": "_Implicit_PostSubprocessGateway_{nodeId}",
-              "type": "bpmn:ExclusiveGateway",
-              "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
-              "parentId": null,
-              "position": {
-                "x": 0,
-                "y": 0
-              },
-              "data": {
-                "label": "Post-Subprocess Branch"
-              }
-            }
-          ],
-          "edges": [
-            {
-              "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
-              "id": "_Implicit_Edge_{nodeId}__Implicit_PostSubprocessGateway_{nodeId}",
-              "source": "{nodeId}",
-              "target": "_Implicit_PostSubprocessGateway_{nodeId}",
-              "type": "bpmn:SequenceFlow",
-              "data": {}
-            },
-            {
-              "forEach": "node.data.inputs.branches",
-              "condition": "node.data.inputs.branches.length > 0",
-              "matchOriginalEdgeByHandle": "branch-{branch.id}",
-              "preserveEdgeId": true,
-              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
-              "type": "bpmn:SequenceFlow",
-              "data": {
-                "conditionExpression": "{branch.conditionExpression}",
-                "label": "{branch.name}"
-              }
-            },
-            {
-              "condition": "node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')",
-              "matchOriginalEdgeByHandle": "default",
-              "preserveEdgeId": true,
-              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
-              "type": "bpmn:SequenceFlow",
-              "data": {
-                "label": "Default"
-              }
-            },
-            {
-              "condition": "hasEdgeFromHandle('error')",
-              "matchOriginalEdgeByHandle": "error",
-              "preserveEdgeId": true,
-              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
-              "type": "bpmn:SequenceFlow",
-              "data": {
-                "conditionExpression": "=js:vars.{nodeId}.error != null || (vars.{nodeId}.output != null && vars.{nodeId}.output.statusCode >= 400)",
-                "label": "Error"
-              }
-            },
-            {
-              "condition": "node.data.inputs.branches.length === 0 && !hasEdgeFromHandle('error')",
-              "matchOriginalEdgeByHandle": "default",
-              "preserveEdgeId": true,
-              "source": "{nodeId}",
-              "type": "bpmn:SequenceFlow"
-            }
-          ]
         }
       }
     },
     {
       "nodeType": "core.action.script",
-      "version": "1.0",
-      "description": "Run custom JavaScript code",
+      "version": "1.0.0",
       "category": "data-operations",
-      "tags": [
-        "code",
-        "javascript",
-        "python"
-      ],
+      "description": "Run custom JavaScript code",
+      "tags": ["code", "javascript", "python"],
       "sortOrder": 35,
+      "supportsErrorHandling": true,
       "display": {
         "label": "Script",
         "icon": "code",
@@ -1652,27 +622,18 @@
         {
           "position": "left",
           "handles": [
-            {
-              "id": "input",
-              "type": "target",
-              "handleType": "input"
-            }
+            { "id": "input", "type": "target", "handleType": "input" }
           ]
         },
         {
           "position": "right",
           "handles": [
-            {
-              "id": "success",
-              "type": "source",
-              "handleType": "output"
-            }
+            { "id": "success", "type": "source", "handleType": "output" }
           ]
         }
       ],
-      "inputDefaults": {
-        "script": ""
-      },
+      "debug": { "runtime": "clientScript" },
+      "model": { "type": "bpmn:ScriptTask" },
       "inputDefinition": {
         "type": "object",
         "properties": {
@@ -1683,10 +644,9 @@
             "validationSeverity": "warning"
           }
         },
-        "required": [
-          "script"
-        ]
+        "required": ["script"]
       },
+      "inputDefaults": { "script": "" },
       "outputDefinition": {
         "output": {
           "type": "object",
@@ -1702,57 +662,25 @@
           "schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
-            "required": [
-              "code",
-              "message",
-              "detail",
-              "category",
-              "status"
-            ],
+            "required": ["code", "message", "detail", "category", "status"],
             "properties": {
-              "code": {
-                "type": "string",
-                "description": "Error code as a string"
-              },
-              "message": {
-                "type": "string",
-                "description": "High-level error message"
-              },
-              "detail": {
-                "type": "string",
-                "description": "Detailed error description"
-              },
-              "category": {
-                "type": "string",
-                "description": "Error category"
-              },
-              "status": {
-                "type": "integer",
-                "description": "HTTP status code"
-              }
+              "code": { "type": "string", "description": "Error code as a string" },
+              "message": { "type": "string", "description": "High-level error message" },
+              "detail": { "type": "string", "description": "Detailed error description" },
+              "category": { "type": "string", "description": "Error category" },
+              "status": { "type": "integer", "description": "HTTP status code" }
             },
             "additionalProperties": false
           }
         }
-      },
-      "debug": {
-        "runtime": "clientScript"
-      },
-      "model": {
-        "type": "bpmn:ScriptTask"
       }
     },
     {
       "nodeType": "core.logic.decision",
-      "version": "1.0",
-      "description": "Branch based on a true/false condition",
+      "version": "1.0.0",
       "category": "control-flow",
-      "tags": [
-        "control-flow",
-        "if",
-        "loop",
-        "switch"
-      ],
+      "description": "Branch based on a true/false condition",
+      "tags": ["control-flow", "if", "loop", "switch"],
       "sortOrder": 20,
       "display": {
         "label": "Decision",
@@ -1764,11 +692,7 @@
         {
           "position": "left",
           "handles": [
-            {
-              "id": "input",
-              "type": "target",
-              "handleType": "input"
-            }
+            { "id": "input", "type": "target", "handleType": "input" }
           ],
           "visible": true
         },
@@ -1780,45 +704,29 @@
               "type": "source",
               "handleType": "output",
               "label": "{inputs.trueLabel}",
-              "constraints": {
-                "minConnections": 1
-              }
+              "constraints": { "minConnections": 1 }
             },
             {
               "id": "false",
               "type": "source",
               "handleType": "output",
               "label": "{inputs.falseLabel}",
-              "constraints": {
-                "minConnections": 1
-              }
+              "constraints": { "minConnections": 1 }
             }
           ],
           "visible": true
         }
       ],
-      "inputDefaults": {
-        "trueLabel": "True",
-        "falseLabel": "False"
-      },
+      "debug": { "runtime": "clientScript" },
+      "model": { "type": "bpmn:InclusiveGateway" },
       "inputDefinition": {
         "type": "object",
         "properties": {
-          "expression": {
-            "type": "string",
-            "minLength": 1,
-            "errorMessage": "A condition expression is required"
-          },
-          "trueLabel": {
-            "type": "string"
-          },
-          "falseLabel": {
-            "type": "string"
-          }
+          "expression": { "type": "string", "minLength": 1, "errorMessage": "A condition expression is required" },
+          "trueLabel": { "type": "string" },
+          "falseLabel": { "type": "string" }
         },
-        "required": [
-          "expression"
-        ]
+        "required": ["expression"]
       },
       "outputDefinition": {
         "matchedCase": {
@@ -1832,24 +740,14 @@
           "var": "matchedCaseId"
         }
       },
-      "debug": {
-        "runtime": "clientScript"
-      },
-      "model": {
-        "type": "bpmn:InclusiveGateway"
-      }
+      "inputDefaults": { "trueLabel": "True", "falseLabel": "False" }
     },
     {
       "nodeType": "core.control.end",
-      "version": "1.0",
-      "description": "Mark the end of a workflow path",
+      "version": "1.0.0",
       "category": "control-flow",
-      "tags": [
-        "control-flow",
-        "end",
-        "finish",
-        "complete"
-      ],
+      "description": "Mark the end of a workflow path",
+      "tags": ["control-flow", "end", "finish", "complete"],
       "sortOrder": 20,
       "display": {
         "label": "End",
@@ -1860,17 +758,11 @@
         {
           "position": "left",
           "handles": [
-            {
-              "id": "input",
-              "type": "target",
-              "handleType": "input"
-            }
+            { "id": "input", "type": "target", "handleType": "input" }
           ]
         }
       ],
-      "model": {
-        "type": "bpmn:EndEvent"
-      }
+      "model": { "type": "bpmn:EndEvent" }
     }
   ],
   "bindings": [],
@@ -1888,108 +780,64 @@
         "id": "getWeather.output",
         "type": "object",
         "description": "HTTP response from open-meteo API",
-        "binding": {
-          "nodeId": "getWeather",
-          "outputId": "output"
-        }
+        "binding": { "nodeId": "getWeather", "outputId": "output" }
       },
       {
         "id": "getWeather.error",
         "type": "object",
         "description": "Error if weather fetch fails",
-        "binding": {
-          "nodeId": "getWeather",
-          "outputId": "error"
-        }
+        "binding": { "nodeId": "getWeather", "outputId": "error" }
       },
       {
         "id": "formatSummary.output",
         "type": "object",
         "description": "Formatted weather summary with temperature and description",
-        "binding": {
-          "nodeId": "formatSummary",
-          "outputId": "output"
-        }
+        "binding": { "nodeId": "formatSummary", "outputId": "output" }
       },
       {
         "id": "formatSummary.error",
         "type": "object",
         "description": "Error if formatting script fails",
-        "binding": {
-          "nodeId": "formatSummary",
-          "outputId": "error"
-        }
+        "binding": { "nodeId": "formatSummary", "outputId": "error" }
       }
     ]
   },
   "layout": {
     "nodes": {
       "start": {
-        "position": {
-          "x": 200,
-          "y": 144
-        },
-        "size": {
-          "width": 96,
-          "height": 96
-        },
+        "position": { "x": 200, "y": 144 },
+        "size": { "width": 96, "height": 96 },
         "collapsed": false
       },
       "getWeather": {
-        "position": {
-          "x": 450,
-          "y": 144
-        },
-        "size": {
-          "width": 96,
-          "height": 96
-        },
+        "position": { "x": 450, "y": 144 },
+        "size": { "width": 96, "height": 96 },
         "collapsed": false
       },
       "formatSummary": {
-        "position": {
-          "x": 700,
-          "y": 144
-        },
-        "size": {
-          "width": 96,
-          "height": 96
-        },
+        "position": { "x": 700, "y": 144 },
+        "size": { "width": 96, "height": 96 },
         "collapsed": false
       },
       "checkTemperature": {
-        "position": {
-          "x": 950,
-          "y": 144
-        },
-        "size": {
-          "width": 96,
-          "height": 96
-        },
+        "position": { "x": 950, "y": 144 },
+        "size": { "width": 96, "height": 96 },
         "collapsed": false
       },
       "endNiceDay": {
-        "position": {
-          "x": 1200,
-          "y": 44
-        },
-        "size": {
-          "width": 96,
-          "height": 96
-        },
+        "position": { "x": 1200, "y": 44 },
+        "size": { "width": 96, "height": 96 },
         "collapsed": false
       },
       "endBringJacket": {
-        "position": {
-          "x": 1200,
-          "y": 244
-        },
-        "size": {
-          "width": 96,
-          "height": 96
-        },
+        "position": { "x": 1200, "y": 244 },
+        "size": { "width": 96, "height": 96 },
         "collapsed": false
       }
     }
+  },
+  "metadata": {
+    "createdAt": "2026-04-15T19:41:18.514Z",
+    "updatedAt": "2026-04-15T19:41:18.514Z"
   }
 }

--- a/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/BellevueWeather.flow
+++ b/tests/tasks/uipath-maestro-flow/edit/templates/initial_flow/BellevueWeather/BellevueWeather/BellevueWeather.flow
@@ -1,13 +1,15 @@
 {
   "id": "51e93e69-8d7b-4543-b079-cec6c73673ff",
-  "version": "1.0.0",
+  "version": "1.2",
   "name": "BellevueWeather",
   "nodes": [
     {
       "id": "start",
       "type": "core.trigger.manual",
-      "typeVersion": "1.0.0",
-      "display": { "label": "Manual trigger" },
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Manual trigger"
+      },
       "inputs": {},
       "outputs": {
         "output": {
@@ -25,8 +27,10 @@
     {
       "id": "getWeather",
       "type": "core.action.http",
-      "typeVersion": "1.0.0",
-      "display": { "label": "Get Bellevue Weather" },
+      "typeVersion": "1.1",
+      "display": {
+        "label": "Get Bellevue Weather"
+      },
       "inputs": {
         "mode": "manual",
         "method": "GET",
@@ -53,13 +57,17 @@
           "var": "error"
         }
       },
-      "model": { "type": "bpmn:ServiceTask" }
+      "model": {
+        "type": "bpmn:ServiceTask"
+      }
     },
     {
       "id": "formatSummary",
       "type": "core.action.script",
-      "typeVersion": "1.0.0",
-      "display": { "label": "Format Weather Summary" },
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Format Weather Summary"
+      },
       "inputs": {
         "script": "const tempF = $vars.getWeather.output.body.current.temperature_2m;\nconst time = $vars.getWeather.output.body.current.time;\nreturn {\n  temperatureF: tempF,\n  summary: 'Bellevue weather today: ' + tempF + 'F at ' + time\n};"
       },
@@ -77,45 +85,59 @@
           "var": "error"
         }
       },
-      "model": { "type": "bpmn:ScriptTask" }
+      "model": {
+        "type": "bpmn:ScriptTask"
+      }
     },
     {
       "id": "checkTemperature",
       "type": "core.logic.decision",
-      "typeVersion": "1.0.0",
-      "display": { "label": "Temp > 60F?" },
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Temp > 60F?"
+      },
       "inputs": {
         "expression": "$vars.formatSummary.output.temperatureF > 60",
         "trueLabel": "Nice Day",
         "falseLabel": "Bring a Jacket"
       },
-      "model": { "type": "bpmn:InclusiveGateway" }
+      "model": {
+        "type": "bpmn:InclusiveGateway"
+      }
     },
     {
       "id": "endNiceDay",
       "type": "core.control.end",
-      "typeVersion": "1.0.0",
-      "display": { "label": "Nice Day" },
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Nice Day"
+      },
       "inputs": {},
       "outputs": {
         "summary": {
           "source": "=js:({ message: 'nice day', temperatureF: $vars.formatSummary.output.temperatureF, description: $vars.formatSummary.output.summary })"
         }
       },
-      "model": { "type": "bpmn:EndEvent" }
+      "model": {
+        "type": "bpmn:EndEvent"
+      }
     },
     {
       "id": "endBringJacket",
       "type": "core.control.end",
-      "typeVersion": "1.0.0",
-      "display": { "label": "Bring a Jacket" },
+      "typeVersion": "1.0",
+      "display": {
+        "label": "Bring a Jacket"
+      },
       "inputs": {},
       "outputs": {
         "summary": {
           "source": "=js:({ message: 'bring a jacket', temperatureF: $vars.formatSummary.output.temperatureF, description: $vars.formatSummary.output.summary })"
         }
       },
-      "model": { "type": "bpmn:EndEvent" }
+      "model": {
+        "type": "bpmn:EndEvent"
+      }
     }
   ],
   "edges": [
@@ -159,9 +181,13 @@
     {
       "nodeType": "core.trigger.manual",
       "version": "1.0.0",
-      "category": "trigger",
       "description": "Start workflow manually",
-      "tags": ["trigger", "start", "manual"],
+      "category": "trigger",
+      "tags": [
+        "trigger",
+        "start",
+        "manual"
+      ],
       "sortOrder": 40,
       "display": {
         "label": "Manual trigger",
@@ -180,25 +206,15 @@
               "handleType": "output",
               "showButton": true,
               "constraints": {
-                "forbiddenTargetCategories": ["trigger"]
+                "forbiddenTargetCategories": [
+                  "trigger"
+                ]
               }
             }
           ],
           "visible": true
         }
       ],
-      "model": {
-        "type": "bpmn:StartEvent",
-        "entryPointId": true
-      },
-      "outputDefinition": {
-        "output": {
-          "type": "object",
-          "description": "Data passed when manually triggering the workflow.",
-          "source": "null",
-          "var": "output"
-        }
-      },
       "toolbarExtensions": {
         "design": {
           "actions": [
@@ -209,16 +225,33 @@
             }
           ]
         }
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "Data passed when manually triggering the workflow.",
+          "source": "null",
+          "var": "output"
+        }
+      },
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": true
       }
     },
     {
       "nodeType": "core.action.http",
       "version": "1.0.0",
-      "category": "data-operations",
       "description": "Make API calls with branching and retry",
-      "tags": ["connector", "http", "api", "rest", "request"],
+      "category": "data-operations",
+      "tags": [
+        "connector",
+        "http",
+        "api",
+        "rest",
+        "request"
+      ],
       "sortOrder": 35,
-      "supportsErrorHandling": true,
       "display": {
         "label": "HTTP Request",
         "icon": "app-window",
@@ -257,6 +290,168 @@
           "visible": true
         }
       ],
+      "inputDefaults": {
+        "mode": "manual",
+        "method": "GET",
+        "url": "",
+        "swaggerDefinition": null,
+        "authenticationType": "manual",
+        "application": "",
+        "connection": "",
+        "headers": {},
+        "queryParams": {},
+        "body": "",
+        "contentType": "application/json",
+        "timeout": "PT15M",
+        "retryCount": 0,
+        "branches": []
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "Method is required"
+          },
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(.*\\.\\S.*|.*\\$vars.*)$",
+            "errorMessage": {
+              "minLength": "URL is required",
+              "pattern": "URL must be a valid URL or variable expression"
+            }
+          },
+          "swaggerDefinition": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "authenticationType": {
+            "type": "string"
+          },
+          "application": {
+            "type": "string"
+          },
+          "connection": {
+            "type": "string"
+          },
+          "headers": {
+            "type": "object"
+          },
+          "queryParams": {
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "timeout": {
+            "type": "string",
+            "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$",
+            "errorMessage": {
+              "pattern": "Timeout must be in ISO 8601 duration format (e.g., PT15M, PT1H, P1D)"
+            }
+          },
+          "retryCount": {
+            "type": "number"
+          },
+          "branches": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "conditionExpression": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "method",
+          "url"
+        ]
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "HTTP response object",
+          "source": "=response",
+          "var": "output",
+          "properties": {
+            "body": {
+              "type": "object",
+              "description": "Response body content",
+              "additionalProperties": true
+            },
+            "statusCode": {
+              "type": "number",
+              "description": "HTTP status code"
+            },
+            "headers": {
+              "type": "object",
+              "description": "Response headers",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the node fails",
+          "source": "=Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
       "debug": {
         "runtime": "bpmnEngine"
       },
@@ -336,14 +531,22 @@
                   "id": "_Implicit_StartEvent_{nodeId}",
                   "type": "bpmn:StartEvent",
                   "parentId": "{nodeId}",
-                  "position": { "x": 0, "y": 0 },
-                  "data": { "label": "HTTP Request Start" }
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "data": {
+                    "label": "HTTP Request Start"
+                  }
                 },
                 {
                   "id": "_Implicit_HttpTask_{nodeId}",
                   "type": "bpmn:SendTask",
                   "parentId": "{nodeId}",
-                  "position": { "x": 0, "y": 0 },
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
                   "propagate": {
                     "retry": {
                       "condition": "node.data.inputs.retryCount > 0",
@@ -360,15 +563,48 @@
                       "serviceType": "Intsvc.HttpExecution",
                       "version": "v1",
                       "context": [
-                        { "name": "mode", "type": "string", "source": "node.data.inputs.mode" },
-                        { "name": "method", "type": "string", "source": "node.data.inputs.method" },
-                        { "name": "url", "type": "string", "source": "node.data.inputs.url" },
-                        { "name": "headers", "type": "json", "source": "node.data.inputs.headers", "format": "json" },
-                        { "name": "parameters", "type": "json", "source": "node.data.inputs.queryParams", "format": "json" },
-                        { "name": "body", "type": "json", "source": "node.data.inputs.body", "format": "json" }
+                        {
+                          "name": "mode",
+                          "type": "string",
+                          "source": "node.data.inputs.mode"
+                        },
+                        {
+                          "name": "method",
+                          "type": "string",
+                          "source": "node.data.inputs.method"
+                        },
+                        {
+                          "name": "url",
+                          "type": "string",
+                          "source": "node.data.inputs.url"
+                        },
+                        {
+                          "name": "headers",
+                          "type": "json",
+                          "source": "node.data.inputs.headers",
+                          "format": "json"
+                        },
+                        {
+                          "name": "parameters",
+                          "type": "json",
+                          "source": "node.data.inputs.queryParams",
+                          "format": "json"
+                        },
+                        {
+                          "name": "body",
+                          "type": "json",
+                          "source": "node.data.inputs.body",
+                          "format": "json"
+                        }
                       ],
                       "outputs": [
-                        { "name": "response", "type": "json", "source": "=response", "var": "response", "internal": true }
+                        {
+                          "name": "response",
+                          "type": "json",
+                          "source": "=response",
+                          "var": "response",
+                          "internal": true
+                        }
                       ]
                     }
                   }
@@ -377,23 +613,36 @@
                   "id": "_Implicit_EndEvent_Default_{nodeId}",
                   "type": "bpmn:EndEvent",
                   "parentId": "{nodeId}",
-                  "position": { "x": 0, "y": 0 },
-                  "data": { "label": "Default" }
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "data": {
+                    "label": "Default"
+                  }
                 },
                 {
                   "condition": "hasEdgeFromHandle('error')",
                   "id": "_Implicit_EndEvent_Failure_{nodeId}",
                   "type": "bpmn:EndEvent",
                   "parentId": "{nodeId}",
-                  "position": { "x": 0, "y": 0 },
-                  "data": { "label": "Failure" }
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "data": {
+                    "label": "Failure"
+                  }
                 },
                 {
                   "condition": "hasEdgeFromHandle('error')",
                   "id": "_Implicit_BoundaryError_{nodeId}",
                   "type": "bpmn:BoundaryEvent",
                   "parentId": "{nodeId}",
-                  "position": { "x": 0, "y": 0 },
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
                   "data": {
                     "label": "Error",
                     "attachedToId": "_Implicit_HttpTask_{nodeId}",
@@ -403,7 +652,13 @@
                     },
                     "model": {
                       "outputs": [
-                        { "name": "Error", "type": "jsonSchema", "source": "=Error", "var": "error", "internal": true }
+                        {
+                          "name": "Error",
+                          "type": "jsonSchema",
+                          "source": "=Error",
+                          "var": "error",
+                          "internal": true
+                        }
                       ]
                     }
                   }
@@ -439,7 +694,10 @@
               "id": "_Implicit_SubprocessBoundaryError_{nodeId}",
               "type": "bpmn:BoundaryEvent",
               "parentId": null,
-              "position": { "x": 0, "y": 0 },
+              "position": {
+                "x": 0,
+                "y": 0
+              },
               "data": {
                 "label": "",
                 "attachedToId": "{nodeId}",
@@ -449,7 +707,12 @@
                 },
                 "model": {
                   "outputs": [
-                    { "name": "Error", "type": "jsonSchema", "source": "=Error", "var": "{nodeId}.boundaryError" }
+                    {
+                      "name": "Error",
+                      "type": "jsonSchema",
+                      "source": "=Error",
+                      "var": "{nodeId}.boundaryError"
+                    }
                   ]
                 }
               }
@@ -459,8 +722,13 @@
               "type": "bpmn:ExclusiveGateway",
               "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
               "parentId": null,
-              "position": { "x": 0, "y": 0 },
-              "data": { "label": "Post-Subprocess Branch" }
+              "position": {
+                "x": 0,
+                "y": 0
+              },
+              "data": {
+                "label": "Post-Subprocess Branch"
+              }
             }
           ],
           "edges": [
@@ -490,7 +758,9 @@
               "preserveEdgeId": true,
               "source": "_Implicit_PostSubprocessGateway_{nodeId}",
               "type": "bpmn:SequenceFlow",
-              "data": { "label": "Default" }
+              "data": {
+                "label": "Default"
+              }
             },
             {
               "condition": "hasEdgeFromHandle('error')",
@@ -512,49 +782,361 @@
             }
           ]
         }
+      }
+    },
+    {
+      "nodeType": "core.action.script",
+      "version": "1.0.0",
+      "description": "Run custom JavaScript code",
+      "category": "data-operations",
+      "tags": [
+        "code",
+        "javascript",
+        "python"
+      ],
+      "sortOrder": 35,
+      "display": {
+        "label": "Script",
+        "icon": "code",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "success",
+              "type": "source",
+              "handleType": "output"
+            }
+          ]
+        }
+      ],
+      "inputDefaults": {
+        "script": ""
       },
       "inputDefinition": {
         "type": "object",
         "properties": {
-          "mode": { "type": "string" },
-          "method": { "type": "string", "minLength": 1, "errorMessage": "Method is required" },
-          "url": {
+          "script": {
             "type": "string",
             "minLength": 1,
-            "pattern": "^(.*\\.\\S.*|.*\\$vars.*)$",
-            "errorMessage": {
-              "minLength": "URL is required",
-              "pattern": "URL must be a valid URL or variable expression"
-            }
-          },
-          "swaggerDefinition": { "type": ["object", "null"] },
-          "authenticationType": { "type": "string" },
-          "application": { "type": "string" },
-          "connection": { "type": "string" },
-          "headers": { "type": "object" },
-          "queryParams": { "type": "object" },
-          "body": { "type": "string" },
-          "contentType": { "type": "string" },
-          "timeout": {
-            "type": "string",
-            "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$",
-            "errorMessage": { "pattern": "Timeout must be in ISO 8601 duration format (e.g., PT15M, PT1H, P1D)" }
-          },
-          "retryCount": { "type": "number" },
-          "branches": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "id": { "type": "string" },
-                "name": { "type": "string" },
-                "conditionExpression": { "type": "string" }
-              }
-            }
+            "errorMessage": "A script function is required",
+            "validationSeverity": "warning"
           }
         },
-        "required": ["method", "url"]
+        "required": [
+          "script"
+        ]
       },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "The return value of the script",
+          "source": "=result.response",
+          "var": "output"
+        },
+        "error": {
+          "type": "object",
+          "description": "Error information if the script fails",
+          "source": "=result.Error",
+          "var": "error",
+          "schema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:ScriptTask"
+      }
+    },
+    {
+      "nodeType": "core.logic.decision",
+      "version": "1.0.0",
+      "description": "Branch based on a true/false condition",
+      "category": "control-flow",
+      "tags": [
+        "control-flow",
+        "if",
+        "loop",
+        "switch"
+      ],
+      "sortOrder": 20,
+      "display": {
+        "label": "Decision",
+        "icon": "trending-up-down",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "true",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.trueLabel}",
+              "constraints": {
+                "minConnections": 1
+              }
+            },
+            {
+              "id": "false",
+              "type": "source",
+              "handleType": "output",
+              "label": "{inputs.falseLabel}",
+              "constraints": {
+                "minConnections": 1
+              }
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "inputDefaults": {
+        "trueLabel": "True",
+        "falseLabel": "False"
+      },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "expression": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "A condition expression is required"
+          },
+          "trueLabel": {
+            "type": "string"
+          },
+          "falseLabel": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "expression"
+        ]
+      },
+      "outputDefinition": {
+        "matchedCase": {
+          "type": "string",
+          "description": "The label of the matched branch (true/false label)",
+          "var": "matchedCase"
+        },
+        "matchedCaseId": {
+          "type": "string",
+          "description": "The branch that was taken (true or false)",
+          "var": "matchedCaseId"
+        }
+      },
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:InclusiveGateway"
+      }
+    },
+    {
+      "nodeType": "core.control.end",
+      "version": "1.0.0",
+      "description": "Mark the end of a workflow path",
+      "category": "control-flow",
+      "tags": [
+        "control-flow",
+        "end",
+        "finish",
+        "complete"
+      ],
+      "sortOrder": 20,
+      "display": {
+        "label": "End",
+        "icon": "circle-check",
+        "shape": "circle"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ]
+        }
+      ],
+      "model": {
+        "type": "bpmn:EndEvent"
+      }
+    },
+    {
+      "nodeType": "core.trigger.manual",
+      "version": "1.0",
+      "description": "Start workflow manually",
+      "category": "trigger",
+      "tags": [
+        "trigger",
+        "start",
+        "manual"
+      ],
+      "sortOrder": 40,
+      "display": {
+        "label": "Manual trigger",
+        "icon": "play",
+        "shape": "circle",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "output",
+              "type": "source",
+              "handleType": "output",
+              "showButton": true,
+              "constraints": {
+                "forbiddenTargetCategories": [
+                  "trigger"
+                ]
+              }
+            }
+          ],
+          "visible": true
+        }
+      ],
+      "toolbarExtensions": {
+        "design": {
+          "actions": [
+            {
+              "id": "change-trigger-type",
+              "icon": "replace",
+              "label": "Change trigger type"
+            }
+          ]
+        }
+      },
+      "outputDefinition": {
+        "output": {
+          "type": "object",
+          "description": "Data passed when manually triggering the workflow.",
+          "source": "null",
+          "var": "output"
+        }
+      },
+      "model": {
+        "type": "bpmn:StartEvent",
+        "entryPointId": true
+      }
+    },
+    {
+      "nodeType": "core.action.http",
+      "version": "1.1",
+      "description": "Make API calls with branching and retry",
+      "category": "data-operations",
+      "tags": [
+        "connector",
+        "http",
+        "api",
+        "rest",
+        "request"
+      ],
+      "sortOrder": 35,
+      "display": {
+        "label": "HTTP Request",
+        "icon": "app-window",
+        "iconBackground": "linear-gradient(225deg, #FAFAFB 0%, #ECEDEF 100%)",
+        "iconBackgroundDark": "linear-gradient(225deg, #526069 0%, rgba(50, 60, 66, 0.6) 100%)"
+      },
+      "handleConfiguration": [
+        {
+          "position": "left",
+          "handles": [
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
+          ],
+          "visible": true
+        },
+        {
+          "position": "right",
+          "handles": [
+            {
+              "id": "branch-{item.id}",
+              "type": "source",
+              "handleType": "output",
+              "label": "{item.name}",
+              "repeat": "inputs.branches"
+            },
+            {
+              "id": "default",
+              "type": "source",
+              "handleType": "output",
+              "label": "Default"
+            }
+          ],
+          "visible": true
+        }
+      ],
       "inputDefaults": {
         "mode": "manual",
         "method": "GET",
@@ -571,6 +1153,86 @@
         "retryCount": 0,
         "branches": []
       },
+      "inputDefinition": {
+        "type": "object",
+        "properties": {
+          "mode": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "Method is required"
+          },
+          "url": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "^(.*\\.\\S.*|.*\\$vars.*)$",
+            "errorMessage": {
+              "minLength": "URL is required",
+              "pattern": "URL must be a valid URL or variable expression"
+            }
+          },
+          "swaggerDefinition": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "authenticationType": {
+            "type": "string"
+          },
+          "application": {
+            "type": "string"
+          },
+          "connection": {
+            "type": "string"
+          },
+          "headers": {
+            "type": "object"
+          },
+          "queryParams": {
+            "type": "object"
+          },
+          "body": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "timeout": {
+            "type": "string",
+            "pattern": "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$",
+            "errorMessage": {
+              "pattern": "Timeout must be in ISO 8601 duration format (e.g., PT15M, PT1H, P1D)"
+            }
+          },
+          "retryCount": {
+            "type": "number"
+          },
+          "branches": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "conditionExpression": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "method",
+          "url"
+        ]
+      },
       "outputDefinition": {
         "output": {
           "type": "object",
@@ -578,9 +1240,22 @@
           "source": "=response",
           "var": "output",
           "properties": {
-            "body": { "type": "object", "description": "Response body content", "additionalProperties": true },
-            "statusCode": { "type": "number", "description": "HTTP status code" },
-            "headers": { "type": "object", "description": "Response headers", "additionalProperties": { "type": "string" } }
+            "body": {
+              "type": "object",
+              "description": "Response body content",
+              "additionalProperties": true
+            },
+            "statusCode": {
+              "type": "number",
+              "description": "HTTP status code"
+            },
+            "headers": {
+              "type": "object",
+              "description": "Response headers",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
           }
         },
         "error": {
@@ -591,27 +1266,382 @@
           "schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
-            "required": ["code", "message", "detail", "category", "status"],
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
             "properties": {
-              "code": { "type": "string", "description": "Error code as a string" },
-              "message": { "type": "string", "description": "High-level error message" },
-              "detail": { "type": "string", "description": "Detailed error description" },
-              "category": { "type": "string", "description": "Error category" },
-              "status": { "type": "integer", "description": "HTTP status code" }
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
             },
             "additionalProperties": false
           }
+        }
+      },
+      "debug": {
+        "runtime": "bpmnEngine"
+      },
+      "model": {
+        "type": "bpmn:ServiceTask",
+        "expansion": {
+          "processLevelVariables": [
+            {
+              "id": "{nodeId}.output",
+              "name": "output",
+              "type": "jsonSchema",
+              "elementId": "{nodeId}",
+              "custom": true
+            },
+            {
+              "condition": "hasEdgeFromHandle('error')",
+              "id": "{nodeId}.error",
+              "name": "error",
+              "type": "jsonSchema",
+              "elementId": "{nodeId}",
+              "custom": true
+            },
+            {
+              "condition": "!hasEdgeFromHandle('error')",
+              "id": "{nodeId}.boundaryError",
+              "name": "Error",
+              "type": "jsonSchema",
+              "elementId": "_Implicit_SubprocessBoundaryError_{nodeId}"
+            }
+          ],
+          "nodes": [
+            {
+              "id": "{nodeId}",
+              "type": "bpmn:SubProcess",
+              "replaceOriginal": true,
+              "data": {
+                "label": "{node.data.label}",
+                "isExpanded": true,
+                "model": {
+                  "serviceType": "BPMN.Variables",
+                  "subprocessVariables": {
+                    "inputOutputs": [
+                      {
+                        "id": "response",
+                        "name": "response",
+                        "type": "jsonSchema",
+                        "variableType": "inputOutput"
+                      },
+                      {
+                        "id": "error",
+                        "name": "error",
+                        "type": "jsonSchema",
+                        "variableType": "inputOutput"
+                      }
+                    ]
+                  },
+                  "outputs": [
+                    {
+                      "name": "output",
+                      "type": "jsonSchema",
+                      "source": "=vars.response",
+                      "var": "{nodeId}.output",
+                      "custom": true
+                    },
+                    {
+                      "name": "Error",
+                      "type": "jsonSchema",
+                      "source": "=vars.error",
+                      "var": "{nodeId}.error",
+                      "custom": true
+                    }
+                  ]
+                }
+              },
+              "nodes": [
+                {
+                  "id": "_Implicit_StartEvent_{nodeId}",
+                  "type": "bpmn:StartEvent",
+                  "parentId": "{nodeId}",
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "data": {
+                    "label": "HTTP Request Start"
+                  }
+                },
+                {
+                  "id": "_Implicit_HttpTask_{nodeId}",
+                  "type": "bpmn:SendTask",
+                  "parentId": "{nodeId}",
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "propagate": {
+                    "retry": {
+                      "condition": "node.data.inputs.retryCount > 0",
+                      "maxRetryCount": "node.data.inputs.retryCount",
+                      "retryBackoff": "node.data.inputs.timeout",
+                      "retryBackoffDefault": "PT1S",
+                      "retryAllErrors": "true",
+                      "retryBackoffType": "Static"
+                    }
+                  },
+                  "data": {
+                    "label": "{node.data.label}",
+                    "model": {
+                      "serviceType": "Intsvc.HttpExecution",
+                      "version": "v1",
+                      "context": [
+                        {
+                          "name": "mode",
+                          "type": "string",
+                          "source": "node.data.inputs.mode"
+                        },
+                        {
+                          "name": "method",
+                          "type": "string",
+                          "source": "node.data.inputs.method"
+                        },
+                        {
+                          "name": "url",
+                          "type": "string",
+                          "source": "node.data.inputs.url"
+                        },
+                        {
+                          "name": "headers",
+                          "type": "json",
+                          "source": "node.data.inputs.headers",
+                          "format": "json"
+                        },
+                        {
+                          "name": "parameters",
+                          "type": "json",
+                          "source": "node.data.inputs.queryParams",
+                          "format": "json"
+                        },
+                        {
+                          "name": "body",
+                          "type": "json",
+                          "source": "node.data.inputs.body",
+                          "format": "json"
+                        }
+                      ],
+                      "outputs": [
+                        {
+                          "name": "response",
+                          "type": "json",
+                          "source": "=response",
+                          "var": "response",
+                          "internal": true
+                        }
+                      ]
+                    }
+                  }
+                },
+                {
+                  "id": "_Implicit_EndEvent_Default_{nodeId}",
+                  "type": "bpmn:EndEvent",
+                  "parentId": "{nodeId}",
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "data": {
+                    "label": "Default"
+                  }
+                },
+                {
+                  "condition": "hasEdgeFromHandle('error')",
+                  "id": "_Implicit_EndEvent_Failure_{nodeId}",
+                  "type": "bpmn:EndEvent",
+                  "parentId": "{nodeId}",
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "data": {
+                    "label": "Failure"
+                  }
+                },
+                {
+                  "condition": "hasEdgeFromHandle('error')",
+                  "id": "_Implicit_BoundaryError_{nodeId}",
+                  "type": "bpmn:BoundaryEvent",
+                  "parentId": "{nodeId}",
+                  "position": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "data": {
+                    "label": "Error",
+                    "attachedToId": "_Implicit_HttpTask_{nodeId}",
+                    "eventDefinition": {
+                      "type": "bpmn:ErrorEventDefinition",
+                      "id": "_Implicit_BoundaryError_{nodeId}_Error"
+                    },
+                    "model": {
+                      "outputs": [
+                        {
+                          "name": "Error",
+                          "type": "jsonSchema",
+                          "source": "=Error",
+                          "var": "error",
+                          "internal": true
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "edges": [
+                {
+                  "id": "_Implicit_Edge__Implicit_StartEvent_{nodeId}__Implicit_HttpTask_{nodeId}",
+                  "source": "_Implicit_StartEvent_{nodeId}",
+                  "target": "_Implicit_HttpTask_{nodeId}",
+                  "type": "bpmn:SequenceFlow",
+                  "data": {}
+                },
+                {
+                  "id": "_Implicit_Edge__Implicit_HttpTask_{nodeId}__Implicit_EndEvent_Default_{nodeId}",
+                  "source": "_Implicit_HttpTask_{nodeId}",
+                  "target": "_Implicit_EndEvent_Default_{nodeId}",
+                  "type": "bpmn:SequenceFlow",
+                  "data": {}
+                },
+                {
+                  "condition": "hasEdgeFromHandle('error')",
+                  "id": "_Implicit_Edge__Implicit_BoundaryError_{nodeId}__Implicit_EndEvent_Failure_{nodeId}",
+                  "source": "_Implicit_BoundaryError_{nodeId}",
+                  "target": "_Implicit_EndEvent_Failure_{nodeId}",
+                  "type": "bpmn:SequenceFlow",
+                  "data": {}
+                }
+              ]
+            },
+            {
+              "condition": "!hasEdgeFromHandle('error')",
+              "id": "_Implicit_SubprocessBoundaryError_{nodeId}",
+              "type": "bpmn:BoundaryEvent",
+              "parentId": null,
+              "position": {
+                "x": 0,
+                "y": 0
+              },
+              "data": {
+                "label": "",
+                "attachedToId": "{nodeId}",
+                "eventDefinition": {
+                  "type": "bpmn:ErrorEventDefinition",
+                  "id": "_Implicit_SubprocessBoundaryError_{nodeId}_Error"
+                },
+                "model": {
+                  "outputs": [
+                    {
+                      "name": "Error",
+                      "type": "jsonSchema",
+                      "source": "=Error",
+                      "var": "{nodeId}.boundaryError"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "id": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:ExclusiveGateway",
+              "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
+              "parentId": null,
+              "position": {
+                "x": 0,
+                "y": 0
+              },
+              "data": {
+                "label": "Post-Subprocess Branch"
+              }
+            }
+          ],
+          "edges": [
+            {
+              "condition": "(node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')) && originalEdges.length > 0",
+              "id": "_Implicit_Edge_{nodeId}__Implicit_PostSubprocessGateway_{nodeId}",
+              "source": "{nodeId}",
+              "target": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": {}
+            },
+            {
+              "forEach": "node.data.inputs.branches",
+              "condition": "node.data.inputs.branches.length > 0",
+              "matchOriginalEdgeByHandle": "branch-{branch.id}",
+              "preserveEdgeId": true,
+              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": {
+                "conditionExpression": "{branch.conditionExpression}",
+                "label": "{branch.name}"
+              }
+            },
+            {
+              "condition": "node.data.inputs.branches.length > 0 || hasEdgeFromHandle('error')",
+              "matchOriginalEdgeByHandle": "default",
+              "preserveEdgeId": true,
+              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": {
+                "label": "Default"
+              }
+            },
+            {
+              "condition": "hasEdgeFromHandle('error')",
+              "matchOriginalEdgeByHandle": "error",
+              "preserveEdgeId": true,
+              "source": "_Implicit_PostSubprocessGateway_{nodeId}",
+              "type": "bpmn:SequenceFlow",
+              "data": {
+                "conditionExpression": "=js:vars.{nodeId}.error != null || (vars.{nodeId}.output != null && vars.{nodeId}.output.statusCode >= 400)",
+                "label": "Error"
+              }
+            },
+            {
+              "condition": "node.data.inputs.branches.length === 0 && !hasEdgeFromHandle('error')",
+              "matchOriginalEdgeByHandle": "default",
+              "preserveEdgeId": true,
+              "source": "{nodeId}",
+              "type": "bpmn:SequenceFlow"
+            }
+          ]
         }
       }
     },
     {
       "nodeType": "core.action.script",
-      "version": "1.0.0",
-      "category": "data-operations",
+      "version": "1.0",
       "description": "Run custom JavaScript code",
-      "tags": ["code", "javascript", "python"],
+      "category": "data-operations",
+      "tags": [
+        "code",
+        "javascript",
+        "python"
+      ],
       "sortOrder": 35,
-      "supportsErrorHandling": true,
       "display": {
         "label": "Script",
         "icon": "code",
@@ -622,18 +1652,27 @@
         {
           "position": "left",
           "handles": [
-            { "id": "input", "type": "target", "handleType": "input" }
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
           ]
         },
         {
           "position": "right",
           "handles": [
-            { "id": "success", "type": "source", "handleType": "output" }
+            {
+              "id": "success",
+              "type": "source",
+              "handleType": "output"
+            }
           ]
         }
       ],
-      "debug": { "runtime": "clientScript" },
-      "model": { "type": "bpmn:ScriptTask" },
+      "inputDefaults": {
+        "script": ""
+      },
       "inputDefinition": {
         "type": "object",
         "properties": {
@@ -644,9 +1683,10 @@
             "validationSeverity": "warning"
           }
         },
-        "required": ["script"]
+        "required": [
+          "script"
+        ]
       },
-      "inputDefaults": { "script": "" },
       "outputDefinition": {
         "output": {
           "type": "object",
@@ -662,25 +1702,57 @@
           "schema": {
             "$schema": "http://json-schema.org/draft-07/schema#",
             "type": "object",
-            "required": ["code", "message", "detail", "category", "status"],
+            "required": [
+              "code",
+              "message",
+              "detail",
+              "category",
+              "status"
+            ],
             "properties": {
-              "code": { "type": "string", "description": "Error code as a string" },
-              "message": { "type": "string", "description": "High-level error message" },
-              "detail": { "type": "string", "description": "Detailed error description" },
-              "category": { "type": "string", "description": "Error category" },
-              "status": { "type": "integer", "description": "HTTP status code" }
+              "code": {
+                "type": "string",
+                "description": "Error code as a string"
+              },
+              "message": {
+                "type": "string",
+                "description": "High-level error message"
+              },
+              "detail": {
+                "type": "string",
+                "description": "Detailed error description"
+              },
+              "category": {
+                "type": "string",
+                "description": "Error category"
+              },
+              "status": {
+                "type": "integer",
+                "description": "HTTP status code"
+              }
             },
             "additionalProperties": false
           }
         }
+      },
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:ScriptTask"
       }
     },
     {
       "nodeType": "core.logic.decision",
-      "version": "1.0.0",
-      "category": "control-flow",
+      "version": "1.0",
       "description": "Branch based on a true/false condition",
-      "tags": ["control-flow", "if", "loop", "switch"],
+      "category": "control-flow",
+      "tags": [
+        "control-flow",
+        "if",
+        "loop",
+        "switch"
+      ],
       "sortOrder": 20,
       "display": {
         "label": "Decision",
@@ -692,7 +1764,11 @@
         {
           "position": "left",
           "handles": [
-            { "id": "input", "type": "target", "handleType": "input" }
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
           ],
           "visible": true
         },
@@ -704,29 +1780,45 @@
               "type": "source",
               "handleType": "output",
               "label": "{inputs.trueLabel}",
-              "constraints": { "minConnections": 1 }
+              "constraints": {
+                "minConnections": 1
+              }
             },
             {
               "id": "false",
               "type": "source",
               "handleType": "output",
               "label": "{inputs.falseLabel}",
-              "constraints": { "minConnections": 1 }
+              "constraints": {
+                "minConnections": 1
+              }
             }
           ],
           "visible": true
         }
       ],
-      "debug": { "runtime": "clientScript" },
-      "model": { "type": "bpmn:InclusiveGateway" },
+      "inputDefaults": {
+        "trueLabel": "True",
+        "falseLabel": "False"
+      },
       "inputDefinition": {
         "type": "object",
         "properties": {
-          "expression": { "type": "string", "minLength": 1, "errorMessage": "A condition expression is required" },
-          "trueLabel": { "type": "string" },
-          "falseLabel": { "type": "string" }
+          "expression": {
+            "type": "string",
+            "minLength": 1,
+            "errorMessage": "A condition expression is required"
+          },
+          "trueLabel": {
+            "type": "string"
+          },
+          "falseLabel": {
+            "type": "string"
+          }
         },
-        "required": ["expression"]
+        "required": [
+          "expression"
+        ]
       },
       "outputDefinition": {
         "matchedCase": {
@@ -740,14 +1832,24 @@
           "var": "matchedCaseId"
         }
       },
-      "inputDefaults": { "trueLabel": "True", "falseLabel": "False" }
+      "debug": {
+        "runtime": "clientScript"
+      },
+      "model": {
+        "type": "bpmn:InclusiveGateway"
+      }
     },
     {
       "nodeType": "core.control.end",
-      "version": "1.0.0",
-      "category": "control-flow",
+      "version": "1.0",
       "description": "Mark the end of a workflow path",
-      "tags": ["control-flow", "end", "finish", "complete"],
+      "category": "control-flow",
+      "tags": [
+        "control-flow",
+        "end",
+        "finish",
+        "complete"
+      ],
       "sortOrder": 20,
       "display": {
         "label": "End",
@@ -758,11 +1860,17 @@
         {
           "position": "left",
           "handles": [
-            { "id": "input", "type": "target", "handleType": "input" }
+            {
+              "id": "input",
+              "type": "target",
+              "handleType": "input"
+            }
           ]
         }
       ],
-      "model": { "type": "bpmn:EndEvent" }
+      "model": {
+        "type": "bpmn:EndEvent"
+      }
     }
   ],
   "bindings": [],
@@ -780,64 +1888,108 @@
         "id": "getWeather.output",
         "type": "object",
         "description": "HTTP response from open-meteo API",
-        "binding": { "nodeId": "getWeather", "outputId": "output" }
+        "binding": {
+          "nodeId": "getWeather",
+          "outputId": "output"
+        }
       },
       {
         "id": "getWeather.error",
         "type": "object",
         "description": "Error if weather fetch fails",
-        "binding": { "nodeId": "getWeather", "outputId": "error" }
+        "binding": {
+          "nodeId": "getWeather",
+          "outputId": "error"
+        }
       },
       {
         "id": "formatSummary.output",
         "type": "object",
         "description": "Formatted weather summary with temperature and description",
-        "binding": { "nodeId": "formatSummary", "outputId": "output" }
+        "binding": {
+          "nodeId": "formatSummary",
+          "outputId": "output"
+        }
       },
       {
         "id": "formatSummary.error",
         "type": "object",
         "description": "Error if formatting script fails",
-        "binding": { "nodeId": "formatSummary", "outputId": "error" }
+        "binding": {
+          "nodeId": "formatSummary",
+          "outputId": "error"
+        }
       }
     ]
   },
   "layout": {
     "nodes": {
       "start": {
-        "position": { "x": 200, "y": 144 },
-        "size": { "width": 96, "height": 96 },
+        "position": {
+          "x": 200,
+          "y": 144
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        },
         "collapsed": false
       },
       "getWeather": {
-        "position": { "x": 450, "y": 144 },
-        "size": { "width": 96, "height": 96 },
+        "position": {
+          "x": 450,
+          "y": 144
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        },
         "collapsed": false
       },
       "formatSummary": {
-        "position": { "x": 700, "y": 144 },
-        "size": { "width": 96, "height": 96 },
+        "position": {
+          "x": 700,
+          "y": 144
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        },
         "collapsed": false
       },
       "checkTemperature": {
-        "position": { "x": 950, "y": 144 },
-        "size": { "width": 96, "height": 96 },
+        "position": {
+          "x": 950,
+          "y": 144
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        },
         "collapsed": false
       },
       "endNiceDay": {
-        "position": { "x": 1200, "y": 44 },
-        "size": { "width": 96, "height": 96 },
+        "position": {
+          "x": 1200,
+          "y": 44
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        },
         "collapsed": false
       },
       "endBringJacket": {
-        "position": { "x": 1200, "y": 244 },
-        "size": { "width": 96, "height": 96 },
+        "position": {
+          "x": 1200,
+          "y": 244
+        },
+        "size": {
+          "width": 96,
+          "height": 96
+        },
         "collapsed": false
       }
     }
-  },
-  "metadata": {
-    "createdAt": "2026-04-15T19:41:18.514Z",
-    "updatedAt": "2026-04-15T19:41:18.514Z"
   }
 }

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
@@ -13,6 +13,10 @@ tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:execute, feature:eval]
 
 run_limits:
   max_turns: 90
+  # Agent issues `uip ... eval run start --wait --timeout 600` which can block
+  # the entire turn for up to 600s; default 900s turn_timeout left no headroom
+  # for the surrounding ops in the same turn and timed out at iteration 1.
+  turn_timeout: 1500
 
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"


### PR DESCRIPTION
## Summary
- **Active alerts + Patterns** share a window picker (Current rotation, Previous rotation, Last 7 / 30 / 90 days) that drives /api/maestro/dri/jira-tickets via a new window param. Cache keyed on rotation start + window so each option is isolated.
- **Athena tests** gets its own time picker (7 / 14 / 30 / 60 days) wired to the existing days param.
- **Severity over time** legend now shows per-severity totals for the selected period; Sev 2/3/4 line colours recoloured to red / green / blue so they do not blur together.
- **Trends** charts default to 7 days (was 90).
- Removed the rotation subtitle from the global page header — each rotation-scoped tab now carries its own window label.

## Test plan
- [ ] On /maestro/dri/alerts, switch the picker between Current rotation, Previous rotation, 7d, 30d, 90d — counts + tickets refetch and label updates.
- [ ] /maestro/dri/patterns shares the same picker state as Active alerts.
- [ ] /maestro/dri/customers shows no picker (independent — list is currently-open issues).
- [ ] /maestro/dri/athena picker switches range; daily trend chart + top failing tests refresh.
- [ ] /maestro/dri/trends defaults to Last 7 days on first load. Severity chart legend shows per-Sev totals.
- [ ] Hard refresh — picker selections re-fetch (not just stale-cached).
