### PR TITLE
test(uipath-maestro-flow): add scheduled-trigger smoke test

### DIFF
--- a/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""ScheduledReport: structural check for the scheduled trigger (`core.trigger.scheduled`).
+
+Validate-only — does NOT run `uip maestro flow debug` (a scheduled BPMN timer
+fires only inside a live engine the test sandbox cannot provision). Asserts the
+flow's start node is a scheduled trigger that *replaced* the default manual
+trigger and carries a valid recurring schedule:
+
+  1. Exactly one node with `type == "core.trigger.scheduled"` (exact ==, so a
+     different trigger/timer variant fails).
+  2. The manual trigger is GONE and there is exactly one trigger node:
+       - zero nodes of type `core.trigger.manual`;
+       - the scheduled trigger is the only `core.trigger.*` node (so it
+         *replaced* the manual trigger rather than being added alongside).
+  3. It is the start node: no edge targets it (a trigger has no input port, so
+     `edges[]` must contain no entry whose `targetNodeId` is the trigger id).
+  4. Valid schedule config on the node `inputs`:
+       - `timerType == "timeCycle"`;
+       - `timerPreset` present and non-empty;
+       - the effective cycle expression — `timerValue` when
+         `timerPreset == "custom"`, otherwise `timerPreset` — is a valid ISO
+         8601 repeating interval (`R/...`), matching the registry's own
+         pattern. `custom` without a non-empty `timerValue` fails.
+  5. `typeVersion` present and non-empty (the agent-under-test copies the
+     `version` field from the registry, so we do NOT pin a specific value —
+     this node has already advanced past 1.0).
+  6. The scheduled-trigger *definition* is present and correct, and the manual
+     definition is gone:
+       - exactly one `definitions[]` entry with
+         `nodeType == "core.trigger.scheduled"`, carrying
+         `model.type == "bpmn:StartEvent"` and
+         `model.eventDefinition == "bpmn:TimerEventDefinition"` (this is what
+         makes the BPMN timer event fire);
+       - zero `definitions[]` entries with `nodeType == "core.trigger.manual"`.
+"""
+
+import glob
+import json
+import re
+import sys
+from typing import NoReturn
+
+SCHEDULED = "core.trigger.scheduled"
+MANUAL = "core.trigger.manual"
+TRIGGER_PREFIX = "core.trigger."
+
+# ISO 8601 repeating-interval pattern, copied verbatim from the
+# `core.trigger.scheduled` registry definition (inputDefinition.then for
+# timerValue). Accepts R/PT1H, R/P1D, R/P1W, R/PT45M, R/2026-05-14T09:00:00Z/P1W, ...
+CYCLE_RE = re.compile(
+    r"^R\d*\/(P(?=\d|T)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?"
+    r"(\/\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?)?"
+    r"|\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})?)?"
+    r"\/P(?=\d|T)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?)$"
+)
+
+
+def _fail(msg: str) -> NoReturn:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/ScheduledReport*.flow", recursive=True)
+    if not flows:
+        _fail("no ScheduledReport*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _check_single_scheduled_trigger(flow: dict) -> dict:
+    nodes = flow.get("nodes", [])
+    triggers = [n for n in nodes if str(n.get("type", "")).startswith(TRIGGER_PREFIX)]
+    scheduled = [n for n in nodes if n.get("type") == SCHEDULED]
+    manual = [n for n in nodes if n.get("type") == MANUAL]
+
+    if manual:
+        _fail(
+            f"found {len(manual)} {MANUAL!r} node(s) — the scheduled trigger must "
+            "REPLACE the manual trigger, not coexist with it."
+        )
+    if not scheduled:
+        types = sorted({n.get("type") for n in nodes})
+        _fail(f"no node with type {SCHEDULED!r}; node types seen: {types}")
+    if len(scheduled) > 1:
+        _fail(f"expected exactly one {SCHEDULED!r} node, found {len(scheduled)}")
+    if len(triggers) != 1:
+        trig_types = sorted(n.get("type") for n in triggers)
+        _fail(
+            f"expected exactly one trigger node, found {len(triggers)}: {trig_types}. "
+            "A flow must have exactly one trigger."
+        )
+    return scheduled[0]
+
+
+def _check_start_node(flow: dict, node_id: str) -> None:
+    edges = flow.get("edges") or []
+    incoming = [e for e in edges if e.get("targetNodeId") == node_id]
+    if incoming:
+        _fail(
+            f"the scheduled trigger ({node_id!r}) has {len(incoming)} incoming edge(s); "
+            "a trigger is the flow's start node and must have no incoming edge."
+        )
+
+
+def _check_schedule_config(inputs: dict) -> None:
+    timer_type = inputs.get("timerType")
+    if timer_type != "timeCycle":
+        _fail(
+            f"inputs.timerType={timer_type!r}; a scheduled trigger must use "
+            '"timeCycle".'
+        )
+
+    timer_preset = inputs.get("timerPreset")
+    if not isinstance(timer_preset, str) or not timer_preset.strip():
+        _fail("inputs.timerPreset missing or empty — required for a scheduled trigger.")
+
+    if timer_preset == "custom":
+        cycle = inputs.get("timerValue")
+        if not isinstance(cycle, str) or not cycle.strip():
+            _fail(
+                "inputs.timerPreset is 'custom' but inputs.timerValue is missing or "
+                "empty — add an ISO 8601 repeating interval (e.g. R/PT45M)."
+            )
+        label = "inputs.timerValue"
+    else:
+        cycle = timer_preset
+        label = "inputs.timerPreset"
+
+    if not CYCLE_RE.match(cycle):
+        _fail(
+            f"{label}={cycle!r} is not a valid ISO 8601 repeating interval "
+            "(e.g. R/PT1H, R/P1D, R/PT45M)."
+        )
+    # A grammatically-valid but all-zero duration (e.g. R/PT0H) is a
+    # never-firing schedule. Every real recurring interval has a non-zero
+    # component, so require at least one.
+    if not re.search(r"[1-9]", cycle):
+        _fail(
+            f"{label}={cycle!r} is an all-zero, never-firing schedule — "
+            "use a non-zero recurring interval such as R/PT1H."
+        )
+
+
+def _check_type_version(node: dict) -> None:
+    tv = node.get("typeVersion")
+    if not isinstance(tv, str) or not tv.strip():
+        _fail(
+            "typeVersion missing or empty — copy the `version` field from "
+            "`uip maestro flow registry get core.trigger.scheduled --output json`."
+        )
+
+
+def _check_definition(flow: dict) -> None:
+    defs = flow.get("definitions") or []
+    if any(d.get("nodeType") == MANUAL for d in defs):
+        _fail(
+            f"a {MANUAL!r} entry is still present in definitions[] — remove it when "
+            "replacing the manual trigger with the scheduled trigger."
+        )
+    sched_defs = [d for d in defs if d.get("nodeType") == SCHEDULED]
+    if len(sched_defs) != 1:
+        def_types = sorted(d.get("nodeType") for d in defs)
+        _fail(
+            f"expected exactly one definitions[] entry with nodeType {SCHEDULED!r}, "
+            f"found {len(sched_defs)}; definition nodeTypes: {def_types}. Append the "
+            "object from `uip maestro flow registry get core.trigger.scheduled --output json`."
+        )
+    model = sched_defs[0].get("model") or {}
+    if model.get("type") != "bpmn:StartEvent":
+        _fail(
+            f"scheduled definition model.type={model.get('type')!r}; must be "
+            '"bpmn:StartEvent". Re-copy the definition from the registry.'
+        )
+    if model.get("eventDefinition") != "bpmn:TimerEventDefinition":
+        _fail(
+            f"scheduled definition model.eventDefinition={model.get('eventDefinition')!r}; "
+            'must be "bpmn:TimerEventDefinition" — without it the BPMN timer never fires.'
+        )
+
+
+def main():
+    flow = _read_flow()
+    node = _check_single_scheduled_trigger(flow)
+    inputs = node.get("inputs") or {}
+
+    _check_start_node(flow, node.get("id"))
+    _check_schedule_config(inputs)
+    _check_type_version(node)
+    _check_definition(flow)
+
+    print(
+        f"OK: start node is {SCHEDULED} (manual trigger replaced); "
+        f"timerType={inputs.get('timerType')!r}, timerPreset={inputs.get('timerPreset')!r}; "
+        f"typeVersion set; definition carries bpmn:StartEvent + bpmn:TimerEventDefinition"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
@@ -1,0 +1,75 @@
+task_id: skill-flow-scheduled-trigger
+description: >
+  Scaffold a UiPath Flow whose start node is a Scheduled Trigger
+  (`core.trigger.scheduled`) that REPLACES the default manual trigger and
+  carries a valid recurring schedule. Exercises the previously-untested
+  scheduled-trigger plugin: the manual->scheduled replacement procedure, the
+  `timeCycle`/`timerPreset` input shape, and the `bpmn:TimerEventDefinition`
+  that the node definition must carry. Validate-only and pure-OOTB — no tenant,
+  no `flow debug` (a scheduled BPMN timer fires only inside a live engine the
+  test sandbox cannot provision).
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, shape:single-node, node:scheduled-trigger, feature:trigger]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "ScheduledReport" whose flow is started by
+  a **scheduled trigger** that runs every hour.
+
+  A Flow project MUST live inside a solution:
+    1. Create the solution first (`uip solution init`).
+    2. Create the Flow project inside it (`uip maestro flow init`). The correct
+       flow-file path is:
+         ScheduledReport/ScheduledReport/ScheduledReport.flow
+
+  `uip maestro flow init` scaffolds the flow with a default **manual** trigger
+  (`core.trigger.manual`). REPLACE that manual trigger with a **scheduled**
+  trigger so the flow's start node is a scheduled trigger:
+
+    - The start node `type` must be `core.trigger.scheduled`.
+    - Keep the existing `entryPointId` from the manual trigger's `inputs`.
+    - `inputs.timerType` must be `"timeCycle"`.
+    - `inputs.timerPreset` must be `"R/PT1H"` (every hour — an ISO 8601
+      repeating interval). Do NOT use `"custom"` for this smoke test.
+    - Set the node `typeVersion` from the registry for `core.trigger.scheduled`
+      — do NOT hardcode a guessed version
+      (`uip maestro flow registry get core.trigger.scheduled --output json`).
+    - Remove the `core.trigger.manual` node AND its `definitions[]` entry, and
+      append the `core.trigger.scheduled` definition from the registry get above
+      (it carries `model.type: "bpmn:StartEvent"` and
+      `model.eventDefinition: "bpmn:TimerEventDefinition"`). A flow must have
+      exactly one trigger.
+
+  The task is NOT complete until `uip maestro flow validate` passes for that
+  exact flow-file path.
+
+  Important:
+    - The `uip` CLI is already available; use `--output json` on uip commands.
+    - Validate locally with `uip maestro flow validate` — do NOT run
+      `uip maestro flow debug` (the schedule fires only in a live engine).
+    - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+      planning and implementation. Build the complete flow end-to-end in a
+      single pass.
+    - Before starting, load the uipath-maestro-flow skill and follow its
+      scheduled-trigger plugin docs and the "Replace manual trigger with
+      scheduled trigger" procedure exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate ScheduledReport/ScheduledReport/ScheduledReport.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks (scheduled trigger replaced manual; valid schedule) ─
+  - type: run_command
+    description: "Start node is core.trigger.scheduled, manual trigger removed, valid timeCycle schedule + bpmn:TimerEventDefinition"
+    command: "python3 $TASK_DIR/check_scheduled_trigger_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py
@@ -1,0 +1,176 @@
+"""Unit tests for check_scheduled_trigger_flow.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/smoke/test_check_scheduled_trigger_flow.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CHECKER = Path(__file__).resolve().parent / "check_scheduled_trigger_flow.py"
+
+
+def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
+    d = tmp_path / "ScheduledReport" / "ScheduledReport"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "ScheduledReport.flow").write_text(json.dumps(payload))
+    (d / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)], cwd=str(cwd), capture_output=True, text=True
+    )
+
+
+def _out(r: subprocess.CompletedProcess[str]) -> str:
+    return (r.stdout + r.stderr).lower()
+
+
+def _scheduled_node(**inputs: Any) -> dict[str, Any]:
+    base = {"entryPointId": "ep-1", "timerType": "timeCycle", "timerPreset": "R/PT1H"}
+    base.update(inputs)
+    return {
+        "id": "start",
+        "type": "core.trigger.scheduled",
+        "typeVersion": "1.1",
+        "display": {"label": "Every Hour"},
+        "inputs": base,
+        "outputs": {"output": {"type": "object", "source": "=result.response", "var": "output"}},
+    }
+
+
+def _well_formed() -> dict[str, Any]:
+    """A single scheduled trigger that replaced the manual trigger (trigger-only flow)."""
+    return {
+        "version": "1.2",
+        "nodes": [_scheduled_node()],
+        "edges": [],
+        "definitions": [
+            {"nodeType": "core.trigger.scheduled", "version": "1.1",
+             "model": {"type": "bpmn:StartEvent", "eventDefinition": "bpmn:TimerEventDefinition"}},
+        ],
+    }
+
+
+def test_preset_passes(tmp_path: Path) -> None:
+    _write_flow(tmp_path, _well_formed())
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_custom_with_timer_value_passes(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerPreset="custom", timerValue="R/PT45M")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_manual_node_present_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"].append({"id": "m1", "type": "core.trigger.manual", "typeVersion": "1.0",
+                       "display": {"label": "Manual trigger"}, "inputs": {"entryPointId": "ep-2"}})
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "manual" in _out(r)
+
+
+def test_no_scheduled_node_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"] = [{"id": "s1", "type": "core.action.script", "typeVersion": "1.0",
+                   "display": {"label": "X"}, "inputs": {"script": "return {};"}}]
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "core.trigger.scheduled" in (r.stdout + r.stderr)
+
+
+def test_wrong_timer_type_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerType="timeDuration")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "timecycle" in _out(r)
+
+
+def test_bad_preset_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerPreset="hourly")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "iso 8601" in _out(r)
+
+
+def test_zero_duration_preset_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerPreset="R/PT0H")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "all-zero" in _out(r)
+
+
+def test_custom_missing_timer_value_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"][0] = _scheduled_node(timerPreset="custom")
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "timervalue" in _out(r)
+
+
+def test_missing_type_version_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"][0].pop("typeVersion", None)
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "typeversion" in _out(r)
+
+
+def test_incoming_edge_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["edges"] = [{"id": "e1", "sourceNodeId": "x", "sourcePort": "output",
+                   "targetNodeId": "start", "targetPort": "input"}]
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "incoming" in _out(r)
+
+
+def test_manual_definition_present_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["definitions"].append({"nodeType": "core.trigger.manual", "version": "1.0",
+                             "model": {"type": "bpmn:StartEvent"}})
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "manual" in _out(r)
+
+
+def test_missing_event_definition_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    for d in p["definitions"]:
+        if d["nodeType"] == "core.trigger.scheduled":
+            d["model"].pop("eventDefinition", None)
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "timereventdefinition" in _out(r)
+
+
+def test_missing_scheduled_definition_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["definitions"] = []
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "definitions" in _out(r)


