### PR TITLE
docs(uipath-coded-apps): add Validation Station widget guide

### DIFF
--- a/skills/uipath-coded-apps/SKILL.md
+++ b/skills/uipath-coded-apps/SKILL.md
@@ -13,6 +13,7 @@ Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps usi
 - User wants to **build, debug, or deploy** a UiPath Coded Web App or Coded Action App
 - User asks about `uip codedapp` commands, `.uipath/` directory, `app.config.json`, or `action-schema.json`
 - User wants to **scaffold** a new React/Vue frontend for UiPath Cloud or an Action Center form
+- User wants to embed the **Document Understanding Validation Station** widget for human review of DU extraction results
 - User wants to **push/pull source** between local and Studio Web
 - User wants to use the `@uipath/uipath-typescript` SDK from a coded app
 - User wants to run the **full pipeline** (build → pack → publish → deploy)
@@ -56,6 +57,7 @@ Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps usi
 | **Push/pull code to Studio Web** | [references/file-sync.md](references/file-sync.md) |
 | **Package and deploy** | [references/pack-publish-deploy.md](references/pack-publish-deploy.md) |
 | **Full CLI command reference** | [references/commands-reference.md](references/commands-reference.md) |
+| **Embed the DU Validation Station widget** | [references/widgets/validation-station.md](references/widgets/validation-station.md) |
 | **OAuth scopes for SDK services** | [references/oauth-scopes.md](references/oauth-scopes.md) |
 | **SDK: Import paths & subpath exports** | [references/sdk/imports.md](references/sdk/imports.md) |
 | **SDK: Assets, Queues, Buckets, Processes, Jobs, Attachments** | [references/sdk/orchestrator.md](references/sdk/orchestrator.md) |

