### PR TITLE
fix(catalog): make catalog refresh build the full verb set (#1203 root cause)

### DIFF
--- a/.github/workflows/refresh-uip-catalog.yml
+++ b/.github/workflows/refresh-uip-catalog.yml
@@ -66,20 +66,17 @@ jobs:
       - name: Rebuild catalog
         if: steps.check.outputs.exists != 'true'
         run: |
-          # Reset the @uipath scope to public npm before building. The alpha
-          # CLI is installed from GitHub Packages (step above), but the tool
-          # plugins (@uipath/*-tool) live only on public npm. Leaving the
-          # scope on GitHub Packages makes `uip tools install` resolve there,
-          # find nothing, install no tools, and collapse the catalog to the
-          # ~31 base verbs (#1203). build-uip-catalog.py's docstring documents
-          # this requirement.
-          npm config set @uipath:registry https://registry.npmjs.org/
+          # Install tools from GitHub Packages @alpha — the scope the install
+          # step already configured. Do NOT reset to public npm: the tool
+          # plugins must version-match the alpha CLI to register their full
+          # command tree. Stable (public-npm) tools install but fail to load
+          # reliably against the alpha CLI (e.g. the `rpa` group never appears;
+          # diagnostics confirmed the alpha `rpa-tool` does). Catalog tracks
+          # cli/main, so its tools must come from the same @alpha feed.
           # Guards: fail the build (no PR opened) if tool installs all fail or
           # the verb count collapses vs the committed snapshot.
-          # --min-verbs 1000 is a deliberate hard tripwire and is the binding
-          # guard at the current ~1115-verb size (the 20% relative floor is
-          # ~892). If the CLI ever legitimately trends below ~1000 verbs, the
-          # nightly will hard-fail until this floor is lowered — intentional:
+          # --min-verbs 1000 is a deliberate hard tripwire — it caught the
+          # orchestrator-tool drop (#1203 follow-up). The build must clear it;
           # a stuck refresh is louder than a silently shrunk catalog.
           python3 scripts/build-uip-catalog.py --install-tools \
             --min-verbs 1000 --max-drop-frac 0.2

--- a/scripts/build-uip-catalog.py
+++ b/scripts/build-uip-catalog.py
@@ -107,7 +107,14 @@ def run_uip(args):
 
 
 def strip_args(name):
-    return ARG_SIG.sub("", name).strip()
+    # Drop the trailing "[options]" / "<arg>" signature, then any alias suffix.
+    # `uip --help --output json` bakes aliases into a subcommand's Name with a
+    # pipe — orchestrator renders as "or|orchestrator" (it's the only aliased
+    # tool). Keep the canonical first token ("or") so the group matches its
+    # CommandPrefix and walks as `uip or …`; otherwise the whole orchestrator
+    # group is dropped (#1203 follow-up). Harmless once cli #2331 emits a bare
+    # Name + separate Aliases — the split is then a no-op.
+    return ARG_SIG.sub("", name).strip().split("|", 1)[0].strip()
 
 
 def install_all_tools():

--- a/scripts/build-uip-catalog.py
+++ b/scripts/build-uip-catalog.py
@@ -65,6 +65,23 @@ UNWALKABLE = set()
 PLATFORM_SPECIFIC_PREFIXES = {"rpa"}
 
 
+def _ci(d, key):
+    """Case-insensitive dict lookup for `uip --output json` payloads.
+
+    The CLI PascalCases every key of a `--output json` `Data` payload (cli
+    PR #2266), so a tool's name arrives as `Name`, not `name`. Reading the
+    documented lowercase key yields None — which made install_all_tools skip
+    every tool and collapse the catalog to the 31 base verbs (#1203). Same
+    break class guarded by tests/scripts/test_runtime_payload_key_casing.py.
+    """
+    if not isinstance(d, dict):
+        return None
+    for k, v in d.items():
+        if isinstance(k, str) and k.lower() == key.lower():
+            return v
+    return None
+
+
 def run_uip(args):
     try:
         proc = subprocess.run(
@@ -113,12 +130,14 @@ def install_all_tools():
     def short(name):
         return name.rsplit("/", 1)[-1] if name else ""
 
-    installed = {short(t.get("name", "")) for t in listed.get("Data", []) or []}
+    # Read tool names case-insensitively — the CLI returns `Name`, not `name`
+    # (see _ci). A raw `.get("name")` silently skips every tool (#1203).
+    installed = {short(_ci(t, "name") or "") for t in (_ci(listed, "data") or [])}
 
     search_results = run_uip(["tools", "search"]) or {}
     attempted = succeeded = 0
-    for tool in search_results.get("Data", []) or []:
-        name = tool.get("name") or ""
+    for tool in (_ci(search_results, "data") or []):
+        name = _ci(tool, "name") or ""
         if not name or short(name) in installed:
             continue
         attempted += 1
@@ -178,11 +197,14 @@ def collect_top_level():
     # 1:1 to the prefix (`integrationservice-tool` → `is`, etc.) — so we
     # cannot infer prefixes for uninstalled tools without false positives.
     tools = run_uip(["tools", "list"]) or {}
-    for tool in tools.get("Data", []) or []:
-        prefix = tool.get("commandPrefix")
+    for tool in (_ci(tools, "data") or []):
+        # Case-insensitive: the CLI returns `CommandPrefix`/`Name`, not the
+        # lowercase forms (see _ci). A raw lowercase read yields None and
+        # silently disables broken-tool detection.
+        prefix = _ci(tool, "commandPrefix")
         if prefix and prefix not in groups:
             UNWALKABLE.add(prefix)
-            print(f"tool {tool.get('name')!r}: installed but {prefix!r} is "
+            print(f"tool {_ci(tool, 'name')!r}: installed but {prefix!r} is "
                   f"not exposed as top-level subcommand — marking unwalkable",
                   file=sys.stderr)
     # Platform-specific tools that simply aren't installed on this runner —

--- a/scripts/build-uip-catalog.py
+++ b/scripts/build-uip-catalog.py
@@ -123,12 +123,14 @@ def install_all_tools():
     search`. Plugin groups (solution, maestro, tm, df, ...) only contribute
     verbs to the catalog when installed.
 
-    The @uipath/* packages live on public npm. The internal GitHub Packages
-    feed carries divergent 1.0.0-alpha.* prereleases under the same scope, so
-    if npm's @uipath scope is mapped there the catalog will pick up alpha
-    surface. The nightly workflow pins the scope to public npm before this
-    runs (`npm config set @uipath:registry https://registry.npmjs.org/`);
-    set the same locally if you hit auth errors.
+    Tools must be installed from the SAME feed as the CLI. The nightly tracks
+    cli/main, so it installs the CLI and the tools from GitHub Packages under
+    the `@alpha` dist-tag (`npm config set @uipath:registry
+    https://npm.pkg.github.com/` + auth token, done by the workflow). Stable
+    public-npm tools install but fail to register their command tree against
+    an alpha CLI (e.g. the `rpa` group never loads), collapsing coverage.
+    Locally, install the CLI and tools from whichever feed you intend the
+    catalog to reflect — keep both on the same one.
     """
     listed = run_uip(["tools", "list"]) or {}
     # `uip tools list` returns short names like "solution-tool".

--- a/tests/scripts/test_catalog_build_guards.py
+++ b/tests/scripts/test_catalog_build_guards.py
@@ -143,3 +143,64 @@ def test_install_all_tools_ok_when_nothing_to_install(monkeypatch):
         raise AssertionError("subprocess.run should not be called")
     monkeypatch.setattr(build.subprocess, "run", boom)
     build.install_all_tools()  # no SystemExit
+
+
+# --- PascalCase tool-name handling (#1203 real root cause) ------------------
+
+def test_ci_reads_pascalcase_and_lowercase():
+    """The CLI PascalCases --output json keys, so `Name` must resolve via the
+    documented `name` lookup."""
+    assert build._ci({"Name": "x"}, "name") == "x"
+    assert build._ci({"name": "y"}, "name") == "y"
+    assert build._ci({"NAME": "z"}, "name") == "z"
+    assert build._ci({"Data": [1, 2]}, "data") == [1, 2]
+    assert build._ci({}, "name") is None
+    assert build._ci(None, "name") is None
+
+
+def test_install_all_tools_handles_pascalcase_names(monkeypatch):
+    """The exact #1203 break: `uip tools search` returns tool names under
+    `Name` (PascalCase). install_all_tools must still attempt to install every
+    discovered tool — reading lowercase `name` skipped them all and collapsed
+    the catalog to 31 base verbs."""
+    def fake_run_uip(argv):
+        if argv == ["tools", "list"]:
+            return {"Data": []}                       # fresh: nothing installed
+        if argv == ["tools", "search"]:
+            return {"Data": [{"Name": "@uipath/solution-tool"},
+                             {"Name": "@uipath/df-tool"}]}
+        return {}
+    monkeypatch.setattr(build, "run_uip", fake_run_uip)
+
+    installs = []
+    def fake_run(argv, *a, **k):
+        installs.append(argv)
+        return types.SimpleNamespace(returncode=0, stdout="{}", stderr="")
+    monkeypatch.setattr(build.subprocess, "run", fake_run)
+
+    build.install_all_tools()
+
+    attempted = [c[3] for c in installs if c[:3] == ["uip", "tools", "install"]]
+    assert attempted == ["@uipath/solution-tool", "@uipath/df-tool"]
+
+
+def test_install_all_tools_skips_already_installed_pascalcase(monkeypatch):
+    """`tools list` is also PascalCase; an already-installed tool (matched on
+    short name) is not reinstalled."""
+    def fake_run_uip(argv):
+        if argv == ["tools", "list"]:
+            return {"Data": [{"Name": "solution-tool"}]}   # already installed
+        if argv == ["tools", "search"]:
+            return {"Data": [{"Name": "@uipath/solution-tool"},
+                             {"Name": "@uipath/df-tool"}]}
+        return {}
+    monkeypatch.setattr(build, "run_uip", fake_run_uip)
+    installs = []
+    monkeypatch.setattr(
+        build.subprocess, "run",
+        lambda argv, *a, **k: installs.append(argv) or types.SimpleNamespace(
+            returncode=0, stdout="{}", stderr=""),
+    )
+    build.install_all_tools()
+    attempted = [c[3] for c in installs if c[:3] == ["uip", "tools", "install"]]
+    assert attempted == ["@uipath/df-tool"]            # solution-tool skipped

--- a/tests/scripts/test_catalog_build_guards.py
+++ b/tests/scripts/test_catalog_build_guards.py
@@ -147,6 +147,18 @@ def test_install_all_tools_ok_when_nothing_to_install(monkeypatch):
 
 # --- PascalCase tool-name handling (#1203 real root cause) ------------------
 
+def test_strip_args_drops_alias_suffix():
+    """`uip --help --output json` renders the aliased orchestrator tool as
+    "or|orchestrator". strip_args must yield the canonical "or" so the group
+    walks as `uip or …` instead of being dropped (cli #2331)."""
+    assert build.strip_args("or|orchestrator") == "or"
+    assert build.strip_args("or|orchestrator [options]") == "or"
+    # Non-aliased names (the other ~23 tools) are unaffected.
+    assert build.strip_args("admin") == "admin"
+    assert build.strip_args("admin <subcommand>") == "admin"
+    assert build.strip_args("solution [options]") == "solution"
+
+
 def test_ci_reads_pascalcase_and_lowercase():
     """The CLI PascalCases --output json keys, so `Name` must resolve via the
     documented `name` lookup."""

--- a/tests/scripts/test_runtime_payload_key_casing.py
+++ b/tests/scripts/test_runtime_payload_key_casing.py
@@ -84,3 +84,49 @@ def test_guard_matches_raw_reads_in_either_casing():
     # The sanctioned form passes the key as a _get_ci positional arg, not via
     # `.get("…")` / `[...]`, so it must NOT be flagged.
     assert not _RAW_READ.search('_get_ci(payload, "finalStatus", "FinalStatus")')
+
+
+# --- build-uip-catalog.py: `uip tools` payload keys (#1203) -----------------
+# The catalog builder reads `uip tools list/search --output json` payloads.
+# The CLI PascalCases those keys (Name/CommandPrefix), so a raw *lowercase*
+# `.get("name")` / `.get("commandPrefix")` silently skipped every tool and
+# collapsed the catalog to 31 base verbs (#1203). Those reads must route
+# through the builder's `_ci` case-insensitive accessor.
+#
+# Case-SENSITIVE (no IGNORECASE) on purpose: a direct PascalCase read like
+# `sub.get("Name")` (used for `uip --help` Subcommands) works fine against the
+# current CLI and must NOT be flagged. Only the lowercase form — the exact
+# #1203 regression — is an error.
+_CATALOG_BUILDER = REPO_ROOT / "scripts" / "build-uip-catalog.py"
+_TOOL_PAYLOAD_KEYS = ("name", "commandPrefix")
+_CATALOG_RAW_READ = re.compile(
+    r"""\.get\(\s*['"](?:%s)['"]\s*[,)]|\[\s*['"](?:%s)['"]\s*\]"""
+    % ("|".join(_TOOL_PAYLOAD_KEYS), "|".join(_TOOL_PAYLOAD_KEYS)),
+)
+
+
+def test_catalog_builder_reads_tool_payload_keys_case_insensitively():
+    offenders = []
+    for lineno, line in enumerate(_CATALOG_BUILDER.read_text().splitlines(), 1):
+        if line.lstrip().startswith("#"):
+            continue
+        if _CATALOG_RAW_READ.search(line):
+            offenders.append(f"build-uip-catalog.py:{lineno}: {line.strip()}")
+    assert not offenders, (
+        "uip tools payload keys must be read via _ci (case-insensitive) so a "
+        "PascalCasing CLI cannot silently skip every tool (#1203). Offenders:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_catalog_guard_flags_lowercase_but_not_pascalcase():
+    """Catches the #1203 regression (lowercase) without flagging the working
+    PascalCase `--help` reads or the sanctioned `_ci` accessor."""
+    assert _CATALOG_RAW_READ.search('tool.get("name")')
+    assert _CATALOG_RAW_READ.search("tool.get('commandPrefix')")
+    assert _CATALOG_RAW_READ.search('tool["name"]')
+    # Working PascalCase reads (uip --help Subcommands) must NOT be flagged.
+    assert not _CATALOG_RAW_READ.search('sub.get("Name", "")')
+    assert not _CATALOG_RAW_READ.search('tool.get("CommandPrefix")')
+    # The sanctioned accessor form must NOT be flagged.
+    assert not _CATALOG_RAW_READ.search('_ci(tool, "name")')


### PR DESCRIPTION
## Why
The nightly catalog refresh was silently producing a **31-verb** snapshot (vs ~1115), breaking every PR's CLI Verb Gate (#1203). Root-causing it surfaced three independent bugs in `build-uip-catalog.py` and the refresh workflow. This PR fixes all three; verified in CI to rebuild **1249 verbs** with `or`/`rpa` restored.

## The three fixes

1. **PascalCase tool-payload keys (the actual #1203 cause).** `uip tools search --output json` returns tool names under `Name` (PascalCase, cli PR #2266), but `install_all_tools` read `tool.get("name")` (lowercase) → `None` → every tool skipped → **0 installs** → only the 31 base verbs. Added a case-insensitive `_ci()` accessor and routed the tool-payload reads (search loop, the installed-set from `tools list`, and the `commandPrefix` broken-tool detection) through it.

2. **Alias-joined subcommand name.** `uip --help --output json` bakes aliases into a subcommand's `Name` with a pipe — orchestrator (the only aliased tool) rendered as `"or|orchestrator"`, so the whole orchestrator group (188 verbs) was dropped. `strip_args` now takes the canonical first token. Recovers `or` on the current alpha CLI **without** waiting for the upstream fix (UiPath/cli#2331), and is a no-op once that lands.

3. **Tool feed mismatch.** Tools were installed from public npm while the CLI comes from GitHub Packages `@alpha`; stable tools don't register reliably against the alpha CLI (e.g. `rpa` never loads). The Rebuild step now installs tools from the same `@alpha` feed as the CLI, so groups load and version-match.

## Guards retained
`--min-verbs 1000` / `--max-drop-frac 0.2` stay — the floor correctly **caught** the orchestrator drop during this investigation. A build that doesn't clear the floor aborts before opening a PR (proven in CI).

## Tests
- `_ci` casing; `install_all_tools` installs PascalCase-named tools / skips already-installed; `strip_args` alias stripping.
- Extended the key-casing contract guard to flag a lowercase regression of the tool-payload keys in `build-uip-catalog.py`.
- 36/36 in `tests/scripts/` pass.

## Verification
Dispatched `refresh-uip-catalog.yml` off this branch: **1249 verbs** (or=188, rpa present), guards passed, refresh PR opened automatically. (That verification PR is closed; a clean catalog-only refresh will be generated from main after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)