### PR TITLE
fix(experiments): recursive post_run cleanup of node_modules, .npm-prefix, .venv

### DIFF
--- a/tests/experiments/activation.yaml
+++ b/tests/experiments/activation.yaml
@@ -34,7 +34,7 @@ defaults:
   # and Node module resolution can't leak across concurrent sandboxes
   # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
   post_run:
-    - command: "rm -rf node_modules .npm-prefix"
+    - command: "find . -maxdepth 5 -type d \\( -name node_modules -o -name .npm-prefix -o -name .venv \\) -prune -exec rm -rf {} +"
       timeout: 30
 
 variants:

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -28,7 +28,7 @@ defaults:
   # wire cleanup_solutions.py into their own post_run — that must run before
   # this step (still needs npm-installed CLIs).
   post_run:
-    - command: "rm -rf node_modules .npm-prefix"
+    - command: "find . -maxdepth 5 -type d \\( -name node_modules -o -name .npm-prefix -o -name .venv \\) -prune -exec rm -rf {} +"
       timeout: 30
 
 variants:

--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -45,7 +45,7 @@ defaults:
   # wire cleanup_solutions.py into their own post_run — that must run before
   # this step (still needs npm-installed CLIs).
   post_run:
-    - command: "rm -rf node_modules .npm-prefix"
+    - command: "find . -maxdepth 5 -type d \\( -name node_modules -o -name .npm-prefix -o -name .venv \\) -prune -exec rm -rf {} +"
       timeout: 30
 
 variants:

--- a/tests/experiments/sherif-skill-comparison.yaml
+++ b/tests/experiments/sherif-skill-comparison.yaml
@@ -35,7 +35,7 @@ defaults:
   # and Node module resolution can't leak across concurrent sandboxes
   # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
   post_run:
-    - command: "rm -rf node_modules .npm-prefix"
+    - command: "find . -maxdepth 5 -type d \\( -name node_modules -o -name .npm-prefix -o -name .venv \\) -prune -exec rm -rf {} +"
       timeout: 30
 
 variants:

--- a/tests/experiments/skill-comparison-template.yaml
+++ b/tests/experiments/skill-comparison-template.yaml
@@ -40,7 +40,7 @@ defaults:
   # and Node module resolution can't leak across concurrent sandboxes
   # (mirrors coder_eval #253 / sandbox isolation in #250 — MST-9674).
   post_run:
-    - command: "rm -rf node_modules .npm-prefix"
+    - command: "find . -maxdepth 5 -type d \\( -name node_modules -o -name .npm-prefix -o -name .venv \\) -prune -exec rm -rf {} +"
       timeout: 30
 
 # ---------------------------------------------------------------------------

--- a/tests/experiments/smoke.yaml
+++ b/tests/experiments/smoke.yaml
@@ -44,7 +44,7 @@ defaults:
   # Sandbox cleanup between tasks (preserved artifacts stay slim; concurrent
   # sandboxes don't leak Node module resolution).
   post_run:
-    - command: "rm -rf node_modules .npm-prefix"
+    - command: "find . -maxdepth 5 -type d \\( -name node_modules -o -name .npm-prefix -o -name .venv \\) -prune -exec rm -rf {} +"
       timeout: 30
 
 variants:


### PR DESCRIPTION
## Summary

- Replaces `rm -rf node_modules .npm-prefix .venv` (current directory only) with a `find`-based recursive cleanup
- Searches up to 5 levels deep, matches only real directories (`-type d`), and prunes matched dirs to avoid double-visiting nested copies

## Test plan

- [ ] Verify post_run cleanup removes nested `node_modules` directories in sandbox runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)