### PR TITLE
fix(uipath-agents): make guardrail escalation auth HOME-robust and collapse Apps-API dance [AL-450]

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
@@ -35,8 +35,9 @@ Filter the result for entries whose `Type` is `"Workflow Action"` (Coded / Coded
 `Key` gives you everything you need to identify the backing app, but `resource list` does not return `systemName` or `deployVersion` — both are required to fetch the action schema in Step 3. Query the Apps API once, filtered client-side by `id == <KEY>`, to extract them:
 
 ```bash
-# SECURITY: Never read ~/.uipath/.auth directly. Keep the token inside the shell.
-bash -c 'source <(grep = ~/.uipath/.auth) && curl -s \
+# SECURITY: Never read the auth file directly. Keep the token inside the shell.
+# Auth lives at $HOME/.uipath/.auth normally; fall back to /.uipath/.auth (root) for some sandboxes.
+bash -c 'A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; set -a; source "$A"; set +a; curl -s \
   "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-apps?state=deployed&pageNumber=0&limit=100" \
   -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
   -H "X-Uipath-Tenantid: $UIPATH_TENANT_ID" \
@@ -55,7 +56,7 @@ From the matching entry in `.deployed[]`, extract:
 Use `systemName` and `deployVersion` from Step 2.
 
 ```bash
-bash -c 'source <(grep = ~/.uipath/.auth) && curl -s \
+bash -c 'A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; set -a; source "$A"; set +a; curl -s \
   "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-schema?appSystemName=<SYSTEM_NAME>&version=<DEPLOY_VERSION>" \
   -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
   -H "X-Uipath-Tenantid: $UIPATH_TENANT_ID" \
@@ -97,7 +98,7 @@ From the action-schema response, construct the channel fields:
 Ask the user who should receive the task. If they say "me" or don't specify, fall back to the current user's email from the JWT `email` claim:
 
 ```bash
-bash -c 'source <(grep = ~/.uipath/.auth) && echo "$UIPATH_ACCESS_TOKEN" | python3 -c "
+bash -c 'A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; set -a; source "$A"; set +a; echo "$UIPATH_ACCESS_TOKEN" | python3 -c "
 import sys, base64, json
 tok = sys.stdin.read().strip()
 payload = tok.split(\".\")[1]

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -272,47 +272,58 @@ Example entry:
 
 > **Important:** Do NOT use `--kind Process` with `Type: "webApp"` to find Action Center apps. Those entries are the code-behind processes — their `Key` values are process release GUIDs, not app deployment IDs. Using them as `app.id` will cause runtime resolution failures.
 
-**Step 2 — Validate the app's action schema**
+**Step 2 — Verify the app exposes the guardrail action-schema contract** (do this **before** writing the guardrail JSON — an incompatible app must be rejected, not authored).
 
-A guardrail escalation app must expose a specific action schema contract. Validate **before** writing the guardrail JSON. If any check below fails, stop and report to the user: `<APP_NAME> does not have the required action schema configuration for tool guardrails.` (replace `<APP_NAME>` with the app's `Name` from Step 1).
+A guardrail escalation app must expose a specific action-schema contract. If verification fails, stop and report to the user: `<APP_NAME> does not have the required action schema configuration for tool guardrails.` (replace `<APP_NAME>` with the app's `Name` from Step 1). Do NOT write the guardrail.
 
-**SECURITY:** Never read `~/.uipath/.auth` directly — keep the token inside the shell. Always use a `bash -c` wrapper that sources the auth file and makes the API call in a single shell invocation, so Claude only sees the API response.
+> **SECURITY:** Never read the auth file into Claude's context. The verifier sources it and makes the API calls inside one shell invocation, so Claude sees only the verdict.
 
-2a. Look up `systemName` and `deployVersion` from the Apps API (use `Key` from Step 1 to filter client-side by `id`):
-
-```bash
-bash -c 'set -a; source ~/.uipath/.auth; set +a; curl -s \
-  "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-apps?state=deployed&pageNumber=0&limit=100" \
-  -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
-  -H "X-Uipath-Tenantid: $UIPATH_TENANT_ID" \
-  -H "Accept: application/json"'
-```
-
-From the entry whose `id` matches the `Key` from Step 1, extract `systemName` and `deployVersion`. If no entry matches → report error and stop.
-
-2b. Fetch the action schema:
+One verifier does the whole check — looks up `systemName`/`deployVersion` from `action-apps`, fetches `action-schema`, and confirms every required argument name. This replaces hand-rolled multi-step curl + JSON parsing, which is slow and error-prone. Auth lives at `$HOME/.uipath/.auth` in normal environments; the verifier falls back to `/.uipath/.auth` (some sandboxes write it at the filesystem root). Run both commands as one invocation:
 
 ```bash
-bash -c 'set -a; source ~/.uipath/.auth; set +a; curl -s \
-  "${UIPATH_URL}/${UIPATH_ORGANIZATION_ID}/apps_/default/api/v1/default/action-schema?appSystemName=<SYSTEM_NAME>&version=<DEPLOY_VERSION>" \
-  -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
-  -H "X-Uipath-Tenantid: $UIPATH_TENANT_ID" \
-  -H "Accept: application/json"'
+cat > /tmp/verify_escalation_app.py <<'PY'
+import os, sys, json, urllib.request, urllib.error
+key = sys.argv[1]
+base = f"{os.environ['UIPATH_URL']}/{os.environ['UIPATH_ORGANIZATION_ID']}/apps_/default/api/v1/default"
+hdr = {"Authorization": "Bearer " + os.environ["UIPATH_ACCESS_TOKEN"],
+       "X-Uipath-Tenantid": os.environ["UIPATH_TENANT_ID"], "Accept": "application/json"}
+def get(u):
+    try:
+        return json.load(urllib.request.urlopen(urllib.request.Request(u, headers=hdr)))
+    except urllib.error.HTTPError as e:
+        sys.exit(f"API_ERROR {e.code}: Apps API call failed (HTTP {e.code}) — could not verify action schema.")
+apps = get(base + "/action-apps?state=deployed&pageNumber=0&limit=100").get("deployed", [])
+app = next((a for a in apps if a.get("id") == key), None)
+if not app: sys.exit("NO_APP: no deployed app with id " + key)
+sch = get(base + f"/action-schema?appSystemName={app['systemName']}&version={app['deployVersion']}")
+need = {"inputs": {"GuardrailName", "GuardrailDescription", "TenantName", "AgentTrace", "Tool", "ExecutionStage", "ToolInputs", "ToolOutputs"},
+        "outputs": {"ReviewedInputs", "ReviewedOutputs", "Reason"},
+        "outcomes": {"Approve", "Reject"}}
+miss = {k: sorted(v - {x["name"] for x in sch.get(k, [])}) for k, v in need.items() if v - {x["name"] for x in sch.get(k, [])}}
+print("OK" if not miss else "MISSING: " + json.dumps(miss))
+sys.exit(0 if not miss else 1)
+PY
+bash -c 'A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; set -a; source "$A"; set +a; python3 /tmp/verify_escalation_app.py "<Key from Step 1>"'
 ```
 
-If the response is empty, not valid JSON, or missing the `inputs`/`outputs`/`outcomes` arrays → report error and stop.
+Decision rule — the verifier exits 0 (`OK`) or 1 (with a tagged reason). All exit-1 cases mean **do NOT write the guardrail**:
 
-2c. Check required arguments by name. All three categories must pass — the app may have extra arguments beyond these, but must have at least:
+| Verifier output | Meaning | Action |
+|-----------------|---------|--------|
+| exit 0, `OK` | Contract satisfied | Proceed to Step 3 |
+| exit 1, `MISSING: {...}` | App exists but its action schema is missing required argument names | Stop. Report `<APP_NAME> does not have the required action schema configuration for tool guardrails.` |
+| exit 1, `NO_APP: ...` | No deployed app matches the `Key` from Step 1 | Stop. Report the app was not found among deployed action apps |
+| exit 1, `API_ERROR <code>` | Apps API unreachable or token lacks Apps permission | Stop. Report `<APP_NAME> could not be verified for the required action schema configuration.` **Do NOT re-authenticate, source the auth file manually, or try alternate endpoints** — a single failed verifier call is terminal for this run |
 
-| Category | Required Names |
+The check is **name-only** (types, `required` flags, `isList` are not checked); the app may carry extra arguments beyond these:
+
+| Category | Required names |
 |----------|---------------|
 | `inputs` (8) | `GuardrailName`, `GuardrailDescription`, `TenantName`, `AgentTrace`, `Tool`, `ExecutionStage`, `ToolInputs`, `ToolOutputs` |
 | `outputs` (3) | `ReviewedInputs`, `ReviewedOutputs`, `Reason` |
 | `outcomes` (2) | `Approve`, `Reject` |
 
-Validation is **name-only** — types, `required` flags, and `isList` are not checked. Verify every required name appears in the corresponding array's `name` fields. If any required name is missing → report error and stop.
-
-**Step 3 — Construct and add the escalate action** in `agent.json`'s `guardrails` array:
+**Step 3 — Construct and add the escalate action** in `agent.json`'s `guardrails` array (only after Step 2 passed):
 
 ```json
 {
@@ -331,7 +342,7 @@ Validation is **name-only** — types, `required` flags, and `isList` are not ch
 
 **Step 4 — Generate solution resource files**
 
-Run these two commands from the solution root:
+Run from the solution root:
 
 ```bash
 uip agent validate <AgentName> --output json
@@ -339,7 +350,7 @@ uip agent migrate  <AgentName> --output json
 uip solution resource refresh  --output json
 ```
 
-- `validate` is a read-only check. Reports `MigrationPending: true` if migration is needed.
+- `validate` is a read-only check; regenerates `.agent-builder/agent.json`. Reports `MigrationPending: true` if migration is needed.
 - `migrate` generates `bindings_v2.json` with a `resource: "app"` binding for the escalation app. The binding carries both `name` (from `app.name`) and `folderPath` (translated from `app.folderName`).
 - `refresh` reads `bindings_v2.json`, fetches the app from the Resource Catalog Service using the joint `(name, folderPath)` key, and generates all 4 solution-level resource files (`app/workflow Action/`, `appVersion/`, `package/`, `process/webApp/`) plus the `debug_overwrites.json` entries for both the app and its code-behind process.
 
@@ -972,7 +983,7 @@ Add the `guardrails` array at the agent.json root level alongside `settings`, `m
 10. **Do not use Action Center apps with `Type: "VB Action"` or `Type: "Coded"` as escalation targets** — only entries with `Type: "Workflow Action"` can back a guardrail escalation. Always filter `uip solution resource list --kind App` results by this type.
 11. **Do not use `--kind Process` (Type: `"webApp"`) to find escalation apps** — those entries are code-behind processes, not app deployments. Their `Key` values are process release GUIDs, not app IDs. Always use `--kind App` with `Type: "Workflow Action"`.
 12. **Do not put `"solution_folder"` into `app.folderName`** — set it to the literal `Folder` from `uip solution resource list --kind App` (e.g., `"Shared/Approvals"`). `uip agent migrate` translates it to `folderPath` in the App binding inside `bindings_v2.json`. Omit `app.folderId`. `FolderKey` from `resource list` is NOT used in any `app.*` field — it IS correct in `debug_overwrites.json` entries, where it maps the solution-embedded resource to its real runtime location.
-13. **Do not use `source <(grep = ~/.uipath/.auth)` for Apps API calls in guardrail setup** — it fails to export variables to the surrounding shell in some environments. Use `set -a; source ~/.uipath/.auth; set +a` instead.
+13. **Do not hardcode the auth-file path for Apps API calls in guardrail setup.** `source <(grep = ...)` fails to export variables to the surrounding shell in some environments, and `~/.uipath/.auth` is wrong when the sandbox writes auth at the filesystem root. Use the HOME-robust prelude: `A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; set -a; source "$A"; set +a`.
 14. **Do not add a Tool-scoped guardrail before the tool is added to the agent** — every name in `selector.matchNames` must match an existing tool resource under `<AGENT_NAME>/resources/<ToolName>/resource.json`. A guardrail referencing a non-existent tool will be caught by `uip agent validate` and fail with an error. Always run `uip agent tool list` first (Step 2) and confirm target tools are present.
 15. **Do not skip action schema validation for escalation apps** — before writing a guardrail with `"$actionType": "escalate"`, fetch the app's action schema and verify all required inputs (8), outputs (3), and outcomes (2) are present by name. If any are missing, report `<APP_NAME> does not have the required action schema configuration for tool guardrails.` and do not proceed. See [§ Adding an escalation guardrail — Step 2](#adding-an-escalation-guardrail--step-by-step).
 16. **Do not use `Agent` or `Llm` scopes on custom guardrails** — custom guardrails (`$guardrailType: "custom"`) only support `"Tool"` scope with exactly one tool in `matchNames`. Custom rules depend on the tool's input/output schema, so they cannot target multiple tools. Create a separate custom guardrail per tool.

--- a/skills/uipath-agents/references/lowcode/capabilities/process/solution-files.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/process/solution-files.md
@@ -489,7 +489,7 @@ Returns, for each match:
 Use a shell wrapper to query the Releases API — this keeps the access token inside the shell. Filter by `ProcessKey` (string, exact match):
 
 ```bash
-bash -c 'source <(grep = ~/.uipath/.auth) && curl -s "${UIPATH_URL}/${UIPATH_ORGANIZATION_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Releases?\$filter=ProcessKey%20eq%20'\''<PROCESS_KEY>'\''&\$top=1&\$select=Key,Name,ProcessKey,ProcessVersion,ProcessType,FeedId,TargetRuntime,Description,Arguments,Id" \
+bash -c 'A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; set -a; source "$A"; set +a; curl -s "${UIPATH_URL}/${UIPATH_ORGANIZATION_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Releases?\$filter=ProcessKey%20eq%20'\''<PROCESS_KEY>'\''&\$top=1&\$select=Key,Name,ProcessKey,ProcessVersion,ProcessType,FeedId,TargetRuntime,Description,Arguments,Id" \
   -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
   -H "X-UIPATH-FolderKey: <FOLDER_KEY_GUID>"'
 ```
@@ -507,7 +507,7 @@ Returns:
 This API returns JSON Schema format input/output arguments and entry point metadata. It works for **all 4 process types**.
 
 ```bash
-bash -c 'source <(grep = ~/.uipath/.auth) && curl -s "${UIPATH_URL}/${UIPATH_ORGANIZATION_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.GetPackageEntryPointsV2(key='\''<PROCESS_KEY>:<VERSION>'\'')?feedId=<FEED_ID>" \
+bash -c 'A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; set -a; source "$A"; set +a; curl -s "${UIPATH_URL}/${UIPATH_ORGANIZATION_NAME}/${UIPATH_TENANT_NAME}/orchestrator_/odata/Processes/UiPath.Server.Configuration.OData.GetPackageEntryPointsV2(key='\''<PROCESS_KEY>:<VERSION>'\'')?feedId=<FEED_ID>" \
   -H "Authorization: Bearer $UIPATH_ACCESS_TOKEN" \
   -H "X-UIPATH-FolderKey: <FOLDER_KEY_GUID>"'
 ```

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -8,7 +8,7 @@ description: >
   `uip solution resource list` to look up the escalation app, and
   correctly authors the escalate action with $actionType, app.name,
   app.version, app.folderName, and a recipient.
-tags: [uipath-agents, smoke, low-code, guardrail]
+tags: [uipath-agents, e2e, low-code, guardrail]
 
 agent:
   # Disallow built-in todo tools — they aren't gated by allowed_tools, and the

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -8,7 +8,7 @@ description: >
   `uip solution resource list` to look up the escalation app, and
   correctly authors the escalate action with $actionType, app.name,
   app.version, app.folderName, and a recipient.
-tags: [uipath-agents, e2e, low-code, guardrail]
+tags: [uipath-agents, smoke, low-code, guardrail]
 
 agent:
   # Disallow built-in todo tools — they aren't gated by allowed_tools, and the


### PR DESCRIPTION
## What changed?

Fixes the `skill-agent-guardrail-escalation-app` eval, which hit `MAX_TURNS_EXHAUSTED` (63 turns, score 0.67). The agent burned ~40 turns hand-rolling auth + curl to verify the escalation app's action schema, and never reached guardrail authoring or `uip agent validate` — so the guardrail-shape, validate, and `.agent-builder/agent.json` criteria all failed on a pristine scaffold.

Two root causes in the `uipath-agents` skill, both fixed:

1. **Auth-path fragility.** Live auth commands hardcoded `~/.uipath/.auth`, which is wrong when the sandbox writes auth at the filesystem root (`$HOME` mismatch). The agent spent ~15 turns hunting for the file. Replaced with a HOME-robust prelude (`A="$HOME/.uipath/.auth"; [ -f "$A" ] || A="/.uipath/.auth"; ...`) across `guardrails.md`, `escalation.md`, and `process/solution-files.md` (5 commands + the matching critical-rule note).

2. **Expensive multi-call verification.** The `action-apps → systemName/deployVersion → action-schema → name-check` sequence was hand-rolled curl + manual JSON parsing (~20 turns of iteration). Replaced with **one self-contained verifier script** that runs the whole check and exits `0`/`1`, with a clean terminal diagnostic on HTTP failure (no `uip login status` nudge that would re-trigger the auth hunt) and a decision-rule table covering all three exit-1 branches (`MISSING` / `NO_APP` / `API_ERROR`).

Verify-before-write ordering is **preserved** so the negative-case sibling task (`escalation_app_validation`, which must reject an incompatible app *before* writing) still passes.

## How has this been tested?

- Verifier script: syntax + set-difference logic checked offline (tolerates extra args, flags missing names); runs cleanly against the live Apps API (403 on the local tenant is a permission limitation, surfaced as a clean `API_ERROR 403` diagnostic with exit 1 — not a traceback).
- The exact `cat <<'PY' ... PY` heredoc + `bash -c` block was executed verbatim: parses and runs with zero quoting errors.
- `/lint-task` on `escalation_app.yaml`: **OK** (CLI-verb check Info-only; task YAML unchanged).
- **Fresh no-context subagent** reproduced the task against the edited file: reached the verifier in **8 commands with zero auth-hunting** (vs. 63 thrashing turns originally), first-try auth resolution, and correctly declined to write the guardrail when verification failed. This run also surfaced the missing `API_ERROR` decision branch, which is fixed in this PR.

Note: `coder-eval` is not installed locally and the local tenant 403s on the Apps API, so the happy-path tail wasn't exercised end-to-end locally — it will be in the eval, whose token has Apps permission.

## Are there any breaking changes?

- [x] None — documentation-only changes to the `uipath-agents` skill references.

Closes AL-450