### PR TITLE
fix(agents): document example_calls semantics and pre-seed mocking eval fixtures

### DIFF
--- a/skills/uipath-agents/references/coded/lifecycle/evaluate.md
+++ b/skills/uipath-agents/references/coded/lifecycle/evaluate.md
@@ -80,6 +80,15 @@ def fetch_weather(query: str) -> dict:
 
 During evaluations, calls matching an `ExampleCall.input` return the paired `output`. During normal execution, the real function runs.
 
+`@mockable` only *registers* the function as interceptable — mock values come from the test case's `mockingStrategy`. `example_calls` matter only for LLM-driven mocking:
+
+| Mock values supplied by | `example_calls` needed? |
+|---|---|
+| Declarative `mockingStrategy: mockito` behaviors | No — bare `@mockable()` is correct; mockito ignores `example_calls` |
+| LLM mocking (`mockingStrategy: llm`, or user wants LLM-decided substitution values) | Yes — they ground the LLM mocker; without them outputs are nondeterministic and structured-output evaluators score erratically |
+
+When `example_calls` are needed, provide ≥1 `ExampleCall` per decorated function with `output` matching the real return shape. Do NOT add `example_calls` to mockito-mocked functions. If no mock matches at runtime, the real function runs.
+
 **Declarative** — Set `mockingStrategy` on each test case in the eval set (`type: "mockito"` for function mocks, `type: "llm"` for LLM mocks). See [Evaluation Sets](evaluations/evaluation-sets.md) § Mocking Strategies.
 
 ## Troubleshooting

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/main.py
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/main.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+import requests
+from uipath.platform import UiPath
+
+
+@dataclass
+class SecretPeekInput:
+    asset_name: str
+
+
+@dataclass
+class SecretPeekOutput:
+    masked_key: str
+    label: str
+
+
+def fetch_label(key_id: str) -> str:
+    """Fetch human-readable label from remote registry."""
+    url = f"https://registry.example.com/labels/{key_id}"
+    try:
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("label", "unknown")
+    except Exception:
+        return "unknown"
+
+
+def mask_secret(secret: str) -> str:
+    """Mask secret: first 4 chars + stars padded to original length."""
+    if len(secret) < 4:
+        return "*" * len(secret)
+    return secret[:4] + "*" * (len(secret) - 4)
+
+
+def main(input: SecretPeekInput) -> SecretPeekOutput:
+    sdk = UiPath()
+
+    # Read asset from Shared folder
+    asset = sdk.assets.retrieve(input.asset_name, folder_name="Shared")
+    secret_value = asset.value
+
+    # Mask the secret
+    masked = mask_secret(secret_value)
+
+    # Fetch label from registry
+    label = fetch_label(input.asset_name)
+
+    return SecretPeekOutput(masked_key=masked, label=label)

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/pyproject.toml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "asset-retriever"
+version = "0.0.1"
+description = "UiPath agent that returns a structured summary of an asset with masked value and remote label"
+authors = [{ name = "john doe", email = "john.doe@example.com" }]
+dependencies = [
+    "requests>=2.34.2",
+    "uipath>=2.10.0, <2.11.0",
+]
+requires-python = ">=3.11"
+
+[dependency-groups]
+dev = [
+    "uipath-dev>=0.0.79",
+]

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/uipath.json
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/uipath.json
@@ -1,0 +1,5 @@
+{
+  "functions": {
+    "main": "main.py:main"
+  }
+}

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -7,83 +7,21 @@ description: >
   looks up a remote label via a helper (mocked in-code via
   `@mockable` so eval-time substitutes example outputs). Output is
   structured JSON, eval'd with `JsonSimilarityEvaluator`. The full
-  pipeline runs offline.
+  pipeline runs offline. Project files are pre-seeded via `pre_run`
+  (fixtures in `_fixtures/`) so the eval grades mocking + evaluator
+  wiring, not file transcription.
 tags: [uipath-agents, e2e, coded, mode:build, feature:eval, feature:eval-mocking, feature:framework-simple]
 max_iterations: 1
 
+pre_run:
+  - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever ."
+    timeout: 10
+
 initial_prompt: |
