### PR TITLE
feat(uipath-agents): add model configuration guide for low-code agents [PC-4635]

### DIFF
--- a/skills/uipath-agents/references/lowcode/agent-definition.md
+++ b/skills/uipath-agents/references/lowcode/agent-definition.md
@@ -352,9 +352,10 @@ For each resource type's full schema, see the relevant capability file:
 
 ### Change Model Settings
 
-1. Edit `agent.json` → `settings.model`, `.temperature`, `.maxTokens`, or `.maxIterations`
-2. Current models: `anthropic.claude-sonnet-4-6`, `gpt-4.1-2025-04-14`, `gpt-5.2-2025-12-11`
-3. Validate, then migrate
+1. Discover available models — see [model-selection-guide.md](model-selection-guide.md). Only choose from the available models
+2. Edit `agent.json` → `settings.model` to the chosen model's `name` value
+3. Optionally adjust `.temperature`, `.maxTokens`, `.maxIterations`
+4. Validate, then migrate
 
 ### Capability-Adding Edits
 

--- a/skills/uipath-agents/references/lowcode/model-selection-guide.md
+++ b/skills/uipath-agents/references/lowcode/model-selection-guide.md
@@ -1,0 +1,74 @@
+# Model Selection Guide
+
+Programmatic model discovery and selection for low-code agents.
+
+## Discover Available Models
+
+```bash
+uip agent model list --all-fields --output json
+```
+
+> **`--all-fields` is mandatory.** Without it the response omits priority and capability fields listed below — making informed model selection impossible.
+
+## Response Fields
+
+Response shape:
+
+```json
+{ "Result": "Success", "Code": "AgentModelList", "Data": [...] }
+```
+
+Each object in `Data[]`:
+
+| Field | Description |
+|-------|-------------|
+| `name` | Model identifier — use directly as `settings.model` |
+| `provider` | Hosting provider (`AwsBedrock`, `OpenAi`, `VertexAi`) |
+| `isSuggested` | UiPath-recommended model |
+| `isPreview` | Preview/experimental |
+| `isByo` | Bring-your-own model (requires `byoModelConnectionId`) |
+| `defaultPriority` | Auto-selection rank for autonomous agents (lower = higher priority, null = not candidate) |
+| `defaultConversationalPriority` | Auto-selection rank for conversational agents (same semantics) |
+| `maxInputTokens` | Input context window (may be null) |
+| `maxTokens` | Max output tokens |
+
+## Selection Rules
+
+1. Prefer `isSuggested: true`
+2. For platform default: use `defaultPriority` (autonomous) or `defaultConversationalPriority` (conversational) — filter to non-null, sort ascending, pick the entry with the smallest value
+3. Skip `isByo: true` unless user explicitly provides a BYO connection
+
+## Example Output
+
+Truncated — representative entries showing suggested and default-priority patterns:
+
+```json
+{
+  "Result": "Success",
+  "Code": "AgentModelList",
+  "Data": [
+    {
+      "name": "anthropic.claude-sonnet-4-6",
+      "provider": "AwsBedrock",
+      "isSuggested": true,
+      "isPreview": false,
+      "isByo": false,
+      "defaultPriority": 1,
+      "defaultConversationalPriority": null,
+      "maxInputTokens": 200000,
+      "maxTokens": 16384
+    },
+    {
+      "name": "gpt-4.1-2025-04-14",
+      "provider": "OpenAi",
+      "isSuggested": true,
+      "isPreview": false,
+      "isByo": false,
+      "defaultPriority": 2,
+      "defaultConversationalPriority": 1,
+      "maxInputTokens": 1047576,
+      "maxTokens": 32768
+    }
+  ]
+}
+```

--- a/skills/uipath-agents/references/lowcode/project-lifecycle.md
+++ b/skills/uipath-agents/references/lowcode/project-lifecycle.md
@@ -61,6 +61,16 @@ Returns an array of validator definitions. Each entry contains:
 
 **Mandatory first step** before adding any built-in validator guardrail. Only use validators with `Status: "Available"`. If a validator is missing from the list, it does not exist on this tenant. If `Status: "Unauthorised"`, user is not entitled to use guardrails — do not add the guardrail, inform user accordingly.
 
+### `uip agent model list`
+
+List LLM models available on the tenant with capacity and priority metadata.
+
+```bash
+uip agent model list --all-fields --output json
+```
+
+See [model-selection-guide.md](model-selection-guide.md) for field definitions and selection rules.
+
 ### `uip agent validate`
 
 **Read-only** check of agent project structure and schema. Does not write any files. Run after every bulk of agent edits to catch errors early.
