### PR TITLE
test(uipath-maestro-flow): add merge parallel-sync smoke test

### DIFF
--- a/tests/tasks/uipath-maestro-flow/smoke/check_merge_parallel_sync_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_merge_parallel_sync_flow.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""ParallelSync: structural check for the parallel-sync merge topology.
+
+Validate-only — does NOT run `uip maestro flow debug` (a `bpmn:ParallelGateway`
+join only synchronizes inside a live BPMN engine the test sandbox cannot
+provision). Asserts a fork/join parallel-sync built around a `core.logic.merge`
+node:
+
+  1. Exactly one node with `type == "core.logic.merge"` (the join), with a
+     non-empty `typeVersion` (the agent-under-test copies the registry
+     `version`, so we do NOT pin a specific value).
+  2. The merge *definition* is present in `definitions[]` with
+     `model.type == "bpmn:ParallelGateway"`.
+  3. Two parallel branches CONVERGE on the merge: at least 2 incoming edges
+     (`targetNodeId == merge id`) originating from at least 2 DISTINCT source
+     nodes (so it is a real fan-in, not two edges from one node).
+  4. The sync CONTINUES: the merge has at least one outgoing edge
+     (`sourceNodeId == merge id`).
+  5. A FORK exists upstream: some node has at least 2 outgoing edges — the
+     parallel split the branches diverge from.
+  6. The converging branches are genuine branches, not orphans: each distinct
+     source node that feeds the merge itself has an incoming edge.
+"""
+
+import glob
+import json
+import sys
+from collections import Counter
+from typing import NoReturn
+
+NODE_TYPE = "core.logic.merge"
+
+
+def _fail(msg: str) -> NoReturn:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/ParallelSync*.flow", recursive=True)
+    if not flows:
+        _fail("no ParallelSync*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _find_merge(flow: dict) -> dict:
+    matches = [n for n in flow.get("nodes", []) if n.get("type") == NODE_TYPE]
+    if not matches:
+        types = sorted({n.get("type") for n in flow.get("nodes", [])})
+        _fail(f"no node with type {NODE_TYPE!r}; node types seen: {types}")
+    if len(matches) > 1:
+        _fail(f"expected exactly one {NODE_TYPE} node (the join), found {len(matches)}")
+    node = matches[0]
+    tv = node.get("typeVersion")
+    if not isinstance(tv, str) or not tv.strip():
+        _fail(
+            "merge node typeVersion missing or empty — copy the `version` field "
+            "from `uip maestro flow registry get core.logic.merge --output json`."
+        )
+    return node
+
+
+def _check_definition(flow: dict) -> None:
+    defs = [d for d in (flow.get("definitions") or []) if d.get("nodeType") == NODE_TYPE]
+    if len(defs) != 1:
+        types = sorted(d.get("nodeType") for d in (flow.get("definitions") or []))
+        _fail(
+            f"expected exactly one definitions[] entry with nodeType {NODE_TYPE!r}, "
+            f"found {len(defs)}; definition nodeTypes: {types}. Append the object from "
+            "`uip maestro flow registry get core.logic.merge --output json`."
+        )
+    model = defs[0].get("model") or {}
+    if model.get("type") != "bpmn:ParallelGateway":
+        _fail(
+            f"merge definition model.type={model.get('type')!r}; must be "
+            '"bpmn:ParallelGateway". Re-copy the definition from the registry.'
+        )
+
+
+def _check_convergence(flow: dict, merge_id: str) -> set:
+    edges = flow.get("edges") or []
+    incoming = [e for e in edges if e.get("targetNodeId") == merge_id]
+    sources = {e.get("sourceNodeId") for e in incoming if e.get("sourceNodeId")}
+    if len(incoming) < 2:
+        _fail(
+            f"merge {merge_id!r} has only {len(incoming)} incoming edge(s); a "
+            "parallel-sync needs at least two branches converging on it."
+        )
+    if len(sources) < 2:
+        _fail(
+            f"merge {merge_id!r} has {len(incoming)} incoming edge(s) but only "
+            f"{len(sources)} distinct source node(s) ({sorted(sources)}); the two "
+            "parallel branches must come from two DIFFERENT upstream nodes."
+        )
+    return sources
+
+
+def _check_continuation(flow: dict, merge_id: str) -> None:
+    outgoing = [e for e in (flow.get("edges") or []) if e.get("sourceNodeId") == merge_id]
+    if not outgoing:
+        _fail(
+            f"merge {merge_id!r} has no outgoing edge; the synchronized branch must "
+            "continue to a downstream node (e.g. the End node)."
+        )
+
+
+def _check_fork(flow: dict) -> None:
+    out_counts = Counter(
+        e.get("sourceNodeId") for e in (flow.get("edges") or []) if e.get("sourceNodeId")
+    )
+    forks = [nid for nid, c in out_counts.items() if c >= 2]
+    if not forks:
+        _fail(
+            "no fork found: no node has 2+ outgoing edges. A parallel-sync must "
+            "diverge into branches from a single upstream node before converging."
+        )
+
+
+def _check_branches_wired(flow: dict, sources: set) -> None:
+    edges = flow.get("edges") or []
+    targets_with_incoming = {e.get("targetNodeId") for e in edges}
+    orphans = [s for s in sources if s not in targets_with_incoming]
+    if orphans:
+        _fail(
+            f"branch node(s) {sorted(orphans)} feed the merge but have no incoming "
+            "edge — each parallel branch must itself be reached from the fork."
+        )
+
+
+def main():
+    flow = _read_flow()
+    merge = _find_merge(flow)
+    merge_id = merge.get("id")
+
+    _check_definition(flow)
+    sources = _check_convergence(flow, merge_id)
+    _check_continuation(flow, merge_id)
+    _check_fork(flow)
+    _check_branches_wired(flow, sources)
+
+    print(
+        f"OK: exactly one {NODE_TYPE} ({merge_id!r}); {len(sources)} distinct branches "
+        f"converge on it ({sorted(sources)}); fork present; merge continues downstream; "
+        "definition carries bpmn:ParallelGateway"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/smoke/check_merge_parallel_sync_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_merge_parallel_sync_flow.py
@@ -36,10 +36,14 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/ParallelSync*.flow", recursive=True)
+    flows = sorted(glob.glob("**/ParallelSync*.flow", recursive=True))
     if not flows:
         _fail("no ParallelSync*.flow found under cwd")
-    with open(flows[0]) as f:
+    # Prefer the canonical project path; fall back to the first match so the
+    # read is deterministic even if stray *.flow files exist.
+    canonical = "ParallelSync/ParallelSync/ParallelSync.flow"
+    path = canonical if canonical in flows else flows[0]
+    with open(path) as f:
         return json.load(f)
 
 
@@ -51,6 +55,8 @@ def _find_merge(flow: dict) -> dict:
     if len(matches) > 1:
         _fail(f"expected exactly one {NODE_TYPE} node (the join), found {len(matches)}")
     node = matches[0]
+    if not node.get("id"):
+        _fail(f"the {NODE_TYPE} node is missing its 'id' field")
     tv = node.get("typeVersion")
     if not isinstance(tv, str) or not tv.strip():
         _fail(

--- a/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
@@ -1,0 +1,80 @@
+task_id: skill-flow-merge-parallel-sync
+description: >
+  Build a UiPath Flow with two parallel branches that fork from the trigger and
+  converge on a single `core.logic.merge` (parallel-sync) node before reaching
+  the End node. Exercises the merge node in isolation — previously it was only
+  hit incidentally inside larger flows. Asserts merge presence, that both
+  upstream branches wire into it from two distinct nodes, and that a fork
+  exists. Validate-only and pure-OOTB — no tenant, no `flow debug` (a
+  ParallelGateway join only synchronizes inside a live BPMN engine the test
+  sandbox cannot provision).
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, shape:multi-node, node:merge]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow project named "ParallelSync" that runs two branches in
+  parallel and synchronizes them with a Merge node before finishing.
+
+  A Flow project MUST live inside a solution:
+    1. Create the solution first (`uip solution init`).
+    2. Create the Flow project inside it (`uip maestro flow init`). The correct
+       flow-file path is:
+         ParallelSync/ParallelSync/ParallelSync.flow
+
+  Build this exact fork/join topology (the default manual trigger is fine — keep
+  it as the start node and use it as the fork):
+
+      trigger ──> branchA ──┐
+              └─> branchB ──┴─> merge ──> end
+
+    - The trigger FORKS to two branches: add two outgoing edges from the
+      trigger, one to `branchA` and one to `branchB`.
+    - `branchA` and `branchB` are two OOTB Script nodes (`core.action.script`),
+      each with a trivial `inputs.script` that returns an object
+      (e.g. `return { ok: true };`). The Script node's output port is
+      `success`.
+    - Add ONE Merge node (`core.logic.merge`) — the join. Wire BOTH branches
+      into it: an `edges[]` entry from `branchA` to the merge and another from
+      `branchB` to the merge (both with `targetNodeId` = the merge node id).
+      The merge node has empty `inputs` (`{}`).
+    - Add a `core.control.end` node and wire the merge's output to it (an
+      `edges[]` entry whose `sourceNodeId` is the merge node id).
+    - Set every node's `typeVersion` from the registry — do NOT hardcode guessed
+      versions (`uip maestro flow registry get core.logic.merge --output json`,
+      etc.). Append each node type's definition to `definitions[]` (the merge
+      definition carries `model.type: "bpmn:ParallelGateway"`).
+
+  The task is NOT complete until `uip maestro flow validate` passes for that
+  exact flow-file path.
+
+  Important:
+    - The `uip` CLI is already available; use `--output json` on uip commands.
+    - Validate locally with `uip maestro flow validate` — do NOT run
+      `uip maestro flow debug` (the parallel join only synchronizes in a live
+      engine).
+    - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+      planning and implementation. Build the complete flow end-to-end in a
+      single pass.
+    - Before starting, load the uipath-maestro-flow skill and follow its merge
+      plugin docs and edge-wiring (editing-operations) procedures exactly.
+
+success_criteria:
+  # ── Flow file validity ─────────────────────────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate ParallelSync/ParallelSync/ParallelSync.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Structural checks (merge present; two distinct branches converge) ────
+  - type: run_command
+    description: "Exactly one core.logic.merge with >=2 distinct branches converging, a fork upstream, and a downstream continuation"
+    command: "python3 $TASK_DIR/check_merge_parallel_sync_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
@@ -29,18 +29,23 @@ initial_prompt: |
       trigger ──> branchA ──┐
               └─> branchB ──┴─> merge ──> end
 
-    - The trigger FORKS to two branches: add two outgoing edges from the
-      trigger, one to `branchA` and one to `branchB`.
     - `branchA` and `branchB` are two OOTB Script nodes (`core.action.script`),
       each with a trivial `inputs.script` that returns an object
-      (e.g. `return { ok: true };`). The Script node's output port is
-      `success`.
-    - Add ONE Merge node (`core.logic.merge`) — the join. Wire BOTH branches
-      into it: an `edges[]` entry from `branchA` to the merge and another from
-      `branchB` to the merge (both with `targetNodeId` = the merge node id).
-      The merge node has empty `inputs` (`{}`).
-    - Add a `core.control.end` node and wire the merge's output to it (an
-      `edges[]` entry whose `sourceNodeId` is the merge node id).
+      (e.g. `return { ok: true };`).
+    - Add ONE Merge node (`core.logic.merge`) — the join — with empty `inputs`
+      (`{}`). Add a `core.control.end` node.
+    - Every node (trigger, both scripts, merge, end) MUST have a
+      `display` object with a `label` — validate rejects a node without it.
+    - Wire these FIVE edges. Every edge needs both `sourcePort` and
+      `targetPort` (validate rejects an edge missing either). Use the correct
+      port ids per the registry/skill:
+        - trigger `output` → branchA `input`
+        - trigger `output` → branchB `input`   (this fork = trigger has 2 outgoing edges)
+        - branchA `success` → merge `input`
+        - branchB `success` → merge `input`     (both branches converge on the merge `input`)
+        - merge `output` → end `input`
+      The two edges into the merge must have `targetNodeId` = the merge node id;
+      the edge out of the merge must have `sourceNodeId` = the merge node id.
     - Set every node's `typeVersion` from the registry — do NOT hardcode guessed
       versions (`uip maestro flow registry get core.logic.merge --output json`,
       etc.). Append each node type's definition to `definitions[]` (the merge
@@ -51,9 +56,10 @@ initial_prompt: |
 
   Important:
     - The `uip` CLI is already available; use `--output json` on uip commands.
-    - Validate locally with `uip maestro flow validate` — do NOT run
-      `uip maestro flow debug` (the parallel join only synchronizes in a live
-      engine).
+    - After wiring, you may run `uip maestro flow format <file>` to normalize
+      layout/variables, then validate with `uip maestro flow validate` — do NOT
+      run `uip maestro flow debug` (the parallel join only synchronizes in a
+      live engine).
     - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
       planning and implementation. Build the complete flow end-to-end in a
       single pass.

--- a/tests/tasks/uipath-maestro-flow/smoke/test_check_merge_parallel_sync_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/test_check_merge_parallel_sync_flow.py
@@ -1,0 +1,184 @@
+"""Unit tests for check_merge_parallel_sync_flow.py — purely structural, no CLI.
+
+Run with ``pytest tests/tasks/uipath-maestro-flow/smoke/test_check_merge_parallel_sync_flow.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+CHECKER = Path(__file__).resolve().parent / "check_merge_parallel_sync_flow.py"
+
+
+def _write_flow(tmp_path: Path, payload: dict[str, Any]) -> None:
+    d = tmp_path / "ParallelSync" / "ParallelSync"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "ParallelSync.flow").write_text(json.dumps(payload))
+    (d / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+
+
+def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER)], cwd=str(cwd), capture_output=True, text=True
+    )
+
+
+def _out(r: subprocess.CompletedProcess[str]) -> str:
+    return (r.stdout + r.stderr).lower()
+
+
+def _well_formed() -> dict[str, Any]:
+    """trigger forks to two script branches that converge on a merge -> end."""
+    return {
+        "version": "1.2",
+        "nodes": [
+            {"id": "start", "type": "core.trigger.manual", "typeVersion": "1.0",
+             "display": {"label": "Manual trigger"}},
+            {"id": "branchA", "type": "core.action.script", "typeVersion": "1.0",
+             "display": {"label": "Branch A"}, "inputs": {"script": "return { ok: true };"}},
+            {"id": "branchB", "type": "core.action.script", "typeVersion": "1.0",
+             "display": {"label": "Branch B"}, "inputs": {"script": "return { ok: true };"}},
+            {"id": "merge1", "type": "core.logic.merge", "typeVersion": "1.0",
+             "display": {"label": "Join"}, "inputs": {}},
+            {"id": "end1", "type": "core.control.end", "typeVersion": "1.0",
+             "display": {"label": "End"}, "inputs": {}},
+        ],
+        "edges": [
+            {"id": "e1", "sourceNodeId": "start", "sourcePort": "output", "targetNodeId": "branchA", "targetPort": "input"},
+            {"id": "e2", "sourceNodeId": "start", "sourcePort": "output", "targetNodeId": "branchB", "targetPort": "input"},
+            {"id": "e3", "sourceNodeId": "branchA", "sourcePort": "success", "targetNodeId": "merge1", "targetPort": "input"},
+            {"id": "e4", "sourceNodeId": "branchB", "sourcePort": "success", "targetNodeId": "merge1", "targetPort": "input"},
+            {"id": "e5", "sourceNodeId": "merge1", "sourcePort": "output", "targetNodeId": "end1", "targetPort": "input"},
+        ],
+        "definitions": [
+            {"nodeType": "core.trigger.manual", "version": "1.0", "model": {"type": "bpmn:StartEvent"}},
+            {"nodeType": "core.action.script", "version": "1.0", "model": {"type": "bpmn:ScriptTask"}},
+            {"nodeType": "core.logic.merge", "version": "1.0", "model": {"type": "bpmn:ParallelGateway"}},
+            {"nodeType": "core.control.end", "version": "1.0", "model": {"type": "bpmn:EndEvent"}},
+        ],
+    }
+
+
+def test_well_formed_passes(tmp_path: Path) -> None:
+    _write_flow(tmp_path, _well_formed())
+    r = _run(tmp_path)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_no_merge_node_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    for n in p["nodes"]:
+        if n["type"] == "core.logic.merge":
+            n["type"] = "core.action.script"
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "core.logic.merge" in (r.stdout + r.stderr)
+
+
+def test_two_merge_nodes_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["nodes"].append({"id": "merge2", "type": "core.logic.merge", "typeVersion": "1.0",
+                       "display": {"label": "Join 2"}, "inputs": {}})
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "exactly one" in _out(r)
+
+
+def test_single_incoming_edge_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["edges"] = [e for e in p["edges"] if e["id"] != "e4"]
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "incoming" in _out(r)
+
+
+def test_same_source_fan_in_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    for e in p["edges"]:
+        if e["id"] == "e4":
+            e["sourceNodeId"] = "branchA"  # both incoming edges now from branchA
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "distinct" in _out(r)
+
+
+def test_no_outgoing_edge_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["edges"] = [e for e in p["edges"] if e["id"] != "e5"]
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "outgoing" in _out(r)
+
+
+def test_no_fork_fails(tmp_path: Path) -> None:
+    # Drop the second fork edge so no node has 2+ outgoing edges.
+    p = _well_formed()
+    p["edges"] = [e for e in p["edges"] if e["id"] != "e2"]
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "fork" in _out(r)
+
+
+def test_orphan_branch_fails(tmp_path: Path) -> None:
+    # A third source feeds the merge but is never reached (no incoming edge).
+    p = _well_formed()
+    p["nodes"].append({"id": "ghost", "type": "core.action.script", "typeVersion": "1.0",
+                       "display": {"label": "Ghost"}, "inputs": {"script": "return {};"}})
+    p["edges"].append({"id": "e6", "sourceNodeId": "ghost", "sourcePort": "success",
+                       "targetNodeId": "merge1", "targetPort": "input"})
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "no incoming edge" in _out(r)
+
+
+def test_missing_merge_definition_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    p["definitions"] = [d for d in p["definitions"] if d["nodeType"] != "core.logic.merge"]
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "definitions" in _out(r)
+
+
+def test_wrong_merge_model_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    for d in p["definitions"]:
+        if d["nodeType"] == "core.logic.merge":
+            d["model"] = {"type": "bpmn:ExclusiveGateway"}
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "parallelgateway" in _out(r)
+
+
+def test_missing_type_version_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    for n in p["nodes"]:
+        if n["type"] == "core.logic.merge":
+            n.pop("typeVersion", None)
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "typeversion" in _out(r)
+
+
+def test_merge_missing_id_fails(tmp_path: Path) -> None:
+    p = _well_formed()
+    for n in p["nodes"]:
+        if n["type"] == "core.logic.merge":
+            n.pop("id", None)
+    _write_flow(tmp_path, p)
+    r = _run(tmp_path)
+    assert r.returncode != 0
+    assert "id" in _out(r)


