### PR TITLE
fix(uipath-maestro-case): keep action recipient as a Phase-2 field, never defer it

### DIFF
--- a/skills/uipath-maestro-case/references/phased-execution.md
+++ b/skills/uipath-maestro-case/references/phased-execution.md
@@ -48,7 +48,7 @@ Each hard stop gives user review checkpoint before agent commits to costly downs
 
 | Task class | Resolved resources | Phase 2 shape |
 |---|---|---|
-| Non-connector (`process`, `agent`, `rpa`, `action`, `api-workflow`, `case-management`, `wait-for-timer`) | `task-type-id` resolved | Full `data.inputs[]` schema written (from `uip maestro case tasks describe`). Each input's `value` field is empty (`""`). Outputs populated per plugin. |
+| Non-connector (`process`, `agent`, `rpa`, `action`, `api-workflow`, `case-management`, `wait-for-timer`) | `task-type-id` resolved | Full `data.inputs[]` schema written (from `uip maestro case tasks describe`). Each input's `value` field is empty (`""`). Outputs and task-specific scalar fields (e.g. `action`'s `taskTitle`/`priority`/`recipient`/`labels`) populated per plugin — these are final at Step 2; only input `value`s defer to Phase 3. |
 | Connector (`connector-activity`, `connector-trigger`) | `type-id` + `connection-id` resolved | `data.typeId` + `data.connectionId` set. `data.inputs` omitted or empty. **No `case spec` call in Phase 2** — schema discovery is deferred to Phase 3. |
 | Any task | Unresolved (`<UNRESOLVED: …>` in `tasks.md`) | Placeholder task per Rule 8 of `SKILL.md` — empty `data: {}` (plus `data.taskTitle` / `data.priority` / `data.recipient` for `action`). Marker preserved. See [placeholder-tasks.md](placeholder-tasks.md). |
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/impl-json.md
@@ -40,7 +40,7 @@
 | `data.actionCatalogName` | **Optional.** Must bind to an existing action catalog resource. Omit unless tasks.md references a known catalog. |
 | `data.labels` | Label set from tasks.md |
 
-`recipient.Type` values: `0` = user ID (sdd `User:`), `1` = group ID (sdd `UserGroup:` / `Role:`), `2` = email address, `3` = `"=vars.<varId>"`. **Fallback when sdd.md value is not a resolved UUID:** write `{ "Type": <picked>, "Value": "<sdd-string-as-is>" }` — schema-conformant placeholder, user resolves Value later. Drop `data.recipient` only when no Type maps. **Never invent a non-conforming shape** (`{ kind, id }`, `{ scope, target, value }`, etc.) — Studio Web canvas crashes silently; CLI validate misses it.
+`recipient.Type` values: `0` = user ID (sdd `User:`), `1` = group ID (sdd `UserGroup:` / `Role:`), `2` = email address, `3` = `"=vars.<varId>"` (sdd `Expression:`). **Fallback when sdd.md value is not a resolved UUID:** write `{ "Type": <picked>, "Value": "<sdd-string-as-is>" }` — schema-conformant placeholder, user resolves Value later. Drop `data.recipient` only when no Type maps. **Never invent a non-conforming shape** (`{ kind, id }`, `{ scope, target, value }`, etc.) — Studio Web canvas crashes silently; CLI validate misses it.
 
 ## Procedure
 
@@ -65,14 +65,14 @@ Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 **Step 2 — Write task:**
 
 1. Generate `id` (`t` + 8 chars) and `elementId` (`<stageId>-<taskId>`)
