### PR TITLE
fix(test): de-flake healing-agent-no-license

### DIFF
--- a/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
@@ -17,9 +17,9 @@ agent:
 
 run_limits:
   expected_turns: 42
-  task_timeout: 2400
+  task_timeout: 5400
   max_turns: 60
-  turn_timeout: 1800
+  turn_timeout: 3600
 
 sandbox:
   template_sources:
@@ -51,12 +51,10 @@ success_criteria:
     weight: 0.5
 
   - type: file_contains
-    description: "state.json names the healing-agent-no-license playbook (not the older selector-failure-manual / no-recovery-data classification)"
+    description: "state.json names the healing-agent-no-license playbook as a match (the agent may also legitimately note selector-failure-manual / no-recovery-data as lower-confidence secondary matches — the llm_judge grades which is primary)"
     path: .local/investigations/state.json
     includes:
       - "healing-agent-no-license"
-    excludes:
-      - "selector-failure-manual"
     weight: 1.0
 
   - type: file_contains

--- a/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
@@ -17,9 +17,9 @@ agent:
 
 run_limits:
   expected_turns: 42
-  task_timeout: 5400
+  task_timeout: 3600
   max_turns: 60
-  turn_timeout: 3600
+  turn_timeout: 2400
 
 sandbox:
   template_sources:


### PR DESCRIPTION
## Problem

The `healing-agent-no-license` troubleshoot task was flaky on nightly. Two independent flake sources:

1. **Brittle `state.json` criterion.** The `file_contains` check on `.local/investigations/state.json` had `excludes: [selector-failure-manual]`. But the agent *legitimately* records `selector-failure-manual.md` as a **medium-confidence secondary** match — the surface error genuinely is an aria-label selector typo, and `RESOLUTION.md` itself lists "correct the aria-label typo" as an acceptable secondary fix. Whether the agent notes the secondary varies run-to-run, so the exclude failed ~50% of runs. This grades internal bookkeeping rather than the presented conclusion — exactly what `tests/tasks/uipath-troubleshoot/CLAUDE.md` prohibits ("grade presentation, not internal state").

2. **Turn timeout too tight.** The entire investigation runs inside simulation turn 1, landing right at the 30-min `turn_timeout: 1800` cap. Faster runs squeak under; slower ones get killed with `status=ERROR`. The directory CLAUDE.md documents `turn_timeout: 2400` / `task_timeout: 3600` for exactly this reason.

## Changes

- Drop `excludes: [selector-failure-manual]` from the state.json criterion; keep the `includes: [healing-agent-no-license]`. The `llm_judge` already grades which playbook is *primary*.
- Raise `task_timeout` 2400→3600 and `turn_timeout` 1800→2400 to the documented standard.

## Evidence

Reproduced the nightly failure locally: **2 of 4 baseline runs failed** on the state.json exclude (`Includes: 1/1 found; Excludes: 0/1 absent`), the rest 1.0. The `llm_judge` (the contract-correct grader) passed 1.0 in every run. After dropping the exclude, the criterion scored **1.0 on every graded run**; the remaining failures were the turn-timeout ERRORs this PR also addresses.