### PR DESCRIPTION
## What

Adds a **validate-only** smoke test for `core.logic.merge` — a fork/join parallel-sync flow. Until now the merge node was exercised only incidentally inside larger flows, with no isolated test.

Jira: [MST-10351](https://uipath.atlassian.net/browse/MST-10351)

## Why

> Multi-node task with two parallel branches converging on a `core.logic.merge` node; assert merge presence and that both upstream branches wire into it. Validate-only. Background: merge is exercised only incidentally inside larger flows with no isolated parallel-sync test.

## Files

- `tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml` — task `skill-flow-merge-parallel-sync`
- `tests/tasks/uipath-maestro-flow/smoke/check_merge_parallel_sync_flow.py` — pure-Python structural checker

## Topology

```
trigger ──> branchA ──┐
        └─> branchB ──┴─> merge ──> end
```

The trigger forks to two OOTB Script branches that both converge on a single `core.logic.merge`, which continues to an End node.

## What it asserts

- exactly one `core.logic.merge` node (`typeVersion` copied from the registry, not pinned)
- merge definition carries `model.type == bpmn:ParallelGateway`
- ≥2 incoming edges from **≥2 distinct** branch nodes converge on the merge (a real fan-in, not two edges from one node)
- the merge continues downstream (≥1 outgoing edge)
- a fork exists upstream (some node with ≥2 outgoing edges)
- each converging branch is itself wired in (not an orphan)
- `uip maestro flow validate` passes

## Design notes

- **Validate-only** — no `flow debug` (a ParallelGateway join only synchronizes in a live engine).
- **Runs offline** in the unauthenticated sandbox: `core.logic.merge` / `core.action.script` / `core.control.end` are in the bundled `@uipath/flow-core` OOTB manifest.
- The structural checker is **pure Python and never invokes `uip`**.

## Verification

- `coder-eval plan` → task valid.
- `coder-eval evaluate` vs a golden solution → **2/2 criteria pass**.
- `coder-eval evaluate` vs broken solutions → **correctly fail**.
- Checker rejects 7 hand-built broken variants (missing merge, single incoming, same-source fan-in, no continuation, no fork, missing/wrong definition).

> Note: an adversarial multi-lens review of this test is in progress; any resulting refinements will be pushed to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MST-10351]: https://uipath.atlassian.net/browse/MST-10351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