### PR TITLE
docs: document pack source-traceability metadata flags

### DIFF
--- a/skills/uipath-api-workflow/references/cli-reference.md
+++ b/skills/uipath-api-workflow/references/cli-reference.md
@@ -324,6 +324,12 @@ uip solution pack <solutionPath> <outputPath> \
   [--name <name>] \
   [--version <version>] \
   [--login-validity <minutes>] \
+  [--repository-url <url>] \
+  [--repository-commit <sha>] \
+  [--repository-branch <branch>] \
+  [--repository-type <type>] \
+  [--release-notes <text>] \
+  [--project-url <url>] \
   [--output json]
 ```
 
@@ -334,6 +340,12 @@ uip solution pack <solutionPath> <outputPath> \
 | `-n, --name <name>` | no | Package name. Defaults to solution folder name. |
 | `-v, --version <version>` | no | Package version. Default `1.0.0`. |
 | `--login-validity <minutes>` | no | Min minutes before token refresh. Default `10`. |
+| `--repository-url <url>` | no | Source repository URL, recorded in each project's `.nuspec` for traceability. |
+| `--repository-commit <sha>` | no | Source repository commit hash. |
+| `--repository-branch <branch>` | no | Source repository branch. |
+| `--repository-type <type>` | no | Source repository type. Defaults to `git` when `--repository-url` is set. |
+| `--release-notes <text>` | no | Release notes recorded in the package. |
+| `--project-url <url>` | no | Automation Hub idea URL (nuspec `<projectUrl>`). |
 
 ### What the API workflow packager does
 

--- a/skills/uipath-coded-apps/references/commands-reference.md
+++ b/skills/uipath-coded-apps/references/commands-reference.md
@@ -114,6 +114,12 @@ uip codedapp pack <dist> [options]
 | `--description <desc>` | Package description | Prompted |
 | `--main-file <file>` | Main entry file | `index.html` |
 | `--content-type <type>` | Content type: `webapp`, `library`, `process` | `webapp` |
+| `--repository-url <url>` | Source repository URL, recorded for traceability | -- |
+| `--repository-commit <sha>` | Source repository commit hash | -- |
+| `--repository-branch <branch>` | Source repository branch | -- |
+| `--repository-type <type>` | Source repository type | `git` when `--repository-url` set |
+| `--release-notes <text>` | Release notes recorded in the package | -- |
+| `--project-url <url>` | Automation Hub idea URL (nuspec `<projectUrl>`) | -- |
 | `--dry-run` | Preview packaging without creating the file | `false` |
 | `--reuse-client` | Reuse existing clientId from uipath.json | `false` |
 | `--base-url <url>` | UiPath base URL | From `.env` |

--- a/skills/uipath-coded-apps/references/pack-publish-deploy.md
+++ b/skills/uipath-coded-apps/references/pack-publish-deploy.md
@@ -44,6 +44,12 @@ uip codedapp pack dist -n my-webapp --version 1.0.0 -a "My Team" --description "
 | `--description <desc>` | Package description | Prompted |
 | `--main-file <file>` | Main entry file | `index.html` |
 | `--content-type <type>` | `webapp`, `library`, or `process` | `webapp` |
+| `--repository-url <url>` | Source repository URL, recorded for traceability | -- |
+| `--repository-commit <sha>` | Source repository commit hash | -- |
+| `--repository-branch <branch>` | Source repository branch | -- |
+| `--repository-type <type>` | Source repository type | `git` when `--repository-url` set |
+| `--release-notes <text>` | Release notes recorded in the package | -- |
+| `--project-url <url>` | Automation Hub idea URL (nuspec `<projectUrl>`) | -- |
 | `--dry-run` | Preview without creating | `false` |
 | `--reuse-client` | Reuse clientId from `uipath.json` | `false` |
 

--- a/skills/uipath-maestro-bpmn/references/operate/references/ship.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/ship.md
@@ -45,6 +45,7 @@ uip maestro bpmn pack <project-path> <OutputDir> --output json
 ```
 
 Use `--name` and `--version` only when the user provides a public-safe package identity.
+Optional source-traceability flags recorded in the `.nupkg`: `--repository-url`, `--repository-commit`, `--repository-branch`, `--repository-type` (defaults to `git` when `--repository-url` is set), `--release-notes`, and `--project-url` (Automation Hub idea URL). Only set these from public-safe values.
 Report the package path and package identity returned by the CLI.
 If packing changes generated files, explain whether the change came from BPMN source, CLI enrichment,
 or package generation.

--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -116,6 +116,12 @@ uip maestro case pack ./my-case-project ./dist --name MyCase --version 2.0.0
 | `<output-path>` | **(required)** Output directory for the `.nupkg` |
 | `-n, --name <name>` | Package name (default: project folder name) |
 | `-v, --version <version>` | Package version (default: `1.0.0`) |
