### PR TITLE
fix(uipath-troubleshoot): normalize getasset task_id prefixes to skill-troubleshoot-

### DIFF
--- a/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-name-mismatch/task.yaml
@@ -1,4 +1,4 @@
-task_id: skill-troubleshooting-getasset-name-mismatch
+task_id: skill-troubleshoot-getasset-name-mismatch
 description: >
   UiPath troubleshooting agent must troubleshoot a Get Credential failure where
   the workflow's AssetName property is misspelled ("myHiddenAset" —

--- a/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-network-connectivity/task.yaml
@@ -1,4 +1,4 @@
-task_id: skill-troubleshooting-getasset-network-connectivity
+task_id: skill-troubleshoot-getasset-network-connectivity
 description: >
   UiPath troubleshooting agent must troubleshoot a Get Credential failure where
   the asset, folder, robot license, and robot roles are all correctly


### PR DESCRIPTION
## Problem

Two `get-asset` troubleshoot scenarios still carry the pre-rename `skill-troubleshooting-` prefix (with "-ing"), while the other seven use `skill-troubleshoot-`:

- `skill-troubleshooting-getasset-name-mismatch`
- `skill-troubleshooting-getasset-network-connectivity`

Cosmetic, but it shows up as inconsistent task ids in run output / the evalboard and breaks at-a-glance grouping of the family.

## Change

Rename the `task_id` field (line 1) of each to `skill-troubleshoot-…`. Folders were already named correctly (`getasset-name-mismatch`, `getasset-network-connectivity`); only the in-file `task_id` drifted.

Verified no other repo references to the old ids (only the two `task.yaml` files matched). Historical run artifacts under the old ids remain untouched; new runs will use the normalized ids.

## Evidence of passing run

Both scenarios were run via `coder-eval` (experiment `default.yaml`, standard `5400/3600` limits) and **passed**:

- `getasset-name-mismatch` — **1.000** (×2 replicates, in the 8-sibling regression sweep for #1223).
- `getasset-network-connectivity` — **1.000** (sweep rep 00, 2046s; and again on a fresh single-replicate run, 1599s). One sweep replicate tail-clipped on the `turn_timeout` (an intermittent timeout, unrelated to this change).

Note: these runs executed under the **pre-rename** `task_id`. `task_id` is a metadata field that only names the run/persist directory — it does not affect fixtures, success criteria, the agent's behavior, or grading — so the passing runs evidence identical behavior under the normalized id. (Verified separately that no other file references the id, and the new id is shorter, so there is no path-length regression.)

Found while running the 8-sibling regression sweep for #1223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)