@@ -365,6 +375,7 @@ All solution lifecycle operations go through `uip solution` CLI. Never call Auto
 | Validate (read-only) | `uip agent validate [path] --output json` | Agent dir or any with path | — |
 | Migrate + regenerate builder | `uip agent migrate [path] --output json` | Agent dir or any with path | — |
 | List guardrail validators | `uip agent guardrails list --output json` | Any directory | — |
+| List available models | `uip agent model list --all-fields --output json` | Any directory | — |
 | Discover resources | `uip solution resource list --kind <Kind> --source remote [--search <term>] --output json` | Solution directory | — |
 | Refresh resources | `uip solution resource refresh --output json` | Solution directory | — |
 | Add one resource (local stub or remote import) | `uip solution resource add --source local\|remote --kind <Kind> --name <NAME> [--folder-path <FOLDER>] --output json` | Solution directory | Idempotent on `(kind, name, folder)` for local, on key for remote |

--- a/tests/tasks/uipath-agents/lowcode/model_selection/check_model_selection.py
+++ b/tests/tasks/uipath-agents/lowcode/model_selection/check_model_selection.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Model-selection check.
+
+Validates the final state of ModelAgent after the agent has
+scaffolded it and selected a model via `uip agent model list`:
+
+  1. agent.json exists and is valid JSON.
+  2. settings.model is a non-empty string.
+  3. settings.model contains 'gpt-5.4' — proves the agent
+     selected the requested model.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "ModelSol" / "ModelAgent"
+AGENT = ROOT / "agent.json"
+
+EXPECTED_MODEL_SUBSTRING = "gpt-5.4"
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def assert_model_selected(agent: dict) -> None:
+    settings = agent.get("settings")
+    if not isinstance(settings, dict):
+        sys.exit(f"FAIL: agent.json.settings is not an object: {settings!r}")
+
+    model = settings.get("model")
+    if not model or not isinstance(model, str) or not model.strip():
+        sys.exit(
+            f"FAIL: settings.model is missing or empty: {model!r} "
+            "— agent did not set a model"
+        )
+
+    if EXPECTED_MODEL_SUBSTRING not in model:
+        sys.exit(
+            f"FAIL: settings.model is '{model}' — expected it to contain "
+            f"'{EXPECTED_MODEL_SUBSTRING}'"
+        )
+
+    print(f"OK: settings.model is '{model}' (contains '{EXPECTED_MODEL_SUBSTRING}')")
+
+
+def main() -> None:
+    agent = load(AGENT)
+    assert_model_selected(agent)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/model_selection/model_selection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/model_selection/model_selection.yaml
@@ -1,0 +1,64 @@
+task_id: skill-agent-model-selection
+description: >
+  Skill-guided evaluation: scaffold a low-code agent, discover available
+  models with `uip agent model list`, select a model, set it in
+  settings.model, validate and migrate. Tests whether the skill teaches
+  CLI-based model discovery before selection.
+tags: [uipath-agents, smoke, low-code, mode:build]
+
+run_limits:
+  expected_turns: 15
+  max_turns: 60
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a low-code agent named "ModelAgent" in a solution called
+  "ModelSol". The agent takes a required `query` (string) input and
+  returns a `response` (string).
+
+  Use the gpt 5.4 model.
+
+  Make sure the agent is valid before you're done.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Complete the entire task end-to-end in
+  a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent discovered models with uip agent model list --all-fields --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+model\s+list\s+.*--all-fields\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the agent project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "ModelAgent/agent.json was created"
+    path: "ModelSol/ModelAgent/agent.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "settings.model is set to a non-default value, proving agent performed model discovery"
+    command: "python3 $TASK_DIR/check_model_selection.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Add model discovery and configuration guidance for low-code agents — new model selection guide, updated agent definition workflow, lifecycle command reference, and eval task.

## Changes

- **model-selection-guide.md** (new): model discovery command, response field reference, selection rules, mandatory `--all-fields` warning, example output
- **agent-definition.md**: updated "Change Model Settings" to link to model selection guide and require discovery before choosing a model
- **project-lifecycle.md**: added `uip agent model list` command reference and quick-reference table entry
- **model_selection.yaml** (new): eval task — agent scaffolds a low-code agent and configures gpt 5.4 via model discovery
- **check_model_selection.py** (new): validation script — verifies `settings.model` contains `gpt-5.4`

## Eval results

2/2 runs passed — 5/5 criteria, score 1.000

Jira: PC-4635