### PR TITLE
docs(uipath-maestro-case): clarify connector caseShape splice scope

### DIFF
--- a/skills/uipath-maestro-case/references/connector-integration.md
+++ b/skills/uipath-maestro-case/references/connector-integration.md
@@ -87,6 +87,8 @@ Spec output carries the full operation contract:
 | `caseShape` | FE-canonical `inputs[]` / `outputs[]` / `context[]` ready to drop into `caseplan.json` (after binding-id substitution); only present when `--skip-case-shape` is NOT set |
 | `diagnostics` | Per-endpoint `fetched` / `fallbacks` |
 
+> **Splice scope.** Only `caseShape` reaches `caseplan.json` (≈5–12 KB). Rest of the envelope — `outputs`, `filter`, `identity`, `references`, `diagnostics` (≈14–49 KB total) — is discovery metadata, never written. Size the splice off `caseShape`, not the cache file.
+
 Full input-details contract (the `--input-details` JSON shape): [`case-spec-input-details.md`](case-spec-input-details.md).
 
 > **Generic-typed activities** (`Config.activityType === "Generic"`) carry an empty/templated `objectName` in the typecache because one definition is shared across every object the connector exposes (e.g. Salesforce `InsertRecord`). The CLI fails fast on `case spec --type activity` without `--object-name`. Discover the available objects via `uip is resources list --connector-key <connector-key>` and `uip is resources describe --connector-key <connector-key> --object-name <name>`, then pass the picked name as `--object-name` on the Phase 3 call.


### PR DESCRIPTION
## Why

When implementing connector tasks, an agent can misread "persist the full `case spec` response … splice verbatim" as needing to write the **full ~49 KB response** into `caseplan.json` — over-estimating cost or reaching for a forbidden script. In practice only `Data.caseShape` is written, and it's a fraction of the envelope.

## What

One note at the spec-output table in `references/connector-integration.md` — the place you'd actually size the splice:

> **Splice scope.** Only `caseShape` reaches `caseplan.json` (≈5–12 KB). Rest of the envelope — `outputs`, `filter`, `identity`, `references`, `diagnostics` (≈14–49 KB total) — is discovery metadata, never written. Size the splice off `caseShape`, not the cache file.

The other connector anchors (`connector-activity/impl-json.md`, `connector-trigger-common.md`) already distinguish "full response → cache" from "`caseShape.context` → splice", so no change there — avoids duplicating the same statement across files.

## Sizes (measured live via `uip maestro case spec`)

- Slack trigger: envelope 15.9 KB → `caseShape` **4.8 KB**
- Outlook Send Email activity: envelope 13.8 KB → `caseShape` **5.9 KB** unpopulated (~12 KB with filter/body populated)

## Scope

1 file, +2 lines. **No behavioral or CLI change.** No SKILL.md / frontmatter / Critical Rules; no cross-skill references; no new skill (CODEOWNERS unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)