### PR TITLE
fix(uipath-troubleshoot): correct getasset-external-vault-failure expected_turns typo

### DIFF
--- a/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-external-vault-failure/task.yaml
@@ -15,7 +15,7 @@ agent:
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:
-  expected_turns: 252
+  expected_turns: 34
   task_timeout: 5400
 
   max_turns: 60


### PR DESCRIPTION
## Change

`expected_turns: 252` in `getasset-external-vault-failure/task.yaml` is a copy-paste typo — nonsensical next to `max_turns: 60` and inconsistent with sibling scenarios (~34). Set it to **34**. It's an informational field only (no runtime effect).

## Scope note

This PR originally also bumped `turn_timeout`/`task_timeout` for external-vault and network-connectivity to absorb CI tail-clips. Per review, **we're keeping the documented standard** (`task_timeout: 5400`, `turn_timeout: 3600`) rather than adding per-scenario timeout exceptions — occasional tail-clips are handled by running **≥2 replicates** in CI. So those timeout changes were dropped; this PR is now just the `expected_turns` correction.

The scenario itself is sound (passes locally — sweep reps scored 0.925 and 1.000); no content/fixture/RESOLUTION changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)