### PR TITLE
test(uipath-maestro-flow): capture raw flow-debug payload on output-assert failure

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -42,6 +42,17 @@ import sys
 from typing import Any, Iterable, Sequence
 
 
+# Raw stdout of the most recent ``uip maestro flow debug`` invocation, stashed by
+# :func:`run_debug` so the output-assertion helpers can dump the FULL runtime
+# response to stderr when they fail. This is the diagnostic channel for the
+# chronic "debug Completes but Variables/Globals come back empty" flake
+# (e.g. skill-flow-calculator 0.375): the captured stderr lands in
+# ``task.json.success_criteria_results[].details``, so a failing eval preserves
+# the exact payload (finalStatus, elementExecutions, globals, incidents) that the
+# checker saw — which is otherwise ephemeral and unrecoverable post-run.
+_LAST_DEBUG_RAW: str | None = None
+
+
 # ── Public helpers ──────────────────────────────────────────────────────────
 
 
@@ -66,6 +77,8 @@ def run_debug(
     for var_id, local_path in (attachments or {}).items():
         cmd.extend(["--attachment", f"{var_id}={local_path}"])
     r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    global _LAST_DEBUG_RAW
+    _LAST_DEBUG_RAW = r.stdout
     if r.returncode != 0:
         _fail(f"flow debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}")
     data = _parse_json(r.stdout)
@@ -239,7 +252,7 @@ def assert_outputs_contain(
     ok = len(missing) == 0 if require_all else len(present) > 0
     if not ok:
         mode = "all of" if require_all else "any of"
-        _fail(
+        _fail_with_capture(
             f"Outputs missing {mode} {list(needles)}; present={present}; "
             f"missing={missing}\nOutputs: {haystack[:1000]}"
         )
@@ -252,7 +265,7 @@ def assert_output_int_in_range(payload: dict, lo: int, hi: int) -> int:
     haystack = _stringify(collect_outputs(payload))
     hits = [int(m) for m in re.findall(r"-?\d+", haystack) if lo <= int(m) <= hi]
     if not hits:
-        _fail(
+        _fail_with_capture(
             f"No integer in [{lo}, {hi}] found in outputs\nOutputs: {haystack[:1000]}"
         )
     return hits[0]
@@ -272,7 +285,9 @@ def assert_output_value(payload: dict, expected: Any) -> None:
         if isinstance(expected, str) and isinstance(v, str):
             if expected.lower() in v.lower():
                 return
-    _fail(f"No output equals expected {expected!r}\nOutputs: {_stringify(outs)[:1000]}")
+    _fail_with_capture(
+        f"No output equals expected {expected!r}\nOutputs: {_stringify(outs)[:1000]}"
+    )
 
 
 def read_flow_input_vars(project_dir: str) -> list[str]:
@@ -412,6 +427,65 @@ def _is_flow_project(path: str) -> bool:
 
 def _stringify(values: Iterable[Any]) -> str:
     return json.dumps(list(values), default=str).lower()
+
+
+def _dump_debug_capture(context: str = "") -> None:
+    """Emit the most recent raw ``flow debug`` response to stderr for diagnosis.
+
+    Called on output-assertion failures so the captured criterion output preserves
+    the full runtime payload — the only way to inspect the chronic
+    "Completed-but-empty-Variables" flake after the (ephemeral) debug run is gone.
+    Best-effort and side-effect-free: never raises, so it cannot mask the real
+    assertion failure that follows.
+    """
+    raw = _LAST_DEBUG_RAW
+    if not raw:
+        return
+    tag = f" ({context})" if context else ""
+    lines = [f"=== FLOW_DEBUG_RAW_CAPTURE BEGIN{tag} ==="]
+    try:
+        # Parse via the tolerant helper, not bare json.loads: the CLI may emit a
+        # banner/warning before the JSON (the reason run_debug uses _parse_json),
+        # and a plain json.loads would drop the whole structured summary to
+        # "<unparsable>" even though the run produced a valid payload.
+        parsed = _parse_json(raw)
+        if parsed is None:
+            raise ValueError("no JSON object found in debug stdout")
+        data = _get_ci(parsed, "Data") or {}
+        variables = _get_ci(data, "variables", "Variables") or {}
+        summary = {
+            "finalStatus": _get_ci(data, "finalStatus", "FinalStatus"),
+            "globals": _get_ci(variables, "globals", "Globals"),
+            "globalVariables": _get_ci(variables, "globalVariables", "GlobalVariables"),
+            "elementOutputs": [
+                {
+                    "id": _get_ci(e, "elementId", "ElementId", "id", "Id"),
+                    "outputs": _get_ci(e, "outputs", "Outputs"),
+                }
+                for e in (_get_ci(variables, "elements", "Elements") or [])
+            ],
+            "elementExecutions": [
+                {
+                    "id": _get_ci(x, "elementId", "ElementId", "id", "Id"),
+                    "type": _get_ci(x, "elementType", "ElementType", "extensionType"),
+                    "status": _get_ci(x, "status", "Status"),
+                }
+                for x in (_get_ci(data, "elementExecutions", "ElementExecutions") or [])
+            ],
+            "incidents": _get_ci(data, "incidents", "Incidents"),
+        }
+        lines.append("SUMMARY: " + json.dumps(summary, default=str))
+    except Exception as exc:  # noqa: BLE001 — diagnostics must never mask the real failure
+        lines.append(f"SUMMARY: <unparsable: {exc!r}>")
+    lines.append("RAW: " + raw.strip())
+    lines.append("=== FLOW_DEBUG_RAW_CAPTURE END ===")
+    print("\n".join(lines), file=sys.stderr)
+
+
+def _fail_with_capture(msg: str):
+    """Dump the raw debug payload (diagnostics) then fail with ``msg``."""
+    _dump_debug_capture(msg.split("\n", 1)[0])
+    _fail(msg)
 
 
 def _fail(msg: str):

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -358,6 +358,90 @@ def test_find_project_dir_uses_central_filter(tmp_path, monkeypatch):
     assert find_project_dir() == os.path.join("Mixed", "MainFlow")
 
 
+# ── raw-debug-payload capture on output-assertion failure ───────────────────
+#
+# When an output assertion fails, the helpers dump the raw `flow debug` response
+# (stashed by run_debug) to stderr so a failing eval's task.json preserves the
+# full runtime payload. This is the diagnostic for the chronic "Completed but
+# Variables/Globals empty" flake (skill-flow-calculator 0.375), whose debug
+# session is otherwise ephemeral and unrecoverable after the run.
+
+import json as _json  # noqa: E402
+
+import flow_check  # noqa: E402
+
+# A debug response shaped like the flake: the run Completed and every node
+# executed, yet the runtime returned an empty global-variable space.
+_FLAKE_RAW = _json.dumps(
+    {
+        "Result": "Success",
+        "Code": "FlowDebug",
+        "Data": {
+            "FinalStatus": "Completed",
+            "Variables": {"Globals": {}, "GlobalVariables": [], "Elements": []},
+            "elementExecutions": [
+                {"elementId": "start", "elementType": "StartEvent", "status": "Completed"},
+                {"elementId": "multiply", "elementType": "ScriptTask", "status": "Completed"},
+                {"elementId": "end", "elementType": "EndEvent", "status": "Completed"},
+            ],
+            "incidents": [],
+        },
+    }
+)
+
+
+@pytest.fixture
+def _reset_debug_raw():
+    saved = flow_check._LAST_DEBUG_RAW
+    yield
+    flow_check._LAST_DEBUG_RAW = saved
+
+
+def test_output_assert_failure_dumps_raw_capture(capsys, _reset_debug_raw):
+    flow_check._LAST_DEBUG_RAW = _FLAKE_RAW
+    # Empty Globals → no output equals 391 → fail, and the capture must fire.
+    payload = {"variables": {"globals": {}}}
+    with pytest.raises(SystemExit, match="expected 391"):
+        assert_output_value(payload, 391)
+    err = capsys.readouterr().err
+    assert "FLOW_DEBUG_RAW_CAPTURE BEGIN" in err
+    assert "FLOW_DEBUG_RAW_CAPTURE END" in err
+    # The summary localizes the defect: Completed run, nodes ran, globals empty.
+    assert '"finalStatus": "Completed"' in err
+    assert '"globals": {}' in err
+    assert "ScriptTask" in err  # elementExecutions surfaced
+    assert _FLAKE_RAW in err  # full raw payload preserved verbatim
+
+
+def test_output_assert_success_emits_no_capture(capsys, _reset_debug_raw):
+    flow_check._LAST_DEBUG_RAW = _FLAKE_RAW  # stale buffer must not leak on success
+    payload = _payload(elements=[{"outputs": {"product": 391}}])
+    assert_output_value(payload, 391)  # passes
+    assert "FLOW_DEBUG_RAW_CAPTURE" not in capsys.readouterr().err
+
+
+def test_capture_noop_when_no_debug_raw(capsys, _reset_debug_raw):
+    flow_check._LAST_DEBUG_RAW = None  # e.g. a static check that never ran debug
+    with pytest.raises(SystemExit, match="expected 391"):
+        assert_output_value(_payload(globals_=[{"value": 42}]), 391)
+    assert "FLOW_DEBUG_RAW_CAPTURE" not in capsys.readouterr().err
+
+
+def test_capture_summary_survives_cli_preamble(capsys, _reset_debug_raw):
+    """The capture must parse via the tolerant _parse_json, like run_debug — so a
+    CLI banner before the JSON still yields the structured SUMMARY, not
+    `<unparsable>`. Guards the same preamble case run_debug already handles."""
+    flow_check._LAST_DEBUG_RAW = (
+        "Tool factory already registered for project type 'Flow', skipping.\n"
+        "[ManifestClient] fetchDynamicNodes ok: total=59\n" + _FLAKE_RAW
+    )
+    with pytest.raises(SystemExit, match="expected 391"):
+        assert_output_value({"variables": {"globals": {}}}, 391)
+    err = capsys.readouterr().err
+    assert '"finalStatus": "Completed"' in err  # structured summary recovered
+    assert "<unparsable>" not in err
+
+
 # ── _get_ci / PascalCase tolerance (CLI #2266 contract) ─────────────────────
 #
 # `uip … --output json` PascalCases its Data keys when the CLI carries PR #2266


### PR DESCRIPTION
## Why

`skill-flow-calculator` flakes chronically at **0.375** (validate passes, the `flow debug` execution check fails). Across its history, byte-equivalent flow shapes both **pass and fail**, with no static-artifact, CLI-version, api-routing, or model differentiator — the run reports `finalStatus=Completed` yet the checker sees **`Outputs: []`** (empty `Variables.Globals`). That points at a **server-side Maestro debug-runtime non-determinism**, not the agent or the skill docs.

We can't confirm the mechanism, because the failure path discards the payload:

- On failure the checker prints only the flattened `collect_outputs()` (`Outputs: []`).
- `uip maestro flow debug` is an **ephemeral Studio Web robotdebug session** — it leaves no retained Orchestrator/Maestro instance, and the eval's `cleanup_solutions.py` deletes the solution. So the payload is **unrecoverable after the run**.

(Full investigation: the eval runs as `coder-eval-bot` with a StudioPro personal robot; debug runs server-side; instances are not persisted. A local repro is blocked — the tenant has 0 attended-class licenses, so a personal workspace can't be enabled for an interactive account.)

## What

A **failure-path-only** diagnostic capture in `_shared/flow_check.py`:

- `run_debug` stashes the raw `flow debug` stdout in a module buffer.
- `assert_output_value` / `assert_outputs_contain` / `assert_output_int_in_range` emit a `FLOW_DEBUG_RAW_CAPTURE` block to **stderr** before failing — a structured **SUMMARY** (`finalStatus`, `globals`, `globalVariables`, `elementOutputs`, per-node `elementExecutions`, `incidents`) **plus the full raw payload**.
- Stderr is captured into `task.json.success_criteria_results[].details`, so the **next eval flake** (run as `coder-eval-bot`, which has a working robot) preserves the exact payload — letting us localize the defect to *output-surfacing* vs *node-execution* vs *input-binding*, and confirm whether `finalStatus` is genuinely `Completed`.

Best-effort and **silent on success** — passing runs are unchanged, and the dump never raises so it can't mask the real assertion failure.

## Tests

- 3 new regression tests: flake shape (Completed + empty globals) dumps the capture; a normal payload stays silent; no-op when no debug ran.
- Full suite green: `pytest tests/tasks/uipath-maestro-flow/` → **98 passed**.

## Notes

- This is **diagnostic instrumentation**, not a fix. It does not change pass/fail behavior; it makes the chronic flake diagnosable. The durable fix (Maestro flow-debug runtime bug for empty `Variables.Globals` on a Completed trivial flow, and/or retry/replicate tolerance in the execution checker) follows once a captured payload confirms the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)