### PR TITLE
fix(evals): skill-agents-batch-transform-coded-smoke-trigger — fix prompt

### DIFF
--- a/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
@@ -5,9 +5,6 @@ description: >
   agent (LangGraph). Verifies the skill fires for the
   Python-coded-agent + CSV signal pair.
 tags: [uipath-agents, smoke, coded, lifecycle:discover, context-grounding]
-
-sandbox: {}
-
 run_limits:
   max_turns: 50
 

--- a/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
@@ -6,15 +6,16 @@ description: >
   Python-coded-agent + CSV signal pair.
 tags: [uipath-agents, smoke, coded, lifecycle:discover, context-grounding]
 
+sandbox: {}
+
 run_limits:
-  expected_turns: 5
+  max_turns: 50
 
 initial_prompt: |
-  I have a coded agent project with `pyproject.toml` (deps: uipath,
-  uipath-langchain) and `langgraph.json`. I want it to read a CSV of
-  ~1000 vendor rows and add two LLM-filled columns: a 4-digit MCC code
-  and a confidence label. Tell me which skill applies and the high-level
-  pipeline shape. Do NOT scaffold any files.
+  I want it to read a CSV of ~1000 vendor rows and add two LLM-filled columns: a 4-digit MCC code
+  and a confidence label.
+
+  How can I do this with a coded agent. Do not scaffold, tell me the plan first.
 
 success_criteria:
   - type: skill_triggered


### PR DESCRIPTION
## Summary

- Removes meta-question from prompt ("Tell me which skill applies") that caused the agent to answer from general knowledge instead of invoking the skill
- Removes invalid `expected_turns` field (no longer in schema)
- Adds `sandbox: {}` for schema compliance

## Test plan

- [ ] 1/1 local runs pass (score 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)