### PR DESCRIPTION
## What

Adds a **validate-only** smoke test for the previously-untested **scheduled-trigger** plugin (`core.trigger.scheduled`).

Jira: [MST-10352](https://uipath.atlassian.net/browse/MST-10352)

## Why

> Scaffold a flow whose start node is `core.trigger.scheduled`; assert it replaces the manual trigger and carries a valid schedule config. Validate-only. Background: the scheduled-trigger plugin is completely untested.

## Files

- `tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml` — task `skill-flow-scheduled-trigger`
- `tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py` — pure-Python structural checker

## What it asserts

The agent scaffolds a Flow, then **replaces the default manual trigger** with a scheduled trigger. The checker requires:
- start node is `core.trigger.scheduled` (manual trigger fully removed — node **and** definition)
- exactly one trigger; trigger is the topology start (no incoming edge)
- valid recurring schedule (`timeCycle` + ISO-8601 repeating interval; rejects never-firing all-zero intervals like `R/PT0H`)
- definition carries `bpmn:StartEvent` + `bpmn:TimerEventDefinition`
- `uip maestro flow validate` passes

## Design notes

- **Validate-only** — no `flow debug` (a scheduled BPMN timer only fires in a live engine).
- **Runs offline** in the unauthenticated eval sandbox: `core.trigger.scheduled` (v1.1) is in the bundled `@uipath/flow-core` OOTB manifest, so `registry get` + `validate` resolve without a tenant (same class as the green `single_node/delay` test).
- The structural checker is **pure Python and never invokes `uip`** (avoids the sandbox npm auto-install fallback). `typeVersion` is checked non-empty, not pinned.

## Verification

- `coder-eval plan` → task valid.
- `coder-eval evaluate` vs a golden solution → **2/2 criteria pass**.
- `coder-eval evaluate` vs a not-replaced (manual-only) solution → **correctly fails** (catches what plain `validate` misses).
- Checker rejects 10 hand-built broken variants; schedule regex accepts 11 valid intervals / rejects 8 invalid ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-10352]: https://uipath.atlassian.net/browse/MST-10352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