--- a/skills/uipath-coded-apps/references/create-action-app.md
+++ b/skills/uipath-coded-apps/references/create-action-app.md
@@ -11,6 +11,8 @@ When an automation creates a human task (via `CreateAppTask` RPA activity/Maestr
 
 The data contract is defined in `action-schema.json`.
 
+> **Document Understanding validation app?** If the user wants a human-review form for DU extraction results (correct fields, edit tables, approve a document), embed the **Validation Station widget** instead of generating a custom form. Follow [widgets/validation-station.md](widgets/validation-station.md) — it replaces the `src/components/Form.tsx` produced by Q4 below.
+
 ---
 
 ## Pre-flight: Collect Required Information

--- a/skills/uipath-coded-apps/references/create-web-app.md
+++ b/skills/uipath-coded-apps/references/create-web-app.md
@@ -175,6 +175,8 @@ const records = await entities.getAllRecords('<entity-id>'); // entity ID is a U
 
 See [oauth-scopes.md](oauth-scopes.md) for the full list of methods and their required scopes.
 
+If the user wants a **Document Understanding validation UI** (review/correct extraction results), embed the Validation Station widget — see [widgets/validation-station.md](widgets/validation-station.md). Required scope: `OR.Buckets` (plus `OR.Tasks` if the widget completes an Action Center task on save). Add to `VITE_UIPATH_SCOPE` during scaffold (Step 1).
+
 When implementing specific SDK services, read the corresponding reference:
 
 | Service | Reference |

--- a/skills/uipath-coded-apps/references/oauth-scopes.md
+++ b/skills/uipath-coded-apps/references/oauth-scopes.md
@@ -230,6 +230,26 @@ Combined scopes required: `OR.Execution` · `OR.Folders` · `OR.Jobs` · `Conver
 
 ---
 
+## Widgets
+
+Scopes required by `@uipath/ui-widgets-*` React components. The widget's own runtime API calls are listed here — add scopes from the sections above for any additional SDK calls the host app makes.
+
+### Validation Station (`@uipath/ui-widgets-validation-station`)
+
+| Required Scope | Why |
+|----------------|-----|
+| `OR.Buckets` | Widget reads the document and extraction artifacts from a storage bucket and uploads the validated payload during save. Read-only `OR.Buckets.Read` is insufficient — the upload step requires write. |
+| `OR.Tasks` or `OR.Tasks.Write` | Required when the host app calls `task.complete()` in `onSaveComplete` (action apps, and web apps that complete the task on save). |
+
+See [widgets/validation-station.md](widgets/validation-station.md) for the full integration guide.
+
+> **TODO:** Document scopes for the remaining widgets when their integration guides land in `references/widgets/`:
+> - `@uipath/ui-widgets-conversational-agent-chat`
+> - `@uipath/ui-widgets-datatable`
+> - `@uipath/ui-widgets-multi-file-upload`
+
+---
+
 ## Common Scope Bundles
 
 | App uses... | Minimum scopes needed |

--- a/skills/uipath-coded-apps/references/sdk/action-center.md
+++ b/skills/uipath-coded-apps/references/sdk/action-center.md
@@ -42,7 +42,7 @@ import type {
 
 ```typescript
 import {
-  TaskType,          // Form = 'FormTask', External = 'ExternalTask', App = 'AppTask'
+  TaskType,          // Form, External, App, DocumentValidation, DocumentClassification, DataLabeling
   TaskPriority,      // Low, Medium, High, Critical
   TaskStatus,        // Unassigned, Pending, Completed
   TaskSlaStatus,     // OverdueLater, OverdueSoon, Overdue, CompletedInTime
@@ -51,6 +51,17 @@ import {
   TaskSourceName,    // Agent, Workflow, Maestro, Default
 } from '@uipath/uipath-typescript/tasks';
 ```
+
+`TaskType` string values:
+
+| Member | API string | Notes |
+|--------|------------|-------|
+| `TaskType.Form` | `'FormTask'` | Renders a UiPath form layout |
+| `TaskType.External` | `'ExternalTask'` | Externally managed task |
+| `TaskType.App` | `'AppTask'` | Powered by a UiPath App |
+| `TaskType.DocumentValidation` | `'DocumentValidationTask'` | DU validation — owned by the Validation Station widget. See [../widgets/validation-station.md](../widgets/validation-station.md) |
+| `TaskType.DocumentClassification` | `'DocumentClassificationTask'` | DU classification task |
+| `TaskType.DataLabeling` | `'DataLabelingTask'` | Training-data annotation task |
 
 ## Tasks Service
 
@@ -66,9 +77,18 @@ Returns `NonPaginatedResponse<TaskGetResponse>` or `PaginatedResponse<TaskGetRes
 
 ### getById(id: number, options?: TaskGetByIdOptions, folderId?: number)
 
-Returns `Promise<TaskGetResponse>` with attached methods. For form tasks, `folderId` is required.
+Returns `Promise<TaskGetResponse>` with attached methods.
 
-`TaskGetResponse` key fields: `id`, `title`, `status`, `type`, `priority`, `folderId`, `key`, `data`, `isDeleted`, `isCompleted`, `createdTime`, `assignedToUser`, `formLayout` (for form tasks), `taskAssignments`, `activities`, `tags`, `taskSource`, `parentOperationId`, `externalTag`.
+`TaskGetByIdOptions.taskType` is an optimization. Without it, the SDK issues a generic GET, inspects `type`, then issues a second type-specific GET. With it, the SDK skips the discovery call and goes straight to the type-specific endpoint — **`folderId` then becomes required** (throws `ValidationError` otherwise). Use for any non-`External` task when you already know the type:
+
+```typescript
+// Faster — single round-trip. Required pattern for Validation Station hydration.
+const dvTask = await tasks.getById(taskId, { taskType: TaskType.DocumentValidation }, folderId);
+```
+
+For `TaskType.Form`, the SDK auto-adds `expandOnFormLayout: true` so `formLayout` is populated.
+
+`TaskGetResponse` key fields: `id`, `title`, `status`, `type`, `priority`, `folderId`, `key`, `data`, `isDeleted`, `isCompleted`, `createdTime`, `assignedToUser`, `formLayout` (form tasks), `taskAssignments`, `activities`, `tags`, `taskSource`, `parentOperationId`, `externalTag`.
 
 **OData filtering:** `TaskGetAllOptions` supports `filter` (OData `$filter` string) and `orderby` for server-side filtering and sorting. Examples:
 - Pending tasks only: `filter: "Status ne 'Completed'"`
@@ -95,9 +115,10 @@ Returns `Promise<OperationResponse<{ taskId: number }[] | TaskAssignmentResponse
 
 Returns `Promise<OperationResponse<TaskCompletionOptions>>`. The `folderId` is required.
 
-`TaskCompletionOptions` is a discriminated union:
-- For `TaskType.External`: `{ type: TaskType.External, taskId: number, data?: any, action?: string }`
-- For other types: `{ type: TaskType.Form | TaskType.App, taskId: number, data: any, action: string }`
+`TaskCompletionOptions` is a discriminated union on `type`:
+- `External`, `DocumentValidation`, `DocumentClassification`, `DataLabeling`: `{ type, taskId, data?, action? }` — both `data` and `action` optional. Routes to the generic complete endpoint.
+- `Form`: `{ type: TaskType.Form, taskId, data, action }` — both required. Routes to the form-task endpoint.
+- `App`: `{ type: TaskType.App, taskId, data, action }` — both required. Routes to the app-task endpoint.
 
 ## Task-Attached Methods (TaskMethods)
 
@@ -173,10 +194,15 @@ The `type` field determines which other fields are required:
 | Task Type | `data` | `action` | Example |
 |-----------|--------|----------|---------|
 | `TaskType.External` | Optional | Optional | `{ type: TaskType.External, action: 'Approve' }` |
+| `TaskType.DocumentValidation` | Optional | Optional | `{ type: TaskType.DocumentValidation, action: 'Completed' }` |
+| `TaskType.DocumentClassification` | Optional | Optional | `{ type: TaskType.DocumentClassification, action: 'Completed' }` |
+| `TaskType.DataLabeling` | Optional | Optional | `{ type: TaskType.DataLabeling, action: 'Completed' }` |
 | `TaskType.Form` | **Required** | **Required** | `{ type: TaskType.Form, action: 'Submit', data: formData }` |
 | `TaskType.App` | **Required** | **Required** | `{ type: TaskType.App, action: 'Approve', data: {} }` |
 
 For Maestro HITL tasks (approve/reject flows), tasks are typically `TaskType.App` or `TaskType.External`. Pass `data: {}` (empty object) for App tasks when there's no form data to submit.
+
+For `TaskType.DocumentValidation`, the Validation Station widget owns the data contract — call `task.complete({ type: TaskType.DocumentValidation, action: 'Completed' })` from `onSaveComplete`. Do NOT pass `data` yourself; the widget already uploaded the validated payload to the bucket before firing the callback. See [../widgets/validation-station.md](../widgets/validation-station.md).
 
 ### Action strings
 

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -33,7 +33,7 @@ Registry flag forces the public npm registry (skill default — users may have `
 
 ## Static Assets — Vite Plugin
 
-Append to `vite.config.ts`. The plugin runs after `build` and copies the WC's `du-assets/` next to the emitted JS chunks:
+Replace `vite.config.ts` with the full file below. The plugin runs after `build` and copies the WC's `du-assets/` next to the emitted JS chunks:
 
 ```typescript
 import react from '@vitejs/plugin-react';
@@ -242,6 +242,8 @@ function ValidatePage({ taskId, folderId }: { taskId: number; folderId: number }
     />
   );
 }
+
+export default ValidatePage;
 ```
 
 Two things to lock in:

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -14,12 +14,14 @@ If the user just wants a generic form (no DU document), use the standard Action 
 
 ## Critical Rules
 
-1. **Peer versions are hard requirements.** Widget requires `react >= 19.2.0`, `react-dom >= 19.2.0`, `@uipath/uipath-typescript >= 1.3.9`. The Vite scaffold pins React 19.2+, but verify in `package.json` before installing.
+1. **Peer versions are hard requirements.** Widget requires `react >= 19.2.0`, `react-dom >= 19.2.0`, `@uipath/uipath-typescript >= 1.4.1`. The Vite scaffold pins React 19.2+, but verify in `package.json` before installing.
 2. **Copy `du-assets/` into build output.** The underlying web component loads PDF.js worker, cmaps, wasm, and i18n from a sibling `du-assets/` directory resolved via `import.meta.url`. Without this, **PDF rendering and translations silently 404 in production** — no build error. See "Static assets" below.
 3. **Set `optimizeDeps.exclude: ['@uipath/du-validation-station-wc']` in `vite.config.ts`.** Vite's pre-bundler rewrites `import.meta.url` and breaks runtime asset resolution.
 4. **Body needs `light` or `dark` class** for theming. Match it to the `theme` prop. Action apps already manage this via `onInitTheme` from `CodedActionAppService.getTask()`.
 5. **`sdk` must already be initialized.** Pass the same `UiPath` instance produced by `useAuth()` (web app) or constructed in `src/uipath.ts` (action app). Do not construct a second SDK just for the widget — auth state will diverge.
 6. **Required SDK scopes:** `OR.Buckets` (the widget fetches the document and extraction artifacts from a storage bucket). Add `OR.Tasks` as well when the widget is rendered inside an Action Center task (action app, or web app that completes a task on save). Add to `VITE_UIPATH_SCOPE` before first run; mismatch fails silently with 401/403. See [../oauth-scopes.md](../oauth-scopes.md).
+7. **Widget does NOT surface failures.** `onSubmitComplete` / `onSaveAsDraftComplete` fire with `{ success: false, error }` on failure but render no toast — the host owns all UI feedback (toast, retry, log). Wire these callbacks or failures are silent.
+8. **Report-as-exception makes no API call.** `onReportExceptionComplete(documentId, reason)` only hands the host the data — it does NOT persist. The host must call `OrchestratorDuModule.submitExceptionReport(taskId, documentId, reason, { folderId })` itself, or the user's "Report as exception" click is a no-op. Needs `OR.Tasks`.
 
 ## Install
 
@@ -85,15 +87,18 @@ Full table in the package README. Inside a coded app you usually only touch:
 |------|----------|-------|
 | `sdk` | Yes | `UiPath` instance — from `useAuth()` or `src/uipath.ts`. Must be initialized. |
 | `data` | Yes | `ContentValidationData` — for action apps, this comes from the task payload. For web apps, fetch and pass yourself. |
-| `folderId` | No | Falls back to `data.FolderId`. Pass explicitly if the data payload omits it. |
+| `folderId` | No* | Falls back to `data.FolderId`. One of the two must resolve to a value or the widget errors — pass explicitly when the payload omits it. |
 | `theme` | No | `'light' \| 'dark' \| 'light-hc' \| 'dark-hc'`. Keep in sync with body class. |
-| `language` | No | `Language` enum re-exported from the package. |
+| `language` | No | `ValidationStationLanguage` enum exported from the package (e.g. `English`, `German`, `Japanese`, `ChineseSimplified`). |
 | `isReadonly` | No | `true` to render in read-only mode (e.g., audit view). |
-| `enableSaveAsDraft` | No | Adds a "Save as draft" action. |
-| `save` | No | Controlled trigger: `{ validate: true }` to validate before saving. Set from a button. |
-| `onSaveComplete` | No | Fires after ProcessExtractedData + bucket upload finishes. Use to call `task.complete(...)`. |
+| `options` | No | `IValidationStationOptions` — fine-grained WC feature flags. Set `emitDtoStateChanges: true` to enable save-as-draft. |
+| `save` | No | Controlled trigger from a button. `{ validate: true }` = **submit** (validate, then save). `{ validate: false }` = **save as draft** (requires `options.emitDtoStateChanges: true`, else no-op). |
+| `discardChanges` | No | Controlled trigger: `{ value: true }` to discard pending edits. Pass a fresh object each time — the widget watches for the new reference, so repeated `{ value: true }` calls all fire. |
+| `onSubmitComplete` | No | Fires after **submit** (`save={{ validate: true }}`): ProcessExtractedData + bucket upload. Receives `SaveValidatedDataResult`. Use to complete the task with the approve action. |
+| `onSaveAsDraftComplete` | No | Fires after **save as draft** (`save={{ validate: false }}`): uploads in-progress data, no ProcessExtractedData. Receives `SaveValidatedDataResult`. |
+| `onReportExceptionComplete` | No | Fires when the user reports an exception. Signature `(documentId, reason)`, **not** `SaveValidatedDataResult`. Widget makes **no API call** — host must persist via `OrchestratorDuModule.submitExceptionReport(...)`. |
 
-`onSaveComplete` receives `SaveValidatedDataResult` — `{ success: true }` or `{ success: false, error: string }`. The widget already shows a toast on failure; only add custom retry/analytics here if needed.
+The widget surfaces three flows. **Submit** and **save as draft** are owned end-to-end by the widget and hand the host a `SaveValidatedDataResult` — `{ success: true }` or `{ success: false, error: string }`. **Report as exception** is forwarded to the host as raw `(documentId, reason)` strings with no API call. The widget renders no failure UI for any flow — handle `success: false` in the callback yourself (toast, retry, log).
 
 ## Integration: Action App (most common)
 
@@ -104,10 +109,12 @@ Validation Station as the form inside an Action Center DU validation task. Repla
 import { useState, useEffect, useCallback } from 'react';
 import {
   ValidationStation,
-  Language,
+  ValidationStationLanguage,
   type SaveValidatedDataResult,
 } from '@uipath/ui-widgets-validation-station';
-import { Theme } from '@uipath/coded-action-app';
+import type { DuFramework } from '@uipath/uipath-typescript/document-understanding';
+import { OrchestratorDuModule } from '@uipath/uipath-typescript/orchestrator-du-module';
+import { MessageSeverity, Theme } from '@uipath/coded-action-app';
 import { sdk, codedActionAppService } from '../uipath';
 
 const isDarkTheme = (t: Theme) =>
@@ -118,7 +125,8 @@ interface FormProps {
 }
 
 function Form({ onInitTheme }: FormProps) {
-  const [data, setData] = useState<unknown>(null);
+  const [data, setData] = useState<DuFramework.ContentValidationData | null>(null);
+  const [taskId, setTaskId] = useState<number | undefined>(undefined);
   const [folderId, setFolderId] = useState<number | undefined>(undefined);
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
   const [isReadonly, setIsReadonly] = useState(false);
@@ -126,8 +134,9 @@ function Form({ onInitTheme }: FormProps) {
 
   useEffect(() => {
     codedActionAppService.getTask().then((task) => {
-      // Task payload carries ContentValidationData under task.data
-      setData(task.data);
+      // task.data is typed `unknown`; the payload is ContentValidationData
+      setData(task.data as DuFramework.ContentValidationData);
+      setTaskId(task.taskId);
       setFolderId(task.folderId);
       setIsReadonly(task.isReadOnly);
       const dark = isDarkTheme(task.theme);
@@ -136,12 +145,38 @@ function Form({ onInitTheme }: FormProps) {
     });
   }, [onInitTheme]);
 
-  const handleSaveComplete = useCallback(
+  // Submit succeeded → approve the task. Widget shows no error toast — handle failure here.
+  const handleSubmitComplete = useCallback(
     async (result: SaveValidatedDataResult) => {
-      if (!result.success) return; // widget already shows a toast
+      if (!result.success) {
+        codedActionAppService.showMessage(result.error, MessageSeverity.Error);
+        return;
+      }
       await codedActionAppService.completeTask('Approve', {});
     },
     [],
+  );
+
+  // Report-as-exception is not persisted by the widget — call the SDK, then reject the task.
+  const handleReportException = useCallback(
+    async (documentId: string, reason: string) => {
+      if (taskId === undefined) return;
+      const response = await new OrchestratorDuModule(sdk).submitExceptionReport(
+        taskId,
+        documentId,
+        reason || 'Reported via Validation Station',
+        { folderId },
+      );
+      if (!response.IsSuccessful) {
+        codedActionAppService.showMessage(
+          response.ErrorMessage ?? 'Failed to report exception',
+          MessageSeverity.Error,
+        );
+        return;
+      }
+      await codedActionAppService.completeTask('Reject', {});
+    },
+    [taskId, folderId],
   );
 
   if (!data) return null; // wait for task payload
@@ -156,10 +191,11 @@ function Form({ onInitTheme }: FormProps) {
         data={data}
         folderId={folderId}
         theme={theme}
-        language={Language.English}
+        language={ValidationStationLanguage.English}
         isReadonly={isReadonly}
         save={save}
-        onSaveComplete={handleSaveComplete}
+        onSubmitComplete={handleSubmitComplete}
+        onReportExceptionComplete={handleReportException}
       />
     </>
   );
@@ -204,9 +240,10 @@ Same widget, sdk comes from `useAuth()`. Typical flow: list `TaskType.DocumentVa
 import { useEffect, useMemo, useState } from 'react';
 import {
   ValidationStation,
-  Language,
+  ValidationStationLanguage,
   type SaveValidatedDataResult,
 } from '@uipath/ui-widgets-validation-station';
+import type { DuFramework } from '@uipath/uipath-typescript/document-understanding';
 import { Tasks, TaskType } from '@uipath/uipath-typescript/tasks';
 import type { TaskGetResponse } from '@uipath/uipath-typescript/tasks';
 import { useAuth } from '../hooks/useAuth';
@@ -218,11 +255,11 @@ function ValidatePage({ taskId, folderId }: { taskId: number; folderId: number }
 
   // getAll() rows don't carry `data` — fetch the full task by id.
   useEffect(() => {
-    tasks.getById(taskId, undefined, folderId).then(setSelectedTask);
+    tasks.getById(taskId, { taskType: TaskType.DocumentValidation }, folderId).then(setSelectedTask);
   }, [tasks, taskId, folderId]);
 
-  const handleSaveComplete = async (result: SaveValidatedDataResult) => {
-    if (!result.success || !selectedTask) return; // widget already shows a toast
+  const handleSubmitComplete = async (result: SaveValidatedDataResult) => {
+    if (!result.success || !selectedTask) return; // widget renders no error UI — surface it yourself
     await selectedTask.complete({
       action: 'Completed',
       type: TaskType.DocumentValidation,
@@ -234,11 +271,11 @@ function ValidatePage({ taskId, folderId }: { taskId: number; folderId: number }
   return (
     <ValidationStation
       sdk={sdk}
-      data={selectedTask.data}
+      data={selectedTask.data as DuFramework.ContentValidationData}
       folderId={selectedTask.folderId}
       theme="light"
-      language={Language.English}
-      onSaveComplete={handleSaveComplete}
+      language={ValidationStationLanguage.English}
+      onSubmitComplete={handleSubmitComplete}
     />
   );
 }
@@ -248,7 +285,7 @@ export default ValidatePage;
 
 Two things to lock in:
 
-- **Always call `tasks.getById(id, undefined, folderId)` before rendering the widget.** Even if you already have a `TaskGetResponse` from `getAll()`, its `data` field is undefined. Re-fetch by id.
+- **Always call `tasks.getById(id, { taskType: TaskType.DocumentValidation }, folderId)` before rendering the widget.** Even if you already have a `TaskGetResponse` from `getAll()`, its `data` field is undefined. Re-fetch by id.
 - **DU validation tasks are `TaskType.DocumentValidation`** — do not pass `TaskType.Form`, `App`, or `External`. The action string for a successful validation is `"Completed"`. Prefer the task-attached `selectedTask.complete(...)` over the service-level `tasks.complete(...)` — no `taskId`/`folderId` to thread through. See [../sdk/action-center.md](../sdk/action-center.md) for the broader Tasks API.
 
 Body theme class — toggle on the document body (e.g., from `useAuth` user preferences or a theme switcher):
@@ -263,8 +300,9 @@ useEffect(() => {
 ## Anti-patterns
 
 - **Do not skip the `du-assets/` copy step.** PDF rendering and translations 404 silently in prod; "works on my machine" because dev serves from `node_modules`.
-- **Do not `npm install playwright` or pre-bundle the WC.** `optimizeDeps.exclude` is mandatory.
 - **Do not construct a second `UiPath` SDK** for the widget. Reuse the app's authenticated instance.
 - **Do not call `setTaskData` and try to drive a custom form alongside the widget.** The widget owns the data contract end-to-end; mixing produces stale state and double saves.
-- **Do not pass a `tasks.getAll()` row straight into the widget.** `getAll()` rows omit `data` — the viewer renders empty. Hydrate with `tasks.getById(id, undefined, folderId)` first.
-- **Do not call `completeTask` inside the `save` setter.** Always wait for `onSaveComplete` with `success: true` — saving may fail validation, and completing early submits unvalidated data.
+- **Do not pass a `tasks.getAll()` row straight into the widget.** `getAll()` rows omit `data` — the viewer renders empty. Hydrate with `tasks.getById(id, { taskType: TaskType.DocumentValidation }, folderId)` first.
+- **Do not call `completeTask` inside the `save` setter.** Always wait for `onSubmitComplete` with `success: true` — submit may fail validation, and completing early submits unvalidated data.
+- **Do not assume the widget shows an error on failure — it does not.** `onSubmitComplete`/`onSaveAsDraftComplete` with `success: false` render no UI; surface the error yourself (`showMessage`, toast, etc.).
+- **Do not treat `onReportExceptionComplete` like the save callbacks.** It receives `(documentId, reason)`, not `SaveValidatedDataResult`, and persists nothing — you must call `OrchestratorDuModule.submitExceptionReport(...)` before completing the task.

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -1,0 +1,268 @@
+# Validation Station Widget
+
+React wrapper around the UiPath Document Understanding **Validation Station** web component. Use when the app must let a human review and correct extraction results from a DU document.
+
+Package: [`@uipath/ui-widgets-validation-station`](https://www.npmjs.com/package/@uipath/ui-widgets-validation-station). Full prop/API surface lives in the package README — this file covers only the integration steps that are easy to get wrong inside a Coded App.
+
+## When to Use
+
+- User asks to **validate, review, correct, or approve** Document Understanding extraction results.
+- App receives a `ContentValidationData` payload (bucket paths + document ID) — either from an Action Center task created by a DU workflow, or fetched at runtime in a web app.
+- Replaces a hand-rolled PDF viewer + field editor. Do **not** rebuild this UI from scratch — the widget already handles PDF rendering, bounding boxes, table editing, translations, and save/discard plumbing.
+
+If the user just wants a generic form (no DU document), use the standard Action App form pattern in [../create-action-app.md](../create-action-app.md) instead.
+
+## Critical Rules
+
+1. **Peer versions are hard requirements.** Widget requires `react >= 19.2.0`, `react-dom >= 19.2.0`, `@uipath/uipath-typescript >= 1.3.9`. The Vite scaffold pins React 19.2+, but verify in `package.json` before installing.
+2. **Copy `du-assets/` into build output.** The underlying web component loads PDF.js worker, cmaps, wasm, and i18n from a sibling `du-assets/` directory resolved via `import.meta.url`. Without this, **PDF rendering and translations silently 404 in production** — no build error. See "Static assets" below.
+3. **Set `optimizeDeps.exclude: ['@uipath/du-validation-station-wc']` in `vite.config.ts`.** Vite's pre-bundler rewrites `import.meta.url` and breaks runtime asset resolution.
+4. **Body needs `light` or `dark` class** for theming. Match it to the `theme` prop. Action apps already manage this via `onInitTheme` from `CodedActionAppService.getTask()`.
+5. **`sdk` must already be initialized.** Pass the same `UiPath` instance produced by `useAuth()` (web app) or constructed in `src/uipath.ts` (action app). Do not construct a second SDK just for the widget — auth state will diverge.
+6. **Required SDK scopes:** `OR.Buckets` (the widget fetches the document and extraction artifacts from a storage bucket). Add `OR.Tasks` as well when the widget is rendered inside an Action Center task (action app, or web app that completes a task on save). Add to `VITE_UIPATH_SCOPE` before first run; mismatch fails silently with 401/403. See [../oauth-scopes.md](../oauth-scopes.md).
+
+## Install
+
+From inside the scaffolded app directory:
+
+```bash
+npm install @uipath/ui-widgets-validation-station --@uipath:registry=https://registry.npmjs.org
+```
+
+Registry flag forces the public npm registry (skill default — users may have `@uipath` scoped to GitHub Packages).
+
+## Static Assets — Vite Plugin
+
+Append to `vite.config.ts`. The plugin runs after `build` and copies the WC's `du-assets/` next to the emitted JS chunks:
+
+```typescript
+import react from '@vitejs/plugin-react';
+import { cp } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { defineConfig, type Plugin } from 'vite';
+
+const require = createRequire(import.meta.url);
+
+function copyDuValidationStationAssets(): Plugin {
+  let destDir = '';
+  return {
+    name: 'copy-du-validation-station-assets',
+    apply: 'build',
+    configResolved(config) {
+      destDir = resolve(
+        config.root,
+        config.build.outDir,
+        config.build.assetsDir,
+        'du-assets',
+      );
+    },
+    async closeBundle() {
+      const wcRoot = dirname(
+        require.resolve('@uipath/du-validation-station-wc/package.json'),
+      );
+      await cp(resolve(wcRoot, 'du-assets'), destDir, { recursive: true });
+    },
+  };
+}
+
+export default defineConfig({
+  plugins: [react(), copyDuValidationStationAssets()],
+  base: './',
+  optimizeDeps: {
+    exclude: ['@uipath/du-validation-station-wc'],
+  },
+});
+```
+
+Verify after `npm run build`: `ls dist/assets/du-assets/` must list `pdfjs/`, `cmaps/`, `wasm/`, `i18n/`. Empty or missing → plugin did not run.
+
+## Key Props
+
+Full table in the package README. Inside a coded app you usually only touch:
+
+| Prop | Required | Notes |
+|------|----------|-------|
+| `sdk` | Yes | `UiPath` instance — from `useAuth()` or `src/uipath.ts`. Must be initialized. |
+| `data` | Yes | `ContentValidationData` — for action apps, this comes from the task payload. For web apps, fetch and pass yourself. |
+| `folderId` | No | Falls back to `data.FolderId`. Pass explicitly if the data payload omits it. |
+| `theme` | No | `'light' \| 'dark' \| 'light-hc' \| 'dark-hc'`. Keep in sync with body class. |
+| `language` | No | `Language` enum re-exported from the package. |
+| `isReadonly` | No | `true` to render in read-only mode (e.g., audit view). |
+| `enableSaveAsDraft` | No | Adds a "Save as draft" action. |
+| `save` | No | Controlled trigger: `{ validate: true }` to validate before saving. Set from a button. |
+| `onSaveComplete` | No | Fires after ProcessExtractedData + bucket upload finishes. Use to call `task.complete(...)`. |
+
+`onSaveComplete` receives `SaveValidatedDataResult` — `{ success: true }` or `{ success: false, error: string }`. The widget already shows a toast on failure; only add custom retry/analytics here if needed.
+
+## Integration: Action App (most common)
+
+Validation Station as the form inside an Action Center DU validation task. Replaces `src/components/Form.tsx` from the standard action-app scaffold.
+
+```typescript
+// src/components/Form.tsx
+import { useState, useEffect, useCallback } from 'react';
+import {
+  ValidationStation,
+  Language,
+  type SaveValidatedDataResult,
+} from '@uipath/ui-widgets-validation-station';
+import { Theme } from '@uipath/coded-action-app';
+import { sdk, codedActionAppService } from '../uipath';
+
+const isDarkTheme = (t: Theme) =>
+  t === Theme.Dark || t === Theme.DarkHighContrast;
+
+interface FormProps {
+  onInitTheme: (isDark: boolean) => void;
+}
+
+function Form({ onInitTheme }: FormProps) {
+  const [data, setData] = useState<unknown>(null);
+  const [folderId, setFolderId] = useState<number | undefined>(undefined);
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [isReadonly, setIsReadonly] = useState(false);
+  const [save, setSave] = useState<{ validate: boolean } | undefined>(undefined);
+
+  useEffect(() => {
+    codedActionAppService.getTask().then((task) => {
+      // Task payload carries ContentValidationData under task.data
+      setData(task.data);
+      setFolderId(task.folderId);
+      setIsReadonly(task.isReadOnly);
+      const dark = isDarkTheme(task.theme);
+      setTheme(dark ? 'dark' : 'light');
+      onInitTheme(dark);
+    });
+  }, [onInitTheme]);
+
+  const handleSaveComplete = useCallback(
+    async (result: SaveValidatedDataResult) => {
+      if (!result.success) return; // widget already shows a toast
+      await codedActionAppService.completeTask('Approve', {});
+    },
+    [],
+  );
+
+  if (!data) return null; // wait for task payload
+
+  return (
+    <>
+      <button type="button" onClick={() => setSave({ validate: true })} disabled={isReadonly}>
+        Validate &amp; submit
+      </button>
+      <ValidationStation
+        sdk={sdk}
+        data={data}
+        folderId={folderId}
+        theme={theme}
+        language={Language.English}
+        isReadonly={isReadonly}
+        save={save}
+        onSaveComplete={handleSaveComplete}
+      />
+    </>
+  );
+}
+
+export default Form;
+```
+
+Adjust `src/uipath.ts` to export the initialized `sdk` alongside `codedActionAppService`:
+
+```typescript
+import { UiPath } from '@uipath/uipath-typescript/core';
+import { CodedActionAppService } from '@uipath/coded-action-app';
+
+export const sdk = new UiPath();
+await sdk.initialize();
+export const codedActionAppService = new CodedActionAppService();
+```
+
+`action-schema.json` for a DU validation task typically has no `inputs`/`outputs` — the widget owns the data contract. A minimal schema:
+
+```json
+{
+  "inputs":  { "type": "object", "properties": {} },
+  "outputs": { "type": "object", "properties": {} },
+  "inOuts":  { "type": "object", "properties": {} },
+  "outcomes": {
+    "type": "object",
+    "properties": {
+      "Approve": { "type": "string" },
+      "Reject":  { "type": "string" }
+    }
+  }
+}
+```
+
+## Integration: Web App
+
+Same widget, sdk comes from `useAuth()`. Typical flow: list `TaskType.DocumentValidation` tasks with `tasks.getAll(...)`, **then hydrate the selected row with `tasks.getById(...)` to load `task.data`** — `getAll()` returns task summaries without `data` populated, so passing a `getAll` row straight into the widget produces an empty viewer.
+
+```typescript
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ValidationStation,
+  Language,
+  type SaveValidatedDataResult,
+} from '@uipath/ui-widgets-validation-station';
+import { Tasks, TaskType } from '@uipath/uipath-typescript/tasks';
+import type { TaskGetResponse } from '@uipath/uipath-typescript/tasks';
+import { useAuth } from '../hooks/useAuth';
+
+function ValidatePage({ taskId, folderId }: { taskId: number; folderId: number }) {
+  const { sdk } = useAuth();
+  const tasks = useMemo(() => new Tasks(sdk), [sdk]);
+  const [selectedTask, setSelectedTask] = useState<TaskGetResponse | null>(null);
+
+  // getAll() rows don't carry `data` — fetch the full task by id.
+  useEffect(() => {
+    tasks.getById(taskId, undefined, folderId).then(setSelectedTask);
+  }, [tasks, taskId, folderId]);
+
+  const handleSaveComplete = async (result: SaveValidatedDataResult) => {
+    if (!result.success || !selectedTask) return; // widget already shows a toast
+    await selectedTask.complete({
+      action: 'Completed',
+      type: TaskType.DocumentValidation,
+    });
+  };
+
+  if (!selectedTask) return null;
+
+  return (
+    <ValidationStation
+      sdk={sdk}
+      data={selectedTask.data}
+      folderId={selectedTask.folderId}
+      theme="light"
+      language={Language.English}
+      onSaveComplete={handleSaveComplete}
+    />
+  );
+}
+```
+
+Two things to lock in:
+
+- **Always call `tasks.getById(id, undefined, folderId)` before rendering the widget.** Even if you already have a `TaskGetResponse` from `getAll()`, its `data` field is undefined. Re-fetch by id.
+- **DU validation tasks are `TaskType.DocumentValidation`** — do not pass `TaskType.Form`, `App`, or `External`. The action string for a successful validation is `"Completed"`. Prefer the task-attached `selectedTask.complete(...)` over the service-level `tasks.complete(...)` — no `taskId`/`folderId` to thread through. See [../sdk/action-center.md](../sdk/action-center.md) for the broader Tasks API.
+
+Body theme class — toggle on the document body (e.g., from `useAuth` user preferences or a theme switcher):
+
+```typescript
+useEffect(() => {
+  document.body.classList.toggle('dark', isDark);
+  document.body.classList.toggle('light', !isDark);
+}, [isDark]);
+```
+
+## Anti-patterns
+
+- **Do not skip the `du-assets/` copy step.** PDF rendering and translations 404 silently in prod; "works on my machine" because dev serves from `node_modules`.
+- **Do not `npm install playwright` or pre-bundle the WC.** `optimizeDeps.exclude` is mandatory.
+- **Do not construct a second `UiPath` SDK** for the widget. Reuse the app's authenticated instance.
+- **Do not call `setTaskData` and try to drive a custom form alongside the widget.** The widget owns the data contract end-to-end; mixing produces stale state and double saves.
+- **Do not pass a `tasks.getAll()` row straight into the widget.** `getAll()` rows omit `data` — the viewer renders empty. Hydrate with `tasks.getById(id, undefined, folderId)` first.
+- **Do not call `completeTask` inside the `save` setter.** Always wait for `onSaveComplete` with `success: true` — saving may fail validation, and completing early submits unvalidated data.


### PR DESCRIPTION
https://uipath.atlassian.net/browse/PLT-105126

## Summary
- New `references/widgets/validation-station.md` documenting how to embed `@uipath/ui-widgets-validation-station` inside Coded Action Apps and Coded Web Apps — install, the `du-assets` build-copy Vite plugin, required scopes (`OR.Buckets`, plus `OR.Tasks` when wired to Action Center), and full integration examples.
- Web App example shows the correct completion path: list with `tasks.getAll`, hydrate the selected row via `tasks.getById(id, undefined, folderId)` so `task.data` is populated, then complete from `onSaveComplete` with `selectedTask.complete({ action: 'Completed', type: TaskType.DocumentValidation })`.
- SKILL.md and the two `create-*-app.md` guides cross-link to the new reference so the scaffold flow picks it up when the user asks for a DU validation UI.

## Test plan
- [ ] Scaffold a Coded Action App, follow the widget guide, verify `dist/assets/du-assets/` is populated after `npm run build`
- [ ] Run the action app against a DU validation task — confirm PDF renders, save → `onSaveComplete` fires, task completes
- [ ] Scaffold a Coded Web App, list DU tasks, hydrate with `getById`, render the widget, complete with `TaskType.DocumentValidation`
- [ ] `bash hooks/validate-skill-descriptions.sh` passes (SKILL.md description still under 1024 chars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)