### PR TITLE
fix(uipath-troubleshoot): nest run limits under run_limits: block (11 tasks)

### DIFF
--- a/tests/tasks/uipath-troubleshoot/invokevba-code-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-code-file/task.yaml
@@ -11,9 +11,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-com-interop/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-method-name/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-method-name/task.yaml
@@ -11,9 +11,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-params/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-params/task.yaml
@@ -12,9 +12,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-trust-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-trust-access/task.yaml
@@ -11,9 +11,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-active-filters/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-active-filters/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-file-locked/task.yaml
@@ -15,9 +15,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-formula-cells/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-formula-cells/task.yaml
@@ -17,9 +17,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-invalid-range/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-not-installed/task.yaml
@@ -12,9 +12,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-null-reference/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:


### PR DESCRIPTION
## Problem

11 `uipath-troubleshoot` tasks (`invokevba-*` ×5, `lookuprange-*` ×6) declare `task_timeout`, `max_turns`, and `turn_timeout` as **top-level** task fields. coder_eval honors run limits only from the nested **`run_limits:` block**. The legacy top-level form used to be lifted in by the `_hoist_legacy_agent_timing` grace shim, whose **removal date was 2026-05-20**. That date has passed, so the top-level fields are now **silently ignored** and the run falls back to the experiment-default `turn_timeout` (900s).

## Evidence

The run `skill-troubleshoot-invokevba-com-interop` (2026-06-04) **ERRORed**: `Agent turn timed out after 900s`. The run's resolved config shows `turn_timeout: 900` with lineage `source: experiment-defaults` — not the intended `3600`. The agent had already **confirmed its root-cause hypothesis** (`hypotheses.json` H1 `is_root_cause: true`) when the wall-clock cap killed it at 908s / 155 turns — a pure config false-negative, not a content failure.

Controlled comparison: the `getasset-*` siblings, which already use the `run_limits:` block, resolve `turn_timeout: 3600` with lineage `source: task` and complete normally.

## Fix

Wrap the three fields in a `run_limits:` block, matching the `getasset-*` siblings. **Values unchanged** (`task_timeout: 5400`, `max_turns: 60`, `turn_timeout: 3600`).

```diff
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
```

## Note

`logon-failure-password-mismatch` has the same misplacement but lives in open PR #843 (not yet on main); it is being fixed within that PR's branch separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)