### PR TITLE
test: add waitFor eval test

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/check_outlook_waitfor_email.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/check_outlook_waitfor_email.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""OutlookWaitForEmail: structural check (no execution).
+
+The flow must be:
+  manual start trigger
+    -> mid-flow Wait-for-event node (Outlook email-received, Inbox)
+       filtered to SUBJECT CONTAINS "TestWaitFor"
+    -> End
+
+`flow debug` is intentionally NOT run — the task only requires the flow to
+build and validate. So every assertion here is static, read from the `.flow`
+source:
+
+  1. The start trigger is preserved (manual/scheduled) — the event node was
+     added mid-flow, NOT used to replace the trigger.
+  2. A Wait-for-event node of the Outlook email-received connector event exists
+     (`uipath.connector.event.uipath-microsoft-outlook365.email-received`).
+  3. That node carries a structured `filter` tree with a `subject` / `Contains`
+     leaf whose literal value is "TestWaitFor". `node configure` persists this
+     tree inside the `inputs.detail.configuration` blob (a `=jsonString:`
+     envelope, under `essentialConfiguration.filter`) and compiles the JMESPath
+     into `inputs.detail.filterExpression`. We match the structured tree — a
+     bare `filterExpression` string (which the CLI rejects as an INPUT field,
+     MST-8802) cannot satisfy the check on its own.
+"""
+
+import glob
+import json
+import sys
+
+EVENT_MARKERS = (
+    "uipath.connector.event",
+    "uipath-microsoft-outlook365",
+    "email-received",
+)
+FILTER_VALUE = "TestWaitFor"
+_JSONSTRING_PREFIX = "=jsonString:"
+
+
+def _fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _parse_jsonstring(value: object) -> dict:
+    """Decode a `=jsonString:{...}` envelope (or a plain dict) to a dict."""
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str) and value.startswith(_JSONSTRING_PREFIX):
+        try:
+            parsed = json.loads(value[len(_JSONSTRING_PREFIX):])
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _filter_trees(detail: dict):
+    """Yield every structured filter tree on a configured connector-event node.
+
+    `node configure` stores the tree in `inputs.detail.configuration`
+    (`=jsonString:` → `essentialConfiguration.filter`). Older shapes may expose
+    `inputs.detail.filter` directly. Yield whatever is present."""
+    direct = detail.get("filter")
+    if isinstance(direct, dict):
+        yield direct
+    config = _parse_jsonstring(detail.get("configuration"))
+    essential = config.get("essentialConfiguration") or {}
+    tree = essential.get("filter") if isinstance(essential, dict) else None
+    if isinstance(tree, dict):
+        yield tree
+
+
+def _read_flow() -> dict:
+    flows = glob.glob("**/OutlookWaitForEmail*.flow", recursive=True)
+    if not flows:
+        _fail("no OutlookWaitForEmail*.flow found under cwd")
+    with open(flows[0]) as f:
+        return json.load(f)
+
+
+def _iter_filter_leaves(node_filter: dict):
+    """Yield every leaf condition in a (possibly nested) filter tree."""
+    if not isinstance(node_filter, dict):
+        return
+    for leaf in node_filter.get("filters") or []:
+        if isinstance(leaf, dict):
+            yield leaf
+    for group in node_filter.get("groups") or []:
+        yield from _iter_filter_leaves(group)
+
+
+def _leaf_value(leaf: dict) -> str:
+    """Extract the literal value from a WorkflowValue-wrapped leaf, tolerating
+    both the wrapped shape and a bare string."""
+    v = leaf.get("value")
+    if isinstance(v, dict):
+        return str(v.get("value", ""))
+    return str(v) if v is not None else ""
+
+
+def main() -> None:
+    flow = _read_flow()
+    nodes = flow.get("nodes") or []
+    types_seen = sorted({str(n.get("type", "")) for n in nodes})
+
+    # 1. Start trigger preserved.
+    if not any(str(n.get("type", "")).startswith("core.trigger.") for n in nodes):
+        _fail(
+            "no start trigger (core.trigger.*) — the Wait-for-event node must be "
+            f"added mid-flow, not replace the start trigger. Types: {types_seen}"
+        )
+
+    # 2. Outlook email-received Wait-for-event node present.
+    event_nodes = [
+        n
+        for n in nodes
+        if all(m in str(n.get("type", "")).lower() for m in EVENT_MARKERS)
+    ]
+    if not event_nodes:
+        _fail(
+            "no Outlook email-received Wait-for-event node "
+            f"(type containing {' + '.join(EVENT_MARKERS)}). Types: {types_seen}"
+        )
+
+    # 3. A subject / Contains / "TestWaitFor" leaf in the structured filter tree.
+    for node in event_nodes:
+        detail = (node.get("inputs") or {}).get("detail") or {}
+        if not isinstance(detail, dict):
+            continue
+        for tree in _filter_trees(detail):
+            for leaf in _iter_filter_leaves(tree):
+                field = str(leaf.get("id", "")).lower()
+                operator = str(leaf.get("operator", "")).lower()
+                value = _leaf_value(leaf)
+                if "subject" in field and "contains" in operator and value == FILTER_VALUE:
+                    print(
+                        "OK: start trigger preserved; mid-flow Outlook email-received "
+                        f"node filters subject Contains {FILTER_VALUE!r} via the filter tree"
+                    )
+                    return
+
+    _fail(
+        "Outlook email-received node found, but no structured filter leaf matches "
+        f"subject / Contains / {FILTER_VALUE!r}. The subject filter must be a "
+        "`filter` tree leaf (id=subject, operator=Contains, value=TestWaitFor), "
+        "not a bare filterExpression string."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
@@ -1,0 +1,72 @@
+task_id: skill-flow-outlook-waitfor-email
+description: >
+  Build-and-validate: a Flow with a manual start trigger, a mid-flow
+  Wait-for-event node that pauses until a Microsoft Outlook 365 email is
+  received in the Inbox
+  (`uipath.connector.event.uipath-microsoft-outlook365.email-received`)
+  WHOSE SUBJECT CONTAINS the fixed string "TestWaitFor", then an End. Exercises
+  the connector-trigger plugin's "Wait for events" variant (event node added
+  mid-flow with `node add`, NOT replacing the start trigger; bound to the
+  Outlook connection with `parentFolderId` resolved for Inbox) AND the
+  structured `filter` tree (a `subject` / `Contains` / "TestWaitFor" literal
+  leaf — never a `filterExpression` string input). No execution — `flow debug`
+  is intentionally omitted; the task only requires the flow to build and
+  validate. Distinct from `outlook_trigger_inbox`, which uses the same event as
+  the flow's START trigger; this one uses it as a mid-flow wait.
+tags:
+  [
+    uipath-maestro-flow,
+    integration,
+    mode:build,
+    lifecycle:generate,
+    shape:single-node,
+    feature:trigger,
+    connector,
+    uipath-microsoft-outlook365,
+    filter,
+  ]
+run_limits:
+  expected_turns: 55
+  turn_timeout: 600
+
+initial_prompt: |
+  Create a UiPath Flow named "OutlookWaitForEmail".
+
+  Keep the flow's manual start trigger. After it, add a mid-flow
+  Wait-for-event node that pauses the flow until a Microsoft Outlook 365 email
+  is received in the **Inbox** folder whose SUBJECT CONTAINS the string
+  "TestWaitFor". Then End the flow.
+
+  Validate the flow. Do NOT run `uip maestro flow debug` — the task is complete
+  once `uip maestro flow validate` passes.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single
+  pass. Before starting, load the uipath-maestro-flow skill and follow its
+  connector-trigger plugin "Wait for events" workflow exactly — the event node
+  is added mid-flow with `node add` and must NOT replace the start trigger, and
+  the subject filter must be a structured `filter` tree, not a
+  `filterExpression` string.
+
+success_criteria:
+  # ── Structural: flow builds and validates ──────────────────────────────
+  - type: run_command
+    description: "uip maestro flow validate passes on the flow file"
+    command: "uip maestro flow validate OutlookWaitForEmail/OutlookWaitForEmail/OutlookWaitForEmail.flow"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── Composite: event node mid-flow + subject-contains-"TestWaitFor" filter ─
+  - type: run_command
+    description: "Mid-flow Outlook email-received node filters subject contains 'TestWaitFor'"
+    command: "python3 $TASK_DIR/check_outlook_waitfor_email.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120


### PR DESCRIPTION
pure structure smoke test, no debug included, because wait for node requires real time event (e.g. send email right after node is executed)

![image.png](https://github.com/user-attachments/assets/3e3850d5-d597-4ac5-915b-b2ee4032d333)