-2. Set `data.taskTitle`, `data.priority`, `data.recipient`, `data.labels` from tasks.md. Set `data.actionCatalogName` only when tasks.md references an existing action catalog — otherwise omit.
+2. Set `data.taskTitle`, `data.priority`, `data.labels` from tasks.md now (plain strings, not Phase-3 bindings); set `data.actionCatalogName` only when tasks.md references an existing catalog. **`data.recipient` is an object, NEVER a bare string.** The tasks.md `recipient:` line carries a bare value (the SDD typed prefix is stripped in planning) — wrap it as `{ "Type": <int>, "Value": <value> }`, inferring Type from the value shape (`=vars.X` → `3`, email → `2`, UUID → `0`/`1`). E.g. `recipient: =vars.assignedLoanOfficer` → `{ "Type": 3, "Value": "=vars.assignedLoanOfficer" }`. Do not copy the bare value through as `data.recipient`.
 3. Set `data.name` = `=bindings.<nameBindingId>`, `data.folderPath` = `=bindings.<folderPathBindingId>`
 4. Write `data.inputs[]` / `data.outputs[]` from Step 0 schema. Each input: `{ name, type, id, var, elementId, value: "" }`. Each output: `{ name, type, id, var, value, source, target, elementId }`.
 
    **Output binding.** Apply [io-binding/impl-json.md § Output Binding Shapes](../../variables/io-binding/impl-json.md#output-binding-shapes). The Step 0 schema for this plugin is the `tasks describe` output (Step 0 above).
 5. Append to target stage's `tasks[laneIndex][]`
 
-> Entry conditions added in Step 10. Input value bindings in Phase 3 per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md).
+> Entry conditions added in Step 10. Only `data.inputs[].value` is deferred to Phase 3 per [io-binding/impl-json.md](../../variables/io-binding/impl-json.md); the scalar `data.*` fields above are final at Step 2.
 
 ## Post-Write Verification
 
@@ -81,4 +81,10 @@ Dedup per [§ Deduplication](../../variables/bindings/impl-json.md).
 - `data.name` and `data.folderPath` start with `=bindings.`
 - the bindings array has 2 entries: `resource: "app"`, no `resourceSubType`, `propertyAttribute` = `name` / `folderPath`
 - `data.inputs` and `data.outputs` populated (unless placeholder)
+- `data.recipient` is an **object** `{ Type, Value }`, never a bare string — present whenever tasks.md recorded a `recipient:` line (omitted only for group/role, Skip, or no-Type-maps)
 - `id` captured in `id-map.json`
+
+## Anti-patterns
+
+- **Do NOT emit `data.recipient` as a bare string, drop it, or "resolve" it.** It is always the object `{ Type, Value }` written at Step 2 (not an io-binding target). The tasks.md value (`=vars.X`, email, UUID) is the `Value` — wrap it, don't pass it through. `Type 3` `=vars.X` is the finished runtime reference; copying it through as a string, deferring to Phase 3, or rewriting it to the var's email each break the task. Symptoms: `data.recipient` is a string, or missing while `tasks.md` has `recipient: =vars.X`.
+- **CLI `validate` does NOT check `data.recipient`** — verify presence/shape explicitly (Post-Write Verification).


### PR DESCRIPTION
## Problem

`data.recipient` was dropped from all 11 action tasks in a generated caseplan — every task shipped **unassigned**. SDD and `tasks.md` both carried `recipient: =vars.assignedLoanOfficer`; the impl agent misread the `Type-3` (`=vars.X`) recipient as a Phase-3 io-binding needing "resolution to an email", deferred it, and never wrote it (`build-issues.md`: *"Phase 3 I/O binding: Pending"*). `Type 3` is actually the finished runtime reference — and `validate` doesn't check `recipient`, so it slipped through.

## Fix

Two read paths both lacked the rule that resolved action tasks write `recipient` (and other scalar fields) in full at **Step 2 / Phase 2**, not as Phase-3 bindings:

**`action/impl-json.md`** — already said to set `recipient` in Step 2 and documented `Type 3 = =vars.<varId>`, but never said it's final there:
- Type table: `Type 3` = sdd `Expression:`; `=vars.X` written verbatim.
- Step 2: scalar `data.*` fields (incl. recipient) written now, not deferred.
- Phase-3 callout: only `data.inputs[].value` is deferred.
- Post-Write Verification: assert recipient present when tasks.md recorded one.
- Anti-patterns: don't defer/resolve recipient; validate won't catch it.

**`phased-execution.md`** — the Phase-2 table's resolved-task row mentioned only inputs/outputs (the placeholder row named `recipient`, but the resolved row did not). Added: outputs **and task-specific scalar fields** are written per plugin at Step 2; only input values defer to Phase 3. Closes the second read path so the deferral can't recur.

Docs-only, 2 files. Planning was already correct. Independent of #1210.

🤖 Generated with [Claude Code](https://claude.com/claude-code)