-  Recreate the coded agent project under `asset-retriever/`
-  exactly as below.
-
-  **asset-retriever/pyproject.toml**:
-  [project]
-  name = "asset-retriever"
-  version = "0.0.1"
-  description = "UiPath agent that returns a structured summary of an asset with masked value and remote label"
-  authors = [{ name = "john doe", email = "john.doe@example.com" }]
-  dependencies = [
-      "requests>=2.34.2",
-      "uipath>=2.10.0, <2.11.0",
-  ]
-  requires-python = ">=3.11"
-
-  [dependency-groups]
-  dev = [
-      "uipath-dev>=0.0.79",
-  ]
-
-  **asset-retriever/main.py**:
-  from dataclasses import dataclass
-  import requests
-  from uipath.platform import UiPath
-
-  @dataclass
-  class SecretPeekInput:
-      asset_name: str
-
-  @dataclass
-  class SecretPeekOutput:
-      masked_key: str
-      label: str
-
-  def fetch_label(key_id: str) -> str:
-      """Fetch human-readable label from remote registry."""
-      url = f"https://registry.example.com/labels/{key_id}"
-      try:
-          response = requests.get(url, timeout=5)
-          response.raise_for_status()
-          data = response.json()
-          return data.get("label", "unknown")
-      except Exception:
-          return "unknown"
-
-  def mask_secret(secret: str) -> str:
-      """Mask secret: first 4 chars + stars padded to original length."""
-      if len(secret) < 4:
-          return "*" * len(secret)
-      return secret[:4] + "*" * (len(secret) - 4)
-
-  def main(input: SecretPeekInput) -> SecretPeekOutput:
-      sdk = UiPath()
-
-      # Read asset from Shared folder
-      asset = sdk.assets.retrieve(input.asset_name, folder_name="Shared")
-      secret_value = asset.value
-
-      # Mask the secret
-      masked = mask_secret(secret_value)
-
-      # Fetch label from registry
-      label = fetch_label(input.asset_name)
-
-      return SecretPeekOutput(masked_key=masked, label=label)
-
-    **asset-retriever/uipath.json**:
-      {
-    "functions": {
-      "main": "main.py:main"
-      }
-    }
+  I have an existing coded agent project at `asset-retriever/`
+  (`main.py`, `pyproject.toml`, `uipath.json`). It reads an
+  Orchestrator asset from the Shared folder, masks its value, and
+  fetches a human-readable label from a remote registry over HTTP.
 
   Add a smoke evaluation suite with 2–3 cases covering different
   asset values and run it locally. The evals must pass without
@@ -92,9 +30,12 @@ initial_prompt: |
   `eval-results.json` in the project root.
 
   For scoring, use a **structured-output evaluator** — we care
-  about the shape of `{"masked_key": ..., "label": ...}. Those
+  about the shape of `{"masked_key": ..., "label": ...}`. Those
   should be as similar as possible to what we expect.
 
+  I also want to be able (in the future) to have an llm deciding
+  what mocking values should be substituted at runtime.
+  
   Do NOT publish, upload, or deploy. Complete it in a single pass.
 
 success_criteria:
@@ -124,7 +65,7 @@ success_criteria:
     pass_threshold: 1.0
 
 run_limits:
-  expected_turns: 76
-  max_turns: 80
+  expected_turns: 45
+  max_turns: 55
   turn_timeout: 1800
   task_timeout: 1800


### PR DESCRIPTION
## Summary
- `evaluate.md` now documents when `example_calls` are required: only for LLM-driven mocking; mockito-mocked functions keep bare `@mockable()` (mockito ignores `example_calls`)
- `eval_mocking_mockito` pre-seeds the project via `pre_run` fixtures instead of asking the agent to transcribe files from the prompt
- run limits tightened (expected 45 / max 55, down from 76/80)

## Why

the previous run on the dashboard failed exactly on bare `@mockable()` without `ExampleCall` -> the skill showed the pattern but never explained the strategy split, and the eval wasted most of its turns on file transcription.

passing-run claim: local run with these changes scores 1.0 in 42 turns / 296s / $1.03 (vs old skill remote run: 0.375, 65 turns, 932s, $1.95), both on sonnet 4.6.