### PR TITLE
feat: add CLI versions config for alpha/staging/cloud

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,9 @@
 # Plugin-namespaced slash commands (e.g., /uipath:install-permissions)
 /commands/ @DragosUnguru @tmatup
 
+# CLI versions config (per-environment CLI versions)
+/assets/cli-versions.json @vlad-uipath
+
 # Activity references (bundled inside uipath-rpa skill)
 /skills/uipath-rpa/references/activity-docs/ @DragosUnguru
 

--- a/assets/cli-versions.json
+++ b/assets/cli-versions.json
@@ -1,4 +1,5 @@
 {
+  "schemaVersion": 1,
   "generated_at": "2026-06-02T00:00:00Z",
   "environments": {
     "alpha": {

--- a/assets/cli-versions.json
+++ b/assets/cli-versions.json
@@ -1,0 +1,14 @@
+{
+  "generated_at": "2026-06-02T00:00:00Z",
+  "environments": {
+    "alpha": {
+      "cliVersion": "1.2"
+    },
+    "staging": {
+      "cliVersion": "1.1"
+    },
+    "cloud": {
+      "cliVersion": "1.0"
+    }
+  }
+}


### PR DESCRIPTION
## What

Adds `assets/cli-versions.json` — per-environment CLI versions (`alpha`, `staging`, `cloud`) in `X.Y` format.

| Environment | cliVersion |
|-------------|-----------|
| alpha       | 1.2       |
| staging     | 1.1       |
| cloud       | 1.0       |

## Why

Tracks the CLI version live across environments. Intended to be populated by an API call against each live app. Carries a `generated_at` timestamp so the fetch time is recorded.

## Location rationale

Placed under `assets/` to match the existing `assets/uip-catalog-snapshot.json` convention — both are data snapshots sourced from a live system, not root-level config/manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)