### PR TITLE
fix(hitl): correct binding criterion format in quality_10

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
@@ -49,7 +49,7 @@ success_criteria:
     description: "Input fields have binding expressions pointing to upstream script output"
     path: "SupplierOnboarding/SupplierOnboarding/SupplierOnboarding.flow"
     includes:
-      - '"binding": "=js:$vars.'
+      - '"binding": "vars.'
       - "fetchSupplier"
       - ".output.supplierName"
     weight: 3.0


### PR DESCRIPTION
## Summary

- HITL input field bindings use raw path format: `"binding": "vars.<nodeId>.output.<field>"`
- The criterion was checking for `"=js:$vars."` — the expression format used by script/HTTP nodes
- A correctly-written HITL binding will never contain `=js:$vars.` in a `binding` key, so the criterion permanently scored 0.67 (2/3 includes found)

## Evidence

Verified against the actual agent artifact (`SupplierOnboarding.flow`):
```
"binding": "vars.fetchSupplier.output.supplierName"  ← correct HITL format
"binding": "vars.fetchSupplier.output.riskScore"
"binding": "vars.fetchSupplier.output.country"
```

Also confirmed by `sampleHITL.flow` in the uipcli repo and the quickform reference doc (Step 1b: "No `=js:$` prefix — HITL binding is a raw path, not an expression").

## Fix

One character change: `"=js:$vars.` → `"vars.` in the binding includes check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)