### PR TITLE
fix(hitl): remove timeout requirement from e2e_03 GDPR test

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -5,9 +5,9 @@ task_id: skill-hitl-e2e-gdpr-compliance-greenfield
 description: >
   Authoring E2E golden scenario (green field): agent builds a GDPR deletion
   request flow with a privacy officer sign-off checkpoint. Tests proactive
-  compliance pattern detection, schema design with Reject path, and timeout
-  duration configuration. Real business use case. Full Discover -> Plan ->
-  Build -> Verify loop. Does not deploy or run the flow.
+  compliance pattern detection and schema design with Reject path. Real
+  business use case. Full Discover -> Plan -> Build -> Verify loop. Does not
+  deploy or run the flow.
 tags: [uipath-human-in-the-loop, e2e, green-field, compliance, gdpr]
 
 run_limits:
@@ -19,11 +19,9 @@ initial_prompt: |
   Build a UiPath Flow named "GdprDeletionApproval" that processes GDPR
   data deletion requests. Each request must be reviewed and signed off by
   a privacy officer before the deletion runs — we need an audit trail for
-  every decision. If the officer doesn't respond within 7 days, escalate
-  automatically.
+  every decision.
 
-  Give the privacy officer Approve and Reject outcomes. The review task
-  must expire automatically if the officer does not respond within 7 days.
+  Give the privacy officer Approve and Reject outcomes.
 
   Validate the flow when you're done.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
@@ -57,13 +55,6 @@ success_criteria:
     path: "GdprDeletionApproval/GdprDeletionApproval/GdprDeletionApproval.flow"
     includes:
       - '"completed"'
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: file_matches_regex
-    description: "Flow configures a 7-day ISO 8601 timeout (P7D or PT168H or similar)"
-    path: "GdprDeletionApproval/GdprDeletionApproval/GdprDeletionApproval.flow"
-    pattern: '"P(7D|T168H|1W)"'
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

- Removes "7 days / escalate automatically" language from `e2e_03_gdpr_compliance_greenfield.yaml` prompt
- Drops the `file_matches_regex` criterion checking for `P7D`/`PT168H`/`P1W` in the flow file
- Updates description to remove stale "timeout duration configuration" reference

## Root Cause

HITL nodes don't have a native timeout field. The prompt language caused the agent to spend ~30 turns searching for non-existent timeout configuration, exhausting `max_turns` (48 turns, score 0.30) without ever building the flow.

## Test plan

- [ ] Re-run `skill-hitl-e2e-gdpr-compliance-greenfield` — agent should build the flow without entering a timeout research loop
- [ ] Remaining criteria (file_exists, HITL node type, Approve/Reject outcomes, completed handle, validate) should all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)