### PR TITLE
docs(uipath-maestro-flow): require triggerNodeId on parent flow inputs forwarded to subflows

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/subflow/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/subflow/impl.md
@@ -182,6 +182,56 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
 }
 ```
 
+## Passing a Flow Input Into the Subflow
+
+When the **parent flow** itself takes an input the caller supplies at trigger time (e.g. a
+`text` to reverse) and forwards it into the subflow, the parent's `in` variable needs the
+**same `triggerNodeId` treatment as a subflow `in` variable** (rule #3) — set it to the
+parent's trigger node ID. Omitting it is a silent trap: `uip maestro flow validate` still
+reports **Valid**, but at `flow debug` the trigger output is empty, the value arrives as
+`null`, and the subflow script faults (e.g. `Cannot read property 'split' of null`).
+
+**Parent flow `variables.globals`** — note `triggerNodeId` on the `in` variable:
+```json
+{
+  "variables": {
+    "globals": [
+      { "id": "text", "direction": "in", "type": "string", "defaultValue": "", "triggerNodeId": "start" },
+      { "id": "reversedText", "direction": "out", "type": "string", "defaultValue": "" }
+    ]
+  }
+}
+```
+
+**Parent trigger + subflow node** — the subflow node reads the trigger output and maps it to
+the subflow's `in` variable:
+```json
+{
+  "nodes": [
+    {
+      "id": "start",
+      "type": "core.trigger.manual",
+      "typeVersion": "1.0",
+      "inputs": { "entryPointId": "<uuid>", "isDefaultEntryPoint": true },
+      "outputs": { "output": { "type": "object", "source": "=result.response", "var": "output" } }
+    },
+    {
+      "id": "reverseSubflow",
+      "type": "core.subflow",
+      "typeVersion": "<DEFINITION_VERSION>",
+      "inputs": { "text": "=js:$vars.start.output.text" }
+    }
+  ]
+}
+```
+
+Value flow: caller input `text` → (bound to `start` via the parent global's `triggerNodeId`)
+→ `$vars.start.output.text` → subflow node input `text` → the subflow's own `in` variable
+(with its **own** `triggerNodeId: "<subflowStart>"`) → `$vars.<subflowStart>.output.text`
+inside the subflow. The parent `in` var and the subflow `in` var are **independent variables
+in separate scopes**, joined only by the subflow node's `inputs` mapping; each needs its own
+`triggerNodeId` pointing at its respective Start node.
+
 ## Subflow Rules
 
 1. Every subflow **must** have its own Start node (`core.trigger.manual`) and End node (`core.control.end`)
@@ -193,6 +243,7 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
 7. Subflows can be nested (subflow inside subflow), up to 3 levels
 8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections
 9. Subflow node positions go in the subflow's own `layout.nodes` — NOT in the top-level `layout.nodes`. Each subflow scope is independent.
+10. When the **parent flow** takes an external input and forwards it to a subflow, the parent's `in` variable **must** also have `triggerNodeId` set to the parent's trigger node ID — the same rule as #3, one scope up. `uip maestro flow validate` does **not** catch its absence; the forwarded value silently arrives as `null` at runtime. See [Passing a Flow Input Into the Subflow](#passing-a-flow-input-into-the-subflow).
 
 ## Creating a Subflow
 
@@ -203,6 +254,7 @@ For the step-by-step procedure, see [Edit/Write: Create a subflow](../../editing
 | Error | Cause | Fix |
 | --- | --- | --- |
 | `$vars.inputData` undefined inside subflow script | Missing `triggerNodeId` on subflow `in` variable, or using `$vars.{varId}` directly | Add `triggerNodeId: "{startNodeId}"` to each `in` variable and access via `$vars.{startNodeId}.output.{varId}` |
+| Subflow script sees `null` for a value forwarded from the parent (e.g. `Cannot read property 'split' of null`) | Parent flow's `in` variable is missing `triggerNodeId`, so the parent trigger output is empty and `null` is forwarded into the subflow | Add `triggerNodeId: "{parentStartNodeId}"` to the parent flow's `in` variable (same fix as the row above, but for the root flow) |
 | `$vars.parentNode` undefined inside subflow | Parent scope not accessible | Pass values via subflow `in` variables |
 | Subflow output is null | Missing output mapping on subflow's End node | Map all `out` variables in the End node's `outputs` |
 | Script output is null | Missing inline `outputs` on script node | Add `outputs.output` and `outputs.error` inline on the script node |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/subflow/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/subflow/impl.md
@@ -87,33 +87,6 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
               "type": "object",
               "description": "Error information if the script fails",
               "source": "=result.Error",
-              "var": "error",
-              "schema": {
-                "$schema": "http://json-schema.org/draft-07/schema#",
-                "type": "object",
-                "required": ["code", "message", "detail", "category", "status"],
-                "properties": {
-                  "code": { "type": "string" },
-                  "message": { "type": "string" },
-                  "detail": { "type": "string" },
-                  "category": { "type": "string" },
-                  "status": { "type": "integer" }
-                },
-                "additionalProperties": false
-              }
-            }
-          },
-          "outputs": {
-            "output": {
-              "type": "object",
-              "description": "The return value of the script",
-              "source": "=result.response",
-              "var": "output"
-            },
-            "error": {
-              "type": "object",
-              "description": "Error information if the script fails",
-              "source": "=result.Error",
               "var": "error"
             }
           }
@@ -184,12 +157,11 @@ Subflow contents are stored in a top-level `subflows` object keyed by the parent
 
 ## Passing a Flow Input Into the Subflow
 
-When the **parent flow** itself takes an input the caller supplies at trigger time (e.g. a
-`text` to reverse) and forwards it into the subflow, the parent's `in` variable needs the
-**same `triggerNodeId` treatment as a subflow `in` variable** (rule #3) — set it to the
-parent's trigger node ID. Omitting it is a silent trap: `uip maestro flow validate` still
-reports **Valid**, but at `flow debug` the trigger output is empty, the value arrives as
-`null`, and the subflow script faults (e.g. `Cannot read property 'split' of null`).
+A **parent flow** forwarding its own trigger input into a subflow must give the parent's `in`
+variable a `triggerNodeId` — same as a subflow `in` variable (rule #3), pointing at the
+parent's trigger node. Omit it and it's a silent trap: `uip maestro flow validate` still
+reports **Valid**, but at `flow debug` the trigger output is empty, the value arrives `null`,
+and the subflow script faults (e.g. `Cannot read property 'split' of null`).
 
 **Parent flow `variables.globals`** — note `triggerNodeId` on the `in` variable:
 ```json