+| `--repository-url <url>` | Source repository URL, recorded in the `.nupkg` for traceability |
+| `--repository-commit <sha>` | Source repository commit hash |
+| `--repository-branch <branch>` | Source repository branch |
+| `--repository-type <type>` | Source repository type (defaults to `git` when `--repository-url` is set) |
+| `--release-notes <text>` | Release notes recorded in the package |
+| `--project-url <url>` | Automation Hub idea URL (nuspec `<projectUrl>`) |
 
 > `pack` + `uip solution publish` deploys directly to Orchestrator — bypasses Studio Web. Default publish path is `uip solution upload`.
 

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -86,6 +86,8 @@ uip maestro flow pack <project-path> <OutputDir> --output json
 
 Requires `content/package-descriptor.json` and `content/operate.json` in the project. Output: `<Name>.flow.Flow.<version>.nupkg`.
 
+**Package metadata (optional, recorded in the `.nupkg` for source traceability):** `--repository-url <url>`, `--repository-commit <sha>`, `--repository-branch <branch>`, `--repository-type <type>` (defaults to `git` when `--repository-url` is set), `--release-notes <text>`, and `--project-url <url>` (Automation Hub idea URL → nuspec `<projectUrl>`).
+
 > **Note:** `pack` + `uip solution publish` deploys directly to Orchestrator — the user cannot visualize or edit the flow in Studio Web via this path. Only use this when the user explicitly asks to deploy to Orchestrator. The default publish path is `uip solution upload` (see below). See [uipath-solution](/uipath:uipath-solution) for `solution publish` commands.
 
 ## uip solution resource refresh

--- a/skills/uipath-solution/references/operate/pack-and-deploy.md
+++ b/skills/uipath-solution/references/operate/pack-and-deploy.md
@@ -41,6 +41,13 @@ uip solution pack ./MySolution ./output --output json
 
 # With explicit name and version
 uip solution pack ./MySolution ./output --name "MySolution" --version "2.0.0" --output json
+
+# Stamp source-traceability metadata into the package
+uip solution pack ./MySolution ./output \
+  --repository-url https://github.com/acme/repo \
+  --repository-commit "$(git rev-parse HEAD)" \
+  --repository-branch main \
+  --release-notes "v2.0.0 release" --output json
 ```
 
 | Option | Description | Default |
@@ -49,6 +56,12 @@ uip solution pack ./MySolution ./output --name "MySolution" --version "2.0.0" --
 | `<output-path>` | Directory where the .zip will be written (required positional, no default — omitting it errors with `missing required argument 'output-path'`) | -- |
 | `--name <name>` | Override the package name | Name from `.uipx` |
 | `--version <version>` | Set the package version | `1.0.0` |
+| `--repository-url <url>` | Source repository URL, recorded in the package for traceability | -- |
+| `--repository-commit <sha>` | Source repository commit hash | -- |
+| `--repository-branch <branch>` | Source repository branch | -- |
+| `--repository-type <type>` | Source repository type | `git` when `--repository-url` is set |
+| `--release-notes <text>` | Release notes recorded in the package | -- |
+| `--project-url <url>` | Automation Hub idea URL (nuspec `<projectUrl>`) | -- |
 
 The output is a `.zip` file named `<name>.<version>.zip` written under `<output-path>/` (e.g., `MySolution.2.0.0.zip`). Run `solution resource refresh` first (from inside the solution dir, or with `--solution-folder <path>`) to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
 


### PR DESCRIPTION
## What & why

UiPath CLI PR [UiPath/cli#2323](https://github.com/UiPath/cli/pull/2323) ([STUD-80227](https://uipath.atlassian.net/browse/STUD-80227)) restores the legacy **source-traceability metadata** flags on every `.nupkg`/`.zip`-producing `pack` command, so a deployed package can be traced back to the source change that produced it.

This documents those six flags in the skills' canonical pack references:

- `--repository-url <url>`
- `--repository-commit <sha>`
- `--repository-branch <branch>`
- `--repository-type <type>` — defaults to `git` when `--repository-url` is set
- `--release-notes <text>`
- `--project-url <url>` — Automation Hub idea URL → nuspec `<projectUrl>`

## Files touched

| Skill | File | Command |
|-------|------|---------|
| uipath-solution | `references/operate/pack-and-deploy.md` | `uip solution pack` |
| uipath-api-workflow | `references/cli-reference.md` | `uip solution pack` |
| uipath-coded-apps | `references/commands-reference.md`, `references/pack-publish-deploy.md` | `uip codedapp pack` |
| uipath-maestro-case | `references/case-commands.md` | `uip maestro case pack` |
| uipath-maestro-flow | `references/shared/cli-commands.md` | `uip maestro flow pack` |
| uipath-maestro-bpmn | `references/operate/references/ship.md` | `uip maestro bpmn pack` |

Docs-only change to existing reference files (no SKILL.md / new-skill changes).

[STUD-80227]: https://uipath.atlassian.net/browse/STUD-80227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