### PR TITLE
fix(evals): push-pull-roundtrip — fix mock and tighten criteria

### DIFF
--- a/skills/uipath-agents/references/coded/lifecycle/file-sync.md
+++ b/skills/uipath-agents/references/coded/lifecycle/file-sync.md
@@ -27,7 +27,7 @@ uip codedagent push --ignore-resources
 ## Prerequisites
 
 - Authenticated session (see [authentication](../../authentication.md)).
-- `UIPATH_PROJECT_ID` set in `.env` (the CLI does not inject this one — it identifies the target project in Studio Web).
+- `UIPATH_PROJECT_ID` set in `.env` — verify by reading the file directly (`Read <project-dir>/.env`). The CLI reads this file at runtime; do not check `$UIPATH_PROJECT_ID` in the shell (env vars do not persist across Bash tool calls).
 
 ```env
 UIPATH_PROJECT_ID=12345

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
@@ -3,7 +3,7 @@ description: >
   Verifies the agent knows to use uip codedagent push and pull when
   UIPATH_PROJECT_ID is already wired in .env. Project is pre-seeded;
   tests command selection, not cloud connectivity.
-tags: [uipath-agents, integration, mode:operate, coded, lifecycle:execute, feature:file-sync]
+tags: [uipath-agents, smoke, integration, mode:operate, coded, lifecycle:execute, feature:file-sync]
 
 run_limits:
   max_turns: 30
@@ -11,6 +11,10 @@ run_limits:
   turn_timeout: 300
 
 sandbox:
+  template_sources:
+    - type: template_dir
+      path: mocks
+      mount_point: mocks
   mock_path_dirs:
     - mocks
 
@@ -30,7 +34,7 @@ success_criteria:
   - type: command_executed
     description: "Agent pushed to Studio Web with uip codedagent push"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedagent\s+push'
+    command_pattern: 'uip\s+codedagent\s+push(?!\s+--help)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -38,7 +42,7 @@ success_criteria:
   - type: command_executed
     description: "Agent pulled from Studio Web with uip codedagent pull"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedagent\s+pull'
+    command_pattern: 'uip\s+codedagent\s+pull(?!\s+--help)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- Add `template_sources` so `mocks/` is copied into the sandbox — without this, `mock_path_dirs` had nothing to prepend to PATH and the real `uip` binary ran, returning `"UIPATH_PROJECT_ID environment variable not found"`
- Tighten `command_pattern` to exclude `--help` matches which caused false positives
- Update `file-sync.md` prerequisites to tell the agent to use `Read` on `.env` rather than checking `$UIPATH_PROJECT_ID` in the shell (env vars don't persist across Bash tool calls)

## Test plan

- [x] 1/1 local run passes (score 1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)