@@ -243,7 +215,7 @@ in separate scopes**, joined only by the subflow node's `inputs` mapping; each n
 7. Subflows can be nested (subflow inside subflow), up to 3 levels
 8. Each subflow has its own `nodes`, `edges`, `variables`, and `layout` sections
 9. Subflow node positions go in the subflow's own `layout.nodes` — NOT in the top-level `layout.nodes`. Each subflow scope is independent.
-10. When the **parent flow** takes an external input and forwards it to a subflow, the parent's `in` variable **must** also have `triggerNodeId` set to the parent's trigger node ID — the same rule as #3, one scope up. `uip maestro flow validate` does **not** catch its absence; the forwarded value silently arrives as `null` at runtime. See [Passing a Flow Input Into the Subflow](#passing-a-flow-input-into-the-subflow).
+10. Parent flow forwarding an external input to a subflow: the parent's `in` variable **must** also set `triggerNodeId` to the parent's trigger node ID — same as #3, one scope up. `uip maestro flow validate` still reports **Valid** (it does not fail on the omission); the value silently arrives `null` at runtime. See [Passing a Flow Input Into the Subflow](#passing-a-flow-input-into-the-subflow).
 
 ## Creating a Subflow
 


### PR DESCRIPTION
## What

Documents that a **parent flow's** `in` variable must carry `triggerNodeId` when its value is forwarded into a subflow — the same rule already documented for subflow-internal `in` variables (Rule #3), one scope up.

## Why

`skill-flow-subflow` is a chronically flaky e2e test. In the failing runs the agent emits a flow that `uip maestro flow validate` accepts as **Valid** and that passes the static structure check, but **faults at `flow debug`** with `[300501] Cannot read property 'split' of null`.

Root cause: the parent `text` input global is missing `triggerNodeId: "start"`, so the debug-injected input never reaches `$vars.start.output.text`; the subflow receives `null` and the reversal script crashes. A byte-diff against a passing run shows that single missing field is the only difference between green and red.

The subflow doc heavily emphasizes `triggerNodeId` for the *subflow's* inputs, but its parent-node example used literal inputs (`a: 2, b: 3`) and never showed a parent threading an external input through its trigger — so the agent applies the rule to the subflow and omits it on the parent.

## Changes

- New section **"Passing a Flow Input Into the Subflow"** — parent `variables.globals` with `triggerNodeId: "start"`, the trigger + subflow-node wiring, and the end-to-end value-flow chain.
- New **Rule #10** stating the parent `in`-var requirement (and that `flow validate` does not catch its absence).
- New **Debug-table row** mapping the `null.split` symptom to the missing parent `triggerNodeId`.

Companion CLI change (surfaces this as a `flow validate` warning): UiPath/cli `fix/flow-validate-trigger-binding`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
